### PR TITLE
TINKERPOP-1044: Gremlin server REST endpoint - Add Exception Class and Message in Response

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * VertexPrograms can now declare traverser requirements, e.g. to have access to the path when used with `.program()`.
 * New build options for `gremlin-python` where `-DglvPython` is no longer required.
 * Added missing `InetAddress` to GraphSON extension module.
+* Added functionality to Gremlin-Server REST endpoint to forward Exception Messages and Class in HTTP Response
 
 [[release-3-2-2]]
 TinkerPop 3.2.2 (Release Date: September 6, 2016)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -252,11 +252,12 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
                             }
                         }));
 
-                evalFuture.exceptionally(t -> {
-					
-					String errorMessage = (t.getMessage() != null) ? t.getMessage() : 
-										String.format("Error encountered evaluating script: %s", requestArguments.getValue0());
-					sendError(ctx, INTERNAL_SERVER_ERROR, errorMessage, Optional.of(t));
+                evalFuture.exceptionally(t -> {		
+					if (t.getMessage() != null)
+						sendError(ctx, INTERNAL_SERVER_ERROR, t.getMessage(), Optional.of(t));
+					else
+						sendError(ctx, INTERNAL_SERVER_ERROR, String.format("Error encountered evaluating script: %s", requestArguments.getValue0())
+									 , Optional.of(t));			
                     promise.setFailure(t);
                     return null;
                 });
@@ -459,7 +460,6 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
 		if (t.isPresent()){
 			node.put("Exception-Class", t.get().getClass().getName());
 		}
-		
 		
         final FullHttpResponse response = new DefaultFullHttpResponse(
                 HTTP_1_1, status, Unpooled.copiedBuffer(node.toString(), CharsetUtil.UTF_8));

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -253,8 +253,19 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
                         }));
 
                 evalFuture.exceptionally(t -> {
-                    sendError(ctx, INTERNAL_SERVER_ERROR,
-                            String.format("Error encountered evaluating script: %s", requestArguments.getValue0()), Optional.of(t));
+					
+					if (t.getMessage() != null) {
+						sendError(ctx, INTERNAL_SERVER_ERROR,
+								String.format("Error encountered evaluating script: %s\nExecution Interrupted by %s\nMessage: %s", 
+											  requestArguments.getValue0(), t.getClass().getName(), t.getMessage()),
+								Optional.of(t));
+                    } else {
+						sendError(ctx, INTERNAL_SERVER_ERROR,
+								String.format("Error encountered evaluating script: %s\nExecution Interrupted by %s", 
+											  requestArguments.getValue0(), t.getClass().getName()),
+								Optional.of(t));
+					}
+					
                     promise.setFailure(t);
                     return null;
                 });


### PR DESCRIPTION
When using Gremlin-Server Client over REST endpoint and the gremlin query results in a groovy script Exception/Error, will output the Throwable class name as well as the Throwable Message in the message body of the HTTP Response