### PR TITLE
TINKERPOP-1471: IncidentToAdjacentStrategy use hidden marker to avoid repeated recursion.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* `IncidentToAdjacentStrategy` now uses a hidden label marker model to avoid repeated recursion for invalidating steps.
 * `SparkGraphComputer` no longer starts a worker iteration if the worker's partition is empty.
 * Added `ProjectStep.getProjectKeys()` for strategies that rely on such information.
 * Added `VertexFeatures.supportsDuplicateMultiProperties()` for graphs that only support unique values in multi-properties.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -105,21 +105,11 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
         this.vertexPropertyCriterion = null == vertexPropertyCriterion ? null : vertexPropertyCriterion.asAdmin().clone();
 
         if (null != this.vertexCriterion)
-            this.addLabelMarker(this.vertexCriterion);
+            TraversalHelper.applyTraversalRecursively(t -> t.getStartStep().addLabel(MARKER), this.vertexCriterion);
         if (null != this.edgeCriterion)
-            this.addLabelMarker(this.edgeCriterion);
+            TraversalHelper.applyTraversalRecursively(t -> t.getStartStep().addLabel(MARKER), this.edgeCriterion);
         if (null != this.vertexPropertyCriterion)
-            this.addLabelMarker(this.vertexPropertyCriterion);
-    }
-
-    private final void addLabelMarker(final Traversal.Admin<?, ?> traversal) {
-        traversal.getStartStep().addLabel(MARKER);
-        for (final Step<?, ?> step : traversal.getSteps()) {
-            if (step instanceof TraversalParent) {
-                ((TraversalParent) step).getLocalChildren().forEach(this::addLabelMarker);
-                ((TraversalParent) step).getGlobalChildren().forEach(this::addLabelMarker);
-            }
-        }
+            TraversalHelper.applyTraversalRecursively(t -> t.getStartStep().addLabel(MARKER), this.vertexPropertyCriterion);
     }
 
     private static void applyCriterion(final List<Step> stepsToApplyCriterionAfter, final Traversal.Admin traversal,

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
@@ -22,7 +22,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathStep;
@@ -77,13 +76,9 @@ public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
         // using a hidden label marker to denote whether the traversal should not be processed by this strategy
-        if (traversal.getParent() instanceof EmptyStep) {
-            if (TraversalHelper.hasStepOfAssignableClassRecursively(INVALIDATING_STEP_CLASSES, traversal)) {
-                addLabelMarker(traversal);
-                traversal.getStartStep().removeLabel(MARKER);
-                return;
-            }
-        } else if (traversal.getStartStep().getLabels().contains(MARKER)) {
+        if (traversal.getParent() instanceof EmptyStep && TraversalHelper.hasStepOfAssignableClassRecursively(INVALIDATING_STEP_CLASSES, traversal))
+            TraversalHelper.applyTraversalRecursively(t -> t.getStartStep().addLabel(MARKER), traversal);
+        if (traversal.getStartStep().getLabels().contains(MARKER)) {
             traversal.getStartStep().removeLabel(MARKER);
             return;
         }
@@ -99,16 +94,6 @@ public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<
         if (!stepsToReplace.isEmpty()) {
             for (final Pair<VertexStep, Step> pair : stepsToReplace) {
                 optimizeSteps(traversal, pair.getValue0(), pair.getValue1());
-            }
-        }
-    }
-
-    private final void addLabelMarker(final Traversal.Admin<?, ?> traversal) {
-        traversal.getStartStep().addLabel(MARKER);
-        for (final Step<?, ?> step : traversal.getSteps()) {
-            if (step instanceof TraversalParent) {
-                ((TraversalParent) step).getLocalChildren().forEach(this::addLabelMarker);
-                ((TraversalParent) step).getGlobalChildren().forEach(this::addLabelMarker);
             }
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -55,6 +55,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -443,6 +444,26 @@ public final class TraversalHelper {
             if (anyStepRecursively(predicate, globalChild)) return true;
         }
         return false;
+    }
+
+    /**
+     * Apply the provider {@link Consumer} function to the provided {@link Traversal} and all of its children.
+     *
+     * @param consumer  the function to apply to the each traversal in the tree
+     * @param traversal the root traversal to start application
+     */
+    public static void applyTraversalRecursively(final Consumer<Traversal.Admin<?, ?>> consumer, final Traversal.Admin<?, ?> traversal) {
+        consumer.accept(traversal);
+        for (final Step<?, ?> step : traversal.getSteps()) {
+            if (step instanceof TraversalParent) {
+                for (final Traversal.Admin<?, ?> local : ((TraversalParent) step).getLocalChildren()) {
+                    applyTraversalRecursively(consumer, local);
+                }
+                for (final Traversal.Admin<?, ?> global : ((TraversalParent) step).getGlobalChildren()) {
+                    applyTraversalRecursively(consumer, global);
+                }
+            }
+        }
     }
 
     public static <S> void addToCollection(final Collection<S> collection, final S s, final long bulk) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1471

Hidden labels can be used by strategies as a way to communicate between "layers" of the compilation tree. This model is now applied to `IncidentToAdjacentStrategy` where if the traversal (as a whole) should NOT be processed by `IncidentToAdjacentStrategy`, then each traversal in the tree is "marked." If the traversal can be processed by `IncidentToAdjacentStrategy`, then there is no need to mark the traversals. This removes the need to, for every traversal, do a recursion from the parent traversal looking for invalidating step classes.

VOTE +1.