### PR TITLE
TINKERPOP-1529 LazyBarrierStrategy is too aggressive

### DIFF
--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -39,7 +39,7 @@ function usage {
 
 while [ ! -z "$1" ]; do
   case "$1" in
-    -t | --tests ) RUN_TESTS=tue; shift ;;
+    -t | --tests ) RUN_TESTS=true; shift ;;
     -i | --integration-tests ) RUN_INTEGRATION_TESTS=true; shift ;;
     -n | --neo4j ) INCLUDE_NEO4J=true; shift ;;
     -j | --java-docs ) BUILD_JAVA_DOCS=true; shift ;;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/LazyBarrierStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/LazyBarrierStrategy.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.SideEffectHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 
 import java.util.Arrays;
@@ -44,7 +45,7 @@ import java.util.Set;
  */
 public final class LazyBarrierStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy> implements TraversalStrategy.OptimizationStrategy {
 
-    private final boolean IS_TESTING = Boolean.valueOf(System.getProperty("is.testing", "false"));
+    protected static final int MAX_BARRIER_SIZE = 2500;
     private static final LazyBarrierStrategy INSTANCE = new LazyBarrierStrategy();
     private static final Set<Class<? extends OptimizationStrategy>> PRIORS = new HashSet<>(Arrays.asList(
             RangeByIsCountStrategy.class,
@@ -56,9 +57,13 @@ public final class LazyBarrierStrategy extends AbstractTraversalStrategy<Travers
             MatchPredicateStrategy.class));
 
     private static final int BIG_START_SIZE = 5;
-    protected static final int MAX_BARRIER_SIZE = 2500;
+    private final boolean IS_TESTING = Boolean.valueOf(System.getProperty("is.testing", "false"));
 
     private LazyBarrierStrategy() {
+    }
+
+    public static LazyBarrierStrategy instance() {
+        return INSTANCE;
     }
 
     @Override
@@ -69,12 +74,13 @@ public final class LazyBarrierStrategy extends AbstractTraversalStrategy<Travers
                         TraversalHelper.hasStepOfAssignableClass(ProfileSideEffectStep.class, TraversalHelper.getRootTraversal(traversal)))) // necessary cause ProfileTest analyzes counts
             return;
 
+        final Set<String> frozenStepIds = SideEffectHelper.determineFrozenStepIds(traversal);
         boolean foundFlatMap = false;
         boolean labeledPath = false;
         for (int i = 0; i < traversal.getSteps().size(); i++) {
             final Step<?, ?> step = traversal.getSteps().get(i);
 
-            if (step instanceof PathProcessor) {
+            if (step instanceof PathProcessor && labeledPath) {
                 final Set<String> keepLabels = ((PathProcessor) step).getKeepLabels();
                 if (null != keepLabels && keepLabels.isEmpty()) // if no more path data, then start barrier'ing again
                     labeledPath = false;
@@ -84,12 +90,16 @@ public final class LazyBarrierStrategy extends AbstractTraversalStrategy<Travers
                     (step instanceof GraphStep &&
                             (i > 0 || ((GraphStep) step).getIds().length >= BIG_START_SIZE ||
                                     (((GraphStep) step).getIds().length == 0 && !(step.getNextStep() instanceof HasStep))))) {
-                if (foundFlatMap && !labeledPath &&
+                if (foundFlatMap && !labeledPath && !frozenStepIds.contains(step.getId()) &&
                         !(step.getNextStep() instanceof Barrier) &&
                         (!(step.getNextStep() instanceof EmptyStep) || step.getTraversal().getParent() instanceof EmptyStep)) {
                     final Step noOpBarrierStep = new NoOpBarrierStep<>(traversal, MAX_BARRIER_SIZE);
-                    TraversalHelper.copyLabels(step, noOpBarrierStep, true);
+                    if (labeledPath = !step.getLabels().isEmpty()) {
+                        TraversalHelper.copyLabels(step, noOpBarrierStep, true);
+                    }
                     TraversalHelper.insertAfterStep(noOpBarrierStep, step, traversal);
+                    i++;
+                    continue;
                 } else
                     foundFlatMap = true;
             }
@@ -99,13 +109,8 @@ public final class LazyBarrierStrategy extends AbstractTraversalStrategy<Travers
         }
     }
 
-
     @Override
     public Set<Class<? extends OptimizationStrategy>> applyPrior() {
         return PRIORS;
-    }
-
-    public static LazyBarrierStrategy instance() {
-        return INSTANCE;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/SideEffectHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/SideEffectHelper.java
@@ -18,7 +18,23 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSideEffects;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
+import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
+import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -43,5 +59,63 @@ public final class SideEffectHelper {
     public static void validateSideEffectKeyValue(final String key, final Object value) throws IllegalArgumentException {
         SideEffectHelper.validateSideEffectKey(key);
         SideEffectHelper.validateSideEffectValue(value);
+    }
+
+    public static Set<String> determineFrozenStepIds(final Traversal.Admin<?, ?> traversal) {
+        final Set<String> frozenStepIds = new HashSet<>();
+        if (!TraversalHelper.onGraphComputer(traversal)) {
+            final Map<String, LinkedList<List<String>>> frozenStepIdMap = new HashMap<>();
+            processSideEffectSteps(new HashSet<>(), frozenStepIdMap, traversal);
+            for (final LinkedList<List<String>> list : frozenStepIdMap.values()) {
+                list.removeLast();
+                list.forEach(frozenStepIds::addAll);
+            }
+        }
+        return frozenStepIds;
+    }
+
+    private static void processSideEffectSteps(final Set<String> activeSideEffectKeys,
+                                               final Map<String, LinkedList<List<String>>> frozenStepIdMap,
+                                               final Traversal.Admin<?, ?> traversal) {
+        for (final Step step : traversal.getSteps()) {
+            if (step instanceof SideEffectCapable && !(step instanceof Barrier)) {
+                final String sideEffectKey = ((SideEffectCapable) step).getSideEffectKey();
+                if (!frozenStepIdMap.containsKey(sideEffectKey)) {
+                    frozenStepIdMap.put(sideEffectKey, new LinkedList<>());
+                    frozenStepIdMap.get(sideEffectKey).add(new ArrayList<>());
+                }
+                activeSideEffectKeys.add(sideEffectKey);
+                continue;
+            }
+            if (step instanceof Barrier) {
+                activeSideEffectKeys.clear();
+                for (final LinkedList<List<String>> list : frozenStepIdMap.values()) {
+                    if (!list.getLast().isEmpty()) {
+                        list.add(new ArrayList<>());
+                    }
+                }
+            }
+            if (activeSideEffectKeys.isEmpty()) {
+                continue;
+            }
+            for (final String key : activeSideEffectKeys) {
+                frozenStepIdMap.get(key).getLast().add(step.getId());
+            }
+            if (step instanceof Scoping && step.getRequirements().contains(TraverserRequirement.SIDE_EFFECTS)) {
+                for (final String key : ((Scoping) step).getScopeKeys()) {
+                    if (frozenStepIdMap.containsKey(key) && activeSideEffectKeys.contains(key)) {
+                        frozenStepIdMap.get(key).add(new ArrayList<>());
+                    }
+                }
+            } else if (step instanceof LambdaHolder) {
+                for (final LinkedList<List<String>> list : frozenStepIdMap.values()) {
+                    list.add(new ArrayList<>());
+                }
+            } else if (step instanceof TraversalParent) {
+                final TraversalParent traversalParent = (TraversalParent) step;
+                traversalParent.getGlobalChildren().forEach(t -> processSideEffectSteps(activeSideEffectKeys, frozenStepIdMap, t));
+                traversalParent.getLocalChildren().forEach(t -> processSideEffectSteps(activeSideEffectKeys, frozenStepIdMap, t));
+            }
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyStoreTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyStoreTest.groovy
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet
 import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -48,6 +49,11 @@ public abstract class GroovyStoreTest {
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX_capXaX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.store('a').by(__.outE('created').count).out.out.store('a').by(__.inE('created').weight.sum).cap('a')");
+        }
+
+        @Override
+        public Traversal<Vertex, BulkSet<String>> get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX() {
+            new ScriptTraversal(g, "gremlin-groovy", "g.V.order.by(id).store('a').by('name').out.select('a')")
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreTest.java
@@ -23,12 +23,17 @@ import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.function.HashSetSupplier;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
@@ -43,6 +48,14 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(GremlinProcessRunner.class)
 public abstract class StoreTest extends AbstractGremlinProcessTest {
+
+    @SafeVarargs
+    private static <E> BulkSet<E> makeBulkSet(final E... elements) {
+        final BulkSet<E> result = new BulkSet<>();
+        Collections.addAll(result, elements);
+        return result;
+    }
+
     public abstract Traversal<Vertex, Collection> get_g_V_storeXaX_byXnameX_out_capXaX();
 
     public abstract Traversal<Vertex, Collection> get_g_VX1X_storeXaX_byXnameX_out_storeXaX_byXnameX_name_capXaX(final Object v1Id);
@@ -50,6 +63,8 @@ public abstract class StoreTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Set<String>> get_g_withSideEffectXa_setX_V_both_name_storeXaX_capXaX();
 
     public abstract Traversal<Vertex, Collection> get_g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX_capXaX();
+
+    public abstract Traversal<Vertex, BulkSet<String>> get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -114,6 +129,33 @@ public abstract class StoreTest extends AbstractGremlinProcessTest {
         assertFalse(store.isEmpty());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX() {
+        final Traversal<Vertex, BulkSet<String>> traversal = get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX();
+        printTraversalForm(traversal);
+        final List<BulkSet<String>> expected = new ArrayList<>(6);
+        expected.addAll(Arrays.asList(
+                makeBulkSet("marko"),
+                makeBulkSet("marko"),
+                makeBulkSet("marko"),
+                makeBulkSet("marko", "vadas", "lop", "josh"),
+                makeBulkSet("marko", "vadas", "lop", "josh"),
+                makeBulkSet("marko", "vadas", "lop", "josh", "ripple", "peter")));
+        while (traversal.hasNext()) {
+            final BulkSet<String> a = traversal.next();
+            boolean match = false;
+            for (int i = 0; i < expected.size(); i++) {
+                if (match = expected.get(i).equals(a)) {
+                    expected.remove(i);
+                    break;
+                }
+            }
+            assertTrue(match);
+        }
+        assertTrue(expected.isEmpty());
+    }
+
     public static class Traversals extends StoreTest {
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXnameX_out_capXaX() {
@@ -133,6 +175,11 @@ public abstract class StoreTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX_capXaX() {
             return g.V().store("a").by(outE("created").count()).out().out().store("a").by(inE("created").values("weight").sum()).cap("a");
+        }
+
+        @Override
+        public Traversal<Vertex, BulkSet<String>> get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX() {
+            return g.V().order().by(T.id).store("a").by("name").out().select("a");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1529

This fixes a long-term bug that was introduced when `LazyBarrierStrategy` and `PathRetractionStrategy` started adding `NoOpBarrierSteps`. The bug prevented a traversal from inspecting intermediate side-effect results produced by non-barrier `SideEffectSteps` like `StoreStep`.

I'm going to create another PR that will solve the problem using a strategy.