### PR TITLE
TINKERPOP-1557 Improve docker build time with this one weird trick!

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,7 +31,7 @@ TinkerPop 3.1.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fully shutdown metrics services in Gremlin Server on shutdown.
 * Deprecated `tryRandomCommit()` in `AbstractGremlinTest` - the annotation was never added in 3.1.1, and was only deprecated via javadoc.
 * Minor fixes to various test feature requirements in `gremlin-test`.
-* Allow developers to pass options to `docker run` with DOCKER_OPTS environment variable
+* Allow developers to pass options to `docker run` with TINKERPOP_DOCKER_OPTS environment variable
 
 Improvements
 ^^^^^^^^^^^^

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,6 +47,6 @@ CMD ["sh", "-c", "docker/scripts/build.sh $@"]
 EOF
 
 docker build -t tinkerpop:${BUILD_TAG} .
-docker run ${DOCKER_OPTS} --rm -ti tinkerpop:${BUILD_TAG}
+docker run ${TINKERPOP_DOCKER_OPTS} --rm -ti tinkerpop:${BUILD_TAG}
 
 popd > /dev/null

--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -56,6 +56,13 @@ TINKERPOP_BUILD_OPTIONS=""
 [ -z "${INCLUDE_NEO4J}" ] || TINKERPOP_BUILD_OPTIONS="${TINKERPOP_BUILD_OPTIONS} -DincludeNeo4j"
 [ -z "${BUILD_JAVA_DOCS}" ] && TINKERPOP_BUILD_OPTIONS="${TINKERPOP_BUILD_OPTIONS} -Dmaven.javadoc.skip=true"
 
+# If the tmpfs (in-memory filesystem exists, use it)
+if [ -d "/usr/src/tinkermem" ]; then
+  echo Copying source to in-memory tmpfs
+  rsync -a . /usr/src/tinkermem
+  cd /usr/src/tinkermem
+fi
+
 mvn clean install process-resources ${TINKERPOP_BUILD_OPTIONS} || exit 1
 [ -z "${BUILD_JAVA_DOCS}" ] || mvn process-resources -Djavadoc || exit 1
 

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -56,7 +56,7 @@ Docker Integration
 ------------------
 
 TinkerPop provides a shell script, that can start several build tasks within a Docker container. The
-required Docker images will be built automatically if they don't exist yet. Thus the first invokation
+required Docker images will be built automatically if they don't exist yet. Thus the first invocation
 of the Docker script is expected to take some time.
 
 The script can be found under `PROJECT_HOME/docker/build.sh`. The following tasks are currently
@@ -70,10 +70,26 @@ supported:
 A list of command line options is provided by `docker/build.sh --help`. The container will install,
 configure and start all required dependencies, such as Hadoop.
 
+Options can be passed to Docker by setting the `TINKERPOP_DOCKER_OPTS` environment variable. A speed boost can
+be gained at the expense of memory by using tmpfs and the special directory `/usr/src/tinkermem`.
+
+[source,bash]
+.Build in-memory
+----
+TINKERPOP_DOCKER_OPTS="--tmpfs /usr/src/tinkermem:exec,mode=0755,rw,noatime,size=2000m"
+----
+
+[source,bash]
+.Disable IPv6 for Hadoop
+----
+TINKERPOP_DOCKER_OPTS="--sysctl net.ipv6.conf.all.disable_ipv6=1 --sysctl net.ipv6.conf.default.disable_ipv6=1"
+----
+
 If the container is used to generate the user docs, it will start a web server and show the URL that
 is used to host the HTML docs.
 
 After finishing all tasks, the script will immediately destroy the container.
+
 
 IDE Setup with Intellij
 -----------------------

--- a/giraph-gremlin/src/test/resources/giraph-site.xml
+++ b/giraph-gremlin/src/test/resources/giraph-site.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <property>
+        <name>giraph.zkServerlistPollMsecs</name>
+        <value>500</value>
+    </property>
+    <property>
+        <name>giraph.logLevel</name>
+        <value>info</value>
+    </property>
+</configuration>


### PR DESCRIPTION
Total time went from just over 4 hours to 2:20m. Get back 1:40m of your cycles!

Giraph: startup would wait 3s to connect. solution: wait less. There's still about 7s for shutting down that can be gained back  per test!

Neo4j: very disk IO heavy. solution: work in memory. this benefits the entire build as well. This requires something special below.

In order to build in-memory, you must configure tmpfs with the magical directory name `/usr/src/tinkermem`.

example: 

```
export DOCKER_OPTS="--tmpfs /usr/src/tinkermem:exec,mode=0755,rw,noatime,size=1000m"
```

You can use `1000m` for typical `-t -i -n` usage.  Use `2000m` if building the world plus javadoc, asciidocs.
 
I will add some of this to the docker contributing / development-environment docs.
