### PR TITLE
TINKERPOP-1457 Fixed Lambda serialization in bytecode for java/groovy.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.
 * Added tests to `DedupTest` for the `dedup(Scope, String...)` overload.
+* Fixed a bug in serialization of `Lambda` instances in GraphSON, which prevented their use in remote traversals.
 * Fixed a naming bug in Gremlin-Python where `P._and` and `P._or` should be `P.and_` and `P.or_`. (*breaking*)
 * `where()` predicate-based steps now support `by()`-modulation.
 * `TraversalRing` returns a `null` if it does not contain traversals (previously `IdentityTraversal`).

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
@@ -51,41 +51,9 @@ import java.util.Iterator;
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupCountTest",
         method = "g_V_hasXnoX_groupCountXaX_capXaX",
-        reason = "This test asserts an empty side-effect which reflects as a null rather than an \"empty\" and thus doens't assert")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.BranchTest",
-        method = "g_V_branchXlabelX_optionXperson__ageX_optionXsoftware__langX_optionXsoftware__nameX",
-        reason = "Issues with Longs")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
-        method = "g_V_chooseXout_countX_optionX2L__nameX_optionX3L__valueMapX",
-        reason = "Issues with Longs")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
-        method = "g_V_chooseXlabel_eqXpersonX__outXknowsX__inXcreatedXX_name",
-        reason = "Issues with Longs")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
-        method = "g_withSackXBigInteger_TEN_powX1000X_assignX_V_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack",
-        reason = "Issues with BigInteger")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_withSideEffectXa_g_VX2XX_VX1X_out_whereXneqXaXX",
-        reason = "Issues with Longs")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
-        method = "g_VXlistXv1_v2_v3XX_name",
-        reason = "Issues with ids")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
-        method = "g_VXv1X_hasXage_gt_30X",
-        reason = "Issues with ids")
+        reason = "This test asserts an empty side-effect which reflects as a null rather than an \"empty\" and thus doesn't assert")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest",
-        method = "*",
-        reason = "hmmmm")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectTest",
         method = "*",
         reason = "hmmmm")
 @Graph.OptOut(
@@ -97,9 +65,17 @@ import java.util.Iterator;
         method = "*",
         reason = "hmmmm")
 @Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectTest",
+        method = "g_V_hasLabelXpersonX_projectXa_bX_byXoutE_countX_byXageX",
+        reason = "Not happy in OLAP.")
+@Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectTest",
+        method = "g_V_outXcreatedX_projectXa_bX_byXnameX_byXinXcreatedX_countX_order_byXselectXbX__decrX_selectXaX",
+        reason = "Not happy in OLAP.")
+@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.CoreTraversalTest",
         method = "*",
-        reason = "RemoteGraph can't serialize a lambda so the test fails before it has a chance for the Traversal to be evaluated")
+        reason = "The test suite does not support profiling or lambdas and for groovy tests: 'Could not locate method: GraphTraversalSource.withStrategies([{traversalCategory=interface org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy$DecorationStrategy}])'")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ProgramTest",
         method = "*",

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeSerializer.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.apache.tinkerpop.shaded.jackson.annotation.JsonTypeInfo;
 import org.apache.tinkerpop.shaded.jackson.core.JsonGenerator;
 import org.apache.tinkerpop.shaded.jackson.databind.BeanProperty;
@@ -198,6 +199,8 @@ public class GraphSONTypeSerializer extends TypeSerializer {
             return InetAddress.class;
         } else if (Traverser.class.isAssignableFrom(c)) {
             return Traverser.class;
+        } else if (Lambda.class.isAssignableFrom(c)) {
+            return Lambda.class;
         }
         return c;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapper;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONXModuleV2d0;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.InputShim;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.KryoShim;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.OutputShim;
@@ -125,7 +126,11 @@ public final class GryoSerializers {
     }
 
     public final static class BytecodeSerializer implements SerializerShim<Bytecode> {
-        private static final GraphSONMapper mapper = GraphSONMapper.build().version(GraphSONVersion.V2_0).create();
+        private static final GraphSONMapper mapper = GraphSONMapper.build()
+                .version(GraphSONVersion.V2_0)
+                .addCustomModule(GraphSONXModuleV2d0.build().create(false))
+                .create();
+
         @Override
         public <O extends OutputShim> void write(final KryoShim<?, O> kryo, final O output, final Bytecode bytecode) {
             try {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assume.assumeThat;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public abstract class AbstractGremlinServerIntegrationTest {
-    private GremlinServer server;
+    protected GremlinServer server;
     private final static String epollOption = "gremlin.server.epoll";
     private static final boolean GREMLIN_SERVER_EPOLL = "true".equalsIgnoreCase(System.getProperty(epollOption));
     private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinServerIntegrationTest.class);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1457

Standard tests using lambdas are ignored which is why we didn't catch this in the process tests. I added a single test to `GremlinServerIntegrationTest` to just validate that lambdas could be sent, so we at least have a basic smoke test for that functionality.

Also opened up a few tests by removing some `OptOut` entries on `RemoteGraph`. 

All tests pass with: 

```text
$ mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false
```

Going to kick off a full docker build tonight too.

VOTE +1