### PR TITLE
TINKERPOP-1455: Provide String-based withStrategy()/withoutStrategy() for language variant usage

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,9 +26,11 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Added `TraversalSource.withComputer(Object...)` for better language variant support.
+* Fixed a `String` bug in `GroovyTranslator` and `PythonTranslator` where if the string has double-quotes, use """ """.
+* Fixed a `List` and `Map` bug in `JavaTranslator` where such collections were not being internally translated.
+* Added `TraversalSource.withComputer(Map<String,Object>)` for better language variant support.
+* Added `TraversalSource.withStrategies(Map<String,Object>)`/`withoutStrategies(String...)` for better language variant support.
 * Added `PartitionStrategy.Builder.readPartitions()` and deprecated `PartitionStrategy.Builder.addPartition()`.
-* Added `TraversalSource.withStrategy(String,Object...)`/`withoutStrategy(String)` for better language variant support.
 * `FilterRankStrategy` now propagates labels "right" over non-`Scoping` filters.
 * Fixed a bug in `ConnectiveP` where nested equivalent connectives should be inlined.
 * Fixed a bug in `IncidentToAdjacentStrategy` where `TreeStep` traversals were allowed.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `TraversalSource.withComputer(Object...)` for better language variant support.
+* Added `PartitionStrategy.Builder.readPartitions()` and deprecated `PartitionStrategy.Builder.addPartition()`.
+* Added `TraversalSource.withStrategy(String,Object...)`/`withoutStrategy(String)` for better language variant support.
 * `FilterRankStrategy` now propagates labels "right" over non-`Scoping` filters.
 * Fixed a bug in `ConnectiveP` where nested equivalent connectives should be inlined.
 * Fixed a bug in `IncidentToAdjacentStrategy` where `TreeStep` traversals were allowed.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,10 +26,15 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Fixed a `String` bug in `GroovyTranslator` and `PythonTranslator` where if the string has double-quotes, use """ """.
-* Fixed a `List` and `Map` bug in `JavaTranslator` where such collections were not being internally translated.
+* Fixed a `Set`, `List`, `Map` bug in the various `Translators` where such collections were not being internally translated.
+* Fixed a `Bytecode` bug where nested structures (map, list, set) were not being analyzed for bindings and bytecode conversions.
+* Fixed a `String` bug in `GroovyTranslator` and `PythonTranslator` where if the string has double-quotes it now uses """ """.
+* Added a default `TraversalStrategy.getConfiguration()` which returns the configuration needed to construct the strategy.
+* Gremlin-Java `TraversalStrategy` and `Computer` instances are now converted to `Map`-representations in `Bytecode`.
+* `Computer` instances can be created with `Computer.create(Configuration)` and accessed via `Computer.getConf()`.
+* Every `TraversalStrategy` can be created via a `Configuration` and a static `MyStrategy.create(Configuration)`.
 * Added `TraversalSource.withComputer(Map<String,Object>)` for better language variant support.
-* Added `TraversalSource.withStrategies(Map<String,Object>)`/`withoutStrategies(String...)` for better language variant support.
+* Added `TraversalSource.withStrategies(Map<String,Object>...)`/`withoutStrategies(String...)` for better language variant support.
 * Added `PartitionStrategy.Builder.readPartitions()` and deprecated `PartitionStrategy.Builder.addPartition()`.
 * `FilterRankStrategy` now propagates labels "right" over non-`Scoping` filters.
 * Fixed a bug in `ConnectiveP` where nested equivalent connectives should be inlined.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -227,15 +227,15 @@ it is possible to use the `withBindings()`-model as Gremlin-Python's `Bindings.o
 Traversal Strategies
 ~~~~~~~~~~~~~~~~~~~~
 
-In order to add and remove <<traversalstrategy,traversal strategies>> from a traversal source, the `withStrategy()` and
-`withoutStrategy()` steps should be used.
+In order to add and remove <<traversalstrategy,traversal strategies>> from a traversal source, the `withStrategies(Map<String,Object>...)` and
+`withoutStrategies(String...)` steps should be used.
 
 [gremlin-python,modern]
 ----
-g = g.withStrategy('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy','vertices',__.hasLabel('person'),'edges',__.has('weight',gt(0.5)))
+g = g.withStrategies({'strategy':'org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy','vertices': hasLabel('person'),'edges': has('weight',gt(0.5))})
 g.V().name.toList()
 g.V().outE().valueMap(True).toList()
-g = g.withoutStrategy('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy')
+g = g.withoutStrategies('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy')
 g.V().name.toList()
 g.V().outE().valueMap(True).toList()
 ----

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -224,6 +224,25 @@ in statically typed languages where bindings need to have the same typing as the
 it is possible to use the `withBindings()`-model as Gremlin-Python's `Bindings.of()` simply returns a 2-tuple of `(str,object)`
 (see <<connecting-via-remotegraph,`Bindings`>>).
 
+Traversal Strategies
+~~~~~~~~~~~~~~~~~~~~
+
+In order to add and remove <<traversalstrategy,traversal strategies>> from a traversal source, the `withStrategy()` and
+`withoutStrategy()` steps should be used.
+
+[gremlin-python,modern]
+----
+g = g.withStrategy('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy','vertices',__.hasLabel('person'),'edges',__.has('weight',gt(0.5)))
+g.V().name.toList()
+g.V().outE().valueMap(True).toList()
+g = g.withoutStrategy('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy')
+g.V().name.toList()
+g.V().outE().valueMap(True).toList()
+----
+
+IMPORTANT: While Gremlin is language agnostic, the executing traversal machine typically is not. Thus, strategies are
+traversal machine dependent and identified by the class name in the traversal machine's implementation language.
+
 The Lambda Solution
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -163,7 +163,7 @@ Configurable Strategies
 
 `TraversalSource.withStrategies()` and `TraversalSource.withoutStrategies()` use Java objects. In order to make strategy
 manipulation possible from Gremlin language variants like Gremlin-Python, it is important to support non-JVM-based versions
-of these methods. As such, `TraversalSource.withStrategy(String,Object...)` and `TraversalSource.withoutStrategy(String)`
+of these methods. As such, `TraversalSource.withStrategies(Map<String,Object>...)` and `TraversalSource.withoutStrategies(String...)`
 were added.
 
 If the provider has non-configurable `TraversalStrategy` classes, those classes should expose a static `instance()`-method.
@@ -175,30 +175,59 @@ a `SubgraphStrategy`, it does the following:
 [source,python]
 ----
 g = Graph().traversal().withRemote(connection).
-        withStrategy('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy',
-            'vertices', __.hasLabel('person'),
-            'edges', __.has('weight',gt(0.5))
+        withStrategy({'strategy':'org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy',
+            'vertices': __.hasLabel('person'),
+            'edges': __.has('weight',gt(0.5))})
 ---
 
-`SubgraphStrategy.create(Configuration)`-method is defined as:
+The `SubgraphStrategy.create(Configuration)`-method is defined as:
 
 [source,java]
 ----
 public static SubgraphStrategy create(final Configuration configuration) {
     final Builder builder = SubgraphStrategy.build();
-    configuration.getKeys().forEachRemaining(key -> {
-        if (key.equals("vertices") || key.equals("vertexCriterion"))
-            builder.vertices((Traversal) configuration.getProperty(key));
-        else if (key.equals("edges") || key.equals("edgeCriterion"))
-            builder.edges((Traversal) configuration.getProperty(key));
-        else if (key.equals("vertexProperties"))
-            builder.vertexProperties((Traversal) configuration.getProperty(key));
-        else
-            throw new IllegalArgumentException("The following " + SubgraphStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
-        });
-        return builder.create();
-    }
+    if (configuration.containsKey(VERTICES))
+        builder.vertices((Traversal) configuration.getProperty(VERTICES));
+    if (configuration.containsKey(EDGES))
+        builder.edges((Traversal) configuration.getProperty(EDGES));
+    if (configuration.containsKey(VERTEX_PROPERTIES))
+        builder.vertexProperties((Traversal) configuration.getProperty(VERTEX_PROPERTIES));
+    return builder.create();
+}
 ----
+
+Finally, in order to make serialization possible from JVM-based Gremlin language variants, all strategies have a
+`TraverserStrategy.getConfiguration()` method which returns a `Configuration` that can be used to `create()` the
+`TraversalStrategy`.
+
+The `SubgraphStrategy.getConfiguration()`-method is defined as:
+
+[source,java]
+----
+@Override
+public Configuration getConfiguration() {
+    final Map<String, Object> map = new HashMap<>();
+    map.put(STRATEGY, SubgraphStrategy.class.getCanonicalName());
+    if (null != this.vertexCriterion)
+        map.put(VERTICES, this.vertexCriterion);
+    if (null != this.edgeCriterion)
+            map.put(EDGES, this.edgeCriterion);
+    if (null != this.vertexPropertyCriterion)
+        map.put(VERTEX_PROPERTIES, this.vertexPropertyCriterion);
+    return new MapConfiguration(map);
+}
+----
+
+The default implementation of `TraversalStrategy.getConfiguration()` is defined as:
+
+[source,java]
+----
+public default Configuration getConfiguration() {
+    return new MapConfiguration(Collections.singletonMap(STRATEGY, this.getClass().getCanonicalName()));
+}
+----
+
+Thus, if the provider does not have any "builder"-based strategies, then no updates to their strategies are required.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1455[TINKERPOP-1455]
 

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -158,6 +158,50 @@ Upgrading for Providers
 Graph System Providers
 ^^^^^^^^^^^^^^^^^^^^^^
 
+Configurable Strategies
++++++++++++++++++++++++
+
+`TraversalSource.withStrategies()` and `TraversalSource.withoutStrategies()` use Java objects. In order to make strategy
+manipulation possible from Gremlin language variants like Gremlin-Python, it is important to support non-JVM-based versions
+of these methods. As such, `TraversalSource.withStrategy(String,Object...)` and `TraversalSource.withoutStrategy(String)`
+were added.
+
+If the provider has non-configurable `TraversalStrategy` classes, those classes should expose a static `instance()`-method.
+This is typical and thus, backwards compatible. However, if the provider has a `TraversalStrategy` that can be configured
+(e.g. via a `Builder`), then it should expose a static `create(Configuration)`-method, where the keys of the configuration
+are the method names of the `Builder` and the values are the method arguments. For instance, for Gremlin-Python to create
+a `SubgraphStrategy`, it does the following:
+
+[source,python]
+----
+g = Graph().traversal().withRemote(connection).
+        withStrategy('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy',
+            'vertices', __.hasLabel('person'),
+            'edges', __.has('weight',gt(0.5))
+---
+
+`SubgraphStrategy.create(Configuration)`-method is defined as:
+
+[source,java]
+----
+public static SubgraphStrategy create(final Configuration configuration) {
+    final Builder builder = SubgraphStrategy.build();
+    configuration.getKeys().forEachRemaining(key -> {
+        if (key.equals("vertices") || key.equals("vertexCriterion"))
+            builder.vertices((Traversal) configuration.getProperty(key));
+        else if (key.equals("edges") || key.equals("edgeCriterion"))
+            builder.edges((Traversal) configuration.getProperty(key));
+        else if (key.equals("vertexProperties"))
+            builder.vertexProperties((Traversal) configuration.getProperty(key));
+        else
+            throw new IllegalArgumentException("The following " + SubgraphStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
+        });
+        return builder.create();
+    }
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1455[TINKERPOP-1455]
+
 Deprecated elementNotFound
 ++++++++++++++++++++++++++
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/Computer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/Computer.java
@@ -20,6 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.computer;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -65,7 +66,7 @@ public final class Computer implements Function<Graph, GraphComputer>, Serializa
             final Computer computer = new Computer();
             for (final String key : (List<String>) IteratorUtils.asList(configuration.getKeys())) {
                 if (key.equals(GRAPH_COMPUTER))
-                    computer.graphComputerClass = (Class) Class.forName(configuration.getString("graphComputer"));
+                    computer.graphComputerClass = (Class) Class.forName(configuration.getString(key));
                 else if (key.equals(WORKERS))
                     computer.workers = configuration.getInt(key);
                 else if (key.equals(PERSIST))
@@ -197,5 +198,24 @@ public final class Computer implements Function<Graph, GraphComputer>, Serializa
 
     public int getWorkers() {
         return this.workers;
+    }
+
+    public Configuration getConf() {
+        final Map<String, Object> map = new HashMap<>();
+        if (-1 != this.workers)
+            map.put(WORKERS, this.workers);
+        if (null != this.persist)
+            map.put(PERSIST, this.persist.name());
+        if (null != this.resultGraph)
+            map.put(RESULT, this.resultGraph.name());
+        if (null != this.vertices)
+            map.put(RESULT, this.vertices);
+        if (null != this.edges)
+            map.put(EDGES, this.edges);
+        map.put(GRAPH_COMPUTER, this.graphComputerClass.getCanonicalName());
+        for (final Map.Entry<String, Object> entry : this.configuration.entrySet()) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return new MapConfiguration(map);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/Computer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/Computer.java
@@ -45,27 +45,36 @@ public final class Computer implements Function<Graph, GraphComputer>, Serializa
     private Traversal<Vertex, Vertex> vertices = null;
     private Traversal<Vertex, Edge> edges = null;
 
+    public static final String GRAPH_COMPUTER = "graphComputer";
+    public static final String WORKERS = "workers";
+    public static final String PERSIST = "persist";
+    public static final String RESULT = "result";
+    public static final String VERTICES = "vertices";
+    public static final String EDGES = "edges";
+
     private Computer(final Class<? extends GraphComputer> graphComputerClass) {
         this.graphComputerClass = graphComputerClass;
     }
 
+    private Computer() {
+
+    }
+
     public static Computer compute(final Configuration configuration) {
         try {
-            final Computer computer = new Computer(configuration.containsKey("graphComputer") ?
-                    (Class) Class.forName(configuration.getString("graphComputer")) :
-                    GraphComputer.class);
+            final Computer computer = new Computer();
             for (final String key : (List<String>) IteratorUtils.asList(configuration.getKeys())) {
-                if (key.equals("graphComputer")) {
-                    // do nothing
-                } else if (key.equals("workers"))
+                if (key.equals(GRAPH_COMPUTER))
+                    computer.graphComputerClass = (Class) Class.forName(configuration.getString("graphComputer"));
+                else if (key.equals(WORKERS))
                     computer.workers = configuration.getInt(key);
-                else if (key.equals("persist"))
+                else if (key.equals(PERSIST))
                     computer.persist = GraphComputer.Persist.valueOf(configuration.getString(key));
-                else if (key.equals("result"))
+                else if (key.equals(RESULT))
                     computer.resultGraph = GraphComputer.ResultGraph.valueOf(configuration.getString(key));
-                else if (key.equals("vertices"))
+                else if (key.equals(VERTICES))
                     computer.vertices = (Traversal) configuration.getProperty(key);
-                else if (key.equals("edges"))
+                else if (key.equals(EDGES))
                     computer.edges = (Traversal) configuration.getProperty(key);
                 else
                     computer.configuration.put(key, configuration.getProperty(key));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/GraphComputerHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/GraphComputerHelper.java
@@ -18,13 +18,19 @@
  */
 package org.apache.tinkerpop.gremlin.process.computer.util;
 
+import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -76,5 +82,24 @@ public final class GraphComputerHelper {
 
         if (!(b instanceof MapReduce)) return false;
         return a.getClass().equals(b.getClass()) && a.getMemoryKey().equals(((MapReduce) b).getMemoryKey());
+    }
+
+    public static TraversalStrategy[] getTraversalStrategies(final TraversalSource traversalSource, final Computer computer) {
+        Class<? extends GraphComputer> graphComputerClass;
+        if (computer.getGraphComputerClass().equals(GraphComputer.class)) {
+            try {
+                graphComputerClass = computer.apply(traversalSource.getGraph()).getClass();
+            } catch (final Exception e) {
+                graphComputerClass = GraphComputer.class;
+            }
+        } else
+            graphComputerClass = computer.getGraphComputerClass();
+        final List<TraversalStrategy<?>> graphComputerStrategies = TraversalStrategies.GlobalCache.getStrategies(graphComputerClass).toList();
+        final TraversalStrategy[] traversalStrategies = new TraversalStrategy[graphComputerStrategies.size() + 1];
+        traversalStrategies[0] = new VertexProgramStrategy(computer);
+        for (int i = 0; i < graphComputerStrategies.size(); i++) {
+            traversalStrategies[i + 1] = graphComputerStrategies.get(i);
+        }
+        return traversalStrategies;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bindings.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bindings.java
@@ -55,4 +55,9 @@ public final class Bindings {
     protected void clear() {
         this.map.clear();
     }
+
+    @Override
+    public String toString() {
+        return this.map.toString();
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bytecode.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bytecode.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -249,7 +250,13 @@ public final class Bytecode implements Cloneable, Serializable {
     private final Object convertArgument(final Object argument) {
         if (argument instanceof Traversal)
             return ((Traversal) argument).asAdmin().getBytecode();
-
+        else if (argument instanceof Map) {
+            final Map<Object, Object> map = new LinkedHashMap<>(((Map) argument).size());
+            for (final Map.Entry<?, ?> entry : ((Map<?, ?>) argument).entrySet()) {
+                map.put(convertArgument(entry.getKey()), convertArgument(entry.getValue()));
+            }
+            return map;
+        }
         if (null != this.bindings) {
             final String variable = this.bindings.getBoundVariable(argument);
             if (null != variable)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategy.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.RangeByIsCountStrategy;
@@ -74,6 +76,16 @@ public interface TraversalStrategy<S extends TraversalStrategy> extends Serializ
      */
     public default Class<S> getTraversalCategory() {
         return (Class) TraversalStrategy.class;
+    }
+
+    /**
+     * Get the configuration representation of this strategy.
+     * This is useful for converting a strategy into a serialized form.
+     *
+     * @return the configuration used to create this strategy
+     */
+    public default Configuration getConfiguration() {
+        return new MapConfiguration(Collections.singletonMap(STRATEGY, this.getClass().getCanonicalName()));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategy.java
@@ -43,6 +43,7 @@ import java.util.Set;
  */
 public interface TraversalStrategy<S extends TraversalStrategy> extends Serializable, Comparable<Class<? extends TraversalStrategy>> {
 
+    public static final String STRATEGY = "strategy";
 
     public void apply(final Traversal.Admin<?, ?> traversal);
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -127,6 +127,11 @@ public class GraphTraversalSource implements TraversalSource {
     }
 
     @Override
+    public GraphTraversalSource withComputer(final Object... namedArguments) {
+        return (GraphTraversalSource) TraversalSource.super.withComputer(namedArguments);
+    }
+
+    @Override
     public GraphTraversalSource withComputer(final Computer computer) {
         return (GraphTraversalSource) TraversalSource.super.withComputer(computer);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -142,6 +142,16 @@ public class GraphTraversalSource implements TraversalSource {
     }
 
     @Override
+    public GraphTraversalSource withStrategy(final String strategyName, final Object... nameArguments) {
+        return (GraphTraversalSource) TraversalSource.super.withStrategy(strategyName, nameArguments);
+    }
+
+    @Override
+    public GraphTraversalSource withoutStrategy(final String strategyName) {
+        return (GraphTraversalSource) TraversalSource.super.withoutStrategy(strategyName);
+    }
+
+    @Override
     public GraphTraversalSource withStrategies(final TraversalStrategy... traversalStrategies) {
         return (GraphTraversalSource) TraversalSource.super.withStrategies(traversalStrategies);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -45,6 +45,7 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
@@ -122,13 +123,35 @@ public class GraphTraversalSource implements TraversalSource {
     //// CONFIGURATIONS
 
     @Override
+    @SuppressWarnings({"unchecked"})
+    public GraphTraversalSource withStrategies(final Map<String, Object>... traversalStrategyConfigurations) {
+        return (GraphTraversalSource) TraversalSource.super.withStrategies(traversalStrategyConfigurations);
+    }
+
+    @Override
+    public GraphTraversalSource withoutStrategies(final String... traversalStrategyNames) {
+        return (GraphTraversalSource) TraversalSource.super.withoutStrategies(traversalStrategyNames);
+    }
+
+    @Override
+    public GraphTraversalSource withStrategies(final TraversalStrategy... traversalStrategies) {
+        return (GraphTraversalSource) TraversalSource.super.withStrategies(traversalStrategies);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public GraphTraversalSource withoutStrategies(final Class<? extends TraversalStrategy>... traversalStrategyClasses) {
+        return (GraphTraversalSource) TraversalSource.super.withoutStrategies(traversalStrategyClasses);
+    }
+
+    @Override
     public GraphTraversalSource withBindings(final Bindings bindings) {
         return (GraphTraversalSource) TraversalSource.super.withBindings(bindings);
     }
 
     @Override
-    public GraphTraversalSource withComputer(final Object... namedArguments) {
-        return (GraphTraversalSource) TraversalSource.super.withComputer(namedArguments);
+    public GraphTraversalSource withComputer(final Map<String,Object> computerConfiguration) {
+        return (GraphTraversalSource) TraversalSource.super.withComputer(computerConfiguration);
     }
 
     @Override
@@ -144,27 +167,6 @@ public class GraphTraversalSource implements TraversalSource {
     @Override
     public GraphTraversalSource withComputer() {
         return (GraphTraversalSource) TraversalSource.super.withComputer();
-    }
-
-    @Override
-    public GraphTraversalSource withStrategy(final String strategyName, final Object... nameArguments) {
-        return (GraphTraversalSource) TraversalSource.super.withStrategy(strategyName, nameArguments);
-    }
-
-    @Override
-    public GraphTraversalSource withoutStrategy(final String strategyName) {
-        return (GraphTraversalSource) TraversalSource.super.withoutStrategy(strategyName);
-    }
-
-    @Override
-    public GraphTraversalSource withStrategies(final TraversalStrategy... traversalStrategies) {
-        return (GraphTraversalSource) TraversalSource.super.withStrategies(traversalStrategies);
-    }
-
-    @Override
-    @SuppressWarnings({"unchecked", "varargs"})
-    public GraphTraversalSource withoutStrategies(final Class<? extends TraversalStrategy>... traversalStrategyClasses) {
-        return (GraphTraversalSource) TraversalSource.super.withoutStrategies(traversalStrategyClasses);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Parameterizing;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -40,6 +41,8 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -152,16 +155,24 @@ public final class ElementIdStrategy extends AbstractTraversalStrategy<Traversal
         }
     }
 
+    public static final String ID_PROPERTY_KEY = "idPropertyKey";
+    public static final String ID_MAKER = "idMaker";
+
     public static ElementIdStrategy create(final Configuration configuration) {
         final ElementIdStrategy.Builder builder = ElementIdStrategy.build();
-        configuration.getKeys().forEachRemaining(key -> {
-            if (key.equals("idPropertyKey"))
-                builder.idPropertyKey((String) configuration.getProperty(key));
-            else if (key.equals("idMaker"))
-                builder.idMaker((Supplier) configuration.getProperty(key));
-            else
-                throw new IllegalArgumentException("The following " + ElementIdStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
-        });
+        if (configuration.containsKey(ID_MAKER))
+            builder.idMaker((Supplier) configuration.getProperty(ID_MAKER));
+        if (configuration.containsKey(ID_PROPERTY_KEY))
+            builder.idPropertyKey(configuration.getString(ID_PROPERTY_KEY));
         return builder.create();
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STRATEGY, ElementIdStrategy.class.getCanonicalName());
+        map.put(ID_PROPERTY_KEY, this.idPropertyKey);
+        map.put(ID_MAKER, this.idMaker);
+        return new MapConfiguration(map);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Parameterizing;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -27,9 +28,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.IdStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
@@ -149,5 +150,18 @@ public final class ElementIdStrategy extends AbstractTraversalStrategy<Traversal
         public ElementIdStrategy create() {
             return new ElementIdStrategy(idPropertyKey, idMaker);
         }
+    }
+
+    public static ElementIdStrategy create(final Configuration configuration) {
+        final ElementIdStrategy.Builder builder = ElementIdStrategy.build();
+        configuration.getKeys().forEachRemaining(key -> {
+            if (key.equals("idPropertyKey"))
+                builder.idPropertyKey((String) configuration.getProperty(key));
+            else if (key.equals("idMaker"))
+                builder.idMaker((Supplier) configuration.getProperty(key));
+            else
+                throw new IllegalArgumentException("The following " + ElementIdStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
+        });
+        return builder.create();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/HaltedTraverserStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/HaltedTraverserStrategy.java
@@ -19,6 +19,7 @@
 
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
@@ -56,6 +57,14 @@ public final class HaltedTraverserStrategy extends AbstractTraversalStrategy<Tra
         else
             traverser.set(DetachedFactory.detach(traverser.get(), true));
         return traverser;
+    }
+
+    public static HaltedTraverserStrategy create(final Configuration configuration) {
+        try {
+            return new HaltedTraverserStrategy(Class.forName((String) configuration.getProperty("haltedTraverserFactory")));
+        } catch (final ClassNotFoundException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
     }
 
     ////////////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/HaltedTraverserStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/HaltedTraverserStrategy.java
@@ -20,12 +20,16 @@
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -67,6 +71,14 @@ public final class HaltedTraverserStrategy extends AbstractTraversalStrategy<Tra
         } catch (final ClassNotFoundException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STRATEGY, HaltedTraverserStrategy.class.getCanonicalName());
+        map.put(HALTED_TRAVERSER_FACTORY, this.haltedTraverserFactory.getCanonicalName());
+        return new MapConfiguration(map);
     }
 
     ////////////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/HaltedTraverserStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/HaltedTraverserStrategy.java
@@ -59,9 +59,11 @@ public final class HaltedTraverserStrategy extends AbstractTraversalStrategy<Tra
         return traverser;
     }
 
+    public static final String HALTED_TRAVERSER_FACTORY = "haltedTraverserFactory";
+
     public static HaltedTraverserStrategy create(final Configuration configuration) {
         try {
-            return new HaltedTraverserStrategy(Class.forName((String) configuration.getProperty("haltedTraverserFactory")));
+            return new HaltedTraverserStrategy(Class.forName(configuration.getString(HALTED_TRAVERSER_FACTORY)));
         } catch (final ClassNotFoundException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Parameterizing;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
@@ -33,12 +34,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartSte
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LambdaMapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertyMapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
@@ -53,6 +54,7 @@ import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,7 +85,7 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
         this.writePartition = builder.writePartition;
         this.partitionKey = builder.partitionKey;
         this.readPartitions = Collections.unmodifiableSet(builder.readPartitions);
-        this.includeMetaProperties  = builder.includeMetaProperties;
+        this.includeMetaProperties = builder.includeMetaProperties;
     }
 
     public String getWritePartition() {
@@ -190,8 +192,8 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
         }
 
         final List<Step> stepsToInsertPropertyMutations = traversal.getSteps().stream().filter(step ->
-            step instanceof AddEdgeStep || step instanceof AddVertexStep ||
-                    step instanceof AddVertexStartStep || (includeMetaProperties && step instanceof AddPropertyStep)
+                step instanceof AddEdgeStep || step instanceof AddVertexStep ||
+                        step instanceof AddVertexStartStep || (includeMetaProperties && step instanceof AddPropertyStep)
         ).collect(Collectors.toList());
 
         stepsToInsertPropertyMutations.forEach(step -> {
@@ -271,11 +273,11 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
      * {@link VertexProperty} it applies a filter based on the current partitioning.  If is not a
      * {@link VertexProperty} the property is simply passed through.
      */
-    public final class MapPropertiesFilter implements Function<Traverser<Map<String,List<Property>>>, Map<String,List<Property>>>, Serializable {
+    public final class MapPropertiesFilter implements Function<Traverser<Map<String, List<Property>>>, Map<String, List<Property>>>, Serializable {
         @Override
         public Map<String, List<Property>> apply(final Traverser<Map<String, List<Property>>> mapTraverser) {
-            final Map<String,List<Property>> values = mapTraverser.get();
-            final Map<String,List<Property>> filtered = new HashMap<>();
+            final Map<String, List<Property>> values = mapTraverser.get();
+            final Map<String, List<Property>> filtered = new HashMap<>();
 
             // note the final filter that removes the partitionKey from the outgoing Map
             values.entrySet().forEach(p -> {
@@ -302,11 +304,11 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
     /**
      * Takes a {@link Map} of a {@link List} of {@link Property} objects and unwraps the {@link Property#value()}.
      */
-    public final class MapPropertiesConverter implements Function<Traverser<Map<String,List<Property>>>, Map<String,List<Property>>>, Serializable {
+    public final class MapPropertiesConverter implements Function<Traverser<Map<String, List<Property>>>, Map<String, List<Property>>>, Serializable {
         @Override
         public Map<String, List<Property>> apply(final Traverser<Map<String, List<Property>>> mapTraverser) {
-            final Map<String,List<Property>> values = mapTraverser.get();
-            final Map<String,List<Property>> converted = new HashMap<>();
+            final Map<String, List<Property>> values = mapTraverser.get();
+            final Map<String, List<Property>> converted = new HashMap<>();
 
             values.entrySet().forEach(p -> {
                 final List l = p.getValue().stream().map(property -> property.value()).collect(Collectors.toList());
@@ -322,13 +324,31 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
         }
     }
 
+    public static PartitionStrategy create(final Configuration configuration) {
+        final PartitionStrategy.Builder builder = PartitionStrategy.build();
+        configuration.getKeys().forEachRemaining(key -> {
+            if (key.equals("includeMetaProperties"))
+                builder.includeMetaProperties((Boolean) configuration.getProperty(key));
+            else if (key.equals("writePartition"))
+                builder.writePartition((String) configuration.getProperty(key));
+            else if (key.equals("partitionKey"))
+                builder.partitionKey((String) configuration.getProperty(key));
+            else if (key.equals("readPartitions"))
+                builder.readPartitions((List<String>) configuration.getProperty(key));
+            else
+                throw new IllegalArgumentException("The following " + PartitionStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
+        });
+        return builder.create();
+    }
+
     public final static class Builder {
         private String writePartition;
         private String partitionKey;
         private Set<String> readPartitions = new HashSet<>();
         private boolean includeMetaProperties = false;
 
-        Builder() { }
+        Builder() {
+        }
 
         /**
          * Set to {@code true} if the {@link VertexProperty} instances should get assigned to partitions.  This
@@ -367,6 +387,26 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
          * Specifies the partition of the graph to read from.  It is possible to assign multiple partition keys so
          * as to read from multiple partitions at the same time.
          */
+        public Builder readPartitions(final List<String> readPartitions) {
+            this.readPartitions.addAll(readPartitions);
+            return this;
+        }
+
+        /**
+         * Specifies the partition of the graph to read from.  It is possible to assign multiple partition keys so
+         * as to read from multiple partitions at the same time.
+         */
+        public Builder readPartitions(final String... readPartitions) {
+            return this.readPartitions(Arrays.asList(readPartitions));
+        }
+
+        /**
+         * Specifies the partition of the graph to read from.  It is possible to assign multiple partition keys so
+         * as to read from multiple partitions at the same time.
+         *
+         * @deprecated Since 3.2.3. Use {@link Builder#readPartitions} instead
+         */
+        @Deprecated
         public Builder addReadPartition(final String readPartition) {
             this.readPartitions.add(readPartition);
             return this;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
@@ -324,20 +324,21 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
         }
     }
 
+    public static final String INCLUDE_META_PROPERTIES = "includeMetaProperties";
+    public static final String WRITE_PARTITION = "writePartition";
+    public static final String PARTITION_KEY = "partitionKey";
+    public static final String READ_PARTITIONS = "readPartitions";
+
     public static PartitionStrategy create(final Configuration configuration) {
         final PartitionStrategy.Builder builder = PartitionStrategy.build();
-        configuration.getKeys().forEachRemaining(key -> {
-            if (key.equals("includeMetaProperties"))
-                builder.includeMetaProperties((Boolean) configuration.getProperty(key));
-            else if (key.equals("writePartition"))
-                builder.writePartition((String) configuration.getProperty(key));
-            else if (key.equals("partitionKey"))
-                builder.partitionKey((String) configuration.getProperty(key));
-            else if (key.equals("readPartitions"))
-                builder.readPartitions((List<String>) configuration.getProperty(key));
-            else
-                throw new IllegalArgumentException("The following " + PartitionStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
-        });
+        if (configuration.containsKey(INCLUDE_META_PROPERTIES))
+            builder.includeMetaProperties(configuration.getBoolean(INCLUDE_META_PROPERTIES));
+        if (configuration.containsKey(WRITE_PARTITION))
+            builder.writePartition(configuration.getString(WRITE_PARTITION));
+        if (configuration.containsKey(PARTITION_KEY))
+            builder.partitionKey(configuration.getString(PARTITION_KEY));
+        if (configuration.containsKey(READ_PARTITIONS))
+            builder.readPartitions((List) configuration.getList(READ_PARTITIONS));
         return builder.create();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
@@ -404,7 +404,7 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
          * Specifies the partition of the graph to read from.  It is possible to assign multiple partition keys so
          * as to read from multiple partitions at the same time.
          *
-         * @deprecated Since 3.2.3. Use {@link Builder#readPartitions} instead
+         * @deprecated As of release 3.2.3, replaced by {@link Builder#readPartitions(List)}.
          */
         @Deprecated
         public Builder addReadPartition(final String readPartition) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Parameterizing;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
@@ -55,6 +56,7 @@ import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -324,6 +326,20 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
         }
     }
 
+    @Override
+    public Configuration getConfiguration() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STRATEGY, PartitionStrategy.class.getCanonicalName());
+        map.put(INCLUDE_META_PROPERTIES, this.includeMetaProperties);
+        if (null != this.writePartition)
+            map.put(WRITE_PARTITION, this.writePartition);
+        if (null != this.readPartitions)
+            map.put(READ_PARTITIONS, this.readPartitions);
+        if (null != this.partitionKey)
+            map.put(PARTITION_KEY, this.partitionKey);
+        return new MapConfiguration(map);
+    }
+
     public static final String INCLUDE_META_PROPERTIES = "includeMetaProperties";
     public static final String WRITE_PARTITION = "writePartition";
     public static final String PARTITION_KEY = "partitionKey";
@@ -338,7 +354,7 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
         if (configuration.containsKey(PARTITION_KEY))
             builder.partitionKey(configuration.getString(PARTITION_KEY));
         if (configuration.containsKey(READ_PARTITIONS))
-            builder.readPartitions((List) configuration.getList(READ_PARTITIONS));
+            builder.readPartitions(new ArrayList((Collection)configuration.getProperty(READ_PARTITIONS)));
         return builder.create();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
@@ -120,7 +121,7 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
     }
 
     private static void applyCriterion(final List<Step> stepsToApplyCriterionAfter, final Traversal.Admin traversal,
-                                final Traversal.Admin<? extends Element, ?> criterion) {
+                                       final Traversal.Admin<? extends Element, ?> criterion) {
         for (final Step<?, ?> step : stepsToApplyCriterionAfter) {
             // re-assign the step label to the criterion because the label should apply seamlessly after the filter
             final Step filter = new TraversalFilterStep<>(traversal, criterion.clone());
@@ -288,6 +289,21 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
 
     public Traversal<VertexProperty, ?> getVertexPropertyCriterion() {
         return this.vertexPropertyCriterion;
+    }
+
+    public static SubgraphStrategy create(final Configuration configuration) {
+        final Builder builder = SubgraphStrategy.build();
+        configuration.getKeys().forEachRemaining(key -> {
+            if (key.equals("vertices") || key.equals("vertexCriterion"))
+                builder.vertices((Traversal) configuration.getProperty(key));
+            else if (key.equals("edges") || key.equals("edgeCriterion"))
+                builder.edges((Traversal) configuration.getProperty(key));
+            else if (key.equals("vertexProperties"))
+                builder.vertexProperties((Traversal) configuration.getProperty(key));
+            else
+                throw new IllegalArgumentException("The following configuration is unknown: " + key + ":" + configuration.getProperty(key));
+        });
+        return builder.create();
     }
 
     public static Builder build() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -301,7 +301,7 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
             else if (key.equals("vertexProperties"))
                 builder.vertexProperties((Traversal) configuration.getProperty(key));
             else
-                throw new IllegalArgumentException("The following configuration is unknown: " + key + ":" + configuration.getProperty(key));
+                throw new IllegalArgumentException("The following " + SubgraphStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
         });
         return builder.create();
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -90,8 +90,8 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
         } else {
             final Traversal.Admin<Edge, ?> vertexPredicate;
             vertexPredicate = __.<Edge>and(
-                    __.inV().filter(this.vertexCriterion.clone()),
-                    __.outV().filter(this.vertexCriterion.clone())).asAdmin();
+                    __.inV().filter(this.vertexCriterion),
+                    __.outV().filter(this.vertexCriterion)).asAdmin();
 
             // if there is a vertex predicate then there is an implied edge filter on vertices even if there is no
             // edge predicate provided by the user.
@@ -204,8 +204,8 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
         if (null != this.vertexPropertyCriterion) {
             final OrStep<Object> checkPropertyCriterion = new OrStep(traversal,
                     new DefaultTraversal<>().addStep(new ClassFilterStep<>(traversal, VertexProperty.class, false)),
-                    new DefaultTraversal<>().addStep(new TraversalFilterStep<>(traversal, this.vertexPropertyCriterion.clone())));
-            final Traversal.Admin nonCheckPropertyCriterion = new DefaultTraversal<>().addStep(new TraversalFilterStep<>(traversal, this.vertexPropertyCriterion.clone()));
+                    new DefaultTraversal<>().addStep(new TraversalFilterStep<>(traversal, this.vertexPropertyCriterion)));
+            final Traversal.Admin nonCheckPropertyCriterion = new DefaultTraversal<>().addStep(new TraversalFilterStep<>(traversal, this.vertexPropertyCriterion));
 
             // turn all ElementValueTraversals into filters
             for (final Step<?, ?> step : traversal.getSteps()) {
@@ -291,18 +291,18 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
         return this.vertexPropertyCriterion;
     }
 
+    public static final String VERTICES = "vertices";
+    public static final String EDGES = "edges";
+    public static final String VERTEX_PROPERTIES = "vertexProperties";
+
     public static SubgraphStrategy create(final Configuration configuration) {
         final Builder builder = SubgraphStrategy.build();
-        configuration.getKeys().forEachRemaining(key -> {
-            if (key.equals("vertices") || key.equals("vertexCriterion"))
-                builder.vertices((Traversal) configuration.getProperty(key));
-            else if (key.equals("edges") || key.equals("edgeCriterion"))
-                builder.edges((Traversal) configuration.getProperty(key));
-            else if (key.equals("vertexProperties"))
-                builder.vertexProperties((Traversal) configuration.getProperty(key));
-            else
-                throw new IllegalArgumentException("The following " + SubgraphStrategy.class.getSimpleName() + " configuration is unknown: " + key + ":" + configuration.getProperty(key));
-        });
+        if (configuration.containsKey(VERTICES))
+            builder.vertices((Traversal) configuration.getProperty(VERTICES));
+        if (configuration.containsKey(EDGES))
+            builder.edges((Traversal) configuration.getProperty(EDGES));
+        if (configuration.containsKey(VERTEX_PROPERTIES))
+            builder.vertexProperties((Traversal) configuration.getProperty(VERTEX_PROPERTIES));
         return builder.create();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/MatchAlgorithmStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/MatchAlgorithmStrategy.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization;
 
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
@@ -25,11 +27,15 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public final class MatchAlgorithmStrategy extends AbstractTraversalStrategy<TraversalStrategy.FinalizationStrategy> implements TraversalStrategy.FinalizationStrategy {
 
+    private static final String MATCH_ALGORITHM = "matchAlgorithm";
     private final Class<? extends MatchStep.MatchAlgorithm> matchAlgorithmClass;
 
     private MatchAlgorithmStrategy(final Class<? extends MatchStep.MatchAlgorithm> matchAlgorithmClass) {
@@ -43,6 +49,24 @@ public final class MatchAlgorithmStrategy extends AbstractTraversalStrategy<Trav
                 ((MatchStep) step).setMatchAlgorithm(this.matchAlgorithmClass);
             }
         }
+    }
+
+    public static MatchAlgorithmStrategy create(final Configuration configuration) {
+        try {
+            return new MatchAlgorithmStrategy((Class) Class.forName(configuration.getString(MATCH_ALGORITHM)));
+        } catch (final ClassNotFoundException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STRATEGY, MatchAlgorithmStrategy.class.getCanonicalName());
+        map.put(MATCH_ALGORITHM, null != this.matchAlgorithmClass.getDeclaringClass() ?
+                this.matchAlgorithmClass.getCanonicalName().replace("." + this.matchAlgorithmClass.getSimpleName(), "$" + this.matchAlgorithmClass.getSimpleName()) :
+                this.matchAlgorithmClass.getCanonicalName());
+        return new MapConfiguration(map);
     }
 
     public static Builder build() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Set;
 
@@ -52,7 +53,7 @@ public final class StandardVerificationStrategy extends AbstractTraversalStrateg
         }
 
         for (final Step<?, ?> step : traversal.getSteps()) {
-            for (String label : step.getLabels()) {
+            for (String label : new ArrayList<>(step.getLabels())) {
                 if (Graph.Hidden.isHidden(label))
                     step.removeLabel(label);
             }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
@@ -53,7 +53,7 @@ public final class StandardVerificationStrategy extends AbstractTraversalStrateg
         }
 
         for (final Step<?, ?> step : traversal.getSteps()) {
-            for (String label : new ArrayList<>(step.getLabels())) {
+            for (String label : step.getLabels()) {
                 if (Graph.Hidden.isHidden(label))
                     step.removeLabel(label);
             }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslatorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslatorTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.jsr223;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Bindings;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class JavaTranslatorTest {
+
+    @Test
+    public void shouldTranslateNestedBindings() {
+        final Bindings b = new Bindings();
+        final GraphTraversalSource g = EmptyGraph.instance().traversal().withBindings(b);
+
+        final Bytecode bytecode = g.withStrategies(new HashMap<String, Object>() {{
+            put(SubgraphStrategy.STRATEGY, SubgraphStrategy.class.getCanonicalName());
+            put(SubgraphStrategy.VERTICES, b.of("a", __.has("name", "marko")));
+        }}).V().out(b.of("b", "created")).asAdmin().getBytecode();
+
+        Traversal.Admin<?, ?> traversal = JavaTranslator.of(EmptyGraph.instance().traversal()).translate(bytecode);
+        assertFalse(traversal.isLocked());
+        assertEquals(2, traversal.getSteps().size());
+        // assertEquals(traversal.getBytecode(),bytecode); TODO: bindings are removed -- should translated bytecode be the same bytecode?!
+        traversal.applyStrategies();
+        assertEquals(5, TraversalHelper.getStepsOfAssignableClassRecursively(TraversalFilterStep.class, traversal).size());
+
+        // JavaTranslator should not mutate original bytecode
+        assertTrue(bytecode.getBindings().containsKey("a"));
+        assertTrue(bytecode.getBindings().containsKey("b"));
+        assertEquals(2, bytecode.getBindings().size());
+        assertEquals(__.has("name", "marko").asAdmin().getBytecode(), bytecode.getBindings().get("a"));
+        assertEquals("created", bytecode.getBindings().get("b"));
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
@@ -24,6 +24,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.Read
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -59,18 +62,20 @@ public class GraphTraversalSourceTest {
     public void shouldSupportStringBasedStrategies() throws Exception {
         GraphTraversalSource g = EmptyGraph.instance().traversal();
         assertFalse(g.getStrategies().getStrategy(SubgraphStrategy.class).isPresent());
-        g = g.withStrategy(SubgraphStrategy.class.getCanonicalName(),
-                "vertices", __.hasLabel("person"),
-                "vertexProperties", __.limit(0),
-                "edges", __.hasLabel("knows"));
+        g = g.withStrategies(new HashMap<String, Object>() {{
+            put("strategy", SubgraphStrategy.class.getCanonicalName());
+            put("vertices", __.hasLabel("person"));
+            put("vertexProperties", __.limit(0));
+            put("edges", __.hasLabel("knows"));
+        }});
         assertTrue(g.getStrategies().getStrategy(SubgraphStrategy.class).isPresent());
-        g = g.withoutStrategy(SubgraphStrategy.class.getCanonicalName());
+        g = g.withoutStrategies(SubgraphStrategy.class.getCanonicalName());
         assertFalse(g.getStrategies().getStrategy(SubgraphStrategy.class).isPresent());
         //
         assertFalse(g.getStrategies().getStrategy(ReadOnlyStrategy.class).isPresent());
-        g = g.withStrategy(ReadOnlyStrategy.class.getCanonicalName());
+        g = g.withStrategies(Collections.singletonMap("strategy", ReadOnlyStrategy.class.getCanonicalName()));
         assertTrue(g.getStrategies().getStrategy(ReadOnlyStrategy.class).isPresent());
-        g = g.withoutStrategy(ReadOnlyStrategy.class.getCanonicalName());
+        g = g.withoutStrategies(ReadOnlyStrategy.class.getCanonicalName());
         assertFalse(g.getStrategies().getStrategy(ReadOnlyStrategy.class).isPresent());
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
@@ -59,7 +59,7 @@ public class GraphTraversalSourceTest {
     }
 
     @Test
-    public void shouldSupportStringBasedStrategies() throws Exception {
+    public void shouldSupportMapBasedStrategies() throws Exception {
         GraphTraversalSource g = EmptyGraph.instance().traversal();
         assertFalse(g.getStrategies().getStrategy(SubgraphStrategy.class).isPresent());
         g = g.withStrategies(new HashMap<String, Object>() {{

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
@@ -19,9 +19,13 @@
 package org.apache.tinkerpop.gremlin.process.traversal.dsl.graph;
 
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -49,5 +53,24 @@ public class GraphTraversalSourceTest {
 
         verify(mock1, times(1)).close();
         verify(mock2, times(1)).close();
+    }
+
+    @Test
+    public void shouldSupportStringBasedStrategies() throws Exception {
+        GraphTraversalSource g = EmptyGraph.instance().traversal();
+        assertFalse(g.getStrategies().getStrategy(SubgraphStrategy.class).isPresent());
+        g = g.withStrategy(SubgraphStrategy.class.getCanonicalName(),
+                "vertices", __.hasLabel("person"),
+                "vertexProperties", __.limit(0),
+                "edges", __.hasLabel("knows"));
+        assertTrue(g.getStrategies().getStrategy(SubgraphStrategy.class).isPresent());
+        g = g.withoutStrategy(SubgraphStrategy.class.getCanonicalName());
+        assertFalse(g.getStrategies().getStrategy(SubgraphStrategy.class).isPresent());
+        //
+        assertFalse(g.getStrategies().getStrategy(ReadOnlyStrategy.class).isPresent());
+        g = g.withStrategy(ReadOnlyStrategy.class.getCanonicalName());
+        assertTrue(g.getStrategies().getStrategy(ReadOnlyStrategy.class).isPresent());
+        g = g.withoutStrategy(ReadOnlyStrategy.class.getCanonicalName());
+        assertFalse(g.getStrategies().getStrategy(ReadOnlyStrategy.class).isPresent());
     }
 }

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
@@ -21,16 +21,23 @@ package org.apache.tinkerpop.gremlin.groovy.jsr223;
 
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
-import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslator;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.junit.Test;
 
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -40,6 +47,34 @@ import static org.junit.Assert.assertFalse;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class GroovyTranslatorTest extends AbstractGremlinTest {
+
+    @Test
+    @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+    public void shouldHandleStrategies() throws Exception {
+        GraphTraversalSource g = graph.traversal();
+        g = g.withStrategies(new HashMap<String, Object>() {{
+            put(SubgraphStrategy.STRATEGY, SubgraphStrategy.class.getCanonicalName());
+            put(SubgraphStrategy.VERTICES, __.has("name", "marko"));
+        }});
+        final Bindings bindings = new SimpleBindings();
+        bindings.put("g", g);
+        Traversal.Admin<Vertex, Object> traversal = new GremlinGroovyScriptEngine().eval(g.V().values("name").asAdmin().getBytecode(), bindings);
+        assertEquals("marko", traversal.next());
+        assertFalse(traversal.hasNext());
+        //
+        g = g.withoutStrategies(SubgraphStrategy.class.getCanonicalName());
+        traversal = new GremlinGroovyScriptEngine().eval(g.V().count().asAdmin().getBytecode(), bindings);
+        assertEquals(new Long(6), traversal.next());
+        assertFalse(traversal.hasNext());
+        //
+        g = graph.traversal().withStrategies(new HashMap<String, Object>() {{
+            put(SubgraphStrategy.STRATEGY, SubgraphStrategy.class.getCanonicalName());
+            put(SubgraphStrategy.VERTICES, __.has("name", "marko"));
+        }}, Collections.singletonMap(ReadOnlyStrategy.STRATEGY, ReadOnlyStrategy.class.getCanonicalName()));
+        traversal = new GremlinGroovyScriptEngine().eval(g.V().values("name").asAdmin().getBytecode(), bindings);
+        assertEquals("marko", traversal.next());
+        assertFalse(traversal.hasNext());
+    }
 
     @Test
     @LoadGraphWith(LoadGraphWith.GraphData.MODERN)

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
@@ -24,7 +24,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.SackFunctions;
 import org.apache.tinkerpop.gremlin.process.traversal.Translator;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -78,15 +77,12 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
         final StringBuilder traversalScript = new StringBuilder(start);
         for (final Bytecode.Instruction instruction : bytecode.getInstructions()) {
             final String methodName = instruction.getOperator();
-            if (methodName.equals(TraversalSource.Symbols.withStrategies))
-                continue;
-            final Object[] arguments = instruction.getArguments();
-            if (0 == arguments.length)
+            if (0 == instruction.getArguments().length)
                 traversalScript.append(".").append(methodName).append("()");
             else {
                 traversalScript.append(".");
                 String temp = methodName + "(";
-                for (final Object object : arguments) {
+                for (final Object object : instruction.getArguments()) {
                     temp = temp + convertToString(object) + ",";
                 }
                 traversalScript.append(temp.substring(0, temp.length() - 1)).append(")");

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
@@ -19,6 +19,7 @@
 
 package org.apache.tinkerpop.gremlin.groovy.jsr223;
 
+import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.SackFunctions;
@@ -79,7 +80,7 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
         final StringBuilder traversalScript = new StringBuilder(start);
         for (final Bytecode.Instruction instruction : bytecode.getInstructions()) {
             final String methodName = instruction.getOperator();
-            if (IS_TESTING && methodName.equals(TraversalSource.Symbols.withStrategies))
+            if(IS_TESTING && methodName.equals(TraversalSource.Symbols.withStrategies))
                 continue;
             if (0 == instruction.getArguments().length)
                 traversalScript.append(".").append(methodName).append("()");
@@ -126,6 +127,8 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
             return ((Enum) object).getDeclaringClass().getSimpleName() + "." + object.toString();
         else if (object instanceof Element)
             return convertToString(((Element) object).id()); // hack
+        else if (object instanceof Computer)
+            return "";
         else if (object instanceof Lambda) {
             final String lambdaString = ((Lambda) object).getLambdaScript().trim();
             return lambdaString.startsWith("{") ? lambdaString : "{" + lambdaString + "}";

--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/TraversalSourceGenerator.groovy
@@ -254,9 +254,24 @@ class Bytecode(object):
         if isinstance(arg, Traversal):
             self.bindings.update(arg.bytecode.bindings)
             return arg.bytecode
+        elif isinstance(arg, dict):
+            newDict = {}
+            for key in arg:
+                newDict[self.__convertArgument(key)] = self.__convertArgument(arg[key])
+            return newDict
+        elif isinstance(arg, list):
+            newList = []
+            for item in arg:
+                newList.append(self.__convertArgument(item))
+            return newList
+        elif isinstance(arg, set):
+            newSet = set()
+            for item in arg:
+                newSet.add(self.__convertArgument(item))
+            return newSet
         elif isinstance(arg, tuple) and 2 == len(arg) and isinstance(arg[0], str):
             self.bindings[arg[0]] = arg[1]
-            return Binding(arg[0],arg[1])
+            return Binding(arg[0],self.__convertArgument(arg[1]))
         else:
             return arg
     def __repr__(self):

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/GremlinJythonScriptEngine.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/GremlinJythonScriptEngine.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.util.CoreImports;
 import org.python.jsr223.PyScriptEngine;
 import org.python.jsr223.PyScriptEngineFactory;
@@ -66,8 +67,12 @@ public class GremlinJythonScriptEngine implements GremlinScriptEngine {
                     "  elif isinstance(index,slice):\n    return self.range(index.start,index.stop)\n" +
                     "  else:\n    return TypeError('Index must be int or slice')");
             this.pyScriptEngine.eval(GraphTraversal.class.getSimpleName() + ".__getitem__ = getitem_bypass");
-            this.pyScriptEngine.eval(GraphTraversal.class.getSimpleName() + ".__getattr__ = lambda self, key: self.values(key)");
-
+            this.pyScriptEngine.eval(GraphTraversal.class.getSimpleName() + ".__getattr__ = lambda self, key: self.values(key)\n");
+            // necessary cause of var args bug in Jython (http://bugs.jython.org/issue1615)
+            this.pyScriptEngine.eval("def withStrategies_bypass(self, *args):\n" +
+                    "  self.getBytecode().addSource(\"withStrategies\", *args)\n" +
+                    "  return self\n");
+            this.pyScriptEngine.eval(GraphTraversalSource.class.getSimpleName() + ".withStrategies = withStrategies_bypass\n");
             this.pyScriptEngine.eval("\n" +
                     "from java.lang import Long\n" +
                     "import org.apache.tinkerpop.gremlin.util.function.Lambda\n" + // todo: remove or remove imported subclass names? (choose)

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
@@ -19,6 +19,7 @@
 
 package org.apache.tinkerpop.gremlin.python.jsr223;
 
+import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -157,6 +158,8 @@ public class PythonTranslator implements Translator.ScriptTranslator {
             return convertToString(((Element) object).id()); // hack
         else if (object instanceof Bytecode)
             return this.internalTranslate("__", (Bytecode) object);
+        else if (object instanceof Computer)
+            return "";
         else if (object instanceof Lambda)
             return convertLambdaToString((Lambda) object);
         else

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
@@ -60,6 +60,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
 
     private final String traversalSource;
     private final boolean importStatics;
+    private static final boolean isTesting = Boolean.valueOf(System.getProperty("is.testing", "false"));
 
     PythonTranslator(final String traversalSource, final boolean importStatics) {
         this.traversalSource = traversalSource;
@@ -101,7 +102,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
         for (final Bytecode.Instruction instruction : bytecode.getInstructions()) {
             final String methodName = instruction.getOperator();
             final Object[] arguments = instruction.getArguments();
-            if (methodName.equals(TraversalSource.Symbols.withStrategies))
+            if (isTesting && methodName.equals(TraversalSource.Symbols.withStrategies))
                 continue;
             else if (0 == arguments.length)
                 traversalScript.append(".").append(SymbolHelper.toPython(methodName)).append("()");

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -57,17 +57,9 @@ class GraphTraversalSource(object):
     source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
     source.bytecode.add_source("withStrategies", *args)
     return source
-  def withStrategy(self, *args):
-    source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
-    source.bytecode.add_source("withStrategy", *args)
-    return source
   def withoutStrategies(self, *args):
     source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
     source.bytecode.add_source("withoutStrategies", *args)
-    return source
-  def withoutStrategy(self, *args):
-    source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
-    source.bytecode.add_source("withoutStrategy", *args)
     return source
   def withRemote(self, remote_connection):
     source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -57,9 +57,17 @@ class GraphTraversalSource(object):
     source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
     source.bytecode.add_source("withStrategies", *args)
     return source
+  def withStrategy(self, *args):
+    source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
+    source.bytecode.add_source("withStrategy", *args)
+    return source
   def withoutStrategies(self, *args):
     source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
     source.bytecode.add_source("withoutStrategies", *args)
+    return source
+  def withoutStrategy(self, *args):
+    source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
+    source.bytecode.add_source("withoutStrategy", *args)
     return source
   def withRemote(self, remote_connection):
     source = GraphTraversalSource(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -313,9 +313,24 @@ class Bytecode(object):
         if isinstance(arg, Traversal):
             self.bindings.update(arg.bytecode.bindings)
             return arg.bytecode
+        elif isinstance(arg, dict):
+            newDict = {}
+            for key in arg:
+                newDict[self.__convertArgument(key)] = self.__convertArgument(arg[key])
+            return newDict
+        elif isinstance(arg, list):
+            newList = []
+            for item in arg:
+                newList.append(self.__convertArgument(item))
+            return newList
+        elif isinstance(arg, set):
+            newSet = set()
+            for item in arg:
+                newSet.add(self.__convertArgument(item))
+            return newSet
         elif isinstance(arg, tuple) and 2 == len(arg) and isinstance(arg[0], str):
             self.bindings[arg[0]] = arg[1]
-            return Binding(arg[0],arg[1])
+            return Binding(arg[0],self.__convertArgument(arg[1]))
         else:
             return arg
     def __repr__(self):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -47,7 +47,7 @@ class GraphSONWriter(object):
             if isinstance(object, key):
                 return serializers[key]._dictify(object)
         # list and map are treated as normal json objects (could be isolated serializers)
-        if isinstance(object, list):
+        if isinstance(object, list) or isinstance(object, set):
             newList = []
             for item in object:
                 newList.append(GraphSONWriter._dictify(item))
@@ -181,7 +181,8 @@ class NumberSerializer(GraphSONSerializer):
     def _dictify(self, number):
         if isinstance(number, bool):  # python thinks that 0/1 integers are booleans
             return number
-        elif isinstance(number, long) or (abs(number) > 2147483647): # in python all numbers are int unless specified otherwise
+        elif isinstance(number, long) or (
+                    abs(number) > 2147483647):  # in python all numbers are int unless specified otherwise
             return _SymbolHelper.objectify("Int64", number)
         elif isinstance(number, int):
             return _SymbolHelper.objectify("Int32", number)

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -26,6 +26,7 @@ from gremlin_python import statics
 from gremlin_python.statics import long
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.traversal import Traverser
+from gremlin_python.process.graph_traversal import __
 from gremlin_python.structure.graph import Graph
 from gremlin_python.structure.graph import Vertex
 
@@ -57,6 +58,19 @@ class TestDriverRemoteConnection(TestCase):
         assert 2 == g.V()[:2].count().next()
         # todo: need a traversal metrics deserializer
         g.V().out().profile().next()
+        connection.close()
+
+    def test_strategies(self):
+        statics.load_statics(globals())
+        connection = DriverRemoteConnection('ws://localhost:8182/gremlin', 'g')
+        g = Graph().traversal().withRemote(connection).withStrategy(
+            "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy",
+            "vertices", __.hasLabel("person"),
+            "edges", __.hasLabel("created"))
+        assert 4 == g.V().count().next()
+        assert 0 == g.E().count().next()
+        assert 1 == g.V().label().dedup().count().next()
+        assert "person" == g.V().label().dedup().next()
         connection.close()
 
     def test_side_effects(self):
@@ -104,7 +118,7 @@ class TestDriverRemoteConnection(TestCase):
         assert 3 == n["lop"]
         assert 1 == n["ripple"]
         #
-        t = g.withSideEffect('m',32).V().map(lambda: "x: x.sideEffects('m')")
+        t = g.withSideEffect('m', 32).V().map(lambda: "x: x.sideEffects('m')")
         results = t.toSet()
         assert 1 == len(results)
         assert 32 == list(results)[0]

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -71,6 +71,12 @@ class TestDriverRemoteConnection(TestCase):
         assert 0 == g.E().count().next()
         assert 1 == g.V().label().dedup().count().next()
         assert "person" == g.V().label().dedup().next()
+        #
+        g = g.withComputer("workers", 4, "vertices", __.has("name", "marko"))
+        assert 1 == g.V().count().next()
+        assert 0 == g.E().count().next()
+        assert "person" == g.V().label().next()
+        assert "marko" == g.V().name.next()
         connection.close()
 
     def test_side_effects(self):

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -72,7 +72,7 @@ class TestDriverRemoteConnection(TestCase):
         assert 1 == g.V().label().dedup().count().next()
         assert "person" == g.V().label().dedup().next()
         #
-        g = g.withComputer("workers", 4, "vertices", __.has("name", "marko"))
+        g = g.withoutStrategy("org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy").withComputer("workers", 4, "vertices", __.has("name", "marko"), "edges", __.limit(0))
         assert 1 == g.V().count().next()
         assert 0 == g.E().count().next()
         assert "person" == g.V().label().next()

--- a/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
+++ b/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
@@ -19,16 +19,26 @@
 
 package org.apache.tinkerpop.gremlin.python.jsr223;
 
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.apache.tinkerpop.gremlin.util.ScriptEngineCache;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.junit.Test;
 
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -38,6 +48,30 @@ import static org.junit.Assert.assertFalse;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class JythonTranslatorTest {
+
+    @Test
+    public void shouldHandleStrategies() throws Exception {
+        GraphTraversalSource g = TinkerFactory.createModern().traversal();
+        g = g.withStrategies(new HashMap<String, Object>() {{
+            put(SubgraphStrategy.STRATEGY, SubgraphStrategy.class.getCanonicalName());
+            put(SubgraphStrategy.VERTICES, __.has("name", "marko"));
+        }});
+        final Bindings bindings = new SimpleBindings();
+        bindings.put("g", g);
+        //System.out.println(JythonTranslator.of("g").translate(g.V().values("name").asAdmin().getBytecode()));
+        Traversal.Admin<Vertex, String> traversal = ((GremlinScriptEngine) ScriptEngineCache.get("gremlin-jython")).eval(g.V().values("name").asAdmin().getBytecode(), bindings);
+        assertEquals("marko", traversal.next());
+        assertFalse(traversal.hasNext());
+        //
+        g = g.withStrategies(new HashMap<String, Object>() {{
+            put(SubgraphStrategy.STRATEGY, SubgraphStrategy.class.getCanonicalName());
+            put(SubgraphStrategy.VERTICES, __.has("name", "marko"));
+        }}, Collections.singletonMap(ReadOnlyStrategy.STRATEGY, ReadOnlyStrategy.class.getCanonicalName()));
+        //System.out.println(JythonTranslator.of("g").translate(g.V().values("name").asAdmin().getBytecode()));
+        traversal = ((GremlinScriptEngine) ScriptEngineCache.get("gremlin-jython")).eval(g.V().values("name").asAdmin().getBytecode(), bindings);
+        assertEquals("marko", traversal.next());
+        assertFalse(traversal.hasNext());
+    }
 
     @Test
     public void shouldSupportStringSupplierLambdas() throws Exception {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
@@ -31,6 +30,7 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -39,7 +39,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -51,8 +55,8 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     public void shouldAppendPartitionToVertex() {
         final PartitionStrategy partitionStrategy = PartitionStrategy.build()
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final Vertex v = create(partitionStrategy).addV().property("any", "thing").next();
+                .partitionKey(partition).writePartition("A").readPartitions("A").create();
+        final Vertex v = g.withStrategies(partitionStrategy).addV().property("any", "thing").next();
 
         assertNotNull(v);
         assertEquals("thing", v.property("any").value());
@@ -65,8 +69,8 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldAppendPartitionToVertexProperty() {
         final PartitionStrategy partitionStrategy = PartitionStrategy.build()
                 .includeMetaProperties(true)
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final Vertex v = create(partitionStrategy).addV().property("any", "thing").next();
+                .partitionKey(partition).writePartition("A").readPartitions("A").create();
+        final Vertex v = g.withStrategies(partitionStrategy).addV().property("any", "thing").next();
 
         assertNotNull(v);
         assertEquals("thing", v.property("any").value());
@@ -81,8 +85,8 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldAppendPartitionToVertexPropertyOverMultiProperty() {
         final PartitionStrategy partitionStrategy = PartitionStrategy.build()
                 .includeMetaProperties(true)
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final Vertex v = create(partitionStrategy).addV().property(VertexProperty.Cardinality.list, "any", "thing")
+                .partitionKey(partition).writePartition("A").readPartitions("A").create();
+        final Vertex v = g.withStrategies(partitionStrategy).addV().property(VertexProperty.Cardinality.list, "any", "thing")
                 .property(VertexProperty.Cardinality.list, "any", "more").next();
 
         assertNotNull(v);
@@ -97,8 +101,8 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldNotAppendPartitionToVertexProperty() {
         final PartitionStrategy partitionStrategy = PartitionStrategy.build()
                 .includeMetaProperties(false)
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final Vertex v = create(partitionStrategy).addV().property("any", "thing").next();
+                .partitionKey(partition).writePartition("A").readPartitions("A").create();
+        final Vertex v = g.withStrategies(partitionStrategy).addV().property("any", "thing").next();
 
         assertNotNull(v);
         assertEquals("thing", v.property("any").value());
@@ -111,19 +115,19 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldAppendPartitionToAllVertexProperties() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
 
-        final GraphTraversalSource gOverB = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverB = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("B").addReadPartition("B").create());
 
-        final GraphTraversalSource gOverAB = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverAB = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("B").addReadPartition("B").addReadPartition("A").create());
 
-        final Vertex v = gOverA.addV().property("any", "thing").property("some","thing").next();
+        final Vertex v = gOverA.addV().property("any", "thing").property("some", "thing").next();
 
         assertNotNull(v);
         assertEquals("thing", v.property("any").value());
@@ -173,7 +177,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForValues() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
@@ -191,9 +195,9 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForValuesWithEmptyKeys() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create());
+                .partitionKey(partition).writePartition("A").readPartitions("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
 
         assertEquals(1l, (long) gOverA.V(v).values().count().next());
@@ -204,7 +208,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForProperties() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
@@ -221,9 +225,9 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForPropertiesWithEmptyKeys() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create());
+                .partitionKey(partition).writePartition("A").readPartitions("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
 
         assertEquals(1l, (long) gOverA.V(v).properties().count().next());
@@ -234,9 +238,9 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForPropertyMap() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create());
+                .partitionKey(partition).writePartition("A").readPartitions("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
 
         gOverA.V(v).propertyMap(partition).next();
@@ -246,7 +250,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForPropertyMapWithEmptyKeys() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
@@ -255,10 +259,11 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         assertEquals("thing", ((List<VertexProperty>) gOverA.V(v).propertyMap().next().get("any")).get(0).value());
     }
 
+    @Test
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForValueMap() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
@@ -267,8 +272,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
             gOverA.V(v).valueMap(partition).next();
             fail("Should have thrown exception");
         } catch (Exception ex) {
-            final Throwable root = ExceptionUtils.getRootCause(ex);
-            assertThat(root.getMessage(), startsWith("Cannot explicitly request the partitionKey in the traversal"));
+
         }
     }
 
@@ -276,7 +280,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
     public void shouldHidePartitionKeyForValueMapWithEmptyKeys() {
-        final GraphTraversalSource gOverA = create(PartitionStrategy.build()
+        final GraphTraversalSource gOverA = g.withStrategies(PartitionStrategy.build()
                 .includeMetaProperties(true)
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
@@ -290,7 +294,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldAppendPartitionToEdge() {
         final PartitionStrategy partitionStrategy = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final GraphTraversalSource source = create(partitionStrategy);
+        final GraphTraversalSource source = g.withStrategies(partitionStrategy);
         final Vertex v1 = source.addV().property("any", "thing").next();
         final Vertex v2 = source.addV().property("some", "thing").next();
         final Edge e = source.withSideEffect("v2", v2).V(v1.id()).addE("connectsTo").from("v2").property("every", "thing").next();
@@ -314,19 +318,19 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldWriteVerticesToMultiplePartitions() {
         final PartitionStrategy partitionStrategyAA = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final GraphTraversalSource sourceAA = create(partitionStrategyAA);
+        final GraphTraversalSource sourceAA = g.withStrategies(partitionStrategyAA);
 
         final PartitionStrategy partitionStrategyBA = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("B").addReadPartition("A").create();
-        final GraphTraversalSource sourceBA = create(partitionStrategyBA);
+        final GraphTraversalSource sourceBA = g.withStrategies(partitionStrategyBA);
 
         final PartitionStrategy partitionStrategyBB = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("B").addReadPartition("B").create();
-        final GraphTraversalSource sourceBB = create(partitionStrategyBB);
+        final GraphTraversalSource sourceBB = g.withStrategies(partitionStrategyBB);
 
         final PartitionStrategy partitionStrategyBAB = PartitionStrategy.build()
-                .partitionKey(partition).writePartition("B").addReadPartition("A").addReadPartition("B").create();
-        final GraphTraversalSource sourceBAB = create(partitionStrategyBAB);
+                .partitionKey(partition).writePartition("B").readPartitions("A", "B").create();
+        final GraphTraversalSource sourceBAB = g.withStrategies(partitionStrategyBAB);
 
 
         final Vertex vA = sourceAA.addV().property("any", "a").next();
@@ -351,11 +355,11 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldThrowExceptionOnVInDifferentPartition() {
         final PartitionStrategy partitionStrategyAA = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final GraphTraversalSource sourceAA = create(partitionStrategyAA);
+        final GraphTraversalSource sourceAA = g.withStrategies(partitionStrategyAA);
 
         final PartitionStrategy partitionStrategyA = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("A").create();
-        final GraphTraversalSource sourceA = create(partitionStrategyA);
+        final GraphTraversalSource sourceA = g.withStrategies(partitionStrategyA);
 
         final Vertex vA = sourceAA.addV().property("any", "a").next();
         assertEquals(vA.id(), sourceAA.V(vA.id()).id().next());
@@ -373,11 +377,11 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldThrowExceptionOnEInDifferentPartition() {
         final PartitionStrategy partitionStrategyAA = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final GraphTraversalSource sourceAA = create(partitionStrategyAA);
+        final GraphTraversalSource sourceAA = g.withStrategies(partitionStrategyAA);
 
         final PartitionStrategy partitionStrategyA = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("A").create();
-        final GraphTraversalSource sourceA = create(partitionStrategyA);
+        final GraphTraversalSource sourceA = g.withStrategies(partitionStrategyA);
 
         final Vertex vA = sourceAA.addV().property("any", "a").next();
         final Edge e = sourceAA.withSideEffect("vA", vA).V(vA.id()).addE("knows").to("vA").next();
@@ -396,24 +400,24 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
     public void shouldWriteToMultiplePartitions() {
         final PartitionStrategy partitionStrategyAA = PartitionStrategy.build()
-                .partitionKey(partition).writePartition("A").addReadPartition("A").create();
-        final GraphTraversalSource sourceAA = create(partitionStrategyAA);
+                .partitionKey(partition).writePartition("A").readPartitions("A").create();
+        final GraphTraversalSource sourceAA = g.withStrategies(partitionStrategyAA);
 
         final PartitionStrategy partitionStrategyBA = PartitionStrategy.build()
-                .partitionKey(partition).writePartition("B").addReadPartition("A").create();
-        final GraphTraversalSource sourceBA = create(partitionStrategyBA);
+                .partitionKey(partition).writePartition("B").readPartitions("A").create();
+        final GraphTraversalSource sourceBA = g.withStrategies(partitionStrategyBA);
 
         final PartitionStrategy partitionStrategyCAB = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("C").addReadPartition("A").addReadPartition("B").create();
-        final GraphTraversalSource sourceCAB = create(partitionStrategyCAB);
+        final GraphTraversalSource sourceCAB = g.withStrategies(partitionStrategyCAB);
 
         final PartitionStrategy partitionStrategyC = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("C").create();
-        final GraphTraversalSource sourceC = create(partitionStrategyC);
+        final GraphTraversalSource sourceC = g.withStrategies(partitionStrategyC);
 
         final PartitionStrategy partitionStrategyCA = PartitionStrategy.build()
-                .partitionKey(partition).writePartition("C").addReadPartition("A").create();
-        final GraphTraversalSource sourceCA = create(partitionStrategyCA);
+                .partitionKey(partition).writePartition("C").readPartitions("A").create();
+        final GraphTraversalSource sourceCA = g.withStrategies(partitionStrategyCA);
 
         final PartitionStrategy partitionStrategyCABC = PartitionStrategy.build()
                 .partitionKey(partition)
@@ -421,15 +425,18 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .addReadPartition("A")
                 .addReadPartition("B")
                 .addReadPartition("C").create();
-        final GraphTraversalSource sourceCABC = create(partitionStrategyCABC);
+        final GraphTraversalSource sourceCABC = g.withStrategy(PartitionStrategy.class.getCanonicalName(),
+                "writePartition", "C",
+                "partitionKey", partition,
+                "readPartitions", Arrays.asList("A", "B", "C"));
 
         final PartitionStrategy partitionStrategyCC = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("C").addReadPartition("C").create();
-        final GraphTraversalSource sourceCC = create(partitionStrategyCC);
+        final GraphTraversalSource sourceCC = g.withStrategies(partitionStrategyCC);
 
         final PartitionStrategy partitionStrategyCBC = PartitionStrategy.build()
-                .partitionKey(partition).writePartition("C").addReadPartition("C").addReadPartition("B").create();
-        final GraphTraversalSource sourceCBC = create(partitionStrategyCBC);
+                .partitionKey(partition).writePartition("C").readPartitions(Arrays.asList("B", "C")).create();
+        final GraphTraversalSource sourceCBC = g.withStrategies(partitionStrategyCBC);
 
         final Vertex vA = sourceAA.addV().property("any", "a").next();
         final Vertex vAA = sourceAA.addV().property("any", "aa").next();
@@ -479,9 +486,5 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         assertEquals(vB.id(), sourceCBC.E(eBtovC.id()).outV().id().next());
         assertEquals(vC.id(), sourceCBC.E(eAtovC.id()).inV().id().next());
         assertFalse(sourceCBC.E(eAtovC.id()).outV().hasNext());
-    }
-
-    private GraphTraversalSource create(final PartitionStrategy strategy) {
-        return graphProvider.traversal(graph, strategy);
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -419,17 +420,12 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .partitionKey(partition).writePartition("C").readPartitions("A").create();
         final GraphTraversalSource sourceCA = g.withStrategies(partitionStrategyCA);
 
-        final PartitionStrategy partitionStrategyCABC = PartitionStrategy.build()
-                .partitionKey(partition)
-                .writePartition("C")
-                .addReadPartition("A")
-                .addReadPartition("B")
-                .addReadPartition("C").create();
-        final GraphTraversalSource sourceCABC = g.withStrategy(PartitionStrategy.class.getCanonicalName(),
-                "writePartition", "C",
-                "partitionKey", partition,
-                "readPartitions", Arrays.asList("A", "B", "C"));
-
+        final GraphTraversalSource sourceCABC = g.withStrategies(new HashMap<String, Object>() {{
+            put(PartitionStrategy.STRATEGY, PartitionStrategy.class.getCanonicalName());
+            put(PartitionStrategy.WRITE_PARTITION, "C");
+            put(PartitionStrategy.PARTITION_KEY, partition);
+            put(PartitionStrategy.READ_PARTITIONS, Arrays.asList("A", "B", "C"));
+        }});
         final PartitionStrategy partitionStrategyCC = PartitionStrategy.build()
                 .partitionKey(partition).writePartition("C").addReadPartition("C").create();
         final GraphTraversalSource sourceCC = g.withStrategies(partitionStrategyCC);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -371,7 +372,10 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(CREW)
     public void shouldFilterVertexProperties() throws Exception {
-        GraphTraversalSource sg = g.withStrategy(SubgraphStrategy.class.getCanonicalName(), "vertexProperties", __.has("startTime", P.gt(2005)));
+        GraphTraversalSource sg = g.withStrategies(new HashMap<String, Object>() {{
+            put(SubgraphStrategy.STRATEGY, SubgraphStrategy.class.getCanonicalName());
+            put(SubgraphStrategy.VERTEX_PROPERTIES, __.has("startTime", P.gt(2005)));
+        }});
         checkResults(Arrays.asList("purcellville", "baltimore", "oakland", "seattle", "aachen"), sg.V().properties("location").value());
         checkResults(Arrays.asList("purcellville", "baltimore", "oakland", "seattle", "aachen"), sg.V().values("location"));
         if (sg.getStrategies().getStrategy(InlineFilterStrategy.class).isPresent())
@@ -397,7 +401,11 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
         sg = g.withStrategies(SubgraphStrategy.build().vertices(has("location")).vertexProperties(hasNot("endTime")).create());
         checkOrderedResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().order().by("location", Order.incr).values("location"));
         //
-        sg = g.withStrategy(SubgraphStrategy.class.getCanonicalName(), "vertices", __.has("location"), "vertexProperties", __.hasNot("endTime"));
+        sg = g.withStrategies(new HashMap<String, Object>() {{
+            put(SubgraphStrategy.STRATEGY, SubgraphStrategy.class.getCanonicalName());
+            put(SubgraphStrategy.VERTICES, __.has("location"));
+            put(SubgraphStrategy.VERTEX_PROPERTIES, __.hasNot("endTime"));
+        }});
         checkResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().valueMap("location").select(Column.values).unfold().unfold());
         checkResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().propertyMap("location").select(Column.values).unfold().unfold().value());
         //

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
@@ -31,7 +31,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.Inli
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,8 +65,7 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldFilterVertexCriterion() throws Exception {
         final Traversal<Vertex, ?> vertexCriterion = has("name", P.within("josh", "lop", "ripple"));
 
-        final SubgraphStrategy strategy = SubgraphStrategy.build().vertexCriterion(vertexCriterion).create();
-        final GraphTraversalSource sg = create(strategy);
+        final GraphTraversalSource sg = g.withStrategies(SubgraphStrategy.build().vertexCriterion(vertexCriterion).create());
 
         // three vertices are included in the subgraph
         assertEquals(6, g.V().count().next().longValue());
@@ -154,7 +152,7 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
         );
 
         final SubgraphStrategy strategy = SubgraphStrategy.build().edgeCriterion(edgeCriterion).create();
-        final GraphTraversalSource sg = create(strategy);
+        final GraphTraversalSource sg = g.withStrategies(strategy);
 
         // all vertices are here
         assertEquals(6, g.V().count().next().longValue());
@@ -261,8 +259,8 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
                 has("weight", 1.0d).hasLabel("created") // 10
         );
 
-        final SubgraphStrategy strategy = SubgraphStrategy.build().edgeCriterion(edgeCriterion).vertexCriterion(vertexCriterion).create();
-        final GraphTraversalSource sg = create(strategy);
+        final SubgraphStrategy strategy = SubgraphStrategy.build().edges(edgeCriterion).vertices(vertexCriterion).create();
+        final GraphTraversalSource sg = g.withStrategies(strategy);
 
         // three vertices are included in the subgraph
         assertEquals(6, g.V().count().next().longValue());
@@ -337,8 +335,7 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
         // this will exclude "peter"
         final Traversal<Vertex, ?> vertexCriterion = has("name", P.within("ripple", "josh", "marko"));
 
-        final SubgraphStrategy strategy = SubgraphStrategy.build().vertexCriterion(vertexCriterion).create();
-        final GraphTraversalSource sg = create(strategy);
+        final GraphTraversalSource sg = g.withStrategies(SubgraphStrategy.build().vertexCriterion(vertexCriterion).create());
 
         assertEquals(9, g.V().as("a").out().in().as("b").dedup("a", "b").count().next().intValue());
         assertEquals(2, sg.V().as("a").out().in().as("b").dedup("a", "b").count().next().intValue());
@@ -352,8 +349,7 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
     public void shouldGetExcludedVertex() throws Exception {
         final Traversal<Vertex, ?> vertexCriterion = has("name", P.within("josh", "lop", "ripple"));
 
-        final SubgraphStrategy strategy = SubgraphStrategy.build().vertexCriterion(vertexCriterion).create();
-        final GraphTraversalSource sg = create(strategy);
+        final GraphTraversalSource sg = g.withStrategies(SubgraphStrategy.build().vertexCriterion(vertexCriterion).create());
 
         sg.V(convertToVertexId("marko")).next();
     }
@@ -367,8 +363,7 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
                 has("weight", 1.0d).hasLabel("created") // 10
         );
 
-        final SubgraphStrategy strategy = SubgraphStrategy.build().edgeCriterion(edgeCriterion).create();
-        final GraphTraversalSource sg = create(strategy);
+        final GraphTraversalSource sg = g.withStrategies(SubgraphStrategy.build().edges(edgeCriterion).create());
 
         sg.E(sg.E(convertToEdgeId("marko", "knows", "vadas")).next()).next();
     }
@@ -376,48 +371,45 @@ public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(CREW)
     public void shouldFilterVertexProperties() throws Exception {
-        GraphTraversalSource sg = create(SubgraphStrategy.build().vertexProperties(has("startTime", P.gt(2005))).create());
+        GraphTraversalSource sg = g.withStrategy(SubgraphStrategy.class.getCanonicalName(), "vertexProperties", __.has("startTime", P.gt(2005)));
         checkResults(Arrays.asList("purcellville", "baltimore", "oakland", "seattle", "aachen"), sg.V().properties("location").value());
         checkResults(Arrays.asList("purcellville", "baltimore", "oakland", "seattle", "aachen"), sg.V().values("location"));
         if (sg.getStrategies().getStrategy(InlineFilterStrategy.class).isPresent())
             assertFalse(TraversalHelper.hasStepOfAssignableClassRecursively(TraversalFilterStep.class, sg.V().properties("location").value().iterate().asAdmin()));
         // check to make sure edge properties are not analyzed
-        sg = create(SubgraphStrategy.build().vertexProperties(has("startTime", P.gt(2005))).create());
+        sg = g.withStrategies(SubgraphStrategy.build().vertexProperties(has("startTime", P.gt(2005))).create());
         checkResults(Arrays.asList("purcellville", "baltimore", "oakland", "seattle", "aachen"), sg.V().as("a").properties("location").as("b").select("a").outE().properties().select("b").value().dedup());
         checkResults(Arrays.asList("purcellville", "baltimore", "oakland", "seattle", "aachen"), sg.V().as("a").values("location").as("b").select("a").outE().properties().select("b").dedup());
         if (sg.getStrategies().getStrategy(InlineFilterStrategy.class).isPresent())
             assertFalse(TraversalHelper.hasStepOfAssignableClassRecursively(TraversalFilterStep.class, sg.V().as("a").values("location").as("b").select("a").outE().properties().select("b").dedup().iterate().asAdmin()));
         //
-        sg = create(SubgraphStrategy.build().vertices(has("name", P.neq("stephen"))).vertexProperties(has("startTime", P.gt(2005))).create());
+        sg = g.withStrategies(SubgraphStrategy.build().vertices(has("name", P.neq("stephen"))).vertexProperties(has("startTime", P.gt(2005))).create());
         checkResults(Arrays.asList("baltimore", "oakland", "seattle", "aachen"), sg.V().properties("location").value());
         checkResults(Arrays.asList("baltimore", "oakland", "seattle", "aachen"), sg.V().values("location"));
         //
-        sg = create(SubgraphStrategy.build().vertices(has("name", P.not(P.within("stephen", "daniel")))).vertexProperties(has("startTime", P.gt(2005))).create());
+        sg = g.withStrategies(SubgraphStrategy.build().vertices(has("name", P.not(P.within("stephen", "daniel")))).vertexProperties(has("startTime", P.gt(2005))).create());
         checkResults(Arrays.asList("baltimore", "oakland", "seattle"), sg.V().properties("location").value());
         checkResults(Arrays.asList("baltimore", "oakland", "seattle"), sg.V().values("location"));
         //
-        sg = create(SubgraphStrategy.build().vertices(has("name", P.eq("matthias"))).vertexProperties(has("startTime", P.gte(2014))).create());
+        sg = g.withStrategies(SubgraphStrategy.build().vertices(has("name", P.eq("matthias"))).vertexProperties(has("startTime", P.gte(2014))).create());
         checkResults(makeMapList(1, "seattle", 1L), sg.V().groupCount().by("location"));
         //
-        sg = create(SubgraphStrategy.build().vertices(has("location")).vertexProperties(hasNot("endTime")).create());
+        sg = g.withStrategies(SubgraphStrategy.build().vertices(has("location")).vertexProperties(hasNot("endTime")).create());
         checkOrderedResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().order().by("location", Order.incr).values("location"));
         //
-        sg = create(SubgraphStrategy.build().vertices(has("location")).vertexProperties(hasNot("endTime")).create());
+        sg = g.withStrategy(SubgraphStrategy.class.getCanonicalName(), "vertices", __.has("location"), "vertexProperties", __.hasNot("endTime"));
         checkResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().valueMap("location").select(Column.values).unfold().unfold());
         checkResults(Arrays.asList("aachen", "purcellville", "santa fe", "seattle"), sg.V().propertyMap("location").select(Column.values).unfold().unfold().value());
         //
-        sg = create(SubgraphStrategy.build().edges(__.<Edge>hasLabel("uses").has("skill", 5)).create());
+        sg = g.withStrategies(SubgraphStrategy.build().edges(__.<Edge>hasLabel("uses").has("skill", 5)).create());
         checkResults(Arrays.asList(5, 5, 5), sg.V().outE().valueMap().select(Column.values).unfold());
         checkResults(Arrays.asList(5, 5, 5), sg.V().outE().propertyMap().select(Column.values).unfold().value());
         //
-        sg = create(SubgraphStrategy.build().vertexProperties(__.hasNot("skill")).create());
+        sg = g.withStrategies(SubgraphStrategy.build().vertexProperties(__.hasNot("skill")).create());
         checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().outE("uses").values("skill"));
         checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().as("a").properties().select("a").dedup().outE().values("skill"));
         checkResults(Arrays.asList(3, 3, 3, 4, 4, 5, 5, 5), sg.V().as("a").properties().select("a").dedup().outE().properties("skill").as("b").identity().select("b").by(__.value()));
     }
 
 
-    private GraphTraversalSource create(final SubgraphStrategy strategy) {
-        return graphProvider.traversal(graph, strategy);
-    }
 }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.tinkergraph.process;
 
 import org.apache.tinkerpop.gremlin.GraphProvider;
+import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.TinkerGraphProvider;
@@ -37,7 +38,11 @@ public class TinkerGraphComputerProvider extends TinkerGraphProvider {
     @Override
     public GraphTraversalSource traversal(final Graph graph) {
         return RANDOM.nextBoolean() ?
-                graph.traversal().withComputer() :
+                graph.traversal().withComputer(
+                        "workers", RANDOM.nextInt(4) + 1,
+                        "graphComputer", RANDOM.nextBoolean() ?
+                                GraphComputer.class.getCanonicalName() :
+                                TinkerGraphComputer.class.getCanonicalName()) :
                 graph.traversal(GraphTraversalSource.computer());
     }
 }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
@@ -19,12 +19,14 @@
 package org.apache.tinkerpop.gremlin.tinkergraph.process;
 
 import org.apache.tinkerpop.gremlin.GraphProvider;
+import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.TinkerGraphProvider;
 import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComputer;
 
+import java.util.HashMap;
 import java.util.Random;
 
 /**
@@ -38,11 +40,12 @@ public class TinkerGraphComputerProvider extends TinkerGraphProvider {
     @Override
     public GraphTraversalSource traversal(final Graph graph) {
         return RANDOM.nextBoolean() ?
-                graph.traversal().withComputer(
-                        "workers", RANDOM.nextInt(Runtime.getRuntime().availableProcessors()) + 1,
-                        "graphComputer", RANDOM.nextBoolean() ?
-                                GraphComputer.class.getCanonicalName() :
-                                TinkerGraphComputer.class.getCanonicalName()) :
+                graph.traversal().withComputer(new HashMap<String, Object>() {{
+                    put(Computer.WORKERS, RANDOM.nextInt(Runtime.getRuntime().availableProcessors()) + 1);
+                    put(Computer.GRAPH_COMPUTER, RANDOM.nextBoolean() ?
+                            GraphComputer.class.getCanonicalName() :
+                            TinkerGraphComputer.class.getCanonicalName());
+                }}) :
                 graph.traversal(GraphTraversalSource.computer());
     }
 }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
@@ -39,7 +39,7 @@ public class TinkerGraphComputerProvider extends TinkerGraphProvider {
     public GraphTraversalSource traversal(final Graph graph) {
         return RANDOM.nextBoolean() ?
                 graph.traversal().withComputer(
-                        "workers", RANDOM.nextInt(4) + 1,
+                        "workers", RANDOM.nextInt(Runtime.getRuntime().availableProcessors()) + 1,
                         "graphComputer", RANDOM.nextBoolean() ?
                                 GraphComputer.class.getCanonicalName() :
                                 TinkerGraphComputer.class.getCanonicalName()) :

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/groovy/jsr223/TinkerGraphGroovyTranslatorProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/groovy/jsr223/TinkerGraphGroovyTranslatorProvider.java
@@ -27,6 +27,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategyProcessTest;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategyProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.TinkerGraphProvider;
@@ -52,6 +54,7 @@ public class TinkerGraphGroovyTranslatorProvider extends TinkerGraphProvider {
             ProgramTest.Traversals.class.getCanonicalName(),
             TraversalInterruptionTest.class.getCanonicalName(),
             TraversalInterruptionComputerTest.class.getCanonicalName(),
+            EventStrategyProcessTest.class.getCanonicalName(),
             ElementIdStrategyProcessTest.class.getCanonicalName()));
 
 

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/jsr223/TinkerGraphJavaTranslatorProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/jsr223/TinkerGraphJavaTranslatorProvider.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategyProcessTest;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategyProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.TinkerGraphProvider;
@@ -48,6 +49,8 @@ public class TinkerGraphJavaTranslatorProvider extends TinkerGraphProvider {
             TraversalInterruptionComputerTest.class.getCanonicalName(),
             "shouldNeverPropagateANoBulkTraverser",
             "shouldNeverPropagateANullValuedTraverser",
+            ElementIdStrategyProcessTest.class.getCanonicalName(),
+            EventStrategyProcessTest.class.getCanonicalName(),
             ProgramTest.Traversals.class.getCanonicalName()));
 
 

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/HaltedTraverserStrategyTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/HaltedTraverserStrategyTest.java
@@ -19,10 +19,11 @@
 
 package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.strategy.decoration;
 
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedPath;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedProperty;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
@@ -58,7 +59,7 @@ public class HaltedTraverserStrategyTest {
     @Test
     public void shouldReturnDetachedElements() {
         final Graph graph = TinkerFactory.createModern();
-        final GraphTraversalSource g = graph.traversal().withComputer().withStrategies(HaltedTraverserStrategy.detached());
+        final GraphTraversalSource g = graph.traversal().withComputer().withStrategy(HaltedTraverserStrategy.class.getCanonicalName(), "haltedTraverserFactory", DetachedFactory.class.getCanonicalName());
         g.V().out().forEachRemaining(vertex -> assertEquals(DetachedVertex.class, vertex.getClass()));
         g.V().out().properties("name").forEachRemaining(vertexProperty -> assertEquals(DetachedVertexProperty.class, vertexProperty.getClass()));
         g.V().out().values("name").forEachRemaining(value -> assertEquals(String.class, value.getClass()));

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/HaltedTraverserStrategyTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/HaltedTraverserStrategyTest.java
@@ -38,6 +38,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -59,7 +61,10 @@ public class HaltedTraverserStrategyTest {
     @Test
     public void shouldReturnDetachedElements() {
         final Graph graph = TinkerFactory.createModern();
-        final GraphTraversalSource g = graph.traversal().withComputer().withStrategy(HaltedTraverserStrategy.class.getCanonicalName(), "haltedTraverserFactory", DetachedFactory.class.getCanonicalName());
+        final GraphTraversalSource g = graph.traversal().withComputer().withStrategies(new HashMap<String, Object>() {{
+            put(HaltedTraverserStrategy.STRATEGY, HaltedTraverserStrategy.class.getCanonicalName());
+            put(HaltedTraverserStrategy.HALTED_TRAVERSER_FACTORY, DetachedFactory.class.getCanonicalName());
+        }});
         g.V().out().forEachRemaining(vertex -> assertEquals(DetachedVertex.class, vertex.getClass()));
         g.V().out().properties("name").forEachRemaining(vertexProperty -> assertEquals(DetachedVertexProperty.class, vertexProperty.getClass()));
         g.V().out().values("name").forEachRemaining(value -> assertEquals(String.class, value.getClass()));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1455

Added TraversalSource.withStrategy(String, Object...) and TraversalSource.withoutStrategy(String). This allows Gremlin language variants (e.g. Gremlin-Python) to add and remove strategies from a traversal source. Prior to this moment, strategy addition/removal was via strategy instances (Java objects) and classes (Class objects). That is not language variants friendly.

This branch is backwards compatible. If a `TraversalStrategy` does not have a builder and exposes a static `instance()`-method, then `g.withStrategy('com.blah.MyStrategy')` will work as expected. If a `TraversalStrategy` does have a builder (that is, can be configured), then it should expose a static `create(Configuration)`-method. Note Gremlin language variants could not use `withStrategies()` prior to this and thus, this addition is backwards compatible. Finally, `TraversalSource.withComputer(Object...)` was added as well for the same reasons.

```
>>> g = g.withStrategy('org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy','vertices',hasLabel('person'),'edges',has('weight',gt(0.5)))
>>> g.V().name.toList()
[u'marko', u'vadas', u'josh', u'peter']
```

The CHANGELOG, gremlin-variants.asciidoc, and upgrade doc have all been updated accordingly.

VOTE +1