### PR TITLE
TINKERPOP-1545 IncidentToAdjacentStrategy is buggy (tp32)

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategyTest.java
@@ -69,6 +69,8 @@ public class IncidentToAdjacentStrategyTest {
                 {__.bothE().outV(), __.bothE().outV()},
                 {__.outE().as("a").inV(), __.outE().as("a").inV()}, // todo: this can be optimized, but requires a lot more checks
                 {__.outE().inV().path(), __.outE().inV().path()},
+                {__.outE().inV().simplePath(), __.outE().inV().simplePath()},
+                {__.outE().inV().cyclicPath(), __.outE().inV().cyclicPath()},
                 {__.outE().inV().tree().as("a"), __.outE().inV().tree().as("a")},
                 {__.outE().inV().map(lambda), __.outE().inV().map(lambda)},
                 {__.union(__.outE().inV(), __.inE().outV()).path(), __.union(__.outE().inV(), __.inE().outV()).path()},


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1545

Made SimplePathStep implement PathProcessor and IncidentToAdjacentStrategy skip all traversals that contain path processing steps.

VOTE: +1