### PR TITLE
TINKERPOP-1530 Consistent use of instance()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Added `ProjectStep.getProjectKeys()` for strategies that rely on such information.
 * Added `VertexFeatures.supportsDuplicateMultiProperties()` for graphs that only support unique values in multi-properties.
 * Deprecated the "performance" tests in `OptIn`.
+* Deprecated `getInstance()` methods in favor of `instance()` for better consistency with the rest of the API.
 * Block calls to "remote" traversal side-effects until the traversal read is complete which signifies an end to iteration.
 * Added `Pick.none` and `Pick.any` to the serializers and importers.
 * Added a class loader to `TraversalStrategies.GlobalCache` which guarantees strategies are registered prior to `GlobalCache.getStrategies()`.

--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -19,7 +19,7 @@ limitations under the License.
 *******************************************************************************
 import java.time.*
 mapper = GraphSONMapper.build().
-                        addRegistry(TinkerIoRegistry.getInstance()).
+                        addRegistry(TinkerIoRegistry.instance()).
                         addCustomModule(new org.apache.tinkerpop.gremlin.driver.ser.AbstractGraphSONMessageSerializerV1d0.GremlinServerModule()).
                         version(GraphSONVersion.V1_0).create().createMapper()
 graph = TinkerFactory.createTheCrew()
@@ -105,7 +105,7 @@ file.withWriter { writer ->
 }
 
 mapper = GraphSONMapper.build().
-                        addRegistry(TinkerIoRegistryV2d0.getInstance()).
+                        addRegistry(TinkerIoRegistryV2d0.instance()).
                         typeInfo(TypeInfo.PARTIAL_TYPES).
                         addCustomModule(GraphSONXModuleV2d0.build().create(false)).
                         addCustomModule(new org.apache.tinkerpop.gremlin.driver.ser.AbstractGraphSONMessageSerializerV2d0.GremlinServerModule()).

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -80,6 +80,16 @@ following fields were deprecated:
 * `OptIn.SUITE_PROCESS_PERFORMANCE`
 * `OptIn.SUITE_STRUCTURE_PERFORMANCE`
 
+Deprecated getInstance()
+++++++++++++++++++++++++
+
+TinkerPop has generally preferred static `instance()` methods over `getInstance()`, but `getInstance()` was used in
+some cases nonetheless. As of this release, `getInstance()` methods have been deprecated in favor of `instance()`.
+Of specific note, custom `IoRegistry` (as related to IO in general) and `Supplier<ClassResolver>` (as related to
+Gryo serialization in general) now both prefer `instance()` over `getInstance()` given this deprecation.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1530[TINKERPOP-1530]
+
 Drivers Providers
 ^^^^^^^^^^^^^^^^^
 

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/App.java
@@ -26,7 +26,7 @@ public class App {
     private static final Logger logger = LoggerFactory.getLogger(App.class);
 
     public static void main(String[] args) throws Exception {
-        Service service = Service.getInstance();
+        Service service = Service.instance();
         try {
             logger.info("Sending request....");
 

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
@@ -49,7 +49,7 @@ public class Service implements AutoCloseable {
 
     private Service() {}
 
-    public static Service getInstance() {
+    public static Service instance() {
         return INSTANCE;
     }
 

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/java/ServiceTest.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/java/ServiceTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.CoreMatchers.is;
 public class ServiceTest {
     private GremlinServer server;
 
-    private static Service service = Service.getInstance();
+    private static Service service = Service.instance();
 
     @Before
     public void setUp() throws Exception {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/SingleGremlinScriptEngineManager.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/SingleGremlinScriptEngineManager.java
@@ -28,7 +28,14 @@ public class SingleGremlinScriptEngineManager {
 
     private SingleGremlinScriptEngineManager() {}
 
+    /**
+     * @deprecated As of release 3.2.4, replaced by {@link #instance()}.
+     */
     public static GremlinScriptEngineManager getInstance(){
+        return instance();
+    }
+
+    public static GremlinScriptEngineManager instance(){
         return cached;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoRegistry.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoRegistry.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  * A generalized custom serializer registry for providers implementing a {@link Graph}.  Providers should develop an
  * implementation of this interface if their implementation requires custom serialization of identifiers or other
  * such content housed in their graph.  Consider extending from {@link AbstractIoRegistry} and ensure that the
- * implementation has a zero-arg constructor or a static "getInstance" method that returns an {@code IoRegistry}
+ * implementation has a zero-arg constructor or a static "instance" method that returns an {@code IoRegistry}
  * instance, as implementations may need to be constructed from reflection given different parts of the TinkerPop
  * stack.
  * <p/>

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoPool.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoPool.java
@@ -228,13 +228,13 @@ public final class GryoPool {
                     final String className = c.toString();
                     final Class<?> clazz = Class.forName(className);
                     try {
-                        final Method instanceMethod = clazz.getDeclaredMethod("getInstance");
+                        final Method instanceMethod = tryInstanceMethod(clazz);
                         if (IoRegistry.class.isAssignableFrom(instanceMethod.getReturnType()))
                             registries.add((IoRegistry) instanceMethod.invoke(null));
                         else
                             throw new Exception();
                     } catch (Exception methodex) {
-                        // tried getInstance() and that failed so try newInstance() no-arg constructor
+                        // tried instance() and that failed so try newInstance() no-arg constructor
                         registries.add((IoRegistry) clazz.newInstance());
                     }
                 } catch (Exception ex) {
@@ -242,6 +242,25 @@ public final class GryoPool {
                 }
             });
             return registries;
+        }
+
+        private static Method tryInstanceMethod(final Class clazz) {
+            Method instanceMethod;
+            try {
+                instanceMethod = clazz.getDeclaredMethod("instance");
+            } catch (Exception methodex) {
+                instanceMethod = null;
+            }
+
+            if (null == instanceMethod) {
+                try {
+                    instanceMethod = clazz.getDeclaredMethod("getInstance");
+                } catch (Exception methodex) {
+                    instanceMethod = null;
+                }
+            }
+
+            return instanceMethod;
         }
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/IoXIoRegistry.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/IoXIoRegistry.java
@@ -51,7 +51,7 @@ public class IoXIoRegistry {
             register(GryoIo.class, IoX.class, null);
         }
 
-        public static InstanceBased getInstance() {
+        public static InstanceBased instance() {
             return INSTANCE;
         }
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/IoYIoRegistry.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/IoYIoRegistry.java
@@ -46,7 +46,7 @@ public class IoYIoRegistry {
             register(GryoIo.class, IoY.class, null);
         }
 
-        public static InstanceBased getInstance() {
+        public static InstanceBased instance() {
             return INSTANCE;
         }
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapperTest.java
@@ -174,8 +174,8 @@ public class GryoMapperTest {
     @Test
     public void shouldRegisterMultipleIoRegistryToSerialize() throws Exception {
         final GryoMapper mapper = GryoMapper.build()
-                .addRegistry(IoXIoRegistry.InstanceBased.getInstance())
-                .addRegistry(IoYIoRegistry.InstanceBased.getInstance()).create();
+                .addRegistry(IoXIoRegistry.InstanceBased.instance())
+                .addRegistry(IoYIoRegistry.InstanceBased.instance()).create();
         final Kryo kryo = mapper.createMapper();
         try (final OutputStream stream = new ByteArrayOutputStream()) {
             final Output out = new Output(stream);
@@ -197,12 +197,12 @@ public class GryoMapperTest {
     @Test
     public void shouldExpectReadFailureAsIoRegistryOrderIsNotRespected() throws Exception {
         final GryoMapper mapperWrite = GryoMapper.build()
-                .addRegistry(IoXIoRegistry.InstanceBased.getInstance())
-                .addRegistry(IoYIoRegistry.InstanceBased.getInstance()).create();
+                .addRegistry(IoXIoRegistry.InstanceBased.instance())
+                .addRegistry(IoYIoRegistry.InstanceBased.instance()).create();
 
         final GryoMapper mapperRead = GryoMapper.build()
-                .addRegistry(IoYIoRegistry.InstanceBased.getInstance())
-                .addRegistry(IoXIoRegistry.InstanceBased.getInstance()).create();
+                .addRegistry(IoYIoRegistry.InstanceBased.instance())
+                .addRegistry(IoXIoRegistry.InstanceBased.instance()).create();
 
         final Kryo kryoWriter = mapperWrite.createMapper();
         final Kryo kryoReader = mapperRead.createMapper();

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGryoMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGryoMessageSerializerV1d0.java
@@ -124,10 +124,10 @@ public abstract class AbstractGryoMessageSerializerV1d0 extends AbstractMessageS
             try {
                 final Class<?> clazz = Class.forName(className);
                 try {
-                    final Method instanceMethod = clazz.getDeclaredMethod("getInstance");
+                    final Method instanceMethod = tryInstanceMethod(clazz);
                     builder.classResolver((Supplier<ClassResolver>) instanceMethod.invoke(null));
                 } catch (Exception methodex) {
-                    // tried getInstance() and that failed so try newInstance() no-arg constructor
+                    // tried instance() and that failed so try newInstance() no-arg constructor
                     builder.classResolver((Supplier<ClassResolver>) clazz.newInstance());
                 }
             } catch (Exception ex) {

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -233,7 +233,7 @@ public final class TinkerGraph implements Graph {
 
     @Override
     public <I extends Io> I io(final Io.Builder<I> builder) {
-        return (I) builder.graph(this).onMapper(mapper -> mapper.addRegistry(TinkerIoRegistry.getInstance())).create();
+        return (I) builder.graph(this).onMapper(mapper -> mapper.addRegistry(TinkerIoRegistry.instance())).create();
     }
 
     @Override

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistry.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistry.java
@@ -78,7 +78,15 @@ public final class TinkerIoRegistry extends AbstractIoRegistry {
         register(GraphSONIo.class, null, new TinkerModule());
     }
 
+    /**
+     * @deprecated As of release 3.2.4, replaced by {@link #instance()}.
+     */
+    @Deprecated
     public static TinkerIoRegistry getInstance() {
+        return instance();
+    }
+
+    public static TinkerIoRegistry instance() {
         return INSTANCE;
     }
 

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistryV2d0.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistryV2d0.java
@@ -74,7 +74,15 @@ public final class TinkerIoRegistryV2d0 extends AbstractIoRegistry {
         register(GraphSONIo.class, null, new TinkerModuleV2d0());
     }
 
+    /**
+     * @deprecated As of release 3.2.4, replaced by {@link #instance()}.
+     */
+    @Deprecated
     public static TinkerIoRegistryV2d0 getInstance() {
+        return INSTANCE;
+    }
+
+    public static TinkerIoRegistryV2d0 instance() {
         return INSTANCE;
     }
 

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGraphSONSerializerV2d0Test.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGraphSONSerializerV2d0Test.java
@@ -65,14 +65,14 @@ public class TinkerGraphGraphSONSerializerV2d0Test {
     private final Mapper defaultMapperV2d0 = GraphSONMapper.build()
             .version(GraphSONVersion.V2_0)
             .addCustomModule(GraphSONXModuleV2d0.build().create(false))
-            .addRegistry(TinkerIoRegistryV2d0.getInstance())
+            .addRegistry(TinkerIoRegistryV2d0.instance())
             .create();
 
     private final Mapper noTypesMapperV2d0 = GraphSONMapper.build()
             .version(GraphSONVersion.V2_0)
             .addCustomModule(GraphSONXModuleV2d0.build().create(false))
             .typeInfo(TypeInfo.NO_TYPES)
-            .addRegistry(TinkerIoRegistryV2d0.getInstance())
+            .addRegistry(TinkerIoRegistryV2d0.instance())
             .create();
 
     /**

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -521,7 +521,7 @@ public class TinkerGraphTest {
         final ArrayList<Color> colorList = new ArrayList<>(Arrays.asList(Color.RED, Color.GREEN));
 
         final Supplier<ClassResolver> classResolver = new CustomClassResolverSupplier();
-        final GryoMapper mapper = GryoMapper.build().addRegistry(TinkerIoRegistry.getInstance()).classResolver(classResolver).create();
+        final GryoMapper mapper = GryoMapper.build().addRegistry(TinkerIoRegistry.instance()).classResolver(classResolver).create();
         final Kryo kryo = mapper.createMapper();
         try (final ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
             final Output out = new Output(stream);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1530

Deprecated `getInstance()` usage in favor of `instance()`. This is a non-breaking change for 3.2.0. Will likely remove the deprecated methods for 3.3.0 as a breaking change

All good with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1