### PR TITLE
TINKERPOP-1529 LazyBarrierStrategy is too aggressive (variant 2)

### DIFF
--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -39,7 +39,7 @@ function usage {
 
 while [ ! -z "$1" ]; do
   case "$1" in
-    -t | --tests ) RUN_TESTS=tue; shift ;;
+    -t | --tests ) RUN_TESTS=true; shift ;;
     -i | --integration-tests ) RUN_INTEGRATION_TESTS=true; shift ;;
     -n | --neo4j ) INCLUDE_NEO4J=true; shift ;;
     -j | --java-docs ) BUILD_JAVA_DOCS=true; shift ;;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/AbstractRemoteTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/AbstractRemoteTraversal.java
@@ -42,15 +42,7 @@ import java.util.Set;
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public abstract class AbstractRemoteTraversal<S,E> implements RemoteTraversal<S,E> {
-
-    /**
-     * Note that internally {@link #nextTraverser()} is called from within a loop (specifically in
-     * {@link AbstractStep#next()} that breaks properly when a {@link java.util.NoSuchElementException} is thrown. In
-     * other words the "results" should be iterated to force that failure.
-     */
-    @Override
-    public abstract Traverser.Admin<E> nextTraverser();
+public abstract class AbstractRemoteTraversal<S, E> implements RemoteTraversal<S, E> {
 
     @Override
     public Bytecode getBytecode() {
@@ -93,17 +85,22 @@ public abstract class AbstractRemoteTraversal<S,E> implements RemoteTraversal<S,
     }
 
     @Override
-    public void setStrategies(final TraversalStrategies strategies) {
-        throw new UnsupportedOperationException("Remote traversals do not support this method");
-    }
-
-    @Override
     public TraversalStrategies getStrategies() {
         throw new UnsupportedOperationException("Remote traversals do not support this method");
     }
 
     @Override
-    public void setParent(final TraversalParent step) {
+    public void setStrategies(final TraversalStrategies strategies) {
+        throw new UnsupportedOperationException("Remote traversals do not support this method");
+    }
+
+    @Override
+    public <T> Optional<T> getMetadata(final String key) {
+        throw new UnsupportedOperationException("Remote traversals do not support this method");
+    }
+
+    @Override
+    public <T> void setMetadata(final String key, final T value) {
         throw new UnsupportedOperationException("Remote traversals do not support this method");
     }
 
@@ -113,7 +110,7 @@ public abstract class AbstractRemoteTraversal<S,E> implements RemoteTraversal<S,
     }
 
     @Override
-    public Admin<S, E> clone() {
+    public void setParent(final TraversalParent step) {
         throw new UnsupportedOperationException("Remote traversals do not support this method");
     }
 
@@ -129,6 +126,19 @@ public abstract class AbstractRemoteTraversal<S,E> implements RemoteTraversal<S,
 
     @Override
     public void setGraph(final Graph graph) {
+        throw new UnsupportedOperationException("Remote traversals do not support this method");
+    }
+
+    /**
+     * Note that internally {@link #nextTraverser()} is called from within a loop (specifically in
+     * {@link AbstractStep#next()} that breaks properly when a {@link java.util.NoSuchElementException} is thrown. In
+     * other words the "results" should be iterated to force that failure.
+     */
+    @Override
+    public abstract Traverser.Admin<E> nextTraverser();
+
+    @Override
+    public Admin<S, E> clone() {
         throw new UnsupportedOperationException("Remote traversals do not support this method");
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
@@ -59,14 +59,6 @@ import java.util.stream.StreamSupport;
  */
 public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, AutoCloseable {
 
-    public static class Symbols {
-        private Symbols() {
-            // static fields only
-        }
-
-        public static final String profile = "profile";
-    }
-
     /**
      * Get access to administrative methods of the traversal via its accompanying {@link Traversal.Admin}.
      *
@@ -236,20 +228,6 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
         // do nothing by default
     }
 
-    /**
-     * A collection of {@link Exception} types associated with Traversal execution.
-     */
-    public static class Exceptions {
-
-        public static IllegalStateException traversalIsLocked() {
-            return new IllegalStateException("The traversal strategies are complete and the traversal can no longer be modulated");
-        }
-
-        public static IllegalStateException traversalIsNotReversible() {
-            return new IllegalStateException("The traversal is not reversible as it contains steps that are not reversible");
-        }
-    }
-
     public interface Admin<S, E> extends Traversal<S, E> {
 
         /**
@@ -389,13 +367,6 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
         }
 
         /**
-         * Set the {@link TraversalSideEffects} of this traversal.
-         *
-         * @param sideEffects the sideEffects to set for this traversal.
-         */
-        public void setSideEffects(final TraversalSideEffects sideEffects);
-
-        /**
          * Get the {@link TraversalSideEffects} associated with the traversal.
          *
          * @return The traversal sideEffects
@@ -403,11 +374,11 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
         public TraversalSideEffects getSideEffects();
 
         /**
-         * Set the {@link TraversalStrategies} to be used by this traversal at evaluation time.
+         * Set the {@link TraversalSideEffects} of this traversal.
          *
-         * @param strategies the strategies to use on this traversal
+         * @param sideEffects the sideEffects to set for this traversal.
          */
-        public void setStrategies(final TraversalStrategies strategies);
+        public void setSideEffects(final TraversalSideEffects sideEffects);
 
         /**
          * Get the {@link TraversalStrategies} associated with this traversal.
@@ -417,12 +388,23 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
         public TraversalStrategies getStrategies();
 
         /**
-         * Set the {@link org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent} {@link Step} that is the parent of this traversal.
-         * Traversals can be nested and this is the means by which the traversal tree is connected.
+         * Set the {@link TraversalStrategies} to be used by this traversal at evaluation time.
          *
-         * @param step the traversal holder parent step
+         * @param strategies the strategies to use on this traversal
          */
-        public void setParent(final TraversalParent step);
+        public void setStrategies(final TraversalStrategies strategies);
+
+        /**
+         * Get the metadata entry for the given key.
+         *
+         * @return the metadata entry for the given key.
+         */
+        public <T> Optional<T> getMetadata(final String key);
+
+        /**
+         * Set the metadata entry for the given key.
+         */
+        public <T> void setMetadata(final String key, final T value);
 
         /**
          * Get the {@link org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent} {@link Step} that is the parent of this traversal.
@@ -431,6 +413,14 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
          * @return the traversal holder parent step
          */
         public TraversalParent getParent();
+
+        /**
+         * Set the {@link org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent} {@link Step} that is the parent of this traversal.
+         * Traversals can be nested and this is the means by which the traversal tree is connected.
+         *
+         * @param step the traversal holder parent step
+         */
+        public void setParent(final TraversalParent step);
 
         /**
          * Cloning is used to duplicate the traversal typically in OLAP environments.
@@ -469,6 +459,28 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
             return this.getEndStep().next();
         }
 
+    }
+
+    public static class Symbols {
+        public static final String profile = "profile";
+
+        private Symbols() {
+            // static fields only
+        }
+    }
+
+    /**
+     * A collection of {@link Exception} types associated with Traversal execution.
+     */
+    public static class Exceptions {
+
+        public static IllegalStateException traversalIsLocked() {
+            return new IllegalStateException("The traversal strategies are complete and the traversal can no longer be modulated");
+        }
+
+        public static IllegalStateException traversalIsNotReversible() {
+            return new IllegalStateException("The traversal is not reversible as it contains steps that are not reversible");
+        }
     }
 
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.Inci
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.InlineFilterStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.MatchPredicateStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.NoBarrierStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.OrderLimitStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathRetractionStrategy;
@@ -62,52 +63,6 @@ import java.util.stream.Collectors;
 public interface TraversalStrategies extends Serializable, Cloneable {
 
     static List<Class<? extends TraversalStrategy>> STRATEGY_CATEGORIES = Collections.unmodifiableList(Arrays.asList(TraversalStrategy.DecorationStrategy.class, TraversalStrategy.OptimizationStrategy.class, TraversalStrategy.ProviderOptimizationStrategy.class, TraversalStrategy.FinalizationStrategy.class, TraversalStrategy.VerificationStrategy.class));
-
-    /**
-     * Return all the {@link TraversalStrategy} singleton instances associated with this {@link TraversalStrategies}.
-     */
-    public List<TraversalStrategy<?>> toList();
-
-    /**
-     * Return the {@link TraversalStrategy} instance associated with the provided class.
-     *
-     * @param traversalStrategyClass the class of the strategy to get
-     * @param <T>                    the strategy class type
-     * @return an optional containing the strategy instance or not
-     */
-    public default <T extends TraversalStrategy> Optional<T> getStrategy(final Class<T> traversalStrategyClass) {
-        return (Optional) toList().stream().filter(s -> traversalStrategyClass.isAssignableFrom(s.getClass())).findAny();
-    }
-
-    /**
-     * Apply all the {@link TraversalStrategy} optimizers to the {@link Traversal} for the stated {@link TraversalEngine}.
-     * This method must ensure that the strategies are sorted prior to application.
-     *
-     * @param traversal the traversal to apply the strategies to
-     */
-    public void applyStrategies(final Traversal.Admin<?, ?> traversal);
-
-    /**
-     * Add all the provided {@link TraversalStrategy} instances to the current collection.
-     * When all the provided strategies have been added, the collection is resorted.
-     *
-     * @param strategies the traversal strategies to add
-     * @return the newly updated/sorted traversal strategies collection
-     */
-    public TraversalStrategies addStrategies(final TraversalStrategy<?>... strategies);
-
-    /**
-     * Remove all the provided {@link TraversalStrategy} classes from the current collection.
-     * When all the provided strategies have been removed, the collection is resorted.
-     *
-     * @param strategyClasses the traversal strategies to remove by their class
-     * @return the newly updated/sorted traversal strategies collection
-     */
-    @SuppressWarnings({"unchecked", "varargs"})
-    public TraversalStrategies removeStrategies(final Class<? extends TraversalStrategy>... strategyClasses);
-
-    @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
-    public TraversalStrategies clone();
 
     /**
      * Sorts the list of provided strategies such that the {@link TraversalStrategy#applyPost()}
@@ -174,7 +129,6 @@ public interface TraversalStrategies extends Serializable, Cloneable {
         return sortedStrategies;
     }
 
-
     static void visit(Map<Class<? extends TraversalStrategy>, Set<Class<? extends TraversalStrategy>>> dependencyMap, List<Class<? extends TraversalStrategy>> sortedStrategyClasses, Set<Class<? extends TraversalStrategy>> seenStrategyClases, List<Class<? extends TraversalStrategy>> unprocessedStrategyClasses, Class<? extends TraversalStrategy> strategyClass) {
         if (seenStrategyClases.contains(strategyClass)) {
             throw new IllegalStateException("Cyclic dependency between traversal strategies: ["
@@ -193,6 +147,51 @@ public interface TraversalStrategies extends Serializable, Cloneable {
         }
     }
 
+    /**
+     * Return all the {@link TraversalStrategy} singleton instances associated with this {@link TraversalStrategies}.
+     */
+    public List<TraversalStrategy<?>> toList();
+
+    /**
+     * Return the {@link TraversalStrategy} instance associated with the provided class.
+     *
+     * @param traversalStrategyClass the class of the strategy to get
+     * @param <T>                    the strategy class type
+     * @return an optional containing the strategy instance or not
+     */
+    public default <T extends TraversalStrategy> Optional<T> getStrategy(final Class<T> traversalStrategyClass) {
+        return (Optional) toList().stream().filter(s -> traversalStrategyClass.isAssignableFrom(s.getClass())).findAny();
+    }
+
+    /**
+     * Apply all the {@link TraversalStrategy} optimizers to the {@link Traversal} for the stated {@link TraversalEngine}.
+     * This method must ensure that the strategies are sorted prior to application.
+     *
+     * @param traversal the traversal to apply the strategies to
+     */
+    public void applyStrategies(final Traversal.Admin<?, ?> traversal);
+
+    /**
+     * Add all the provided {@link TraversalStrategy} instances to the current collection.
+     * When all the provided strategies have been added, the collection is resorted.
+     *
+     * @param strategies the traversal strategies to add
+     * @return the newly updated/sorted traversal strategies collection
+     */
+    public TraversalStrategies addStrategies(final TraversalStrategy<?>... strategies);
+
+    /**
+     * Remove all the provided {@link TraversalStrategy} classes from the current collection.
+     * When all the provided strategies have been removed, the collection is resorted.
+     *
+     * @param strategyClasses the traversal strategies to remove by their class
+     * @return the newly updated/sorted traversal strategies collection
+     */
+    @SuppressWarnings({"unchecked", "varargs"})
+    public TraversalStrategies removeStrategies(final Class<? extends TraversalStrategy>... strategyClasses);
+
+    @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
+    public TraversalStrategies clone();
 
     public static final class GlobalCache {
 
@@ -208,6 +207,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
                     AdjacentToIncidentStrategy.instance(),
                     FilterRankingStrategy.instance(),
                     MatchPredicateStrategy.instance(),
+                    NoBarrierStrategy.instance(),
                     RepeatUnrollStrategy.instance(),
                     RangeByIsCountStrategy.instance(),
                     PathRetractionStrategy.instance(),

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
@@ -52,20 +52,19 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
     }
 
     @Override
-    public List<Step> getSteps() {
-        return null == this.bypassTraversal ? Collections.emptyList() : this.bypassTraversal.getSteps();
-    }
-
-    @Override
     public Bytecode getBytecode() {
         return null == this.bypassTraversal ? new Bytecode() : this.bypassTraversal.getBytecode();
     }
 
+    @Override
+    public void addStart(final Traverser.Admin<S> start) {
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.addStart(start);
+    }
 
     @Override
-    public void reset() {
-        if (null != this.bypassTraversal)
-            this.bypassTraversal.reset();
+    public List<Step> getSteps() {
+        return null == this.bypassTraversal ? Collections.emptyList() : this.bypassTraversal.getSteps();
     }
 
     @Override
@@ -90,14 +89,30 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
     }
 
     @Override
+    public Set<TraverserRequirement> getTraverserRequirements() {
+        return null == this.bypassTraversal ? REQUIREMENTS : this.bypassTraversal.getTraverserRequirements();
+    }
+
+    @Override
+    public void reset() {
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.reset();
+    }
+
+    @Override
+    public TraversalSideEffects getSideEffects() {
+        return null == this.bypassTraversal ? EmptyTraversalSideEffects.instance() : this.bypassTraversal.getSideEffects();
+    }
+
+    @Override
     public void setSideEffects(final TraversalSideEffects sideEffects) {
         if (null != this.bypassTraversal)
             this.bypassTraversal.setSideEffects(sideEffects);
     }
 
     @Override
-    public TraversalSideEffects getSideEffects() {
-        return null == this.bypassTraversal ? EmptyTraversalSideEffects.instance() : this.bypassTraversal.getSideEffects();
+    public TraversalStrategies getStrategies() {
+        return null == this.bypassTraversal ? EmptyTraversalStrategies.instance() : this.bypassTraversal.getStrategies();
     }
 
     @Override
@@ -107,16 +122,14 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
     }
 
     @Override
-    public TraversalStrategies getStrategies() {
-        return null == this.bypassTraversal ? EmptyTraversalStrategies.instance() : this.bypassTraversal.getStrategies();
+    public <T> Optional<T> getMetadata(final String key) {
+        return null == this.bypassTraversal ? Optional.empty() : this.bypassTraversal.getMetadata(key);
     }
 
     @Override
-    public void setParent(final TraversalParent step) {
-        if (null != this.bypassTraversal) {
-            this.bypassTraversal.setParent(step);
-            step.integrateChild(this.bypassTraversal);
-        }
+    public <T> void setMetadata(final String key, final T value) {
+        if (null != this.bypassTraversal)
+            this.bypassTraversal.setMetadata(key, value);
     }
 
     @Override
@@ -125,40 +138,11 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
     }
 
     @Override
-    public Traversal.Admin<S, E> clone() {
-        try {
-            final AbstractLambdaTraversal<S, E> clone = (AbstractLambdaTraversal<S, E>) super.clone();
-            if (null != this.bypassTraversal)
-                clone.bypassTraversal = this.bypassTraversal.clone();
-            return clone;
-        } catch (final CloneNotSupportedException e) {
-            throw new IllegalStateException(e.getMessage(), e);
+    public void setParent(final TraversalParent step) {
+        if (null != this.bypassTraversal) {
+            this.bypassTraversal.setParent(step);
+            step.integrateChild(this.bypassTraversal);
         }
-    }
-
-    @Override
-    public E next() {
-        if (null != this.bypassTraversal)
-            return this.bypassTraversal.next();
-        throw new UnsupportedOperationException("The " + this.getClass().getSimpleName() + " can only be used as a predicate traversal");
-    }
-
-    @Override
-    public Traverser.Admin<E> nextTraverser() {
-        if (null != this.bypassTraversal)
-            return this.bypassTraversal.nextTraverser();
-        throw new UnsupportedOperationException("The " + this.getClass().getSimpleName() + " can only be used as a predicate traversal");
-    }
-
-    @Override
-    public boolean hasNext() {
-        return null == this.bypassTraversal || this.bypassTraversal.hasNext();
-    }
-
-    @Override
-    public void addStart(final Traverser.Admin<S> start) {
-        if (null != this.bypassTraversal)
-            this.bypassTraversal.addStart(start);
     }
 
     @Override
@@ -179,8 +163,22 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
     }
 
     @Override
-    public Set<TraverserRequirement> getTraverserRequirements() {
-        return null == this.bypassTraversal ? REQUIREMENTS : this.bypassTraversal.getTraverserRequirements();
+    public Traverser.Admin<E> nextTraverser() {
+        if (null != this.bypassTraversal)
+            return this.bypassTraversal.nextTraverser();
+        throw new UnsupportedOperationException("The " + this.getClass().getSimpleName() + " can only be used as a predicate traversal");
+    }
+
+    @Override
+    public boolean hasNext() {
+        return null == this.bypassTraversal || this.bypassTraversal.hasNext();
+    }
+
+    @Override
+    public E next() {
+        if (null != this.bypassTraversal)
+            return this.bypassTraversal.next();
+        throw new UnsupportedOperationException("The " + this.getClass().getSimpleName() + " can only be used as a predicate traversal");
     }
 
     @Override
@@ -191,6 +189,18 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
     @Override
     public boolean equals(final Object object) {
         return this.getClass().equals(object.getClass()) && this.hashCode() == object.hashCode();
+    }
+
+    @Override
+    public Traversal.Admin<S, E> clone() {
+        try {
+            final AbstractLambdaTraversal<S, E> clone = (AbstractLambdaTraversal<S, E>) super.clone();
+            if (null != this.bypassTraversal)
+                clone.bypassTraversal = this.bypassTraversal.clone();
+            return clone;
+        } catch (final CloneNotSupportedException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
     }
 
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/NoBarrierStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/NoBarrierStrategy.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
+import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
+import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Daniel Kuppitz (http://gremlin.guru)
+ */
+public class NoBarrierStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy>
+        implements TraversalStrategy.OptimizationStrategy {
+
+    static final String LAZY_STEPS_METADATA_KEY = "gremlin.noBarrier.lazySteps";
+    private static final NoBarrierStrategy INSTANCE = new NoBarrierStrategy();
+    private final Set<Class<? extends OptimizationStrategy>> postStrategies;
+
+    private NoBarrierStrategy() {
+        postStrategies = new HashSet<>(2);
+        postStrategies.add(LazyBarrierStrategy.class);
+        postStrategies.add(PathRetractionStrategy.class);
+    }
+
+    private static void processSideEffectSteps(final Set<String> activeSideEffectKeys,
+                                               final Map<String, LinkedList<List<String>>> lazyStepIdMap,
+                                               final Traversal.Admin<?, ?> traversal) {
+        for (final Step step : traversal.getSteps()) {
+            if (step instanceof SideEffectCapable && !(step instanceof Barrier)) {
+                final String sideEffectKey = ((SideEffectCapable) step).getSideEffectKey();
+                if (!lazyStepIdMap.containsKey(sideEffectKey)) {
+                    lazyStepIdMap.put(sideEffectKey, new LinkedList<>());
+                    lazyStepIdMap.get(sideEffectKey).add(new ArrayList<>());
+                }
+                activeSideEffectKeys.add(sideEffectKey);
+                continue;
+            }
+            if (step instanceof Barrier) {
+                activeSideEffectKeys.clear();
+                for (final LinkedList<List<String>> list : lazyStepIdMap.values()) {
+                    if (!list.getLast().isEmpty()) {
+                        list.add(new ArrayList<>());
+                    }
+                }
+            }
+            if (activeSideEffectKeys.isEmpty()) {
+                continue;
+            }
+            for (final String key : activeSideEffectKeys) {
+                lazyStepIdMap.get(key).getLast().add(step.getId());
+            }
+            if (step instanceof Scoping && step.getRequirements().contains(TraverserRequirement.SIDE_EFFECTS)) {
+                for (final String key : ((Scoping) step).getScopeKeys()) {
+                    if (lazyStepIdMap.containsKey(key) && activeSideEffectKeys.contains(key)) {
+                        lazyStepIdMap.get(key).add(new ArrayList<>());
+                    }
+                }
+            } else if (step instanceof LambdaHolder) {
+                for (final LinkedList<List<String>> list : lazyStepIdMap.values()) {
+                    list.add(new ArrayList<>());
+                }
+            } else if (step instanceof TraversalParent) {
+                final TraversalParent traversalParent = (TraversalParent) step;
+                traversalParent.getGlobalChildren().forEach(t -> processSideEffectSteps(activeSideEffectKeys, lazyStepIdMap, t));
+                traversalParent.getLocalChildren().forEach(t -> processSideEffectSteps(activeSideEffectKeys, lazyStepIdMap, t));
+            }
+        }
+    }
+
+    public static NoBarrierStrategy instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        if (traversal.getParent() instanceof EmptyStep && !TraversalHelper.onGraphComputer(traversal)) {
+            final Set<String> lazyStepIds = new HashSet<>();
+            if (!TraversalHelper.onGraphComputer(traversal)) {
+                final Map<String, LinkedList<List<String>>> lazyStepIdMap = new HashMap<>();
+                processSideEffectSteps(new HashSet<>(), lazyStepIdMap, traversal);
+                for (final LinkedList<List<String>> list : lazyStepIdMap.values()) {
+                    list.removeLast();
+                    list.forEach(lazyStepIds::addAll);
+                }
+            }
+            traversal.setMetadata(LAZY_STEPS_METADATA_KEY, lazyStepIds);
+        }
+    }
+
+    @Override
+    public Set<Class<? extends OptimizationStrategy>> applyPost() {
+        return postStrategies;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
@@ -48,13 +48,11 @@ import java.util.Set;
  */
 public final class PathRetractionStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy> implements TraversalStrategy.OptimizationStrategy {
 
-    public static Integer MAX_BARRIER_SIZE = 2500;
-
-    private static final PathRetractionStrategy INSTANCE = new PathRetractionStrategy(MAX_BARRIER_SIZE);
     // these strategies do strong rewrites involving path labeling and thus, should run prior to PathRetractionStrategy
     private static final Set<Class<? extends OptimizationStrategy>> PRIORS = new HashSet<>(Arrays.asList(
             RepeatUnrollStrategy.class, MatchPredicateStrategy.class, PathProcessorStrategy.class));
-
+    public static Integer MAX_BARRIER_SIZE = 2500;
+    private static final PathRetractionStrategy INSTANCE = new PathRetractionStrategy(MAX_BARRIER_SIZE);
     private final int standardBarrierSize;
 
     private PathRetractionStrategy(final int standardBarrierSize) {
@@ -69,9 +67,10 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
     public void apply(final Traversal.Admin<?, ?> traversal) {
         // do not apply this strategy if there are lambdas as you can't introspect to know what path information the lambdas are using
         // do not apply this strategy if a PATH requirement step is being used (in the future, we can do PATH requirement lookhead to be more intelligent about its usage)
-        if (TraversalHelper.anyStepRecursively(step -> step instanceof LambdaHolder || step.getRequirements().contains(TraverserRequirement.PATH), TraversalHelper.getRootTraversal(traversal)))
+        if (TraversalHelper.anyStepRecursively(step -> (step instanceof LambdaHolder || step.getRequirements().contains(TraverserRequirement.PATH)), TraversalHelper.getRootTraversal(traversal)))
             return;
 
+        final Set<String> lazyStepIds = traversal.<Set<String>>getMetadata(NoBarrierStrategy.LAZY_STEPS_METADATA_KEY).orElse(Collections.emptySet());
         final boolean onGraphComputer = TraversalHelper.onGraphComputer(traversal);
         final Set<String> foundLabels = new HashSet<>();
         final Set<String> keepLabels = new HashSet<>();
@@ -109,7 +108,8 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
                         !(currentStep instanceof MatchStep) &&
                         !(currentStep instanceof Barrier) &&
                         !(currentStep.getNextStep() instanceof Barrier) &&
-                        !(currentStep.getTraversal().getParent() instanceof MatchStep))
+                        !(currentStep.getTraversal().getParent() instanceof MatchStep) &&
+                        !(lazyStepIds.contains(currentStep.getId())))
                     TraversalHelper.insertAfterStep(new NoOpBarrierStep<>(traversal, this.standardBarrierSize), currentStep, traversal);
             }
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/EmptyTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/EmptyTraversal.java
@@ -45,16 +45,115 @@ public final class EmptyTraversal<S, E> implements Traversal.Admin<S, E> {
     private static final TraversalSideEffects SIDE_EFFECTS = EmptyTraversalSideEffects.instance();
     private static final TraversalStrategies STRATEGIES = EmptyTraversalStrategies.instance();
 
-    public static <A, B> EmptyTraversal<A, B> instance() {
-        return INSTANCE;
-    }
-
     protected EmptyTraversal() {
 
     }
 
+    public static <A, B> EmptyTraversal<A, B> instance() {
+        return INSTANCE;
+    }
+
     public Bytecode getBytecode() {
         return new Bytecode();
+    }
+
+    @Override
+    public void addStarts(final Iterator<Traverser.Admin<S>> starts) {
+
+    }
+
+    @Override
+    public void addStart(final Traverser.Admin<S> start) {
+
+    }
+
+    @Override
+    public List<Step> getSteps() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <E2> Traversal.Admin<S, E2> addStep(final Step<?, E2> step) {
+        return instance();
+    }
+
+    @Override
+    public <S2, E2> Traversal.Admin<S2, E2> addStep(final int index, final Step<?, ?> step) throws IllegalStateException {
+        return (Traversal.Admin) this;
+    }
+
+    @Override
+    public <S2, E2> Traversal.Admin<S2, E2> removeStep(final int index) throws IllegalStateException {
+        return (Traversal.Admin) this;
+    }
+
+    @Override
+    public void applyStrategies() {
+
+    }
+
+    @Override
+    public TraverserGenerator getTraverserGenerator() {
+        return null;
+    }
+
+    @Override
+    public Set<TraverserRequirement> getTraverserRequirements() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public TraversalSideEffects getSideEffects() {
+        return SIDE_EFFECTS;
+    }
+
+    @Override
+    public void setSideEffects(final TraversalSideEffects sideEffects) {
+    }
+
+    @Override
+    public TraversalStrategies getStrategies() {
+        return STRATEGIES;
+    }
+
+    @Override
+    public void setStrategies(final TraversalStrategies traversalStrategies) {
+
+    }
+
+    @Override
+    public <T> Optional<T> getMetadata(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> void setMetadata(String key, T value) {
+
+    }
+
+    @Override
+    public TraversalParent getParent() {
+        return EmptyStep.instance();
+    }
+
+    @Override
+    public void setParent(final TraversalParent step) {
+
+    }
+
+    @Override
+    public boolean isLocked() {
+        return true;
+    }
+
+    @Override
+    public Optional<Graph> getGraph() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setGraph(final Graph graph) {
+
     }
 
     @Override
@@ -73,82 +172,8 @@ public final class EmptyTraversal<S, E> implements Traversal.Admin<S, E> {
     }
 
     @Override
-    public TraversalSideEffects getSideEffects() {
-        return SIDE_EFFECTS;
-    }
-
-    @Override
-    public void applyStrategies() {
-
-    }
-
-    @Override
-    public void addStarts(final Iterator<Traverser.Admin<S>> starts) {
-
-    }
-
-    @Override
-    public void addStart(final Traverser.Admin<S> start) {
-
-    }
-
-    @Override
-    public <E2> Traversal.Admin<S, E2> addStep(final Step<?, E2> step) {
-        return instance();
-    }
-
-    @Override
-    public List<Step> getSteps() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public EmptyTraversal<S, E> clone() {
-        return instance();
-    }
-
-    @Override
-    public boolean isLocked() {
-        return true;
-    }
-
-    @Override
-    public TraverserGenerator getTraverserGenerator() {
-        return null;
-    }
-
-    @Override
-    public void setSideEffects(final TraversalSideEffects sideEffects) {
-    }
-
-    @Override
-    public TraversalStrategies getStrategies() {
-        return STRATEGIES;
-    }
-
-    @Override
-    public void setParent(final TraversalParent step) {
-
-    }
-
-    @Override
-    public TraversalParent getParent() {
-        return EmptyStep.instance();
-    }
-
-    @Override
-    public void setStrategies(final TraversalStrategies traversalStrategies) {
-
-    }
-
-    @Override
-    public <S2, E2> Traversal.Admin<S2, E2> addStep(final int index, final Step<?, ?> step) throws IllegalStateException {
-        return (Traversal.Admin) this;
-    }
-
-    @Override
-    public <S2, E2> Traversal.Admin<S2, E2> removeStep(final int index) throws IllegalStateException {
-        return (Traversal.Admin) this;
+    public int hashCode() {
+        return -343564565;
     }
 
     @Override
@@ -157,22 +182,7 @@ public final class EmptyTraversal<S, E> implements Traversal.Admin<S, E> {
     }
 
     @Override
-    public int hashCode() {
-        return -343564565;
-    }
-
-    @Override
-    public Set<TraverserRequirement> getTraverserRequirements() {
-        return Collections.emptySet();
-    }
-
-    @Override
-    public Optional<Graph> getGraph() {
-        return Optional.empty();
-    }
-
-    @Override
-    public void setGraph(final Graph graph) {
-
+    public EmptyTraversal<S, E> clone() {
+        return instance();
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyStoreTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyStoreTest.groovy
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet
 import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -48,6 +49,11 @@ public abstract class GroovyStoreTest {
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX_capXaX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.store('a').by(__.outE('created').count).out.out.store('a').by(__.inE('created').weight.sum).cap('a')");
+        }
+
+        @Override
+        public Traversal<Vertex, BulkSet<String>> get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX() {
+            new ScriptTraversal(g, "gremlin-groovy", "g.V.order.by(id).store('a').by('name').out.select('a')")
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreTest.java
@@ -23,12 +23,17 @@ import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.function.HashSetSupplier;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
@@ -43,6 +48,14 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(GremlinProcessRunner.class)
 public abstract class StoreTest extends AbstractGremlinProcessTest {
+
+    @SafeVarargs
+    private static <E> BulkSet<E> makeBulkSet(final E... elements) {
+        final BulkSet<E> result = new BulkSet<>();
+        Collections.addAll(result, elements);
+        return result;
+    }
+
     public abstract Traversal<Vertex, Collection> get_g_V_storeXaX_byXnameX_out_capXaX();
 
     public abstract Traversal<Vertex, Collection> get_g_VX1X_storeXaX_byXnameX_out_storeXaX_byXnameX_name_capXaX(final Object v1Id);
@@ -50,6 +63,8 @@ public abstract class StoreTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Set<String>> get_g_withSideEffectXa_setX_V_both_name_storeXaX_capXaX();
 
     public abstract Traversal<Vertex, Collection> get_g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX_capXaX();
+
+    public abstract Traversal<Vertex, BulkSet<String>> get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -114,6 +129,33 @@ public abstract class StoreTest extends AbstractGremlinProcessTest {
         assertFalse(store.isEmpty());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX() {
+        final Traversal<Vertex, BulkSet<String>> traversal = get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX();
+        printTraversalForm(traversal);
+        final List<BulkSet<String>> expected = new ArrayList<>(6);
+        expected.addAll(Arrays.asList(
+                makeBulkSet("marko"),
+                makeBulkSet("marko"),
+                makeBulkSet("marko"),
+                makeBulkSet("marko", "vadas", "lop", "josh"),
+                makeBulkSet("marko", "vadas", "lop", "josh"),
+                makeBulkSet("marko", "vadas", "lop", "josh", "ripple", "peter")));
+        while (traversal.hasNext()) {
+            final BulkSet<String> a = traversal.next();
+            boolean match = false;
+            for (int i = 0; i < expected.size(); i++) {
+                if (match = expected.get(i).equals(a)) {
+                    expected.remove(i);
+                    break;
+                }
+            }
+            assertTrue(match);
+        }
+        assertTrue(expected.isEmpty());
+    }
+
     public static class Traversals extends StoreTest {
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXnameX_out_capXaX() {
@@ -133,6 +175,11 @@ public abstract class StoreTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX_capXaX() {
             return g.V().store("a").by(outE("created").count()).out().out().store("a").by(inE("created").values("weight").sum()).cap("a");
+        }
+
+        @Override
+        public Traversal<Vertex, BulkSet<String>> get_g_V_order_byXidX_storeXaX_byXnameX_out_selectXaX() {
+            return g.V().order().by(T.id).store("a").by("name").out().select("a");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1529

This fixes a long-term bug that was introduced when `LazyBarrierStrategy` and `PathRetractionStrategy` started adding `NoOpBarrierSteps`. The bug prevented a traversal from inspecting intermediate side-effect results produced by non-barrier `SideEffectSteps` like `StoreStep`.

In contrast to https://github.com/apache/tinkerpop/pull/484 this PR extends the `Traversal` interface (adds support for metadata) and solves the issue using a new traversal strategy called `NoBarrierStrategy`.