### PR TITLE
TINKERPOP-1402 Added IoBuilder.onMapper() method.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.2.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Changed scope of log4j dependencies so that they would only be used in tests and the binary distributions of Gremlin Console and Server.
+* Deprecated `Io.Builder.registry()` in favor of the newly introduced `Io.Builder.onMapper()`.
 * Added new recipe for "Traversal Induced Values".
 * Fixed a potential leak of a `ReferenceCounted` resource in Gremlin Server.
 * Added class registrations for `Map.Entry` implementations to `GryoMapper`.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -50,6 +50,17 @@ Upgrading for Providers
 Graph System Providers
 ^^^^^^^^^^^^^^^^^^^^^^
 
+Deprecated Io.Builder.registry()
+++++++++++++++++++++++++++++++++
+
+The `Io.Builder.registry()` has been deprecated in favor of `Io.Builder.onMapper(Consumer<Mapper>)`. This change gives
+the `Graph` implementation greater flexibility over how to modify the `Mapper` implementation. In most cases, the
+implementation will simply add its `IoRegistry` to allow the `Mapper` access to custom serialization classes, but this
+approach makes it possible to also set other specific settings that aren't generalized across all IO implementations.
+A good example of this type of usage would be to provide a custom `ClassRessolver` implementation to a `GryoMapper`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1402[TINKERPOP-1402]
+
 Log4j Dependencies
 ++++++++++++++++++
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/Io.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/Io.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.structure.io;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * Ties together the core interfaces of an IO format: {@link GraphReader}, {@link GraphWriter} and {@link Mapper}.
@@ -90,8 +91,23 @@ public interface Io<R extends GraphReader.ReaderBuilder, W extends GraphWriter.W
          * should not use this method directly.  If a user wants to register custom serializers, then such things
          * can be done via calls to {@link Io#mapper()} after the {@link Io} is constructed via
          * {@link Graph#io(Io.Builder)}.
+         * @deprecated As of release 3.2.2, replaced by {@link #onMapper(Consumer)}.
          */
+        @Deprecated
         public Builder<? extends Io> registry(final IoRegistry registry);
+
+        /**
+         * Allows a {@link Graph} implementation to have full control over the {@link Mapper.Builder} instance.
+         * Typically, the implementation will just pass in its {@link IoRegistry} implementation so that the
+         * {@link Mapper} that gets built will have knowledge of any custom classes and serializers it may have. Note
+         * that if {@link #registry(IoRegistry)} is also set on a {@code Builder} instance it will be applied first
+         * prior to that instance being passed to {@code Consumer}.
+         * <p/>
+         * End-users should not use this method directly.  If a user wants to register custom serializers, then such
+         * things can be done via calls to {@link Io#mapper()} after the {@link Io} is constructed via
+         * {@link Graph#io(Io.Builder)}.
+         */
+        public Builder<? extends Io> onMapper(final Consumer<Mapper.Builder> onMapper);
 
         /**
          * Providers use this method to supply the current instance of their {@link Graph} to the builder.  End-users

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLIo.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLIo.java
@@ -21,13 +21,15 @@ package org.apache.tinkerpop.gremlin.structure.io.graphml;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.io.IoRegistry;
-import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapper;
+import org.apache.tinkerpop.gremlin.structure.io.Mapper;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * Constructs GraphML IO implementations given a {@link Graph} and {@link IoRegistry}. Implementers of the {@link Graph}
@@ -38,9 +40,11 @@ import java.io.OutputStream;
  */
 public final class GraphMLIo implements Io<GraphMLReader.Builder, GraphMLWriter.Builder, GraphMLMapper.Builder> {
     private final Graph graph;
+    private Optional<Consumer<Mapper.Builder>> onMapper;
 
-    private GraphMLIo(final Graph graph) {
-        this.graph = graph;
+    private GraphMLIo(final Builder builder) {
+        this.graph = builder.graph;
+        this.onMapper = Optional.ofNullable(builder.onMapper);
     }
 
     /**
@@ -64,7 +68,9 @@ public final class GraphMLIo implements Io<GraphMLReader.Builder, GraphMLWriter.
      */
     @Override
     public GraphMLMapper.Builder mapper() {
-        return GraphMLMapper.build();
+        final GraphMLMapper.Builder builder = GraphMLMapper.build();
+        onMapper.ifPresent(c -> c.accept(builder));
+        return builder;
     }
 
     /**
@@ -94,10 +100,21 @@ public final class GraphMLIo implements Io<GraphMLReader.Builder, GraphMLWriter.
     public final static class Builder implements Io.Builder<GraphMLIo> {
 
         private Graph graph;
+        private Consumer<Mapper.Builder> onMapper = null;
 
+        /**
+         * @deprecated As of release 3.2.2, replaced by {@link #onMapper(Consumer)}.
+         */
+        @Deprecated
         @Override
         public Io.Builder<GraphMLIo> registry(final IoRegistry registry) {
             // GraphML doesn't make use of a registry but the contract should simply exist
+            return this;
+        }
+
+        @Override
+        public Io.Builder<? extends Io> onMapper(final Consumer<Mapper.Builder> onMapper) {
+            this.onMapper = onMapper;
             return this;
         }
 
@@ -110,7 +127,7 @@ public final class GraphMLIo implements Io<GraphMLReader.Builder, GraphMLWriter.
         @Override
         public GraphMLIo create() {
             if (null == graph) throw new IllegalArgumentException("The graph argument was not specified");
-            return new GraphMLIo(graph);
+            return new GraphMLIo(this);
         }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONIo.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONIo.java
@@ -21,12 +21,15 @@ package org.apache.tinkerpop.gremlin.structure.io.graphson;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.io.IoRegistry;
+import org.apache.tinkerpop.gremlin.structure.io.Mapper;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * Constructs GraphSON IO implementations given a {@link Graph} and {@link IoRegistry}. Implementers of the {@link Graph}
@@ -37,10 +40,12 @@ import java.io.OutputStream;
 public final class GraphSONIo implements Io<GraphSONReader.Builder, GraphSONWriter.Builder, GraphSONMapper.Builder> {
     private final IoRegistry registry;
     private final Graph graph;
+    private Optional<Consumer<Mapper.Builder>> onMapper;
 
-    private GraphSONIo(final IoRegistry registry, final Graph graph) {
-        this.registry = registry;
-        this.graph = graph;
+    private GraphSONIo(final Builder builder) {
+        this.registry = builder.registry;
+        this.graph = builder.graph;
+        this.onMapper = Optional.ofNullable(builder.onMapper);
     }
 
     /**
@@ -64,7 +69,9 @@ public final class GraphSONIo implements Io<GraphSONReader.Builder, GraphSONWrit
      */
     @Override
     public GraphSONMapper.Builder mapper() {
-        return (null == this.registry) ? GraphSONMapper.build() : GraphSONMapper.build().addRegistry(registry);
+        final GraphSONMapper.Builder builder = (null == this.registry) ? GraphSONMapper.build() : GraphSONMapper.build().addRegistry(this.registry);
+        onMapper.ifPresent(c -> c.accept(builder));
+        return builder;
     }
 
     /**
@@ -95,10 +102,21 @@ public final class GraphSONIo implements Io<GraphSONReader.Builder, GraphSONWrit
 
         private IoRegistry registry = null;
         private Graph graph;
+        private Consumer<Mapper.Builder> onMapper = null;
 
+        /**
+         * @deprecated As of release 3.2.2, replaced by {@link #onMapper(Consumer)}.
+         */
+        @Deprecated
         @Override
         public Io.Builder<GraphSONIo> registry(final IoRegistry registry) {
             this.registry = registry;
+            return this;
+        }
+
+        @Override
+        public Io.Builder<? extends Io> onMapper(final Consumer<Mapper.Builder> onMapper) {
+            this.onMapper = onMapper;
             return this;
         }
 
@@ -111,7 +129,7 @@ public final class GraphSONIo implements Io<GraphSONReader.Builder, GraphSONWrit
         @Override
         public GraphSONIo create() {
             if (null == graph) throw new IllegalArgumentException("The graph argument was not specified");
-            return new GraphSONIo(registry, graph);
+            return new GraphSONIo(this);
         }
     }
 }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -231,7 +231,7 @@ public final class TinkerGraph implements Graph {
 
     @Override
     public <I extends Io> I io(final Io.Builder<I> builder) {
-        return (I) builder.graph(this).registry(TinkerIoRegistry.getInstance()).create();
+        return (I) builder.graph(this).onMapper(mapper -> mapper.addRegistry(TinkerIoRegistry.getInstance())).create();
     }
 
     @Override

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
@@ -453,7 +454,8 @@ public class TinkerGraphTest {
 
         //Test write graph
         graph.close();
-        assertEquals(TestIoBuilder.calledRegistry, 1);
+        assertEquals(TestIoBuilder.calledRegistry, 0);
+        assertEquals(TestIoBuilder.calledOnMapper, 1);
         assertEquals(TestIoBuilder.calledGraph, 1);
         assertEquals(TestIoBuilder.calledCreate, 1);
 
@@ -465,7 +467,8 @@ public class TinkerGraphTest {
 
         //Test read graph
         final TinkerGraph readGraph = TinkerGraph.open(conf);
-        assertEquals(TestIoBuilder.calledRegistry, 1);
+        assertEquals(TestIoBuilder.calledRegistry, 0);
+        assertEquals(TestIoBuilder.calledOnMapper, 1);
         assertEquals(TestIoBuilder.calledGraph, 1);
         assertEquals(TestIoBuilder.calledCreate, 1);
     }
@@ -575,25 +578,32 @@ public class TinkerGraphTest {
         }
     }
 
-    public static class TestIoBuilder implements Io.Builder{
+    public static class TestIoBuilder implements Io.Builder {
 
-        static int calledRegistry, calledGraph, calledCreate;
+        static int calledRegistry, calledGraph, calledCreate, calledOnMapper;
 
         public TestIoBuilder(){
             //Looks awkward to reset static vars inside a constructor, but makes sense from testing perspective
-            calledRegistry=0;
-            calledGraph=0;
-            calledCreate=0;
+            calledRegistry = 0;
+            calledGraph = 0;
+            calledCreate = 0;
+            calledOnMapper = 0;
         }
 
         @Override
-        public Io.Builder<? extends Io> registry(IoRegistry registry) {
+        public Io.Builder<? extends Io> registry(final IoRegistry registry) {
             calledRegistry++;
             return this;
         }
 
         @Override
-        public Io.Builder<? extends Io> graph(Graph graph) {
+        public Io.Builder<? extends Io> onMapper(final Consumer onMapper) {
+            calledOnMapper++;
+            return this;
+        }
+
+        @Override
+        public Io.Builder<? extends Io> graph(final Graph graph) {
             calledGraph++;
             return this;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1402

Deprecated IoBuilder.registry() in the process of doing that. This should provide greater flexibility to Graph providers who can now not only supply a custom IoRegistry but also access other non-generalized features of a Mapper.Builder instance.

Tested with `mvn clean install`. I did a one-time test before changing TinkerGraph to stop using the deprecated `registry` method and the build worked fine so I think that even though we can't directly test the old `registry` method anymore, it still should be working ok if provides elect to stick with it.

VOTE +1