### PR TITLE
Finished renaming distribution from 'apache-' to 'apache-tinkerpop-'

### DIFF
--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -41,7 +41,7 @@ mvn -Dmaven.javadoc.skip=true --projects tinkergraph-gremlin test
 ** Build AsciiDocs (but don't evaluate code blocks): `bin/process-docs.sh --dryRun`
 ** Build AsciiDocs (but don't evaluate code blocks in specific files): `bin/process-docs.sh --dryRun docs/src/reference/the-graph.asciidoc,docs/src/tutorial/getting-started,...`
 ** Build AsciiDocs (but evaluate code blocks only in specific files): `bin/process-docs.sh --fullRun docs/src/reference/the-graph.asciidoc,docs/src/tutorial/getting-started,...`
-** Process a single AsciiDoc file: +pass:[docs/preprocessor/preprocess-file.sh `pwd`/gremlin-console/target/apache-gremlin-console-*-standalone `pwd`/docs/src/xyz.asciidoc]+
+** Process a single AsciiDoc file: +pass:[docs/preprocessor/preprocess-file.sh `pwd`/gremlin-console/target/apache-tinkerpop-gremlin-console-*-standalone `pwd`/docs/src/xyz.asciidoc]+
 * Build JavaDocs: `mvn process-resources -Djavadoc`
 * Check for Apache License headers: `mvn apache-rat:check`
 * Check for newer dependencies: `mvn versions:display-dependency-updates` or `mvn versions:display-plugin-updates`

--- a/docs/src/dev/developer/for-committers.asciidoc
+++ b/docs/src/dev/developer/for-committers.asciidoc
@@ -310,8 +310,8 @@ The binary LICENSE/NOTICE is perhaps most impacted by changes to the various `po
 `pom.xml` file of any module, build both Gremlin Console and Gremlin Server and examine the contents of both binary
 distributions, either:
 
-* target/apache-gremlin-console-x.y.z-distribution.zip
-* target/apache-gremlin-server-x.y.z-distribution.zip
+* target/apache-tinkerpop-gremlin-console-x.y.z-distribution.zip
+* target/apache-tinkerpop-gremlin-server-x.y.z-distribution.zip
 
 Apache licensed software does not need to be included in LICENSE, but if the new dependency is an Apache-approved
 license (e.g. BSD, MIT) then it should be added in the pattern already defined. A copy of the LICENSE should be

--- a/docs/src/dev/developer/release.asciidoc
+++ b/docs/src/dev/developer/release.asciidoc
@@ -174,8 +174,8 @@ The source distribution is provided by:
 	apache-tinkerpop-xx.yy.zz-src.zip
 
 Two binary distributions are provided for user convenience:
-	apache-gremlin-console-xx.yy.zz-bin.zip
-	apache-gremlin-server-xx.yy.zz-bin.zip
+	apache-tinkerpop-gremlin-console-xx.yy.zz-bin.zip
+	apache-tinkerpop-gremlin-server-xx.yy.zz-bin.zip
 
 The GPG key used to sign the release artifacts is available at:
     https://dist.apache.org/repos/dist/dev/tinkerpop/KEYS
@@ -236,8 +236,8 @@ there is breaking change, an important game-changing feature or two, etc.]
 
 The release artifacts can be found at this location:
 
-https://www.apache.org/dyn/closer.lua/tinkerpop/xx.yy.zz/apache-gremlin-console-xx.yy.zz-bin.zip
-https://www.apache.org/dyn/closer.lua/tinkerpop/xx.yy.zz/apache-gremlin-server-xx.yy.zz-bin.zip
+https://www.apache.org/dyn/closer.lua/tinkerpop/xx.yy.zz/apache-tinkerpop-gremlin-console-xx.yy.zz-bin.zip
+https://www.apache.org/dyn/closer.lua/tinkerpop/xx.yy.zz/apache-tinkerpop-gremlin-server-xx.yy.zz-bin.zip
 
 The online docs can be found here:
 

--- a/docs/src/tutorials/getting-started/index.asciidoc
+++ b/docs/src/tutorials/getting-started/index.asciidoc
@@ -51,13 +51,13 @@ NOTE: Are you unsure of what a vertex or edge is? That topic is covered in the <
 but please allow the tutorial to get you oriented with the Gremlin Console first, so that you have an understanding of
 the tool that will help you with your learning experience.
 
-link:https://www.apache.org/dyn/closer.lua/tinkerpop/x.y.z/apache-gremlin-console-x.y.z-bin.zip[Download the console],
+link:https://www.apache.org/dyn/closer.lua/tinkerpop/x.y.z/apache-tinkerpop-gremlin-console-x.y.z-bin.zip[Download the console],
 unpackage it and start it:
 
 [source,text]
 ----
-$ unzip apache-gremlin-console-x.y.z-bin.zip
-$ cd apache-gremlin-console-x.y.z-bin.zip
+$ unzip apache-tinkerpop-gremlin-console-x.y.z-bin.zip
+$ cd apache-tinkerpop-gremlin-console-x.y.z-bin.zip
 $ bin/gremlin.sh
 
          \,,,/
@@ -532,9 +532,9 @@ containing a Gremlin script to be processed with results returned.
 
 [source,text]
 ----
-$ curl -L -O https://www.apache.org/dist/tinkerpop/x.y.z/apache-gremlin-server-x.y.z-bin.zip
-$ unzip apache-gremlin-server-x.y.z-bin.zip
-$ cd apache-gremlin-server-x.y.z-bin.zip
+$ curl -L -O https://www.apache.org/dist/tinkerpop/x.y.z/apache-tinkerpop-gremlin-server-x.y.z-bin.zip
+$ unzip apache-tinkerpop-gremlin-server-x.y.z-bin.zip
+$ cd apache-tinkerpop-gremlin-server-x.y.z-bin.zip
 $ bin/gremlin-server.sh conf/gremlin-server-modern.yaml
 [INFO] GremlinServer -
          \,,,/

--- a/gremlin-console/bin/gremlin.sh
+++ b/gremlin-console/bin/gremlin.sh
@@ -20,5 +20,5 @@
 #
 
 OPTS=$@
-set JAVA_OPTIONS="-Dtinkerpop.ext=/../target/apache-gremlin-*-standalone/ext -Dlog4j.configuration=conf/log4j-console.properties -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL"
-`dirname $0`/../target/apache-gremlin-*-standalone/bin/gremlin.sh $OPTS
+set JAVA_OPTIONS="-Dtinkerpop.ext=/../target/apache-tinkerpop-gremlin-*-standalone/ext -Dlog4j.configuration=conf/log4j-console.properties -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL"
+`dirname $0`/../target/apache-tinkerpop-gremlin-*-standalone/bin/gremlin.sh $OPTS

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -116,7 +116,7 @@ limitations under the License.
                     <descriptors>
                         <descriptor>src/assembly/standalone.xml</descriptor>
                     </descriptors>
-                    <finalName>apache-${project.artifactId}-${project.version}</finalName>
+                    <finalName>apache-tinkerpop-${project.artifactId}-${project.version}</finalName>
                     <outputDirectory>target</outputDirectory>
                     <workDirectory>target/assembly/work</workDirectory>
                     <tarLongFileMode>warn</tarLongFileMode>


### PR DESCRIPTION
Fixed gremlin.sh and assembly descriptor, updated documentation