### PR TITLE
Cleanup of Python code in groovy traversal generator

### DIFF
--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
@@ -53,7 +53,8 @@ specific language governing permissions and limitations
 under the License.
 '''
 """)
-        pythonClass.append("from abc import abstractmethod\n")
+        pythonClass.append("import abc\n")
+        pythonClass.append("import six\n")
         pythonClass.append("from aenum import Enum\n")
         pythonClass.append("from .. import statics\n")
 
@@ -189,17 +190,16 @@ class TraversalStrategies(object):
     global_cache = {}
     def __init__(self, traversal_strategies=None):
         self.traversal_strategies = traversal_strategies.traversal_strategies if traversal_strategies is not None else []
-        return
     def add_strategies(self, traversal_strategies):
         self.traversal_strategies = self.traversal_strategies + traversal_strategies
     def apply_strategies(self, traversal):
         for traversal_strategy in self.traversal_strategies:
             traversal_strategy.apply(traversal)
-        return
 
 
+@six.add_metaclass(abc.ABCMeta)
 class TraversalStrategy(object):
-    @abstractmethod
+    @abc.abstractmethod
     def apply(self, traversal):
         return
 
@@ -220,13 +220,11 @@ class Bytecode(object):
         for arg in args:
             instruction.append(self.__convertArgument(arg))
         self.source_instructions.append(instruction)
-        return
     def add_step(self, step_name, *args):
         instruction = [step_name]
         for arg in args:
             instruction.append(self.__convertArgument(arg))
         self.step_instructions.append(instruction)
-        return
     def __convertArgument(self,arg):
         if isinstance(arg, Traversal):
             self.bindings.update(arg.bytecode.bindings)

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -16,7 +16,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 '''
-from abc import abstractmethod
+import abc
+import six
 from aenum import Enum
 from .. import statics
 
@@ -247,17 +248,16 @@ class TraversalStrategies(object):
     global_cache = {}
     def __init__(self, traversal_strategies=None):
         self.traversal_strategies = traversal_strategies.traversal_strategies if traversal_strategies is not None else []
-        return
     def add_strategies(self, traversal_strategies):
         self.traversal_strategies = self.traversal_strategies + traversal_strategies
     def apply_strategies(self, traversal):
         for traversal_strategy in self.traversal_strategies:
             traversal_strategy.apply(traversal)
-        return
 
 
+@six.add_metaclass(abc.ABCMeta)
 class TraversalStrategy(object):
-    @abstractmethod
+    @abc.abstractmethod
     def apply(self, traversal):
         return
 
@@ -278,13 +278,11 @@ class Bytecode(object):
         for arg in args:
             instruction.append(self.__convertArgument(arg))
         self.source_instructions.append(instruction)
-        return
     def add_step(self, step_name, *args):
         instruction = [step_name]
         for arg in args:
             instruction.append(self.__convertArgument(arg))
         self.step_instructions.append(instruction)
-        return
     def __convertArgument(self,arg):
         if isinstance(arg, Traversal):
             self.bindings.update(arg.bytecode.bindings)


### PR DESCRIPTION
This PR makes some very simple changes to the groovy traversal source generator:

- Removes unnecessary `return` statements (Python returns `None` implicitly)
- Makes the class `TraversalStrategy` into a real base class.  