### PR TITLE
GraphSON 2.0 Deser tweaks and improvements

### DIFF
--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGraphSONSerializerV2d0Test.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGraphSONSerializerV2d0Test.java
@@ -469,30 +469,23 @@ public class TinkerGraphGraphSONSerializerV2d0Test {
     }
 
     @Test
-    public void deserializersTree() {
+    public void deserializersTestsTree() {
         final TinkerGraph tg = TinkerFactory.createModern();
 
-        final GraphWriter writer = getWriter(noTypesMapperV2d0);
-        final GraphReader reader = getReader(noTypesMapperV2d0);
+        final GraphWriter writer = getWriter(defaultMapperV2d0);
+        final GraphReader reader = getReader(defaultMapperV2d0);
 
         final Tree t = tg.traversal().V().out().out().tree().next();
 
         try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            final Vertex v = tg.traversal().V(1).next();
-                     v.property("myUUIDprop", UUID.randomUUID());
-            writer.writeObject(out, v);
-
-
-//            writer.writeObject(out, t);
+            writer.writeObject(out, t);
             final String json = out.toString();
 
-            //System.out.println("json = " + json);
-
-//            Tree treeRead = (Tree)reader.readObject(new ByteArrayInputStream(json.getBytes()), Object.class);
+            Tree treeRead = (Tree)reader.readObject(new ByteArrayInputStream(json.getBytes()), Object.class);
             //Map's equals should check each component of the tree recursively
             //on each it will call "equals()" which for Vertices will compare ids, which
             //is ok. Complete vertex deser is checked elsewhere.
-//            assertEquals(t, treeRead);
+            assertEquals(t, treeRead);
 
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
There's 2 commits: 

- the first brings a massive improvement to the GraphSON 2.0 deserialization, avoiding a lot of useless copies done on the JSON parser when parsing to detect a type in the payload. There's in almost every case no copy done anymore, thus reducing the memory impact and improves performances.
- second fixes a bug I had on my machine that was causing a StackOverflow exception when deserializing a `Tree` from GraphSON2.0. The issue has been pinned down to understanding that there could be a never-ending recursive reference when creating a `JavaType` to be indexed in the GraphSONTypeIdResolver. All detailed in comments in the code but now I have a special case for when a `Tree` is registered that force a non-cyclic reference type. It is still unclear to me why this happens to me but not all the time for @spmallette for example. In any case this fixes it for me and should be fixing for everybody..