### PR TITLE
Fixed issue in NumberSerializer that could cause integer out of bounds

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -181,7 +181,7 @@ class NumberSerializer(GraphSONSerializer):
     def _dictify(self, number):
         if isinstance(number, bool):  # python thinks that 0/1 integers are booleans
             return number
-        elif isinstance(number, long) or (number > 2147483647): # in python all numbers are int unless specified otherwise
+        elif isinstance(number, long) or (abs(number) > 2147483647): # in python all numbers are int unless specified otherwise
             return _SymbolHelper.objectify("Int64", number)
         elif isinstance(number, int):
             return _SymbolHelper.objectify("Int32", number)

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -181,7 +181,7 @@ class NumberSerializer(GraphSONSerializer):
     def _dictify(self, number):
         if isinstance(number, bool):  # python thinks that 0/1 integers are booleans
             return number
-        elif isinstance(number, long):
+        elif isinstance(number, long) or (number > 2147483647): # in python all numbers are int unless specified otherwise
             return _SymbolHelper.objectify("Int64", number)
         elif isinstance(number, int):
             return _SymbolHelper.objectify("Int32", number)


### PR DESCRIPTION
In python, unless a number is specified with an L, it will be an int whether it's a 32 or 64 bit integer. When a 64 bit integer is serialized, it could potentially be labeled as an int32 which would cause an integer out of bounds error. 