### PR TITLE
TINKERPOP-1493 Groovy project doesn't build on Windows

### DIFF
--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/util/DependencyGrabberIntegrateTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/util/DependencyGrabberIntegrateTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class DependencyGrabberIntegrateTest {
     private static final GroovyClassLoader dummyClassLoader = new GroovyClassLoader();
-    private static final File extTestDir = new File(System.getProperty("user.dir"), TestHelper.makeTestDataDirectory(DependencyGrabberIntegrateTest.class));
+    private static final File extTestDir = TestHelper.makeTestDataPath(DependencyGrabberIntegrateTest.class);
     private static final DependencyGrabber dg = new DependencyGrabber(dummyClassLoader, extTestDir.getAbsolutePath());
 
     @AfterClass


### PR DESCRIPTION
Removed support for user.dir property as it was being prepended to a
fully qualified path and the second drive letter was making the path
illegal.

Made sure JarFile instances were being closed so that Groovy could
delete the directory without encountering file locked errors.
