### PR TITLE
Remove dashes from labels and property keys

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 * Fixed bug in `IoGraphTest` causing IllegalArgumentException: URI is not hierarchical error for external graph implementations.
 * Improved `TinkerGraph` performance when iterating vertices and edges.
 * Fixed a bug where timeout functions provided to the `GremlinExecutor` were not executing in the same thread as the script evaluation.
+* Graph providers should no longer rely on the test suite to validate that hyphens work for property keys.
 * Optimized a few special cases in `RangeByIsCountStrategy`.
 * Added more "invalid" variable bindings to the list used by Gremlin Server to validate incoming bindings on requests.
 * Named the thread pool used by Gremlin Server sessions: "gremlin-server-session-$n".

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -85,6 +85,11 @@ changes there may prove important for the provider's implementation.
 Graph Database Providers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+Property Keys and Hyphens
++++++++++++++++++++++++++
+
+Graph providers should no longer rely on the test suite to validate that hyphens work for property keys.
+
 Vertex and Edge Counts
 ++++++++++++++++++++++
 

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -88,7 +88,7 @@ Graph Database Providers
 Property Keys and Hyphens
 +++++++++++++++++++++++++
 
-Graph providers should no longer rely on the test suite to validate that hyphens work for property keys.
+Graph providers should no longer rely on the test suite to validate that hyphens work for labels and property keys.
 
 Vertex and Edge Counts
 ++++++++++++++++++++++

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -719,7 +719,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
             ((Mutating) this.asAdmin().getEndStep()).addPropertyMutations(propertyKeyValues);
             return (GraphTraversal<S, Edge>) this;
         } else {
-            // addInE("a", "co-developer", "b", "year", 2009)
+            // addInE("a", "codeveloper", "b", "year", 2009)
             this.addE(edgeLabelOrSecondVertexKey);
             if (direction.equals(Direction.OUT))
                 this.from(firstVertexKeyOrEdgeLabel).to((String) propertyKeyValues[0]);

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddEdgeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddEdgeTest.groovy
@@ -48,7 +48,7 @@ public abstract class GroovyAddEdgeTest {
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_addEXcodeveloperX_fromXaX_toXbX_propertyXyear_2009X() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').in('created').where(neq('a')).as('b').addE('co-developer').from('a').to('b').property('year', 2009)", g)
+            TraversalScriptHelper.compute("g.V.as('a').out('created').in('created').where(neq('a')).as('b').addE('codeveloper').from('a').to('b').property('year', 2009)", g)
         }
 
         @Override
@@ -74,7 +74,7 @@ public abstract class GroovyAddEdgeTest {
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_selectXa_bX_addInEXa_codeveloper_b_year_2009X() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').in('created').where(neq('a')).as('b').select('a','b').addInE('a', 'co-developer', 'b', 'year', 2009)", g)
+            TraversalScriptHelper.compute("g.V.as('a').out('created').in('created').where(neq('a')).as('b').select('a','b').addInE('a', 'codeveloper', 'b', 'year', 2009)", g)
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
@@ -210,7 +210,7 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         int count = 0;
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
-            assertEquals("co-developer", edge.label());
+            assertEquals("codeveloper", edge.label());
             assertEquals(2009, (int) edge.value("year"));
             assertEquals(1, IteratorUtils.count(edge.properties()));
             assertEquals("person", edge.inVertex().label());
@@ -235,7 +235,7 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         int count = 0;
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
-            assertEquals("co-developer", edge.label());
+            assertEquals("codeveloper", edge.label());
             assertEquals(2009, (int) edge.value("year"));
             assertEquals(1, IteratorUtils.count(edge.properties()));
             assertEquals("person", edge.inVertex().label());
@@ -321,7 +321,7 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_addEXcodeveloperX_fromXaX_toXbX_propertyXyear_2009X() {
-            return g.V().as("a").out("created").in("created").where(P.neq("a")).as("b").addE("co-developer").from("a").to("b").property("year", 2009);
+            return g.V().as("a").out("created").in("created").where(P.neq("a")).as("b").addE("codeveloper").from("a").to("b").property("year", 2009);
         }
 
         @Override
@@ -348,7 +348,7 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_selectXa_bX_addInEXa_codeveloper_b_year_2009X() {
-            return g.V().as("a").out("created").in("created").where(P.neq("a")).as("b").select("a", "b").addInE("a", "co-developer", "b", "year", 2009);
+            return g.V().as("a").out("created").in("created").where(P.neq("a")).as("b").select("a", "b").addInE("a", "codeveloper", "b", "year", 2009);
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -414,14 +414,14 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
 
         final Vertex vA = sourceAA.addV().property("any", "a").next();
         final Vertex vAA = sourceAA.addV().property("any", "aa").next();
-        final Edge eAtoAA = sourceAA.withSideEffect("vAA", vAA).V(vA.id()).addE("a->a").to("vAA").next();
+        final Edge eAtoAA = sourceAA.withSideEffect("vAA", vAA).V(vA.id()).addE("aTOa").to("vAA").next();
 
         final Vertex vB = sourceBA.addV().property("any", "b").next();
-        sourceBA.withSideEffect("vB", vB).V(vA.id()).addE("a->b").to("vB").next();
+        sourceBA.withSideEffect("vB", vB).V(vA.id()).addE("aTOb").to("vB").next();
 
         final Vertex vC = sourceCAB.addV().property("any", "c").next();
-        final Edge eBtovC = sourceCAB.withSideEffect("vC", vC).V(vB.id()).addE("b->c").to("vC").next();
-        final Edge eAtovC = sourceCAB.withSideEffect("vC", vC).V(vA.id()).addE("a->c").to("vC").next();
+        final Edge eBtovC = sourceCAB.withSideEffect("vC", vC).V(vB.id()).addE("bTOc").to("vC").next();
+        final Edge eAtovC = sourceCAB.withSideEffect("vC", vC).V(vA.id()).addE("aTOc").to("vC").next();
 
         assertEquals(0, IteratorUtils.count(sourceC.V()));
         assertEquals(0, IteratorUtils.count(sourceC.E()));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
@@ -106,7 +106,7 @@ public class EdgeTest {
         public void shouldHaveExceptionConsistencyWhenUsingNullVertex() {
             final Vertex v = graph.addVertex();
             try {
-                v.addEdge("to-nothing", null);
+                v.addEdge("tonothing", null);
                 fail("Call to Vertex.addEdge() should throw an exception when vertex is null");
             } catch (Exception ex) {
                 validateException(Graph.Exceptions.argumentCanNotBeNull("vertex"), ex);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
@@ -71,7 +71,7 @@ public class PropertyTest {
             final Vertex v = graph.addVertex("name", "marko");
             tryCommit(graph, (graph) -> {
                 final Vertex v1 = graph.vertices(v.id()).next();
-                final VertexProperty p = v1.property("nonexistent-key");
+                final VertexProperty p = v1.property("nonexistentkey");
                 assertEquals(VertexProperty.empty(), p);
             });
         }
@@ -191,10 +191,10 @@ public class PropertyTest {
         public void shouldGetValueThatIsNotPresentOnVertex() {
             final Vertex v = graph.addVertex();
             try {
-                v.value("does-not-exist");
+                v.value("doesnotexist");
                 fail("Call to Element.value() with a key that is not present should throw an exception");
             } catch (Exception ex) {
-                validateException(Property.Exceptions.propertyDoesNotExist(v, "does-not-exist"), ex);
+                validateException(Property.Exceptions.propertyDoesNotExist(v, "doesnotexist"), ex);
             }
 
         }
@@ -207,10 +207,10 @@ public class PropertyTest {
             final Vertex v = graph.addVertex();
             final Edge e = v.addEdge("self", v);
             try {
-                e.value("does-not-exist");
+                e.value("doesnotexist");
                 fail("Call to Element.value() with a key that is not present should throw an exception");
             } catch (Exception ex) {
-                validateException(Property.Exceptions.propertyDoesNotExist(e, "does-not-exist"), ex);
+                validateException(Property.Exceptions.propertyDoesNotExist(e, "doesnotexist"), ex);
             }
 
         }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
@@ -270,7 +270,7 @@ public class IoTest {
             final Vertex v1 = source.addVertex();
             final Vertex v2 = source.addVertex();
             v1.addEdge("CONTROL", v2);
-            v1.addEdge("SELF-LOOP", v1);
+            v1.addEdge("SELFLOOP", v1);
 
             final Configuration targetConf = graphProvider.newGraphConfiguration("target", this.getClass(), name.getMethodName(), null);
             final Graph target = graphProvider.openTestGraph(targetConf);
@@ -299,7 +299,7 @@ public class IoTest {
             final Vertex v1 = source.addVertex();
             final Vertex v2 = source.addVertex();
             v1.addEdge("CONTROL", v2);
-            v1.addEdge("SELF-LOOP", v1);
+            v1.addEdge("SELFLOOP", v1);
 
             final Configuration targetConf = graphProvider.newGraphConfiguration("target", this.getClass(), name.getMethodName(), null);
             final Graph target = graphProvider.openTestGraph(targetConf);;
@@ -444,7 +444,7 @@ public class IoTest {
             final Vertex v1 = source.addVertex();
             final Vertex v2 = source.addVertex();
             v1.addEdge("CONTROL", v2);
-            v1.addEdge("SELF-LOOP", v1);
+            v1.addEdge("SELFLOOP", v1);
 
             final Configuration targetConf = graphProvider.newGraphConfiguration("target", this.getClass(), name.getMethodName(), null);
             final Graph target = graphProvider.openTestGraph(targetConf);


### PR DESCRIPTION
Our provider implementation doesn't allow dashes in property keys. Hence remove them from the gremlin-test.