### PR TITLE
TINKERPOP-1449 Streamline gremlin-python build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ benchmarks/
 __pycache__/
 *.py[cdo]
 __version__.py
+.glv

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Fixed a `JavaTranslator` bug where `Bytecode` instructions were being mutated during translation.
 * Added `Path` to Gremlin-Python with respective GraphSON 2.0 deserializer.
+* New build options for `gremlin-python` where `-DglvPython` is no longer required.
 * Added missing `InetAddress` to GraphSON extension module.
 
 [[release-3-2-2]]

--- a/docs/preprocessor/preprocess-file.sh
+++ b/docs/preprocessor/preprocess-file.sh
@@ -133,7 +133,7 @@ if [ ! ${SKIP} ] && [ $(grep -c '^\[gremlin' ${input}) -gt 0 ]; then
 
   sed 's/\t/    /g' ${input} |
   awk -f ${AWK_SCRIPTS}/prepare.awk |
-  awk -f ${AWK_SCRIPTS}/init-code-blocks.awk -v TP_HOME="${TP_HOME}" -v PYTHONPATH="./gremlin-python/target/classes/Lib" |
+  awk -f ${AWK_SCRIPTS}/init-code-blocks.awk -v TP_HOME="${TP_HOME}" -v PYTHONPATH="${TP_HOME}/gremlin-python/target/classes/Lib" |
   awk -f ${AWK_SCRIPTS}/progressbar.awk -v tpl=${AWK_SCRIPTS}/progressbar.groovy.template |
   HADOOP_GREMLIN_LIBS="${CONSOLE_HOME}/ext/giraph-gremlin/lib:${CONSOLE_HOME}/ext/tinkergraph-gremlin/lib" bin/gremlin.sh |
   ${lb} awk -f ${AWK_SCRIPTS}/ignore.awk   |

--- a/docs/preprocessor/preprocess-file.sh
+++ b/docs/preprocessor/preprocess-file.sh
@@ -133,7 +133,7 @@ if [ ! ${SKIP} ] && [ $(grep -c '^\[gremlin' ${input}) -gt 0 ]; then
 
   sed 's/\t/    /g' ${input} |
   awk -f ${AWK_SCRIPTS}/prepare.awk |
-  awk -f ${AWK_SCRIPTS}/init-code-blocks.awk -v TP_HOME="${TP_HOME}" PYTHONPATH="." |
+  awk -f ${AWK_SCRIPTS}/init-code-blocks.awk -v TP_HOME="${TP_HOME}" -v PYTHONPATH="./gremlin-python/target/classes/Lib" |
   awk -f ${AWK_SCRIPTS}/progressbar.awk -v tpl=${AWK_SCRIPTS}/progressbar.groovy.template |
   HADOOP_GREMLIN_LIBS="${CONSOLE_HOME}/ext/giraph-gremlin/lib:${CONSOLE_HOME}/ext/tinkergraph-gremlin/lib" bin/gremlin.sh |
   ${lb} awk -f ${AWK_SCRIPTS}/ignore.awk   |

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ////
+[[development-environment]]
 Development Environment
 =======================
 
@@ -21,6 +22,7 @@ TinkerPop is fairly large body of code spread across many modules and covering m
 this complexity, it remains relatively straightforward a project to build. This following subsections explain how to
 configure a development environment for TinkerPop.
 
+[[system-configuration]]
 System Configuration
 --------------------
 

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -65,6 +65,16 @@ As of TinkerPop 3.2.2, the build optionally requires link:https://www.python.org
 Java tests that require Python code will be skipped. Developers should also install link:https://pypi.python.org/pypi/pip[pip]
 and link:https://virtualenv.pypa.io/en/stable/[virtualenv].
 
+Once the Python environment is established, the full building and testing of `gremlin-python` may commence. It can be
+done manually from the command line with:
+
+[source,text]
+mvn clean install -Pglv-python
+
+which enables the "glv-python" Maven profile or in a more automated fashion simply add a `.glv` file to the root of the
+`gremlin-python` module which will signify to Maven that the environment is Python-ready. The `.glv` file need not have
+any contents and is ignored by Git. A standard `mvn clean install` will then build `gremlin-python` in full.
+
 [[release-environment]]
 Release Environment
 ~~~~~~~~~~~~~~~~~~~
@@ -117,7 +127,6 @@ mvn -Dmaven.javadoc.skip=true --projects tinkergraph-gremlin test
 ** Clean the `.groovy/grapes/org.apache.tinkerpop` directory on build: `mvn clean install -DcleanGrapes`
 ** Turn off "heavy" logging in the "process" tests: `mvn clean install -DargLine="-DmuteTestLogs=true"`
 ** The test suite for `neo4j-gremlin` is disabled by default - to turn it on: `mvn clean install -DincludeNeo4j`
-** Build and execute with native Python tests (see <<python-environment,Python Environment>>: `mvn clean install -DglvPython`
 * Regenerate test data (only necessary given changes to IO classes): `mvn clean install -Dio` from `tinkergraph-gremlin` directory
 ** If there are changes to the Gryo format, it may be necessary to generate the Grateful Dead dataset from GraphSON (see `IoDataGenerationTest.shouldWriteGratefulDead`)
 * Check license headers are present: `mvn apache-rat:check`

--- a/docs/src/dev/developer/release.asciidoc
+++ b/docs/src/dev/developer/release.asciidoc
@@ -32,6 +32,10 @@ from a previous version or from recent `SNAPSHOT`. When using one generated for 
 commands end up being set to the version that is being released, making cut and paste of those commands less labor
 intensive and error prone.
 
+IMPORTANT: The following instructions assume that the release manager's <<development-environment,environment> is setup
+properly for release and includes a `.glv` file in `gremlin-python` as described in the <<python-environment,Python Environment>>
+section, so that the `gremlin-python` module builds in full.
+
 Pre-flight Check
 ----------------
 
@@ -46,7 +50,7 @@ and communicating with other members of the community.
 under release is protected. Tweaks to documentation and other odds and ends related to release are still allowed
 during this period.
 . At some point during the week:
-.. Run the full integration test suite: `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j -DglvPython`
+.. Run the full integration test suite: `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`
 .. Deploy a final SNAPSHOT to the snapshot repository.
 .. Review LICENSE and NOTICE files to make sure that no <<dependencies,changes are needed>>.
 .. Review javadoc filters on the "Core API" docs to be sure nothing needs to change.
@@ -70,7 +74,7 @@ A release candidate is an unofficial release that is represented by a tagged ver
 offered in cases where there is significant change in a particular version and the potential for upgrades and problems
 might be high.
 
-. `mvn clean install -DincludeNeo4j -DglvPython`
+. `mvn clean install -DincludeNeo4j`
 .. `mvn verify -DskipIntegrationTests=false -DincludeNeo4j`
 .. `mvn verify -DskipPerformanceTests=false`
 . `bin/publish-docs.sh <username>` - note that under a release candidate the documentation is published as SNAPSHOT
@@ -147,14 +151,14 @@ Release & Promote
 -----------------
 
 . Login to link:https://repository.apache.org/[Apache Nexus] and release the previously closed repository.
-. Deploy to link:https://pypi.python.org/pypi[pypi] with `mvn clean install -DskipTests -DglvPython -Dpypi`. It is likely necessary
-that this build will occur from the tag for the release, so be sure to checkout the tag first before executing this step.
+. Deploy to link:https://pypi.python.org/pypi[pypi]
+.. This build will likely occur from the tag for the release, so be sure to checkout the tag first before executing this step.
+.. `mvn clean install -DskipTests`
+.. `mvn deploy -pl gremlin-python -DskipTests -Dpypi`
 . `svn co --depth empty https://dist.apache.org/repos/dist/dev/tinkerpop dev; svn up dev/xx.yy.zz`
 . `svn co --depth empty https://dist.apache.org/repos/dist/release/tinkerpop release; mkdir release/xx.yy.zz`
 . Copy release files from `dev/xx.yy.zz` to `release/xx.yy.zz`.
 . `cd release; svn add xx.yy.zz/; svn ci -m "TinkerPop xx.yy.zz release"`
-. Deploy `gremlin-python` to pypi with `mvn deploy -pl gremlin-python -Dpypi -DskipTests` (note that `gremlin-python`
-should be built with `-DglvPython` first without skipping tests so that the distribution will be present)
 . Update homepage with references to latest distribution and to other internal links elsewhere on the page.
 . Wait for Apache Sonatype to sync the artifacts to Maven Central at (link:http://repo1.maven.org/maven2/org/apache/tinkerpop/tinkerpop/[http://repo1.maven.org/maven2/org/apache/tinkerpop/tinkerpop/]).
 . Wait for zip distributions to to sync to the Apache mirrors (i.e ensure the download links work from a mirror).

--- a/giraph-gremlin/pom.xml
+++ b/giraph-gremlin/pom.xml
@@ -228,24 +228,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <invokeDynamic>true</invokeDynamic>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -206,24 +206,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                        <configuration>
-                            <invokeDynamic>true</invokeDynamic>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/gremlin-groovy-test/pom.xml
+++ b/gremlin-groovy-test/pom.xml
@@ -50,24 +50,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <invokeDynamic>true</invokeDynamic>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -113,24 +113,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <invokeDynamic>true</invokeDynamic>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -275,7 +275,7 @@
     </build>
 
     <profiles>
-        <!-- This default profile works around the issue where the glvPython profile which is expected to run all tests
+        <!-- This default profile works around the issue where the glv-python profile which is expected to run all tests
              can't override the exclusions defined below. -->
         <profile>
             <id>glv-python-standard</id>
@@ -307,9 +307,9 @@
             <id>glv-python</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>glvPython</name>
-                </property>
+                <file>
+                    <exists>.glv</exists>
+                </file>
             </activation>
             <build>
 

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -324,14 +324,13 @@
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
-                    <!-- required for the jython tests  -->
                     <plugin>
                         <groupId>net.sf.mavenjython</groupId>
                         <artifactId>jython-compile-maven-plugin</artifactId>
                         <version>1.4</version>
                         <executions>
                             <execution>
-                                <phase>compile</phase>
+                                <phase>process-resources</phase>
                                 <goals>
                                     <goal>jython</goal>
                                 </goals>
@@ -413,12 +412,11 @@
                             </execution>
                             <execution>
                                 <id>native-python-build</id>
-                                <phase>generate-test-resources</phase>
+                                <phase>compile</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <skip>${skipTests}</skip>
                                     <target>
                                         <exec executable="env/bin/python" dir="${project.build.directory}/python"
                                               failonerror="true">

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <!-- provide a way to convert maven.test.skip value to skipTests for use in skipping python tests -->
+        <!-- provides a way to convert maven.test.skip value to skipTests for use in skipping python tests -->
         <maven.test.skip>false</maven.test.skip>
         <skipTests>${maven.test.skip}</skipTests>
         <gremlin.server.dir>${project.parent.basedir}/gremlin-server</gremlin.server.dir>
@@ -285,13 +285,13 @@
             <build>
                 <plugins>
                     <!-- excludes python related tests that require python itself installed on the system - run with the
-                         python profile if python is present -->
+                         python profile if glVPython is present -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <python.home>${project.build.testOutputDirectory}</python.home>
+                                <python.home>${project.build.outputDirectory}</python.home>
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/jsr223/Python*Test.java</exclude>
@@ -320,7 +320,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <python.home>${project.build.testOutputDirectory}</python.home>
+                                <python.home>${project.build.outputDirectory}</python.home>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -331,19 +331,11 @@
                         <version>1.4</version>
                         <executions>
                             <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jython</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>pythonDependencies</id>
-                                <phase>generate-test-resources</phase>
+                                <phase>compile</phase>
                                 <goals>
                                     <goal>jython</goal>
                                 </goals>
                                 <configuration>
-                                    <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                                     <libraries>
                                         <param>aenum==1.4.5</param>
                                         <param>tornado==4.4.1</param>
@@ -431,7 +423,7 @@
                                         <exec executable="env/bin/python" dir="${project.build.directory}/python"
                                               failonerror="true">
                                             <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py build --build-lib ${project.build.testOutputDirectory}/Lib"/>
+                                            <arg line="setup.py build --build-lib ${project.build.outputDirectory}/Lib"/>
                                         </exec>
                                     </target>
                                 </configuration>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -124,24 +124,6 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <invokeDynamic>true</invokeDynamic>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -458,7 +440,8 @@
 
                             <!--
                             use pytest to execute native python tests - output of xunit output is configured in setup.cfg.
-                            had to use the ant plugin - maven-exec-plugin
+                            this has to be an integration-test because we need gremlin-server running and the standard
+                            test phase doesn't have a pre/post event like integration-test does.
                             -->
                             <execution>
                                 <id>native-python-test</id>
@@ -482,7 +465,6 @@
                     <plugin>
                         <groupId>org.codehaus.gmavenplus</groupId>
                         <artifactId>gmavenplus-plugin</artifactId>
-                        <version>1.2</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.codehaus.groovy</groupId>

--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -223,24 +223,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <invokeDynamic>true</invokeDynamic>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -94,24 +94,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <invokeDynamic>true</invokeDynamic>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@ limitations under the License.
                         <exclude>**/src/main/static/**</exclude>
                         <exclude>**/_bsp/**</exclude>
                         <exclude>DEPENDENCIES</exclude>
-                        <exclude>.glv</exclude>
+                        <exclude>**/.glv</exclude>
                     </excludes>
                     <licenses>
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>
@@ -432,6 +432,29 @@ limitations under the License.
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${javadoc-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>1.5</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>addSources</goal>
+                                <goal>addTestSources</goal>
+                                <goal>generateStubs</goal>
+                                <goal>compile</goal>
+                                <goal>testGenerateStubs</goal>
+                                <goal>testCompile</goal>
+                                <goal>removeStubs</goal>
+                                <goal>removeTestStubs</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <targetBytecode>1.8</targetBytecode>
+                        <invokeDynamic>true</invokeDynamic>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,7 @@ limitations under the License.
                         <exclude>**/src/main/static/**</exclude>
                         <exclude>**/_bsp/**</exclude>
                         <exclude>DEPENDENCIES</exclude>
+                        <exclude>.glv</exclude>
                     </excludes>
                     <licenses>
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -362,24 +362,6 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>testGenerateStubs</goal>
-                            <goal>testCompile</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <invokeDynamic>true</invokeDynamic>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Provides implementation for both: 

https://issues.apache.org/jira/browse/TINKERPOP-1449
https://issues.apache.org/jira/browse/TINKERPOP-1431

I'm really happy with this PR. Cleaned up a lot of weird/inconsistent things in the gremlin-python build. Most importantly, I got rid of `-DglvPython` - which I somehow manage to forget to include on more occasions that i care to admit to. The solution is pretty simple - if you have an environment setup to build gremlin-python then you add a `.glv` file to the root of `gremlin-python` (hidden from git). If maven sees that file, it knows that it's OK to activate the profile that builds it.

You can still obviously do:

```text
mvn clean install -pl gremlin-server -Pglv-python
```

which directly activates the profile by its name.

Also note that I bumped to the latest version of the gmavenplus-plugin and centralized its configuration in the parent pom.xml.

All docs are updated to reflect the change to how `gremlin-python` is now built. Tests all seem to run ok. I even did a manual test to deploy python artifacts to pypitest and it worked nicely with:

```text
mvn clean deploy -pl gremlin-python -Dpypi -DskipTests
```

Docs are now generating with `-DskipTests` as well.

VOTE: +1