### PR TITLE
Message scope initialization in PeerPressureVertexProgram

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -58,8 +58,6 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
 
     private MessageScope.Local<?> voteScope = MessageScope.Local.of(__::outE);
     private MessageScope.Local<?> countScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.voteScope));
-    private final Set<MessageScope> VOTE_SCOPE = new HashSet<>(Collections.singletonList(this.voteScope));
-    private final Set<MessageScope> COUNT_SCOPE = new HashSet<>(Collections.singletonList(this.countScope));
 
     public static final String CLUSTER = "gremlin.peerPressureVertexProgram.cluster";
     private static final String VOTE_STRENGTH = "gremlin.peerPressureVertexProgram.voteStrength";
@@ -120,6 +118,8 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
 
     @Override
     public Set<MessageScope> getMessageScopes(final Memory memory) {
+        final Set<MessageScope> VOTE_SCOPE = new HashSet<>(Collections.singletonList(this.voteScope));
+        final Set<MessageScope> COUNT_SCOPE = new HashSet<>(Collections.singletonList(this.countScope));
         return this.distributeVote && memory.isInitialIteration() ? COUNT_SCOPE : VOTE_SCOPE;
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkdumping/BulkDumperVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkdumping/BulkDumperVertexProgramTest.java
@@ -48,7 +48,6 @@ public class BulkDumperVertexProgramTest extends AbstractGremlinProcessTest {
                 assertEquals(1, IteratorUtils.count(v.values("age", "lang")));
                 final String name = v.value("name");
                 if (name.equals("marko")) {
-                    assertEquals(1, v.id());
                     assertEquals("person", v.label());
                     assertEquals(Integer.valueOf(29), v.value("age"));
                     assertEquals(3, IteratorUtils.count(v.edges(Direction.OUT)));
@@ -56,21 +55,18 @@ public class BulkDumperVertexProgramTest extends AbstractGremlinProcessTest {
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.OUT, "created")));
                     assertEquals(0, IteratorUtils.count(v.edges(Direction.IN)));
                 } else if (name.equals("vadas")) {
-                    assertEquals(2, v.id());
                     assertEquals("person", v.label());
                     assertEquals(Integer.valueOf(27), v.value("age"));
                     assertEquals(0, IteratorUtils.count(v.edges(Direction.OUT)));
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.IN)));
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.IN, "knows")));
                 } else if (name.equals("lop")) {
-                    assertEquals(3, v.id());
                     assertEquals("software", v.label());
                     assertEquals("java", v.value("lang"));
                     assertEquals(0, IteratorUtils.count(v.edges(Direction.OUT)));
                     assertEquals(3, IteratorUtils.count(v.edges(Direction.IN)));
                     assertEquals(3, IteratorUtils.count(v.edges(Direction.IN, "created")));
                 } else if (name.equals("josh")) {
-                    assertEquals(4, v.id());
                     assertEquals("person", v.label());
                     assertEquals(Integer.valueOf(32), v.value("age"));
                     assertEquals(2, IteratorUtils.count(v.edges(Direction.OUT)));
@@ -78,14 +74,12 @@ public class BulkDumperVertexProgramTest extends AbstractGremlinProcessTest {
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.IN)));
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.IN, "knows")));
                 } else if (name.equals("ripple")) {
-                    assertEquals(5, v.id());
                     assertEquals("software", v.label());
                     assertEquals("java", v.value("lang"));
                     assertEquals(0, IteratorUtils.count(v.edges(Direction.OUT)));
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.IN)));
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.IN, "created")));
                 } else if (name.equals("peter")) {
-                    assertEquals(6, v.id());
                     assertEquals("person", v.label());
                     assertEquals(Integer.valueOf(35), v.value("age"));
                     assertEquals(1, IteratorUtils.count(v.edges(Direction.OUT)));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
@@ -648,7 +648,7 @@ public class TransactionTest extends AbstractGremlinTest {
         } catch (Exception ex) {
             assertThat(ex, instanceOf(IllegalStateException.class));
         } finally {
-            threadedG.tx().rollback();
+            if (threadedG.tx().isOpen()) threadedG.tx().rollback();
         }
     }
 


### PR DESCRIPTION
These updates resolve issues observed running tinkerpop-3.2.2 tests against Titan. Sorry if this should have been submitted through JIRA.

### Message scope initialization in PeerPressureTest

Failing test was `g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX`

During test execution it was observed at the failing (vote) step that the message scope was `VertexStep(OUT,[knows],edge)`, but this didn't match the message scope, `VertexStep(OUT,edge)`, in the statically initialized set, `VOTE_SCOPE`, returned by `PeerPressureVertexProgram#getMessageScopes`. This caused an error in the custom memory implementation that is resolved by moving the initialization as shown in this PR.

### Vertex id checks in BulkDumperVertexProgramTest

Vertex id checks fail when implementation does not support user-specified ids

### Transaction rollback in TransactionTest

Implementation fails to rollback a transaction that is already closed
