### PR TITLE
TINKERPOP-1493 Groovy project doesn't build on Windows

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Returned a confirmation on session close from Gremlin Server.
 * Fully shutdown metrics services in Gremlin Server on shutdown.
 * Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,12 @@ TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fully shutdown metrics services in Gremlin Server on shutdown.
 * Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.
+* Allow developers to pass options to `docker run` with DOCKER_OPTS environment variable
+
+Improvements
+^^^^^^^^^^^^
+
+* TINKERPOP-1556 Allow Hadoop to run on IPv6 systems
 
 [[release-3-1-5]]
 TinkerPop 3.1.5 (Release Date: October 17, 2016)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.
 
 [[release-3-1-5]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ Bugs
 * TINKERPOP-1451 TinkerGraph persistence cannot handle a single file name as the graph location
 * TINKERPOP-1467 Improve close() operations on the Java driver
 * TINKERPOP-1478 Propogate ScriptEngine fixes from groovy to GremlinGroovyScriptEngine
+* TINKERPOP-1512 gremlin-server-classic.yaml is broken
 
 Improvements
 ^^^^^^^^^^^^

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,7 +31,7 @@ TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fully shutdown metrics services in Gremlin Server on shutdown.
 * Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.
-* Allow developers to pass options to `docker run` with DOCKER_OPTS environment variable
+* Allow developers to pass options to `docker run` with TINKERPOP_DOCKER_OPTS environment variable
 
 Improvements
 ^^^^^^^^^^^^

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Returned a confirmation on session close from Gremlin Server.
+* Use non-default port for running tests on Gremlin Server.
 * Fully shutdown metrics services in Gremlin Server on shutdown.
 * Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Minor fixes to various test feature requirements in `gremlin-test`.
 
 [[release-3-1-5]]
 TinkerPop 3.1.5 (Release Date: October 17, 2016)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,11 @@ TinkerPop 3.1.0 (A 187 On The Undercover Gremlinz)
 
 image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-gangster.png[width=185]
 
+[[release-3-1-6]]
+TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
 [[release-3-1-5]]
 TinkerPop 3.1.5 (Release Date: October 17, 2016)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fully shutdown metrics services in Gremlin Server on shutdown.
 * Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.
 

--- a/bin/validate-distribution.sh
+++ b/bin/validate-distribution.sh
@@ -117,11 +117,11 @@ if [ "${TYPE}" = "SOURCE" ]; then
 cd ${DIR_NAME}
 echo -n "* building project ... "
 LOG_FILE="${TMP_DIR}/mvn-clean-install-${VERSION}.log"
-mvn clean install -q 2>&1 > "${LOG_FILE}" || {
+mvn clean install -q > "${LOG_FILE}" 2>&1 || {
   echo "failed"
   echo
   tail -n50 "${LOG_FILE}"
-  echo -e "\n\e[1mThe full log file can be inspected under `pwd`/${LOG_FILE}.\e[0m\n"
+  echo -e "\n\e[1mThe full log file can be inspected under ${LOG_FILE}.\e[0m\n"
   exit 1
 }
 echo "OK"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,6 +47,6 @@ CMD ["sh", "-c", "docker/scripts/build.sh $@"]
 EOF
 
 docker build -t tinkerpop:${BUILD_TAG} .
-docker run --rm -ti tinkerpop:${BUILD_TAG}
+docker run ${DOCKER_OPTS} --rm -ti tinkerpop:${BUILD_TAG}
 
 popd > /dev/null

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,6 +47,6 @@ CMD ["sh", "-c", "docker/scripts/build.sh $@"]
 EOF
 
 docker build -t tinkerpop:${BUILD_TAG} .
-docker run ${DOCKER_OPTS} --rm -ti tinkerpop:${BUILD_TAG}
+docker run ${TINKERPOP_DOCKER_OPTS} --rm -ti tinkerpop:${BUILD_TAG}
 
 popd > /dev/null

--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -56,6 +56,13 @@ TINKERPOP_BUILD_OPTIONS=""
 [ -z "${INCLUDE_NEO4J}" ] || TINKERPOP_BUILD_OPTIONS="${TINKERPOP_BUILD_OPTIONS} -DincludeNeo4j"
 [ -z "${BUILD_JAVA_DOCS}" ] && TINKERPOP_BUILD_OPTIONS="${TINKERPOP_BUILD_OPTIONS} -Dmaven.javadoc.skip=true"
 
+# If the tmpfs (in-memory filesystem exists, use it)
+if [ -d "/usr/src/tinkermem" ]; then
+  echo Copying source to in-memory tmpfs
+  rsync -a . /usr/src/tinkermem
+  cd /usr/src/tinkermem
+fi
+
 mvn clean install process-resources ${TINKERPOP_BUILD_OPTIONS} || exit 1
 [ -z "${BUILD_JAVA_DOCS}" ] || mvn process-resources -Djavadoc || exit 1
 

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -56,7 +56,7 @@ Docker Integration
 ------------------
 
 TinkerPop provides a shell script, that can start several build tasks within a Docker container. The
-required Docker images will be built automatically if they don't exist yet. Thus the first invokation
+required Docker images will be built automatically if they don't exist yet. Thus the first invocation
 of the Docker script is expected to take some time.
 
 The script can be found under `PROJECT_HOME/docker/build.sh`. The following tasks are currently
@@ -70,10 +70,26 @@ supported:
 A list of command line options is provided by `docker/build.sh --help`. The container will install,
 configure and start all required dependencies, such as Hadoop.
 
+Options can be passed to Docker by setting the `TINKERPOP_DOCKER_OPTS` environment variable. A speed boost can
+be gained at the expense of memory by using tmpfs and the special directory `/usr/src/tinkermem`.
+
+[source,bash]
+.Build in-memory
+----
+TINKERPOP_DOCKER_OPTS="--tmpfs /usr/src/tinkermem:exec,mode=0755,rw,noatime,size=2000m"
+----
+
+[source,bash]
+.Disable IPv6 for Hadoop
+----
+TINKERPOP_DOCKER_OPTS="--sysctl net.ipv6.conf.all.disable_ipv6=1 --sysctl net.ipv6.conf.default.disable_ipv6=1"
+----
+
 If the container is used to generate the user docs, it will start a web server and show the URL that
 is used to host the HTML docs.
 
 After finishing all tasks, the script will immediately destroy the container.
+
 
 IDE Setup with Intellij
 -----------------------

--- a/docs/src/dev/developer/release.asciidoc
+++ b/docs/src/dev/developer/release.asciidoc
@@ -76,7 +76,7 @@ might be high.
 . `bin/publish-docs.sh <username>` - note that under a release candidate the documentation is published as SNAPSHOT
 . `mvn versions:set -DnewVersion=xx.yy.zz -DgenerateBackupPoms=false` to update the project files to reference a non-SNAPSHOT version
 . `pushd gremlin-console/bin; ln -fs ../target/apache-tinkerpop-gremlin-console-xx.yy.zz-standalone/bin/gremlin.sh gremlin.sh; popd`
-. `git diff` and review the updated files (expect all `pom.xml` files and this README)
+. `git diff` and review the updated files
 . `git commit -a -m "TinkerPop xx.yy.zz release"` and `git push`
 . `git tag -a -m "TinkerPop xx.yy.zz release" xx.yy.zz` and `git push --tags`
 . `mvn clean install`
@@ -104,13 +104,13 @@ validity into question.
 ... Be sure to include a link to other versions in the `CHANGELOG.asciidoc` that were previously released while the
 current release was under development as this new release will have those changes included within it. Please see
 3.2.1 for an example.
-.. Organize "breaking" changes to be clearly marked (use JIRA and the "breaking" label to identify those)
+.. Format "breaking" changes to be clearly marked (use JIRA and the "breaking" label to identify those)
 . Update "upgrade documentation":
 .. Update the release date.
 .. Update the link to `CHANGELOG.asciidoc` - this link may already be correct but will not exist until the repository is tagged.
 . `mvn versions:set -DnewVersion=xx.yy.zz -DgenerateBackupPoms=false` to update project files to reference the non-SNAPSHOT version
 . `pushd gremlin-console/bin; ln -fs ../target/apache-tinkerpop-gremlin-console-xx.yy.zz-standalone/bin/gremlin.sh gremlin.sh; popd`
-. `git diff` and review the updated files (expect all `pom.xml` files and this README)
+. `git diff` and review the updated files
 . `git commit -a -m "TinkerPop xx.yy.zz release"` and push
 . `mvn clean install` - need to build first so that the right version of the console is used with `bin/publish-docs.sh`
 . `bin/process-docs.sh` and validate the generated documentation locally (don't rely on "SUCCESS" - scroll up through logs to ensure there were no errors and view the HTML directly)
@@ -139,7 +139,7 @@ for generating javadoc and without that the binary distributions won't contain t
 .. `pushd gremlin-console/bin; ln -fs ../target/apache-tinkerpop-gremlin-console-xx.yy.zz-SNAPSHOT-standalone/bin/gremlin.sh gremlin.sh; popd`
 .. Update CHANGELOG and upgrade docs to have the appropriate headers for the next version.
 .. `mvn clean install -DskipTests` - need to build first so that the right version of the console is used with `bin/publish-docs.sh`
-.. `mvn deploy` - deploy the new `SNAPSHOT`
+.. `mvn deploy -DskipTests` - deploy the new `SNAPSHOT`
 .. `bin/process-docs.sh` and validate the generated `SNAPSHOT` documentation locally and then `bin/publish-docs.sh <username>`
 .. Commit and push the `SNAPSHOT` changes to git
 .. Send email to advise that code freeze is lifted.
@@ -155,12 +155,18 @@ Release & Promote
 . `svn co --depth empty https://dist.apache.org/repos/dist/release/tinkerpop release; mkdir release/xx.yy.zz`
 . Copy release files from `dev/xx.yy.zz` to `release/xx.yy.zz`.
 . `cd release; svn add xx.yy.zz/; svn ci -m "TinkerPop xx.yy.zz release"`
-. Update homepage with references to latest distribution and to other internal links elsewhere on the page.
-.. On the link:http://tinkerpop.apache.org/downloads.html[Downloads] page, when moving "Current Releases" to "Archived
-Releases" recall that the hyperlink must change to point to version in the link:https://archive.apache.org/dist/tinkerpop/[Apache Archives].
 . Wait for Apache Sonatype to sync the artifacts to Maven Central at (link:http://repo1.maven.org/maven2/org/apache/tinkerpop/tinkerpop/[http://repo1.maven.org/maven2/org/apache/tinkerpop/tinkerpop/]).
 . Wait for zip distributions to to sync to the Apache mirrors (i.e ensure the download links work from a mirror).
-. If there are releases present in SVN that represents lines of code that are no longer under development, then remove those releases. In other words, if `3.2.0` is present and `3.2.1` is released then remove `3.2.0`.  However, if `3.1.3` is present and that line of code is still under potential development, it may stay.
+. Update home page site with references to latest distribution - specifically:
+.. Update the `template/header-footer.html`.
+.. Update `index.html`.
+.. Update link:http://tinkerpop.apache.org/downloads.html[Downloads] page, when moving "Current Releases" to "Archived
+Releases" recall that the hyperlink must change to point to version in the link:https://archive.apache.org/dist/tinkerpop/[Apache Archives].
+. Execute `bin/update-current-docs.sh` to migrate to the latest documentation set for `/current`.
+. This step should olny occur after the website is updated and all links are working. If there are releases present in
+SVN that represents lines of code that are no longer under development, then remove those releases. In other words,
+if `3.2.0` is present and `3.2.1` is released then remove `3.2.0`.  However, if `3.1.3` is present and that line of
+code is still under potential development, it may stay.
 . Announce release on `dev@`/`gremlin-users@` mailing lists and tweet from `@apachetinkerpop`
 
 Email Templates
@@ -259,7 +265,7 @@ https://www.apache.org/dyn/closer.lua/tinkerpop/xx.yy.zz/apache-tinkerpop-gremli
 The online docs can be found here:
 
 http://tinkerpop.apache.org/docs/xx.yy.zz/reference/ (user docs)
-http://tinkerpop.apache.org/docs/xx.yy.zz/upgrade.html#XXXXXXXXXXXXXXXXXX (upgrade docs)
+http://tinkerpop.apache.org/docs/xx.yy.zz/upgrade/#XXXXXXXXXXXXXXXXXX (upgrade docs)
 http://tinkerpop.apache.org/javadocs/xx.yy.zz/core/ (core javadoc)
 http://tinkerpop.apache.org/javadocs/xx.yy.zz/full/ (full javadoc)
 http://tinkerpop.apache.org/docs/xx.yy.zz/some-new-content/ (some new content) [NEW!]

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -817,7 +817,7 @@ Gremlin Server are deployed, session state is not shared among them.
 !Key !Description
 !`authentication` !A request that contains the response to a server challenge for authentication.
 !`eval` !Evaluate a Gremlin script provided as a `String`.
-!`close` !Close the specified session and rollback any open transactions.
+!`close` !Close the specified session. Will return a `NO CONTENT` message as confirmation of the close being completed.
 |=========================================================
 
 '`authentication` operation arguments'

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -29,7 +29,7 @@ Neo4j-Gremlin
 <dependency>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-  <version>0.1-2.2</version>
+  <version>0.3-2.3.2</version>
 </dependency>
 ----
 

--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -679,7 +679,7 @@ final Graph graph = TinkerFactory.createModern();
 graph.io(IoCore.gryo()).writeGraph("tinkerpop-modern.kryo");
 
 final Graph newGraph = TinkerGraph.open();
-newGraph.io(IoCore.gryo()).readGraph("tinkerpop-modern.kryo")'
+newGraph.io(IoCore.gryo()).readGraph("tinkerpop-modern.kryo");
 ----
 
 If a custom configuration is required, then have the `Graph` generate a `GraphReader` or `GraphWriter` "builder" instance:

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2100,7 +2100,7 @@ supplier yields a single traverser to continue to the next step. Examples includ
 
 In Gremlin OLAP (see <<traversalvertexprogram,`TraversalVertexProgram`>>), a barrier is introduced at the end of
 every <<vertex-steps,adjacent vertex step>>. This means that the traversal does its best to compute as much as
-possible at the current, local vertex. What is can't compute without referencing an adjacent vertex is aggregated
+possible at the current, local vertex. What it can't compute without referencing an adjacent vertex is aggregated
 into a barrier collection. When there are no more traversers at the local vertex, the barriered traversers are the
 messages that are propagated to remote vertices for further processing.
 

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -22,6 +22,13 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *A 187 On The Undercover Gremlinz*
 
+TinkerPop 3.1.6
+---------------
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.1.6/CHANGELOG.asciidoc#release-3-1-6[changelog] for a complete list of all the modifications that are part of this release.
+
 TinkerPop 3.1.5
 ---------------
 

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -29,6 +29,24 @@ TinkerPop 3.1.6
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.1.6/CHANGELOG.asciidoc#release-3-1-6[changelog] for a complete list of all the modifications that are part of this release.
 
+Upgrading for Providers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Driver Providers
+^^^^^^^^^^^^^^^^
+
+Session Close Confirmation
+++++++++++++++++++++++++++
+
+When a session is closed, it now returns a confirmation in the form of a single `NO CONTENT` message. When the message
+arrives, it means that the server has already destroyed the session. Prior to this change, the request was somewhat
+one-way, in that the client could send the request and the server would silently honor it. The confirmation makes it
+a bit easier to ensure from the client perspective that the close did what it was supposed to do, allowing the client
+to proceed only when the server was fully complete with its work.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1544[TINKERPOP-1544]
+
+
 TinkerPop 3.1.5
 ---------------
 

--- a/giraph-gremlin/pom.xml
+++ b/giraph-gremlin/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>giraph-gremlin</artifactId>
     <name>Apache TinkerPop :: Giraph Gremlin</name>

--- a/giraph-gremlin/src/test/resources/giraph-site.xml
+++ b/giraph-gremlin/src/test/resources/giraph-site.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <property>
+        <name>giraph.zkServerlistPollMsecs</name>
+        <value>500</value>
+    </property>
+    <property>
+        <name>giraph.logLevel</name>
+        <value>info</value>
+    </property>
+</configuration>

--- a/gremlin-archetype/gremlin-archetype-server/pom.xml
+++ b/gremlin-archetype/gremlin-archetype-server/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>gremlin-archetype</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>gremlin-archetype-server</artifactId>

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
@@ -32,7 +32,7 @@ public class Service implements AutoCloseable {
     /**
      * There typically needs to be only one Cluster instance in an application.
      */
-    private final Cluster cluster = Cluster.open();
+    private final Cluster cluster = Cluster.build().port(45940).create();
 
     /**
      * Use the Cluster instance to construct different Client instances (e.g. one for sessionless communication

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/java/ServiceTest.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/java/ServiceTest.java
@@ -78,7 +78,7 @@ public class ServiceTest {
 
     @Test
     public void shouldCreateGraph() throws Exception {
-        List<String> result = service.findCreatorsOfSoftware("lop");
+        final List<String> result = service.findCreatorsOfSoftware("lop");
         assertThat(result, is(Arrays.asList("marko", "josh", "peter")));
     }
 }

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/resources/gremlin-server.yaml
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/resources/gremlin-server.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 host: localhost
-port: 8182
+port: 45940
 threadPoolWorker: 1
 gremlinPool: 8
 scriptEvaluationTimeout: 30000

--- a/gremlin-archetype/gremlin-archetype-tinkergraph/pom.xml
+++ b/gremlin-archetype/gremlin-archetype-tinkergraph/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>gremlin-archetype</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>gremlin-archetype-tinkergraph</artifactId>

--- a/gremlin-archetype/pom.xml
+++ b/gremlin-archetype/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <artifactId>tinkerpop</artifactId>
         <groupId>org.apache.tinkerpop</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>gremlin-archetype</artifactId>

--- a/gremlin-console/bin/gremlin.sh
+++ b/gremlin-console/bin/gremlin.sh
@@ -1,1 +1,1 @@
-../target/apache-tinkerpop-gremlin-console-3.1.5-standalone/bin/gremlin.sh
+../target/apache-tinkerpop-gremlin-console-3.1.6-SNAPSHOT-standalone/bin/gremlin.sh

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <artifactId>tinkerpop</artifactId>
         <groupId>org.apache.tinkerpop</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-console</artifactId>
     <name>Apache TinkerPop :: Gremlin Console</name>

--- a/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/groovy/plugin/gremlin-server-integration.yaml
+++ b/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/groovy/plugin/gremlin-server-integration.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 host: localhost
-port: 8182
+port: 45940
 threadPoolWorker: 1
 gremlinPool: 8
 scriptEvaluationTimeout: 30000

--- a/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/groovy/plugin/remote.yaml
+++ b/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/groovy/plugin/remote.yaml
@@ -16,5 +16,5 @@
 # under the License.
 
 hosts: [localhost]
-port: 8182
+port: 45940
 serializer: { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}

--- a/gremlin-core/pom.xml
+++ b/gremlin-core/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-core</artifactId>
     <name>Apache TinkerPop :: Gremlin Core</name>

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-driver</artifactId>
     <name>Apache TinkerPop :: Gremlin Driver</name>

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -281,7 +281,7 @@ final class Connection {
                     // make sure we get a response here to validate that things closed as expected.  on error, we'll let
                     // the server try to clean up on its own.  the primary error here should probably be related to
                     // protocol issues which should not be something a user has to fuss with.
-                    closed.get(cluster.connectionPoolSettings().maxWaitForSessionClose, TimeUnit.MILLISECONDS);
+                    closed.join().all().get(cluster.connectionPoolSettings().maxWaitForSessionClose, TimeUnit.MILLISECONDS);
                 } catch (TimeoutException ex) {
                     final String msg = String.format(
                             "Timeout while trying to close connection on %s - force closing - server will close session on shutdown or expiration.",

--- a/gremlin-groovy-test/pom.xml
+++ b/gremlin-groovy-test/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-groovy-test</artifactId>
     <name>Apache TinkerPop :: Gremlin Groovy Test</name>

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPathTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPathTest.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -53,6 +53,11 @@ public abstract class GroovyPathTest {
         @Override
         public Traversal<Vertex, Path> get_g_V_asXaX_hasXname_markoX_asXbX_hasXage_29X_asXcX_path() {
             TraversalScriptHelper.compute("g.V.as('a').has('name', 'marko').as('b').has('age', 29).as('c').path", g)
+        }
+
+        @Override
+        public Traversal<Vertex, Path> get_g_VX1X_outEXcreatedX_inV_inE_outV_path(final Object v1Id) {
+            TraversalScriptHelper.compute("g.V(v1Id).outE('created').inV.inE.outV.path()", g, "v1Id", v1Id)
         }
     }
 }

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-groovy</artifactId>
     <name>Apache TinkerPop :: Gremlin Groovy</name>

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/util/DependencyGrabberIntegrateTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/util/DependencyGrabberIntegrateTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class DependencyGrabberIntegrateTest {
     private static final GroovyClassLoader dummyClassLoader = new GroovyClassLoader();
-    private static final File extTestDir = new File(System.getProperty("user.dir"), TestHelper.makeTestDataDirectory(DependencyGrabberIntegrateTest.class));
+    private static final File extTestDir = TestHelper.makeTestDataPath(DependencyGrabberIntegrateTest.class);
     private static final DependencyGrabber dg = new DependencyGrabber(dummyClassLoader, extTestDir.getAbsolutePath());
 
     @AfterClass

--- a/gremlin-server/conf/gremlin-server-classic.yaml
+++ b/gremlin-server/conf/gremlin-server-classic.yaml
@@ -29,7 +29,7 @@ scriptEngines: {
   gremlin-groovy: {
     imports: [java.lang.Math],
     staticImports: [java.lang.Math.PI],
-    scripts: [scripts/complex-lifecycle.groovy]}}
+    scripts: [scripts/generate-classic.groovy]}}
 serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}       # application/vnd.gremlin-v1.0+gryo
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-server</artifactId>
     <name>Apache TinkerPop :: Gremlin Server</name>

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -313,6 +313,11 @@ public class GremlinServer {
                 }
             });
 
+            // kills reporter threads. this is a last bit of cleanup that can be done. typically, the jvm is headed
+            // for shutdown which would obviously kill the reporters, but when it isn't they just keep reporting.
+            // removing them all will silent them up and release the appropriate resources.
+            MetricManager.INSTANCE.removeAllReporters();
+
             logger.info("Gremlin Server - shutdown complete");
             serverStopped.complete(null);
         }, SERVER_THREAD_PREFIX + "stop").start();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAuthenticationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAuthenticationHandler.java
@@ -83,7 +83,7 @@ public class SaslAuthenticationHandler extends ChannelInboundHandlerAdapter {
                         saslResponse = Base64.getDecoder().decode((String) saslObject);
                     } else {
                         final ResponseMessage error = ResponseMessage.build(request.get())
-                                .statusMessage("Incorrect type for : " + Tokens.ARGS_SASL + ". byte[] or String is expected")
+                                .statusMessage("Incorrect type for : " + Tokens.ARGS_SASL + " - byte[] or base64 encoded String is expected")
                                 .code(ResponseStatusCode.REQUEST_ERROR_MALFORMED_REQUEST).create();
                         ctx.writeAndFlush(error);
                         return;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -115,6 +115,11 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                 }
 
                 sessionToClose.manualKill();
+
+                // send back a confirmation of the close
+                ctx.getChannelHandlerContext().writeAndFlush(ResponseMessage.build(requestMessage)
+                        .code(ResponseStatusCode.NO_CONTENT)
+                        .create());
             });
         } else {
             return Optional.empty();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerPerformanceTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerPerformanceTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractGremlinServerPerformanceTest {
         logger.info("Gremlin Server is started and ready for performance test to execute");
 
         host = System.getProperty("host", "localhost");
-        port = System.getProperty("port", "8182");
+        port = System.getProperty("port", "45940");
     }
 
     @AfterClass

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinAdditionPerformanceTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinAdditionPerformanceTest.java
@@ -81,7 +81,7 @@ public class GremlinAdditionPerformanceTest extends AbstractGremlinServerPerform
         final Serializers[] mimes = new Serializers[]{Serializers.GRAPHSON, Serializers.GRAPHSON_V1D0, Serializers.GRYO_V1D0};
         final Serializers mimeType = mimes[rand.nextInt(3)];
         logger.info(mimeType.toString());
-        final Cluster cluster = Cluster.build("localhost")
+        final Cluster cluster = TestClientFactory.build()
                 .serializer(mimeType)
                 .create();
         final Client client = cluster.connect();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -134,7 +134,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldEventuallySucceedAfterChannelLevelError() throws Exception {
-        final Cluster cluster = Cluster.build().addContactPoint("localhost")
+        final Cluster cluster = TestClientFactory.build()
                 .reconnectIntialDelay(500)
                 .reconnectInterval(500)
                 .maxContentLength(1024).create();
@@ -155,7 +155,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldEventuallySucceedAfterMuchFailure() throws Exception {
-        final Cluster cluster = Cluster.build().addContactPoint("localhost").create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         // tested independently to 10000 iterations but for speed, bumped back to 1000
@@ -178,7 +178,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldEventuallySucceedOnSameServer() throws Exception {
         stopServer();
 
-        final Cluster cluster = Cluster.build().addContactPoint("localhost").create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -202,7 +202,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     public void shouldEventuallySucceedWithRoundRobin() throws Exception {
         final String noGremlinServer = "74.125.225.19";
-        final Cluster cluster = Cluster.build(noGremlinServer).addContactPoint("localhost").create();
+        final Cluster cluster = TestClientFactory.build().addContactPoint(noGremlinServer).create();
         final Client client = cluster.connect();
 
         // the first host is dead on init.  request should succeed on localhost
@@ -217,7 +217,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldHandleResultsOfAllSizes() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final String script = "g.V().drop().iterate();\n" +
@@ -256,7 +256,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldFailWithBadClientSideSerialization() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("java.awt.Color.RED");
@@ -279,7 +279,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldFailWithScriptExecutionException() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("1/0");
@@ -302,7 +302,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldProcessRequestsOutOfOrder() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet rsFive = client.submit("Thread.sleep(5000);'five'");
@@ -325,7 +325,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldProcessSessionRequestsInOrder() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         final ResultSet rsFive = client.submit("Thread.sleep(5000);'five'");
@@ -351,7 +351,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldWaitForAllResultsToArrive() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final AtomicInteger checked = new AtomicInteger(0);
@@ -369,7 +369,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldWorkOverNioTransport() throws Exception {
-        final Cluster cluster = Cluster.build().channelizer(Channelizer.NioChannelizer.class.getName()).create();
+        final Cluster cluster = TestClientFactory.build().channelizer(Channelizer.NioChannelizer.class.getName()).create();
         final Client client = cluster.connect();
 
         final AtomicInteger checked = new AtomicInteger(0);
@@ -387,7 +387,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldStream() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("[1,2,3,4,5,6,7,8,9]");
@@ -404,7 +404,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldIterate() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("[1,2,3,4,5,6,7,8,9]");
@@ -426,7 +426,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldGetSomeThenSomeMore() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("[1,2,3,4,5,6,7,8,9]");
@@ -454,7 +454,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldGetOneThenSomeThenSomeMore() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("[1,2,3,4,5,6,7,8,9]");
@@ -502,7 +502,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         // that the client doesn't timeout waiting for an available connection. obviously this can also be fixed
         // by increasing the maxConnectionPoolSize.
         final int requests = workerPoolSizeForDriver * 4;
-        final Cluster cluster = Cluster.build()
+        final Cluster cluster = TestClientFactory.build()
                 .workerPoolSize(workerPoolSizeForDriver)
                 .maxWaitForConnection(300000)
                 .create();
@@ -526,7 +526,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldCloseWithServerDown() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         cluster.connect().init();
 
         stopServer();
@@ -536,7 +536,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldMarkHostDeadSinceServerIsDown() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         assertEquals(0, cluster.availableHosts().size());
         cluster.connect().init();
         assertEquals(1, cluster.availableHosts().size());
@@ -551,7 +551,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldFailWithBadServerSideSerialization() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("TinkerGraph.open().variables()");
@@ -579,7 +579,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final GryoMessageSerializerV1d0 serializer = new GryoMessageSerializerV1d0();
         serializer.configure(m, null);
 
-        final Cluster cluster = Cluster.build().serializer(serializer).create();
+        final Cluster cluster = TestClientFactory.build().serializer(serializer).create();
         final Client client = cluster.connect();
 
         final ResultSet resultSet = client.submit("TinkerFactory.createClassic()");
@@ -597,7 +597,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final GryoMessageSerializerV1d0 serializer = new GryoMessageSerializerV1d0();
         serializer.configure(m, null);
 
-        final Cluster cluster = Cluster.build().serializer(serializer).create();
+        final Cluster cluster = TestClientFactory.build().serializer(serializer).create();
         final Client client = cluster.connect();
 
         final List<Result> json = client.submit("b = new JsonBuilder();b.people{person {fname 'stephen'\nlname 'mallette'}};b").all().join();
@@ -607,7 +607,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldWorkWithGraphSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build("localhost").serializer(Serializers.GRAPHSON_V1D0).create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON_V1D0).create();
         final Client client = cluster.connect();
 
         final List<Result> r = client.submit("TinkerFactory.createModern().traversal().V(1)").all().join();
@@ -644,7 +644,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @org.junit.Ignore("Can't seem to make this test pass consistently")
     public void shouldHandleRequestSentThatNeverReturns() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("Thread.sleep(10000); 'should-not-ever-get-back-coz-we-killed-the-server'");
@@ -669,7 +669,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldFailClientSideWithTooLargeAResponse() {
-        final Cluster cluster = Cluster.build().maxContentLength(1).create();
+        final Cluster cluster = TestClientFactory.build().maxContentLength(1).create();
         final Client client = cluster.connect();
 
         try {
@@ -686,7 +686,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReturnNiceMessageFromOpSelector() {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect();
 
         try {
@@ -704,7 +704,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldExecuteScriptInSession() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect(name.getMethodName());
 
         final ResultSet results1 = client.submit("x = [1,2,3,4,5,6,7,8,9]");
@@ -721,7 +721,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldNotThrowNoSuchElementException() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -734,7 +734,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldCloseSession() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect(name.getMethodName());
 
         final ResultSet results1 = client.submit("x = [1,2,3,4,5,6,7,8,9]");
@@ -757,7 +757,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldExecuteScriptInSessionAssumingDefaultedImports() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         final ResultSet results1 = client.submit("TinkerFactory.class.name");
@@ -770,7 +770,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldExecuteScriptInSessionOnTransactionalGraph() throws Exception {
         assumeNeo4jIsPresent();
 
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         final Vertex vertexBeforeTx = client.submit("v=graph.addVertex(\"name\",\"stephen\")").all().get().get(0).getVertex();
@@ -793,7 +793,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldExecuteScriptInSessionOnTransactionalWithManualTransactionsGraph() throws Exception {
         assumeNeo4jIsPresent();
 
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
         final Client sessionlessClient = cluster.connect();
         client.submit("graph.tx().onReadWrite(Transaction.READ_WRITE_BEHAVIOR.MANUAL);null").all().get();
@@ -830,7 +830,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldExecuteInSessionAndSessionlessWithoutOpeningTransaction() throws Exception {
         assumeNeo4jIsPresent();
 
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client sessionClient = cluster.connect(name.getMethodName());
         final Client sessionlessClient = cluster.connect();
 
@@ -857,7 +857,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldExecuteSessionlessScriptOnTransactionalGraph() throws Exception {
         assumeNeo4jIsPresent();
 
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         // this line is important because it tests GraphTraversal which has a certain transactional path
@@ -878,7 +878,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldExecuteScriptInSessionWithBindingsSavedOnServerBetweenRequests() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         final Map<String, Object> bindings1 = new HashMap<>();
@@ -906,7 +906,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldExecuteScriptsInMultipleSession() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client1 = cluster.connect(name.getMethodName() + "1");
         final Client client2 = cluster.connect(name.getMethodName() + "2");
         final Client client3 = cluster.connect(name.getMethodName() + "3");
@@ -930,7 +930,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldNotHaveKnowledgeOfBindingsBetweenRequestsWhenSessionless() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client1 = cluster.connect();
         final Client client2 = cluster.connect();
         final Client client3 = cluster.connect();
@@ -974,7 +974,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldBeThreadSafeToUseOneClient() throws Exception {
-        final Cluster cluster = Cluster.build().workerPoolSize(2)
+        final Cluster cluster = TestClientFactory.build().workerPoolSize(2)
                 .maxInProcessPerConnection(64)
                 .minInProcessPerConnection(32)
                 .maxConnectionPoolSize(16)
@@ -1009,7 +1009,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldRequireAliasedGraphVariablesInStrictTransactionMode() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -1029,7 +1029,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldAliasGraphVariablesInStrictTransactionMode() throws Exception {
         assumeNeo4jIsPresent();
 
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -1056,7 +1056,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldAliasGraphVariables() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -1083,7 +1083,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldAliasTraversalSourceVariables() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -1110,7 +1110,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldAliasGraphVariablesInSession() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         try {
@@ -1139,7 +1139,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldAliasTraversalSourceVariablesInSession() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         try {
@@ -1170,7 +1170,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldManageTransactionsInSession() throws Exception {
         assumeNeo4jIsPresent();
 
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
         final Client sessionWithManagedTx = cluster.connect(name.getMethodName() + "-managed", true);
         final Client sessionWithoutManagedTx = cluster.connect(name.getMethodName() + "-not-managed");
@@ -1208,7 +1208,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldProcessSessionRequestsInOrderAfterTimeout() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         for(int index = 0; index < 50; index++)
@@ -1251,7 +1251,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldCloseAllClientsOnCloseOfCluster() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client sessionlessOne = cluster.connect();
         final Client session = cluster.connect("session");
         final Client sessionlessTwo = cluster.connect();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -77,7 +77,7 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
         c.put("custom", Arrays.asList("groovy.json.JsonBuilder;org.apache.tinkerpop.gremlin.driver.ser.JsonBuilderGryoSerializer"));
 
         serializer.configure(c, null);
-        cluster = Cluster.build().serializer(serializer).create();
+        cluster = TestClientFactory.build().serializer(serializer).create();
         client = cluster.connect();
     }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -72,7 +72,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldFailIfSslEnabledOnServerButNotClient() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -89,7 +89,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldAuthenticateWithPlainText() throws Exception {
-        final Cluster cluster = Cluster.build().credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -103,7 +103,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldAuthenticateOverSslWithPlainText() throws Exception {
-        final Cluster cluster = Cluster.build()
+        final Cluster cluster = TestClientFactory.build()
                 .enableSsl(true)
                 .credentials("stephen", "password").create();
         final Client client = cluster.connect();
@@ -119,7 +119,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldFailAuthenticateWithPlainTextNoCredentials() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -135,7 +135,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldFailAuthenticateWithPlainTextBadPassword() throws Exception {
-        final Cluster cluster = Cluster.build().credentials("stephen", "bad").create();
+        final Cluster cluster = TestClientFactory.build().credentials("stephen", "bad").create();
         final Client client = cluster.connect();
 
         try {
@@ -152,7 +152,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldFailAuthenticateWithPlainTextBadUsername() throws Exception {
-        final Cluster cluster = Cluster.build().credentials("marko", "password").create();
+        final Cluster cluster = TestClientFactory.build().credentials("marko", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -168,7 +168,8 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldAuthenticateWithPlainTextOverJSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -182,7 +183,8 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldAuthenticateWithPlainTextOverGraphSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON_V1D0).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON_V1D0)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -196,7 +198,8 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldAuthenticateAndWorkWithVariablesOverJsonSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect(name.getMethodName());
 
         try {
@@ -213,7 +216,8 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldAuthenticateAndWorkWithVariablesOverGraphSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON_V1D0).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON_V1D0)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect(name.getMethodName());
 
         try {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthOldIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthOldIntegrateTest.java
@@ -24,7 +24,6 @@ import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
-import org.ietf.jgss.GSSException;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -76,7 +75,7 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldFailIfSslEnabledOnServerButNotClient() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -93,7 +92,7 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldAuthenticateWithPlainText() throws Exception {
-        final Cluster cluster = Cluster.build().credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -107,7 +106,7 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldAuthenticateOverSslWithPlainText() throws Exception {
-        final Cluster cluster = Cluster.build()
+        final Cluster cluster = TestClientFactory.build()
                 .enableSsl(true)
                 .credentials("stephen", "password").create();
         final Client client = cluster.connect();
@@ -123,7 +122,7 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldFailAuthenticateWithPlainTextNoCredentials() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -142,7 +141,7 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldFailAuthenticateWithPlainTextBadPassword() throws Exception {
-        final Cluster cluster = Cluster.build().credentials("stephen", "bad").create();
+        final Cluster cluster = TestClientFactory.build().credentials("stephen", "bad").create();
         final Client client = cluster.connect();
 
         try {
@@ -159,7 +158,7 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldFailAuthenticateWithPlainTextBadUsername() throws Exception {
-        final Cluster cluster = Cluster.build().credentials("marko", "password").create();
+        final Cluster cluster = TestClientFactory.build().credentials("marko", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -175,7 +174,8 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
     
     @Test
     public void shouldAuthenticateWithPlainTextOverJSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -189,7 +189,8 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldAuthenticateWithPlainTextOverGraphSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON_V1D0).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON_V1D0)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
         try {
@@ -203,7 +204,8 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
     
     @Test
     public void shouldAuthenticateAndWorkWithVariablesOverJsonSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect(name.getMethodName());
 
         try {
@@ -220,7 +222,8 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
     
     @Test
     public void shouldAuthenticateAndWorkWithVariablesOverGraphSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build().serializer(Serializers.GRAPHSON_V1D0).credentials("stephen", "password").create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON_V1D0)
+                .credentials("stephen", "password").create();
         final Client client = cluster.connect(name.getMethodName());
 
         try {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
@@ -125,7 +125,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnGETWithNoAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(401, response.getStatusLine().getStatusCode());
@@ -135,7 +135,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnPOSTWithNoAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
 
@@ -147,7 +147,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnGETWithBadAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
         httpget.addHeader("Authorization", "not-base-64-encoded");
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
@@ -158,7 +158,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnPOSTWithBadAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Authorization", "not-base-64-encoded");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -171,7 +171,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnGETWithBadEncodedAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
         httpget.addHeader("Authorization", "Basic: not-base-64-encoded");
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
@@ -182,7 +182,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnPOSTWithBadEncodedAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Authorization", "Basic: not-base-64-encoded");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -195,7 +195,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnGETWithInvalidPasswordAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
         httpget.addHeader("Authorization", "Basic " + encoder.encodeToString("stephen:not-my-password".getBytes()));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
@@ -206,7 +206,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should401OnPOSTWithInvalidPasswordAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Authorization", "Basic " + encoder.encodeToString("stephen:not-my-password".getBytes()));
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -220,7 +220,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Deprecated
     public void should401OnPOSTWithInvalidPasswordAuthorizationHeaderOld() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Authorization", "Basic " + encoder.encodeToString("stephen:not-my-password".getBytes()));
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -233,7 +233,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnGETWithAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
         httpget.addHeader("Authorization", "Basic " + encoder.encodeToString("stephen:password".getBytes()));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
@@ -248,7 +248,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithAuthorizationHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Authorization", "Basic " + encoder.encodeToString("stephen:password".getBytes()));
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -266,7 +266,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Deprecated
     public void should200OnPOSTWithAuthorizationHeaderOld() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Authorization", "Basic " + encoder.encodeToString("stephen:password".getBytes()));
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -283,7 +283,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnGETWithGremlinQueryStringArgumentWithBindingsAndFunction() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=addItUp(Integer.parseInt(x),Integer.parseInt(y))&bindings.x=10&bindings.y=10");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=addItUp(Integer.parseInt(x),Integer.parseInt(y))&bindings.x=10&bindings.y=10"));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -297,7 +297,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnGETWithGremlinQueryStringArgumentWithIteratorResult() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=g.V()");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=g.V()"));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -312,7 +312,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     public void should200OnGETWithGremlinQueryStringArgumentWithIteratorResultAndAliases() throws Exception {
         // we can remove this first test when rebindings are completely removed
         final CloseableHttpClient httpclientLegacy = HttpClients.createDefault();
-        final HttpGet httpgetLegacy = new HttpGet("http://localhost:8182?gremlin=g1.V()&rebindings.g1=g");
+        final HttpGet httpgetLegacy = new HttpGet(TestClientFactory.createURLString("?gremlin=g1.V()&rebindings.g1=g"));
 
         try (final CloseableHttpResponse response = httpclientLegacy.execute(httpgetLegacy)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -323,7 +323,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         }
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=g1.V()&aliases.g1=g");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=g1.V()&aliases.g1=g"));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -337,7 +337,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnGETWithGremlinQueryStringArgument() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -351,7 +351,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnGETWithGremlinQueryStringArgumentReturningVertex() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=graph.addVertex('name','stephen')");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=graph.addVertex('name','stephen')"));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -365,7 +365,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnGETWithGremlinQueryStringArgumentWithBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=Integer.parseInt(x)%2BInteger.parseInt(y)&bindings.x=10&bindings.y=10");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=Integer.parseInt(x)%2BInteger.parseInt(y)&bindings.x=10&bindings.y=10"));
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -379,7 +379,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should400OnGETWithNoGremlinQueryStringArgument() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString());
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(400, response.getStatusLine().getStatusCode());
@@ -389,7 +389,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnGETWithAnyAcceptHeaderDefaultResultToJson() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
         httpget.addHeader("Accept", "*/*");
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
@@ -404,7 +404,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should400OnGETWithBadAcceptHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=1-1");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
         httpget.addHeader("Accept", "application/json+something-else-that-does-not-exist");
 
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
@@ -415,7 +415,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBody() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
 
@@ -433,7 +433,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         // basic test of java.time.* serialization over JSON from the server perspective. more complete tests
         // exist in gremlin-core
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"java.time.Instant.MAX\"}", Consts.UTF_8));
 
@@ -451,7 +451,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         assumeNeo4jIsPresent();
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"graph.addVertex('name','stephen');g.V().count()\"}", Consts.UTF_8));
 
@@ -463,7 +463,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
             assertEquals(1, node.get("result").get("data").get(0).intValue());
         }
 
-        final HttpGet httpget = new HttpGet("http://localhost:8182?gremlin=g.V().count()");
+        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=g.V().count()"));
         httpget.addHeader("Accept", "application/json");
 
         // execute this a bunch of times so that there's a good chance a different thread on the server processes
@@ -485,7 +485,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
 
         // we can remove this first test when rebindings are completely removed
         final CloseableHttpClient httpclientLegacy = HttpClients.createDefault();
-        final HttpPost httppostLegacy = new HttpPost("http://localhost:8182");
+        final HttpPost httppostLegacy = new HttpPost(TestClientFactory.createURLString());
         httppostLegacy.addHeader("Content-Type", "application/json");
         httppostLegacy.setEntity(new StringEntity("{\"gremlin\":\"g1.addV()\",\"rebindings\":{\"g1\":\"g\"}}", Consts.UTF_8));
 
@@ -498,7 +498,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         }
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"g1.addV()\",\"aliases\":{\"g1\":\"g\"}}", Consts.UTF_8));
 
@@ -514,7 +514,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyWithIteratorResult() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"g.V()\"}", Consts.UTF_8));
 
@@ -530,7 +530,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyWithTinkerGraphResult() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory.createModern()\"}", Consts.UTF_8));
 
@@ -554,7 +554,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     public void should200OnPOSTWithGremlinJsonEndcodedBodyWithIteratorResultAndAliases() throws Exception {
         // we can remove this first test when rebindings are completely removed
         final CloseableHttpClient httpclientLegacy = HttpClients.createDefault();
-        final HttpPost httppostLegacy = new HttpPost("http://localhost:8182");
+        final HttpPost httppostLegacy = new HttpPost(TestClientFactory.createURLString());
         httppostLegacy.addHeader("Content-Type", "application/json");
         httppostLegacy.setEntity(new StringEntity("{\"gremlin\":\"g1.V()\",\"rebindings\":{\"g1\":\"g\"}}", Consts.UTF_8));
 
@@ -567,7 +567,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         }
 
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"g1.V()\",\"aliases\":{\"g1\":\"g\"}}", Consts.UTF_8));
 
@@ -583,7 +583,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x+y\", \"bindings\":{\"x\":10, \"y\":10}}", Consts.UTF_8));
 
@@ -599,7 +599,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndLongBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x\", \"bindings\":{\"x\":10}}", Consts.UTF_8));
 
@@ -615,7 +615,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndDoubleBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x\", \"bindings\":{\"x\":10.5}}", Consts.UTF_8));
 
@@ -631,7 +631,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndStringBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x\", \"bindings\":{\"x\":\"10\"}}", Consts.UTF_8));
 
@@ -647,7 +647,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndBooleanBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x\", \"bindings\":{\"x\":true}}", Consts.UTF_8));
 
@@ -663,7 +663,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndNullBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x\", \"bindings\":{\"x\":null}}", Consts.UTF_8));
 
@@ -679,7 +679,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndArrayBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x\", \"bindings\":{\"x\":[1,2,3]}}", Consts.UTF_8));
 
@@ -698,7 +698,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyAndMapBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x\", \"bindings\":{\"x\":{\"y\":1}}}", Consts.UTF_8));
 
@@ -715,7 +715,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should400OnPOSTWithGremlinJsonEndcodedBodyAndBadBindings() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"x+y\", \"bindings\":10}}", Consts.UTF_8));
 
@@ -727,7 +727,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should400OnPOSTWithGremlinJsonEndcodedBodyWithNoGremlinKey() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremadfadflin\":\"1-1\"}", Consts.UTF_8));
 
@@ -739,7 +739,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should400OnPOSTWithBadAcceptHeader() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Accept", "application/json+something-else-that-does-not-exist");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -752,7 +752,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithAnyAcceptHeaderDefaultResultToJson() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.addHeader("Accept", "*/*");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -769,7 +769,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should200OnPOSTWithComplexAcceptHeaderDefaultResultToJson() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "*.*;q=0.8,application/xhtml");
         httppost.addHeader("Accept", "*/*");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
@@ -786,7 +786,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void should500OnGETWithGremlinEvalFailure() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpPost httppost = new HttpPost("http://localhost:8182");
+        final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
         httppost.setEntity(new StringEntity("{\"gremlin\":\"1/0\"}", Consts.UTF_8));
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -38,7 +38,6 @@ import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import org.apache.tinkerpop.gremlin.driver.simple.NioClient;
 import org.apache.tinkerpop.gremlin.driver.simple.SimpleClient;
-import org.apache.tinkerpop.gremlin.driver.simple.WebSocketClient;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.CompileStaticCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.InterpreterModeCustomizerProvider;
@@ -137,7 +136,10 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.ssl.overrideSslContext(createServerSslContext());
                 break;
             case "shouldStartWithDefaultSettings":
-                return new Settings();
+                // test with defaults exception for port because we want to keep testing off of 8182
+                final Settings defaultSettings = new Settings();
+                defaultSettings.port = TestClientFactory.PORT;
+                return settings;
             case "shouldHaveTheSessionTimeout":
                 settings.processors.clear();
                 final Settings.ProcessorSettings processorSettings = new Settings.ProcessorSettings();
@@ -207,7 +209,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldUseInterpreterMode() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         client.submit("def subtractAway(x,y){x-y};[]").all().get();
@@ -229,7 +231,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldNotUseInterpreterMode() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         client.submit("def subtractAway(x,y){x-y};[]").all().get();
@@ -251,7 +253,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldUseSimpleSandbox() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
@@ -271,7 +273,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldStartWithDefaultSettings() {
         // just quickly validate that results are returning given defaults. no graphs are config'd with defaults
         // so just eval a groovy script.
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         final ResultSet results = client.submit("[1,2,3,4,5,6,7,8,9]");
@@ -283,7 +285,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldEnableSsl() {
-        final Cluster cluster = Cluster.build().enableSsl(true).create();
+        final Cluster cluster = TestClientFactory.build().enableSsl(true).create();
         final Client client = cluster.connect();
 
         try {
@@ -301,7 +303,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         builder.sslProvider(SslProvider.JDK);
 
-        final Cluster cluster = Cluster.build().enableSsl(true).sslContext(builder.build()).create();
+        final Cluster cluster = TestClientFactory.build().enableSsl(true).sslContext(builder.build()).create();
         final Client client = cluster.connect();
 
         try {
@@ -314,7 +316,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldEnableSslButFailIfClientConnectsWithoutIt() {
-        final Cluster cluster = Cluster.build().enableSsl(false).create();
+        final Cluster cluster = TestClientFactory.build().enableSsl(false).create();
         final Client client = cluster.connect();
 
         try {
@@ -336,7 +338,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         assumeThat("Set the 'assertNonDeterministic' property to true to execute this test",
                 System.getProperty("assertNonDeterministic"), is("true"));
 
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -382,7 +384,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReturnInvalidRequestArgsWhenGremlinArgIsNotSupplied() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL).create();
             final ResponseMessage result = client.submit(request).get(0);
             assertThat(result.getStatus().getCode(), is(not(ResponseStatusCode.PARTIAL_CONTENT)));
@@ -392,7 +394,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReturnInvalidRequestArgsWhenInvalidReservedBindingKeyIsUsed() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final Map<String, Object> bindings = new HashMap<>();
             bindings.put(T.id.getAccessor(), "123");
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
@@ -412,7 +414,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             assertTrue(pass.get());
         }
 
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final Map<String, Object> bindings = new HashMap<>();
             bindings.put("id", "123");
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
@@ -435,7 +437,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReturnInvalidRequestArgsWhenInvalidTypeBindingKeyIsUsed() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final Map<Object, Object> bindings = new HashMap<>();
             bindings.put(1, "123");
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
@@ -458,7 +460,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReturnInvalidRequestArgsWhenInvalidNullBindingKeyIsUsed() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final Map<String, Object> bindings = new HashMap<>();
             bindings.put(null, "123");
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
@@ -482,7 +484,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @SuppressWarnings("unchecked")
     public void shouldBatchResultsByTwos() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
                     .addArg(Tokens.ARGS_GREMLIN, "[0,1,2,3,4,5,6,7,8,9]").create();
 
@@ -504,7 +506,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @SuppressWarnings("unchecked")
     public void shouldBatchResultsByOnesByOverridingFromClientSide() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
                     .addArg(Tokens.ARGS_GREMLIN, "[0,1,2,3,4,5,6,7,8,9]")
                     .addArg(Tokens.ARGS_BATCH_SIZE, 1).create();
@@ -518,7 +520,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @SuppressWarnings("unchecked")
     public void shouldWorkOverNioTransport() throws Exception {
-        try (SimpleClient client = new NioClient()) {
+        try (SimpleClient client = TestClientFactory.createNioClient()) {
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
                     .addArg(Tokens.ARGS_GREMLIN, "[0,1,2,3,4,5,6,7,8,9,]").create();
 
@@ -531,7 +533,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldNotThrowNoSuchElementException() throws Exception {
-        try (SimpleClient client = new WebSocketClient()){
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()){
             // this should return "nothing" - there should be no exception
             final List<ResponseMessage> responses = client.submit("g.V().has('name','kadfjaldjfla')");
             assertNull(responses.get(0).getResult().getData());
@@ -541,7 +543,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @SuppressWarnings("unchecked")
     public void shouldReceiveFailureTimeOutOnScriptEval() throws Exception {
-        try (SimpleClient client = new WebSocketClient()){
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()){
             final List<ResponseMessage> responses = client.submit("Thread.sleep(3000);'some-stuff-that-should not return'");
             assertThat(responses.get(0).getStatus().getMessage(), startsWith("Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 200 ms"));
 
@@ -553,7 +555,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @SuppressWarnings("unchecked")
     public void shouldReceiveFailureTimeOutOnScriptEvalUsingOverride() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final RequestMessage msg = RequestMessage.build("eval")
                     .addArg(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 100)
                     .addArg(Tokens.ARGS_GREMLIN, "Thread.sleep(3000);'some-stuff-that-should not return'")
@@ -568,7 +570,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReceiveFailureTimeOutOnScriptEvalOfOutOfControlLoop() throws Exception {
-        try (SimpleClient client = new WebSocketClient()){
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()){
             // timeout configured for 1 second so the timed interrupt should trigger prior to the
             // scriptEvaluationTimeout which is at 30 seconds by default
             final List<ResponseMessage> responses = client.submit("while(true){}");
@@ -582,7 +584,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @SuppressWarnings("unchecked")
     public void shouldReceiveFailureTimeOutOnTotalSerialization() throws Exception {
-        try (SimpleClient client = new WebSocketClient()){
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()){
             final List<ResponseMessage> responses = client.submit("(0..<100000)");
 
             // the last message should contain the error
@@ -596,14 +598,14 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     @SuppressWarnings("unchecked")
     public void shouldLoadInitScript() throws Exception {
-        try (SimpleClient client = new WebSocketClient()){
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()){
             assertEquals(2, ((List<Integer>) client.submit("addItUp(1,1)").get(0).getResult().getData()).get(0).intValue());
         }
     }
 
     @Test
     public void shouldGarbageCollectPhantomButNotHard() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         assertEquals(2, client.submit("addItUp(1,1)").all().join().get(0).getInt());
@@ -626,7 +628,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReceiveFailureOnBadGraphSONSerialization() throws Exception {
-        final Cluster cluster = Cluster.build("localhost").serializer(Serializers.GRAPHSON_V1D0).create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRAPHSON_V1D0).create();
         final Client client = cluster.connect();
 
         try {
@@ -645,7 +647,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldReceiveFailureOnBadGryoSerialization() throws Exception {
-        final Cluster cluster = Cluster.build("localhost").serializer(Serializers.GRYO_V1D0).create();
+        final Cluster cluster = TestClientFactory.build().serializer(Serializers.GRYO_V1D0).create();
         final Client client = cluster.connect();
 
         try {
@@ -665,7 +667,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     @Test
     public void shouldBlockRequestWhenTooBig() throws Exception {
-        final Cluster cluster = Cluster.open();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect();
 
         try {
@@ -692,7 +694,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldFailOnDeadHost() throws Exception {
-        final Cluster cluster = Cluster.build("localhost").create();
+        final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect();
 
         // ensure that connection to server is good
@@ -728,7 +730,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldNotHavePartialContentWithOneResult() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
                     .addArg(Tokens.ARGS_GREMLIN, "10").create();
             final List<ResponseMessage> responses = client.submit(request);
@@ -739,7 +741,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldFailWithBadScriptEval() throws Exception {
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
                     .addArg(Tokens.ARGS_GREMLIN, "new String().doNothingAtAllBecauseThis is a syntax error").create();
             final List<ResponseMessage> responses = client.submit(request);
@@ -752,7 +754,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @SuppressWarnings("unchecked")
     public void shouldStillSupportDeprecatedRebindingsParameterOnServer() throws Exception {
         // this test can be removed when the rebindings arg is removed
-        try (SimpleClient client = new WebSocketClient()) {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final Map<String,String> rebindings = new HashMap<>();
             rebindings.put("xyz", "graph");
             final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
@@ -31,7 +31,6 @@ import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.driver.simple.SimpleClient;
-import org.apache.tinkerpop.gremlin.driver.simple.WebSocketClient;
 import org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor;
 import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
 import org.junit.After;
@@ -114,10 +113,10 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
         // basically, we need one to submit the long run job and one to do the close operation that will cancel the
         // long run job. it is probably possible to do this with some low-level message manipulation but that's
         // probably not necessary
-        final Cluster cluster1 = Cluster.build().create();
+        final Cluster cluster1 = TestClientFactory.open();
         final Client client1 = cluster1.connect(name.getMethodName());
         client1.submit("1+1").all().join();
-        final Cluster cluster2 = Cluster.build().create();
+        final Cluster cluster2 = TestClientFactory.open();
         final Client client2 = cluster2.connect(name.getMethodName());
         client2.submit("1+1").all().join();
 
@@ -144,7 +143,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
     public void shouldRollbackOnEvalExceptionForManagedTransaction() throws Exception {
         assumeNeo4jIsPresent();
 
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName(), true);
 
         try {
@@ -165,7 +164,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
 
     @Test
     public void shouldCloseSessionOnceOnRequest() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         final ResultSet results1 = client.submit("x = [1,2,3,4,5,6,7,8,9]");
@@ -199,7 +198,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
 
     @Test
     public void shouldHaveTheSessionTimeout() throws Exception {
-        final Cluster cluster = Cluster.build().create();
+        final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
 
         final ResultSet results1 = client.submit("x = [1,2,3,4,5,6,7,8,9]");
@@ -235,7 +234,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
 
     @Test
     public void shouldEnsureSessionBindingsAreThreadSafe() throws Exception {
-        final Cluster cluster = Cluster.build().minInProcessPerConnection(16).maxInProcessPerConnection(64).create();
+        final Cluster cluster = TestClientFactory.build().minInProcessPerConnection(16).maxInProcessPerConnection(64).create();
         final Client client = cluster.connect(name.getMethodName());
 
         client.submitAsync("a=100;b=1000;c=10000;null");
@@ -268,7 +267,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
     public void shouldExecuteInSessionAndSessionlessWithoutOpeningTransactionWithSingleClient() throws Exception {
         assumeNeo4jIsPresent();
 
-        try (final SimpleClient client = new WebSocketClient()) {
+        try (final SimpleClient client = TestClientFactory.createWebSocketClient()) {
 
             //open a transaction, create a vertex, commit
             final RequestMessage openRequest = RequestMessage.build(Tokens.OPS_EVAL)
@@ -335,7 +334,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
     public void shouldExecuteInSessionWithTransactionManagement() throws Exception {
         assumeNeo4jIsPresent();
 
-        try (final SimpleClient client = new WebSocketClient()) {
+        try (final SimpleClient client = TestClientFactory.createWebSocketClient()) {
             final RequestMessage addRequest = RequestMessage.build(Tokens.OPS_EVAL)
                     .processor("session")
                     .addArg(Tokens.ARGS_SESSION, name.getMethodName())

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinTraversalPerformanceTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinTraversalPerformanceTest.java
@@ -56,7 +56,7 @@ public class GremlinTraversalPerformanceTest extends AbstractGremlinServerPerfor
     public final static int DEFAULT_CONCURRENT_BENCHMARK_ROUNDS = 500;
     public final static int DEFAULT_CONCURRENT_WARMUP_ROUNDS = 10;
 
-    private final static Cluster cluster = Cluster.build("localhost").maxConnectionPoolSize(32).maxWaitForConnection(30000).create();
+    private final static Cluster cluster = TestClientFactory.build().maxConnectionPoolSize(32).maxWaitForConnection(30000).create();
     private final static AtomicReference<Client> client = new AtomicReference<>();
 
     @Rule

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server;
+
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.simple.NioClient;
+import org.apache.tinkerpop.gremlin.driver.simple.WebSocketClient;
+
+import java.net.URI;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public final class TestClientFactory {
+
+    public static final int PORT = 45940;
+    public static final URI WEBSOCKET_URI = URI.create("ws://localhost:" + PORT);
+    public static final URI NIO_URI = URI.create("gs://localhost:" + PORT);
+    public static final String HTTP = "http://localhost:" + PORT;
+
+    public static Cluster.Builder build() {
+        return Cluster.build("localhost").port(45940);
+    }
+
+    public static Cluster open() {
+        return build().create();
+    }
+
+    public static WebSocketClient createWebSocketClient() {
+        return new WebSocketClient(WEBSOCKET_URI);
+    }
+
+    public static NioClient createNioClient() {
+        return new NioClient(NIO_URI);
+    }
+
+    public static String createURLString() {
+        return createURLString("");
+    }
+
+    public static String createURLString(final String suffix) {
+        return HTTP + suffix;
+    }
+}

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 host: localhost
-port: 8182
+port: 45940
 threadPoolWorker: 1
 gremlinPool: 8
 scriptEvaluationTimeout: 30000

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-performance.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-performance.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 host: localhost
-port: 8182
+port: 45940
 threadPoolWorker: 1
 gremlinPool: 8
 scriptEvaluationTimeout: 30000

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-shaded</artifactId>
     <name>Apache TinkerPop :: Gremlin Shaded</name>

--- a/gremlin-test/pom.xml
+++ b/gremlin-test/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>gremlin-test</artifactId>
     <name>Apache TinkerPop :: Gremlin Test</name>

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -209,6 +209,7 @@ public abstract class AbstractGremlinTest {
      *
      * @deprecated as of 3.1.1-incubating, and is not replaced
      */
+    @Deprecated
     public void tryRandomCommit(final Graph graph) {
         if (graph.features().graph().supportsTransactions() && new Random().nextBoolean())
             graph.tx().commit();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/FeatureRequirementSet.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/FeatureRequirementSet.java
@@ -56,7 +56,7 @@ public @interface FeatureRequirementSet {
             add(FeatureRequirement.Factory.create(Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES, Graph.Features.EdgeFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY, Graph.Features.VertexFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.VertexPropertyFeatures.class));
-            add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.EdgePropertyFeatures.class));
+            add(FeatureRequirement.Factory.create(Graph.Features.EdgePropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.EdgePropertyFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY, Graph.Features.EdgeFeatures.class));
         }};
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/CommunityGeneratorTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/CommunityGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.algorithm.generator;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -84,6 +85,7 @@ public class CommunityGeneratorTest {
 
         @Test
         @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.VertexPropertyFeatures.FEATURE_INTEGER_VALUES)
         public void shouldGenerateDifferentGraph() throws Exception {
             final Configuration configuration = graphProvider.newGraphConfiguration("g1", this.getClass(), name.getMethodName(), null);
             final Graph graph1 = graphProvider.openTestGraph(configuration);
@@ -113,6 +115,7 @@ public class CommunityGeneratorTest {
 
         @Test
         @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.VertexPropertyFeatures.FEATURE_INTEGER_VALUES)
         public void shouldGenerateSameGraph() throws Exception {
             final Configuration configuration = graphProvider.newGraphConfiguration("g1", this.getClass(), name.getMethodName(), null);
             final Graph graph1 = graphProvider.openTestGraph(configuration);
@@ -194,6 +197,7 @@ public class CommunityGeneratorTest {
 
         @Test
         @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.VertexPropertyFeatures.FEATURE_INTEGER_VALUES)
         public void shouldProcessVerticesEdges() {
             final Distribution dist = new NormalDistribution(2);
             final CommunityGenerator generator = CommunityGenerator.build(graph)

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/DistributionGeneratorTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/DistributionGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.algorithm.generator;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -67,6 +68,7 @@ public class DistributionGeneratorTest {
 
         @Test
         @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.VertexPropertyFeatures.FEATURE_INTEGER_VALUES)
         public void shouldGenerateDifferentGraph() throws Exception {
             int executions = 0;
             boolean same = true;
@@ -110,6 +112,7 @@ public class DistributionGeneratorTest {
 
         @Test
         @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.VertexPropertyFeatures.FEATURE_INTEGER_VALUES)
         public void shouldGenerateSameGraph() throws Exception {
             final Configuration configuration = graphProvider.newGraphConfiguration("g1", this.getClass(), name.getMethodName(), null);
             final Graph g1 = graphProvider.openTestGraph(configuration);
@@ -158,6 +161,7 @@ public class DistributionGeneratorTest {
 
         @Test
         @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.VertexPropertyFeatures.FEATURE_INTEGER_VALUES)
         public void shouldProcessEdges() {
             final Distribution dist = new NormalDistribution(2);
             final DistributionGenerator generator = DistributionGenerator.build(graph)

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.structure;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.ExceptionCoverage;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
+import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
@@ -214,11 +215,7 @@ public class EdgeTest {
         }
 
         @Test
-        @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-        @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY)
-        @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_REMOVE_PROPERTY)
-        @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-        @FeatureRequirement(featureClass = Graph.Features.EdgePropertyFeatures.class, feature = FEATURE_STRING_VALUES)
+        @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
         public void shouldGetPropertyKeysOnEdge() {
             final Vertex v = graph.addVertex();
             final Edge e = v.addEdge("friend", v, "name", "marko", "location", "desert", "status", "dope");
@@ -272,10 +269,8 @@ public class EdgeTest {
         }
 
         @Test
-        @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-        @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY)
-        @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-        @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY)
+        @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.VertexPropertyFeatures.FEATURE_INTEGER_VALUES)
         @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_REMOVE_EDGES)
         public void shouldNotHaveAConcurrentModificationExceptionWhenIteratingAndRemovingAddingEdges() {
             final Vertex v1 = graph.addVertex("name", "marko");

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
@@ -748,9 +748,7 @@ public class IoTest {
         final List<Edge> v1Edges = IteratorUtils.list(v1.edges(Direction.BOTH));
         assertEquals(1, v1Edges.size());
         v1Edges.forEach(e -> {
-        	System.out.println("SERGE: e.inVertex().value(\"name\") : " + e.inVertex().value("name").equals("vadas"));
-
-            if (e.inVertex().value("name").equals("vadas")) {
+        	if (e.inVertex().value("name").equals("vadas")) {
                 assertEquals(Edge.DEFAULT_LABEL, e.label());
                 if (assertDouble)
                     assertWeightLoosely(0.5d, e);

--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>hadoop-gremlin</artifactId>
     <name>Apache TinkerPop :: Hadoop Gremlin</name>

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>neo4j-gremlin</artifactId>
     <name>Apache TinkerPop :: Neo4j Gremlin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
     </parent>
     <groupId>org.apache.tinkerpop</groupId>
     <artifactId>tinkerpop</artifactId>
-    <version>3.1.5</version>
+    <version>3.1.6-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Apache TinkerPop</name>
     <description>A Graph Computing Framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,8 @@ limitations under the License.
                         <exclude>**/_bsp/**</exclude>
                         <exclude>DEPENDENCIES</exclude>
                         <exclude>**/.glv</exclude>
+                        <exclude>bin/gremlin.sh</exclude>
+                        <exclude>gremlin-console/bin/gremlin.sh</exclude>
                     </excludes>
                     <licenses>
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>spark-gremlin</artifactId>
     <name>Apache TinkerPop :: Spark Gremlin</name>

--- a/tinkergraph-gremlin/pom.xml
+++ b/tinkergraph-gremlin/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.tinkerpop</groupId>
         <artifactId>tinkerpop</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>tinkergraph-gremlin</artifactId>
     <name>Apache TinkerPop :: TinkerGraph Gremlin</name>


### PR DESCRIPTION
Removed support for user.dir property as it was being prepended to a
fully qualified path and the second drive letter was making the path
illegal.

Made sure JarFile instances were being closed so that Groovy could
delete the directory without encountering file locked errors.

Exclude Unix scripts from RAT plugin

Tinkergraph integration tests fail but can build when skipping
integration tests. Hadoop fails either way. Could be environmental on my
end.
