### PR TITLE
TINKERPOP-1444: Benchmark bytecode->Traversal creation and implement GremlinServer cache if necessary.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
@@ -106,8 +106,8 @@ public final class JavaTranslator<S extends TraversalSource, T extends Traversal
         //////////////////////////
         // populate method cache for fast access to methods in subsequent calls
         final Map<String, List<Method>> methodCache = delegate instanceof TraversalSource ?
-                this.TRAVERSAL_SOURCE_METHOD_CACHE.getOrDefault(delegate.getClass(), new HashMap<>()) :
-                this.TRAVERSAL_METHOD_CACHE.getOrDefault(delegate.getClass(), new HashMap<>());
+                TRAVERSAL_SOURCE_METHOD_CACHE.getOrDefault(delegate.getClass(), new HashMap<>()) :
+                TRAVERSAL_METHOD_CACHE.getOrDefault(delegate.getClass(), new HashMap<>());
         if (methodCache.isEmpty()) {
             for (final Method method : delegate.getClass().getMethods()) {
                 if (!(method.getName().equals("addV") && method.getParameterCount() == 1 && method.getParameters()[0].getType().equals(Object[].class))) { // hack cause its hard to tell Object[] vs. String :|

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -77,7 +77,7 @@ public class TinkerGraphPlayTest {
 
         final Traversal<?, ?> traversal = g.V().repeat(out()).times(2).groupCount().by("name").select(Column.keys).order().by(Order.decr);
         final Bytecode bytecode = traversal.asAdmin().getBytecode();
-
+        //final JavaTranslator translator = JavaTranslator.of(g);
         final Map<Bytecode, Traversal.Admin<?, ?>> cache = new HashMap<>();
         cache.put(bytecode, traversal.asAdmin());
         final HashSet<?> result = new LinkedHashSet<>(Arrays.asList("ripple", "lop"));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1444

GremlinServer caching `Map<Bytecode,Traversal>` is only powerful (really powerful) when bindings are not involved (a solid 50x+ increase in speed). However, given that production systems will typically have bindings in their traversals, then such a cache doesn't help. 

In its place, a update to `JavaTranslator` is provided that makes use of an internal static `METHOD_CACHE` so as to make reflection faster. The speed up is provided below:

```
Prior to method caching:
  Bytecode->JavaTranslator call    : 0.13305238800000002
After method caching:
  Bytecode->JavaTranslator call    : 0.054839154
```

CHANGELOG

```
* Added a static method cache to `JavaTranslator` to reduce the cost of Java reflection.
```

@spmallette --- if you think that a `Map<Bytecode,Traversal>` cache IS necessary for GremlinServer,  then  please VOTE -1 and we can collaborate on this branch to also include a bytecode-cache.
