### PR TITLE
TINKERPOP-1071 Enhance pre-processor output

### DIFF
--- a/docs/preprocessor/preprocess-file.sh
+++ b/docs/preprocessor/preprocess-file.sh
@@ -71,6 +71,13 @@ fi
 trap cleanup INT
 
 function cleanup {
+  if [ -f "${output}" ]; then
+    if [ `wc -l /tmp/foo | awk '{print $1}'` -gt 0 ]; then
+      echo -e "\n\e[1mLast 10 lines of ${output}:\e[0m\n"
+      tail -n10 ${output}
+      echo
+    fi
+  fi
   rm -rf ${output} ${CONSOLE_HOME}/.ext
   exit 255
 }

--- a/docs/preprocessor/preprocess-file.sh
+++ b/docs/preprocessor/preprocess-file.sh
@@ -72,7 +72,7 @@ trap cleanup INT
 
 function cleanup {
   if [ -f "${output}" ]; then
-    if [ `wc -l /tmp/foo | awk '{print $1}'` -gt 0 ]; then
+    if [ `wc -l "${output}" | awk '{print $1}'` -gt 0 ]; then
       echo -e "\n\e[1mLast 10 lines of ${output}:\e[0m\n"
       tail -n10 ${output}
       echo


### PR DESCRIPTION

https://issues.apache.org/jira/browse/TINKERPOP-1071

To test the changes, I've added an invalid `foo + bar` line in one of the code blocks. Here's how the output looked like:

```
$ bin/process-docs.sh 

==========================
+   Installing Plugins   +
==========================

 * tinkerpop-sugar ... done
 * hadoop-gremlin ... done
 * spark-gremlin ... done
 * giraph-gremlin ... done
 * neo4j-gremlin ... done


============================
+   Processing AsciiDocs   +
============================

 * source:   /projects/apache/tinkerpop/docs/src/reference/index.asciidoc
   target:   /projects/apache/tinkerpop/target/postprocess-asciidoc/reference/index.asciidoc
   progress: [====================================================================================================] 100%

 * source:   /projects/apache/tinkerpop/docs/src/reference/preface.asciidoc
   target:   /projects/apache/tinkerpop/target/postprocess-asciidoc/reference/preface.asciidoc
   progress: [====================================================================================================] 100%

 * source:   /projects/apache/tinkerpop/docs/src/reference/intro.asciidoc
   target:   /projects/apache/tinkerpop/target/postprocess-asciidoc/reference/intro.asciidoc
   progress: [==========================================================================>                         ] 74%No such property: foo for class: groovysh_evaluate
Display stack trace? [yN] pb(295); '----'
groovysh_parse: 2: expecting an identifier, found 'this' @ line 2, column 19.
   lities. In total, this is The TinkerPop.'
                     ^

1 error
Display stack trace? [yN] pb(395); '// LAST LINE'


Last 10 lines of /projects/apache/tinkerpop/target/postprocess-asciidoc/reference/intro.asciidoc:

==>v[1]
gremlin> g.V(marko).out('knows') //// <2>
==>v[2]
==>v[4]
gremlin> g.V(marko).out('knows').values('name') //// <3>
==>vadas
==>josh
gremlin> foo + bar
gremlin> lities. In total, this is The TinkerPop.'
gremlin> 

xargs: /projects/apache/tinkerpop/docs/preprocessor/preprocess-file.sh: exited with status 255; aborting
```

Unfortunately I cannot separate the error message from the progress bar output (both go to stderr), but I think  it already helps a lot to see the last 10 lines of the output file.

VOTE: +1