### PR TITLE
TINKERPOP-1456 & TINKERPOP-1472 & TINKERPOP-1412: SubgraphStrategy updates and more!

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,12 +26,14 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a end-step label bug in `MatchPredicateStrategy`.
+* Fixed a bug in `MatchPredicateStrategy` where inlined traversals did not have strategies applied to it.
 * Fixed a bug in `RepeatUnrollStrategy` where inlined traversal did not have strategies applied to it.
 * `TinkerGraphStepStrategy` is now smart about non-`HasContainer` filter steps.
 * Added `TraversalHelper.copyLabels()` for copying (or moving) labels form one step to another.
 * Added `TraversalHelper.applySingleLevelStrategies()` which will apply a subset of strategies but not walk the child tree.
 * Added the concept that hidden labels using during traversal compilation are removed at the end during `StandardVerificationStrategy`. (*breaking*)
-* Added `InlineFilterStrategy` which will determine if a `TraversalFilterStep` or `AndStep` children are filters and if so, inline them.
+* Added `InlineFilterStrategy` which will determine if a `TraversalFilterStep`, `AndStep`, `MatchStep` children are filters and if so, inline them.
 * Removed `IdentityRemovalStrategy` from the default listing as its not worth the clock cycles.
 * Removed the "!" symbol in `NotStep.toString()` as it is confusing and the `NotStep`-name is sufficient.
 * Fixed a bug in `TraversalVertexProgram` (OLAP) around ordering and connectives (i.e. `and()` and `or()`).

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fixed a bug in `TraversalVertexProgram` (OLAP) around ordering and connectives (i.e. `and()` and `or()`).
 * Added `AbstractGremlinProcessTest.checkOrderedResults()` to make testing ordered results easier.
 * `AbstractLambdaTraversal` now supports a `bypassTraversal` and thus, it is possible for strategies to redefine such lambda traversals.
+* `SubgraphStrategy` no longer `filter()`-wraps if the criteria is a chain of filters or connectives.
 * `SubgraphStrategy` now supports vertex property filtering.
 * Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.
 * Fixed a naming bug in Gremlin-Python where `P._and` and `P._or` should be `P.and_` and `P.or_`. (*breaking*)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fixed a bug in `TraversalVertexProgram` (OLAP) around ordering and connectives (i.e. `and()` and `or()`).
 * Added `AbstractGremlinProcessTest.checkOrderedResults()` to make testing ordered results easier.
 * `AbstractLambdaTraversal` now supports a `bypassTraversal` and thus, it is possible for strategies to redefine such lambda traversals.
+* Added an internal utility `ClassFilterStep` which determines if the traverser object's class is an instance of the provided class.
 * `SubgraphStrategy` no longer `filter()`-wraps if the criteria is a chain of filters or connectives.
 * `SubgraphStrategy` now supports vertex property filtering.
 * Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug in `IncidentToAdjacentStrategy` where `TreeStep` traversals were allowed.
 * Fixed a end-step label bug in `MatchPredicateStrategy`.
 * Fixed a bug in `MatchPredicateStrategy` where inlined traversals did not have strategies applied to it.
 * Fixed a bug in `RepeatUnrollStrategy` where inlined traversal did not have strategies applied to it.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,13 +26,17 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `TraversalHelper.applySingleLevelStrategies()` which will apply a subset of strategies but not walk the child tree.
+* Added the concept that hidden labels using during traversal compilation are removed at the end during `StandardVerificationStrategy`. (*breaking*)
+* Added `InlineFilterStrategy` which will determine if a `TraversalFilterStep` or `AndStep` children are filters and if so, inline them.
+* Removed `IdentityRemovalStrategy` from the default listing as its not worth the clock cycles.
+* Removed the "!" symbol in `NotStep.toString()` as it is confusing and the `NotStep`-name is sufficient.
 * Fixed a bug in `TraversalVertexProgram` (OLAP) around ordering and connectives (i.e. `and()` and `or()`).
 * Added `AbstractGremlinProcessTest.checkOrderedResults()` to make testing ordered results easier.
 * `AbstractLambdaTraversal` now supports a `bypassTraversal` where it is possible for strategies to redefine such lambda traversals.
 * Added an internal utility `ClassFilterStep` which determines if the traverser object's class is an instance of the provided class.
-* `ConnectiveStrategy` will concatenate two traversals instead of and'ing them if they are both filter-based.
+* `ConnectiveStep` extends `FilterStep` and thus, is more appropriately categorized in the step hierarchy.
 * `PropertyMapStep` supports a provided traversal for accessing the properties of the element.
-* `SubgraphStrategy` no longer `filter()`-wraps if the criteria is a chain of filters or connectives.
 * `SubgraphStrategy` now supports vertex property filtering.
 * Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.
 * Fixed a naming bug in Gremlin-Python where `P._and` and `P._or` should be `P.and_` and `P.or_`. (*breaking*)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug in `RepeatUnrollStrategy` where inlined traversal did not have strategies applied to it.
 * `TinkerGraphStepStrategy` is now smart about non-`HasContainer` filter steps.
 * Added `TraversalHelper.copyLabels()` for copying (or moving) labels form one step to another.
 * Added `TraversalHelper.applySingleLevelStrategies()` which will apply a subset of strategies but not walk the child tree.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug in `TraversalVertexProgram` (OLAP) around ordering and connectives (i.e. `and()` and `or()`).
+* Added `AbstractGremlinProcessTest.checkOrderedResults()` to make testing ordered results easier.
+* `AbstractLambdaTraversal` now supports a `bypassTraversal` and thus, it is possible for strategies to redefine such lambda traversals.
+* `SubgraphStrategy` now supports vertex property filtering.
 * Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.
 * Fixed a naming bug in Gremlin-Python where `P._and` and `P._or` should be `P.and_` and `P.or_`. (*breaking*)
 * `where()` predicate-based steps now support `by()`-modulation.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,8 +28,10 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Fixed a bug in `TraversalVertexProgram` (OLAP) around ordering and connectives (i.e. `and()` and `or()`).
 * Added `AbstractGremlinProcessTest.checkOrderedResults()` to make testing ordered results easier.
-* `AbstractLambdaTraversal` now supports a `bypassTraversal` and thus, it is possible for strategies to redefine such lambda traversals.
+* `AbstractLambdaTraversal` now supports a `bypassTraversal` where it is possible for strategies to redefine such lambda traversals.
 * Added an internal utility `ClassFilterStep` which determines if the traverser object's class is an instance of the provided class.
+* `ConnectiveStrategy` will concatenate two traversals instead of and'ing them if they are both filter-based.
+* `PropertyMapStep` supports a provided traversal for accessing the properties of the element.
 * `SubgraphStrategy` no longer `filter()`-wraps if the criteria is a chain of filters or connectives.
 * `SubgraphStrategy` now supports vertex property filtering.
 * Fixed a bug in Gremlin-Python `P` where predicates reversed the order of the predicates.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* `TinkerGraphStepStrategy` is now smart about non-`HasContainer` filter steps.
+* Added `TraversalHelper.copyLabels()` for copying (or moving) labels form one step to another.
 * Added `TraversalHelper.applySingleLevelStrategies()` which will apply a subset of strategies but not walk the child tree.
 * Added the concept that hidden labels using during traversal compilation are removed at the end during `StandardVerificationStrategy`. (*breaking*)
 * Added `InlineFilterStrategy` which will determine if a `TraversalFilterStep` or `AndStep` children are filters and if so, inline them.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2599,17 +2599,25 @@ ReadOnlyStrategy
 SubgraphStrategy
 ~~~~~~~~~~~~~~~~
 
-`SubgraphStrategy` is quite similar to `PartitionStrategy` in that it restrains a `Traversal` to certain vertices
-and edges as determined by a `Traversal` criterion defined individually for each.
+`SubgraphStrategy` is similar to `PartitionStrategy` in that it constrains a `Traversal` to certain vertices, edges,
+ and vertex properties as determined by a `Traversal`-based criterion defined individually for each.
 
 [gremlin-groovy]
 ----
-graph = TinkerFactory.createModern()
-strategy = SubgraphStrategy.build().edgeCriterion(hasId(8,9,10)).create()
-g = graph.traversal().withStrategies(strategy)
-g.V() // shows all vertices as no filter for vertices was specified
-g.E() // shows only the edges defined in the edgeCriterion
+graph = TinkerFactory.createTheCrew()
+g = graph.traversal()
+g.V().as('a').values('location').as('b').  <1>
+  select('a','b').by('name').by()
+g = g.withStrategies(SubgraphStrategy.build().vertexProperties(hasNot('endTime')).create()) <2>
+g.V().as('a').values('location').as('b').  <3>
+  select('a','b').by('name').by()
+g.V().as('a').values('location').as('b').
+  select('a','b').by('name').by().explain()
 ----
 
 This strategy is implemented such that the vertices attached to an `Edge` must both satisfy the `vertexCriterion`
 (if present) in order for the `Edge` to be considered a part of the subgraph.
+
+<1> Get all vertices and their vertex property locations.
+<2> Create a `SubgraphStrategy` where vertex properties must not have an `endTime`-property (thus, the current location).
+<3> Get all vertices and their current vertex property locations.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2621,3 +2621,22 @@ This strategy is implemented such that the vertices attached to an `Edge` must b
 <1> Get all vertices and their vertex property locations.
 <2> Create a `SubgraphStrategy` where vertex properties must not have an `endTime`-property (thus, the current location).
 <3> Get all vertices and their current vertex property locations.
+
+The example below uses all three filters: vertex, edge, and vertex property. People vertices must have lived in more than three places,
+edges must be labeled "develops," and vertex properties must be the persons current location or a non-location property.
+
+[gremlin-groovy]
+----
+graph = TinkerFactory.createTheCrew()
+g = graph.traversal().withStrategies(SubgraphStrategy.build().
+  vertices(or(hasNot('location'),properties('location').count().is(gt(3)))).
+  edges(hasLabel('develops')).
+  vertexProperties(or(hasLabel(neq('location')),hasNot('endTime'))).create())
+g.V().valueMap(true)
+g.E().valueMap(true)
+g.V().outE().inV().
+  path().
+    by('name').
+    by().
+    by('name')
+----

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/MasterExecutor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/MasterExecutor.java
@@ -20,15 +20,16 @@
 package org.apache.tinkerpop.gremlin.process.computer.traversal;
 
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
 import org.apache.tinkerpop.gremlin.process.traversal.step.LocalBarrier;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WherePredicateStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.IdStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LabelStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
@@ -38,6 +39,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertyValueStep
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SackStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
 import org.apache.tinkerpop.gremlin.process.traversal.util.PureTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMatrix;
@@ -144,6 +146,7 @@ final class MasterExecutor {
         return step instanceof PropertiesStep || step instanceof PropertyMapStep ||
                 step instanceof IdStep || step instanceof LabelStep || step instanceof SackStep ||
                 step instanceof PropertyKeyStep || step instanceof PropertyValueStep ||
-                step instanceof TailGlobalStep || step instanceof RangeGlobalStep || step instanceof HasStep;
+                step instanceof TailGlobalStep || step instanceof RangeGlobalStep || step instanceof HasStep ||
+                step instanceof ConnectiveStep;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.Adja
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.FilterRankingStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IdentityRemovalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.InlineFilterStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.MatchPredicateStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.OrderLimitStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategy;
@@ -204,8 +205,8 @@ public interface TraversalStrategies extends Serializable, Cloneable {
                     ConnectiveStrategy.instance(),
                     IncidentToAdjacentStrategy.instance(),
                     AdjacentToIncidentStrategy.instance(),
+                    InlineFilterStrategy.instance(),
                     FilterRankingStrategy.instance(),
-                    IdentityRemovalStrategy.instance(),
                     MatchPredicateStrategy.instance(),
                     RepeatUnrollStrategy.instance(),
                     RangeByIsCountStrategy.instance(),

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
@@ -113,8 +113,10 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
 
     @Override
     public void setParent(final TraversalParent step) {
-        if (null != this.bypassTraversal)
+        if (null != this.bypassTraversal) {
             this.bypassTraversal.setParent(step);
+            step.integrateChild(this.bypassTraversal);
+        }
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
@@ -45,73 +45,90 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
 
     private static final Set<TraverserRequirement> REQUIREMENTS = Collections.singleton(TraverserRequirement.OBJECT);
 
-    public List<Step> getSteps() {
-        return Collections.emptyList();
-    }
+    protected Traversal.Admin<S, E> bypassTraversal = null;
 
-    public Bytecode getBytecode() {
-        return new Bytecode();
+    public void setBypassTraversal(final Traversal.Admin<S, E> bypassTraversal) {
+        this.bypassTraversal = bypassTraversal;
     }
 
     @Override
-    public void reset() {
+    public List<Step> getSteps() {
+        return null == this.bypassTraversal ? Collections.emptyList() : this.bypassTraversal.getSteps();
+    }
 
+    @Override
+    public Bytecode getBytecode() {
+        return null == this.bypassTraversal ? new Bytecode() : this.bypassTraversal.getBytecode();
+    }
+
+
+    @Override
+    public void reset() {
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.reset();
     }
 
     @Override
     public <S2, E2> Traversal.Admin<S2, E2> addStep(final int index, final Step<?, ?> step) throws IllegalStateException {
-        return (Traversal.Admin<S2, E2>) this;
+        return null == this.bypassTraversal ? (Traversal.Admin<S2, E2>) this : this.bypassTraversal.addStep(index, step);
     }
 
     @Override
     public <S2, E2> Traversal.Admin<S2, E2> removeStep(final int index) throws IllegalStateException {
-        return (Traversal.Admin<S2, E2>) this;
+        return null == this.bypassTraversal ? (Traversal.Admin<S2, E2>) this : this.bypassTraversal.removeStep(index);
     }
 
     @Override
     public void applyStrategies() throws IllegalStateException {
-
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.applyStrategies();
     }
 
     @Override
     public TraverserGenerator getTraverserGenerator() {
-        return B_O_TraverserGenerator.instance();
+        return null == this.bypassTraversal ? B_O_TraverserGenerator.instance() : this.bypassTraversal.getTraverserGenerator();
     }
 
     @Override
     public void setSideEffects(final TraversalSideEffects sideEffects) {
-
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.setSideEffects(sideEffects);
     }
 
     @Override
     public TraversalSideEffects getSideEffects() {
-        return EmptyTraversalSideEffects.instance();
+        return null == this.bypassTraversal ? EmptyTraversalSideEffects.instance() : this.bypassTraversal.getSideEffects();
     }
 
     @Override
     public void setStrategies(final TraversalStrategies strategies) {
-
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.setStrategies(strategies);
     }
 
     @Override
     public TraversalStrategies getStrategies() {
-        return EmptyTraversalStrategies.instance();
+        return null == this.bypassTraversal ? EmptyTraversalStrategies.instance() : this.bypassTraversal.getStrategies();
     }
 
     @Override
     public void setParent(final TraversalParent step) {
-
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.setParent(step);
     }
 
     @Override
     public TraversalParent getParent() {
-        return EmptyStep.instance();
+        return null == this.bypassTraversal ? EmptyStep.instance() : this.bypassTraversal.getParent();
     }
 
     @Override
     public Traversal.Admin<S, E> clone() {
         try {
-            return (AbstractLambdaTraversal<S, E>) super.clone();
+            final AbstractLambdaTraversal<S, E> clone = (AbstractLambdaTraversal<S, E>) super.clone();
+            if (null != this.bypassTraversal)
+                clone.bypassTraversal = this.bypassTraversal.clone();
+            return clone;
         } catch (final CloneNotSupportedException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -119,41 +136,54 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
 
     @Override
     public E next() {
+        if (null != this.bypassTraversal)
+            return this.bypassTraversal.next();
+        throw new UnsupportedOperationException("The " + this.getClass().getSimpleName() + " can only be used as a predicate traversal");
+    }
+
+    @Override
+    public Traverser.Admin<E> nextTraverser() {
+        if (null != this.bypassTraversal)
+            return this.bypassTraversal.nextTraverser();
         throw new UnsupportedOperationException("The " + this.getClass().getSimpleName() + " can only be used as a predicate traversal");
     }
 
     @Override
     public boolean hasNext() {
-        return true;
+        return null == this.bypassTraversal || this.bypassTraversal.hasNext();
     }
 
     @Override
     public void addStart(final Traverser.Admin<S> start) {
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.addStart(start);
     }
 
     @Override
     public boolean isLocked() {
-        return true;
+        return null == this.bypassTraversal || this.bypassTraversal.isLocked();
     }
 
     @Override
     public Optional<Graph> getGraph() {
-        return Optional.empty();
+        return null == this.bypassTraversal ? Optional.empty() : this.bypassTraversal.getGraph();
     }
 
     @Override
     public void setGraph(final Graph graph) {
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.setGraph(graph);
 
     }
 
     @Override
     public Set<TraverserRequirement> getTraverserRequirements() {
-        return REQUIREMENTS;
+        return null == this.bypassTraversal ? REQUIREMENTS : this.bypassTraversal.getTraverserRequirements();
     }
 
     @Override
     public int hashCode() {
-        return this.getClass().hashCode();
+        return null == this.bypassTraversal ? this.getClass().hashCode() : this.bypassTraversal.hashCode();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/ElementValueTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/ElementValueTraversal.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.lambda;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.Element;
 
 /**
@@ -39,8 +40,13 @@ public final class ElementValueTraversal<V> extends AbstractLambdaTraversal<Elem
     }
 
     @Override
+    public boolean hasNext() {
+        return true;
+    }
+
+    @Override
     public void addStart(final Traverser.Admin<Element> start) {
-        this.value = start.get().value(this.propertyKey);
+        this.value = null == this.bypassTraversal ? start.get().value(this.propertyKey) : TraversalUtil.apply(start, this.bypassTraversal);
     }
 
     public String getPropertyKey() {
@@ -49,11 +55,11 @@ public final class ElementValueTraversal<V> extends AbstractLambdaTraversal<Elem
 
     @Override
     public String toString() {
-        return "value(" + this.propertyKey + ')';
+        return "value(" + (null == this.bypassTraversal ? this.propertyKey : this.bypassTraversal) + ')';
     }
 
     @Override
     public int hashCode() {
-        return this.getClass().hashCode() ^ this.propertyKey.hashCode();
+        return super.hashCode() ^ this.propertyKey.hashCode();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndStep.java
@@ -22,8 +22,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 
-import java.util.NoSuchElementException;
-
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
@@ -34,18 +32,11 @@ public final class AndStep<S> extends ConnectiveStep<S> {
     }
 
     @Override
-    protected Traverser.Admin<S> processNextStart() throws NoSuchElementException {
-        while (true) {
-            final Traverser.Admin<S> start = this.starts.next();
-            boolean alive = true;
-            for (final Traversal.Admin<S, ?> traversal : this.traversals) {
-                if (!TraversalUtil.test(start, traversal)) {
-                    alive = false;
-                    break;
-                }
-            }
-            if (alive)
-                return start;
+    protected boolean filter(final Traverser.Admin<S> traverser) {
+        for (final Traversal.Admin<S, ?> traversal : this.traversals) {
+            if (!TraversalUtil.test(traverser, traversal))
+                return false;
         }
+        return true;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ClassFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ClassFilterStep.java
@@ -29,26 +29,23 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 public final class ClassFilterStep<S, T> extends FilterStep<S> {
 
     private final Class<T> classFilter;
-    private final boolean isInstanceCheck;
+    private final boolean allowClasses;
 
-    public ClassFilterStep(final Traversal.Admin traversal, final Class<T> classFilter, final boolean isInstanceCheck) {
+    public ClassFilterStep(final Traversal.Admin traversal, final Class<T> classFilter, final boolean allowClasses) {
         super(traversal);
         this.classFilter = classFilter;
-        this.isInstanceCheck = isInstanceCheck;
+        this.allowClasses = allowClasses;
     }
 
     public boolean filter(final Traverser.Admin<S> traverser) {
-        return !(this.isInstanceCheck ?
-                this.classFilter.isInstance(traverser.get()) :
-                this.classFilter.equals(traverser.get().getClass()));
-
+        return this.allowClasses == this.classFilter.isInstance(traverser.get());
     }
 
     public int hashCode() {
-        return super.hashCode() ^ this.classFilter.hashCode() + Boolean.valueOf(this.isInstanceCheck).hashCode();
+        return super.hashCode() ^ this.classFilter.hashCode() ^ Boolean.hashCode(this.allowClasses);
     }
 
     public String toString() {
-        return StringFactory.stepString(this, this.classFilter);
+        return StringFactory.stepString(this, this.classFilter.getSimpleName());
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ClassFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ClassFilterStep.java
@@ -1,0 +1,54 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class ClassFilterStep<S, T> extends FilterStep<S> {
+
+    private final Class<T> classFilter;
+    private final boolean isInstanceCheck;
+
+    public ClassFilterStep(final Traversal.Admin traversal, final Class<T> classFilter, final boolean isInstanceCheck) {
+        super(traversal);
+        this.classFilter = classFilter;
+        this.isInstanceCheck = isInstanceCheck;
+    }
+
+    public boolean filter(final Traverser.Admin<S> traverser) {
+        return !(this.isInstanceCheck ?
+                this.classFilter.isInstance(traverser.get()) :
+                this.classFilter.equals(traverser.get().getClass()));
+
+    }
+
+    public int hashCode() {
+        return super.hashCode() ^ this.classFilter.hashCode() + Boolean.valueOf(this.isInstanceCheck).hashCode();
+    }
+
+    public String toString() {
+        return StringFactory.stepString(this, this.classFilter);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ConnectiveStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ConnectiveStep.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class ConnectiveStep<S> extends AbstractStep<S, S> implements TraversalParent {
+public abstract class ConnectiveStep<S> extends FilterStep<S> implements TraversalParent {
 
     public enum Connective {AND, OR}
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStep.java
@@ -64,7 +64,7 @@ public final class NotStep<S> extends FilterStep<S> implements TraversalParent {
 
     @Override
     public String toString() {
-        return StringFactory.stepString(this, "!" + this.notTraversal);
+        return StringFactory.stepString(this, this.notTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/OrStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/OrStep.java
@@ -22,8 +22,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 
-import java.util.NoSuchElementException;
-
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
@@ -34,13 +32,11 @@ public final class OrStep<S> extends ConnectiveStep<S> {
     }
 
     @Override
-    protected Traverser.Admin<S> processNextStart() throws NoSuchElementException {
-        while (true) {
-            final Traverser.Admin<S> start = this.starts.next();
-            for (final Traversal.Admin<S, ?> traversal : this.traversals) {
-                if (TraversalUtil.test(start, traversal))
-                    return start;
-            }
+    protected boolean filter(final Traverser.Admin<S> traverser) {
+        for (final Traversal.Admin<S, ?> traversal : this.traversals) {
+            if (TraversalUtil.test(traverser, traversal))
+                return true;
         }
+        return false;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
@@ -20,56 +20,84 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
-import org.apache.tinkerpop.gremlin.structure.*;
-import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.PropertyType;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class PropertyMapStep<E> extends MapStep<Element, Map<String, E>> {
+public class PropertyMapStep<E> extends MapStep<Element, Map<String, E>> implements TraversalParent {
 
     protected final String[] propertyKeys;
     protected final PropertyType returnType;
     protected final boolean includeTokens;
+    protected Traversal.Admin<Element, ? extends Property> propertyTraversal;
 
     public PropertyMapStep(final Traversal.Admin traversal, final boolean includeTokens, final PropertyType propertyType, final String... propertyKeys) {
         super(traversal);
         this.includeTokens = includeTokens;
         this.propertyKeys = propertyKeys;
         this.returnType = propertyType;
+        this.propertyTraversal = null;
     }
 
     @Override
     protected Map<String, E> map(final Traverser.Admin<Element> traverser) {
-        if (this.returnType.equals(PropertyType.VALUE)) {
-            final Element element = traverser.get();
-            final Map map = traverser.get() instanceof Vertex ?
-                    (Map) ElementHelper.vertexPropertyValueMap((Vertex) element, propertyKeys) :
-                    (Map) ElementHelper.propertyValueMap(element, propertyKeys);
-            if (includeTokens) {
-                if (element instanceof VertexProperty) {
-                    map.put(T.id, element.id());
-                    map.put(T.key, ((VertexProperty) element).key());
-                    map.put(T.value, ((VertexProperty) element).value());
-                } else {
-                    map.put(T.id, element.id());
-                    map.put(T.label, element.label());
+        final Map<Object, Object> map = new HashMap<>();
+        final Element element = traverser.get();
+        final boolean isVertex = traverser.get() instanceof Vertex;
+        final Iterator<? extends Property> properties = null == this.propertyTraversal ?
+                (Iterator) element.properties(this.propertyKeys) :
+                TraversalUtil.applyAll(traverser, this.propertyTraversal);
+        while (properties.hasNext()) {
+            final Property property = properties.next();
+            if (isVertex) {
+                List values = (List) map.get(property.key());
+                if (null == values) {
+                    values = new ArrayList();
+                    map.put(property.key(), values);
                 }
-            }
-            return map;
-
-        } else {
-            return traverser.get() instanceof Vertex ?
-                    (Map) ElementHelper.vertexPropertyMap((Vertex) traverser.get(), propertyKeys) :
-                    (Map) ElementHelper.propertyMap(traverser.get(), propertyKeys);
+                values.add(this.returnType == PropertyType.VALUE ? property.value() : property);
+            } else
+                map.put(property.key(), this.returnType == PropertyType.VALUE ? property.value() : property);
         }
+        if (this.returnType == PropertyType.VALUE && this.includeTokens) {
+            if (element instanceof VertexProperty) {
+                map.put(T.id, element.id());
+                map.put(T.key, ((VertexProperty) element).key());
+                map.put(T.value, ((VertexProperty) element).value());
+            } else {
+                map.put(T.id, element.id());
+                map.put(T.label, element.label());
+            }
+        }
+        return (Map) map;
+    }
+
+    @Override
+    public List<Traversal.Admin<Element, ? extends Property>> getLocalChildren() {
+        return null == this.propertyTraversal ? Collections.emptyList() : Collections.singletonList(this.propertyTraversal);
+    }
+
+    public void setPropertyTraversal(final Traversal.Admin<Element, ? extends Property> propertyTraversal) {
+        this.propertyTraversal = this.integrateChild(propertyTraversal);
     }
 
     public PropertyType getReturnType() {
@@ -89,16 +117,35 @@ public class PropertyMapStep<E> extends MapStep<Element, Map<String, E>> {
     }
 
     @Override
+    public PropertyMapStep<E> clone() {
+        final PropertyMapStep<E> clone = (PropertyMapStep<E>) super.clone();
+        if (null != this.propertyTraversal)
+            clone.propertyTraversal = this.propertyTraversal.clone();
+        return clone;
+    }
+
+    @Override
     public int hashCode() {
         int result = super.hashCode() ^ this.returnType.hashCode() ^ Boolean.hashCode(this.includeTokens);
-        for (final String propertyKey : this.propertyKeys) {
-            result ^= propertyKey.hashCode();
+        if (null == this.propertyTraversal) {
+            for (final String propertyKey : this.propertyKeys) {
+                result ^= propertyKey.hashCode();
+            }
+        } else {
+            result ^= this.propertyTraversal.hashCode();
         }
         return result;
     }
 
     @Override
+    public void setTraversal(final Traversal.Admin<?, ?> parentTraversal) {
+        super.setTraversal(parentTraversal);
+        if (null != this.propertyTraversal)
+            this.integrateChild(this.propertyTraversal);
+    }
+
+    @Override
     public Set<TraverserRequirement> getRequirements() {
-        return Collections.singleton(TraverserRequirement.OBJECT);
+        return this.getSelfAndChildRequirements(TraverserRequirement.OBJECT);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
@@ -113,7 +113,9 @@ public class PropertyMapStep<E> extends MapStep<Element, Map<String, E>> impleme
     }
 
     public String toString() {
-        return StringFactory.stepString(this, Arrays.asList(this.propertyKeys), this.returnType.name().toLowerCase());
+        return null != this.propertyTraversal ?
+                StringFactory.stepString(this, this.propertyTraversal, this.returnType.name().toLowerCase()) :
+                StringFactory.stepString(this, Arrays.asList(this.propertyKeys), this.returnType.name().toLowerCase());
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
@@ -104,10 +104,15 @@ public final class ConnectiveStrategy extends AbstractTraversalStrategy<Traversa
             }
             processConnectiveMarker(leftTraversal);
 
-            TraversalHelper.replaceStep(connectiveStep,
-                    connectiveStep instanceof AndStep ?
-                            new AndStep(traversal, leftTraversal, rightTraversal) :
-                            new OrStep(traversal, leftTraversal, rightTraversal), traversal);
+            if (connectiveStep instanceof AndStep) {
+                if (TraversalHelper.filterOnlyTraversal(leftTraversal) && TraversalHelper.filterOnlyTraversal(rightTraversal)) {
+                    TraversalHelper.insertTraversal((Step) connectiveStep, rightTraversal, traversal);
+                    TraversalHelper.insertTraversal((Step) connectiveStep, leftTraversal, traversal);
+                } else
+                    TraversalHelper.replaceStep((Step) connectiveStep, new AndStep(traversal, leftTraversal, rightTraversal), traversal);
+
+            } else
+                TraversalHelper.replaceStep((Step) connectiveStep, new OrStep(traversal, leftTraversal, rightTraversal), traversal);
         });
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
@@ -104,14 +104,9 @@ public final class ConnectiveStrategy extends AbstractTraversalStrategy<Traversa
             }
             processConnectiveMarker(leftTraversal);
 
-            if (connectiveStep instanceof AndStep) {
-                if (TraversalHelper.filterOnlyTraversal(leftTraversal) && TraversalHelper.filterOnlyTraversal(rightTraversal)) {
-                    TraversalHelper.insertTraversal((Step) connectiveStep, rightTraversal, traversal);
-                    TraversalHelper.insertTraversal((Step) connectiveStep, leftTraversal, traversal);
-                } else
-                    TraversalHelper.replaceStep((Step) connectiveStep, new AndStep(traversal, leftTraversal, rightTraversal), traversal);
-
-            } else
+            if (connectiveStep instanceof AndStep)
+                TraversalHelper.replaceStep((Step) connectiveStep, new AndStep(traversal, leftTraversal, rightTraversal), traversal);
+            else
                 TraversalHelper.replaceStep((Step) connectiveStep, new OrStep(traversal, leftTraversal, rightTraversal), traversal);
         });
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -318,10 +318,10 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
                     }
                 }
             }
-            // when there is no filter()-wrap, the marked steps exist at the same traversal level
-            for (final Step step : traversal.getSteps()) {
-                step.removeLabel(MARKER);
-            }
+        }
+        // when there is no filter()-wrap, the marked steps exist at the same traversal level
+        for (final Step step : traversal.getSteps()) {
+            step.removeLabel(MARKER);
         }
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -307,13 +307,11 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
                             propertyValueStep.addLabel(label);
                         }
                         if ('v' == propertyType) {
-                            final Traversal.Admin<?, ?> temp = nonCheckPropertyCriterion.clone();
                             TraversalHelper.insertAfterStep(propertyValueStep, propertiesStep, traversal);
-                            TraversalHelper.insertTraversal(propertiesStep, temp, traversal);
+                            TraversalHelper.insertTraversal(propertiesStep, nonCheckPropertyCriterion.clone(), traversal);
                         } else {
-                            final Step filterStep = checkPropertyCriterion.clone();
-                            TraversalHelper.insertAfterStep(filterStep, propertiesStep, traversal);
-                            TraversalHelper.insertAfterStep(propertyValueStep, filterStep, traversal);
+                            TraversalHelper.insertAfterStep(propertyValueStep, propertiesStep, traversal);
+                            TraversalHelper.insertAfterStep(checkPropertyCriterion.clone(), propertiesStep, traversal);
                         }
                     }
                 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -24,9 +24,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ClassFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.LambdaFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.OrStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStep;
@@ -216,13 +216,12 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
         // turn g.V().values() to g.V().properties().xxx.value()\
         if (null != this.vertexPropertyCriterion) {
             final OrStep<Object> wrappedCriterion = new OrStep(traversal,
-                    new DefaultTraversal<>().addStep(new LambdaFilterStep<>(traversal, t -> !(t.get() instanceof VertexProperty))),
+                    new DefaultTraversal<>().addStep(new ClassFilterStep<>(traversal, VertexProperty.class, true)),
                     this.vertexPropertyCriterionIsAllFilter ?
                             this.vertexPropertyCriterion.clone() :
                             new DefaultTraversal<>().addStep(new TraversalFilterStep<>(traversal, this.vertexPropertyCriterion.clone())));
             // turn all ElementValueTraversals into filters
             for (final Step<?, ?> step : traversal.getSteps()) {
-                // gremlin> g.V().local(properties('name','stateOfMind').group().by(key()).by(value().fold()))
                 if (step instanceof TraversalParent) {
                     Stream.concat(((TraversalParent) step).getGlobalChildren().stream(), ((TraversalParent) step).getLocalChildren().stream())
                             .filter(t -> t instanceof ElementValueTraversal)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.TreeStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
@@ -57,13 +58,14 @@ import java.util.Set;
  * __.bothE().otherV()     // is replaced by __.both()
  * __.bothE().bothV()      // will not be modified
  * __.outE().inV().path()  // will not be modified
+ * __.outE().inV().tree()  // will not be modified
  * </pre>
  */
 public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy>
         implements TraversalStrategy.OptimizationStrategy {
 
     private static final IncidentToAdjacentStrategy INSTANCE = new IncidentToAdjacentStrategy();
-    private static final Set<Class> INVALIDATING_STEP_CLASSES = new HashSet<>(Arrays.asList(PathStep.class, LambdaHolder.class));
+    private static final Set<Class> INVALIDATING_STEP_CLASSES = new HashSet<>(Arrays.asList(PathStep.class, TreeStep.class, LambdaHolder.class));
 
     private IncidentToAdjacentStrategy() {
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategy.java
@@ -56,7 +56,7 @@ public final class InlineFilterStrategy extends AbstractTraversalStrategy<Traver
                 final Traversal.Admin<?, ?> childTraversal = step.getLocalChildren().get(0);
                 if (TraversalHelper.allStepsInstanceOf(childTraversal, FilterStep.class, true)) {
                     changed = true;
-                    TraversalHelper.applySingleLevelStrategies(childTraversal, traversal.getStrategies(), InlineFilterStrategy.class);
+                    TraversalHelper.applySingleLevelStrategies(traversal, childTraversal, InlineFilterStrategy.class);
                     final Step<?, ?> finalStep = childTraversal.getEndStep();
                     TraversalHelper.insertTraversal((Step) step, childTraversal, traversal);
                     traversal.removeStep(step);
@@ -72,7 +72,7 @@ public final class InlineFilterStrategy extends AbstractTraversalStrategy<Traver
                     Step<?, ?> finalStep = null;
                     for (int i = childTraversals.size() - 1; i >= 0; i--) {
                         final Traversal.Admin<?, ?> childTraversal = childTraversals.get(i);
-                        TraversalHelper.applySingleLevelStrategies(childTraversal, traversal.getStrategies(), InlineFilterStrategy.class);
+                        TraversalHelper.applySingleLevelStrategies(traversal, childTraversal, InlineFilterStrategy.class);
                         if (null == finalStep)
                             finalStep = childTraversal.getEndStep();
                         TraversalHelper.insertTraversal((Step) step, childTraversals.get(i), traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategy.java
@@ -1,0 +1,100 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.optimization.GraphFilterStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class InlineFilterStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy> implements TraversalStrategy.OptimizationStrategy {
+
+    private static final InlineFilterStrategy INSTANCE = new InlineFilterStrategy();
+    private static final Set<Class<? extends OptimizationStrategy>> POSTS = new HashSet<>(Arrays.asList(
+            FilterRankingStrategy.class,
+            GraphFilterStrategy.class));
+
+    private InlineFilterStrategy() {
+    }
+
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        boolean changed = true; // recursively walk child traversals trying to inline them into the current traversal line.
+        while (changed) {
+            changed = false;
+            for (final TraversalFilterStep<?> step : TraversalHelper.getStepsOfAssignableClass(TraversalFilterStep.class, traversal)) {
+                final Traversal.Admin<?, ?> childTraversal = step.getLocalChildren().get(0);
+                if (TraversalHelper.allStepsInstanceOf(childTraversal, FilterStep.class, true)) {
+                    changed = true;
+                    TraversalHelper.applySingleLevelStrategies(childTraversal, traversal.getStrategies(), InlineFilterStrategy.class);
+                    final Step<?, ?> finalStep = childTraversal.getEndStep();
+                    TraversalHelper.insertTraversal((Step) step, childTraversal, traversal);
+                    traversal.removeStep(step);
+                    for (final String label : step.getLabels()) {
+                        finalStep.addLabel(label);
+                    }
+                }
+            }
+            for (final AndStep<?> step : TraversalHelper.getStepsOfAssignableClass(AndStep.class, traversal)) {
+                if (!step.getLocalChildren().stream().filter(t -> !TraversalHelper.allStepsInstanceOf(t, FilterStep.class, true)).findAny().isPresent()) {
+                    changed = true;
+                    final List<Traversal.Admin<?, ?>> childTraversals = (List) step.getLocalChildren();
+                    Step<?, ?> finalStep = null;
+                    for (int i = childTraversals.size() - 1; i >= 0; i--) {
+                        final Traversal.Admin<?, ?> childTraversal = childTraversals.get(i);
+                        TraversalHelper.applySingleLevelStrategies(childTraversal, traversal.getStrategies(), InlineFilterStrategy.class);
+                        if (null == finalStep)
+                            finalStep = childTraversal.getEndStep();
+                        TraversalHelper.insertTraversal((Step) step, childTraversals.get(i), traversal);
+
+                    }
+                    traversal.removeStep(step);
+                    if (null != finalStep) {
+                        for (final String label : step.getLabels()) {
+                            finalStep.addLabel(label);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public Set<Class<? extends OptimizationStrategy>> applyPost() {
+        return POSTS;
+    }
+
+    public static InlineFilterStrategy instance() {
+        return INSTANCE;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/MatchPredicateStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/MatchPredicateStrategy.java
@@ -21,6 +21,8 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WherePredicateStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
@@ -72,7 +74,9 @@ public final class MatchPredicateStrategy extends AbstractTraversalStrategy<Trav
                     (nextStep instanceof SelectOneStep && ((SelectOneStep) nextStep).getLocalChildren().isEmpty())) {
                 if (nextStep instanceof WherePredicateStep || nextStep instanceof WhereTraversalStep) {
                     traversal.removeStep(nextStep);
-                    matchStep.addGlobalChild(new DefaultTraversal<>().addStep(nextStep));
+                    matchStep.addGlobalChild(traversal instanceof GraphTraversal ?
+                            new DefaultGraphTraversal<>().addStep(nextStep) :
+                            new DefaultTraversal<>().addStep(nextStep));
                     nextStep = matchStep.getNextStep();
                 } else if (nextStep instanceof DedupGlobalStep && !((DedupGlobalStep) nextStep).getScopeKeys().isEmpty() && ((DedupGlobalStep) nextStep).getLocalChildren().isEmpty() && !TraversalHelper.onGraphComputer(traversal)) {
                     traversal.removeStep(nextStep);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
@@ -48,9 +48,9 @@ public final class RepeatUnrollStrategy extends AbstractTraversalStrategy<Traver
                 final RepeatStep<?> repeatStep = (RepeatStep) traversal.getSteps().get(i);
                 if (null == repeatStep.getEmitTraversal() && repeatStep.getUntilTraversal() instanceof LoopTraversal && ((LoopTraversal) repeatStep.getUntilTraversal()).getMaxLoops() > 0) {
                     final Traversal.Admin<?, ?> repeatTraversal = repeatStep.getGlobalChildren().get(0);
-                    final int repeatLength = repeatTraversal.getSteps().size() - 1;
-                    repeatTraversal.removeStep(repeatLength); // removes the RepeatEndStep
+                    repeatTraversal.removeStep(repeatTraversal.getSteps().size() - 1); // removes the RepeatEndStep
                     TraversalHelper.applySingleLevelStrategies(traversal, repeatTraversal, RepeatUnrollStrategy.class);
+                    final int repeatLength = repeatTraversal.getSteps().size();
                     int insertIndex = i;
                     final int loops = (int) ((LoopTraversal) repeatStep.getUntilTraversal()).getMaxLoops();
                     for (int j = 0; j < loops; j++) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
@@ -19,7 +19,6 @@
 
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
 
-import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.LoopTraversal;
@@ -61,11 +60,8 @@ public final class RepeatUnrollStrategy extends AbstractTraversalStrategy<Traver
                             traversal.addStep(++insertIndex, new NoOpBarrierStep<>(traversal, 5000));
                     }
                     // label last step if repeat() was labeled
-                    if (!repeatStep.getLabels().isEmpty()) {
-                        final Step<?, ?> lastStep = traversal.getSteps().get(insertIndex);
-                        repeatStep.getLabels().forEach(lastStep::addLabel);
-                    }
-
+                    if (!repeatStep.getLabels().isEmpty())
+                        TraversalHelper.copyLabels(repeatStep, traversal.getSteps().get(insertIndex), false);
                     traversal.removeStep(i); // remove the RepeatStep
                 }
             }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
@@ -51,6 +51,7 @@ public final class RepeatUnrollStrategy extends AbstractTraversalStrategy<Traver
                     final Traversal.Admin<?, ?> repeatTraversal = repeatStep.getGlobalChildren().get(0);
                     final int repeatLength = repeatTraversal.getSteps().size() - 1;
                     repeatTraversal.removeStep(repeatLength); // removes the RepeatEndStep
+                    TraversalHelper.applySingleLevelStrategies(traversal, repeatTraversal, RepeatUnrollStrategy.class);
                     int insertIndex = i;
                     final int loops = (int) ((LoopTraversal) repeatStep.getUntilTraversal()).getMaxLoops();
                     for (int j = 0; j < loops; j++) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
@@ -32,7 +32,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -53,13 +52,9 @@ public final class StandardVerificationStrategy extends AbstractTraversalStrateg
         }
 
         for (final Step<?, ?> step : traversal.getSteps()) {
-            final Set<String> hiddenLabels = new HashSet<>();
             for (String label : step.getLabels()) {
                 if (Graph.Hidden.isHidden(label))
-                   hiddenLabels.add(label);
-            }
-            for(final String label : hiddenLabels) {
-                step.removeLabel(label);
+                    step.removeLabel(label);
             }
             if (step instanceof ReducingBarrierStep && step.getTraversal().getParent() instanceof RepeatStep && step.getTraversal().getParent().getGlobalChildren().get(0).getSteps().contains(step))
                 throw new VerificationException("The parent of a reducing barrier can not be repeat()-step: " + step, traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
@@ -29,8 +29,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierS
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.RequirementsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -50,20 +52,28 @@ public final class StandardVerificationStrategy extends AbstractTraversalStrateg
                 throw new VerificationException("VertexComputing steps must be executed with a GraphComputer: " + TraversalHelper.getStepsOfAssignableClass(VertexComputing.class, traversal), traversal);
         }
 
-        traversal.getSteps().forEach(step -> {
+        for (final Step<?, ?> step : traversal.getSteps()) {
+            final Set<String> hiddenLabels = new HashSet<>();
+            for (String label : step.getLabels()) {
+                if (Graph.Hidden.isHidden(label))
+                   hiddenLabels.add(label);
+            }
+            for(final String label : hiddenLabels) {
+                step.removeLabel(label);
+            }
             if (step instanceof ReducingBarrierStep && step.getTraversal().getParent() instanceof RepeatStep && step.getTraversal().getParent().getGlobalChildren().get(0).getSteps().contains(step))
                 throw new VerificationException("The parent of a reducing barrier can not be repeat()-step: " + step, traversal);
-        });
+        }
 
         // The ProfileSideEffectStep must be the last step, 2nd last step when accompanied by the cap step,
         // or 3rd to last when the traversal ends with a RequirementsStep.
-        final Step<?,?> endStep = traversal.asAdmin().getEndStep();
+        final Step<?, ?> endStep = traversal.asAdmin().getEndStep();
         if (TraversalHelper.hasStepOfClass(ProfileSideEffectStep.class, traversal) &&
                 !(endStep instanceof ProfileSideEffectStep ||
                         (endStep instanceof SideEffectCapStep && endStep.getPreviousStep() instanceof ProfileSideEffectStep) ||
                         (endStep instanceof RequirementsStep && (
                                 endStep.getPreviousStep() instanceof SideEffectCapStep ||
-                                endStep.getPreviousStep() instanceof ProfileSideEffectStep)))) {
+                                        endStep.getPreviousStep() instanceof ProfileSideEffectStep)))) {
             throw new VerificationException("When specified, the profile()-Step must be the last step or followed only by the cap()-step and/or requirements step.", traversal);
         }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -579,10 +579,16 @@ public final class TraversalHelper {
         }
     }
 
-    public static boolean allStepsInstanceOf(final Traversal.Admin<?, ?> traversal, final Class<?> classToCheck, boolean checkIsInstanceOf) {
+    public static boolean allStepsInstanceOf(final Traversal.Admin<?, ?> traversal, final Class<?>... classesToCheck) {
         for (final Step step : traversal.getSteps()) {
-            boolean isInstance = classToCheck.isInstance(step);
-            if ((isInstance && !checkIsInstanceOf) || (!isInstance && checkIsInstanceOf))
+            boolean foundInstance = false;
+            for (final Class<?> classToCheck : classesToCheck) {
+                if (classToCheck.isInstance(step)) {
+                    foundInstance = true;
+                    break;
+                }
+            }
+            if (!foundInstance)
                 return false;
         }
         return true;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -579,7 +579,7 @@ public final class TraversalHelper {
         }
     }
 
-    public static boolean allStepsInstanceOf(final Traversal.Admin<?, ?> traversal, final Class<?>... classesToCheck) {
+    public static boolean hasAllStepsOfClass(final Traversal.Admin<?, ?> traversal, final Class<?>... classesToCheck) {
         for (final Step step : traversal.getSteps()) {
             boolean foundInstance = false;
             for (final Class<?> classToCheck : classesToCheck) {
@@ -592,6 +592,16 @@ public final class TraversalHelper {
                 return false;
         }
         return true;
+    }
+
+    public static boolean hasStepOfClass(final Traversal.Admin<?, ?> traversal, final Class<?>... classesToCheck) {
+        for (final Step<?, ?> step : traversal.getSteps()) {
+            for (final Class<?> classToCheck : classesToCheck) {
+                if (classToCheck.isInstance(step))
+                    return true;
+            }
+        }
+        return false;
     }
 
     public static void applySingleLevelStrategies(final Traversal.Admin<?, ?> parentTraversal, final Traversal.Admin<?, ?> childTraversal, final Class<? extends TraversalStrategy> stopAfterStrategy) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -571,6 +571,14 @@ public final class TraversalHelper {
         }
     }
 
+    public static void copyLabels(final Step<?, ?> fromStep, final Step<?, ?> toStep, final boolean moveLabels) {
+        for (final String label : fromStep.getLabels()) {
+            toStep.addLabel(label);
+            if (moveLabels)
+                fromStep.removeLabel(label);
+        }
+    }
+
     public static boolean allStepsInstanceOf(final Traversal.Admin<?, ?> traversal, final Class<?> classToCheck, boolean checkIsInstanceOf) {
         for (final Step step : traversal.getSteps()) {
             boolean isInstance = classToCheck.isInstance(step);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -22,8 +22,6 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.Traversa
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
@@ -32,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WherePredicateStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
@@ -570,5 +569,13 @@ public final class TraversalHelper {
         while (!traversal.getSteps().isEmpty()) {
             traversal.removeStep(0);
         }
+    }
+
+    public static boolean filterOnlyTraversal(final Traversal.Admin<?, ?> traversal) {
+        for (final Step step : traversal.getSteps()) {
+            if (!(step instanceof FilterStep) && !(step instanceof ConnectiveStep))
+                return false;
+        }
+        return true;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -22,7 +22,6 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.Traversa
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
@@ -581,9 +580,12 @@ public final class TraversalHelper {
         return true;
     }
 
-    public static void applySingleLevelStrategies(final Traversal.Admin<?, ?> traversal, final TraversalStrategies traversalStrategies, final Class<? extends TraversalStrategy> stopAfterStrategy) {
-        for (final TraversalStrategy<?> strategy : traversalStrategies.toList()) {
-            strategy.apply(traversal);
+    public static void applySingleLevelStrategies(final Traversal.Admin<?, ?> parentTraversal, final Traversal.Admin<?, ?> childTraversal, final Class<? extends TraversalStrategy> stopAfterStrategy) {
+        childTraversal.setStrategies(parentTraversal.getStrategies());
+        childTraversal.setSideEffects(parentTraversal.getSideEffects());
+        parentTraversal.getGraph().ifPresent(childTraversal::setGraph);
+        for (final TraversalStrategy<?> strategy : parentTraversal.getStrategies().toList()) {
+            strategy.apply(childTraversal);
             if (null != stopAfterStrategy && stopAfterStrategy.isInstance(strategy))
                 break;
         }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategyTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
 import org.junit.Test;
@@ -27,6 +28,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,33 +50,36 @@ public class FilterRankingStrategyTest {
     @Parameterized.Parameter(value = 1)
     public Traversal optimized;
 
-
-    void applyFilterRankingStrategy(final Traversal traversal) {
-        final TraversalStrategies strategies = new DefaultTraversalStrategies();
-        strategies.addStrategies(FilterRankingStrategy.instance(), IdentityRemovalStrategy.instance());
-        traversal.asAdmin().setStrategies(strategies);
-        traversal.asAdmin().applyStrategies();
-    }
+    @Parameterized.Parameter(value = 2)
+    public Collection<TraversalStrategy> otherStrategies;
 
     @Test
     public void doTest() {
-        applyFilterRankingStrategy(original);
-        assertEquals(optimized, original);
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(FilterRankingStrategy.instance());
+        for (final TraversalStrategy strategy : this.otherStrategies) {
+            strategies.addStrategies(strategy);
+        }
+        this.original.asAdmin().setStrategies(strategies);
+        this.original.asAdmin().applyStrategies();
+        assertEquals(this.optimized, this.original);
     }
 
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> generateTestParameters() {
 
-        return Arrays.asList(new Traversal[][]{
-                {__.dedup().order(), __.dedup().order()},
-                {__.order().dedup(), __.dedup().order()},
-                {__.identity().order().dedup(), __.dedup().order()},
-                {__.order().identity().dedup(), __.dedup().order()},
-                {__.order().out().dedup(), __.order().out().dedup()},
-                {__.has("value", 0).filter(__.out()).dedup(), __.has("value", 0).filter(__.out()).dedup()},
-                {__.dedup().filter(__.out()).has("value", 0), __.has("value", 0).filter(__.out()).dedup()},
-                {__.filter(__.out()).dedup().has("value", 0), __.has("value", 0).filter(__.out()).dedup()},
-                {__.has("value", 0).filter(__.out()).dedup(), __.has("value", 0).filter(__.out()).dedup()},
+        return Arrays.asList(new Object[][]{
+                {__.dedup().order(), __.dedup().order(), Collections.emptyList()},
+                {__.order().dedup(), __.dedup().order(), Collections.emptyList()},
+                {__.order().as("a").dedup(), __.order().as("a").dedup(), Collections.emptyList()},
+                {__.identity().order().dedup(), __.dedup().order(), Collections.singletonList(IdentityRemovalStrategy.instance())},
+                {__.order().identity().dedup(), __.dedup().order(), Collections.singletonList(IdentityRemovalStrategy.instance())},
+                {__.order().out().dedup(), __.order().out().dedup(), Collections.emptyList()},
+                {__.has("value", 0).filter(__.out()).dedup(), __.has("value", 0).filter(__.out()).dedup(), Collections.emptyList()},
+                {__.dedup().filter(__.out()).has("value", 0), __.has("value", 0).filter(__.out()).dedup(), Collections.emptyList()},
+                {__.filter(__.out()).dedup().has("value", 0), __.has("value", 0).filter(__.out()).dedup(), Collections.emptyList()},
+                {__.has("value", 0).filter(__.out()).dedup(), __.has("value", 0).filter(__.out()).dedup(), Collections.emptyList()},
+                {__.has("value", 0).and(__.has("age"), __.has("name", "marko")).is(10), __.is(10).has("value", 0).has("name", "marko").has("age"), Collections.singletonList(InlineFilterStrategy.instance())},
         });
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategyTest.java
@@ -39,24 +39,19 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 public class IncidentToAdjacentStrategyTest {
 
-
     @Parameterized.Parameter(value = 0)
     public Traversal original;
 
     @Parameterized.Parameter(value = 1)
     public Traversal optimized;
 
-    void applyIncidentToAdjacentStrategy(final Traversal traversal) {
-        final TraversalStrategies strategies = new DefaultTraversalStrategies();
-        strategies.addStrategies(IncidentToAdjacentStrategy.instance());
-        traversal.asAdmin().setStrategies(strategies);
-        traversal.asAdmin().applyStrategies();
-    }
-
     @Test
     public void doTest() {
-        applyIncidentToAdjacentStrategy(original);
-        assertEquals(optimized, original);
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(IncidentToAdjacentStrategy.instance());
+        this.original.asAdmin().setStrategies(strategies);
+        this.original.asAdmin().applyStrategies();
+        assertEquals(this.optimized, this.original);
     }
 
     @Parameterized.Parameters(name = "{0}")
@@ -74,6 +69,7 @@ public class IncidentToAdjacentStrategyTest {
                 {__.bothE().outV(), __.bothE().outV()},
                 {__.outE().as("a").inV(), __.outE().as("a").inV()}, // todo: this can be optimized, but requires a lot more checks
                 {__.outE().inV().path(), __.outE().inV().path()},
+                {__.outE().inV().tree().as("a"), __.outE().inV().tree().as("a")},
                 {__.outE().inV().map(lambda), __.outE().inV().map(lambda)},
                 {__.union(__.outE().inV(), __.inE().outV()).path(), __.union(__.outE().inV(), __.inE().outV()).path()},
                 {__.as("a").outE().inV().as("b"), __.as("a").out().as("b")}});

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategyTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.and;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.filter;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+@RunWith(Parameterized.class)
+public class InlineFilterStrategyTest {
+
+    @Parameterized.Parameter(value = 0)
+    public Traversal original;
+
+    @Parameterized.Parameter(value = 1)
+    public Traversal optimized;
+
+
+    void applyInlineFilterStrategy(final Traversal traversal) {
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(InlineFilterStrategy.instance());
+        traversal.asAdmin().setStrategies(strategies);
+        traversal.asAdmin().applyStrategies();
+    }
+
+    @Test
+    public void doTest() {
+        applyInlineFilterStrategy(original);
+        assertEquals(optimized, original);
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> generateTestParameters() {
+
+        return Arrays.asList(new Traversal[][]{
+                {filter(out("knows")), filter(out("knows"))},
+                {filter(has("age", P.gt(10))).as("a"), has("age", P.gt(10)).as("a")},
+                {filter(has("age", P.gt(10)).as("b")).as("a"), has("age", P.gt(10)).as("b","a")},
+                {filter(has("age", P.gt(10))), has("age", P.gt(10))},
+                {filter(and(has("age", P.gt(10)), has("name", "marko"))), has("age", P.gt(10)).has("name", "marko")},
+                {and(has("age", P.gt(10)), filter(has("age", 22))), has("age", P.gt(10)).has("age", 22)},
+                {and(has("age", P.gt(10)).as("a"), and(filter(has("age", 22).as("b")).as("c"), has("name", "marko").as("d"))), has("age", P.gt(10)).as("a").has("age", 22).as("b","c").has("name", "marko").as("d")},
+                {and(has("age", P.gt(10)), and(out("knows"), has("name", "marko"))), has("age", P.gt(10)).and(out("knows"), has("name", "marko"))}
+        });
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategyTest.java
@@ -32,11 +32,15 @@ import java.util.Arrays;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.and;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.dedup;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.drop;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.filter;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.map;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.match;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.tail;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -67,8 +71,8 @@ public class InlineFilterStrategyTest {
                 {filter(out("knows")), filter(out("knows"))},
                 {filter(has("age", P.gt(10))).as("a"), has("age", P.gt(10)).as("a")},
                 {filter(has("age", P.gt(10)).as("b")).as("a"), has("age", P.gt(10)).as("b", "a")},
-                {filter(has("age", P.gt(10))), has("age", P.gt(10))},
-                {filter(and(has("age", P.gt(10)), has("name", "marko"))), has("age", P.gt(10)).has("name", "marko")},
+                {filter(has("age", P.gt(10)).as("a")), has("age", P.gt(10)).as("a")},
+                {filter(and(has("age", P.gt(10)).as("a"), has("name", "marko"))), has("age", P.gt(10)).as("a").has("name", "marko")},
                 //
                 {and(has("age", P.gt(10)), filter(has("age", 22))), has("age", P.gt(10)).has("age", 22)},
                 {and(has("age", P.gt(10)).as("a"), and(filter(has("age", 22).as("b")).as("c"), has("name", "marko").as("d"))), has("age", P.gt(10)).as("a").has("age", 22).as("b", "c").has("name", "marko").as("d")},
@@ -79,6 +83,11 @@ public class InlineFilterStrategyTest {
                 {map(match(as("a").has("age", 10), as("a").filter(has("name")).as("b"))), map(match(as("a").has("age", 10), as("a").has("name").as("b")))},
                 {V().match(as("a").has("age", 10)), V().as("a").has("age", 10)},
                 {V().match(as("a").has("age", 10).as("b"), as("a").filter(has("name")).as("b")), V().as("a").has("age", 10).as("b").match(as("a").has("name").as("b"))},
+                //
+                {filter(dedup()), filter(dedup())},
+                {filter(filter(drop())), filter(drop())},
+                {and(has("name"), limit(10).has("age")), and(has("name"), limit(10).has("age"))},
+                {filter(tail(10).as("a")), filter(tail(10).as("a"))},
         });
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/MatchPredicateStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/MatchPredicateStrategyTest.java
@@ -20,113 +20,64 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
 
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-@RunWith(Enclosed.class)
+@RunWith(Parameterized.class)
 public class MatchPredicateStrategyTest {
 
-    @RunWith(Parameterized.class)
-    public static class StandardTest extends AbstractMatchPredicateStrategyTest {
+    @Parameterized.Parameter(value = 0)
+    public Traversal original;
 
-        @Parameterized.Parameters(name = "{0}")
-        public static Iterable<Object[]> data() {
-            return generateTestParameters();
+    @Parameterized.Parameter(value = 1)
+    public Traversal optimized;
+
+    @Parameterized.Parameter(value = 2)
+    public Collection<TraversalStrategy> otherStrategies;
+
+    @Test
+    public void doTest() {
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(MatchPredicateStrategy.instance());
+        for (final TraversalStrategy strategy : this.otherStrategies) {
+            strategies.addStrategies(strategy);
         }
-
-        @Parameterized.Parameter(value = 0)
-        public Traversal original;
-
-        @Parameterized.Parameter(value = 1)
-        public Traversal optimized;
-
-        @Before
-        public void setup() {
-            this.traversalEngine = mock(TraversalEngine.class);
-            when(this.traversalEngine.getType()).thenReturn(TraversalEngine.Type.STANDARD);
-        }
-
-        @Test
-        public void shouldApplyStrategy() {
-            doTest(original, optimized);
-        }
+        this.original.asAdmin().setStrategies(strategies);
+        this.original.asAdmin().applyStrategies();
+        assertEquals(this.optimized, this.original);
     }
 
-    @RunWith(Parameterized.class)
-    public static class ComputerTest extends AbstractMatchPredicateStrategyTest {
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> generateTestParameters() {
 
-        @Parameterized.Parameters(name = "{0}")
-        public static Iterable<Object[]> data() {
-            return generateTestParameters();
-        }
-
-        @Parameterized.Parameter(value = 0)
-        public Traversal original;
-
-        @Parameterized.Parameter(value = 1)
-        public Traversal optimized;
-
-        @Before
-        public void setup() {
-            this.traversalEngine = mock(TraversalEngine.class);
-            when(this.traversalEngine.getType()).thenReturn(TraversalEngine.Type.COMPUTER);
-        }
-
-        @Test
-        public void shouldApplyStrategy() {
-            doTest(original, optimized);
-        }
+        return Arrays.asList(new Object[][]{
+                {__.out().match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("a").has("name", "marko").match(as("a").out().as("b")), Collections.singletonList(InlineFilterStrategy.instance())}, // has() pull out
+                {__.out().as("a").match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("a").has("name", "marko").match(as("a").out().as("b")), Collections.singletonList(InlineFilterStrategy.instance())}, // has() pull out
+                {__.out().as("a").out().match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("a").out().match(as("a").has("name", "marko"), as("a").out().as("b")), Collections.emptyList()}, // no has() pull out
+                {__.map(__.match(as("a").has("name", "marko"), as("a").out().as("b"))), __.map(__.match(as("a").has("name", "marko"), as("a").out().as("b"))), Collections.emptyList()}, // no has() pull out
+                {__.out().as("c").match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("c").match(as("a").has("name", "marko"), as("a").out().as("b")), Collections.emptyList()}, // no has() pull out
+                /////////
+                {__.match(as("a").out().as("b"), __.where(as("b").out("knows").as("c"))), __.match(as("a").out().as("b"), as("b").where(__.out("knows").as("c"))), Collections.emptyList()}, // make as().where()
+                {__.match(as("a").out().as("b"), __.where("a", P.gt("b"))), __.match(as("a").out().as("b"), __.as("a").where(P.gt("b"))), Collections.emptyList()},  // make as().where()
+                /////////
+                // {__.match(as("a").out().as("b")).where(as("b").out("knows").as("c")), __.match(as("a").out().as("b"), as("b").where(__.out("knows").as("c"))), Collections.emptyList()}, // make as().where()
+                // {__.match(as("a").out().as("b")).where("a", P.gt("b")), __.match(as("a").out().as("b"), __.as("a").where(P.gt("b"))), Collections.emptyList()},  // make as().where()
+        });
     }
 
-    private static abstract class AbstractMatchPredicateStrategyTest {
-
-        protected TraversalEngine traversalEngine;
-
-        void applyMatchWhereStrategy(final Traversal traversal) {
-            final TraversalStrategies strategies = new DefaultTraversalStrategies();
-            strategies.addStrategies(MatchPredicateStrategy.instance(), IdentityRemovalStrategy.instance());
-            traversal.asAdmin().setStrategies(strategies);
-            //traversal.asAdmin().setEngine(this.traversalEngine);
-            traversal.asAdmin().applyStrategies();
-        }
-
-        public void doTest(final Traversal traversal, final Traversal optimized) {
-            applyMatchWhereStrategy(traversal);
-            assertEquals(optimized, traversal);
-        }
-
-        static Iterable<Object[]> generateTestParameters() {
-
-            return Arrays.asList(new Traversal[][]{
-                    {__.out().match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("a").has("name", "marko").match(as("a").out().as("b"))}, // has() pull out
-                    {__.out().as("a").match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("a").has("name", "marko").match(as("a").out().as("b"))}, // has() pull out
-                    {__.out().as("a").out().match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("a").out().match(as("a").has("name", "marko"), as("a").out().as("b"))}, // no has() pull out
-                    {__.map(__.match(as("a").has("name", "marko"), as("a").out().as("b"))), __.map(__.match(as("a").has("name", "marko"), as("a").out().as("b")))}, // no has() pull out
-                    {__.out().as("c").match(as("a").has("name", "marko"), as("a").out().as("b")), __.out().as("c").match(as("a").has("name", "marko"), as("a").out().as("b"))}, // no has() pull out
-                    /////////
-                    {__.match(as("a").out().as("b"), __.where(as("b").out("knows").as("c"))), __.match(as("a").out().as("b"), as("b").where(__.out("knows").as("c")))}, // make as().where()
-                    {__.match(as("a").out().as("b"), __.where("a", P.gt("b"))), __.match(as("a").out().as("b"), __.as("a").where(P.gt("b")))},  // make as().where()
-                    /////////
-                    //{__.match(as("a").out().as("b")).where(as("b").out("knows").as("c")), __.match(as("a").out().as("b"), as("b").where(__.out("knows").as("c")))}, // make as().where()
-                    //{__.match(as("a").out().as("b")).where("a", P.gt("b")), __.match(as("a").out().as("b"), __.as("a").where(P.gt("b")))},  // make as().where()
-            });
-        }
-    }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/MatchPredicateStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/MatchPredicateStrategyTest.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -33,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -75,8 +77,8 @@ public class MatchPredicateStrategyTest {
                 {__.match(as("a").out().as("b"), __.where(as("b").out("knows").as("c"))), __.match(as("a").out().as("b"), as("b").where(__.out("knows").as("c"))), Collections.emptyList()}, // make as().where()
                 {__.match(as("a").out().as("b"), __.where("a", P.gt("b"))), __.match(as("a").out().as("b"), __.as("a").where(P.gt("b"))), Collections.emptyList()},  // make as().where()
                 /////////
-                // {__.match(as("a").out().as("b")).where(as("b").out("knows").as("c")), __.match(as("a").out().as("b"), as("b").where(__.out("knows").as("c"))), Collections.emptyList()}, // make as().where()
-                // {__.match(as("a").out().as("b")).where("a", P.gt("b")), __.match(as("a").out().as("b"), __.as("a").where(P.gt("b"))), Collections.emptyList()},  // make as().where()
+                {__.match(as("a").out().as("b")).where(as("b").filter(has("name")).out("knows").as("c")), __.match(as("a").out().as("b"), as("b").where(has("name").out("knows").as("c"))), Collections.singletonList(InlineFilterStrategy.instance())}, // make as().where()
+                {__.match(as("a").out().as("b")).where("a", P.gt("b")), __.match(as("a").out().as("b"), as("a").where(P.gt("b"))), Collections.emptyList()},  // make as().where()
         });
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategyTest.java
@@ -34,10 +34,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.path;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -56,46 +60,51 @@ public class RepeatUnrollStrategyTest {
         @Parameterized.Parameter(value = 1)
         public Traversal optimized;
 
-
-        private void applyRepeatUnrollStrategy(final Traversal traversal) {
-            final TraversalStrategies strategies = new DefaultTraversalStrategies();
-            strategies.addStrategies(RepeatUnrollStrategy.instance());
-            traversal.asAdmin().setStrategies(strategies);
-            traversal.asAdmin().applyStrategies();
-
-        }
+        @Parameterized.Parameter(value = 2)
+        public Collection<TraversalStrategy> otherStrategies;
 
         @Test
         public void doTest() {
-            applyRepeatUnrollStrategy(original);
-            assertEquals(optimized, original);
+            final TraversalStrategies strategies = new DefaultTraversalStrategies();
+            strategies.addStrategies(RepeatUnrollStrategy.instance());
+            for (final TraversalStrategy strategy : this.otherStrategies) {
+                strategies.addStrategies(strategy);
+            }
+            this.original.asAdmin().setStrategies(strategies);
+            this.original.asAdmin().applyStrategies();
+            assertEquals(this.optimized, this.original);
         }
 
         @Parameterized.Parameters(name = "{0}")
         public static Iterable<Object[]> generateTestParameters() {
             final int maxBarrierSize = 5000;
             final Predicate<Traverser<Vertex>> predicate = t -> t.loops() > 5;
-            return Arrays.asList(new Traversal[][]{
-                    {__.repeat(__.out()).times(0), __.repeat(__.out()).times(0)},
-                    {__.<Vertex>times(0).repeat(__.out()), __.<Vertex>times(0).repeat(__.out())},
-                    {__.identity(), __.identity()},
-                    {__.out().as("a").in().repeat(__.outE("created").bothV()).times(2).in(), __.out().as("a").in().outE("created").bothV().barrier(maxBarrierSize).outE("created").bothV().barrier(maxBarrierSize).in()},
-                    {__.out().repeat(__.outE("created").bothV()).times(1).in(), __.out().outE("created").bothV().barrier(maxBarrierSize).in()},
-                    {__.repeat(__.outE("created").bothV()).times(1).in(), __.outE("created").bothV().barrier(maxBarrierSize).in()},
-                    {__.repeat(__.out()).times(2).as("x").repeat(__.in().as("b")).times(3), __.out().barrier(maxBarrierSize).out().barrier(maxBarrierSize).as("x").in().as("b").barrier(maxBarrierSize).in().as("b").barrier(maxBarrierSize).in().as("b").barrier(maxBarrierSize)},
-                    {__.repeat(__.outE("created").inV()).times(2), __.outE("created").inV().barrier(maxBarrierSize).outE("created").inV().barrier(maxBarrierSize)},
-                    {__.repeat(__.out()).times(3), __.out().barrier(maxBarrierSize).out().barrier(maxBarrierSize).out().barrier(maxBarrierSize)},
-                    {__.repeat(__.local(__.select("a").out("knows"))).times(2), __.local(__.select("a").out("knows")).barrier(maxBarrierSize).local(__.select("a").out("knows")).barrier(maxBarrierSize)},
-                    {__.<Vertex>times(2).repeat(__.out()), __.out().barrier(maxBarrierSize).out().barrier(maxBarrierSize)},
-                    {__.<Vertex>out().times(2).repeat(__.out().as("a")).as("x"), __.out().out().as("a").barrier(maxBarrierSize).out().as("a").barrier(maxBarrierSize).as("x")},
-                    {__.repeat(__.out()).emit().times(2), __.repeat(__.out()).emit().times(2)},
-                    {__.repeat(__.out()).until(predicate), __.repeat(__.out()).until(predicate)},
-                    {__.repeat(__.out()).until(predicate).repeat(__.out()).times(2), __.repeat(__.out()).until(predicate).out().barrier(maxBarrierSize).out().barrier(maxBarrierSize)},
-                    {__.repeat(__.union(__.both(), __.identity())).times(2).out(), __.union(__.both(), __.identity()).barrier(maxBarrierSize).union(__.both(), __.identity()).barrier(maxBarrierSize).out()},
-                    {__.in().repeat(__.out("knows")).times(3).as("a").count().is(0), __.in().out("knows").barrier(maxBarrierSize).out("knows").barrier(maxBarrierSize).out("knows").as("a").count().is(0)},
+            return Arrays.asList(new Object[][]{
+                    {__.repeat(out()).times(0), __.repeat(out()).times(0), Collections.emptyList()},
+                    {__.<Vertex>times(0).repeat(out()), __.<Vertex>times(0).repeat(out()), Collections.emptyList()},
+                    {__.identity(), __.identity(), Collections.emptyList()},
+                    {out().as("a").in().repeat(__.outE("created").bothV()).times(2).in(), out().as("a").in().outE("created").bothV().barrier(maxBarrierSize).outE("created").bothV().barrier(maxBarrierSize).in(), Collections.emptyList()},
+                    {out().repeat(__.outE("created").bothV()).times(1).in(), out().outE("created").bothV().barrier(maxBarrierSize).in(), Collections.emptyList()},
+                    {__.repeat(__.outE("created").bothV()).times(1).in(), __.outE("created").bothV().barrier(maxBarrierSize).in(), Collections.emptyList()},
+                    {__.repeat(out()).times(2).as("x").repeat(__.in().as("b")).times(3), out().barrier(maxBarrierSize).out().barrier(maxBarrierSize).as("x").in().as("b").barrier(maxBarrierSize).in().as("b").barrier(maxBarrierSize).in().as("b").barrier(maxBarrierSize), Collections.emptyList()},
+                    {__.repeat(__.outE("created").inV()).times(2), __.outE("created").inV().barrier(maxBarrierSize).outE("created").inV().barrier(maxBarrierSize), Collections.emptyList()},
+                    {__.repeat(out()).times(3), out().barrier(maxBarrierSize).out().barrier(maxBarrierSize).out().barrier(maxBarrierSize), Collections.emptyList()},
+                    {__.repeat(__.local(__.select("a").out("knows"))).times(2), __.local(__.select("a").out("knows")).barrier(maxBarrierSize).local(__.select("a").out("knows")).barrier(maxBarrierSize), Collections.emptyList()},
+                    {__.<Vertex>times(2).repeat(out()), out().barrier(maxBarrierSize).out().barrier(maxBarrierSize), Collections.emptyList()},
+                    {__.<Vertex>out().times(2).repeat(out().as("a")).as("x"), out().out().as("a").barrier(maxBarrierSize).out().as("a").barrier(maxBarrierSize).as("x"), Collections.emptyList()},
+                    {__.repeat(out()).emit().times(2), __.repeat(out()).emit().times(2), Collections.emptyList()},
+                    {__.repeat(out()).until(predicate), __.repeat(out()).until(predicate), Collections.emptyList()},
+                    {__.repeat(out()).until(predicate).repeat(out()).times(2), __.repeat(out()).until(predicate).out().barrier(maxBarrierSize).out().barrier(maxBarrierSize), Collections.emptyList()},
+                    {__.repeat(__.union(__.both(), __.identity())).times(2).out(), __.union(__.both(), __.identity()).barrier(maxBarrierSize).union(__.both(), __.identity()).barrier(maxBarrierSize).out(), Collections.emptyList()},
+                    {__.in().repeat(out("knows")).times(3).as("a").count().is(0), __.in().out("knows").barrier(maxBarrierSize).out("knows").barrier(maxBarrierSize).out("knows").as("a").count().is(0), Collections.emptyList()},
+                    //
+                    {__.repeat(__.outE().inV()).times(2), __.outE().inV().barrier(maxBarrierSize).outE().inV().barrier(maxBarrierSize), Collections.emptyList()},
+                    {__.repeat(__.outE().filter(path()).inV()).times(2), __.outE().filter(path()).inV().barrier(maxBarrierSize).outE().filter(path()).inV().barrier(maxBarrierSize), Collections.singletonList(IncidentToAdjacentStrategy.instance())},
+                    {__.repeat(__.outE().inV()).times(2), __.out().barrier(maxBarrierSize).out().barrier(maxBarrierSize), Collections.singletonList(IncidentToAdjacentStrategy.instance())},
             });
         }
     }
+
 
     public static class PerformanceTest extends TraversalStrategyPerformanceTest {
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
@@ -102,6 +102,19 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
         assertEquals(StringFactory.traversalSideEffectsString(sideEffects), sideEffects.toString());
     }
 
+    public static <T> void checkOrderedResults(final List<T> expectedResults, final Traversal<?, T> traversal) {
+        final List<T> results = traversal.toList();
+        assertFalse(traversal.hasNext());
+        if (expectedResults.size() != results.size()) {
+            logger.error("Expected results: " + expectedResults);
+            logger.error("Actual results:   " + results);
+            assertEquals("Checking result size", expectedResults.size(), results.size());
+        }
+        for (int i = 0; i < expectedResults.size(); i++) {
+            assertEquals(expectedResults.get(i), results.get(i));
+        }
+    }
+
     public static <T> void checkResults(final List<T> expectedResults, final Traversal<?, T> traversal) {
         final List<T> results = traversal.toList();
         assertFalse(traversal.hasNext());

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
@@ -101,7 +101,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_name_order() {
         final Traversal<Vertex, String> traversal = get_g_V_name_order();
         printTraversalForm(traversal);
-        assertCommon(traversal);
+        checkOrderedResults(Arrays.asList("josh", "lop", "marko", "peter", "ripple", "vadas"), traversal);
     }
 
     @Test
@@ -109,14 +109,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_name_order_byXa1_b1X_byXb2_a2X() {
         final Traversal<Vertex, String> traversal = get_g_V_name_order_byXa1_b1X_byXb2_a2X();
         printTraversalForm(traversal);
-        final List<String> names = traversal.toList();
-        assertEquals(names.size(), 6);
-        assertEquals("marko", names.get(0));
-        assertEquals("vadas", names.get(1));
-        assertEquals("peter", names.get(2));
-        assertEquals("ripple", names.get(3));
-        assertEquals("josh", names.get(4));
-        assertEquals("lop", names.get(5));
+        checkOrderedResults(Arrays.asList("marko", "vadas", "peter", "ripple", "josh", "lop"), traversal);
     }
 
     @Test
@@ -124,7 +117,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_order_byXname_incrX_name() {
         final Traversal<Vertex, String> traversal = get_g_V_order_byXname_incrX_name();
         printTraversalForm(traversal);
-        assertCommon(traversal);
+        checkOrderedResults(Arrays.asList("josh", "lop", "marko", "peter", "ripple", "vadas"), traversal);
     }
 
     @Test
@@ -132,18 +125,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_order_byXnameX_name() {
         final Traversal<Vertex, String> traversal = get_g_V_order_byXnameX_name();
         printTraversalForm(traversal);
-        assertCommon(traversal);
-    }
-
-    private static void assertCommon(Traversal<Vertex, String> traversal) {
-        final List<String> names = traversal.toList();
-        assertEquals(names.size(), 6);
-        assertEquals("josh", names.get(0));
-        assertEquals("lop", names.get(1));
-        assertEquals("marko", names.get(2));
-        assertEquals("peter", names.get(3));
-        assertEquals("ripple", names.get(4));
-        assertEquals("vadas", names.get(5));
+        checkOrderedResults(Arrays.asList("josh", "lop", "marko", "peter", "ripple", "vadas"), traversal);
     }
 
     @Test
@@ -151,15 +133,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_outE_order_byXweight_decrX_weight() {
         final Traversal<Vertex, Double> traversal = get_g_V_outE_order_byXweight_decrX_weight();
         printTraversalForm(traversal);
-        final List<Double> weights = traversal.toList();
-        assertEquals(6, weights.size());
-        assertEquals(Double.valueOf(1.0d), weights.get(0));
-        assertEquals(Double.valueOf(1.0d), weights.get(1));
-        assertEquals(Double.valueOf(0.5d), weights.get(2));
-        assertEquals(Double.valueOf(0.4d), weights.get(3));
-        assertEquals(Double.valueOf(0.4d), weights.get(4));
-        assertEquals(Double.valueOf(0.2d), weights.get(5));
-
+        checkOrderedResults(Arrays.asList(1.0d, 1.0d, 0.5d, 0.4d, 0.4d, 0.2d), traversal);
     }
 
     @Test
@@ -167,14 +141,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_order_byXname_a1_b1X_byXname_b2_a2X_name() {
         final Traversal<Vertex, String> traversal = get_g_V_order_byXname_a1_b1X_byXname_b2_a2X_name();
         printTraversalForm(traversal);
-        final List<String> names = traversal.toList();
-        assertEquals(names.size(), 6);
-        assertEquals("marko", names.get(0));
-        assertEquals("vadas", names.get(1));
-        assertEquals("peter", names.get(2));
-        assertEquals("ripple", names.get(3));
-        assertEquals("josh", names.get(4));
-        assertEquals("lop", names.get(5));
+        checkOrderedResults(Arrays.asList("marko", "vadas", "peter", "ripple", "josh", "lop"), traversal);
     }
 
     @Test
@@ -337,11 +304,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_hasLabelXpersonX_order_byXvalueXageX__decrX_name() {
         final Traversal<Vertex, String> traversal = get_g_V_hasLabelXpersonX_order_byXvalueXageX__decrX_name();
         printTraversalForm(traversal);
-        assertEquals("peter", traversal.next());
-        assertEquals("josh", traversal.next());
-        assertEquals("marko", traversal.next());
-        assertEquals("vadas", traversal.next());
-        assertFalse(traversal.hasNext());
+        checkOrderedResults(Arrays.asList("peter", "josh", "marko", "vadas"), traversal);
     }
 
     @Test
@@ -349,19 +312,10 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_properties_order_byXkey_decrX_key() {
         final Traversal<Vertex, String> traversal = get_g_V_properties_order_byXkey_decrX_key();
         printTraversalForm(traversal);
-        assertEquals("name", traversal.next());
-        assertEquals("name", traversal.next());
-        assertEquals("name", traversal.next());
-        assertEquals("name", traversal.next());
-        assertEquals("name", traversal.next());
-        assertEquals("name", traversal.next());
-        assertEquals("lang", traversal.next());
-        assertEquals("lang", traversal.next());
-        assertEquals("age", traversal.next());
-        assertEquals("age", traversal.next());
-        assertEquals("age", traversal.next());
-        assertEquals("age", traversal.next());
-        assertFalse(traversal.hasNext());
+        checkOrderedResults(Arrays.asList(
+                "name", "name", "name", "name", "name", "name",
+                "lang", "lang",
+                "age", "age", "age", "age"), traversal);
     }
 
     @Test
@@ -391,14 +345,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_both_hasLabelXpersonX_order_byXage_decrX_limitX5X_name() {
         final Traversal<Vertex, String> traversal = get_g_V_both_hasLabelXpersonX_order_byXage_decrX_limitX5X_name();
         printTraversalForm(traversal);
-        final List<String> results = traversal.toList();
-        assertEquals(5, results.size());
-        assertFalse(traversal.hasNext());
-        assertEquals("peter", results.get(0));
-        assertEquals("josh", results.get(1));
-        assertEquals("josh", results.get(2));
-        assertEquals("josh", results.get(3));
-        assertEquals("marko", results.get(4));
+        checkOrderedResults(Arrays.asList("peter", "josh", "josh", "josh", "marko"), traversal);
     }
 
     @Test
@@ -421,19 +368,10 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public void g_V_hasLabelXsongX_order_byXperfomances_decrX_byXnameX_rangeX110_120X_name() {
         final Traversal<Vertex, String> traversal = get_g_V_hasLabelXsongX_order_byXperfomances_decrX_byXnameX_rangeX110_120X_name();
         printTraversalForm(traversal);
-        final List<String> results = traversal.toList();
-        assertEquals(10, results.size());
-        assertEquals("WANG DANG DOODLE", results.get(0));
-        assertEquals("THE ELEVEN", results.get(1));
-        assertEquals("WAY TO GO HOME", results.get(2));
-        assertEquals("FOOLISH HEART", results.get(3));
-        assertEquals("GIMME SOME LOVING", results.get(4));
-        assertEquals("DUPREES DIAMOND BLUES", results.get(5));
-        assertEquals("CORRINA", results.get(6));
-        assertEquals("PICASSO MOON", results.get(7));
-        assertEquals("KNOCKING ON HEAVENS DOOR", results.get(8));
-        assertEquals("MEMPHIS BLUES", results.get(9));
-        assertFalse(traversal.hasNext());
+        checkOrderedResults(Arrays.asList(
+                "WANG DANG DOODLE", "THE ELEVEN", "WAY TO GO HOME", "FOOLISH HEART",
+                "GIMME SOME LOVING", "DUPREES DIAMOND BLUES", "CORRINA", "PICASSO MOON",
+                "KNOCKING ON HEAVENS DOOR", "MEMPHIS BLUES"), traversal);
     }
 
     public static class Traversals extends OrderTest {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
@@ -396,6 +397,14 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
         //
         sg = create(SubgraphStrategy.build().vertices(has("location")).vertexProperties(hasNot("endTime")).create());
         checkOrderedResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().order().by("location", Order.incr).values("location"));
+        //
+        sg = create(SubgraphStrategy.build().vertices(has("location")).vertexProperties(hasNot("endTime")).create());
+        checkResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().valueMap("location").select(Column.values).unfold().unfold());
+        checkResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().propertyMap("location").select(Column.values).unfold().unfold().value());
+        //
+        sg = create(SubgraphStrategy.build().edges(__.<Edge>hasLabel("uses").has("skill", 5)).create());
+        checkResults(Arrays.asList(5, 5, 5), sg.V().outE().valueMap().select(Column.values).unfold());
+        checkResults(Arrays.asList(5, 5, 5), sg.V().outE().propertyMap().select(Column.values).unfold().value());
     }
 
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
@@ -21,12 +21,14 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,6 +41,7 @@ import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.hasNot;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -384,6 +387,13 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
         sg = create(SubgraphStrategy.build().vertices(has("name", P.not(P.within("stephen", "daniel")))).vertexProperties(has("startTime", P.gt(2005))).create());
         checkResults(Arrays.asList("baltimore", "oakland", "seattle"), sg.V().properties("location").value());
         checkResults(Arrays.asList("baltimore", "oakland", "seattle"), sg.V().values("location"));
+        //
+        sg = create(SubgraphStrategy.build().vertices(has("name", P.eq("matthias"))).vertexProperties(has("startTime", P.gte(2014))).create());
+        System.out.println(sg.V().groupCount().by("location").explain());
+        checkResults(makeMapList(1, "seattle", 1L), sg.V().groupCount().by("location"));
+        //
+        sg = create(SubgraphStrategy.build().vertices(has("location")).vertexProperties(hasNot("endTime")).create());
+        checkOrderedResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().order().by("location", Order.incr).values("location"));
     }
 
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilte
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -405,6 +406,11 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
         sg = create(SubgraphStrategy.build().edges(__.<Edge>hasLabel("uses").has("skill", 5)).create());
         checkResults(Arrays.asList(5, 5, 5), sg.V().outE().valueMap().select(Column.values).unfold());
         checkResults(Arrays.asList(5, 5, 5), sg.V().outE().propertyMap().select(Column.values).unfold().value());
+        //
+        sg = create(SubgraphStrategy.build().vertexProperties(__.hasNot("skill")).create());
+        checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().outE("uses").values("skill"));
+        checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().as("a").properties().select("a").dedup().outE().values("skill"));
+        checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().as("a").properties().select("a").outE().properties("skill").as("b").dedup().select("b").by(__.value()));
     }
 
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
@@ -410,7 +410,7 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
         sg = create(SubgraphStrategy.build().vertexProperties(__.hasNot("skill")).create());
         checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().outE("uses").values("skill"));
         checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().as("a").properties().select("a").dedup().outE().values("skill"));
-        checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().as("a").properties().select("a").outE().properties("skill").as("b").dedup().select("b").by(__.value()));
+        checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().as("a").properties().select("a").dedup().outE().properties("skill").as("b").identity().select("b").by(__.value()));
     }
 
 

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/groovy/jsr223/TinkerGraphGroovyTranslatorProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/groovy/jsr223/TinkerGraphGroovyTranslatorProvider.java
@@ -24,6 +24,10 @@ import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslator;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionComputerTest;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProfileTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategyProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
@@ -47,9 +51,13 @@ public class TinkerGraphGroovyTranslatorProvider extends TinkerGraphProvider {
             "g_VX1X_out_injectXv2X_name",
             "shouldNeverPropagateANoBulkTraverser",
             "shouldNeverPropagateANullValuedTraverser",
+            OrderTest.Traversals.class.getCanonicalName(),
+            ProfileTest.Traversals.class.getCanonicalName(),
             ProgramTest.Traversals.class.getCanonicalName(),
             TraversalInterruptionTest.class.getCanonicalName(),
             TraversalInterruptionComputerTest.class.getCanonicalName(),
+            PageRankTest.Traversals.class.getCanonicalName(),
+            PeerPressureTest.Traversals.class.getCanonicalName(),
             ElementIdStrategyProcessTest.class.getCanonicalName()));
 
 

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/groovy/jsr223/TinkerGraphGroovyTranslatorProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/groovy/jsr223/TinkerGraphGroovyTranslatorProvider.java
@@ -21,13 +21,10 @@ package org.apache.tinkerpop.gremlin.tinkergraph.process.groovy.jsr223;
 
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslator;
+import org.apache.tinkerpop.gremlin.process.computer.GraphComputerTest;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionComputerTest;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProfileTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategyProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
@@ -51,13 +48,10 @@ public class TinkerGraphGroovyTranslatorProvider extends TinkerGraphProvider {
             "g_VX1X_out_injectXv2X_name",
             "shouldNeverPropagateANoBulkTraverser",
             "shouldNeverPropagateANullValuedTraverser",
-            OrderTest.Traversals.class.getCanonicalName(),
-            ProfileTest.Traversals.class.getCanonicalName(),
+            GraphComputerTest.class.getCanonicalName(),
             ProgramTest.Traversals.class.getCanonicalName(),
             TraversalInterruptionTest.class.getCanonicalName(),
             TraversalInterruptionComputerTest.class.getCanonicalName(),
-            PageRankTest.Traversals.class.getCanonicalName(),
-            PeerPressureTest.Traversals.class.getCanonicalName(),
             ElementIdStrategyProcessTest.class.getCanonicalName()));
 
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1456
  https://issues.apache.org/jira/browse/TINKERPOP-1412

  There is alot of good work here.

  `SubgraphStrategy` now supports vertex property filtering. Added `InlineFilterStrategy` which analyzes the child traversals of `TraversalFilterStep` and `AndStep` and if they are composed of all `FilterSteps`, then it inlines the child traversal into the parent traversal. This is huge, cause it means there is a better chance of getting vertex-centric index and graph-centric index provider optimizations to pull in filters accordingly for push-down predicates. From there I added lots of test to `SubgraphStrategyXXXTest` and updated the reference documentation with some better uses of `SubgraphStrategy`. Also, I made it so `AbstractLambdaTraversals` can be "bypasses" (necessary for various strategy introspection/mutation scenarios). `ConnectiveSteps` (and/or) extends `FilterStep` (should have the whole time). Added the concept that hiddel labels on steps are purged at execution time. Much like hidden labels in structure are not visible, did the same here in traversal. This makes life alot easier when dealing with multi-nested strategies.

  Here is the CHANGELOG.

  ```
* Added `TraversalHelper.applySingleLevelStrategies()` which will apply a subset of strategies but not walk the child tree.
* Added the concept that hidden labels using during traversal compilation are removed at the end during `StandardVerificationStrategy`. (*breaking*)
* Added `InlineFilterStrategy` which will determine if a `TraversalFilterStep` or `AndStep` children are filters and if so, inline them.
* Removed `IdentityRemovalStrategy` from the default listing as its not worth the clock cycles.
* Removed the "!" symbol in `NotStep.toString()` as it is confusing and the `NotStep`-name is sufficient.
* Fixed a bug in `TraversalVertexProgram` (OLAP) around ordering and connectives (i.e. `and()` and `or()`).
* Added `AbstractGremlinProcessTest.checkOrderedResults()` to make testing ordered results easier.
* `AbstractLambdaTraversal` now supports a `bypassTraversal` where it is possible for strategies to redefine such lambda traversals.
* Added an internal utility `ClassFilterStep` which determines if the traverser object's class is an instance of the provided class.
* `ConnectiveStep` extends `FilterStep` and thus, is more appropriately categorized in the step hierarchy.
* `PropertyMapStep` supports a provided traversal for accessing the properties of the element.
* `SubgraphStrategy` now supports vertex property filtering.
```

VOTE +1