### PR TITLE
Fix InetAddress serialization with GraphSON 2.0.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeSerializer.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeIdResolver;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeSerializer;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 
 /**
@@ -193,6 +194,8 @@ public class GraphSONTypeSerializer extends TypeSerializer {
             return Property.class;
         } else if (ByteBuffer.class.isAssignableFrom(c)) {
             return ByteBuffer.class;
+        } else if (InetAddress.class.isAssignableFrom(c)) {
+            return InetAddress.class;
         } else if (Traverser.class.isAssignableFrom(c)) {
             return Traverser.class;
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONXModuleV2d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONXModuleV2d0.java
@@ -24,6 +24,7 @@ package org.apache.tinkerpop.gremlin.structure.io.graphson;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
@@ -55,6 +56,7 @@ public final class GraphSONXModuleV2d0 extends GraphSONModule {
                 put(BigDecimal.class, "BigDecimal");
                 put(Byte.class, "Byte");
                 put(Character.class, "Char");
+                put(InetAddress.class, "InetAddress");
 
                 // Time serializers/deserializers
                 put(Duration.class, "Duration");

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGraphSONSerializerV2d0Test.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGraphSONSerializerV2d0Test.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -227,6 +228,7 @@ public class TinkerGraphGraphSONSerializerV2d0Test {
         final Duration durationProp = Duration.ofHours(3);
         final Long longProp = 2L;
         final ByteBuffer byteBufferProp = ByteBuffer.wrap("testbb".getBytes());
+        final InetAddress inetAddressProp = InetAddress.getByName("10.10.10.10");
 
         // One Java util type natively supported by Jackson
         v.property("uuid", uuidProp);
@@ -236,6 +238,8 @@ public class TinkerGraphGraphSONSerializerV2d0Test {
         v.property("long", longProp);
         // One Java util type added by GraphSON
         v.property("bytebuffer", byteBufferProp);
+        v.property("inetaddress", inetAddressProp);
+
 
         final GraphWriter writer = getWriter(defaultMapperV2d0);
         final GraphReader reader = getReader(defaultMapperV2d0);
@@ -249,6 +253,7 @@ public class TinkerGraphGraphSONSerializerV2d0Test {
             assertEquals(vRead.property("duration").value(), durationProp);
             assertEquals(vRead.property("long").value(), longProp);
             assertEquals(vRead.property("bytebuffer").value(), byteBufferProp);
+            assertEquals(vRead.property("inetaddress").value(), inetAddressProp);
         }
     }
 


### PR DESCRIPTION
InetAddress serialization/deserialization wasn't working with GraphSON 2.0.

"InetAddress" type has been added to the `GraphSONXModule`.