### PR TITLE
TINKERPOP-1399 NumberHelper needs to go into util and have a private constructor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Moved `NumberHelper` into the `org.apache.tinkerpop.gremlin.util` package.
 * Removed previously deprecated `Console` constructor that took a `String` as an argument from `gremlin-console`.
 * Removed previously deprecated `ConcurrentBindings` from `gremlin-groovy`.
 * Removed previously deprecated `ScriptExecutor` from `gremlin-groovy`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
+import org.apache.tinkerpop.gremlin.util.NumberHelper;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.BinaryOperator;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/SackFunctions.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/SackFunctions.java
@@ -23,9 +23,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSe
 
 import java.util.function.Consumer;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.add;
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.div;
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.mul;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.add;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.div;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.mul;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxLocalStep.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.max;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.max;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanGlobalStep.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
-import org.apache.tinkerpop.gremlin.process.traversal.NumberHelper;
+import org.apache.tinkerpop.gremlin.util.NumberHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
@@ -31,8 +31,8 @@ import java.util.Set;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.div;
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.mul;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.div;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.mul;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanLocalStep.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
-import org.apache.tinkerpop.gremlin.process.traversal.NumberHelper;
+import org.apache.tinkerpop.gremlin.util.NumberHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinLocalStep.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.min;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.min;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumGlobalStep.java
@@ -29,7 +29,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.BinaryOperator;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.NumberHelper.mul;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.mul;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStep.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
-import org.apache.tinkerpop.gremlin.process.traversal.NumberHelper;
+import org.apache.tinkerpop.gremlin.util.NumberHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.tinkerpop.gremlin.process.traversal;
+package org.apache.tinkerpop.gremlin.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -40,7 +40,6 @@ public class NumberHelper {
                 final byte x = a.byteValue(), y = b.byteValue();
                 return x >= y ? x : y;
             });
-
     static final NumberHelper SHORT_NUMBER_HELPER = new NumberHelper(
             (a, b) -> a.shortValue() + b.shortValue(),
             (a, b) -> a.shortValue() - b.shortValue(),
@@ -54,7 +53,6 @@ public class NumberHelper {
                 final short x = a.shortValue(), y = b.shortValue();
                 return x >= y ? x : y;
             });
-
     static final NumberHelper INTEGER_NUMBER_HELPER = new NumberHelper(
             (a, b) -> a.intValue() + b.intValue(),
             (a, b) -> a.intValue() - b.intValue(),
@@ -68,7 +66,6 @@ public class NumberHelper {
                 final int x = a.intValue(), y = b.intValue();
                 return x >= y ? x : y;
             });
-
     static final NumberHelper LONG_NUMBER_HELPER = new NumberHelper(
             (a, b) -> a.longValue() + b.longValue(),
             (a, b) -> a.longValue() - b.longValue(),
@@ -82,7 +79,6 @@ public class NumberHelper {
                 final long x = a.longValue(), y = b.longValue();
                 return x >= y ? x : y;
             });
-
     static final NumberHelper BIG_INTEGER_NUMBER_HELPER = new NumberHelper(
             (a, b) -> bigIntegerValue(a).add(bigIntegerValue(b)),
             (a, b) -> bigIntegerValue(a).subtract(bigIntegerValue(b)),
@@ -96,7 +92,6 @@ public class NumberHelper {
                 final BigInteger x = bigIntegerValue(a), y = bigIntegerValue(b);
                 return x.compareTo(y) >= 0 ? x : y;
             });
-
     static final NumberHelper FLOAT_NUMBER_HELPER = new NumberHelper(
             (a, b) -> a.floatValue() + b.floatValue(),
             (a, b) -> a.floatValue() - b.floatValue(),
@@ -110,7 +105,6 @@ public class NumberHelper {
                 final float x = a.floatValue(), y = b.floatValue();
                 return x >= y ? x : y;
             });
-
     static final NumberHelper DOUBLE_NUMBER_HELPER = new NumberHelper(
             (a, b) -> a.doubleValue() + b.doubleValue(),
             (a, b) -> a.doubleValue() - b.doubleValue(),
@@ -124,7 +118,6 @@ public class NumberHelper {
                 final double x = a.doubleValue(), y = b.doubleValue();
                 return x >= y ? x : y;
             });
-
     static final NumberHelper BIG_DECIMAL_NUMBER_HELPER = new NumberHelper(
             (a, b) -> bigDecimalValue(a).add(bigDecimalValue(b)),
             (a, b) -> bigDecimalValue(a).subtract(bigDecimalValue(b)),
@@ -138,7 +131,6 @@ public class NumberHelper {
                 final BigDecimal x = bigDecimalValue(a), y = bigDecimalValue(b);
                 return x.compareTo(y) >= 0 ? x : y;
             });
-
     public final BiFunction<Number, Number, Number> add;
     public final BiFunction<Number, Number, Number> sub;
     public final BiFunction<Number, Number, Number> mul;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
@@ -25,7 +25,7 @@ import java.util.function.BiFunction;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public class NumberHelper {
+public final class NumberHelper {
 
     static final NumberHelper BYTE_NUMBER_HELPER = new NumberHelper(
             (a, b) -> a.byteValue() + b.byteValue(),

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
@@ -25,7 +25,7 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.ProgramPhase;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.MemoryTraversalSideEffects;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram;
-import org.apache.tinkerpop.gremlin.process.traversal.NumberHelper;
+import org.apache.tinkerpop.gremlin.util.NumberHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1399

Moved `NumberHelper` into `org.apache.tinkerpop.gremlin.util`. Note that it's not necessary to add a private constructor, since the only constructor that exists, is already private.

VOTE: +1