### PR TITLE
TINKERPOP-1409 Print no result line if empty.result.indicator is empty string.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * `TraversalRing` returns a `null` if it does not contain traversals (previously `IdentityTraversal`).
 * Fixed a `JavaTranslator` bug where `Bytecode` instructions were being mutated during translation.
 * Added `Path` to Gremlin-Python with respective GraphSON 2.0 deserializer.
+* If `empty.result.indicator` is set to an empty string, then no "result line" is printed in the console.
 * VertexPrograms can now declare traverser requirements, e.g. to have access to the path when used with `.program()`.
 * New build options for `gremlin-python` where `-DglvPython` is no longer required.
 * Added missing `InetAddress` to GraphSON extension module.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,7 +32,8 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * `TraversalRing` returns a `null` if it does not contain traversals (previously `IdentityTraversal`).
 * Fixed a `JavaTranslator` bug where `Bytecode` instructions were being mutated during translation.
 * Added `Path` to Gremlin-Python with respective GraphSON 2.0 deserializer.
-* If `empty.result.indicator` is set to an empty string, then no "result line" is printed in the console.
+* Renamed the `empty.result.indicator` preference to `result.indicator.null` in Gremlin Console
+* If `result.indicator.null` is set to an empty string, then no "result line" is printed in Gremlin Console.
 * VertexPrograms can now declare traverser requirements, e.g. to have access to the path when used with `.program()`.
 * New build options for `gremlin-python` where `-DglvPython` is no longer required.
 * Added missing `InetAddress` to GraphSON extension module.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -173,7 +173,7 @@ Preferences are set with `:set name value`.  Values can contain spaces when quot
 |result.prompt.color | colors | Color of the result prompt.
 |input.prompt | string | Text of the input prompt.
 |result.prompt | string | Text of the result prompt.
-|empty.result.indicator | string | Text of the void/no results indicator - setting to empty string (i.e. "" at the
+|result.indicator.null | string | Text of the void/no results indicator - setting to empty string (i.e. "" at the
 command line) will print no result line in these cases.
 |=========================================================
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -173,7 +173,8 @@ Preferences are set with `:set name value`.  Values can contain spaces when quot
 |result.prompt.color | colors | Color of the result prompt.
 |input.prompt | string | Text of the input prompt.
 |result.prompt | string | Text of the result prompt.
-|empty.result.indicator | string | Text of the void/no results indicator.
+|empty.result.indicator | string | Text of the void/no results indicator - setting to empty string (i.e. "" at the
+command line) will print no result line in these cases.
 |=========================================================
 
 Colors can contain a comma-separated combination of 1 each of foreground, background, and attribute.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -32,6 +32,33 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.2.3/CHANGELOG.asc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+Renamed Null Result Preference
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In 3.2.2, the Gremlin Console introduced a setting called `empty.result.indicator`, which controlled the output that
+was presented when no result was returned. For consistency, this setting has been renamed to `result.indicator.null`
+and can be set as follows:
+
+[source,text]
+----
+gremlin> graph = TinkerGraph.open()
+==>tinkergraph[vertices:0 edges:0]
+gremlin> graph.close()
+==>null
+gremlin> :set result.indicator.null nil
+gremlin> graph = TinkerGraph.open()
+==>tinkergraph[vertices:0 edges:0]
+gremlin> graph.close()
+==>nil
+gremlin> :set result.indicator.null ""
+gremlin> graph = TinkerGraph.open()
+==>tinkergraph[vertices:0 edges:0]
+gremlin> graph.close()
+gremlin>
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1409[TINKERPOP-1409]
+
 Where Step Supports By-Modulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -199,10 +199,7 @@ class Console {
             if (this.tempIterator.hasNext()) {
                 int counter = 0;
                 while (this.tempIterator.hasNext() && (Preferences.maxIteration == -1 || counter < Preferences.maxIteration)) {
-                    final Object object = this.tempIterator.next()
-                    String prompt = Colorizer.render(Preferences.resultPromptColor, buildResultPrompt())
-                    String colorizedResult = colorizeResult(object)
-                    io.out.println(prompt + ((null == object) ? Preferences.emptyResult : colorizedResult))
+                    printResult(tempIterator.next())
                     counter++;
                 }
                 if (this.tempIterator.hasNext())
@@ -250,13 +247,25 @@ class Console {
                         io.out.println(Colorizer.render(Preferences.resultPromptColor,(buildResultPrompt() + result.prettyPrint(width < 20 ? 80 : width))))
                         return null
                     } else {
-                        io.out.println(Colorizer.render(Preferences.resultPromptColor,buildResultPrompt()).toString() + ((null == result) ? Preferences.emptyResult : colorizeResult(result)))
+                        printResult(result)
                         return null
                     }
                 } catch (final Exception e) {
                     this.tempIterator = Collections.emptyIterator()
                     throw e
                 }
+            }
+        }
+    }
+
+    def printResult(def object) {
+        final String prompt = Colorizer.render(Preferences.resultPromptColor, buildResultPrompt())
+        // if preference is set to empty string then don't print any result
+        if (object != null) {
+            io.out.println(prompt + colorizeResult(object))
+        } else {
+            if (!Preferences.emptyResult.isEmpty()) {
+                io.out.println(prompt + Preferences.emptyResult)
             }
         }
     }

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Preferences.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Preferences.groovy
@@ -73,9 +73,9 @@ public class Preferences {
     public static final String PREF_RESULT_PROMPT_COLOR_DEFAULT = "reset"
     public static String  resultPromptColor = PREF_RESULT_PROMPT_COLOR_DEFAULT
 
-    public static final String PREF_EMPTY_RESULT_IND = "empty.result.indicator"
-    public static final String PREF_EMPTY_RESULT_IND_DEFAULT = "null"
-    public static String  emptyResult = PREF_EMPTY_RESULT_IND_DEFAULT
+    public static final String PREF_RESULT_IND_NULL = "result.indicator.null"
+    public static final String PREF_RESULT_IND_NULL_DEFAULT = "null"
+    public static String  emptyResult = PREF_RESULT_IND_NULL_DEFAULT
 
     public static final String PREF_INPUT_PROMPT = "input.prompt"
     public static final String PREF_INPUT_PROMPT_DEFAULT = "gremlin>"
@@ -212,9 +212,9 @@ public class Preferences {
                             inputPromptColor =  getValidColor(PREF_INPUT_PROMPT_COLOR, evt.newValue, PREF_INPUT_PROMPT_COLOR_DEFAULT)
                         } else if (evt.key == PREF_RESULT_PROMPT_COLOR) {
                             resultPromptColor =  getValidColor(PREF_RESULT_PROMPT_COLOR, evt.newValue, PREF_RESULT_PROMPT_COLOR_DEFAULT)
-                        } else if (evt.key == PREF_EMPTY_RESULT_IND) {
+                        } else if (evt.key == PREF_RESULT_IND_NULL) {
                             if (null == evt.newValue) {
-                                emptyResult =  STORE.get(PREF_EMPTY_RESULT_IND, PREF_EMPTY_RESULT_IND_DEFAULT)
+                                emptyResult =  STORE.get(PREF_RESULT_IND_NULL, PREF_RESULT_IND_NULL_DEFAULT)
                             } else {
                                 emptyResult = evt.newValue
                             }
@@ -285,7 +285,7 @@ public class Preferences {
 
         resultPromptColor =  getValidColor(PREF_RESULT_PROMPT_COLOR, null, PREF_RESULT_PROMPT_COLOR_DEFAULT)
 
-        emptyResult =  STORE.get(PREF_EMPTY_RESULT_IND, PREF_EMPTY_RESULT_IND_DEFAULT)
+        emptyResult =  STORE.get(PREF_RESULT_IND_NULL, PREF_RESULT_IND_NULL_DEFAULT)
 
         inputPrompt =  STORE.get(PREF_INPUT_PROMPT, PREF_INPUT_PROMPT_DEFAULT)
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/GremlinSetCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/GremlinSetCommand.groovy
@@ -66,7 +66,7 @@ class GremlinSetCommand extends SetCommand {
             set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_INFO_COLOR
             set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_INPUT_PROMPT_COLOR
             set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_RESULT_PROMPT_COLOR
-            set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_EMPTY_RESULT_IND
+            set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_RESULT_IND_NULL
             set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_INPUT_PROMPT
             set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_RESULT_PROMPT
             set << org.apache.tinkerpop.gremlin.console.Preferences.PREF_EDGE_COLOR


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1409

This seems like a better use of the empty string setting than to actually just print an empty string line.

```text
gremlin> graph = TinkerGraph.open()
==>tinkergraph[vertices:0 edges:0]
gremlin> graph.close()
==>null
gremlin> graph = TinkerGraph.open()
==>tinkergraph[vertices:0 edges:0]
gremlin> :set empty.result.indicator ""
gremlin> graph.close()
gremlin> 
```

Pretty small change, but, I didn't CTR this in case someone didn't really like this behavior.  If there are -1s I can just kill this and close the JIRA currently hanging out there as I only kept it open because I saw this dangling issue I wanted to implement.

VOTE +1