### PR TITLE
TINKERPOP-1400: SubgraphStrategy introduces infinite recursion if filter has Vertex/Edge steps.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -22,23 +22,26 @@ import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -48,75 +51,98 @@ import java.util.stream.Collectors;
  * it traverses and returns.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalStrategy.DecorationStrategy>
         implements TraversalStrategy.DecorationStrategy {
 
-    private final Traversal<Vertex, ?> vertexCriterion;
-    private final Traversal<Edge, ?> edgeCriterion;
+    private final Traversal.Admin<Vertex, ?> vertexCriterion;
+    private final Traversal.Admin<Edge, ?> edgeCriterion;
+    private final String MARKER = Graph.Hidden.hide(UUID.randomUUID().toString());
 
     private SubgraphStrategy(final Traversal<Vertex, ?> vertexCriterion, final Traversal<Edge, ?> edgeCriterion) {
-        this.vertexCriterion = vertexCriterion;
+        this.vertexCriterion = null == vertexCriterion ? null : vertexCriterion.asAdmin();
 
         // if there is no vertex predicate there is no need to test either side of the edge
-        if (null == vertexCriterion) {
-            this.edgeCriterion = edgeCriterion;
+        if (null == this.vertexCriterion) {
+            this.edgeCriterion = null == edgeCriterion ? null : edgeCriterion.asAdmin();
         } else {
-            final Traversal<Object, Vertex> inVertexPredicate = __.inV().filter(vertexCriterion);
-            final Traversal<Object, Vertex> outVertexPredicate = __.outV().filter(vertexCriterion);
+            final Traversal.Admin<Edge, ?> vertexPredicate = __.<Edge>and(
+                    __.inV().filter(this.vertexCriterion.clone()),
+                    __.outV().filter(this.vertexCriterion.clone())).asAdmin();
 
             // if there is a vertex predicate then there is an implied edge filter on vertices even if there is no
             // edge predicate provided by the user.
             if (null == edgeCriterion)
-                this.edgeCriterion = __.and(inVertexPredicate.asAdmin(), outVertexPredicate.asAdmin());
+                this.edgeCriterion = vertexPredicate;
             else
-                this.edgeCriterion = edgeCriterion.asAdmin().addStep(new TraversalFilterStep<>(edgeCriterion.asAdmin(), __.and(inVertexPredicate.asAdmin(), outVertexPredicate.asAdmin())));
+                this.edgeCriterion = edgeCriterion.asAdmin().addStep(new TraversalFilterStep<>(edgeCriterion.asAdmin(), vertexPredicate));
+        }
+
+        if (null != this.vertexCriterion)
+            this.metadataLabelStartStep(this.vertexCriterion);
+        if (null != this.edgeCriterion)
+            this.metadataLabelStartStep(this.edgeCriterion);
+    }
+
+    private final void metadataLabelStartStep(final Traversal.Admin<?, ?> traversal) {
+        traversal.getStartStep().addLabel(MARKER);
+        for (final Step<?, ?> step : traversal.getSteps()) {
+            if (step instanceof TraversalParent) {
+                ((TraversalParent) step).getLocalChildren().forEach(this::metadataLabelStartStep);
+                ((TraversalParent) step).getGlobalChildren().forEach(this::metadataLabelStartStep);
+            }
         }
     }
 
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
+        // do not apply subgraph strategy to already created subgraph filter branches (or else you get infinite recursion)
+        if (traversal.getStartStep().getLabels().contains(MARKER)) {
+            traversal.getStartStep().removeLabel(MARKER);
+            return;
+        }
+        //
         final List<GraphStep> graphSteps = TraversalHelper.getStepsOfAssignableClass(GraphStep.class, traversal);
         final List<VertexStep> vertexSteps = TraversalHelper.getStepsOfAssignableClass(VertexStep.class, traversal);
-
-        if (vertexCriterion != null) {
+        if (null != this.vertexCriterion) {
             final List<Step> vertexStepsToInsertFilterAfter = new ArrayList<>();
             vertexStepsToInsertFilterAfter.addAll(TraversalHelper.getStepsOfAssignableClass(EdgeOtherVertexStep.class, traversal));
             vertexStepsToInsertFilterAfter.addAll(TraversalHelper.getStepsOfAssignableClass(EdgeVertexStep.class, traversal));
             vertexStepsToInsertFilterAfter.addAll(TraversalHelper.getStepsOfAssignableClass(AddVertexStep.class, traversal));
             vertexStepsToInsertFilterAfter.addAll(TraversalHelper.getStepsOfAssignableClass(AddVertexStartStep.class, traversal));
             vertexStepsToInsertFilterAfter.addAll(graphSteps.stream().filter(GraphStep::returnsVertex).collect(Collectors.toList()));
-
-            applyCriterion(vertexStepsToInsertFilterAfter, traversal, vertexCriterion.asAdmin());
+            applyCriterion(vertexStepsToInsertFilterAfter, traversal, this.vertexCriterion);
         }
 
-        if (edgeCriterion != null) {
+        if (null != this.edgeCriterion) {
             final List<Step> edgeStepsToInsertFilterAfter = new ArrayList<>();
             edgeStepsToInsertFilterAfter.addAll(TraversalHelper.getStepsOfAssignableClass(AddEdgeStep.class, traversal));
             edgeStepsToInsertFilterAfter.addAll(graphSteps.stream().filter(GraphStep::returnsEdge).collect(Collectors.toList()));
             edgeStepsToInsertFilterAfter.addAll(vertexSteps.stream().filter(VertexStep::returnsEdge).collect(Collectors.toList()));
-
-            applyCriterion(edgeStepsToInsertFilterAfter, traversal, edgeCriterion.asAdmin());
+            applyCriterion(edgeStepsToInsertFilterAfter, traversal, this.edgeCriterion);
         }
 
         // explode g.V().out() to g.V().outE().inV() only if there is an edge predicate otherwise
-        vertexSteps.stream().filter(VertexStep::returnsVertex).forEach(s -> {
-            if (null == edgeCriterion)
-                TraversalHelper.insertAfterStep(new TraversalFilterStep<>(traversal, vertexCriterion.asAdmin().clone()), s, traversal);
-            else {
-                final VertexStep someEStep = new VertexStep(traversal, Edge.class, s.getDirection(), s.getEdgeLabels());
-                final Step someVStep = (s.getDirection() == Direction.BOTH) ?
-                        new EdgeOtherVertexStep(traversal) : new EdgeVertexStep(traversal, s.getDirection().opposite());
+        vertexSteps.stream().filter(VertexStep::returnsVertex).forEach(step -> {
+            if (null != this.vertexCriterion && null == edgeCriterion) {
+                TraversalHelper.insertAfterStep(new TraversalFilterStep<>(traversal, this.vertexCriterion.clone()), step, traversal);
+            } else {
+                final VertexStep someEStep = new VertexStep<>(traversal, Edge.class, step.getDirection(), step.getEdgeLabels());
+                final Step someVStep = step.getDirection() == Direction.BOTH ?
+                        new EdgeOtherVertexStep(traversal) :
+                        new EdgeVertexStep(traversal, step.getDirection().opposite());
 
-                // if s was labelled then propagate those labels to the new step that will return the vertex
-                transferLabels(s, someVStep);
+                // if step was labeled then propagate those labels to the new step that will return the vertex
+                transferLabels(step, someVStep);
 
-                TraversalHelper.replaceStep(s, someEStep, traversal);
+                TraversalHelper.replaceStep(step, someEStep, traversal);
                 TraversalHelper.insertAfterStep(someVStep, someEStep, traversal);
-                TraversalHelper.insertAfterStep(new TraversalFilterStep<>(traversal, edgeCriterion.asAdmin().clone()), someEStep, traversal);
 
-                if (vertexCriterion != null)
-                    TraversalHelper.insertAfterStep(new TraversalFilterStep<>(traversal, vertexCriterion.asAdmin().clone()), someVStep, traversal);
+                if (null != this.edgeCriterion)
+                    TraversalHelper.insertAfterStep(new TraversalFilterStep<>(traversal, this.edgeCriterion.clone()), someEStep, traversal);
+                if (null != this.vertexCriterion)
+                    TraversalHelper.insertAfterStep(new TraversalFilterStep<>(traversal, this.vertexCriterion.clone()), someVStep, traversal);
             }
         });
     }
@@ -156,20 +182,36 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
         private Builder() {
         }
 
-        public Builder vertexCriterion(final Traversal<Vertex, ?> predicate) {
-            vertexCriterion = predicate;
+        public Builder vertices(final Traversal<Vertex, ?> vertexPredicate) {
+            this.vertexCriterion = vertexPredicate;
             return this;
         }
 
-        public Builder edgeCriterion(final Traversal<Edge, ?> predicate) {
-            edgeCriterion = predicate;
+        public Builder edges(final Traversal<Edge, ?> edgePredicate) {
+            this.edgeCriterion = edgePredicate;
             return this;
+        }
+
+        @Deprecated
+        /**
+         * @deprecated Since 3.2.2, use {@code Builder#vertices} instead.
+         */
+        public Builder vertexCriterion(final Traversal<Vertex, ?> predicate) {
+            return this.vertices(predicate);
+        }
+
+        /**
+         * @deprecated Since 3.2.2, use {@code Builder#edges} instead.
+         */
+        @Deprecated
+        public Builder edgeCriterion(final Traversal<Edge, ?> predicate) {
+            return this.edges(predicate);
         }
 
         public SubgraphStrategy create() {
-            if (null == edgeCriterion && null == vertexCriterion)
+            if (null == this.edgeCriterion && null == this.vertexCriterion)
                 throw new IllegalStateException("A subgraph must be filtered by an edge or vertex criterion");
-            return new SubgraphStrategy(vertexCriterion, edgeCriterion);
+            return new SubgraphStrategy(this.vertexCriterion, this.edgeCriterion);
         }
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
@@ -41,6 +41,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MeanGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
@@ -158,6 +159,9 @@ public final class SparkStarBarrierInterceptor implements SparkVertexProgramInte
     public static boolean isLegal(final Traversal.Admin<?, ?> traversal) {
         final Step<?, ?> startStep = traversal.getStartStep();
         final Step<?, ?> endStep = traversal.getEndStep();
+        // right now this is not supported because of how the SparkStarBarrierInterceptor mutates the traversal prior to local evaluation
+        if (traversal.getStrategies().toList().stream().filter(strategy -> strategy instanceof SubgraphStrategy).findAny().isPresent())
+            return false;
         if (!startStep.getClass().equals(GraphStep.class) || ((GraphStep) startStep).returnsEdge())
             return false;
         if (!endStep.getClass().equals(CountGlobalStep.class) &&


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1400

There was a severe bug in SubgraphStrategy where the traversal filters that were added for sub-graphing were being recursively applied yielded a StackOverflow. We did not have complex enough tests in SubgraphStrategyProcessTest to illicit the bug. The fix is clever using Step label markers to know if a traversal whose is having their strategy applied is a vertex/edge subgraph filter. Its clever.

* Note: given the differences in strategy application code, this can not easily go into the `tp31`-line without a rewrite. Thus, this is headed to `master/`.

CHANGELOG

```
* Fixed a severe bug in `SubgraphStrategy`.
* Deprecated `SubgraphStrategy.Builder.vertexCriterion()/edgeCriterion()` in favor of `vertices()/edges()`.
```

VOTE +1.