### PR TITLE
TINKERPOP-1548: Traversals can complete before interrupted in TraversalInterruptionComputerTest

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -59,6 +59,7 @@ TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Added a class loader to `TraversalStrategies.GlobalCache` which guarantees strategies are registered prior to `GlobalCache.getStrategies()`.
 * Fixed a severe bug where `GraphComputer` strategies are not being loaded until the second use of the traversal source.
 * The root traversal now throws regular `NoSuchElementException` instead of `FastNoSuchElementException`. (*breaking*)
+* Added a short sleep to prevent traversal from finishing before it can be interrupted during `TraversalInterruptionComputerTest`.
 
 [[release-3-2-3]]
 TinkerPop 3.2.3 (Release Date: October 17, 2016)


### PR DESCRIPTION
I added a short sleep to prevent traversal from finishing before it can be interrupted during `TraversalInterruptionComputerTest`.

This is a small update but I want to make sure this doesn't cause any build issues for folks.  I was getting this failure before the fix regularly.  After this fix, I've had 10 good runs without issue also `docker/build.sh -t -i -n` succeeded.

VOTE: +1