### PR TITLE
TINKERPOP-1437 Added tests for dedup(Scope,String...) overload in DedupTest

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.
+* Added tests to `DedupTest` for the `dedup(Scope, String...)` overload.
 * Fixed a naming bug in Gremlin-Python where `P._and` and `P._or` should be `P.and_` and `P.or_`. (*breaking*)
 * `where()` predicate-based steps now support `by()`-modulation.
 * `TraversalRing` returns a `null` if it does not contain traversals (previously `IdentityTraversal`).

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDedupTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDedupTest.groovy
@@ -33,11 +33,11 @@ public abstract class GroovyDedupTest {
     public static class Traversals extends DedupTest {
         @Override
         public Traversal<Vertex, String> get_g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold() {
-            return new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.in.values('name').fold.dedup(Scope.local).unfold;");
+            return new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.in.values('name').fold.dedup(Scope.local).unfold");
         }
 
         @Override
-        public Traversal<Vertex, Map<String, String>> get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
+        public Traversal<Vertex, Map<String, String>> get_g_V_out_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
             return new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.as('x').in.as('y').select('x','y').by('name').fold.dedup(Scope.local,'x','y').unfold");
         }
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDedupTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDedupTest.groovy
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path
+import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
 import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
@@ -30,6 +31,15 @@ import org.apache.tinkerpop.gremlin.structure.Vertex
 public abstract class GroovyDedupTest {
 
     public static class Traversals extends DedupTest {
+        @Override
+        public Traversal<Vertex, String> get_g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold() {
+            return new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.in.values('name').fold.dedup(Scope.local).unfold;");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
+            return new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.as('x').in.as('y').select('x','y').by('name').fold.dedup(Scope.local,'x','y').unfold");
+        }
 
         @Override
         public Traversal<Vertex, String> get_g_V_both_dedup_name() {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -92,13 +94,13 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
             counter++;
             final String key = (String) keysClasses[i];
             final Class clazz = (Class) keysClasses[i + 1];
-            assertTrue(sideEffects.keys().contains(key));
-            assertTrue(sideEffects.exists(key));
+            assertThat(sideEffects.keys().contains(key), is(true));
+            assertThat(sideEffects.exists(key), is(true));
             assertEquals(clazz, sideEffects.get((String) keysClasses[i]).getClass());
-            assertFalse(sideEffects.exists(UUID.randomUUID().toString()));
+            assertThat(sideEffects.exists(UUID.randomUUID().toString()), is(false));
         }
         assertEquals(sideEffects.keys().size(), counter);
-        assertFalse(sideEffects.keys().contains(UUID.randomUUID().toString()));
+        assertThat(sideEffects.keys().contains(UUID.randomUUID().toString()), is(false));
         assertEquals(StringFactory.traversalSideEffectsString(sideEffects), sideEffects.toString());
     }
 
@@ -113,9 +115,9 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
 
         for (T t : results) {
             if (t instanceof Map) {
-                assertTrue("Checking map result existence: " + t, expectedResults.stream().filter(e -> e instanceof Map).filter(e -> internalCheckMap((Map) e, (Map) t)).findAny().isPresent());
+                assertThat("Checking map result existence: " + t, expectedResults.stream().filter(e -> e instanceof Map).filter(e -> internalCheckMap((Map) e, (Map) t)).findAny().isPresent(), is(true));
             } else {
-                assertTrue("Checking result existence: " + t, expectedResults.contains(t));
+                assertThat("Checking result existence: " + t, expectedResults.contains(t), is(true));
             }
         }
         final Map<T, Long> expectedResultsCount = new HashMap<>();
@@ -124,7 +126,7 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
         expectedResults.forEach(t -> MapHelper.incr(expectedResultsCount, t, 1l));
         results.forEach(t -> MapHelper.incr(resultsCount, t, 1l));
         expectedResultsCount.forEach((k, v) -> assertEquals("Checking result group counts", v, resultsCount.get(k)));
-        assertFalse(traversal.hasNext());
+        assertThat(traversal.hasNext(), is(false));
     }
 
     public static <T> void checkResults(final Map<T, Long> expectedResults, final Traversal<?, T> traversal) {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -38,6 +39,9 @@ import java.util.Set;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.isIn;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -72,6 +76,40 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, String> get_g_V_outE_asXeX_inV_asXvX_selectXeX_order_byXweight_incrX_selectXvX_valuesXnameX_dedup();
 
     public abstract Traversal<Vertex, String> get_g_V_both_both_dedup_byXoutE_countX_name();
+
+    public abstract Traversal<Vertex, String> get_g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold();
+
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold();
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold() {
+        final Traversal<Vertex, String> traversal = get_g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold();
+        final List<String> names = traversal.toList();
+        assertEquals(3, names.size());
+        assertThat(names, containsInAnyOrder("marko", "josh", "peter"));
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold();
+        final List<Map<String,String>> names = traversal.toList();
+        assertEquals(6, names.size());
+        for (final Map<String, String> m : names) {
+            if (m.get("x").equals("lop")) {
+                assertThat(m.get("y"), isIn(Arrays.asList("marko", "josh", "peter")));
+            } else if (m.get("x").equals("vadas")) {
+                assertEquals("marko", m.get("y"));
+            } else if (m.get("x").equals("josh")) {
+                assertEquals("marko", m.get("y"));
+            } else if (m.get("x").equals("ripple")) {
+                assertEquals("josh", m.get("y"));
+            } else {
+                fail("A value was returned that was not expected in the result: " + m.get("x"));
+            }
+        }
+    }
 
     @Test
     @LoadGraphWith(MODERN)
@@ -240,6 +278,16 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
     }
 
     public static class Traversals extends DedupTest {
+        @Override
+        public Traversal<Vertex, String> get_g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold() {
+            return g.V().out().in().values("name").fold().dedup(Scope.local).unfold();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
+            return g.V().out().as("x").in().as("y").select("x","y").by("name").fold().dedup(Scope.local,"x","y").unfold();
+        }
+
         @Override
         public Traversal<Vertex, String> get_g_V_both_dedup_name() {
             return g.V().both().dedup().values("name");

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
@@ -79,36 +79,28 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, String> get_g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold();
 
-    public abstract Traversal<Vertex, Map<String, String>> get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold();
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_out_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold();
 
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold() {
         final Traversal<Vertex, String> traversal = get_g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold();
-        final List<String> names = traversal.toList();
-        assertEquals(3, names.size());
-        assertThat(names, containsInAnyOrder("marko", "josh", "peter"));
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList("marko", "josh", "peter"), traversal);
     }
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
-        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold();
-        final List<Map<String,String>> names = traversal.toList();
-        assertEquals(6, names.size());
-        for (final Map<String, String> m : names) {
-            if (m.get("x").equals("lop")) {
-                assertThat(m.get("y"), isIn(Arrays.asList("marko", "josh", "peter")));
-            } else if (m.get("x").equals("vadas")) {
-                assertEquals("marko", m.get("y"));
-            } else if (m.get("x").equals("josh")) {
-                assertEquals("marko", m.get("y"));
-            } else if (m.get("x").equals("ripple")) {
-                assertEquals("josh", m.get("y"));
-            } else {
-                fail("A value was returned that was not expected in the result: " + m.get("x"));
-            }
-        }
+    public void g_V_out_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_out_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold();
+        printTraversalForm(traversal);
+        checkResults(makeMapList(2,
+                "x", "lop", "y", "marko",
+                "x", "lop", "y", "josh",
+                "x", "lop", "y", "peter",
+                "x", "vadas", "y", "marko",
+                "x", "josh", "y", "marko",
+                "x", "ripple", "y", "josh"), traversal);
     }
 
     @Test
@@ -284,7 +276,7 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, Map<String, String>> get_g_V_out_in_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
+        public Traversal<Vertex, Map<String, String>> get_g_V_out_asXxX_in_asXyX_selectXx_yX_byXnameX_fold_dedupXlocal_x_yX_unfold() {
             return g.V().out().as("x").in().as("y").select("x","y").by("name").fold().dedup(Scope.local,"x","y").unfold();
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1437

Pretty simple - just added a couple of tests - but didn't CTR as I'd feel better with a couple of extra eyes on this as we've had bad tests slip into the suite in the past.  

Runs nicely with `mvn clean install` - doing a `docker/build.sh -t -i -n` now. If anything bad happens I'll post back here.

VOTE +1