### PR TITLE
TINKERPOP-1561 gremiln-python GraphSONWriter doesn't properly serialize long in Python 3.5

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -285,6 +285,16 @@ class Int32IO(_NumberIO):
     graphson_type = "g:Int32"
     graphson_base_type = "Int32"
 
+    @classmethod
+    def dictify(cls, n, writer):
+        if isinstance(n, bool):
+            return n
+        if isinstance(n, LongType):
+            graphson_base_type = Int64IO.graphson_base_type
+        else:
+            graphson_base_type = cls.graphson_base_type
+        return GraphSONUtil.typedValue(graphson_base_type, n)
+
 
 class VertexDeserializer(_GraphSONTypeIO):
     graphson_type = "g:Vertex"

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
@@ -179,6 +179,16 @@ class TestGraphSONWriter(TestCase):
         serdes.dictify.assert_called_once_with(value, writer)
         assert d is serdes.dictify()
 
+    def test_write_long(self):
+
+        mapping = self.graphson_writer.toDict(1)
+        assert mapping['@type'] == 'g:Int32'
+        assert mapping['@value'] == 1
+
+        mapping = self.graphson_writer.toDict(long(1))
+        assert mapping['@type'] == 'g:Int64'
+        assert mapping['@value'] == 1
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1561

Added custom `dictify()` method to `Int32IO` that checks for long type. This ensures proper serialization of `long` when using Python 3. Originally in the Jira ticket I proposed a different approach, but after looking more closely this is the simplest approach. 

VOTE +1