### PR TITLE
Add pytest-runner in order to properly build gremlin-python dependencies.

### DIFF
--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -323,9 +323,8 @@
                                 <configuration>
                                     <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                                     <libraries>
-                                        <param>aenum</param>
-                                        <param>requests</param>
-                                        <param>tornado</param>
+                                        <param>aenum==1.4.5</param>
+                                        <param>tornado==4.4.1</param>
                                     </libraries>
                                 </configuration>
                             </execution>

--- a/gremlin-python/src/main/jython/setup.cfg
+++ b/gremlin-python/src/main/jython/setup.cfg
@@ -22,3 +22,4 @@ test=pytest
 
 [tool:pytest]
 addopts = --junitxml=../python-reports/TEST-native-python.xml
+norecursedirs = '.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg' lib lib64

--- a/gremlin-python/src/main/jython/setup.cfg
+++ b/gremlin-python/src/main/jython/setup.cfg
@@ -17,5 +17,8 @@
 [bdist_wheel]
 universal=1
 
-[pytest]
+[aliases]
+test=pytest
+
+[tool:pytest]
 addopts = --junitxml=../python-reports/TEST-native-python.xml

--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -43,17 +43,6 @@ import __version__
 
 version = __version__.version
 
-class PyTest(Command):
-    user_options = []
-    def initialize_options(self):
-        pass
-    def finalize_options(self):
-        pass
-    def run(self):
-        import sys,subprocess
-        errno = subprocess.call([sys.executable, 'runtest.py'])
-        raise SystemExit(errno)
-
 setup(
     name='gremlinpython',
     version=version,
@@ -63,7 +52,6 @@ setup(
     description='Gremlin-Python for Apache TinkerPop',
     long_description=open("README").read(),
     test_suite="tests",
-    cmdclass = {'test': PyTest},
     setup_requires=[
         'pytest-runner',
     ],

--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -64,12 +64,14 @@ setup(
     long_description=open("README").read(),
     test_suite="tests",
     cmdclass = {'test': PyTest},
+    setup_requires=[
+        'pytest-runner',
+    ],
     tests_require=[
         'pytest'
     ],
     install_requires=[
-        'aenum',
-        'requests',
-        'tornado'
+        'aenum==1.4.5',
+        'tornado==4.4.1'
     ]
 )


### PR DESCRIPTION
Use `pytest-runner` in order to invoke `pytest` using the `setup.py test` command and properly build dependencies. Otherwise, tests will fail unless all dependencies are installed locally. This PR also specifies versions for `tornado` and `aenum`, as well as removing the custom `PyTest` command from `setup.py` (unneeded due to `pytest-runner`).
