### PR TITLE
TINKERPOP-1320 fix GremlinGroovyScriptEngineFileSandboxTest resource loading

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 * Avoid hamcrest conflict by using mockito-core instead of mockito-all dependency in `gremlin-test`.
 * Defaulted to `Edge.DEFAULT` if no edge label was supplied in GraphML.
 * Fixed bug in `IoGraphTest` causing IllegalArgumentException: URI is not hierarchical error for external graph implementations.
+* Fixed bug in `GremlinGroovyScriptEngineFileSandboxTest` resource loading
 * Fixed a bug where timeout functions provided to the `GremlinExecutor` were not executing in the same thread as the script evaluation.
 * Optimized a few special cases in `RangeByIsCountStrategy`.
 * Named the thread pool used by Gremlin Server sessions: "gremlin-server-session-$n".

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoWriter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoWriter.java
@@ -131,7 +131,7 @@ public final class GryoWriter implements GraphWriter {
     public void writeProperty(final OutputStream outputStream, final Property p) throws IOException {
         final Output output = new Output(outputStream);
         writeHeader(output);
-        kryo.writeObject(output, DetachedFactory.detach(p, true));
+        kryo.writeObject(output, DetachedFactory.detach(p));
         output.flush();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoWriter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoWriter.java
@@ -131,7 +131,7 @@ public final class GryoWriter implements GraphWriter {
     public void writeProperty(final OutputStream outputStream, final Property p) throws IOException {
         final Output output = new Output(outputStream);
         writeHeader(output);
-        kryo.writeObject(output, DetachedFactory.detach(p));
+        kryo.writeObject(output, DetachedFactory.detach(p, true));
         output.flush();
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/TestHelper.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/TestHelper.java
@@ -106,7 +106,14 @@ public final class TestHelper {
      * See {@code TestHelper} in gremlin-test for the official version.
      */
     public static File generateTempFileFromResource(final Class resourceClass, final String resourceName, final String extension) throws IOException {
-        final File temp = makeTestDataPath(resourceClass, "resources");
+        return generateTempFileFromResource(resourceClass, resourceClass, resourceName, extension);
+    }
+
+    /**
+     * See {@code TestHelper} in gremlin-test for the official version.
+     */
+    public static File generateTempFileFromResource(final Class graphClass, final Class resourceClass, final String resourceName, final String extension) throws IOException {
+        final File temp = makeTestDataPath(graphClass, "resources");
         if (!temp.exists()) temp.mkdirs();
         final File tempFile = new File(temp, resourceName + extension);
         final FileOutputStream outputStream = new FileOutputStream(tempFile);

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineFileSandboxTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineFileSandboxTest.java
@@ -27,7 +27,7 @@ import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.FileSandboxExtensio
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.hamcrest.MatcherAssert;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.script.Bindings;
@@ -46,10 +46,13 @@ import static org.junit.Assert.fail;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GremlinGroovyScriptEngineFileSandboxTest extends AbstractGremlinTest {
-    @BeforeClass
-    public static void init() throws Exception {
-        final File f = TestHelper.generateTempFileFromResource(GremlinGroovyScriptEngineFileSandboxTest.class, "sandbox.yaml", ".yaml");
-        System.setProperty(FileSandboxExtension.GREMLIN_SERVER_SANDBOX, f.getAbsolutePath());
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        if (System.getProperty(FileSandboxExtension.GREMLIN_SERVER_SANDBOX) == null) {
+            final File f = TestHelper.generateTempFileFromResource(graph.getClass(), GremlinGroovyScriptEngineFileSandboxTest.class, "sandbox.yaml", ".yaml");
+            System.setProperty(FileSandboxExtension.GREMLIN_SERVER_SANDBOX, f.getAbsolutePath());
+        }
     }
 
     @AfterClass

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/TestHelper.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/TestHelper.java
@@ -134,7 +134,15 @@ public final class TestHelper {
      * {@link TestHelper#makeTestDataPath} in a subdirectory called {@code temp/resources}.
      */
     public static File generateTempFileFromResource(final Class resourceClass, final String resourceName, final String extension) throws IOException {
-        final File temp = makeTestDataPath(resourceClass, "resources");
+        return generateTempFileFromResource(resourceClass, resourceClass, resourceName, extension);
+    }
+
+    /**
+     * Copies a file stored as part of a resource to the file system in the path returned from
+     * {@link TestHelper#makeTestDataPath} in a subdirectory called {@code temp/resources}.
+     */
+    public static File generateTempFileFromResource(final Class graphClass, final Class resourceClass, final String resourceName, final String extension) throws IOException {
+        final File temp = makeTestDataPath(graphClass, "resources");
         if (!temp.exists()) temp.mkdirs();
         final File tempFile = new File(temp, resourceName + extension);
         final FileOutputStream outputStream = new FileOutputStream(tempFile);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1320
Passed `mvn clean install -DincludeNeo4j` and integration tests cleanly.
May be CTR worthy. Let me know.
VOTE: +1
