### PR TITLE
TINKERPOP-1506: Optional/Coalesce should not allow sideEffect traversals.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `OptionalStep` for use with `optional()` to better handle issues associated with branch side-effects.
 * Removed all performance tests that were not part of `gremlin-benchmark`.
 * Removed dependency on `junit-benchmarks` and it's related reference to `h2`.
 * Moved the source for the "home page" into the repository under `/site` so that it easier to accept contributions.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1146,12 +1146,11 @@ Option Step
 
 An option to a <<branch-step,`branch()`>> or <<choose-step,`choose()`>>
 
-
 [[optional-step]]
 Optional Step
 ~~~~~~~~~~~~~
 
-The `optional()`-step (*map*) returns the result of the specified traversal if it yields a result else it returns the calling
+The `optional()`-step (*branch/flatMap*) returns the result of the specified traversal if it yields a result else it returns the calling
 element, i.e. the `identity()`.
 
 [gremlin-groovy,modern]
@@ -1160,14 +1159,14 @@ g.V(2).optional(out('knows')) <1>
 g.V(2).optional(__.in('knows')) <2>
 ----
 
-<1> vadas does not have an `out` "know" edge so vadas is returned.
-<2> vadas does have an `in` "knows" edge so marko is returned.
+<1> vadas does not have an outgoing knows-edge so vadas is returned.
+<2> vadas does have an incoming knows-edge so marko is returned.
 
 `optional` is particularly useful for lifting entire graphs when used in conjunction with `path` or `tree`.
 
 [gremlin-groovy,modern]
 ----
-g.V().hasLabel('person').optional(out("knows").optional(out("created"))).path() <1>
+g.V().hasLabel('person').optional(out('knows').optional(out('created'))).path() <1>
 ----
 
 <1> Returns the paths of everybody followed by who they know followed by what they created.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -32,6 +32,14 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.3/CHANGELOG.asc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+OptionalStep and Side-Effects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `optional()`-step was previously implemented using `ChooseStep`. However, if the optional branch contained side-effects,
+then unexpected behaviors can emerge. Thus, a potential backwards compatibility issue arises is side-effects were being
+used in `optional()`. However, the behavior would be unpredictable so this backwards incompatibility is desirable.
+
+See link:https://issues.apache.org/jira/browse/TINKERPOP-1506[TINKERPOP-1506]
 
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,4 +59,4 @@ concerned with breaking changes related to the removal of:
 
 Those graph providers who relied on these tests should simply remove them from their respective test suites.
 
-See: https://issues.apache.org/jira/browse/TINKERPOP-1235[TINKERPOP-1235]
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1235[TINKERPOP-1235]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -42,6 +42,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.BranchStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.LocalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.UnionStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndStep;
@@ -1306,17 +1307,17 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default <E2> GraphTraversal<S, E2> optional(final Traversal<?, E2> optionalTraversal) {
         this.asAdmin().getBytecode().addStep(Symbols.optional, optionalTraversal);
-        return this.asAdmin().addStep(new ChooseStep<>(this.asAdmin(), (Traversal.Admin<E, ?>) optionalTraversal, (Traversal.Admin<E, E2>) optionalTraversal.asAdmin().clone(), (Traversal.Admin<E, E2>) __.<E2>identity()));
+        return this.asAdmin().addStep(new OptionalStep<>(this.asAdmin(), (Traversal.Admin<E2, E2>) optionalTraversal));
     }
 
     public default <E2> GraphTraversal<S, E2> union(final Traversal<?, E2>... unionTraversals) {
         this.asAdmin().getBytecode().addStep(Symbols.union, unionTraversals);
-        return this.asAdmin().addStep(new UnionStep(this.asAdmin(), Arrays.copyOf(unionTraversals, unionTraversals.length, Traversal.Admin[].class)));
+        return this.asAdmin().addStep(new UnionStep<>(this.asAdmin(), Arrays.copyOf(unionTraversals, unionTraversals.length, Traversal.Admin[].class)));
     }
 
     public default <E2> GraphTraversal<S, E2> coalesce(final Traversal<?, E2>... coalesceTraversals) {
         this.asAdmin().getBytecode().addStep(Symbols.coalesce, coalesceTraversals);
-        return this.asAdmin().addStep(new CoalesceStep(this.asAdmin(), Arrays.copyOf(coalesceTraversals, coalesceTraversals.length, Traversal.Admin[].class)));
+        return this.asAdmin().addStep(new CoalesceStep<>(this.asAdmin(), Arrays.copyOf(coalesceTraversals, coalesceTraversals.length, Traversal.Admin[].class)));
     }
 
     public default GraphTraversal<S, E> repeat(final Traversal<?, E> repeatTraversal) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalStep.java
@@ -1,0 +1,92 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.branch;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class OptionalStep<S> extends AbstractStep<S, S> implements TraversalParent {
+
+    private Traversal.Admin<S, S> optionalTraversal;
+
+    public OptionalStep(final Traversal.Admin traversal, final Traversal.Admin<S, S> optionalTraversal) {
+        super(traversal);
+        this.optionalTraversal = optionalTraversal;
+    }
+
+    @Override
+    protected Traverser.Admin<S> processNextStart() throws NoSuchElementException {
+        if (this.optionalTraversal.hasNext())
+            return this.optionalTraversal.nextTraverser();
+        else {
+            final Traverser.Admin<S> traverser = this.starts.next();
+            this.optionalTraversal.addStart(traverser.split());
+            if (this.optionalTraversal.hasNext())
+                return this.optionalTraversal.nextTraverser();
+            else
+                return traverser;
+        }
+    }
+
+    @Override
+    public List<Traversal.Admin<S, S>> getLocalChildren() {
+        return Collections.singletonList(this.optionalTraversal);
+    }
+
+    @Override
+    public OptionalStep<S> clone() {
+        final OptionalStep<S> clone = (OptionalStep<S>) super.clone();
+        clone.optionalTraversal = this.optionalTraversal.clone();
+        return clone;
+    }
+
+    @Override
+    public void setTraversal(final Traversal.Admin<?, ?> parentTraversal) {
+        super.setTraversal(parentTraversal);
+        integrateChild(this.optionalTraversal);
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.stepString(this, this.optionalTraversal);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.optionalTraversal.hashCode();
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return this.optionalTraversal.getTraverserRequirements();
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalStepTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.branch;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.identity;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class OptionalStepTest extends StepTest {
+
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Arrays.asList(
+                __.optional(out()),
+                __.optional(out("knows")),
+                __.optional(in().out()),
+                __.optional(out("created")),
+                __.optional(in().in()),
+                __.optional(identity())
+        );
+    }
+}

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyOptionalTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyOptionalTest.groovy
@@ -50,6 +50,10 @@ public abstract class GroovyOptionalTest {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.optional(out().optional(out())).path")
         }
 
+        @Override
+        public Traversal<Vertex, String> get_g_VX1X_optionalXaddVXdogXX_label(Object v1Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).optional(addV('dog')).label", "v1Id", v1Id)
+        }
     }
 
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalTest.java
@@ -18,23 +18,26 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.branch;
 
+import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
-import org.apache.tinkerpop.gremlin.process.IgnoreEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.addV;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.junit.Assert.assertEquals;
@@ -53,6 +56,8 @@ public abstract class OptionalTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Path> get_g_V_hasLabelXpersonX_optionalXoutXknowsX_optionalXoutXcreatedXXX_path();
 
     public abstract Traversal<Vertex, Path> get_g_V_optionalXout_optionalXoutXX_path();
+
+    public abstract Traversal<Vertex, String> get_g_VX1X_optionalXaddVXdogXX_label(Object v1Id);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -122,27 +127,41 @@ public abstract class OptionalTest extends AbstractGremlinProcessTest {
         assertTrue(paths.isEmpty());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    public void g_VX1X_optionalXaddVXdogXX_label() {
+        final Traversal<Vertex, String> traversal = get_g_VX1X_optionalXaddVXdogXX_label(convertToVertexId(this.graph, "marko"));
+        printTraversalForm(traversal);
+        checkResults(Collections.singletonList("dog"), traversal);
+        assertEquals(7, IteratorUtils.count(graph.vertices()));
+    }
+
     public static class Traversals extends OptionalTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX2X_optionalXoutXknowsXX(Object v2Id) {
-            return this.g.V(v2Id).optional(out("knows"));
+            return g.V(v2Id).optional(out("knows"));
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX2X_optionalXinXknowsXX(Object v2Id) {
-            return this.g.V(v2Id).optional(in("knows"));
+            return g.V(v2Id).optional(in("knows"));
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_hasLabelXpersonX_optionalXoutXknowsX_optionalXoutXcreatedXXX_path() {
-            return this.g.V().hasLabel("person").optional(out("knows").optional(out("created"))).path();
+            return g.V().hasLabel("person").optional(out("knows").optional(out("created"))).path();
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_optionalXout_optionalXoutXX_path() {
-            return this.g.V().optional(out().optional(out())).path();
+            return g.V().optional(out().optional(out())).path();
         }
 
+        @Override
+        public Traversal<Vertex, String> get_g_VX1X_optionalXaddVXdogXX_label(Object v1Id) {
+            return g.V(v1Id).optional(addV("dog")).label();
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalTest.java
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -134,7 +133,7 @@ public abstract class OptionalTest extends AbstractGremlinProcessTest {
         final Traversal<Vertex, String> traversal = get_g_VX1X_optionalXaddVXdogXX_label(convertToVertexId(this.graph, "marko"));
         printTraversalForm(traversal);
         checkResults(Collections.singletonList("dog"), traversal);
-        assertEquals(7, IteratorUtils.count(graph.vertices()));
+        assertEquals(7L, g.V().count().next().longValue());
     }
 
     public static class Traversals extends OptionalTest {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1506

`g.V(1).optional(addV())` created 2 vertices, not one. This is because `optional()` was implemented with the branch-step `ChooseStep`. This has been fixed with a custom `OptionalStep`. Test cases added to verify correct behavior.

Added to `master/` as this is a breaking change. Though, the previous behavior can easily be deemed a bug.

VOTE +1.