### PR TITLE
Implemented side effect interface for gremlin-python

### DIFF
--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
@@ -81,6 +81,10 @@ class Traversal(object):
         if self.last_traverser.bulk <= 0:
             self.last_traverser = None
         return object
+    def sideEffects(self):
+        if self.traversers is None:
+            self.traversal_strategies.apply_strategies(self)
+        return self.side_effects
     def toList(self):
         return list(iter(self))
     def toSet(self):

--- a/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
@@ -70,7 +70,6 @@ class DriverRemoteConnection(RemoteConnection):
 
         :returns: :py:class:`Response` object
         """
-        print(request_id)
         message = self._get_bytecode_message(bytecode, request_id)
         traversers = yield self._execute_message(message, parse_traverser)
         raise gen.Return(traversers)

--- a/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
@@ -61,4 +61,3 @@ class RemoteStrategy(TraversalStrategy):
             remote_traversal = self.remote_connection.submit(traversal.bytecode)
             traversal.side_effects = remote_traversal.side_effects
             traversal.traversers = remote_traversal.traversers
-        return

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -43,6 +43,10 @@ class Traversal(object):
         if self.last_traverser.bulk <= 0:
             self.last_traverser = None
         return object
+    def sideEffects(self):
+        if self.traversers is None:
+            self.traversal_strategies.apply_strategies(self)
+        return self.side_effects
     def toList(self):
         return list(iter(self))
     def toSet(self):


### PR DESCRIPTION
This is my first go at implementing a side effects interface for gremlin-python. It allows you to do things like:

```python
from gremlin_python.structure import Graph
from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection

rc = DriverRemoteConnection('ws://localhost:8182', 'g')
graph = Graph()
g = graph.traversal().withRemote(rc)

resp = g.V().aggregate('a')
side_effects = resp.sideEffects()
side_effects.keys()  # a list of keys
for x in side_effects.get('a'):
    print(x)
```

Alternately, if the traversal has already been executed, the side effects interface can be accessed like a property:

```python
traversal = g.V().aggregate('a')
results = traversal.toList()
side_effects = traversal.side_effects.get('a')

# or call like a function as in previous example:
side_effects = traversal.sideEffects().get('a')
``` 

Now, there may be some cleanup or review necessary, in general I would like to review property getters and setters for the gremlin-python module.

Also note, the above examples are run against the 1278 branch with a configuration that includes the GraphSON v2 serializer:

```
  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { useMapperFromGraph: graph }} # application/vnd.gremlin-v2.0+json
```