### PR TITLE
TINKERPOP-1338 Bumped groovy to 2.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@ limitations under the License.
     </scm>
     <properties>
         <commons.configuration.version>1.10</commons.configuration.version>
-        <groovy.version>2.4.6</groovy.version>
+        <groovy.version>2.4.7</groovy.version>
         <junit.version>4.12</junit.version>
         <metrics.version>3.0.2</metrics.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
No new dependencies introduced.
No other dependency versions changed.

Successful build and verify with:
mvn clean install -pl gremlin-shaded,gremlin-core,gremlin-test,gremlin-groovy,gremlin-groovy-test,tinkergraph-gremlin,neo4j-gremlin,gremlin-driver,gremlin-console,gremlin-server,gremlin-archetype && mvn verify -pl gremlin-server -DskipIntegrationTests=false -DincludeNeo4j

(excludes giraph-gremlin, hadoop-gremlin,spark-gremlin because I have separate issues building them)