### PR TITLE
TINKERPOP-1285 added multi-line line number support

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ TinkerPop 3.2.2 (NOT OFFICIALLY RELEASED YET)
 * Fixed a small bug in `StandardVerificationStrategy` that caused verification to fail when `withPath` was used in conjunction with `ProfileStep`.
 * Added color preferences
 * Added input, result prompt preferences
+* Added multi-line indicator in Gremlin Console
 
 [[release-3-2-1]]
 TinkerPop 3.2.1 (Release Date: July 18, 2016)

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -85,6 +85,14 @@ Prompts
 * result.prompt
 * empty.result.indicator
 
+See: https://issues.apache.org/jira/browse/TINKERPOP-1285[TINKERPOP-1037]
+
+
+Added multi-line indicator.
+
+See: https://issues.apache.org/jira/browse/TINKERPOP-1285[TINKERPOP-1285]
+
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -171,14 +171,14 @@ class Console {
         if (interactive) {
             int lineNo = groovy.buffers.current().size() 
             if (lineNo > 0 ) {
-                String lineStr = lineNo.toString() + "> "
-                int pad = Preferences.inputPrompt.length() - lineStr.length()
+                String lineStr = lineNo.toString() + ">"
+                int pad = Preferences.inputPrompt.length() - lineStr.length() + 2
                 if (pad < 0) {
                     pad = 0
                 }
-                return Colorizer.render(Preferences.inputPromptColor, lineNo.toString().padLeft(pad, '.'))
+                return Colorizer.render(Preferences.inputPromptColor, lineStr.toString().padLeft(pad, '.') + ' ')
             } else {
-                return Colorizer.render(Preferences.inputPromptColor, Preferences.inputPrompt + " ")
+                return Colorizer.render(Preferences.inputPromptColor, Preferences.inputPrompt + ' ')
             }
         } else {
             return ""

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -167,7 +167,23 @@ class Console {
             groovy.setResultHook(handleResultShowNothing)
     }
 
-    private def handlePrompt = { interactive ? Colorizer.render(Preferences.inputPromptColor, Preferences.inputPrompt + " ") : "" }
+    private def handlePrompt = { 
+        if (interactive) {
+            int lineNo = groovy.buffers.current().size() 
+            if (lineNo > 0 ) {
+                String lineStr = lineNo.toString() + "> "
+                int pad = Preferences.inputPrompt.length() - lineStr.length()
+                if (pad < 0) {
+                    pad = 0
+                }
+                return Colorizer.render(Preferences.inputPromptColor, lineNo.toString().padLeft(pad, '.'))
+            } else {
+                return Colorizer.render(Preferences.inputPromptColor, Preferences.inputPrompt + " ")
+            }
+        } else {
+            return ""
+        }
+    }
 
     private def handleResultShowNothing = { args -> null }
 


### PR DESCRIPTION
Looks like:
```
gremlin> 1 +
001    > 2 +
002    > 3 +
003    > x
No such property: x for class: groovysh_evaluate
Display stack trace? [yN] 
003    > 4
==>10

```
Note that the line number remained the same for the correction.

Example from the jira ticket:
```
gremlin> script = """line1
001    > line2
002    > line3
003    > ...
004    > """
==>line1
line2
line3
...

gremlin> 
...

gremlin> 
```

Multi-line query:
```
gremlin> g.V().has(
001    > 'name',
002    > 'marko')
==>v[1]
gremlin>
```