### PR TITLE
TINKERPOP-1341 Add missing classes to GryoRegistrator

### DIFF
--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoRegistrator.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoRegistrator.java
@@ -22,6 +22,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.serializers.JavaSerializer;
 import org.apache.spark.serializer.KryoRegistrator;
+import org.apache.spark.util.collection.CompactBuffer;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopEdge;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopProperty;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopVertex;
@@ -215,6 +216,10 @@ public class GryoRegistrator implements KryoRegistrator {
         } catch (final ClassNotFoundException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
+        //
+        m.put(CompactBuffer[].class, null);
+        m.put(void.class, null);
+        m.put(Void.class, null);
         return m;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1341

GryoRegistrator is missing registrations for three classes registered
in GryoSerializer:

* void
* Void
* CompactBuffer[]

This commit adds all three to GryoRegistrator.getExtraRegistrations().

So far, CompactBuffer[] is the only omission known to cause practical
problems, as detailed by Dylan Bethune-Waddell on the mailing list and
in the referenced issue.  It's not clear whether omitting Void and
void causes practical problems, but they're trivial, so the cost
associated with registering them is tiny.  Might as well.