### PR TITLE
TINKERPOP-1278 : Removed long literal 'L' suffix

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/process/jython_translator.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/jython_translator.py
@@ -57,7 +57,7 @@ class JythonTranslator(Translator):
         if isinstance(arg, str):
             return "\"" + arg + "\""
         elif isinstance(arg, long):
-            return str(arg) + "L" if arg > 9223372036854775807L else "Long(" + str(arg) + ")"
+            return str(arg) + "L" if arg > 9223372036854775807 else "Long(" + str(arg) + ")"
         elif isinstance(arg, Barrier):
             return "Barrier" + "." + SymbolHelper.toJava(str(arg.name))
         elif isinstance(arg, Column):


### PR DESCRIPTION
The 'L' suffix on numeric literals is a syntax error in python3. As far
as I can tell, the suffix on the literal in this expression in
JythonTranslator isn't necessary on python2, so removing it restores 2/3
compatibility.