### PR TITLE
TINKERPOP-1419 : Throw a proper exception when no available host in a SessionedClient

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -654,6 +654,7 @@ public abstract class Client {
             final List<Host> hosts = cluster.allHosts()
                     .stream().filter(Host::isAvailable).collect(Collectors.toList());
             Collections.shuffle(hosts);
+            if (hosts.isEmpty()) throw new IllegalStateException("No available host in the cluster");
             final Host host = hosts.get(0);
             connectionPool = new ConnectionPool(host, this, Optional.of(1), Optional.of(1));
         }


### PR DESCRIPTION
When a SessionedClient is initialized and no host is available in the cluster,
A proper exception is thrown instead of an IndexOutOfBoundsException