### PR TITLE
TINKERPOP-1545 IncidentToAdjacentStrategy is buggy

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
@@ -24,19 +24,17 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.javatuples.Pair;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -63,7 +61,6 @@ public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<
         implements TraversalStrategy.OptimizationStrategy {
 
     private static final IncidentToAdjacentStrategy INSTANCE = new IncidentToAdjacentStrategy();
-    private static final Set<Class> INVALIDATING_STEP_CLASSES = new HashSet<>(Arrays.asList(PathStep.class, LambdaHolder.class));
 
     private IncidentToAdjacentStrategy() {
     }
@@ -71,7 +68,8 @@ public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
         final Traversal.Admin root = TraversalHelper.getRootTraversal(traversal);
-        if (TraversalHelper.hasStepOfAssignableClassRecursively(INVALIDATING_STEP_CLASSES, root))
+        if (TraversalHelper.anyStepRecursively(s -> s instanceof LambdaHolder
+                || (!(s instanceof EdgeOtherVertexStep) && s.getRequirements().contains(TraverserRequirement.PATH)), root))
             return;
         final Collection<Pair<VertexStep, Step>> stepsToReplace = new ArrayList<>();
         Step prev = null;

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategyTest.java
@@ -129,6 +129,8 @@ public class IncidentToAdjacentStrategyTest {
                     {__.bothE().outV(), __.bothE().outV()},
                     {__.outE().as("a").inV(), __.outE().as("a").inV()}, // todo: this can be optimized, but requires a lot more checks
                     {__.outE().inV().path(), __.outE().inV().path()},
+                    {__.outE().inV().simplePath(), __.outE().inV().simplePath()},
+                    {__.outE().inV().tree(), __.outE().inV().tree()},
                     {__.outE().inV().map(lambda), __.outE().inV().map(lambda)},
                     {__.union(__.outE().inV(), __.inE().outV()).path(), __.union(__.outE().inV(), __.inE().outV()).path()},
                     {__.as("a").outE().inV().as("b"), __.as("a").out().as("b")}});


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1545

Made `SimplePathStep` implement `PathProcessor` and `IncidentToAdjacentStrategy` skip all traversals that contain path processing steps.

The first few test suites of `docker/builder -t -i -n` succeeded and I will let it run over night, but I'm confident, that nothing bad is gonna happen in the other test suites (otherwise I'm going to revert the next line tomorrow).

VOTE: +1