### PR TITLE
TINKERPOP-1350 was never quite fixed in 3.1.3.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.1.4 (NOT OFFICIALLY RELEASED YET)
 
 * Fixed a potential leak of a `ReferenceCounted` resource in Gremlin Server.
 * Renamed distributions to make the prefix "apache-tinkerpop-" as opposed to just "apache-".
+* Fixed a problem (previously thought resolved on 3.1.3) causing Gremlin Server to lock up when parallel requests were submitted on the same session if those parallel requests included a script that blocked indefinitely.
 
 [[release-3-1-3]]
 TinkerPop 3.1.3 (Release Date: July 18, 2016)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1261,7 +1261,7 @@ Tuning
 image:gremlin-handdrawn.png[width=120,float=right] Tuning Gremlin Server for a particular environment may require some simple trial-and-error, but the following represent some basic guidelines that might be useful:
 
 * Gremlin Server defaults to a very modest maximum heap size.  Consider increasing this value for non-trivial uses.  Maximum heap size (`-Xmx`) is defined with the `JAVA_OPTIONS` setting in `gremlin-server.sh`.
-* When configuring the size of `threadPoolWorker` start with the default of `1` and increment by one as needed to a maximum of `2*number of cores`. Note that if using sessions that will accept parallel requests on the same session, then this value should be no less than `2`.
+* When configuring the size of `threadPoolWorker` start with the default of `1` and increment by one as needed to a maximum of `2*number of cores`.
 * The "right" size of the `gremlinPool` setting is somewhat dependent on the type of scripts that will be processed
 by Gremlin Server.  As requests arrive to Gremlin Server they are decoded and queued to be processed by threads in
 this pool.  When this pool is exhausted of threads, Gremlin Server will continue to accept incoming requests, but
@@ -1406,10 +1406,6 @@ request.
 
 A session is a "heavier" approach to the simple "request/response" approach of sessionless requests, but is sometimes
 necessary for a given use case.
-
-IMPORTANT: If submitting requests in parallel to a single session in Gremlin Server, then the `threadPoolWorker`
-setting can be no less than `2` or else the session may be prone to becoming locked if scripts sent on that session
-tend to block for extended periods of time.
 
 [[considering-transactions]]
 Considering Transactions

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -22,6 +22,26 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *A 187 On The Undercover Gremlinz*
 
+TinkerPop 3.1.4
+---------------
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.1.4/CHANGELOG.asciidoc#tinkerpop-314-release-date-XXXXXXX-XX-2016[changelog] for a complete list of all the modifications that are part of this release.
+
+Upgrading for Users
+~~~~~~~~~~~~~~~~~~~
+
+Gremlin Server Workers
+^^^^^^^^^^^^^^^^^^^^^^
+
+In release 3.1.3, a link:http://tinkerpop.apache.org/docs/3.1.3/upgrade/#_tinkerpop_3_1_3[recommendation] was made to
+ensure that the `threadPoolWorker` setting for Gremlin Server was no less than `2` in cases where Gremlin Server was
+being used with sessions that accept parallel requests. In 3.1.4, that is no longer the case and a size of `1` remains
+acceptable even in that specific case.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1350[TINKERPOP-1350]
+
 TinkerPop 3.1.3
 ---------------
 
@@ -73,8 +93,6 @@ with sessions that accept parallel requests, then this value should be no less t
 those that block for an extended period of time) may cause Gremlin Server to lock up the session.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1350[TINKERPOP-1350]
-
-
 
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -232,8 +232,6 @@ public class GremlinExecutor implements AutoCloseable {
         return eval(script, language, boundVars, lifeCycle);
     }
 
-    private static final AtomicInteger ugh = new AtomicInteger(0);
-
     /**
      * Evaluate a script and allow for the submission of alteration to the entire evaluation execution lifecycle.
      *


### PR DESCRIPTION
Unfortunately, more testing revealed that the fix for the problem was only masked by the changes in 3.1.3. 

Changed response encoding to not use the session executor when the session has an error condition it is trying to serialize. This should be fine as there is no need to serialized an error condition as part of a transaction and thus no need to have the session thread to do it. That in turn frees up the worker executor to serialize and cancel long run jobs in the session. Removed recommendations for submitting parallel requests on a session from docs.

Works in full with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1