### PR TITLE
TINKERPOP-1386 Bumped to Netty 4.0.40.final

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Included GraphSON as a default serializer (in addition to Gryo, which was already present) in Gremlin Server if none are defined
+* Included GraphSON as a default serializer (in addition to Gryo, which was already present) in Gremlin Server if none are defined.
+* Bumped to Netty 4.0.40.final.
 * Defaulted the `gremlinPool` setting in Gremlin Server to be zero, which will instructs it to use `Runtime.availableProcessors()` for that settings.
 * Changed scope of log4j dependencies so that they would only be used in tests and the binary distributions of Gremlin Console and Server.
 * Deprecated `Io.Builder.registry()` in favor of the newly introduced `Io.Builder.onMapper()`.

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
     <artifactId>gremlin-driver</artifactId>
     <name>Apache TinkerPop :: Gremlin Driver</name>
     <properties>
-        <netty.version>4.0.34.Final</netty.version>
+        <netty.version>4.0.40.Final</netty.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1386

Hand to modify the WebSocketClient slightly as it was taking advantage of a bug in netty that was fixed at 4.0.35.final: https://github.com/netty/netty/commit/2e6544fc0e2581f96652be02d86e777e8e0493bc#diff-e4e87d5bebf757b077c19618841f41a6R56

All good with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1