### PR TITLE
TINKERPOP-1397 Fix StarGraph.addEdge

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -37,6 +37,7 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -290,14 +291,16 @@ public final class StarGraph implements Graph, Serializable {
         public Edge addEdge(final String label, final Vertex inVertex, final Object... keyValues) {
             final Edge edge = this.addOutEdge(label, inVertex, keyValues);
             if (inVertex.equals(this)) {
-                if(null == this.inEdges)
-                    this.inEdges = new HashMap<>();
-                List<Edge> inE = this.inEdges.get(label);
-                if (null == inE) {
-                    inE = new ArrayList<>();
-                    this.inEdges.put(label, inE);
+                if (ElementHelper.getIdValue(keyValues).isPresent()) {
+                    // reuse edge ID from method params
+                    this.addInEdge(label, this, keyValues);
+                } else {
+                    // copy edge ID that we just allocated with addOutEdge
+                    final Object[] keyValuesWithId = Arrays.copyOf(keyValues, keyValues.length + 2);
+                    keyValuesWithId[keyValuesWithId.length - 2] = T.id;
+                    keyValuesWithId[keyValuesWithId.length - 1] = edge.id();
+                    this.addInEdge(label, this, keyValuesWithId);
                 }
-                inE.add(edge);
             }
             return edge;
         }


### PR DESCRIPTION
See:

* old PR #372
* JIRA issue https://issues.apache.org/jira/browse/TINKERPOP-1397

As far as I can tell, GraphFilter did not exist in 3.1, and it may not even be possible to induce the buggy traversal behavior describe in #372 (which was all based on master / 3.2).  The underlying datastructure corruption -- putting a StarOutEdge into the `inEdges` map -- does exist on 3.1, and @okram's `addEdge` fix applies cleanly on 3.1, but without `applyGraphFilter`, I'm not sure it even matters for correctness on 3.1.