### PR TITLE
ResultSet.hasNext should be idempotent

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
@@ -127,7 +127,9 @@ public final class ResultSet implements Iterable<Result> {
 
             @Override
             public boolean hasNext() {
-                nextOne = one();
+                if (null == nextOne) {
+                    nextOne = one();
+                }
                 return nextOne != null;
             }
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultSetTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultSetTest.java
@@ -174,4 +174,23 @@ public class ResultSetTest extends AbstractResultQueueTest {
 
         assertEquals(100, counter.get());
     }
+    
+    @Test
+    public void shouldCallHasNextWithoutSideEffect() throws Exception {
+        final Iterator itty = resultSet.iterator();
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        addToQueue(100, 1, true, true);
+
+        for (int i = 0; i < 101; i++) {
+        	assertThat(itty.hasNext(), is(true));
+        }
+        
+        while (itty.hasNext()) {
+            itty.next();
+            counter.incrementAndGet();
+        }
+
+        assertEquals(100, counter.get());
+    }
 }


### PR DESCRIPTION
Sorry I didn't create a ticket; JIRA is having problems.

Calling hasNext() multiple times would dequeue items.  