### PR TITLE
TINKERPOP-1542: Add Path.isEmpty() with a default implementation.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `Path.head()` and `Path.isEmpty()` with default method implementations.
 * Improved ability to release resources in `GraphProvider` instances in the test suite.
 * Added a `force` option for killing sessions without waiting for transaction close or timeout of a currently running job or multiple jobs.
 * Deprecated `Session.kill()` and `Session.manualKill()`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
@@ -49,6 +49,25 @@ public interface Path extends Cloneable, Iterable<Object> {
     }
 
     /**
+     * Determine if the path is empty or not.
+     *
+     * @return whether the path is empty or not.
+     */
+    public default boolean isEmpty() {
+        return this.size() == 0;
+    }
+
+    /**
+     * Get the head of the path.
+     *
+     * @param <A> the type of the head of the path
+     * @return the head of the path
+     */
+    public default <A> A head() {
+        return (A) this.objects().get(this.size() - 1);
+    }
+
+    /**
      * Add a new step to the path with an object and any number of associated labels.
      *
      * @param object the new head of the path

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePath.java
@@ -61,6 +61,11 @@ public class ImmutablePath implements Path, Serializable, Cloneable {
     }
 
     @Override
+    public boolean isEmpty() {
+        return this.isTail();
+    }
+
+    @Override
     public int size() {
         int counter = 0;
         ImmutablePath currentPath = this;
@@ -69,6 +74,11 @@ public class ImmutablePath implements Path, Serializable, Cloneable {
             counter++;
             currentPath = currentPath.previousPath;
         }
+    }
+
+    @Override
+    public <A> A head() {
+        return (A) this.currentObject;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
@@ -65,6 +65,15 @@ public class MutablePath implements Path, Serializable {
         return clone;
     }
 
+    @Override
+    public boolean isEmpty() {
+        return this.objects.isEmpty();
+    }
+
+    @Override
+    public <A> A head() {
+        return (A) this.objects.get(this.objects.size() - 1);
+    }
 
     @Override
     public int size() {
@@ -133,7 +142,11 @@ public class MutablePath implements Path, Serializable {
 
     @Override
     public boolean hasLabel(final String label) {
-        return this.labels.stream().filter(l -> l.contains(label)).findAny().isPresent();
+        for (final Set<String> set : this.labels) {
+            if (set.contains(label))
+                return true;
+        }
+        return false;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/B_LP_O_S_SE_SL_Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/B_LP_O_S_SE_SL_Traverser.java
@@ -41,7 +41,8 @@ public class B_LP_O_S_SE_SL_Traverser<T> extends B_O_S_SE_SL_Traverser<T> {
     public B_LP_O_S_SE_SL_Traverser(final T t, final Step<T, ?> step, final long initialBulk) {
         super(t, step, initialBulk);
         this.path = ImmutablePath.make();
-        if (!step.getLabels().isEmpty()) this.path = this.path.extend(t, step.getLabels());
+        final Set<String> labels = step.getLabels();
+        if (!labels.isEmpty()) this.path = this.path.extend(t, labels);
     }
 
     /////////////////
@@ -66,7 +67,8 @@ public class B_LP_O_S_SE_SL_Traverser<T> extends B_O_S_SE_SL_Traverser<T> {
     public <R> Traverser.Admin<R> split(final R r, final Step<T, R> step) {
         final B_LP_O_S_SE_SL_Traverser<R> clone = (B_LP_O_S_SE_SL_Traverser<R>) super.split(r, step);
         clone.path = clone.path.clone();
-        if (!step.getLabels().isEmpty()) clone.path = clone.path.extend(r, step.getLabels());
+        final Set<String> labels = step.getLabels();
+        if (!labels.isEmpty()) clone.path = clone.path.extend(r, labels);
         return clone;
     }
 
@@ -80,7 +82,7 @@ public class B_LP_O_S_SE_SL_Traverser<T> extends B_O_S_SE_SL_Traverser<T> {
     @Override
     public void addLabels(final Set<String> labels) {
         if (!labels.isEmpty())
-            this.path = this.path.size() == 0 || !this.path.get(this.path.size() - 1).equals(this.t) ?
+            this.path = this.path.isEmpty() || !this.t.equals(this.path.head()) ?
                     this.path.extend(this.t, labels) :
                     this.path.extend(labels);
     }
@@ -89,9 +91,9 @@ public class B_LP_O_S_SE_SL_Traverser<T> extends B_O_S_SE_SL_Traverser<T> {
     public void keepLabels(final Set<String> labels) {
         final Set<String> retractLabels = new HashSet<>();
         for (final Set<String> stepLabels : this.path.labels()) {
-            for (final String l : stepLabels) {
-                if (!labels.contains(l))
-                    retractLabels.add(l);
+            for (final String label : stepLabels) {
+                if (!labels.contains(label))
+                    retractLabels.add(label);
             }
         }
         this.path = this.path.retract(retractLabels);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/LP_O_OB_S_SE_SL_Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/LP_O_OB_S_SE_SL_Traverser.java
@@ -41,7 +41,8 @@ public class LP_O_OB_S_SE_SL_Traverser<T> extends O_OB_S_SE_SL_Traverser<T> {
     public LP_O_OB_S_SE_SL_Traverser(final T t, final Step<T, ?> step) {
         super(t, step);
         this.path = ImmutablePath.make();
-        if (!step.getLabels().isEmpty()) this.path = this.path.extend(t, step.getLabels());
+        final Set<String> labels = step.getLabels();
+        if (!labels.isEmpty()) this.path = this.path.extend(t, labels);
     }
 
     /////////////////
@@ -66,7 +67,8 @@ public class LP_O_OB_S_SE_SL_Traverser<T> extends O_OB_S_SE_SL_Traverser<T> {
     public <R> Traverser.Admin<R> split(final R r, final Step<T, R> step) {
         final LP_O_OB_S_SE_SL_Traverser<R> clone = (LP_O_OB_S_SE_SL_Traverser<R>) super.split(r, step);
         clone.path = clone.path.clone();
-        if (!step.getLabels().isEmpty()) clone.path = clone.path.extend(r, step.getLabels());
+        final Set<String> labels = step.getLabels();
+        if (!labels.isEmpty()) clone.path = clone.path.extend(r, labels);
         return clone;
     }
 
@@ -80,7 +82,7 @@ public class LP_O_OB_S_SE_SL_Traverser<T> extends O_OB_S_SE_SL_Traverser<T> {
     @Override
     public void addLabels(final Set<String> labels) {
         if (!labels.isEmpty())
-            this.path = this.path.size() == 0 || !this.path.get(this.path.size() - 1).equals(this.t) ?
+            this.path = this.path.isEmpty() || !this.t.equals(this.path.head()) ?
                     this.path.extend(this.t, labels) :
                     this.path.extend(labels);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1542

Added `Path.isEmpty()` and `Path.head()` with default implementations. Have optimized implementations in `ImmutablePath` and `MutablePath`. These methods are used heavily by the `LP`-class of traversers. A few other random tweaks.

VOTE +1.