### PR TITLE
TINKERPOP-1451 TinkerGraph persistence cannot handle a single file name as the graph location

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.1.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+ Removed the `appveyor.yml` file as the AppVeyor build is no longer enabled by Apache Infrastructure.
+* Removed the `appveyor.yml` file as the AppVeyor build is no longer enabled by Apache Infrastructure.
+* Fixed a bug in `RangeByIsCountStrategy` which didn't use the `NotStep` properly.
 
 [[release-3-1-4]]
 TinkerPop 3.1.4 (Release Date: September 6, 2016)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Removed the `appveyor.yml` file as the AppVeyor build is no longer enabled by Apache Infrastructure.
+* Fixed TinkerGraph which was not saving on `close()` if the path only consisted of the file name.
 * Fixed a bug in `RangeByIsCountStrategy` which didn't use the `NotStep` properly.
 
 [[release-3-1-4]]

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
@@ -148,6 +148,8 @@ public class RangeByIsCountStrategyTest {
                     {__.count().is(0).store("x"), __.limit(1).count().is(0).store("x")},
                     {__.repeat(__.out()).until(__.outE().count().is(0)), __.repeat(__.out()).until(__.not(__.outE()))},
                     {__.repeat(__.out()).emit(__.outE().count().is(0)), __.repeat(__.out()).emit(__.not(__.outE()))},
+                    {__.where(__.outE().hasLabel("created").count().is(0)), __.where(__.not(__.outE().hasLabel("created")))},
+                    {__.where(__.out().outE().hasLabel("created").count().is(0)), __.where(__.out().not(__.outE().hasLabel("created")))},
             });
         }
     }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -299,7 +299,9 @@ public final class TinkerGraph implements Graph {
             f.delete();
         } else {
             final File parent = f.getParentFile();
-            if (!parent.exists()) {
+
+            // the parent would be null in the case of an relative path if the graphLocation was simply: "f.gryo"
+            if (parent != null && !parent.exists()) {
                 parent.mkdirs();
             }
         }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.io.GraphReader;
 import org.apache.tinkerpop.gremlin.structure.io.GraphWriter;
@@ -440,25 +441,41 @@ public class TinkerGraphTest {
     }
 
     @Test
-    public void shouldPersistWithRelativePath() {
-        final String graphLocation = "shouldPersistToGryoRelative.kryo";
+    public void shouldPersistToGryoAndHandleMultiProperties() {
+        final String graphLocation = TestHelper.makeTestDataDirectory(TinkerGraphTest.class) + "shouldPersistToGryoMulti.kryo";
         final File f = new File(graphLocation);
         if (f.exists() && f.isFile()) f.delete();
 
-        try {
-            final Configuration conf = new BaseConfiguration();
-            conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "gryo");
-            conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, graphLocation);
-            final TinkerGraph graph = TinkerGraph.open(conf);
-            TinkerFactory.generateModern(graph);
-            graph.close();
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "gryo");
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, graphLocation);
+        final TinkerGraph graph = TinkerGraph.open(conf);
+        TinkerFactory.generateTheCrew(graph);
+        graph.close();
 
-            final TinkerGraph reloadedGraph = TinkerGraph.open(conf);
-            IoTest.assertModernGraph(reloadedGraph, true, false);
-            reloadedGraph.close();
-        } catch (Exception ex) {
-            if (f.exists() && f.isFile()) f.delete();
-        }
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.list.toString());
+        final TinkerGraph reloadedGraph = TinkerGraph.open(conf);
+        IoTest.assertCrewGraph(reloadedGraph, false);
+        reloadedGraph.close();
+    }
+
+    @Test
+    public void shouldPersistWithRelativePath() {
+        final String graphLocation = TestHelper.convertToRelative(TinkerGraphTest.class,
+                new File(TestHelper.makeTestDataDirectory(TinkerGraphTest.class)))  + "shouldPersistToGryoRelative.kryo";
+        final File f = new File(graphLocation);
+        if (f.exists() && f.isFile()) f.delete();
+
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "gryo");
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, graphLocation);
+        final TinkerGraph graph = TinkerGraph.open(conf);
+        TinkerFactory.generateModern(graph);
+        graph.close();
+
+        final TinkerGraph reloadedGraph = TinkerGraph.open(conf);
+        IoTest.assertModernGraph(reloadedGraph, true, false);
+        reloadedGraph.close();
     }
 
     @Test

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -440,6 +440,28 @@ public class TinkerGraphTest {
     }
 
     @Test
+    public void shouldPersistWithRelativePath() {
+        final String graphLocation = "shouldPersistToGryoRelative.kryo";
+        final File f = new File(graphLocation);
+        if (f.exists() && f.isFile()) f.delete();
+
+        try {
+            final Configuration conf = new BaseConfiguration();
+            conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "gryo");
+            conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, graphLocation);
+            final TinkerGraph graph = TinkerGraph.open(conf);
+            TinkerFactory.generateModern(graph);
+            graph.close();
+
+            final TinkerGraph reloadedGraph = TinkerGraph.open(conf);
+            IoTest.assertModernGraph(reloadedGraph, true, false);
+            reloadedGraph.close();
+        } catch (Exception ex) {
+            if (f.exists() && f.isFile()) f.delete();
+        }
+    }
+
+    @Test
     public void shouldPersistToAnyGraphFormat() {
         final String graphLocation = TestHelper.makeTestDataDirectory(TinkerGraphTest.class) + "shouldPersistToAnyGraphFormat.dat";
         final File f = new File(graphLocation);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1451

works nicely now:

```text
gremlin> configuration = new org.apache.commons.configuration.BaseConfiguration()
==>org.apache.commons.configuration.BaseConfiguration@18a3962d
gremlin> configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, 'test4.gryo')
==>null
gremlin> configuration.setProperty(Graph.GRAPH, TinkerGraph.class.getName())
==>null
gremlin> configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, 'gryo')
==>null
gremlin> graph = TinkerGraph.open(configuration)
==>tinkergraph[vertices:0 edges:0]
gremlin> v = graph.addVertex('Person')
==>v[0]
gremlin> v.property(list, 'age', 1)
==>vp[age->1]
gremlin> v.property(list, 'age', 2)
==>vp[age->2]
gremlin> v.properties()
==>vp[age->1]
==>vp[age->2]
gremlin> graph.close()
==>null
gremlin> configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.list.toString());
==>null
gremlin> graph = TinkerGraph.open(configuration)
==>tinkergraph[vertices:1 edges:0]
gremlin> graph.traversal().V().properties()
==>vp[age->1]
==>vp[age->2]
```

VOTE +1