### PR TITLE
gremlin_python: generate/build/deps before tests

### DIFF
--- a/gremlin-variant/pom.xml
+++ b/gremlin-variant/pom.xml
@@ -100,6 +100,39 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>generatePython</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.apache.tinkerpop.gremlin.python.GenerateGremlinPython</mainClass>
+                            <arguments>
+                                <argument>${basedir}/src/main/jython/gremlin_python/gremlin_python.py</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>buildPython</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>python</executable>
+                            <async>true</async>
+                            <workingDirectory>${basedir}/src/main/jython</workingDirectory>
+                            <commandlineArgs>setup.py build --build-lib ${project.build.testOutputDirectory}/Lib</commandlineArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
                 <version>1.2</version>
@@ -132,7 +165,30 @@
                             <goal>jython</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>pythonDependencies</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>jython</goal>
+                        </goals>
+                        <configuration>
+                             <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                            <libraries>
+                                <param>aenum</param>
+                                <param>requests</param>
+                            </libraries>
+                        </configuration>
+                    </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <python.home>${project.build.testOutputDirectory}</python.home>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/gremlin-variant/src/main/java/org/apache/tinkerpop/gremlin/python/GenerateGremlinPython.java
+++ b/gremlin-variant/src/main/java/org/apache/tinkerpop/gremlin/python/GenerateGremlinPython.java
@@ -19,28 +19,15 @@
 
 package org.apache.tinkerpop.gremlin.python;
 
-import org.apache.tinkerpop.gremlin.util.ScriptEngineCache;
-
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
-
-/**
- * @author Marko A. Rodriguez (http://markorodriguez.com)
- */
-public class JythonScriptEngineSetup {
-
-    private JythonScriptEngineSetup() {
-    }
-
-    public static void setup() {
-        try {
-            final ScriptEngine jythonEngine = ScriptEngineCache.get("jython");
-            jythonEngine.eval("from gremlin_python.gremlin_python import *");
-            jythonEngine.eval("from gremlin_python.gremlin_python import __");
-            jythonEngine.eval("from gremlin_python.groovy_translator import GroovyTranslator");
-            jythonEngine.eval("from gremlin_rest_driver import RESTRemoteConnection");
-        } catch (final ScriptException e) {
-            throw new IllegalStateException(e.getMessage(), e);
+public class GenerateGremlinPython {
+    public static void main(String[] args) {
+        String dest;
+        if (args.length > 0) {
+            dest = args[0];
+        } else {
+            System.out.println("Usage: java GenerateGremlinPython <path/to/dest>");
+            return;
         }
+        GremlinPythonGenerator.create(dest);
     }
 }

--- a/gremlin-variant/src/main/jython/setup.py
+++ b/gremlin-variant/src/main/jython/setup.py
@@ -48,6 +48,7 @@ setup(
     description='Gremlin Language Variant for Apache TinkerPop - Gremlin',
     long_description=open("README").read(),
     install_requires=[
-        'aenum'
+        'aenum',
+        'requests'
     ]
 )


### PR DESCRIPTION
Code generation is triggered by Maven before tests are run; dependencies
(currently aenum, requests) are installed, and the generated package is built
into ${project.build.testOutputDirectory}/Lib, which is added to the
classpath for the tests via the python.home property. Jython tests
import the gremlin_python package instead of importing its modules
directly.