### PR TITLE
TINKERPOP-1556 allow developers to pass options to docker

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,12 @@ TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fully shutdown metrics services in Gremlin Server on shutdown.
 * Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.
+* Allow developers to pass options to `docker run` with DOCKER_OPTS environment variable
+
+Improvements
+^^^^^^^^^^^^
+
+* TINKERPOP-1556 Allow Hadoop to run on IPv6 systems
 
 [[release-3-1-5]]
 TinkerPop 3.1.5 (Release Date: October 17, 2016)

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,6 +47,6 @@ CMD ["sh", "-c", "docker/scripts/build.sh $@"]
 EOF
 
 docker build -t tinkerpop:${BUILD_TAG} .
-docker run --rm -ti tinkerpop:${BUILD_TAG}
+docker run ${DOCKER_OPTS} --rm -ti tinkerpop:${BUILD_TAG}
 
 popd > /dev/null


### PR DESCRIPTION
This was a much smaller change than I expected. Originally I was adding some sysctl settings to the dockerfiles. In the end I discovered I could control that and much more from docker itself. So I'm going to go ahead and commit this small change.

example:
```
export DOCKER_OPTS="--cpuset-cpus 0-3 --sysctl net.ipv6.conf.all.disable_ipv6=1 --sysctl net.ipv6.conf.default.disable_ipv6=1"

./docker/build.sh -t -n -i
```