### PR TITLE
TINKERPOP-1063 TinkerGraph Performance

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 * Fixed bug in `SubgraphStrategy` where step labels were not being propogated properly to new steps injected by the strategy.
 * Defaulted to `Edge.DEFAULT` if no edge label was supplied in GraphML.
 * Fixed bug in `IoGraphTest` causing IllegalArgumentException: URI is not hierarchical error for external graph implementations.
+* Improved `TinkerGraph` performance when iterating vertices and edges.
 * Fixed a bug where timeout functions provided to the `GremlinExecutor` were not executing in the same thread as the script evaluation.
 * Optimized a few special cases in `RangeByIsCountStrategy`.
 * Named the thread pool used by Gremlin Server sessions: "gremlin-server-session-$n".

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerHelper;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,17 +80,17 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
         else
             return null == indexedContainer ?
                     this.iteratorList(graph.vertices()) :
-                    TinkerHelper.queryVertexIndex(graph, indexedContainer.getKey(), indexedContainer.getPredicate().getValue()).stream()
-                            .filter(vertex -> HasContainer.testAll(vertex, this.hasContainers))
-                            .collect(Collectors.<Vertex>toList()).iterator();
+                    IteratorUtils.filter(TinkerHelper.queryVertexIndex(graph, indexedContainer.getKey(), indexedContainer.getPredicate().getValue()).iterator(),
+                            vertex -> HasContainer.testAll(vertex, this.hasContainers));
     }
 
     private HasContainer getIndexKey(final Class<? extends Element> indexedClass) {
         final Set<String> indexedKeys = ((TinkerGraph) this.getTraversal().getGraph().get()).getIndexedKeys(indexedClass);
-        return this.hasContainers.stream()
-                .filter(c -> indexedKeys.contains(c.getKey()) && c.getPredicate().getBiPredicate() == Compare.eq)
-                .findAny()
-                .orElseGet(() -> null);
+
+        final Iterator<HasContainer> itty = IteratorUtils.filter(hasContainers.iterator(),
+                c -> c.getPredicate().getBiPredicate() == Compare.eq && indexedKeys.contains(c.getKey()));
+        return itty.hasNext() ? itty.next() : null;
+
     }
 
     @Override

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -36,11 +36,13 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComputer;
 import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComputerView;
 import org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.strategy.optimization.TinkerGraphStepStrategy;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -317,31 +319,36 @@ public final class TinkerGraph implements Graph {
         }
     }
 
-
-
     private <T extends Element> Iterator<T> createElementIterator(final Class<T> clazz, final Map<Object, T> elements,
                                                                   final IdManager idManager,
                                                                   final Object... ids) {
         if (0 == ids.length) {
             return elements.values().iterator();
         } else {
+            final List<Object> idList = Arrays.asList(ids);
             // base the conversion function on the first item in the id list as the expectation is that these
             // id values will be a uniform list
             if (clazz.isAssignableFrom(ids[0].getClass())) {
-                // based on the first item assume all vertices in the argument list
-                if (!Stream.of(ids).allMatch(id -> clazz.isAssignableFrom(id.getClass())))
-                    throw Graph.Exceptions.idArgsMustBeEitherIdOrElement();
-
-                // got a bunch of Elements - have to look each upup because it might be an Attachable instance or
+                // got a bunch of Elements - have to look each up because it might be an Attachable instance or
                 // other implementation. the assumption is that id conversion is not required for detached
                 // stuff - doesn't seem likely someone would detach a Titan vertex then try to expect that
                 // vertex to be findable in OrientDB
-                return Stream.of(ids).map(id -> elements.get(((T) id).id())).filter(Objects::nonNull).iterator();
+                return IteratorUtils.filter(IteratorUtils.map(idList, id -> {
+                    // based on the first item assume all vertices in the argument list
+                    if (!clazz.isAssignableFrom(id.getClass()))
+                        throw Graph.Exceptions.idArgsMustBeEitherIdOrElement();
+
+                    return elements.get(clazz.cast(id).id());
+                }).iterator(), Objects::nonNull);
             } else {
                 final Class<?> firstClass = ids[0].getClass();
-                if (!Stream.of(ids).map(Object::getClass).allMatch(firstClass::equals))
-                    throw Graph.Exceptions.idArgsMustBeEitherIdOrElement();
-                return Stream.of(ids).map(id -> idManager.convert(id)).map(elements::get).filter(Objects::nonNull).iterator();
+                return IteratorUtils.filter(IteratorUtils.map(idList, id -> {
+                    // all items in the list should be of the same class - don't get fancy on a Graph
+                    if (!id.getClass().equals(firstClass))
+                        throw Graph.Exceptions.idArgsMustBeEitherIdOrElement();
+
+                    return elements.get(idManager.convert(id));
+                }).iterator(), Objects::nonNull);
             }
         }
     }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -351,9 +351,14 @@ public final class TinkerGraph implements Graph {
     }
 
     private void validateHomogenousIds(final List<Object> ids) {
-        final Class firstClass = ids.get(0).getClass();
-        for (Object id : ids) {
-            if (!id.getClass().equals(firstClass))
+        final Iterator<Object> iterator = ids.iterator();
+        Object id = iterator.next();
+        if (id == null)
+            throw Graph.Exceptions.idArgsMustBeEitherIdOrElement();
+        final Class firstClass = id.getClass();
+        while (iterator.hasNext()) {
+            id = iterator.next();
+            if (id == null || !id.getClass().equals(firstClass))
                 throw Graph.Exceptions.idArgsMustBeEitherIdOrElement();
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1063

Got rid of `Stream` usage in TinkerGraph vertex/edge iteration.  Tests all pass with `mvn clean install`.

VOTE +1