### PR TITLE
Additions to hadoop-gremlin conf files

### DIFF
--- a/hadoop-gremlin/conf/hadoop-graphson.properties
+++ b/hadoop-gremlin/conf/hadoop-graphson.properties
@@ -28,14 +28,43 @@ gremlin.hadoop.jarsInDistributedCache=true
 # the vertex program to execute
 gremlin.vertexProgram=org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram
 
-####################################
-# SparkGraphComputer Configuration #
-####################################
+############################################
+# SparkGraphComputer Configuration (Local) #
+############################################
 spark.master=local[4]
 
-#####################################
-# GiraphGraphComputer Configuration #
-#####################################
+############################################
+# SparkGraphComputer Configuration (Yarn) #
+############################################
+#spark.master=yarn-client
+# app name in the cluster's history server
+#spark.app.name=TinkerPop
+# faster startup if many cluster users ask for the default 4040 port
+#spark.ui.port=4050
+# needed if the default JAVA_HOME on the cluster is not jdk1.8
+#spark.yarn.appMasterEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+#spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+# below point to your cluster's worker node configs
+#spark.executorEnv.SPARK_CONF_DIR=/etc/spark/conf
+#spark.executorEnv.HADOOP_CONF_DIR=/etc/hadoop/conf
+# needed for Hortonworks Data Platform
+#spark.executor.extraJavaOptions=-Dhdp.version=2.3.2.0-2950
+# optional parameters for tuning your TinkerPop application
+#spark.executor.instances=10
+#spark.executor.memory=4g
+#spark.executor.cores=2
+# needed on a secure cluster to allow for multiple computations
+# on a single Kerberos ticket
+#gremlin.spark.persistContext=true
+
+# Below copy all properties from your spark-client's spark-defaults.conf
+# prop1 ...
+# ...
+# propN ...
+
+############################################
+# GiraphGraphComputer Configuration        #
+############################################
 giraph.minWorkers=2
 giraph.maxWorkers=2
 

--- a/hadoop-gremlin/conf/hadoop-grateful-gryo.properties
+++ b/hadoop-gremlin/conf/hadoop-grateful-gryo.properties
@@ -27,9 +27,46 @@ gremlin.hadoop.outputLocation=output
 gremlin.hadoop.deriveMemory=false
 gremlin.hadoop.jarsInDistributedCache=true
 
-#
-# GiraphGraphComputer Configuration
-#
+
+############################################
+# SparkGraphComputer Configuration (Local) #
+############################################
+spark.master=local[1]
+spark.executor.memory=1g
+spark.serializer=org.apache.spark.serializer.KryoSerializer
+
+############################################
+# SparkGraphComputer Configuration (Yarn) #
+############################################
+#spark.master=yarn-client
+# app name in the cluster's history server
+#spark.app.name=TinkerPop
+# faster startup if many cluster users ask for the default 4040 port
+#spark.ui.port=4050
+# needed if the default JAVA_HOME on the cluster is not jdk1.8
+#spark.yarn.appMasterEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+#spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+# below point to your cluster's worker node configs
+#spark.executorEnv.SPARK_CONF_DIR=/etc/spark/conf
+#spark.executorEnv.HADOOP_CONF_DIR=/etc/hadoop/conf
+# needed for Hortonworks Data Platform
+#spark.executor.extraJavaOptions=-Dhdp.version=2.3.2.0-2950
+# optional parameters for tuning your TinkerPop application
+#spark.executor.instances=10
+#spark.executor.memory=4g
+#spark.executor.cores=2
+# needed on a secure cluster to allow for multiple computations
+# on a single Kerberos ticket
+#gremlin.spark.persistContext=true
+
+# Below copy all properties from your spark-client's spark-defaults.conf
+# prop1 ...
+# ...
+# propN ...
+
+############################################
+# GiraphGraphComputer Configuration        #
+############################################
 giraph.minWorkers=1
 giraph.maxWorkers=1
 giraph.useOutOfCoreGraph=true
@@ -39,11 +76,4 @@ mapred.reduce.child.java.opts=-Xmx1024m
 giraph.numInputThreads=4
 giraph.numComputeThreads=4
 giraph.maxMessagesInMemory=100000
-
-#
-# SparkGraphComputer Configuration
-#
-spark.master=local[1]
-spark.executor.memory=1g
-spark.serializer=org.apache.spark.serializer.KryoSerializer
 

--- a/hadoop-gremlin/conf/hadoop-gryo.properties
+++ b/hadoop-gremlin/conf/hadoop-gryo.properties
@@ -22,9 +22,9 @@ gremlin.hadoop.jarsInDistributedCache=true
 gremlin.hadoop.inputLocation=tinkerpop-modern.kryo
 gremlin.hadoop.outputLocation=output
 
-####################################
-# SparkGraphComputer Configuration #
-####################################
+############################################
+# SparkGraphComputer Configuration (Local) #
+############################################
 spark.master=local[4]
 spark.executor.memory=1g
 spark.serializer=org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerializer
@@ -34,9 +34,38 @@ spark.serializer=org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerial
 # spark.eventLog.dir=/tmp/spark-event-logs
 # spark.ui.killEnabled=true
 
-#####################################
-# GiraphGraphComputer Configuration #
-#####################################
+############################################
+# SparkGraphComputer Configuration (Yarn) #
+############################################
+#spark.master=yarn-client
+# app name in the cluster's history server
+#spark.app.name=TinkerPop
+# faster startup if many cluster users ask for the default 4040 port
+#spark.ui.port=4050
+# needed if the default JAVA_HOME on the cluster is not jdk1.8
+#spark.yarn.appMasterEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+#spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+# below point to your cluster's worker node configs
+#spark.executorEnv.SPARK_CONF_DIR=/etc/spark/conf
+#spark.executorEnv.HADOOP_CONF_DIR=/etc/hadoop/conf
+# needed for Hortonworks Data Platform
+#spark.executor.extraJavaOptions=-Dhdp.version=2.3.2.0-2950
+# optional parameters for tuning your TinkerPop application
+#spark.executor.instances=10
+#spark.executor.memory=4g
+#spark.executor.cores=2
+# needed on a secure cluster to allow for multiple computations
+# on a single Kerberos ticket
+#gremlin.spark.persistContext=true
+
+# Below copy all properties from your spark-client's spark-defaults.conf
+# prop1 ...
+# ...
+# propN ...
+
+############################################
+# GiraphGraphComputer Configuration        #
+############################################
 giraph.minWorkers=2
 giraph.maxWorkers=2
 giraph.useOutOfCoreGraph=true
@@ -50,5 +79,3 @@ giraph.numComputeThreads=2
 ## MapReduce of GiraphGraphComputer ##
 # mapreduce.job.maps=2
 # mapreduce.job.reduces=1
-
-

--- a/hadoop-gremlin/conf/hadoop-script.properties
+++ b/hadoop-gremlin/conf/hadoop-script.properties
@@ -23,9 +23,9 @@ gremlin.hadoop.inputLocation=tinkerpop-classic.txt
 gremlin.hadoop.scriptInputFormat.script=script-input.groovy
 gremlin.hadoop.outputLocation=output
 
-####################################
-# SparkGraphComputer Configuration #
-####################################
+############################################
+# SparkGraphComputer Configuration (Local) #
+############################################
 spark.master=local[4]
 spark.executor.memory=1g
 spark.serializer=org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerializer
@@ -35,9 +35,38 @@ spark.serializer=org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerial
 # spark.eventLog.dir=/tmp/spark-event-logs
 # spark.ui.killEnabled=true
 
-#####################################
-# GiraphGraphComputer Configuration #
-#####################################
+############################################
+# SparkGraphComputer Configuration (Yarn) #
+############################################
+#spark.master=yarn-client
+# app name in the cluster's history server
+#spark.app.name=TinkerPop
+# faster startup if many cluster users ask for the default 4040 port
+#spark.ui.port=4050
+# needed if the default JAVA_HOME on the cluster is not jdk1.8
+#spark.yarn.appMasterEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+#spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-1.8.0-oracle.x86_64/jre
+# below point to your cluster's worker node configs
+#spark.executorEnv.SPARK_CONF_DIR=/etc/spark/conf
+#spark.executorEnv.HADOOP_CONF_DIR=/etc/hadoop/conf
+# needed for Hortonworks Data Platform
+#spark.executor.extraJavaOptions=-Dhdp.version=2.3.2.0-2950
+# optional parameters for tuning your TinkerPop application
+#spark.executor.instances=10
+#spark.executor.memory=4g
+#spark.executor.cores=2
+# needed on a secure cluster to allow for multiple computations
+# on a single Kerberos ticket
+#gremlin.spark.persistContext=true
+
+# Below copy all properties from your spark-client's spark-defaults.conf
+# prop1 ...
+# ...
+# propN ...
+
+############################################
+# GiraphGraphComputer Configuration        #
+############################################
 giraph.minWorkers=2
 giraph.maxWorkers=2
 giraph.useOutOfCoreGraph=true


### PR DESCRIPTION
Hi Marko,

Following your request in:
https://groups.google.com/forum/#!topic/gremlin-users/aE1plgCMhTs
please find the pull request asked for. 

However, I feel there is more to it than just the properties files: 
 - gremlin.sh should accept HADOOP_HOME, SPARK_HOME and YARN_HOME env variables (in addition to HADOOP_GREMLIN_LIBS) and set the CLASS_PATH accordingly. E.g., see:
https://github.com/vtslab/incubator-tinkerpop/blob/3.1.0-hdp-2.3.2.0-2950/gremlin-console/bin/gremlinhdp.sh
 - user documentation could mention the spark-yarn option
 - a spark-yarn test case that can run on the build server

I could prepare an additional pull request for some of these issues.

Regards,    Marc