### PR TITLE
TINKERPOP-1330: by()-modulation for where()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.
+* Fixed a naming bug in Gremlin-Python where `P._and` and `P._or` should be `P.and_` and `P.or_`. (*breaking*)
+* `where()` predicate-based steps now support `by()`-modulation.
+* `TraversalRing` returns an null if it does not contain traversals (previously `IdentityTraversal`).
 * Fixed a `JavaTranslator` bug where `Bytecode` instructions were being mutated during translation.
 * Added `Path` to Gremlin-Python with respective GraphSON 2.0 deserializer.
 * Added missing `InetAddress` to GraphSON extension module.

--- a/docs/src/recipes/traversal-induced-values.asciidoc
+++ b/docs/src/recipes/traversal-induced-values.asciidoc
@@ -40,37 +40,21 @@ g.V(marko).out('knows').has('age', gt(marko.value('age'))).values('name')
 
 The downside to this approach is that it takes two separate traversals to answer the question. Ideally, there should
 be a single traversal, that can query "marko" once, determine his `age` and then use that for the value supplied to
-filter the people he knows. In this way the _value_ for the `age` filter is _induced_ from the `Traversal` itself.
+filter the people he knows. In this way the _value_ for the `age` in the `has()`-filter is _induced_ from the `Traversal`
+itself.
 
 [gremlin-groovy,modern]
 ----
-g.V().has('name','marko').as('marko').         <1>
-  out('knows').as('friend').                   <2>
-  filter(select('marko','friend').by('age').   <3>
-         where('friend', gt('marko'))).        <4>
+g.V().has('name','marko').as('marko').      <1>
+  out('knows').as('friend').                <2>
+    where('friend', gt('marko')).by('age'). <3>
   values('name')
 ----
 
 <1> Find the "marko" `Vertex` and label it as "marko".
-<2> Traverse out on the "knows" edges to the adjacent `Vertex` and label it as "person".
-<3> Filter the incoming "person" vertices. It is within this filter, that the traversal induced values are utilized.
-The inner `select` grabs the "marko" vertex and the current "friend". The `by` modulator extracts the "age" from both
-of those vertices which yields a `Map` with two keys, "marko" and "friend", where the value of each is the "age".
-<4> The `Map` produced in the previous step can then be filtered with `where` to only return a result if the "friend"
-age is greater than the "marko" age. If this is successful, then the `filter` step from the previous line will succeed
-and allow the "friend" vertex to pass through.
-
-This traversal could also be written declaratively with `match` step as follows:
-
-[gremlin-groovy,modern]
-----
-g.V().has('name','marko').match(
-    __.as('marko').values('age').as('a'),
-    __.as('marko').out('knows').as('friend'),
-    __.as('friend').values('age').as('b')
-  ).where('b', gt('a')).select('friend').
-  values('name')
-----
+<2> Traverse out on the "knows" edges to the adjacent `Vertex` and label it as "friend".
+<3> Continue to traverser only if Marko's current friend is older than him.
+<4> Get the name of Marko's older friend.
 
 Traversal induced values are not just for filtering. They can also be used when writing the values of the properties
 of one `Vertex` to another:

--- a/docs/src/recipes/traversal-induced-values.asciidoc
+++ b/docs/src/recipes/traversal-induced-values.asciidoc
@@ -48,7 +48,7 @@ itself.
 g.V().has('name','marko').as('marko').      <1>
   out('knows').as('friend').                <2>
     where('friend', gt('marko')).by('age'). <3>
-  values('name')
+  values('name')                            <4>
 ----
 
 <1> Find the "marko" `Vertex` and label it as "marko".

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2190,6 +2190,18 @@ g.V().where(out('created').count().is(gte(2))).values('name') <3>
 g.V().where(out('knows').where(out('created'))).values('name') <4>
 g.V().where(__.not(out('created'))).where(__.in('knows')).values('name') <5>
 g.V().where(__.not(out('created')).and().in('knows')).values('name') <6>
+g.V().as('a').out('knows').as('b').
+  where('a',gt('b')).
+    by('age').
+  select('a','b').
+    by('name') <7>
+g.V().as('a').out('knows').as('b').
+  where('a',gt('b').or(eq('b'))).
+    by('age').
+    by('age').
+    by(__.in('knows').values('age')).
+  select('a','b').
+    by('name') <8>
 ----
 
 <1> What are the names of the people who have created a project?
@@ -2198,6 +2210,8 @@ g.V().where(__.not(out('created')).and().in('knows')).values('name') <6>
 <4> What are the names of the people who know someone that has created a project? (This only works in OLTP -- see the `WARNING` below)
 <5> What are the names of the people who have not created anything, but are known by someone?
 <6> The concatenation of `where()`-steps is the same as a single `where()`-step with an and'd clause.
+<7> Marko knows josh and vadas but is only older than vadas.
+<8> Marko is younger than josh, but josh knows someone equal in age to marko (which is marko).
 
 WARNING: The anonymous traversal of `where()` processes the current object "locally". In OLAP, where the atomic unit
 of computing is the the vertex and its local "star graph," it is important that the anonymous traversal does not leave

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -29,6 +29,33 @@ TinkerPop 3.2.3
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.2.3/CHANGELOG.asciidoc#release-3-2-3[changelog] for a complete list of all the modifications that are part of this release.
 
+Upgrading for Users
+~~~~~~~~~~~~~~~~~~~
+
+Where Step Supports By-Modulation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is now possible to use `by()` with `where()` predicate-based steps. Previously, without using `match()`, if you wanted
+to know who was older than their friend, the following traversal would be used.
+
+[source,text]
+----
+gremlin> g.V().as('a').out('knows').as('b').
+......1>   filter(select('a','b').by('age').where('a', lt('b')))
+==>v[4]
+----
+
+Now, with `where().by()` support, the above traversal can be expressed more succinctly and more naturally as follows.
+
+[source,text]
+----
+gremlin> g.V().as('a').out('knows').as('b').
+......1>   where('a', lt('b')).by('age')
+==>v[4]
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1330[TINKERPOP-1330]
+
 TinkerPop 3.2.2
 ---------------
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
@@ -53,7 +53,7 @@ public final class PathStep<S> extends MapStep<S, Path> implements TraversalPare
             path = traverser.path();
         else {
             path = MutablePath.make();
-            traverser.path().forEach((object, labels) -> path.extend(TraversalUtil.apply(object, this.traversalRing.next()), labels));
+            traverser.path().forEach((object, labels) -> path.extend(TraversalUtil.applyNullable(object, this.traversalRing.next()), labels));
         }
         this.traversalRing.reset();
         return path;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
@@ -52,7 +52,7 @@ public final class ProjectStep<S, E> extends MapStep<S, Map<String, E>> implemen
     protected Map<String, E> map(final Traverser.Admin<S> traverser) {
         final Map<String, E> end = new LinkedHashMap<>(this.projectKeys.size(), 1.0f);
         for (final String projectKey : this.projectKeys) {
-            end.put(projectKey, TraversalUtil.apply(traverser, this.traversalRing.next()));
+            end.put(projectKey, TraversalUtil.applyNullable(traverser, this.traversalRing.next()));
         }
         this.traversalRing.reset();
         return end;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -66,7 +66,7 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
         for (final String selectKey : this.selectKeys) {
             final E end = this.getNullableScopeValue(this.pop, selectKey, traverser);
             if (null != end)
-                bindings.put(selectKey, TraversalUtil.apply(end, this.traversalRing.next()));
+                bindings.put(selectKey, TraversalUtil.applyNullable(end, this.traversalRing.next()));
             else {
                 this.traversalRing.reset();
                 return null;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -73,7 +73,7 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements T
         Tree depth = topTree;
         final Path path = traverser.path();
         for (int i = 0; i < path.size(); i++) {
-            final Object object = TraversalUtil.apply(path.<Object>get(i), this.traversalRing.next());
+            final Object object = TraversalUtil.applyNullable(path.<Object>get(i), this.traversalRing.next());
             if (!depth.containsKey(object))
                 depth.put(object, new Tree<>());
             depth = (Tree) depth.get(object);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
@@ -59,7 +59,7 @@ public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements Si
         Tree depth = root;
         final Path path = traverser.path();
         for (int i = 0; i < path.size(); i++) {
-            final Object object = TraversalUtil.apply(path.<Object>get(i), this.traversalRing.next());
+            final Object object = TraversalUtil.applyNullable(path.<Object>get(i), this.traversalRing.next());
             if (!depth.containsKey(object))
                 depth.put(object, new Tree<>());
             depth = (Tree) depth.get(object);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
@@ -42,7 +42,7 @@ public final class TraversalRing<A, B> implements Serializable, Cloneable {
 
     public Traversal.Admin<A, B> next() {
         if (this.traversals.size() == 0) {
-            return this.identityTraversal;    // TODO: return null and TraversalUtil.applyNullable()?
+            return null;
         } else {
             this.currentTraversal = (this.currentTraversal + 1) % this.traversals.size();
             return this.traversals.get(this.currentTraversal);

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereStepTest.java
@@ -43,7 +43,11 @@ public class WhereStepTest extends StepTest {
                 as("a").out().as("b").where(as("a").out()),
                 as("a").out().as("b").where(as("a").out().as("b")),
                 as("a").out().as("b").where("a", P.neq("b")),
-                as("a").out().as("b").where("a", P.neq("c"))
+                as("a").out().as("b").where("a", P.neq("c")),
+                as("a").out().as("b").where("a", P.neq("b")).by("name"),
+                as("a").out().as("b").where("a", P.neq("b")).by("name").by("age"),
+                as("a").out().as("b").where("a", P.neq("b")).by("age"),
+                as("a").out().as("b").where("a", P.neq("b").and(P.neq("a"))).by("age")
         );
     }
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyWhereTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyWhereTest.groovy
@@ -132,5 +132,20 @@ public abstract class GroovyWhereTest {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').where(__.as('b').in.count.is(eq(3)).or.where(__.as('b').out('created').and.as('b').has(label,'person'))).select('a','b')")
         }
 
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('created').in('created').as('b').where('a', gt('b')).by('age').select('a', 'b').by('name')")
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').outE('created').as('b').inV().as('c').where('a', gt('b').or(eq('b'))).by('age').by('weight').by('weight').select('a', 'c').by('name')")
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').outE('created').as('b').inV().as('c').in('created').as('d').where('a', lt('b').or(gt('c')).and(neq('d'))).by('age').by('weight').by(__.in('created').values('age').min()).select('a', 'c', 'd').by('name')")
+        }
+
     }
 }

--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
@@ -152,10 +152,10 @@ class Traversal(object):
       return P("${SymbolHelper.toJava(method)}", *args)
 """)
                 };
-        pythonClass.append("""   def _and(self, arg):
-      return P("and", arg, self)
-   def _or(self, arg):
-      return P("or", arg, self)
+        pythonClass.append("""   def and_(self, arg):
+      return P("and", self, arg)
+   def or_(self, arg):
+      return P("or", self, arg)
    def __eq__(self, other):
         return isinstance(other, self.__class__) and self.operator == other.operator and self.value == other.value and self.other == other.other
    def __repr__(self):

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
@@ -175,7 +175,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
             for (int i = 0; i < list.size(); i++) {
                 convertPToString(list.get(i), current);
                 if (i < list.size() - 1)
-                    current.append(p instanceof OrP ? "._or(" : "._and(");
+                    current.append(p instanceof OrP ? ".or_(" : ".and_(");
             }
             current.append(")");
         } else

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -172,10 +172,10 @@ class P(object):
    @staticmethod
    def without(*args):
       return P("without", *args)
-   def _and(self, arg):
-      return P("and", arg, self)
-   def _or(self, arg):
-      return P("or", arg, self)
+   def and_(self, arg):
+      return P("and", self, arg)
+   def or_(self, arg):
+      return P("or", self, arg)
    def __eq__(self, other):
         return isinstance(other, self.__class__) and self.operator == other.operator and self.value == other.value and self.other == other.other
    def __repr__(self):

--- a/gremlin-python/src/main/jython/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/jython/tests/process/test_traversal.py
@@ -23,6 +23,7 @@ import unittest
 from unittest import TestCase
 
 from gremlin_python.structure.graph import Graph
+from gremlin_python.process.traversal import P
 
 
 class TestTraversal(TestCase):
@@ -51,6 +52,13 @@ class TestTraversal(TestCase):
         assert 1 == len(bytecode.step_instructions[0])
         assert 1 == len(bytecode.step_instructions[1])
         assert 2 == len(bytecode.step_instructions[2])
+
+    def test_P(self):
+        # verify that the order of operations is respected
+        assert "and(eq(a),lt(b))" == str(P.eq("a").and_(P.lt("b")))
+        assert "and(or(lt(b),gt(c)),neq(d))" == str(P.lt("b").or_(P.gt("c")).and_(P.neq("d")))
+        assert "and(or(lt(b),gt(c)),or(neq(d),gte(e)))" == str(
+            P.lt("b").or_(P.gt("c")).and_(P.neq("d").or_(P.gte("e"))))
 
 
 if __name__ == '__main__':

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
@@ -27,6 +27,7 @@ from gremlin_python.structure.graph import Vertex
 from gremlin_python.structure.graph import Path
 from gremlin_python.structure.io.graphson import GraphSONReader
 from gremlin_python.structure.io.graphson import GraphSONWriter
+from gremlin_python.process.traversal import P
 
 
 class TestGraphSONReader(TestCase):
@@ -86,6 +87,10 @@ class TestGraphSONWriter(TestCase):
         assert """{"@type":"g:Int64","@value":2}""" == GraphSONWriter.writeObject(2L)
         assert """{"@type":"g:Float","@value":3.2}""" == GraphSONWriter.writeObject(3.2)
         assert """true""" == GraphSONWriter.writeObject(True)
+
+    def test_P(self):
+        assert """{"@type":"g:P","@value":{"predicate":"and","value":[{"@type":"g:P","@value":{"predicate":"or","value":[{"@type":"g:P","@value":{"predicate":"lt","value":"b"}},{"@type":"g:P","@value":{"predicate":"gt","value":"c"}}]}},{"@type":"g:P","@value":{"predicate":"neq","value":"d"}}]}}""" == GraphSONWriter.writeObject(
+            P.lt("b").or_(P.gt("c")).and_(P.neq("d")))
 
 
 if __name__ == '__main__':

--- a/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/structure/io/graphson/GraphSONWriterTest.java
+++ b/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/structure/io/graphson/GraphSONWriterTest.java
@@ -91,7 +91,7 @@ public class GraphSONWriterTest {
     public void shouldSerializeBytecode() throws Exception {
         assertEquals(P.eq(7L), mapper.readValue(jythonEngine.eval("GraphSONWriter.writeObject(P.eq(7L))").toString(), Object.class));
         // TODO: assertEquals(mapper.writeValueAsString(P.between(1, 2).and(P.eq(7L))), jythonEngine.eval("GraphSONWriter.writeObject(P.eq(7L)._and(P.between(1,2)))").toString().replace(" ",""));
-        assertEquals(AndP.class, mapper.readValue(jythonEngine.eval("GraphSONWriter.writeObject(P.eq(7L)._and(P.between(1,2)))").toString(), Object.class).getClass());
+        assertEquals(AndP.class, mapper.readValue(jythonEngine.eval("GraphSONWriter.writeObject(P.eq(7L).and_(P.between(1,2)))").toString(), Object.class).getClass());
         //
         assertEquals(new Bytecode.Binding<>("a", 5L), mapper.readValue(jythonEngine.eval("GraphSONWriter.writeObject(Binding('a',5L))").toString(), Object.class));
         //

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTest.java
@@ -21,24 +21,39 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
-import org.apache.tinkerpop.gremlin.process.IgnoreEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
-import static org.apache.tinkerpop.gremlin.process.traversal.P.*;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.gt;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.lt;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.not;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.within;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.without;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.and;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.not;
-import static org.junit.Assert.*;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.or;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -93,6 +108,14 @@ public abstract class WhereTest extends AbstractGremlinProcessTest {
     // multi-labels
 
     //public abstract Traversal<Vertex, String> get_g_V_asXaX_outXknowsX_asXbX_whereXasXa__bX_outXcreatedX_hasXname__rippleX_name();
+
+    // where()-by
+
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX();
+
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX();
+
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -317,28 +340,64 @@ public abstract class WhereTest extends AbstractGremlinProcessTest {
                 "a", convertToVertex(graph, "josh"), "b", convertToVertex(graph, "lop")), traversal);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX();
+        printTraversalForm(traversal);
+        checkResults(makeMapList(2,
+                "a", "peter", "b", "josh",
+                "a", "peter", "b", "marko",
+                "a", "josh", "b", "marko"), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX();
+        printTraversalForm(traversal);
+        checkResults(makeMapList(2,
+                "a", "peter", "c", "lop",
+                "a", "josh", "c", "lop",
+                "a", "josh", "c", "ripple",
+                "a", "marko", "c", "lop"), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX();
+        printTraversalForm(traversal);
+        checkResults(makeMapList(3,
+                "a", "peter", "c", "lop", "d", "josh",
+                "a", "peter", "c", "lop", "d", "marko",
+                "a", "josh", "c", "lop", "d", "marko",
+                "a", "josh", "c", "lop", "d", "peter"), traversal);
+    }
+
+
     public static class Traversals extends WhereTest {
 
         /// where(local)
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXa_eqXbXX() {
-            return g.V().has("age").as("a").out().in().has("age").as("b").select("a","b").where("a", eq("b"));
+            return g.V().has("age").as("a").out().in().has("age").as("b").select("a", "b").where("a", eq("b"));
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXa_neqXbXX() {
-            return g.V().has("age").as("a").out().in().has("age").as("b").select("a","b").where("a", neq("b"));
+            return g.V().has("age").as("a").out().in().has("age").as("b").select("a", "b").where("a", neq("b"));
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXb_hasXname_markoXX() {
-            return g.V().has("age").as("a").out().in().has("age").as("b").select("a","b").where(as("b").has("name", "marko"));
+            return g.V().has("age").as("a").out().in().has("age").as("b").select("a", "b").where(as("b").has("name", "marko"));
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXa_outXknowsX_bX() {
-            return g.V().has("age").as("a").out().in().has("age").as("b").select("a","b").where(as("a").out("knows").as("b"));
+            return g.V().has("age").as("a").out().in().has("age").as("b").select("a", "b").where(as("a").out("knows").as("b"));
         }
 
         /// where(global)
@@ -391,7 +450,7 @@ public abstract class WhereTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_whereXandXasXaX_outXknowsX_asXbX__orXasXbX_outXcreatedX_hasXname_rippleX__asXbX_inXknowsX_count_isXnotXeqX0XXXXX_selectXa_bX() {
-            return g.V().as("a").out().as("b").where(and(as("a").out("knows").as("b"), or(as("b").out("created").has("name", "ripple"), as("b").in("knows").count().is(not(eq(0)))))).select("a","b");
+            return g.V().as("a").out().as("b").where(and(as("a").out("knows").as("b"), or(as("b").out("created").has("name", "ripple"), as("b").in("knows").count().is(not(eq(0)))))).select("a", "b");
         }
 
         @Override
@@ -401,17 +460,34 @@ public abstract class WhereTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_outXcreatedX_asXbX_whereXandXasXbX_in__notXasXaX_outXcreatedX_hasXname_rippleXXX_selectXa_bX() {
-            return g.V().as("a").out("created").as("b").where(and(as("b").in(), not(as("a").out("created").has("name", "ripple")))).select("a","b");
+            return g.V().as("a").out("created").as("b").where(and(as("b").in(), not(as("a").out("created").has("name", "ripple")))).select("a", "b");
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_outXcreatedX_asXbX_inXcreatedX_asXcX_bothXknowsX_bothXknowsX_asXdX_whereXc__notXeqXaX_orXeqXdXXXX_selectXa_b_c_dX() {
-            return g.V().as("a").out("created").as("b").in("created").as("c").both("knows").both("knows").as("d").where("c", P.not(P.eq("a").or(P.eq("d")))).select("a","b","c","d");
+            return g.V().as("a").out("created").as("b").in("created").as("c").both("knows").both("knows").as("d").where("c", P.not(P.eq("a").or(P.eq("d")))).select("a", "b", "c", "d");
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_whereXin_count_isXeqX3XX_or_whereXoutXcreatedX_and_hasXlabel_personXXX_selectXa_bX() {
-            return g.V().as("a").out().as("b").where(as("b").in().count().is(eq(3)).or().where(as("b").out("created").and().as("b").has(T.label, "person"))).select("a","b");
+            return g.V().as("a").out().as("b").where(as("b").in().count().is(eq(3)).or().where(as("b").out("created").and().as("b").has(T.label, "person"))).select("a", "b");
+        }
+
+        // where()-by
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX() {
+            return g.V().as("a").out("created").in("created").as("b").where("a", gt("b")).by("age").<String>select("a", "b").by("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX() {
+            return g.V().as("a").outE("created").as("b").inV().as("c").where("a", gt("b").or(eq("b"))).by("age").by("weight").by("weight").<String>select("a", "c").by("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX() {
+            return g.V().as("a").outE("created").as("b").inV().as("c").in("created").as("d").where("a", lt("b").or(gt("c")).and(neq("d"))).by("age").by("weight").by(in("created").values("age").min()).<String>select("a", "c", "d").by("name");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1330

 Added `by()`-modulation support to `where()` predicate-based steps. Added 3 solid `WhereTest` cases to verify proper functioning. Ensured proper `hashCode()` construction in `WhereStepTest`. Also, optimized `TraversalRing` to return `null` if there are no traversals in the ring and thus, `TraversalUtil.applyNullable()` can be leveraged instead which
 is more efficient than using `IdentityTraversal`. Finally, there was a severe bug in Gremlin-Python that made a complex `WhereTest` fail because `P.and` and `P.or` nesting was 
 reversed! I have fixed Gremlin-Python `P` in this PR.

---

 Here is an example of the new `where().by()`-model.

```
// give me "a" and "b" is "a" knows "b" and "a" is older than "b".
gremlin> g.V().as("a").out("knows").as("b").
......1>   where("a",gt("b")).by("age").
......2>   select("a","b").by("name")
==>[a:marko,b:vadas]


gremlin>  g.V().as("a").outE("created").as("b").
......1>   inV().as("c").
......2>   in("created").as("d").
......3>     where("a", lt("b").or(gt("c")).and(neq("d"))).
......4>       by("age").
......5>       by("weight").
......6>       by(__.in("created").values("age").min()).
......7>   select("a", "c", "d").by("name")
==>[a:josh,c:lop,d:marko]
==>[a:josh,c:lop,d:peter]
==>[a:peter,c:lop,d:marko]
==>[a:peter,c:lop,d:josh]
```

In the second query:
	a -> "age"
	b -> "weight"
	c -> in("created")...
	d -> "age" // TraversalRings are round-robin structures

Pretty insane-o.

If people start using `where()-by()` heavily, I believe there is an easy translation to `match()` and as such a `TraversalStrategy` would enable us to get the benefits of `match()`-steps runtime query optimizer.

VOTE +1