### PR TITLE
TINKERPOP-1360: compare vertex property ids as Long

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesTest.java
@@ -100,9 +100,8 @@ public abstract class PropertiesTest extends AbstractGremlinProcessTest {
             ids.add(vertexProperty.id());
             assertEquals("name", vertexProperty.key());
             assertEquals(convertToVertex(graph, vertexProperty.value()).values("name").next(), vertexProperty.value());
-            assertEquals(convertToVertex(graph, vertexProperty.value()).properties("name").next().id(), vertexProperty.id());
-            // assertEquals(convertToVertex(graph, vertexProperty.value()), vertexProperty.element());
-            // assertEquals(convertToVertexId(graph, vertexProperty.value()), vertexProperty.element().id());
+            // compare the ids as longs. assumes modern graph uses numeric ids only (long/integer).
+            assertEquals(Long.valueOf(convertToVertex(graph, vertexProperty.value()).properties("name").next().id().toString()), Long.valueOf(vertexProperty.id().toString()));
         }
         assertEquals(4, counter);
         assertEquals(1, keys.size());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1360

Verified with:

```
mvn clean install && mvn verify -q -DskipIntegrationTests=false -pl spark-gremlin
```

And via Docker
```
docker/build.sh -t -i -n
```

@spmallette @dkuppitz Please try out multiple times in your environments since the error only happens 1 out of 4 scenarios (based on 2 different `RANDOM.nextBooolean()` calls). I manually forced each scenario in by setting specific boolean values in `HadoopGraphProvider` and `SparkHadoopGraphProvider`.