### PR TITLE
Fixed behavior of has() methods

### DIFF
--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -83,6 +83,31 @@ gremlin> g.V().as('a').out('knows').as('b').
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1330[TINKERPOP-1330]
 
+Change In has() Method Signatures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The TinkerPop 3.2.2 release unintentionally intoduced a breaking change for some `has()` method overloads. In particular the
+behavior for single item array arguments was changed:
+
+[source,text]
+----
+gremlin> g.V().hasLabel(["software"] as String[]).count()
+==>0
+----
+
+Prior this change single item arrays were treated like there was only that single item:
+
+[source,text]
+----
+gremlin> g.V().hasLabel(["software"] as String[]).count()
+==>2
+gremlin> g.V().hasLabel("software").count()
+==>2
+----
+
+TinkerPop 3.2.3 fixes this misbehavior and all `has()` method overloads behave like before, except that they no longer
+support no arguments.
+
 TinkerPop 3.2.2
 ---------------
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -968,27 +968,20 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     public default GraphTraversal<S, E> has(final T accessor, final Object value, final Object... values) {
-        final Object[] objects;
         if (value instanceof Object[]) {
             final Object[] arr = (Object[]) value;
             if (values.length == 0) {
                 if (arr.length == 1) {
-                    return has(accessor, P.eq(arr));
+                    return has(accessor, P.eq(arr[0]));
                 }
-                objects = arr;
-            } else {
-                objects = new Object[arr.length + values.length];
-                System.arraycopy(arr, 0, objects, 0, arr.length);
-                System.arraycopy(values, 0, objects, arr.length, values.length);
+                return has(accessor, P.within(arr));
             }
-        } else {
-            if (values.length == 0) {
-                return has(accessor, value instanceof P ? (P) value : P.eq(value));
-            }
-            objects = new Object[values.length + 1];
-            objects[0] = value;
-            System.arraycopy(values, 0, objects, 1, values.length);
+        } else if (values.length == 0) {
+            return has(accessor, value instanceof P ? (P) value : P.eq(value));
         }
+        final Object[] objects = new Object[values.length + 1];
+        objects[0] = value;
+        System.arraycopy(values, 0, objects, 1, values.length);
         return has(accessor, P.within(objects));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasStepTest.java
@@ -18,14 +18,19 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.within;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -49,5 +54,66 @@ public class HasStepTest extends StepTest {
                 __.hasValue("marko"),
                 __.hasValue("josh")
         );
+    }
+
+    /**
+     * This test ensures that `has[Id|Label|Key|Value]` are compatible with the old varargs method signatures.
+     */
+    @Test
+    public void testVarargsCompatibility() {
+        final List<List<Traversal>> traversalLists = Arrays.asList(
+                // hasId(Object id, Object... moreIds) should be compatible with hasId(Object... ids)
+                Arrays.asList(
+                        __.hasId(1),
+                        __.hasId(eq(1)),
+                        __.hasId(new Integer[]{1})),
+                Arrays.asList(
+                        __.hasId(1, 2),
+                        __.hasId(within(1, 2)),
+                        __.hasId(new Integer[]{1, 2})),
+
+                // hasLabel(Object label, Object... moreLabels) should be compatible with hasLabel(Object... labels)
+                Arrays.asList(
+                        __.hasLabel("person"),
+                        __.hasLabel(eq("person")),
+                        __.hasLabel(new String[]{"person"})),
+                Arrays.asList(
+                        __.hasLabel("person", "software"),
+                        __.hasLabel(within("person", "software")),
+                        __.hasLabel(new String[]{"person", "software"})),
+
+                // hasKey(Object key, Object... moreKeys) should be compatible with hasKey(Object... keys)
+                Arrays.asList(
+                        __.hasKey("name"),
+                        __.hasKey(eq("name")),
+                        __.hasKey(new String[]{"name"})),
+                Arrays.asList(
+                        __.hasKey("name", "age"),
+                        __.hasKey(within("name", "age")),
+                        __.hasKey(new String[]{"name", "age"})),
+
+                // hasValue(Object value, Object... moreValues) should be compatible with hasValue(Object... values)
+                Arrays.asList(
+                        __.hasValue("marko"),
+                        __.hasValue(eq("marko")),
+                        __.hasValue(new String[]{"marko"})),
+                Arrays.asList(
+                        __.hasValue("marko", 32),
+                        __.hasValue(within("marko", 32)),
+                        __.hasValue(new Object[]{"marko", 32}))
+        );
+        
+        for (final List<Traversal> traversals : traversalLists) {
+            for (Traversal traversal1 : traversals) {
+                final Step step1 = traversal1.asAdmin().getEndStep();
+                assertEquals(step1, step1.clone());
+                assertEquals(step1.hashCode(), step1.clone().hashCode());
+                for (Traversal traversal2 : traversals) {
+                    final Step step2 = traversal2.asAdmin().getEndStep();
+                    assertEquals(step1, step2);
+                    assertEquals(step1.hashCode(), step2.hashCode());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Made `has[Id|Label|Key|Value]` compatible with the old varargs method signature and added tests to ensure the compatibility.

VOTE: +1