### PR TITLE
TINKERPOP-1458 Gremlin Server doesn't return confirmation upon Traversal OpProcessor "close" op

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -77,6 +77,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * VertexPrograms can now declare traverser requirements, e.g. to have access to the path when used with `.program()`.
 * New build options for `gremlin-python` where `-DglvPython` is no longer required.
 * Added missing `InetAddress` to GraphSON extension module.
+* Gremlin Server `TraversalOpProcessor` now returns confirmation upon `Op` `close`.
 
 [[release-3-2-2]]
 TinkerPop 3.2.2 (Release Date: September 6, 2016)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -78,6 +78,7 @@ TinkerPop 3.2.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * New build options for `gremlin-python` where `-DglvPython` is no longer required.
 * Added missing `InetAddress` to GraphSON extension module.
 * Gremlin Server `TraversalOpProcessor` now returns confirmation upon `Op` `close`.
+* Added `close` method Java driver and Python driver `DriverRemoteTraversalSideEffects`.
 
 [[release-3-2-2]]
 TinkerPop 3.2.2 (Release Date: September 6, 2016)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSideEffects.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSideEffects.java
@@ -32,7 +32,7 @@ import java.util.function.UnaryOperator;
  *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public interface TraversalSideEffects extends Cloneable, Serializable {
+public interface TraversalSideEffects extends Cloneable, Serializable, AutoCloseable {
 
     /**
      * Return true if the key is a registered side-effect.
@@ -81,6 +81,13 @@ public interface TraversalSideEffects extends Cloneable, Serializable {
      * @return the keys of the sideEffect
      */
     public Set<String> keys();
+
+    /**
+     * Invalidate the side effect cache for traversal.
+     */
+    public default void close() throws Exception {
+        // do nothing
+    }
 
     /**
      * Determines if there are any side-effects to be retrieved.

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -79,6 +79,11 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -68,7 +68,7 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
                 try {
                     final Result result = client.submitAsync(msg).get().one();
                     sideEffects.put(key, null == result ? null : result.getObject());
-                    if (keys.isEmpty())
+                    if (keys.equals(Collections.emptySet()))
                         keys = new HashSet<>();
                     keys.add(key);
                 } catch (Exception ex) {
@@ -97,7 +97,10 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
                     .addArg(Tokens.ARGS_HOST, host)
                     .processor("traversal").create();
             try {
-                keys = client.submitAsync(msg).get().all().get().stream().map(r -> r.getString()).collect(Collectors.toSet());
+                if (keys.equals(Collections.emptySet()))
+                    keys = new HashSet<>();
+
+                client.submitAsync(msg).get().all().get().forEach(r -> keys.add(r.getString()));
             } catch (Exception ex) {
                 final Throwable root = ExceptionUtils.getRootCause(ex);
                 final String exMsg = null == root ? "" : root.getMessage();

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.remote.traversal.AbstractRemoteTrave
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -67,10 +68,13 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
                 try {
                     final Result result = client.submitAsync(msg).get().one();
                     sideEffects.put(key, null == result ? null : result.getObject());
+                    if (keys.isEmpty())
+                        keys = new HashSet<>();
                     keys.add(key);
                 } catch (Exception ex) {
                     final Throwable root = ExceptionUtils.getRootCause(ex);
-                    if (root.getMessage().equals("Could not find side-effects for " + serverSideEffect + "."))
+                    final String exMsg = null == root ? "" : root.getMessage();
+                    if (exMsg.equals("Could not find side-effects for " + serverSideEffect + "."))
                         sideEffects.put(key, null);
                     else
                         throw new RuntimeException("Could not get keys", root);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * This class is not thread safe.
  */
 public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSideEffects {
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -100,7 +100,8 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
                 keys = client.submitAsync(msg).get().all().get().stream().map(r -> r.getString()).collect(Collectors.toSet());
             } catch (Exception ex) {
                 final Throwable root = ExceptionUtils.getRootCause(ex);
-                if (!root.getMessage().equals("Could not find side-effects for " + serverSideEffect + "."))
+                final String exMsg = null == root ? "" : root.getMessage();
+                if (!exMsg.equals("Could not find side-effects for " + serverSideEffect + "."))
                     throw new RuntimeException("Could not get keys", root);
             }
         }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffectsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffectsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.remote;
+
+import org.apache.tinkerpop.gremlin.driver.AbstractResultQueueTest;
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.ResultSet;
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSideEffects;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class DriverRemoteTraversalSideEffectsTest extends AbstractResultQueueTest {
+
+    @Test
+    public void shouldNotContactRemoteForKeysAfterCloseIsCalled() throws Exception {
+        final Client client = mock(Client.class);
+        mockClientForCall(client);
+        mockClientForCall(client);
+
+        final UUID sideEffectKey = UUID.fromString("31dec2c6-b214-4a6f-a68b-996608dce0d9");
+        final TraversalSideEffects sideEffects = new DriverRemoteTraversalSideEffects(client, sideEffectKey, null);
+
+        assertEquals(1, sideEffects.keys().size());
+        sideEffects.close();
+
+        // call this again and again and it will only hit the cached keys - no more server calls
+        assertEquals(1, sideEffects.keys().size());
+        assertEquals(1, sideEffects.keys().size());
+        assertEquals(1, sideEffects.keys().size());
+        assertEquals(1, sideEffects.keys().size());
+
+        // once for the keys and once for the close message
+        verify(client, times(2)).submitAsync(any(RequestMessage.class));
+    }
+
+    @Test
+    public void shouldNotContactRemoteMoreThanOnceForClose() throws Exception {
+        final Client client = mock(Client.class);
+        mockClientForCall(client);
+        mockClientForCall(client);
+
+        final UUID sideEffectKey = UUID.fromString("31dec2c6-b214-4a6f-a68b-996608dce0d9");
+        final TraversalSideEffects sideEffects = new DriverRemoteTraversalSideEffects(client, sideEffectKey, null);
+
+        sideEffects.close();
+        sideEffects.close();
+        sideEffects.close();
+        sideEffects.close();
+        sideEffects.close();
+
+        assertEquals(0, sideEffects.keys().size());
+
+        // once for the keys and once for the close message
+        verify(client, times(1)).submitAsync(any(RequestMessage.class));
+    }
+
+    private void mockClientForCall(final Client client) throws Exception {
+        final ResultSet returnedResultSet = new ResultSet(resultQueue, pool, readCompleted, RequestMessage.build("traversal").create(), null);
+        addToQueue(1, 0, true, true, 1);
+        final CompletableFuture<ResultSet> returnedFuture = new CompletableFuture<>();
+        returnedFuture.complete(returnedResultSet);
+
+        // the return is just generic garbage from addToQueue for any call to submitAsync() - but given the logic
+        // of DriverRemoteTraversalSideEffects, that's ok
+        when(client.submitAsync(any(RequestMessage.class))).thenReturn(returnedFuture);
+    }
+}

--- a/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
@@ -57,15 +57,19 @@ class RemoteTraversal(Traversal):
 
 
 class RemoteTraversalSideEffects(TraversalSideEffects):
-    def __init__(self, keys_lambda, value_lambda):
+    def __init__(self, keys_lambda, value_lambda, close_lambda):
         self.keys_lambda = keys_lambda
         self.value_lambda = value_lambda
+        self.close_lambda = close_lambda
 
     def keys(self):
         return self.keys_lambda()
 
     def get(self, key):
         return self.value_lambda(key)
+
+    def close(self):
+        return self.close_lambda()
 
 
 class RemoteStrategy(TraversalStrategy):

--- a/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
@@ -58,18 +58,32 @@ class RemoteTraversal(Traversal):
 
 class RemoteTraversalSideEffects(TraversalSideEffects):
     def __init__(self, keys_lambda, value_lambda, close_lambda):
-        self.keys_lambda = keys_lambda
-        self.value_lambda = value_lambda
-        self.close_lambda = close_lambda
+        self._keys_lambda = keys_lambda
+        self._value_lambda = value_lambda
+        self._close_lambda = close_lambda
+        self._keys = set()
+        self._side_effects = {}
+        self._closed = False
 
     def keys(self):
-        return self.keys_lambda()
+        if not self._closed:
+            self._keys = self._keys_lambda()
+        return self._keys
 
     def get(self, key):
-        return self.value_lambda(key)
+        if not self._side_effects.get(key):
+            if not self._closed:
+                results = self._value_lambda(key)
+                self._side_effects[key] = results
+                self._keys.add(key)
+            else:
+                return None
+        return self._side_effects[key]
 
     def close(self):
-        return self.close_lambda()
+        results = self._close_lambda()
+        self._closed = True
+        return results
 
 
 class RemoteStrategy(TraversalStrategy):

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -140,6 +140,8 @@ class TestDriverRemoteConnection(TestCase):
             raise Exception("Accessing a non-existent key should throw an error")
         except KeyError:
             pass
+        connection.close()
+
 
     def test_side_effect_close(self):
         connection = DriverRemoteConnection('ws://localhost:8182/gremlin', 'g')
@@ -173,6 +175,7 @@ class TestDriverRemoteConnection(TestCase):
         # Try to get 'b' directly from server, should throw error
         with pytest.raises(Exception):
             t.side_effects.value_lambda('b')
+        connection.close()
 
 
 if __name__ == '__main__':

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -22,6 +22,8 @@ __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 import unittest
 from unittest import TestCase
 
+import pytest
+
 from gremlin_python import statics
 from gremlin_python.statics import long
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
@@ -126,7 +128,7 @@ class TestDriverRemoteConnection(TestCase):
         assert "ripple" in n.keys()
         assert 3 == n["lop"]
         assert 1 == n["ripple"]
-        #
+
         t = g.withSideEffect('m', 32).V().map(lambda: "x: x.sideEffects('m')")
         results = t.toSet()
         assert 1 == len(results)
@@ -138,6 +140,10 @@ class TestDriverRemoteConnection(TestCase):
             raise Exception("Accessing a non-existent key should throw an error")
         except KeyError:
             pass
+        result = t.side_effects.close()
+        assert not result
+        with pytest.raises(KeyError):
+            x = t.side_effects['m']
         connection.close()
 
 

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -140,11 +140,39 @@ class TestDriverRemoteConnection(TestCase):
             raise Exception("Accessing a non-existent key should throw an error")
         except KeyError:
             pass
-        result = t.side_effects.close()
-        assert not result
-        with pytest.raises(KeyError):
-            x = t.side_effects['m']
-        connection.close()
+
+    def test_side_effect_close(self):
+        connection = DriverRemoteConnection('ws://localhost:8182/gremlin', 'g')
+        g = Graph().traversal().withRemote(connection)
+        t = g.V().aggregate('a').aggregate('b')
+        t.toList()
+
+        # The 'a' key should return some side effects
+        results = t.side_effects.get('a')
+        assert results
+
+        # Close result is None
+        results = t.side_effects.close()
+        assert not results
+
+        # Shouldn't get any new info from server
+        # 'b' isn't in local cache
+        results = t.side_effects.get('b')
+        assert not results
+
+        # But 'a' should still be cached locally
+        results = t.side_effects.get('a')
+        assert results
+
+        # 'a' should have been added to local keys cache, but not 'b'
+        results = t.side_effects.keys()
+        assert len(results) == 1
+        a, = results
+        assert a == 'a'
+
+        # Try to get 'b' directly from server, should throw error
+        with pytest.raises(Exception):
+            t.side_effects.value_lambda('b')
 
 
 if __name__ == '__main__':

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -198,6 +198,9 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
 
                     final Optional<UUID> sideEffect = msg.optionalArgs(Tokens.ARGS_SIDE_EFFECT);
                     cache.invalidate(sideEffect.get());
+
+                    final String successMessage = String.format("Successfully cleared side effect cache for [%s].", Tokens.ARGS_SIDE_EFFECT);
+                    ctx.getChannelHandlerContext().writeAndFlush(ResponseMessage.build(message).code(ResponseStatusCode.NO_CONTENT).statusMessage(successMessage).create());
                 };
 
                 break;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -894,9 +894,9 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         // Try to get side effect from server
         final Cluster cluster = Cluster.build("localhost").create();
         final Client client = cluster.connect();
-        Field field = DriverRemoteTraversalSideEffects.class.getDeclaredField("serverSideEffect");
+        final Field field = DriverRemoteTraversalSideEffects.class.getDeclaredField("serverSideEffect");
         field.setAccessible(true);
-        UUID serverSideEffectId = (UUID) field.get(se);
+        final UUID serverSideEffectId = (UUID) field.get(se);
         final Map<String, String> aliases = new HashMap<>();
         aliases.put("g", "g");
         final RequestMessage msg = RequestMessage.build(Tokens.OPS_GATHER)

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -70,6 +70,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -90,6 +91,7 @@ import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assert.assertEquals;
@@ -831,17 +833,16 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
-    public void shouldCloseSideEffects() throws Exception {
+    public void shouldCloseLocalSideEffects() throws Exception {
         final Graph graph = EmptyGraph.instance();
         final GraphTraversalSource g = graph.traversal().withRemote(conf);
         g.addV("person").property("age", 20).iterate();
         g.addV("person").property("age", 10).iterate();
-        final GraphTraversal traversal = g.V().aggregate("a");
+        final GraphTraversal traversal = g.V().aggregate("a").aggregate("b");
         traversal.iterate();
-        final Set sideEffects = traversal.asAdmin().getSideEffects().keys();
-        assertTrue(sideEffects.contains("a"));
+        final List sideEffects = traversal.asAdmin().getSideEffects().get("a");
+        assertFalse(sideEffects.isEmpty());
         traversal.asAdmin().getSideEffects().close();
-        final Set emptySideEffects = traversal.asAdmin().getSideEffects().keys();
-        assertTrue(emptySideEffects.isEmpty());
+        assertNull(traversal.asAdmin().getSideEffects().get("b"));
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -914,6 +914,3 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         assertThat(error, is(true));
     }
 }
-
-
-

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -65,7 +65,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.channels.ClosedChannelException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1458

This PR updates the Gremlin Server protocol to send a no content confirmation when a client submits a `close` Op with the `traversal` OpProcessor. 

It also adds close methods to the Java driver `DriverRemoteTraversalSideEffects` class and the gremlin-python `RemoteTraversalSideEffects` class. Furthermore, `RemoteTraversalSideEffects` now caches side effects locally in order to maintain consistent behavior between the two implementations.

This functionality is tested using integration tests in both the gremlin-server and gremlin-python module, as well as in the gremlin-driver unit tests with mocked responses.

Thanks to @spmallette for helping me through the Java stuff.