### PR TITLE
TINKERPOP-1541: Select should default to Pop.last semantics

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `Pop.mixed` instead of using `null` to represent such semantics.
+* `select()`-step now defaults to using `Pop.last` instead of `Pop.mixed`. (*breaking*)
 * Removed previously deprecated `Console` constructor that took a `String` as an argument from `gremlin-console`.
 * Removed previously deprecated `ConcurrentBindings` from `gremlin-groovy`.
 * Removed previously deprecated `ScriptExecutor` from `gremlin-groovy`.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -32,6 +32,21 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.3/CHANGELOG.asc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+SelectStep Defaults to Pop.last
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`SelectStep` and `SelectOneStep` (`select()`) are the only `Scoping` steps that default to `Pop.mixed` as their labeled path
+selection criteria. All other steps, like `match()`, `where()` and `dedup()`, use `Pop.last`. In order to better enable optimizations
+around total `Pop.last` traversals, the `select()`-steps now default to `Pop.last`. Most users will not notice a difference as
+it is rare for repeated labels to be used in practice. However, formal backwards compatibility is possible as outlined below.
+
+Assuming that `x` is not a `Pop` argument:
+
+1. Change all `select(x,y,z)` calls to `selectV3d0(x,y,z)` calls.
+2. Change all `select(x,y,z)`-step calls to `select(Pop.mixed,x,y,z)`.
+
+If an explicit `Pop` argument is provided, then no changes are required.
+
 OptionalStep and Side-Effects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
@@ -134,7 +134,9 @@ public interface Path extends Cloneable, Iterable<Object> {
      * @throws IllegalArgumentException if the path does not contain the label
      */
     public default <A> A get(final Pop pop, final String label) throws IllegalArgumentException {
-        if (Pop.all == pop) {
+        if (Pop.mixed == pop) {
+            return this.get(label);
+        } else if (Pop.all == pop) {
             if (this.hasLabel(label)) {
                 final Object object = this.get(label);
                 if (object instanceof List)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Pop.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Pop.java
@@ -19,6 +19,12 @@
 package org.apache.tinkerpop.gremlin.process.traversal;
 
 /**
+ * A {@link Path} may have multiple values associated with a single label.
+ * {@link Pop} is used to determine whether the first value, last value, or
+ * all values are gathered. Note that {@link Pop#mixed} will return results
+ * as a list if there are multiple (like {@link Pop#all}) or as a singleton
+ * if only one object in the path is labeled (like {@link Pop#last}).
+ *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public enum Pop {
@@ -32,7 +38,11 @@ public enum Pop {
      */
     last,
     /**
-     * Get all the items and return them as a list
+     * Get all the items and return them as a list.
      */
-    all
+    all,
+    /**
+     * Get the items as either a list (for multiple) or an object (for singles).
+     */
+    mixed
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -623,7 +623,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         selectKeys[1] = selectKey2;
         System.arraycopy(otherSelectKeys, 0, selectKeys, 2, otherSelectKeys.length);
         this.asAdmin().getBytecode().addStep(Symbols.select, selectKey1, selectKey2, otherSelectKeys);
-        return this.asAdmin().addStep(new SelectStep<>(this.asAdmin(), null, selectKeys));
+        return this.asAdmin().addStep(new SelectStep<>(this.asAdmin(), Pop.last, selectKeys));
     }
 
     public default <E2> GraphTraversal<S, E2> select(final Pop pop, final String selectKey) {
@@ -633,8 +633,31 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default <E2> GraphTraversal<S, E2> select(final String selectKey) {
         this.asAdmin().getBytecode().addStep(Symbols.select, selectKey);
-        return this.asAdmin().addStep(new SelectOneStep<>(this.asAdmin(), null, selectKey));
+        return this.asAdmin().addStep(new SelectOneStep<>(this.asAdmin(), Pop.last, selectKey));
     }
+
+    /**
+     * @deprecated As of release 3.3.0, replaced by {@link GraphTraversal#select(Pop, String)} with {@link Pop#mixed}.
+     */
+    @Deprecated
+    public default <E2> GraphTraversal<S, E2> selectV3d0(final String selectKey) {
+        this.asAdmin().getBytecode().addStep(Symbols.selectV3d0, selectKey);
+        return this.asAdmin().addStep(new SelectOneStep<>(this.asAdmin(), Pop.mixed, selectKey));
+    }
+
+    /**
+     * @deprecated As of release 3.3.0, replaced by {@link GraphTraversal#select(Pop, String, String, String...)} with {@link Pop#mixed}.
+     */
+    @Deprecated
+    public default <E2> GraphTraversal<S, Map<String, E2>> selectV3d0(final String selectKey1, final String selectKey2, String... otherSelectKeys) {
+        final String[] selectKeys = new String[otherSelectKeys.length + 2];
+        selectKeys[0] = selectKey1;
+        selectKeys[1] = selectKey2;
+        System.arraycopy(otherSelectKeys, 0, selectKeys, 2, otherSelectKeys.length);
+        this.asAdmin().getBytecode().addStep(Symbols.selectV3d0, selectKey1, selectKey2, otherSelectKeys);
+        return this.asAdmin().addStep(new SelectStep<>(this.asAdmin(), Pop.mixed, selectKeys));
+    }
+
 
     public default <E2> GraphTraversal<S, E2> unfold() {
         this.asAdmin().getBytecode().addStep(Symbols.unfold);
@@ -678,7 +701,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default <E2 extends Number> GraphTraversal<S, E2> sum(final Scope scope) {
         this.asAdmin().getBytecode().addStep(Symbols.sum, scope);
-        return this.asAdmin().addStep(scope.equals(Scope.global) ? new SumGlobalStep<>(this.asAdmin()) : new SumLocalStep(this.asAdmin()));
+        return this.asAdmin().addStep(scope.equals(Scope.global) ? new SumGlobalStep<>(this.asAdmin()) : new SumLocalStep<>(this.asAdmin()));
     }
 
     public default <E2 extends Number> GraphTraversal<S, E2> max() {
@@ -688,7 +711,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default <E2 extends Number> GraphTraversal<S, E2> max(final Scope scope) {
         this.asAdmin().getBytecode().addStep(Symbols.max, scope);
-        return this.asAdmin().addStep(scope.equals(Scope.global) ? new MaxGlobalStep<>(this.asAdmin()) : new MaxLocalStep(this.asAdmin()));
+        return this.asAdmin().addStep(scope.equals(Scope.global) ? new MaxGlobalStep<>(this.asAdmin()) : new MaxLocalStep<>(this.asAdmin()));
     }
 
     public default <E2 extends Number> GraphTraversal<S, E2> min() {
@@ -708,7 +731,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default <E2 extends Number> GraphTraversal<S, E2> mean(final Scope scope) {
         this.asAdmin().getBytecode().addStep(Symbols.mean, scope);
-        return this.asAdmin().addStep(scope.equals(Scope.global) ? new MeanGlobalStep<>(this.asAdmin()) : new MeanLocalStep(this.asAdmin()));
+        return this.asAdmin().addStep(scope.equals(Scope.global) ? new MeanGlobalStep(this.asAdmin()) : new MeanLocalStep(this.asAdmin()));
     }
 
     public default <K, V> GraphTraversal<S, Map<K, V>> group() {
@@ -1554,6 +1577,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         public static final String propertyMap = "propertyMap";
         public static final String valueMap = "valueMap";
         public static final String select = "select";
+        public static final String selectV3d0 = "selectV3d0";
         public static final String key = "key";
         public static final String value = "value";
         public static final String path = "path";

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -353,6 +353,14 @@ public class __ {
     }
 
     /**
+     * @see GraphTraversal#selectV3d0(String)
+     */
+    @Deprecated
+    public static <A, B> GraphTraversal<A, B> selectV3d0(final String selectKey) {
+        return __.<A>start().selectV3d0(selectKey);
+    }
+
+    /**
      * @see GraphTraversal#select(Pop, String, String, String...)
      */
     public static <A, B> GraphTraversal<A, Map<String, B>> select(final Pop pop, final String selectKey1, final String selectKey2, final String... otherSelectKeys) {
@@ -364,6 +372,14 @@ public class __ {
      */
     public static <A, B> GraphTraversal<A, Map<String, B>> select(final String selectKey1, final String selectKey2, final String... otherSelectKeys) {
         return __.<A>start().select(selectKey1, selectKey2, otherSelectKeys);
+    }
+
+    /**
+     * @see GraphTraversal#selectV3d0(String, String, String...)
+     */
+    @Deprecated
+    public static <A, B> GraphTraversal<A, Map<String, B>> selectV3d0(final String selectKey1, final String selectKey2, final String... otherSelectKeys) {
+        return __.<A>start().selectV3d0(selectKey1, selectKey2, otherSelectKeys);
     }
 
     /**
@@ -465,7 +481,7 @@ public class __ {
     }
 
     /**
-     * @see GraphTraversal#group()
+     * @see GraphTraversal#groupV3d0()
      */
     @Deprecated
     public static <A, K, V> GraphTraversal<A, Map<K, V>> groupV3d0() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/Scoping.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/Scoping.java
@@ -41,7 +41,7 @@ public interface Scoping {
 
     public default <S> S getScopeValue(final Pop pop, final String key, final Traverser.Admin<?> traverser) throws IllegalArgumentException {
         if (traverser.getSideEffects().exists(key))
-            return traverser.getSideEffects().<S>get(key);
+            return traverser.getSideEffects().get(key);
         ///
         final Object object = traverser.get();
         if (object instanceof Map && ((Map<String, S>) object).containsKey(key))
@@ -49,14 +49,14 @@ public interface Scoping {
         ///
         final Path path = traverser.path();
         if (path.hasLabel(key))
-            return null == pop ? path.get(key) : path.get(pop, key);
+            return path.get(pop, key);
         ///
         throw new IllegalArgumentException("Neither the sideEffects, map, nor path has a " + key + "-key: " + this);
     }
 
     public default <S> S getNullableScopeValue(final Pop pop, final String key, final Traverser.Admin<?> traverser) {
         if (traverser.getSideEffects().exists(key))
-            return traverser.getSideEffects().<S>get(key);
+            return traverser.getSideEffects().get(key);
         ///
         final Object object = traverser.get();
         if (object instanceof Map && ((Map<String, S>) object).containsKey(key))
@@ -64,7 +64,7 @@ public interface Scoping {
         ///
         final Path path = traverser.path();
         if (path.hasLabel(key))
-            return null == pop ? path.get(key) : path.get(pop, key);
+            return path.get(pop, key);
         ///
         return null;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
@@ -44,7 +44,7 @@ public final class SelectOneStep<S, E> extends MapStep<S, E> implements Traversa
     private Traversal.Admin<S, E> selectTraversal = null;
     private Set<String> keepLabels;
 
-    public SelectOneStep(final Traversal.Admin traversal, Pop pop, final String selectKey) {
+    public SelectOneStep(final Traversal.Admin traversal, final Pop pop, final String selectKey) {
         super(traversal);
         this.pop = pop;
         this.selectKey = selectKey;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePath.java
@@ -136,7 +136,9 @@ public class ImmutablePath implements Path, Serializable, Cloneable {
 
     @Override
     public <A> A get(final Pop pop, final String label) {
-        if (Pop.all == pop) {
+        if (Pop.mixed == pop) {
+            return this.get(label);
+        } else if (Pop.all == pop) {
             // Recursively build the list to avoid building objects/labels collections.
             final List<Object> list = new ArrayList<>();
             ImmutablePath currentPath = this;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
@@ -113,7 +113,9 @@ public class MutablePath implements Path, Serializable {
 
     @Override
     public <A> A get(final Pop pop, final String label) {
-        if (Pop.all == pop) {
+        if (Pop.mixed == pop) {
+            return this.get(label);
+        } else if (Pop.all == pop) {
             if (this.hasLabel(label)) {
                 final Object object = this.get(label);
                 if (object instanceof List)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathProcessorStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathProcessorStrategy.java
@@ -127,18 +127,17 @@ public final class PathProcessorStrategy extends AbstractTraversalStrategy<Trave
         // process select("a","b").by(...).by(...)
         final List<SelectStep> selectSteps = TraversalHelper.getStepsOfClass(SelectStep.class, traversal);
         for (final SelectStep<?, Object> selectStep : selectSteps) {
-            if (selectStep.getPop() != Pop.all && selectStep.getMaxRequirement().compareTo(PathProcessor.ElementRequirement.ID) > 0) {
-                if (null == selectStep.getPop()) {
-                    boolean oneLabel = true;
-                    for (final String key : selectStep.getScopeKeys()) {
-                        if (labelCount(key, TraversalHelper.getRootTraversal(traversal)) > 1) {
-                            oneLabel = false;
-                            break;
-                        }
+            if (selectStep.getPop() != Pop.all && selectStep.getPop() != Pop.mixed && // TODO: necessary?
+                    selectStep.getMaxRequirement().compareTo(PathProcessor.ElementRequirement.ID) > 0) {
+                boolean oneLabel = true;
+                for (final String key : selectStep.getScopeKeys()) {
+                    if (labelCount(key, TraversalHelper.getRootTraversal(traversal)) > 1) {
+                        oneLabel = false;
+                        break;
                     }
-                    if (!oneLabel)
-                        continue;
                 }
+                if (!oneLabel)
+                    continue;
                 final int index = TraversalHelper.stepIndex(selectStep, traversal);
                 final Map<String, Traversal.Admin<Object, Object>> byTraversals = selectStep.getByTraversals();
                 final String[] keys = new String[byTraversals.size()];
@@ -159,9 +158,9 @@ public final class PathProcessorStrategy extends AbstractTraversalStrategy<Trave
         // process select("a").by(...)
         final List<SelectOneStep> selectOneSteps = TraversalHelper.getStepsOfClass(SelectOneStep.class, traversal);
         for (final SelectOneStep<?, ?> selectOneStep : selectOneSteps) {
-            if (selectOneStep.getPop() != Pop.all &&
+            if (selectOneStep.getPop() != Pop.all && selectOneStep.getPop() != Pop.mixed && // TODO: necessary?
                     selectOneStep.getMaxRequirement().compareTo(PathProcessor.ElementRequirement.ID) > 0 &&
-                    (null != selectOneStep.getPop() || labelCount(selectOneStep.getScopeKeys().iterator().next(), TraversalHelper.getRootTraversal(traversal)) <= 1)) {
+                    labelCount(selectOneStep.getScopeKeys().iterator().next(), TraversalHelper.getRootTraversal(traversal)) <= 1) {
                 final int index = TraversalHelper.stepIndex(selectOneStep, traversal);
                 final Traversal.Admin<?, ?> localChild = selectOneStep.getLocalChildren().get(0);
                 selectOneStep.removeLocalChild(localChild);

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStepTest.java
@@ -41,11 +41,11 @@ public class SelectOneStepTest extends StepTest {
                 __.select(Pop.all, "x"),
                 __.select(Pop.first, "x"),
                 __.select(Pop.last, "x"),
-                __.select("x"),
+                __.select(Pop.mixed, "x"),
                 __.select(Pop.all, "x").by("name"),
                 __.select(Pop.first, "x").by("name"),
                 __.select(Pop.last, "x").by("name"),
-                __.select("x").by("name")
+                __.select(Pop.mixed, "x").by("name")
         );
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStepTest.java
@@ -41,11 +41,11 @@ public class SelectStepTest extends StepTest {
                 __.select(Pop.all, "x", "y"),
                 __.select(Pop.first, "x", "y"),
                 __.select(Pop.last, "x", "y"),
-                __.select("x", "y"),
+                __.select(Pop.mixed, "x", "y"),
                 __.select(Pop.all, "x", "y").by("name").by("age"),
                 __.select(Pop.first, "x", "y").by("name").by("age"),
                 __.select(Pop.last, "x", "y").by("name").by("age"),
-                __.select("x", "y").by("name").by("age")
+                __.select(Pop.mixed, "x", "y").by("name").by("age")
         );
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathProcessorStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathProcessorStrategyTest.java
@@ -97,6 +97,7 @@ public class PathProcessorStrategyTest {
                 {__.select(Pop.first, "a", "b").by("name").by("age"), __.select(Pop.first, "b").map(new ElementValueTraversal<>("age")).as("b").select(Pop.first, "a").map(new ElementValueTraversal<>("name")).as("a").select(Pop.last, "a", "b"), Collections.emptyList()},
                 {__.select(Pop.last, "a", "b").by("name").by("age"), __.select(Pop.last, "b").map(new ElementValueTraversal<>("age")).as("b").select(Pop.last, "a").map(new ElementValueTraversal<>("name")).as("a").select(Pop.last, "a", "b"), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
                 {__.select(Pop.all, "a", "b").by("name").by("age"), __.select(Pop.all, "a", "b").by("name").by("age"), Collections.emptyList()},
+                {__.select(Pop.mixed, "a", "b").by("name").by("age"), __.select(Pop.mixed, "a", "b").by("name").by("age"), Collections.emptyList()},
                 // where(as("a")...)
                 {__.where(__.out("knows")), __.where(__.outE("knows")), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
                 {__.where(__.as("a").out("knows")), __.identity().as("xyz").select(Pop.last, "a").filter(__.out("knows")).select(Pop.last, "xyz"), Collections.emptyList()},

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
@@ -65,28 +65,28 @@ public abstract class GroovyRangeTest {
         }
 
         @Override
-        public Traversal<Vertex, List<String>> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_2X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').in().as('a').in().as('a').select('a').by(unfold().values('name').fold).limit(local,2)")
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').in().as('a').in().as('a').select(mixed,'a').by(unfold().values('name').fold).limit(local,2)")
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_1X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').in().as('a').in().as('a').select('a').by(unfold().values('name').fold).limit(local,1)")
+        public Traversal<Vertex, String> get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').in().as('a').in().as('a').select(mixed,'a').by(unfold().values('name').fold).limit(local,1)")
         }
 
         @Override
-        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,1,3)")
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select(mixed,'a').by(unfold().values('name').fold).range(local,1,3)")
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,1,2)")
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select(mixed,'a').by(unfold().values('name').fold).range(local,1,2)")
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,4,5)")
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select(mixed,'a').by(unfold().values('name').fold).range(local,4,5)")
         }
 
         @Override

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
@@ -60,23 +60,23 @@ public abstract class GroovyTailTest {
         }
 
         @Override
-        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 2)")
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select(mixed,'a').by(unfold().values('name').fold).tail(local, 2)")
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 1)")
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select(mixed,'a').by(unfold().values('name').fold).tail(local, 1)")
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local)")
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select(mixed,'a').by(unfold().values('name').fold).tail(local)")
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(limit(local, 0)).tail(local, 1)")
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select(mixed,'a').by(limit(local, 0)).tail(local, 1)")
         }
 
         @Override

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -333,6 +333,9 @@ class GraphTraversal(Traversal):
   def select(self, *args):
     self.bytecode.add_step("select", *args)
     return self
+  def selectV3d0(self, *args):
+    self.bytecode.add_step("selectV3d0", *args)
+    return self
   def sideEffect(self, *args):
     self.bytecode.add_step("sideEffect", *args)
     return self
@@ -612,6 +615,9 @@ class __(object):
   @staticmethod
   def select(*args):
     return GraphTraversal(None, None, Bytecode()).select(*args)
+  @staticmethod
+  def selectV3d0(*args):
+    return GraphTraversal(None, None, Bytecode()).selectV3d0(*args)
   @staticmethod
   def sideEffect(*args):
     return GraphTraversal(None, None, Bytecode()).sideEffect(*args)
@@ -1033,6 +1039,11 @@ def select(*args):
       return __.select(*args)
 
 statics.add_static('select', select)
+
+def selectV3d0(*args):
+      return __.selectV3d0(*args)
+
+statics.add_static('selectV3d0', selectV3d0)
 
 def sideEffect(*args):
       return __.sideEffect(*args)

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -122,10 +122,11 @@ Pick = Enum('Pick', 'any none')
 statics.add_static('any', Pick.any)
 statics.add_static('none', Pick.none)
 
-Pop = Enum('Pop', 'all_ first last')
+Pop = Enum('Pop', 'all_ first last mixed')
 statics.add_static('first', Pop.first)
 statics.add_static('last', Pop.last)
 statics.add_static('all_', Pop.all_)
+statics.add_static('mixed', Pop.mixed)
 
 Scope = Enum('Scope', 'global_ local')
 statics.add_static('global_', Scope.global_)

--- a/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/structure/io/graphson/GraphSONWriterTest.java
+++ b/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/structure/io/graphson/GraphSONWriterTest.java
@@ -104,6 +104,7 @@ public class GraphSONWriterTest {
         assertEquals(Pop.first, mapper.readValue(jythonEngine.eval("graphson_writer.writeObject(Pop.first)").toString(), Object.class));
         assertEquals(Pop.last, mapper.readValue(jythonEngine.eval("graphson_writer.writeObject(Pop.last)").toString(), Object.class));
         assertEquals(Pop.all, mapper.readValue(jythonEngine.eval("graphson_writer.writeObject(Pop.all_)").toString(), Object.class));
+        assertEquals(Pop.mixed, mapper.readValue(jythonEngine.eval("graphson_writer.writeObject(Pop.mixed)").toString(), Object.class));
         assertEquals(Scope.global, mapper.readValue(jythonEngine.eval("graphson_writer.writeObject(Scope.global_)").toString(), Object.class));
         assertEquals(Scope.local, mapper.readValue(jythonEngine.eval("graphson_writer.writeObject(Scope.local)").toString(), Object.class));
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
@@ -21,24 +21,25 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold;
-import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -61,15 +62,15 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_repeatXbothX_timesX3X_rangeX5_11X();
 
-    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_2X();
+    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X();
 
-    public abstract Traversal<Vertex, String> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_1X();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X();
 
-    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X();
+    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X();
 
-    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X();
 
-    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X();
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_2X();
 
@@ -174,50 +175,58 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         assertEquals(6, counter);
     }
 
-    /** Scenario: limit step, Scope.local, >1 item requested, List<String> input, List<String> output */
+    /**
+     * Scenario: limit step, Scope.local, >1 item requested, List<String> input, List<String> output
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_2X() {
-        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_2X();
+    public void g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X() {
+        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X();
         printTraversalForm(traversal);
         final Set<List<String>> expected =
-            new HashSet(Arrays.asList(
-                            Arrays.asList("ripple", "josh"),
-                            Arrays.asList("lop", "josh")));
+                new HashSet(Arrays.asList(
+                        Arrays.asList("ripple", "josh"),
+                        Arrays.asList("lop", "josh")));
         final Set<List<String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: limit step, Scope.local, 1 item requested, List input, String output */
+    /**
+     * Scenario: limit step, Scope.local, 1 item requested, List input, String output
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_1X() {
-        final Traversal<Vertex, String> traversal = get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_1X();
+    public void g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X();
         printTraversalForm(traversal);
         final Set<String> expected = new HashSet<>(Arrays.asList("ripple", "lop"));
         final Set<List<String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: range step, Scope.local, >1 item requested, List<String> input, List<String> output */
+    /**
+     * Scenario: range step, Scope.local, >1 item requested, List<String> input, List<String> output
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X() {
-        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X() {
+        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X();
         printTraversalForm(traversal);
         final Set<List<String>> expected =
-            new HashSet<>(Arrays.asList(
-                            Arrays.asList("josh", "ripple"),
-                            Arrays.asList("josh", "lop")));
+                new HashSet<>(Arrays.asList(
+                        Arrays.asList("josh", "ripple"),
+                        Arrays.asList("josh", "lop")));
         final Set<List<String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: range step, Scope.local, 1 item requested, List input, String output */
+    /**
+     * Scenario: range step, Scope.local, 1 item requested, List input, String output
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X() {
-        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X();
         printTraversalForm(traversal);
         int counter = 0;
         while (traversal.hasNext()) {
@@ -228,16 +237,20 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         assertEquals(2, counter);
     }
 
-    /** Scenario: range step, Scope.local, 1 item requested, List input, no items selected, stop traversal */
+    /**
+     * Scenario: range step, Scope.local, 1 item requested, List input, no items selected, stop traversal
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X() {
-        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X();
         printTraversalForm(traversal);
         assertEquals(Arrays.asList(), traversal.toList());
     }
 
-    /** Scenario: limit step, Scope.local, >1 item requested, Map input, Map output */
+    /**
+     * Scenario: limit step, Scope.local, >1 item requested, Map input, Map output
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_2X() {
@@ -250,33 +263,39 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         assertEquals(expected, actual);
     }
 
-    /** Scenario: limit step, Scope.local, 1 item requested, Map input, Map output */
+    /**
+     * Scenario: limit step, Scope.local, 1 item requested, Map input, Map output
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_1X() {
         final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_1X();
         printTraversalForm(traversal);
         final Set<Map<String, String>> expected = new HashSet<>(makeMapList(1,
-                 "a", "ripple",
-                 "a", "lop"));
+                "a", "ripple",
+                "a", "lop"));
         final Set<Map<String, String>> actual = new HashSet<>(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: range step, Scope.local, >1 item requested, Map input, Map output */
+    /**
+     * Scenario: range step, Scope.local, >1 item requested, Map input, Map output
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_3X() {
         final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_3X();
         printTraversalForm(traversal);
         final Set<Map<String, String>> expected = new HashSet<>(makeMapList(2,
-                 "b", "josh", "c", "ripple",
-                 "b", "josh", "c", "lop"));
+                "b", "josh", "c", "ripple",
+                "b", "josh", "c", "lop"));
         final Set<Map<String, String>> actual = new HashSet<>(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: range step, Scope.local, 1 item requested, Map input, Map output */
+    /**
+     * Scenario: range step, Scope.local, 1 item requested, Map input, Map output
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X() {
@@ -332,48 +351,48 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, List<String>> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_2X() {
-            return g.V().as("a").in().as("a").in().as("a").<List<String>>select("a").by(unfold().values("name").fold()).limit(local, 2);
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X() {
+            return g.V().as("a").in().as("a").in().as("a").<List<String>>select(Pop.mixed, "a").by(unfold().values("name").fold()).limit(local, 2);
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_1X() {
-            return g.V().as("a").in().as("a").in().as("a").<List<String>>select("a").by(unfold().values("name").fold()).limit(local, 1);
+        public Traversal<Vertex, String> get_g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X() {
+            return g.V().as("a").in().as("a").in().as("a").<List<String>>select(Pop.mixed, "a").by(unfold().values("name").fold()).limit(local, 1);
         }
 
         @Override
-        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X() {
-            return g.V().as("a").out().as("a").out().as("a").<List<String>>select("a").by(unfold().values("name").fold()).range(local, 1, 3);
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X() {
+            return g.V().as("a").out().as("a").out().as("a").<List<String>>select(Pop.mixed, "a").by(unfold().values("name").fold()).range(local, 1, 3);
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X() {
-            return g.V().as("a").out().as("a").out().as("a").<List<String>>select("a").by(unfold().values("name").fold()).range(local, 1, 2);
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X() {
+            return g.V().as("a").out().as("a").out().as("a").<List<String>>select(Pop.mixed, "a").by(unfold().values("name").fold()).range(local, 1, 2);
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X() {
-            return g.V().as("a").out().as("a").out().as("a").<List<String>>select("a").by(unfold().values("name").fold()).range(local, 4, 5);
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X() {
+            return g.V().as("a").out().as("a").out().as("a").<List<String>>select(Pop.mixed, "a").by(unfold().values("name").fold()).range(local, 4, 5);
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_2X() {
-            return g.V().as("a").in().as("b").in().as("c").<Map<String, String>>select("a","b","c").by("name").limit(local, 2);
+            return g.V().as("a").in().as("b").in().as("c").<Map<String, String>>select("a", "b", "c").by("name").limit(local, 2);
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_1X() {
-            return g.V().as("a").in().as("b").in().as("c").<Map<String, String>>select("a","b","c").by("name").limit(local, 1);
+            return g.V().as("a").in().as("b").in().as("c").<Map<String, String>>select("a", "b", "c").by("name").limit(local, 1);
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_3X() {
-            return g.V().as("a").out().as("b").out().as("c").<Map<String, String>>select("a","b","c").by("name").range(local, 1, 3);
+            return g.V().as("a").out().as("b").out().as("c").<Map<String, String>>select("a", "b", "c").by("name").range(local, 1, 3);
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X() {
-            return g.V().as("a").out().as("b").out().as("c").<Map<String, String>>select("a","b","c").by("name").range(local, 1, 2);
+            return g.V().as("a").out().as("b").out().as("c").<Map<String, String>>select("a", "b", "c").by("name").range(local, 1, 2);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
@@ -21,19 +21,11 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold;
-import static org.apache.tinkerpop.gremlin.process.traversal.Scope.global;
-import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,6 +33,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.global;
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Original spec: https://issues.apache.org/jira/browse/TINKERPOP-670
@@ -62,19 +63,21 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Long> get_g_V_repeatXin_outX_timesX3X_tailX7X_count();
 
-    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
+    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
 
-    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
 
-    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX();
 
-    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X();
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_2X();
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X();
 
-    /** Scenario: Global scope */
+    /**
+     * Scenario: Global scope
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_valuesXnameX_order_tailXglobal_2X() {
@@ -83,7 +86,9 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         assertEquals(Arrays.asList("ripple", "vadas"), traversal.toList());
     }
 
-    /** Scenario: Default scope is global */
+    /**
+     * Scenario: Default scope is global
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_valuesXnameX_order_tailX2X() {
@@ -92,7 +97,9 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         assertEquals(Arrays.asList("ripple", "vadas"), traversal.toList());
     }
 
-    /** Scenario: Default is global, N=1 */
+    /**
+     * Scenario: Default is global, N=1
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_valuesXnameX_order_tail() {
@@ -101,7 +108,9 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         assertEquals(Arrays.asList("vadas"), traversal.toList());
     }
 
-    /** Scenario: Global scope, not enough elements */
+    /**
+     * Scenario: Global scope, not enough elements
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_valuesXnameX_order_tailX7X() {
@@ -110,7 +119,9 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         assertEquals(Arrays.asList("josh", "lop", "marko", "peter", "ripple", "vadas"), traversal.toList());
     }
 
-    /** Scenario: Global scope, using repeat (BULK) */
+    /**
+     * Scenario: Global scope, using repeat (BULK)
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_repeatXbothX_timesX3X_tailX7X() {
@@ -124,7 +135,9 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         assertEquals(7, counter);
     }
 
-    /** Scenario: Global scope, using repeat (excess BULK) */
+    /**
+     * Scenario: Global scope, using repeat (excess BULK)
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_repeatXin_outX_timesX3X_tailX7X_count() {
@@ -133,75 +146,87 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         checkResults(Collections.singletonList(7L), traversal);
     }
 
-    /** Scenario: Local scope, List input, N>1 */
+    /**
+     * Scenario: Local scope, List input, N>1
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
-        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
+        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
         printTraversalForm(traversal);
         final Set<List<String>> expected =
-            new HashSet(Arrays.asList(
-                            Arrays.asList("josh", "ripple"),
-                            Arrays.asList("josh", "lop")));
+                new HashSet(Arrays.asList(
+                        Arrays.asList("josh", "ripple"),
+                        Arrays.asList("josh", "lop")));
         final Set<List<String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: Local scope, List input, N=1 */
+    /**
+     * Scenario: Local scope, List input, N=1
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
-        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
         printTraversalForm(traversal);
         final Set<String> expected = new HashSet(Arrays.asList("ripple", "lop"));
         final Set<String> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: Local scope, List input, default N=1 */
+    /**
+     * Scenario: Local scope, List input, default N=1
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
-        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX();
         printTraversalForm(traversal);
         final Set<String> expected = new HashSet(Arrays.asList("ripple", "lop"));
         final Set<String> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: Local scope, List input, N=1, empty input */
+    /**
+     * Scenario: Local scope, List input, N=1, empty input
+     */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
-        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X();
         printTraversalForm(traversal);
         final Set<String> expected = new HashSet();
         final Set<String> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: Local scope, Map input, N>1 */
+    /**
+     * Scenario: Local scope, Map input, N>1
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_2X() {
         final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_2X();
         printTraversalForm(traversal);
         final Set<Map<String, String>> expected = new HashSet(makeMapList(2,
-                 "b", "josh", "c", "ripple",
-                 "b", "josh", "c", "lop"));
+                "b", "josh", "c", "ripple",
+                "b", "josh", "c", "lop"));
         final Set<Map<String, String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
-    /** Scenario: Local scope, Map input, N=1 */
+    /**
+     * Scenario: Local scope, Map input, N=1
+     */
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X() {
         final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X();
         printTraversalForm(traversal);
         final Set<Map<String, String>> expected = new HashSet(makeMapList(1,
-                 "c", "ripple",
-                 "c", "lop"));
+                "c", "ripple",
+                "c", "lop"));
         final Set<Map<String, String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
@@ -239,33 +264,33 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
-            return g.V().as("a").out().as("a").out().as("a").<List<String>>select("a").by(unfold().values("name").fold()).tail(local, 2);
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
+            return g.V().as("a").out().as("a").out().as("a").<List<String>>select(Pop.mixed, "a").by(unfold().values("name").fold()).tail(local, 2);
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
-            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by(unfold().values("name").fold()).tail(local, 1);
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select(Pop.mixed, "a").by(unfold().values("name").fold()).tail(local, 1);
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
-            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by(unfold().values("name").fold()).tail(local);
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select(Pop.mixed, "a").by(unfold().values("name").fold()).tail(local);
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
-            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by(limit(local, 0)).tail(local, 1);
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select(Pop.mixed, "a").by(limit(local, 0)).tail(local, 1);
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_2X() {
-            return g.V().as("a").out().as("b").out().as("c").<String>select("a","b","c").by("name").tail(local, 2);
+            return g.V().as("a").out().as("b").out().as("c").<String>select("a", "b", "c").by("name").tail(local, 2);
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X() {
-            return g.V().as("a").out().as("b").out().as("c").<String>select("a","b","c").by("name").tail(local, 1);
+            return g.V().as("a").out().as("b").out().as("c").<String>select("a", "b", "c").by("name").tail(local, 1);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
@@ -24,7 +24,6 @@ import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -39,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
@@ -140,9 +140,6 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Collection<Set<String>>> get_g_V_asXa_bX_out_asXcX_path_selectXkeysX();
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_outXknowsX_asXbX_localXselectXa_bX_byXnameXX();
-
-    // Useful for permuting Pop use cases
-    protected final static List<Pop> POPS = Arrays.asList(null, Pop.first, Pop.last, Pop.all);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -498,7 +495,7 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_selectXaX() {
-        POPS.forEach(pop -> {
+        Stream.of(Pop.values()).forEach(pop -> {
             final Traversal<Vertex, Object> traversal = get_g_V_selectXaX(pop);
             printTraversalForm(traversal);
             assertEquals(Collections.emptyList(), traversal.toList());
@@ -508,7 +505,7 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_selectXa_bX() {
-        POPS.forEach(pop -> {
+        Stream.of(Pop.values()).forEach(pop -> {
             final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_selectXa_bX(pop);
             printTraversalForm(traversal);
             assertEquals(Collections.emptyList(), traversal.toList());
@@ -518,7 +515,7 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_valueMap_selectXpop_aX() {
-        POPS.forEach(pop -> {
+        Stream.of(Pop.values()).forEach(pop -> {
             final Traversal<Vertex, Object> traversal = get_g_V_valueMap_selectXpop_aX(pop);
             printTraversalForm(traversal);
             assertEquals(Collections.emptyList(), traversal.toList());
@@ -528,7 +525,7 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_valueMap_selectXpop_a_bX() {
-        POPS.forEach(pop -> {
+        Stream.of(Pop.values()).forEach(pop -> {
             final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_valueMap_selectXpop_a_bX(pop);
             printTraversalForm(traversal);
             assertEquals(Collections.emptyList(), traversal.toList());
@@ -771,26 +768,22 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Object> get_g_V_selectXaX(final Pop pop) {
-            final GraphTraversal<Vertex, Vertex> root = g.V();
-            return null == pop ? root.select("a") : root.select(pop, "a");
+            return g.V().select(pop, "a");
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_selectXa_bX(final Pop pop) {
-            final GraphTraversal<Vertex, Vertex> root = g.V();
-            return null == pop ? root.select("a", "b") : root.select(pop, "a", "b");
+            return g.V().select(pop, "a", "b");
         }
 
         @Override
         public Traversal<Vertex, Object> get_g_V_valueMap_selectXpop_aX(final Pop pop) {
-            final GraphTraversal<Vertex, Map<String, Object>> root = g.V().valueMap();
-            return null == pop ? root.select("a") : root.select(pop, "a");
+            return g.V().valueMap().select(pop, "a");
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_valueMap_selectXpop_a_bX(final Pop pop) {
-            final GraphTraversal<Vertex, Map<String, Object>> root = g.V().valueMap();
-            return null == pop ? root.select("a", "b") : root.select(pop, "a", "b");
+            return g.V().valueMap().select(pop, "a", "b");
         }
 
         // when labels don't exist


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1541

All `Scoping` steps use `Pop.last` semantics (`where()`, `match()`, `dedup()`), except `select()` which uses `Pop.mixed`. This is a wart from TinkerPop2 days. I changed `select()` to default to `Pop.last` and provided a `selectV3d0()` backwards compatibility step (@spmallette -- is that how we should name it? or is it `selectV3d2()` now?).

The benefit of this is that we can now introduce a simpler `Path` data structure if a traversal is all `Path.last` (which is 99% of traversals out there).  That is, if the traversal requirements is `LABELED_PATH` and all pops are `Pop.last`, then we don't need to store "historic" path elements and can have a `MapPath` which is backed by a `Map<String,Object>`. Less data and a simpler/faster equality test for bulking.

@robertdale --

```
gremlin> g.V(1).as('a').select(mixed,'a').as('a').select(mixed,'a')
==>[v[1],v[1]]
gremlin> g.V(1).as('a').select('a').as('a').select('a')
==>v[1]
```

VOTE +1.