### PR TITLE
TINKERPOP-1434 Block calls on "remote" traversal to get side-effects

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Added `ProjectStep.getProjectKeys()` for strategies that rely on such information.
 * Added `VertexFeatures.supportsDuplicateMultiProperties()` for graphs that only support unique values in multi-properties.
 * Deprecated the "performance" tests in `OptIn`.
+* Block calls to "remote" traversal side-effects until the traversal read is complete which signifies an end to iteration.
 * Added `Pick.none` and `Pick.any` to the serializers and importers.
 * Added a class loader to `TraversalStrategies.GlobalCache` which guarantees strategies are registered prior to `GlobalCache.getStrategies()`.
 * Fixed a severe bug where `GraphComputer` strategies are not being loaded until the second use of the traversal source.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/AbstractRemoteTraversalSideEffects.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/AbstractRemoteTraversalSideEffects.java
@@ -106,9 +106,4 @@ public abstract class AbstractRemoteTraversalSideEffects implements RemoteTraver
     public <V> Optional<Supplier<V>> getRegisteredSupplier(final String key) {
         throw new UnsupportedOperationException("Remote traversals do not support this method");
     }
-
-    @Override
-    public String toString() {
-        return StringFactory.traversalSideEffectsString(this);
-    }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultQueue.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultQueue.java
@@ -164,12 +164,12 @@ final class ResultQueue {
     }
 
     void markComplete() {
-        this.readComplete.complete(null);
-
         // if there was some aggregation performed in the queue then the full object is hanging out waiting to be
         // added to the ResultSet
         if (aggregatedResult != null)
             add(new Result(aggregatedResult));
+
+        this.readComplete.complete(null);
 
         this.drainAllWaiting();
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
@@ -81,6 +81,19 @@ public final class ResultSet implements Iterable<Result> {
     }
 
     /**
+     * Returns a future that will complete when all items have been returned from the server.
+     */
+    public CompletableFuture<Void> allItemsAvailableAsync() {
+        final CompletableFuture<Void> allAvailable = new CompletableFuture<>();
+        readCompleted.thenRun(() -> allAvailable.complete(null));
+        readCompleted.exceptionally(t -> {
+            allAvailable.completeExceptionally(t);
+            return null;
+        });
+        return allAvailable;
+    }
+
+    /**
      * Gets the number of items available on the client.
      */
     public int getAvailableItemCount() {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversal.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversal.java
@@ -51,7 +51,7 @@ public class DriverRemoteTraversal<S, E> extends AbstractRemoteTraversal<S, E> {
     private final Iterator<Traverser.Admin<E>> traversers;
     private Traverser.Admin<E> lastTraverser = EmptyTraverser.instance();
     private final RemoteTraversalSideEffects sideEffects;
-    private final Client client;
+    private final ResultSet rs;
 
     public DriverRemoteTraversal(final ResultSet rs, final Client client, final boolean attach, final Optional<Configuration> conf) {
         // attaching is really just for testing purposes. it doesn't make sense in any real-world scenario as it would
@@ -65,15 +65,29 @@ public class DriverRemoteTraversal<S, E> extends AbstractRemoteTraversal<S, E> {
             this.traversers = new TraverserIterator<>(rs.iterator());
         }
 
-        this.client = client;
+        this.rs = rs;
         this.sideEffects = new DriverRemoteTraversalSideEffects(
                 client,
                 rs.getOriginalRequestMessage().getRequestId(),
                 rs.getHost());
     }
 
+    /**
+     * Gets a side-effect from the server. Do not call this method prior to completing the iteration of the
+     * {@link DriverRemoteTraversal} that spawned this as the side-effect will not be ready. If this method is called
+     * prior to iteration being complete, then it will block until the traversal notifies it of completion. Generally
+     * speaking, the common user would not get side-effects this way - they would use a call to {@code cap()}.
+     */
     @Override
     public RemoteTraversalSideEffects getSideEffects() {
+        // wait for the read to complete (i.e. iteration on the server) before allowing the caller to get the
+        // side-effect. calling prior to this will result in the side-effect not being found. of course, the
+        // bad part here is that the method blocks indefinitely waiting for the result, but it prevents the
+        // test failure problems that happen on slower systems. in practice, it's unlikely that a user would
+        // try to get a side-effect prior to iteration, but since the API allows it, this at least prevents
+        // the error.
+        rs.allItemsAvailableAsync().join();
+
         return this.sideEffects;
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Host;
 import org.apache.tinkerpop.gremlin.driver.Result;
-import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.AbstractRemoteTraversalSideEffects;
@@ -34,8 +33,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Java driver implementation of {@link TraversalSideEffects}. This class is not thread safe.
@@ -53,6 +51,7 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
 
     private boolean closed = false;
     private boolean retrievedAllKeys = false;
+    private final AtomicInteger counter = new AtomicInteger(0);
 
     public DriverRemoteTraversalSideEffects(final Client client, final UUID serverSideEffect, final Host host) {
         this.client = client;
@@ -136,5 +135,13 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
                 throw new RuntimeException("Error on closing side effects", root);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        // have to override the implementation from TraversalSideEffects because it relies on calls to keys() as
+        // calling that too early can cause unintended failures (i.e. in the debugger, toString() gets called when
+        // introspecting the object from the moment of construction).
+        return "sideEffects[size:" + keys.size() + "]";
     }
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -179,7 +179,7 @@ public abstract class AbstractOpProcessor implements OpProcessor {
                         throw ex;
                     }
 
-                    iterateComplete(ctx, msg, itty);
+                    if (!itty.hasNext()) iterateComplete(ctx, msg, itty);
 
                     // the flush is called after the commit has potentially occurred.  in this way, if a commit was
                     // required then it will be 100% complete before the client receives it. the "frame" at this point

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -552,7 +552,7 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                         throw ex;
                     }
 
-                    iterateComplete(ctx, msg, itty);
+                    if (!itty.hasNext()) iterateComplete(ctx, msg, itty);
 
                     // the flush is called after the commit has potentially occurred.  in this way, if a commit was
                     // required then it will be 100% complete before the client receives it. the "frame" at this point

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -60,6 +60,7 @@ import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -865,11 +866,17 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         se.close();
 
         // Can't get new side effects after close
-        assertNull(se.get("b"));
+        try {
+            se.get("b");
+            fail("The traversal is closed");
+        } catch (Exception ex) {
+            assertThat(ex, instanceOf(IllegalStateException.class));
+            assertEquals("Traversal has been closed - no new side-effects can be retrieved", ex.getMessage());
+        }
 
         // Earlier keys should be cached locally
         final Set<String> localSideEffectKeys = se.keys();
-        assertEquals(1, localSideEffectKeys.size());
+        assertEquals(2, localSideEffectKeys.size());
         final BulkSet localSideEffects = se.get("a");
         assertThat(localSideEffects.isEmpty(), is(false));
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1434

This prevents calls for side-effects that are not yet ready on the server. This was generally a problem in tests, but users could have also run afoul of the issue if they decided to get low-level with the API. It is more likely that they would grab side-effects with a call to `cap()` so this would be a non-issue in that case.

Did multiple runs of `mvn clean install && mvn verify -pl gremlin-server -DincludeNeo4j -DskipIntegrationTests=false` and it passes nicely. I never saw the test failures that triggered the effort to produce a fix for this problem, so @dkuppitz who saw it regularly should give this a review. Also, if travis passes, that would be a good sign - the error was seen there sometimes as well.  Please be sure to use `-DincludeNeo4j` if re-running the tests.

VOTE +1