### PR TITLE
TINKERPOP-944 Deprecate Graph.Exceptions.elementNotFound()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fixed a naming bug in Gremlin-Python where `P._and` and `P._or` should be `P.and_` and `P.or_`. (*breaking*)
 * `where()` predicate-based steps now support `by()`-modulation.
 * `TraversalRing` returns a `null` if it does not contain traversals (previously `IdentityTraversal`).
+* Deprecated `Graph.Exceptions.elementNotFoundException()` as it was not used in the code base outside of the test suite.
 * Fixed a `JavaTranslator` bug where `Bytecode` instructions were being mutated during translation.
 * Added `Path` to Gremlin-Python with respective GraphSON 2.0 deserializer.
 * Added "keep-alive" functionality to the Java driver, which will send a heartbeat to the server when normal request activity on a connection stops for a period of time.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -121,8 +121,24 @@ support no arguments.
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+Graph System Providers
+^^^^^^^^^^^^^^^^^^^^^^
+
+Deprecated elementNotFound
+++++++++++++++++++++++++++
+
+Both `Graph.Exceptions.elementNotFound()` methods have been deprecated. These exceptions were being asserted in the
+test suite but were not being used anywhere in `gremlin-core` itself. The assertions have been modified to simply
+assert that `NoSuchElementException` was thrown, which is precisely the behavior that was being indirected asserted
+when `Graph.Exceptions.elementNotFound()` were being used.
+
+Providers should not need to take any action in this case for their tests to pass, however, it would be wise to remove
+uses of these exception builders as they will be removed in the future.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-944[TINKERPOP-944]
+
 PropertyMapStep with Selection Traversal
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++++++++++
 
 `PropertyMapStep` now supports selection of properties via child property traversal. If a provider was relying solely
 on the provided property keys in a `ProviderOptimizationStrategy`, they will need to check if there is a child traversal

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -1160,12 +1160,24 @@ public interface Graph extends AutoCloseable, Host {
             return new IllegalArgumentException(String.format("The provided argument can not be null: %s", argument));
         }
 
+        /**
+         * Deprecated as of 3.2.3, not replaced.
+         *
+         * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-944">TINKERPOP-944</a>
+         */
+        @Deprecated
         public static NoSuchElementException elementNotFound(final Class<? extends Element> elementClass, final Object id) {
             return (null == id) ?
                     new NoSuchElementException("The " + elementClass.getSimpleName().toLowerCase() + " with id null does not exist in the graph") :
                     new NoSuchElementException("The " + elementClass.getSimpleName().toLowerCase() + " with id " + id + " of type " + id.getClass().getSimpleName() + " does not exist in the graph");
         }
 
+        /**
+         * Deprecated as of 3.2.3, not replaced.
+         *
+         * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-944">TINKERPOP-944</a>
+         */
+        @Deprecated
         public static NoSuchElementException elementNotFound(final Class<? extends Element> elementClass, final Object id, final Exception rootCause) {
             NoSuchElementException elementNotFoundException;
             if (null == id)

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -99,7 +101,7 @@ public class GraphTest extends AbstractGremlinTest {
             graph.vertices(graphProvider.convertId(10000l, Vertex.class)).next();
             fail("Call to g.vertices(10000l) should throw an exception");
         } catch (Exception ex) {
-            assertThat(ex, instanceOf(Graph.Exceptions.elementNotFound(Vertex.class, graphProvider.convertId(10000l, Vertex.class)).getClass()));
+            assertThat(ex, IsInstanceOf.instanceOf(NoSuchElementException.class));
         }
     }
 
@@ -109,7 +111,7 @@ public class GraphTest extends AbstractGremlinTest {
             graph.edges(graphProvider.convertId(10000l, Edge.class)).next();
             fail("Call to g.edges(10000l) should throw an exception");
         } catch (Exception ex) {
-            assertThat(ex, instanceOf(Graph.Exceptions.elementNotFound(Edge.class, graphProvider.convertId(10000l, Edge.class)).getClass()));
+            assertThat(ex, IsInstanceOf.instanceOf(NoSuchElementException.class));
         }
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 
 import java.util.HashSet;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -413,7 +414,7 @@ public class TransactionTest extends AbstractGremlinTest {
             graph.vertices(oid.get()).next();
             fail("Vertex should not be found as close behavior was set to rollback");
         } catch (Exception ex) {
-            validateException(Graph.Exceptions.elementNotFound(Vertex.class, oid), ex);
+            assertThat(ex, instanceOf(NoSuchElementException.class));
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-944

This exception wasn't used  in the code base at all except for tests. Seems best to just deprecate (in case a graph provider is publically using it). Didn't change the nature of the tests that were using this method, so this should be a non-breaking change.

The change is pretty simple, but I decided not to CTR since "deprecation" was involved. All tests good with `mvn clean install`.

VOTE +1