### PR TITLE
TINKERPOP-1354 Added more invalid binding keys to Gremlin Server validation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 * Improved `TinkerGraph` performance when iterating vertices and edges.
 * Fixed a bug where timeout functions provided to the `GremlinExecutor` were not executing in the same thread as the script evaluation.
 * Optimized a few special cases in `RangeByIsCountStrategy`.
+* Added more "invalid" variable bindings to the list used by Gremlin Server to validate incoming bindings on requests.
 * Named the thread pool used by Gremlin Server sessions: "gremlin-server-session-$n".
 * Fixed a bug in `BulkSet.equals()` which made itself apparent when using `store()` and `aggregate()` with labeled `cap()`.
 * Fixed a bug where `Result.one()` could potentially block indefinitely under certain circumstances.

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -32,6 +32,16 @@ Please see the link:https://github.com/apache/incubator-tinkerpop/blob/3.1.3/CHA
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+Reserved Gremlin Server Keys
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Gremlin Server has always considered certain binding keys (request parameters) as reserved, but that list has now
+expanded to be more inclusive all the static enums that are imported to the script engine. It is possible that those
+using Gremlin Server may have to rename their keys if they somehow successfully were using some of the now reserved
+terms in previous versions.
+
+See: https://issues.apache.org/jira/browse/TINKERPOP-1354[TINKERPOP-1354]
+
 Remote Timeout
 ^^^^^^^^^^^^^^
 
@@ -53,6 +63,8 @@ refers to how long the console will wait for a response from the server before g
 set to `none`.
 
 See: https://issues.apache.org/jira/browse/TINKERPOP-1267[TINKERPOP-1267]
+
+
 
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Scope.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Scope.java
@@ -18,8 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
-import java.util.Map;
-
 /**
  * Many {@link Step} instance can have a variable scope.
  * {@link Scope#global}: the step operates on the entire traversal.

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -28,10 +28,15 @@ import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.TimedInterruptTimeoutException;
+import org.apache.tinkerpop.gremlin.process.traversal.Operator;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.handler.Frame;
 import org.apache.tinkerpop.gremlin.server.handler.GremlinResponseFrameEncoder;
 import org.apache.tinkerpop.gremlin.server.handler.StateKey;
+import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.server.Context;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
@@ -54,11 +59,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -84,7 +91,12 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
 
     /**
      * Regex for validating that binding variables.
+     *
+     * @deprecated As of release 3.1.2-incubating, not replaced. This {@code Pattern} is not used internally.
+     * Deprecated rather than just removing as it's possible that someone else might be using it when developing
+     * custom {@link OpProcessor} implementations.
      */
+    @Deprecated
     protected static final Pattern validBindingName = Pattern.compile("[a-zA-Z$_][a-zA-Z0-9$_]*");
 
     /**
@@ -95,12 +107,37 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
      * Use of {@code toUpperCase()} on the accessor values of {@link T} solves an issue where the {@code ScriptEngine}
      * ignores private scope on {@link T} and imports static fields.
      */
-    private static final List<String> invalidBindingsKeys = Arrays.asList(
-            T.id.getAccessor(), T.key.getAccessor(),
-            T.label.getAccessor(), T.value.getAccessor(),
-            T.id.getAccessor().toUpperCase(), T.key.getAccessor().toUpperCase(),
-            T.label.getAccessor().toUpperCase(), T.value.getAccessor().toUpperCase());
-    private static final String invalidBindingKeysJoined = String.join(",", invalidBindingsKeys);
+    protected static final Set<String> INVALID_BINDINGS_KEYS = new HashSet<>();
+
+    static {
+        INVALID_BINDINGS_KEYS.addAll(Arrays.asList(
+                T.id.name(), T.key.name(),
+                T.label.name(), T.value.name(),
+                T.id.getAccessor(), T.key.getAccessor(),
+                T.label.getAccessor(), T.value.getAccessor(),
+                T.id.getAccessor().toUpperCase(), T.key.getAccessor().toUpperCase(),
+                T.label.getAccessor().toUpperCase(), T.value.getAccessor().toUpperCase()));
+
+        for (Column enumItem : Column.values()) {
+            INVALID_BINDINGS_KEYS.add(enumItem.name());
+        }
+
+        for (Order enumItem : Order.values()) {
+            INVALID_BINDINGS_KEYS.add(enumItem.name());
+        }
+
+        for (Operator enumItem : Operator.values()) {
+            INVALID_BINDINGS_KEYS.add(enumItem.name());
+        }
+
+        for (Scope enumItem : Scope.values()) {
+            INVALID_BINDINGS_KEYS.add(enumItem.name());
+        }
+
+        for (Pop enumItem : Pop.values()) {
+            INVALID_BINDINGS_KEYS.add(enumItem.name());
+        }
+    }
 
     protected final boolean manageTransactions;
 
@@ -155,8 +192,9 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
                 throw new OpProcessorException(msg, ResponseMessage.build(message).code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).statusMessage(msg).create());
             }
 
-            if (bindings.keySet().stream().anyMatch(invalidBindingsKeys::contains)) {
-                final String msg = String.format("The [%s] message is using at least one of the invalid binding key of [%s]. It conflicts with standard static imports to Gremlin Server.", Tokens.OPS_EVAL, invalidBindingKeysJoined);
+            final Set<String> badBindings = IteratorUtils.set(IteratorUtils.<String>filter(bindings.keySet().iterator(), INVALID_BINDINGS_KEYS::contains));
+            if (!badBindings.isEmpty()) {
+                final String msg = String.format("The [%s] message supplies one or more invalid parameters key of [%s] - these are reserved names.", Tokens.OPS_EVAL, badBindings);
                 throw new OpProcessorException(msg, ResponseMessage.build(message).code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).statusMessage(msg).create());
             }
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1354

These "invalid" keys are reserved terms for Gremlin Server as they are statically imported enums and shouldn't be used as binding keys. You get some less than easy to understand error messages if those keys are used. 

I would have CTR'd but wanted to see if anyone had other suggestions for additional validations at play. Also, this change is "breaking" in the sense that users who were somehow successfully using some of these newly reserved keys on previous versions (not fully sure if that was even possible) will have to update their code. I don't think this is a massive problem for someone to fix, so while "breaking" it doesn't seem massively detrimental and shouldn't be widely problematic.

Builds with `mvn clean install -DskipTests && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1