### PR TITLE
TINKERPOP-1349: RepeatUnrollStrategy should unroll loops while maintaining equivalent semantics.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.Matc
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.OrderLimitStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.RangeByIsCountStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.RepeatUnrollStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.StandardVerificationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
@@ -193,6 +194,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
                     FilterRankingStrategy.instance(),
                     IdentityRemovalStrategy.instance(),
                     MatchPredicateStrategy.instance(),
+                    RepeatUnrollStrategy.instance(),
                     RangeByIsCountStrategy.instance(),
                     ProfileStrategy.instance(),
                     StandardVerificationStrategy.instance());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/BranchStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/BranchStep.java
@@ -165,15 +165,19 @@ public class BranchStep<S, E, M> extends ComputerAwareStep<S, E> implements Trav
                 final List<Traversal.Admin<S, E>> clonedTraversals = clone.traversalOptions.compute(entry.getKey(), (k, v) ->
                         (v == null) ? new ArrayList<>(traversals.size()) : v);
                 for (final Traversal.Admin<S, E> traversal : traversals) {
-                    final Traversal.Admin<S, E> clonedTraversal = traversal.clone();
-                    clonedTraversals.add(clonedTraversal);
-                    clone.integrateChild(clonedTraversal);
+                    clonedTraversals.add(traversal.clone());
                 }
             }
         }
         clone.branchTraversal = this.branchTraversal.clone();
-        clone.integrateChild(clone.branchTraversal);
         return clone;
+    }
+
+    @Override
+    public void setTraversal(final Traversal.Admin<?, ?> parentTraversal) {
+        super.setTraversal(parentTraversal);
+        this.integrateChild(this.branchTraversal);
+        this.traversalOptions.values().stream().flatMap(List::stream).forEach(this::integrateChild);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/AbstractStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/AbstractStep.java
@@ -124,7 +124,7 @@ public abstract class AbstractStep<S, E> implements Step<S, E> {
             }
         } else {
             while (true) {
-                if(Thread.interrupted()) throw new TraversalInterruptedException();
+                if (Thread.interrupted()) throw new TraversalInterruptedException();
                 final Traverser.Admin<E> traverser = this.processNextStart();
                 if (null != traverser.get() && 0 != traverser.bulk())
                     return this.prepareTraversalForNextStep(traverser);
@@ -139,7 +139,7 @@ public abstract class AbstractStep<S, E> implements Step<S, E> {
         else {
             try {
                 while (true) {
-                    if(Thread.interrupted()) throw new TraversalInterruptedException();
+                    if (Thread.interrupted()) throw new TraversalInterruptedException();
                     this.nextEnd = this.processNextStart();
                     if (null != this.nextEnd.get() && 0 != this.nextEnd.bulk())
                         return true;
@@ -179,6 +179,7 @@ public abstract class AbstractStep<S, E> implements Step<S, E> {
             clone.nextStep = EmptyStep.instance();
             clone.nextEnd = null;
             clone.traversal = EmptyTraversal.instance();
+            clone.labels = new LinkedHashSet<>(this.labels);
             clone.reset();
             return clone;
         } catch (final CloneNotSupportedException e) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
@@ -1,0 +1,75 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.LoopTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class RepeatUnrollStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy> implements TraversalStrategy.OptimizationStrategy {
+
+    private static final RepeatUnrollStrategy INSTANCE = new RepeatUnrollStrategy();
+
+    private RepeatUnrollStrategy() {
+    }
+
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        if (!TraversalHelper.hasStepOfAssignableClass(RepeatStep.class, traversal) ||
+                TraversalHelper.onGraphComputer(traversal))
+            return;
+
+        for (int i = 0; i < traversal.getSteps().size(); i++) {
+            if (traversal.getSteps().get(i) instanceof RepeatStep) {
+                final RepeatStep<?> repeatStep = (RepeatStep) traversal.getSteps().get(i);
+                if (null == repeatStep.getEmitTraversal() && repeatStep.getUntilTraversal() instanceof LoopTraversal) {
+                    final Traversal.Admin<?, ?> repeatTraversal = repeatStep.getGlobalChildren().get(0);
+                    final int repeatLength = repeatTraversal.getSteps().size() - 1;
+                    repeatTraversal.removeStep(repeatLength);
+                    int insertIndex = i;
+                    final int loops = (int) ((LoopTraversal) repeatStep.getUntilTraversal()).getMaxLoops();
+                    for (int j = 0; j < loops; j++) {
+                        TraversalHelper.insertTraversal(insertIndex, repeatTraversal.clone(), traversal); // removes the RepeatEndStep
+                        insertIndex = insertIndex + repeatLength + 1;
+                        traversal.addStep(insertIndex, new NoOpBarrierStep<>(traversal));
+                    }
+                    if (!repeatStep.getLabels().isEmpty()) {
+                        final Step<?, ?> lastStep = (Step) traversal.getSteps().get(insertIndex);
+                        repeatStep.getLabels().forEach(lastStep::addLabel);
+                    }
+                    traversal.removeStep(i); // remove the RepeatStep
+                }
+            }
+        }
+    }
+
+
+    public static RepeatUnrollStrategy instance() {
+        return INSTANCE;
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyPerformanceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyPerformanceTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.tinkerpop.gremlin.process.traversal.strategy;
 
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyPerformanceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyPerformanceTest.java
@@ -114,7 +114,7 @@ public abstract class TraversalStrategyPerformanceTest {
             assertEquals(originalResult, optimizedResult);
         }
 
-        if (getAssertionPercentile() < 100)
+        if (getAssertionPercentile() < 100 && numTraversals > 0)
             assertTrue(((faster * 100.0) / numTraversals) >= getAssertionPercentile());
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyPerformanceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyPerformanceTest.java
@@ -1,0 +1,102 @@
+package org.apache.tinkerpop.gremlin.process.traversal.strategy;
+
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.util.TimeUtil;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Daniel Kuppitz (http://gremlin.guru)
+ */
+public abstract class TraversalStrategyPerformanceTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TraversalStrategyPerformanceTest.class);
+    private static final Random RANDOM = new Random();
+
+    protected int getClockRuns() {
+        return 1000;
+    }
+
+    /**
+     * Specifies for how many percent of all comparisons the optimized traversal must be faster than the
+     * original traversal. Default is 100.
+     */
+    protected double getAssertionPercentile() {
+        return 100.0;
+    }
+
+    protected abstract Class<? extends TraversalStrategy> getStrategyUnderTest();
+
+    protected TraversalStrategy<?> getStrategyUnderTestInstance() throws Exception {
+        return (TraversalStrategy) getStrategyUnderTest().getMethod("instance").invoke(null);
+    }
+
+    protected abstract Iterator<GraphTraversal> getTraversalIterator();
+
+    @Test
+    public void shouldBeFaster() throws Exception {
+
+        final TraversalStrategies withStrategyUnderTest = new DefaultTraversalStrategies();
+        withStrategyUnderTest.addStrategies(getStrategyUnderTestInstance());
+
+        final TraversalStrategies withoutStrategyUnderTest = new DefaultTraversalStrategies();
+        withoutStrategyUnderTest.removeStrategies(getStrategyUnderTest());
+
+        final int clockRuns = getClockRuns();
+        final Iterator<GraphTraversal> iterator = getTraversalIterator();
+        int faster = 0, numTraversals = 0;
+        while (iterator.hasNext()) {
+
+            final GraphTraversal traversal = iterator.next();
+            final GraphTraversal.Admin original = traversal.asAdmin();
+            final GraphTraversal.Admin optimized = original.clone();
+
+            original.setStrategies(withoutStrategyUnderTest);
+            optimized.setStrategies(withStrategyUnderTest);
+
+            final double originalTime, optimizedTime;
+
+            if (RANDOM.nextBoolean()) {
+                originalTime = TimeUtil.clock(clockRuns, () -> original.clone().iterate());
+                optimizedTime = TimeUtil.clock(clockRuns, () -> optimized.clone().iterate());
+            } else {
+                optimizedTime = TimeUtil.clock(clockRuns, () -> optimized.clone().iterate());
+                originalTime = TimeUtil.clock(clockRuns, () -> original.clone().iterate());
+            }
+
+            final List originalResult = original.toList();
+            final List optimizedResult = optimized.toList();
+
+            if (originalTime > optimizedTime) {
+                LOGGER.debug("Original traversal ({} ms): {}", originalTime, original);
+                LOGGER.debug("Optimized traversal ({} ms): {}", optimizedTime, optimized);
+            } else {
+                LOGGER.warn("Original traversal ({} ms): {}", originalTime, original);
+                LOGGER.warn("Optimized traversal ({} ms): {}", optimizedTime, optimized);
+            }
+
+            if (getAssertionPercentile() >= 100) assertTrue(originalTime > optimizedTime);
+            else {
+                if (originalTime > optimizedTime)
+                    faster++;
+                numTraversals++;
+            }
+
+            assertEquals(originalResult, optimizedResult);
+        }
+
+        if (getAssertionPercentile() < 100)
+            assertTrue(((faster * 100.0) / numTraversals) >= getAssertionPercentile());
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.TimeUtil;
 import org.javatuples.Pair;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -43,113 +44,113 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-@RunWith(Parameterized.class)
+
+@RunWith(Enclosed.class)
 public class RepeatUnrollStrategyTest {
 
     private static final Random RANDOM = new Random();
-    private static boolean shouldBeFasterWithUniqueStreamExecuted = false;
-    private static boolean shouldBeFasterWithDuplicateStreamExecuted = false;
 
-    @Parameterized.Parameter(value = 0)
-    public Traversal original;
+    @RunWith(Parameterized.class)
+    public static class ParameterizedTests {
 
-    @Parameterized.Parameter(value = 1)
-    public Traversal optimized;
+        @Parameterized.Parameter(value = 0)
+        public Traversal original;
+
+        @Parameterized.Parameter(value = 1)
+        public Traversal optimized;
 
 
-    private void applyRepeatUnrollStrategy(final Traversal traversal) {
-        final TraversalStrategies strategies = new DefaultTraversalStrategies();
-        strategies.addStrategies(RepeatUnrollStrategy.instance());
-        traversal.asAdmin().setStrategies(strategies);
-        traversal.asAdmin().applyStrategies();
-
-    }
-
-    @Test
-    public void doTest() {
-        applyRepeatUnrollStrategy(original);
-        assertEquals(optimized, original);
-    }
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Iterable<Object[]> generateTestParameters() {
-
-        final Predicate<Traverser<Vertex>> predicate = t -> t.loops() > 5;
-        return Arrays.asList(new Traversal[][]{
-                {__.identity(), __.identity()},
-                {__.out().as("a").in().repeat(__.outE("created").bothV()).times(2).in(), __.out().as("a").in().outE("created").bothV().barrier().outE("created").bothV().barrier().in()},
-                {__.out().repeat(__.outE("created").bothV()).times(1).in(), __.out().outE("created").bothV().barrier().in()},
-                {__.repeat(__.outE("created").bothV()).times(1).in(), __.outE("created").bothV().barrier().in()},
-                {__.repeat(__.out()).times(2).as("x").repeat(__.in().as("b")).times(3), __.out().barrier().out().barrier().as("x").in().as("b").barrier().in().as("b").barrier().in().as("b").barrier()},
-                {__.repeat(__.outE("created").inV()).times(2), __.outE("created").inV().barrier().outE("created").inV().barrier()},
-                {__.repeat(__.out()).times(3), __.out().barrier().out().barrier().out().barrier()},
-                {__.repeat(__.local(__.select("a").out("knows"))).times(2), __.local(__.select("a").out("knows")).barrier().local(__.select("a").out("knows")).barrier()},
-                {__.<Vertex>times(2).repeat(__.out()), __.out().barrier().out().barrier()},
-                {__.<Vertex>out().times(2).repeat(__.out().as("a")).as("x"), __.out().out().as("a").barrier().out().as("a").barrier().as("x")},
-                {__.repeat(__.out()).emit().times(2), __.repeat(__.out()).emit().times(2)},
-                {__.repeat(__.out()).until(predicate), __.repeat(__.out()).until(predicate)},
-                {__.repeat(__.out()).until(predicate).repeat(__.out()).times(2), __.repeat(__.out()).until(predicate).out().barrier().out().barrier()},
-                {__.repeat(__.union(__.both(), __.identity())).times(2).out(), __.union(__.both(), __.identity()).barrier().union(__.both(), __.identity()).barrier().out()},
-                {__.in().repeat(__.out("knows")).times(3).as("a").count().is(0), __.in().out("knows").barrier().out("knows").barrier().out("knows").as("a").count().is(0)},
-        });
-    }
-
-    @Test
-    public void shouldBeFasterWithUniqueStream() {
-        if (shouldBeFasterWithUniqueStreamExecuted)
-            return;
-        shouldBeFasterWithUniqueStreamExecuted = true;
-        final int startSize = 1000;
-        final int clockRuns = 1000;
-        final Integer[] starts = new Integer[startSize];
-        for (int i = 0; i < startSize; i++) {
-            starts[i] = i; // 1000 unique objects
-        }
-        assertEquals(startSize, new HashSet<>(Arrays.asList(starts)).size());
-        clockTraversals(starts, clockRuns);
-    }
-
-    @Test
-    public void shouldBeFasterWithDuplicateStream() {
-        if (shouldBeFasterWithDuplicateStreamExecuted)
-            return;
-        shouldBeFasterWithDuplicateStreamExecuted = true;
-        final int startSize = 1000;
-        final int clockRuns = 1000;
-        final int uniques = 100;
-        final Integer[] starts = new Integer[startSize];
-        for (int i = 0; i < startSize; i++) {
-            starts[i] = i % uniques; // 100 unique objects
-        }
-        assertEquals(uniques, new HashSet<>(Arrays.asList(starts)).size());
-        clockTraversals(starts, clockRuns);
-    }
-
-    private void clockTraversals(final Integer[] starts, final int clockRuns) {
-        final int times = RANDOM.nextInt(4) + 2;
-        assertTrue(times > 1 && times < 6);
-        final Supplier<Long> original = () -> __.inject(starts).repeat(__.identity()).times(times).<Long>sum().next();
-
-        final TraversalStrategies strategies = new DefaultTraversalStrategies();
-        strategies.addStrategies(RepeatUnrollStrategy.instance());
-        final Supplier<Long> optimized = () -> {
-            final Traversal<Integer, Long> traversal = __.inject(starts).repeat(__.identity()).times(times).sum();
+        private void applyRepeatUnrollStrategy(final Traversal traversal) {
+            final TraversalStrategies strategies = new DefaultTraversalStrategies();
+            strategies.addStrategies(RepeatUnrollStrategy.instance());
             traversal.asAdmin().setStrategies(strategies);
-            return traversal.next();
-        };
+            traversal.asAdmin().applyStrategies();
 
-        final Pair<Double, Long> originalResult;
-        final Pair<Double, Long> optimizedResult;
-        if (RANDOM.nextBoolean()) {
-            originalResult = TimeUtil.clockWithResult(clockRuns, original);
-            optimizedResult = TimeUtil.clockWithResult(clockRuns, optimized);
-        } else {
-            optimizedResult = TimeUtil.clockWithResult(clockRuns, optimized);
-            originalResult = TimeUtil.clockWithResult(clockRuns, original);
         }
 
-        // System.out.println(originalResult + "---" + optimizedResult);
-        assertEquals(originalResult.getValue1(), optimizedResult.getValue1());
-        assertTrue(originalResult.getValue0() > optimizedResult.getValue0());
+        @Test
+        public void doTest() {
+            applyRepeatUnrollStrategy(original);
+            assertEquals(optimized, original);
+        }
+
+        @Parameterized.Parameters(name = "{0}")
+        public static Iterable<Object[]> generateTestParameters() {
+
+            final Predicate<Traverser<Vertex>> predicate = t -> t.loops() > 5;
+            return Arrays.asList(new Traversal[][]{
+                    {__.identity(), __.identity()},
+                    {__.out().as("a").in().repeat(__.outE("created").bothV()).times(2).in(), __.out().as("a").in().outE("created").bothV().barrier().outE("created").bothV().barrier().in()},
+                    {__.out().repeat(__.outE("created").bothV()).times(1).in(), __.out().outE("created").bothV().barrier().in()},
+                    {__.repeat(__.outE("created").bothV()).times(1).in(), __.outE("created").bothV().barrier().in()},
+                    {__.repeat(__.out()).times(2).as("x").repeat(__.in().as("b")).times(3), __.out().barrier().out().barrier().as("x").in().as("b").barrier().in().as("b").barrier().in().as("b").barrier()},
+                    {__.repeat(__.outE("created").inV()).times(2), __.outE("created").inV().barrier().outE("created").inV().barrier()},
+                    {__.repeat(__.out()).times(3), __.out().barrier().out().barrier().out().barrier()},
+                    {__.repeat(__.local(__.select("a").out("knows"))).times(2), __.local(__.select("a").out("knows")).barrier().local(__.select("a").out("knows")).barrier()},
+                    {__.<Vertex>times(2).repeat(__.out()), __.out().barrier().out().barrier()},
+                    {__.<Vertex>out().times(2).repeat(__.out().as("a")).as("x"), __.out().out().as("a").barrier().out().as("a").barrier().as("x")},
+                    {__.repeat(__.out()).emit().times(2), __.repeat(__.out()).emit().times(2)},
+                    {__.repeat(__.out()).until(predicate), __.repeat(__.out()).until(predicate)},
+                    {__.repeat(__.out()).until(predicate).repeat(__.out()).times(2), __.repeat(__.out()).until(predicate).out().barrier().out().barrier()},
+                    {__.repeat(__.union(__.both(), __.identity())).times(2).out(), __.union(__.both(), __.identity()).barrier().union(__.both(), __.identity()).barrier().out()},
+                    {__.in().repeat(__.out("knows")).times(3).as("a").count().is(0), __.in().out("knows").barrier().out("knows").barrier().out("knows").as("a").count().is(0)},
+            });
+        }
+    }
+
+    public static class NonParameterizedTests {
+
+        @Test
+        public void shouldBeFasterWithUniqueStream() {
+            final int startSize = 1000;
+            final int clockRuns = 1000;
+            final Integer[] starts = new Integer[startSize];
+            for (int i = 0; i < startSize; i++) {
+                starts[i] = i; // 1000 unique objects
+            }
+            assertEquals(startSize, new HashSet<>(Arrays.asList(starts)).size());
+            clockTraversals(starts, clockRuns);
+        }
+
+        @Test
+        public void shouldBeFasterWithDuplicateStream() {
+            final int startSize = 1000;
+            final int clockRuns = 1000;
+            final int uniques = 100;
+            final Integer[] starts = new Integer[startSize];
+            for (int i = 0; i < startSize; i++) {
+                starts[i] = i % uniques; // 100 unique objects
+            }
+            assertEquals(uniques, new HashSet<>(Arrays.asList(starts)).size());
+            clockTraversals(starts, clockRuns);
+        }
+
+        private void clockTraversals(final Integer[] starts, final int clockRuns) {
+            final int times = RANDOM.nextInt(4) + 2;
+            assertTrue(times > 1 && times < 6);
+            final Supplier<Long> original = () -> __.inject(starts).repeat(__.identity()).times(times).<Long>sum().next();
+
+            final TraversalStrategies strategies = new DefaultTraversalStrategies();
+            strategies.addStrategies(RepeatUnrollStrategy.instance());
+            final Supplier<Long> optimized = () -> {
+                final Traversal<Integer, Long> traversal = __.inject(starts).repeat(__.identity()).times(times).sum();
+                traversal.asAdmin().setStrategies(strategies);
+                return traversal.next();
+            };
+
+            final Pair<Double, Long> originalResult;
+            final Pair<Double, Long> optimizedResult;
+            if (RANDOM.nextBoolean()) {
+                originalResult = TimeUtil.clockWithResult(clockRuns, original);
+                optimizedResult = TimeUtil.clockWithResult(clockRuns, optimized);
+            } else {
+                optimizedResult = TimeUtil.clockWithResult(clockRuns, optimized);
+                originalResult = TimeUtil.clockWithResult(clockRuns, original);
+            }
+
+            // System.out.println(originalResult + "---" + optimizedResult);
+            assertEquals(originalResult.getValue1(), optimizedResult.getValue1());
+            assertTrue(originalResult.getValue0() > optimizedResult.getValue0());
+        }
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
@@ -90,6 +90,7 @@ public class RepeatUnrollStrategyTest {
                 {__.repeat(__.out()).until(predicate), __.repeat(__.out()).until(predicate)},
                 {__.repeat(__.out()).until(predicate).repeat(__.out()).times(2), __.repeat(__.out()).until(predicate).out().barrier().out().barrier()},
                 {__.repeat(__.union(__.both(), __.identity())).times(2).out(), __.union(__.both(), __.identity()).barrier().union(__.both(), __.identity()).barrier().out()},
+                {__.in().repeat(__.out("knows")).times(3).as("a").count().is(0), __.in().out("knows").barrier().out("knows").barrier().out("knows").as("a").count().is(0)},
         });
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
@@ -1,0 +1,154 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.util.TimeUtil;
+import org.javatuples.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+@RunWith(Parameterized.class)
+public class RepeatUnrollStrategyTest {
+
+    private static final Random RANDOM = new Random();
+    private static boolean shouldBeFasterWithUniqueStreamExecuted = false;
+    private static boolean shouldBeFasterWithDuplicateStreamExecuted = false;
+
+    @Parameterized.Parameter(value = 0)
+    public Traversal original;
+
+    @Parameterized.Parameter(value = 1)
+    public Traversal optimized;
+
+
+    private void applyRepeatUnrollStrategy(final Traversal traversal) {
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(RepeatUnrollStrategy.instance());
+        traversal.asAdmin().setStrategies(strategies);
+        traversal.asAdmin().applyStrategies();
+
+    }
+
+    @Test
+    public void doTest() {
+        applyRepeatUnrollStrategy(original);
+        assertEquals(optimized, original);
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> generateTestParameters() {
+
+        final Predicate<Traverser<Vertex>> predicate = t -> t.loops() > 5;
+        return Arrays.asList(new Traversal[][]{
+                {__.identity(), __.identity()},
+                {__.out().as("a").in().repeat(__.outE("created").bothV()).times(2).in(), __.out().as("a").in().outE("created").bothV().barrier().outE("created").bothV().barrier().in()},
+                {__.out().repeat(__.outE("created").bothV()).times(1).in(), __.out().outE("created").bothV().barrier().in()},
+                {__.repeat(__.outE("created").bothV()).times(1).in(), __.outE("created").bothV().barrier().in()},
+                {__.repeat(__.out()).times(2).as("x").repeat(__.in().as("b")).times(3), __.out().barrier().out().barrier().as("x").in().as("b").barrier().in().as("b").barrier().in().as("b").barrier()},
+                {__.repeat(__.outE("created").inV()).times(2), __.outE("created").inV().barrier().outE("created").inV().barrier()},
+                {__.repeat(__.out()).times(3), __.out().barrier().out().barrier().out().barrier()},
+                {__.repeat(__.local(__.select("a").out("knows"))).times(2), __.local(__.select("a").out("knows")).barrier().local(__.select("a").out("knows")).barrier()},
+                {__.<Vertex>times(2).repeat(__.out()), __.out().barrier().out().barrier()},
+                {__.<Vertex>out().times(2).repeat(__.out().as("a")).as("x"), __.out().out().as("a").barrier().out().as("a").barrier().as("x")},
+                {__.repeat(__.out()).emit().times(2), __.repeat(__.out()).emit().times(2)},
+                {__.repeat(__.out()).until(predicate), __.repeat(__.out()).until(predicate)},
+                {__.repeat(__.out()).until(predicate).repeat(__.out()).times(2), __.repeat(__.out()).until(predicate).out().barrier().out().barrier()},
+                {__.repeat(__.union(__.both(), __.identity())).times(2).out(), __.union(__.both(), __.identity()).barrier().union(__.both(), __.identity()).barrier().out()},
+        });
+    }
+
+    @Test
+    public void shouldBeFasterWithUniqueStream() {
+        if (shouldBeFasterWithUniqueStreamExecuted)
+            return;
+        shouldBeFasterWithUniqueStreamExecuted = true;
+        final int startSize = 1000;
+        final int clockRuns = 1000;
+        final Integer[] starts = new Integer[startSize];
+        for (int i = 0; i < startSize; i++) {
+            starts[i] = i; // 1000 unique objects
+        }
+        assertEquals(startSize, new HashSet<>(Arrays.asList(starts)).size());
+        clockTraversals(starts, clockRuns);
+    }
+
+    @Test
+    public void shouldBeFasterWithDuplicateStream() {
+        if (shouldBeFasterWithDuplicateStreamExecuted)
+            return;
+        shouldBeFasterWithDuplicateStreamExecuted = true;
+        final int startSize = 1000;
+        final int clockRuns = 1000;
+        final int uniques = 100;
+        final Integer[] starts = new Integer[startSize];
+        for (int i = 0; i < startSize; i++) {
+            starts[i] = i % uniques; // 100 unique objects
+        }
+        assertEquals(uniques, new HashSet<>(Arrays.asList(starts)).size());
+        clockTraversals(starts, clockRuns);
+    }
+
+    private void clockTraversals(final Integer[] starts, final int clockRuns) {
+        final int times = RANDOM.nextInt(4) + 2;
+        assertTrue(times > 1 && times < 6);
+        final Supplier<Long> original = () -> __.inject(starts).repeat(__.identity()).times(times).<Long>sum().next();
+
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(RepeatUnrollStrategy.instance());
+        final Supplier<Long> optimized = () -> {
+            final Traversal<Integer, Long> traversal = __.inject(starts).repeat(__.identity()).times(times).sum();
+            traversal.asAdmin().setStrategies(strategies);
+            return traversal.next();
+        };
+
+        final Pair<Double, Long> originalResult;
+        final Pair<Double, Long> optimizedResult;
+        if (RANDOM.nextBoolean()) {
+            originalResult = TimeUtil.clockWithResult(clockRuns, original);
+            optimizedResult = TimeUtil.clockWithResult(clockRuns, optimized);
+        } else {
+            optimizedResult = TimeUtil.clockWithResult(clockRuns, optimized);
+            originalResult = TimeUtil.clockWithResult(clockRuns, original);
+        }
+
+        // System.out.println(originalResult + "---" + optimizedResult);
+        assertEquals(originalResult.getValue1(), optimizedResult.getValue1());
+        assertTrue(originalResult.getValue0() > optimizedResult.getValue0());
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1349

`RepeatUnrollStrategy` is a Standard-only strategy that will unroll a `repeat()` into a linear form if and only if it has a known loop amount (e.g. `times(2)`). That is `repeat(out()).times(2)` becomes `out().barrier().out().barrier()`. The `barrier()` insertions are necessary as `repeat()` itself is a barrier step and also, the benefit of bulking is leveraged. `RepeatUnrollStrategy` removes the need for `RepeatStep`, `RepeatEndStep`, and `LoopTraversal`.

`RepeatUnrollStrategyTest` ensures that unrolling is faster than not-unrolling. Here are some runtimes. The first item in the Pair is the runtime and the second item is the amount of unique objects being processed. With more unique objects, the faster it gets. Note that at 10 unique elements (tiny traversal), sometimes rolled is faster than unrolled and vice versa (i.e. they are equal).

```
rolled:[0.22843720299999998, 10]	unrolled:[0.174451055, 10]
rolled:[0.514145509, 100]		unrolled:[0.212532769, 100]
rolled:[1.4944357259999999, 1000]	unrolled:[0.441714987, 1000]
rolled:[28.502658626, 10000]		unrolled:[12.936112649999998, 10000]
```



Also in this ticket, I fixed a bug in `BranchStep` where children were not being integrated and thus, susceptible to clone-problems. Moreover, I added a timing test to `IdentityRemovalStrategyTest`. @spmallette, do you know how to make a test run once and only once in a `Parameterized` test case? If so, can you update `IdentityRemoveStrategyTest` and `RepeatUnrollStrategyTest` accordingly?

---

```
CHANGELOG

* Added `RepeatUnrollStrategy` to linearize a `repeat()`-traversal if loop amount is known at compile time.
* Fixed a bug in `BranchStep` around child integration during `clone()`.
* Fixed a bug in `AbstractStep` around label set cloning.
```

VOTE +1.