### PR TITLE
TINKERPOP-1363 Cleanup Docker build script for next major release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Updated Docker build scripts to include Python dependencies (NOTE: users should remove any previously generated TinkerPop Docker images).
 * Added "attachment requisite" `VertexProperty.element()` and `Property.element()` data in GraphSON serialization.
 * Added `Vertex`, `Edge`, `VertexProperty`, and `Property` serializers to Gremlin-Python and exposed tests that use graph object arguments.
 * `Bytecode.getSourceInstructions()` and `Bytecode.getStepInstructions()` now returns `List<Instruction>` instead of `Iterable<Instruction>`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,10 @@ RUN apt-get update \
     && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
     && add-apt-repository -y ppa:webupd8team/java \
     && apt-get update \
-    && apt-get install -y oracle-java8-installer curl gawk git maven openssh-server \
+    && apt-get install -y oracle-java8-installer curl gawk git maven openssh-server subversion \
+    && apt-get install -y python python-dev python-pip build-essential \
+    && pip install virtualenv virtualenvwrapper \
+    && pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* /var/cache/oracle-jdk8-installer
 
 RUN sed -i 's@PermitRootLogin without-password@PermitRootLogin yes@' /etc/ssh/sshd_config

--- a/docker/build/Dockerfile.template
+++ b/docker/build/Dockerfile.template
@@ -18,6 +18,5 @@
 FROM tinkerpop:hadoop-HADOOP_VERSION
 
 RUN mkdir -p /usr/src/tinkerpop
-RUN curl -s https://bootstrap.pypa.io/ez_setup.py | python
 WORKDIR /usr/src/tinkerpop
 COPY . /usr/src/tinkerpop

--- a/docker/resources/groovy/grapeConfig.xml
+++ b/docker/resources/groovy/grapeConfig.xml
@@ -1,15 +1,22 @@
 <ivysettings>
   <settings defaultResolver="downloadGrapes"/>
+  <property name="m2-pattern" value="${user.home}/.m2/repository/org/apache/tinkerpop/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" />
+  <property name="m2-pattern-ivy" value="${user.home}/.m2/repository/org/apache/tinkerpop/[module]/[revision]/[module]-[revision](-[classifier]).pom" />
+  <caches>
+    <cache name="nocache" useOrigin="true" />
+  </caches>
   <resolvers>
     <chain name="downloadGrapes">
+      <filesystem name="local-maven2" checkmodified="true" changingPattern=".*" changingMatcher="regexp" m2compatible="true" cache="nocache">
+        <artifact pattern="${m2-pattern}"/>
+        <ivy pattern="${m2-pattern-ivy}"/>
+      </filesystem>
       <filesystem name="cachedGrapes">
         <ivy pattern="${user.home}/.groovy/grapes/[organisation]/[module]/ivy-[revision].xml"/>
         <artifact pattern="${user.home}/.groovy/grapes/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]"/>
       </filesystem>
-      <ibiblio name="codehaus" root="http://repository.codehaus.org/" m2compatible="true"/>
-      <ibiblio name="central" root="http://central.maven.org/maven2/" m2compatible="true"/>
-      <ibiblio name="java.net2" root="http://download.java.net/maven/2/" m2compatible="true"/>
-      <ibiblio name="hyracs-releases" root="http://obelix.ics.uci.edu/nexus/content/groups/hyracks-public-releases/" m2compatible="true"/>
+      <ibiblio name="ibiblio" m2compatible="true"/>
+      <ibiblio name="jitpack" root="https://jitpack.io" m2compatible="true"/>
       <ibiblio name="local" root="file:${user.home}/.m2/repository/" m2compatible="true"/>
     </chain>
   </resolvers>

--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -57,10 +57,14 @@ TINKERPOP_BUILD_OPTIONS=""
 [ -z "${BUILD_JAVA_DOCS}" ] && TINKERPOP_BUILD_OPTIONS="${TINKERPOP_BUILD_OPTIONS} -Dmaven.javadoc.skip=true"
 
 # If the tmpfs (in-memory filesystem exists, use it)
-if [ -d "/usr/src/tinkermem" ]; then
-  echo Copying source to in-memory tmpfs
-  rsync -a . /usr/src/tinkermem
-  cd /usr/src/tinkermem
+TINKERMEM_PATH=$(cd .. ; echo `pwd`/tinkermem)
+if [ -d "${TINKERMEM_PATH}" ]; then
+  echo "Moving source to in-memory tmpfs"
+  rsync --remove-source-files -a . ${TINKERMEM_PATH}
+  cd ..
+  rm -rf ${OLDPWD}
+  ln -s ${TINKERMEM_PATH} ${OLDPWD}
+  cd ${TINKERMEM_PATH}
 fi
 
 touch gremlin-python/.glv

--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -63,6 +63,8 @@ if [ -d "/usr/src/tinkermem" ]; then
   cd /usr/src/tinkermem
 fi
 
+touch gremlin-python/.glv
+
 mvn clean install process-resources ${TINKERPOP_BUILD_OPTIONS} || exit 1
 [ -z "${BUILD_JAVA_DOCS}" ] || mvn process-resources -Djavadoc || exit 1
 

--- a/docs/preprocessor/install-plugins.sh
+++ b/docs/preprocessor/install-plugins.sh
@@ -59,7 +59,11 @@ echo "System.exit(0)" >> ${INSTALL_FILE}
 echo -ne " * tinkerpop-sugar ... "
 
 pushd ${CONSOLE_HOME} > /dev/null
-bin/gremlin.sh ${INSTALL_FILE} > /dev/null
+
+mkdir -p ~/.java/.userPrefs
+chmod 700 ~/.java/.userPrefs
+
+bin/gremlin.sh -e ${INSTALL_FILE} > /dev/null
 
 if [ ${PIPESTATUS[0]} -ne 0 ]; then
   popd > /dev/null

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -31,12 +31,12 @@ Console and Server, where a universal plugin system makes it possible to extend 
 important aspects of the plugin system is the ability to help the user install the plugins through the command line
 thus automating the process of gathering dependencies and other error prone activities.
 
-The process of plugin installation is handled by link:http://groovy.codehaus.org/Grape[Grape], which helps resolve
+The process of plugin installation is handled by link:http://www.groovy-lang.org/Grape[Grape], which helps resolve
 dependencies into the classpath.  It is therefore important to ensure that Grape is properly configured in order to
 use the automated capabilities of plugin installation.  Grape is configured by `~/.groovy/grapeConfig.xml` and
 generally speaking, if that file is not present, the default settings will suffice.  However, they will not suffice
 if a required dependency is not in one of the default configured repositories. Please see the
-link:http://groovy.codehaus.org/Grape[Custom Ivy Settings] section of the Grape documentation for more details on
+link:http://www.groovy-lang.org/Grape#Grape-CustomizeIvysettings[Customize Ivy settings] section of the Grape documentation for more details on
 the defaults.  TinkerPop recommends the following configuration in that file:
 
 [source,xml]
@@ -48,28 +48,44 @@ the defaults.  TinkerPop recommends the following configuration in that file:
         <ivy pattern="${user.home}/.groovy/grapes/[organisation]/[module]/ivy-[revision].xml"/>
         <artifact pattern="${user.home}/.groovy/grapes/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]"/>
       </filesystem>
-      <ibiblio name="codehaus" root="http://repository.codehaus.org/" m2compatible="true"/>
-      <ibiblio name="central" root="http://central.maven.org/maven2/" m2compatible="true"/>
+      <ibiblio name="ibiblio" m2compatible="true"/>
       <ibiblio name="jitpack" root="https://jitpack.io" m2compatible="true"/>
-      <ibiblio name="java.net2" root="http://download.java.net/maven/2/" m2compatible="true"/>
     </chain>
   </resolvers>
 </ivysettings>
 
-The Graph configuration can also be modified to include the local system's Maven `.m2` directory by one or both
-of the following entries:
+The Graph configuration can also be modified to include the local system's Maven `.m2` directory:
 
 [source,xml]
-<ibiblio name="apache-snapshots" root="http://repository.apache.org/snapshots/" m2compatible="true"/>
-<ibiblio name="local" root="file:${user.home}/.m2/repository/" m2compatible="true"/>
+<ivysettings>
+  <settings defaultResolver="downloadGrapes"/>
+  <property name="m2-pattern" value="${user.home}/.m2/repository/org/apache/tinkerpop/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" />
+  <property name="m2-pattern-ivy" value="${user.home}/.m2/repository/org/apache/tinkerpop/[module]/[revision]/[module]-[revision](-[classifier]).pom" />
+  <caches>
+    <cache name="nocache" useOrigin="true" />
+  </caches>
+  <resolvers>
+    <chain name="downloadGrapes">
+      <!-- https://mvmn.wordpress.com/2016/02/02/grape-config-for-local-maven-repo/ -->
+      <filesystem name="local-maven2" checkmodified="true" changingPattern=".*" changingMatcher="regexp" m2compatible="true" cache="nocache">
+        <artifact pattern="${m2-pattern}"/>
+        <ivy pattern="${m2-pattern-ivy}"/>
+      </filesystem>
+      <filesystem name="cachedGrapes">
+        <ivy pattern="${user.home}/.groovy/grapes/[organisation]/[module]/ivy-[revision].xml"/>
+        <artifact pattern="${user.home}/.groovy/grapes/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]"/>
+      </filesystem>
+      <ibiblio name="ibiblio" m2compatible="true"/>
+      <ibiblio name="jitpack" root="https://jitpack.io" m2compatible="true"/>
+      <ibiblio name="local" root="file:${user.home}/.m2/repository/" m2compatible="true"/>
+    </chain>
+  </resolvers>
+</ivysettings>
 
 These configurations are useful during development (i.e. if one is working with locally built artifacts) of TinkerPop
 Plugins.  It is important to take note of the order used for these references as Grape will check them in the order
 they are specified and depending on that order, an artifact other than the one expected may be used which is typically
 an issue when working with SNAPSHOT dependencies.
-
-WARNING: If building TinkerPop from source, be sure to clear TinkerPop-related jars from the `~/.groovy/grapes`
-directory as they can become stale on some systems and not re-import properly from the local `.m2` after fresh rebuilds.
 
 [[gremlin-console]]
 Gremlin Console


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1363

Now that i squashed all my commits into 2 commits, it looks like this was all done in no time, what a shame!

Anyway, Python stuff is now part of the base image (this change requires that you - the tester - rebuild your Docker images; just drop the old ones).

I've also cleaned up the docs, which contained some dead links to a Groovy site that longer exists. Furthermore I updated `grapeConfig.xml` - in the docs and the one used by the Docker build script. Note that your local `grapeConfig.xml` may look different and still work, but I swear, what we have in this PR is the only way to make it work a) in Docker and b) on brand new development machines. Any other configuration will likely lead to failures when you try to install Console plugins.

VOTE: +1