### PR TITLE
TINKERPOP-1249 Add keep-alive functionality to websockets Java Driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * `TraversalRing` returns a `null` if it does not contain traversals (previously `IdentityTraversal`).
 * Fixed a `JavaTranslator` bug where `Bytecode` instructions were being mutated during translation.
 * Added `Path` to Gremlin-Python with respective GraphSON 2.0 deserializer.
+* Added "keep-alive" functionality to the Java driver, which will send a heartbeat to the server when normal request activity on a connection stops for a period of time.
 * Renamed the `empty.result.indicator` preference to `result.indicator.null` in Gremlin Console
 * If `result.indicator.null` is set to an empty string, then no "result line" is printed in Gremlin Console.
 * VertexPrograms can now declare traverser requirements, e.g. to have access to the path when used with `.program()`.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -687,6 +687,7 @@ The following table describes the various configuration options for the Gremlin 
 |Key |Description |Default
 |connectionPool.channelizer |The fully qualified classname of the client `Channelizer` that defines how to connect to the server. |`Channelizer.WebSocketChannelizer`
 |connectionPool.enableSsl |Determines if SSL should be enabled or not. If enabled on the server then it must be enabled on the client. |false
+|connectionPool.keepAliveInterval |Length of time in milliseconds to wait on an idle connection before sending a keep-alive request. Set to zero to disable this feature. |1800000
 |connectionPool.keyCertChainFile |The X.509 certificate chain file in PEM format. |_none_
 |connectionPool.keyFile |The `PKCS#8` private key file in PEM format. |_none_
 |connectionPool.keyPassword |The password of the `keyFile` if it's not password-protected |_none_

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -59,6 +59,16 @@ gremlin>
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1409[TINKERPOP-1409]
 
+Java Driver Keep-Alive
+^^^^^^^^^^^^^^^^^^^^^^
+
+The Java Driver now has a `keepAliveInterval` setting, which controls the amount of time in milliseconds it should wait
+on an inactive connection before it sends a message to the server to keep the connection maintained. This should help
+environments that use a load balancer in front of Gremlin Server by ensuring connections are actively maintained even
+during periods of inactivity.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1249[TINKERPOP-1249]
+
 Where Step Supports By-Modulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -163,6 +163,7 @@ public final class Cluster {
                 .port(settings.port)
                 .enableSsl(settings.connectionPool.enableSsl)
                 .trustCertificateChainFile(settings.connectionPool.trustCertChainFile)
+                .keepAliveInterval(settings.connectionPool.keepAliveInterval)
                 .keyCertChainFile(settings.connectionPool.keyCertChainFile)
                 .keyFile(settings.connectionPool.keyFile)
                 .keyPassword(settings.connectionPool.keyPassword)
@@ -388,6 +389,14 @@ public final class Cluster {
     }
 
     /**
+     * Gets time in milliseconds to wait after the last message is sent over a connection before sending a keep-alive
+     * message to the server.
+     */
+    public long getKeepAliveInterval() {
+        return manager.connectionPoolSettings.keepAliveInterval;
+    }
+
+    /**
      * Specifies the load balancing strategy to use on the client side.
      */
     public Class<? extends LoadBalancingStrategy> getLoadBalancingStrategy() {
@@ -478,6 +487,7 @@ public final class Cluster {
         private int reconnectInitialDelay = Connection.RECONNECT_INITIAL_DELAY;
         private int reconnectInterval = Connection.RECONNECT_INTERVAL;
         private int resultIterationBatchSize = Connection.RESULT_ITERATION_BATCH_SIZE;
+        private long keepAliveInterval = Connection.KEEP_ALIVE_INTERVAL;
         private String channelizer = Channelizer.WebSocketChannelizer.class.getName();
         private boolean enableSsl = false;
         private String trustCertChainFile = null;
@@ -569,6 +579,16 @@ public final class Cluster {
          */
         public Builder trustCertificateChainFile(final String certificateChainFile) {
             this.trustCertChainFile = certificateChainFile;
+            return this;
+        }
+
+        /**
+         * Length of time in milliseconds to wait on an idle connection before sending a keep-alive request. This
+         * setting is only relevant to {@link Channelizer} implementations that return {@code true} for
+         * {@link Channelizer#supportsKeepAlive()}.  Set to zero to disable this feature.
+         */
+        public Builder keepAliveInterval(final long keepAliveInterval) {
+            this.keepAliveInterval = keepAliveInterval;
             return this;
         }
 
@@ -871,6 +891,7 @@ public final class Cluster {
             connectionPoolSettings.keyCertChainFile = builder.keyCertChainFile;
             connectionPoolSettings.keyFile = builder.keyFile;
             connectionPoolSettings.keyPassword = builder.keyPassword;
+            connectionPoolSettings.keepAliveInterval = builder.keepAliveInterval;
             connectionPoolSettings.channelizer = builder.channelizer;
 
             sslContextOptional = Optional.ofNullable(builder.sslContext);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -170,7 +170,7 @@ final class ConnectionPool {
         logger.debug("Attempting to return {} on {}", connection, host);
         if (isClosed()) throw new ConnectionException(host.getHostUri(), host.getAddress(), "Pool is shutdown");
 
-        int borrowed = connection.borrowed.decrementAndGet();
+        final int borrowed = connection.borrowed.decrementAndGet();
         if (connection.isDead()) {
             logger.debug("Marking {} as dead", this.host);
             considerUnavailable();

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -20,7 +20,6 @@ package org.apache.tinkerpop.gremlin.driver;
 
 import org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0;
 import org.apache.commons.configuration.Configuration;
-import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
@@ -33,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
@@ -207,6 +205,9 @@ final class Settings {
             if (connectionPoolConf.containsKey("resultIterationBatchSize"))
                 cpSettings.resultIterationBatchSize = connectionPoolConf.getInt("resultIterationBatchSize");
 
+            if (connectionPoolConf.containsKey("keepAliveInterval"))
+                cpSettings.keepAliveInterval = connectionPoolConf.getLong("keepAliveInterval");
+
 
             settings.connectionPool = cpSettings;
         }
@@ -249,6 +250,13 @@ final class Settings {
          * The maximum size of a connection pool for a {@link Host}. By default this is set to 8.
          */
         public int maxSize = ConnectionPool.MAX_POOL_SIZE;
+
+        /**
+         * Length of time in milliseconds to wait on an idle connection before sending a keep-alive request. This
+         * setting is only relevant to {@link Channelizer} implementations that return {@code true} for
+         * {@link Channelizer#supportsKeepAlive()}. Set to zero to disable this feature.
+         */
+        public long keepAliveInterval = Connection.KEEP_ALIVE_INTERVAL;
 
         /**
          * A connection under low use can be destroyed. This setting determines the threshold for determining when

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
@@ -86,6 +86,7 @@ public final class WebSocketClientHandler extends SimpleChannelInboundHandler<Ob
         if (frame instanceof TextWebSocketFrame) {
             ctx.fireChannelRead(frame.retain(2));
         } else if (frame instanceof PongWebSocketFrame) {
+            logger.debug("Received response from keep-alive request");
         } else if (frame instanceof BinaryWebSocketFrame) {
             ctx.fireChannelRead(frame.retain(2));
         } else if (frame instanceof CloseWebSocketFrame)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketGremlinResponseDecoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketGremlinResponseDecoder.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.driver.handler;
 
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
 import io.netty.channel.ChannelHandler;
@@ -47,10 +48,12 @@ public final class WebSocketGremlinResponseDecoder extends MessageToMessageDecod
             if (webSocketFrame instanceof BinaryWebSocketFrame) {
                 final BinaryWebSocketFrame tf = (BinaryWebSocketFrame) webSocketFrame;
                 objects.add(serializer.deserializeResponse(tf.content()));
-            } else {
+            } else if (webSocketFrame instanceof TextWebSocketFrame){
                 final TextWebSocketFrame tf = (TextWebSocketFrame) webSocketFrame;
                 final MessageTextSerializer textSerializer = (MessageTextSerializer) serializer;
                 objects.add(textSerializer.deserializeResponse(tf.text()));
+            } else {
+                throw new RuntimeException(String.format("WebSocket channel does not handle this type of message: %s", webSocketFrame.getClass().getName()));
             }
         } finally {
             ReferenceCountUtil.release(webSocketFrame);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1249

If a connection goes idle, the driver will periodically send a ping to the server to keep the connection alive. 

All good with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`. Also ran some manual tests and did some memory profiling of the driver to make sure there were no leaks.

VOTE +1