### PR TITLE
TINKERPOP-1405 - profile() doesn't like withPath()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ TinkerPop 3.2.2 (NOT OFFICIALLY RELEASED YET)
 * Added methods to retrieve `Cluster` settings in `gremlin-driver`.
 * Fixed a severe bug in `SubgraphStrategy`.
 * Deprecated `SubgraphStrategy.Builder.vertexCriterion()/edgeCriterion()` in favor of `vertices()/edges()`.
+* Fixed a small bug in `StandardVerificationStrategy` that caused verification to fail when `withPath` was used in conjunction with `ProfileStep`.
 
 [[release-3-2-1]]
 TinkerPop 3.2.1 (Release Date: July 18, 2016)


### PR DESCRIPTION
Fixed a small bug in `StandardVerificationStrategy` that caused verification to fail when `withPath` was used in conjunction with `ProfileStep`.  Updated `StandardVerificationStrategyTest` to test traversals with `ProfileStep` and added a test to confirm verification failed on a reducing barrier nested within a repeat while I was at it.

This issue did not arise in TP31 so I took a look and the TP31 `StandardVerificationStrategy` does not have the `ProfileStep` and some other verification verification logic in it that is in master.  Because of this, I pointed this PR only at master but can re-point to TP31 and add the profile step verification in if you guys think that makes sense.

The Travis build appears to have stalled out while downloading artifacts.  Tests passed local with `mvn clean install`

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 24:25 min
[INFO] Finished at: 2016-08-16T08:43:01-05:00
[INFO] Final Memory: 140M/843M
[INFO] ------------------------------------------------------------------------
```

VOTE: +1