### PR TITLE
TINKERPOP-887 Conversion of FastNoSuchElementException to NoSuchElementException for top level traversals

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Added `Pick.none` and `Pick.any` to the serializers and importers.
 * Added a class loader to `TraversalStrategies.GlobalCache` which guarantees strategies are registered prior to `GlobalCache.getStrategies()`.
 * Fixed a severe bug where `GraphComputer` strategies are not being loaded until the second use of the traversal source.
+* Traversals now throw regular NoSuchElementException instead of FastNoSuchElementException.
 
 [[release-3-2-3]]
 TinkerPop 3.2.3 (Release Date: October 17, 2016)

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -46,6 +46,15 @@ g.V().choose(hasLabel('person'),out('created'))
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1508[TINKERPOP-1508]
 
+FastNoSuchElementException converted to regular NoSuchElementException
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In gremlin 3.2.x a call to Traversal#next() that did not have a result would throw a FastNoSuchElementException.
+This has been changed to a regular NoSuchElementException that includes the stack trace. Code that explicitly catches
+FastNoSuchElementException should be converted to NoSuchElementException.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1330[TINKERPOP-1330]
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
@@ -181,11 +182,21 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
 
     @Override
     public E next() {
-        if (!this.locked) this.applyStrategies();
-        if (this.lastTraverser.bulk() == 0L)
-            this.lastTraverser = this.finalEndStep.next();
-        this.lastTraverser.setBulk(this.lastTraverser.bulk() - 1L);
-        return this.lastTraverser.get();
+        try {
+            if (!this.locked) this.applyStrategies();
+            if (this.lastTraverser.bulk() == 0L)
+                this.lastTraverser = this.finalEndStep.next();
+            this.lastTraverser.setBulk(this.lastTraverser.bulk() - 1L);
+            return this.lastTraverser.get();
+        }
+        catch(FastNoSuchElementException e) {
+            if(parent == EmptyStep.instance()) {
+                throw new NoSuchElementException();
+            }
+            else {
+                throw e;
+            }
+        }
     }
 
     @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -393,8 +393,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
             sourceA.E(e.id()).next();
             fail("Edge should not be in this partition");
         } catch (Exception ex) {
-            final Exception expected = FastNoSuchElementException.instance();
-            assertEquals(expected.getClass(), ex.getClass());
+            assertEquals(NoSuchElementException.class, ex.getClass());
         }
     }
 


### PR DESCRIPTION
Added exception handler strategy to convert FastNoSuchElementExceptions in to regular NoSuchElementExceptions when exiting a traversal.
