### PR TITLE
revise a mutable default kwarg on GraphTraversalSource

### DIFF
--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
@@ -66,9 +66,11 @@ under the License.
 //////////////////////////
         pythonClass.append(
                 """class GraphTraversalSource(object):
-  def __init__(self, graph, traversal_strategies, bytecode=Bytecode()):
+  def __init__(self, graph, traversal_strategies, bytecode=None):
     self.graph = graph
     self.traversal_strategies = traversal_strategies
+    if bytecode is None:
+      bytecode = Bytecode()
     self.bytecode = bytecode
   def __repr__(self):
     return "graphtraversalsource[" + str(self.graph) + "]"

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -22,9 +22,11 @@ from traversal import Bytecode
 from gremlin_python import statics
 
 class GraphTraversalSource(object):
-  def __init__(self, graph, traversal_strategies, bytecode=Bytecode()):
+  def __init__(self, graph, traversal_strategies, bytecode=None):
     self.graph = graph
     self.traversal_strategies = traversal_strategies
+    if bytecode is None:
+      bytecode = Bytecode()
     self.bytecode = bytecode
   def __repr__(self):
     return "graphtraversalsource[" + str(self.graph) + "]"


### PR DESCRIPTION
previously, in the signature of GraphTraversalSource.__init__, the
bytecode kwarg had a default value of `Bytecode()`. In python, mutable
default kwargs are evaluated at definition time, not when the function
is called. Thus, prior to this commit, the following script would print
`True`:

```python
from gremlin_python.structure import RemoteGraph
from gremlin_python.process import GroovyTranslator

graph = RemoteGraph(GroovyTranslator('g'), None)
traversal_source1 = graph.traversal()
traversal_source2 = graph.traversal()

print(traversal_source1.bytecode is traversal_source2.bytecode)
```

This means that if self.bytecode were mutated, the changes would
persist, and future invocations of `GraphTraversalSource.__init__` would
have created `GraphTraversalSource`s with dirty `self.bytecode`.