### PR TITLE
TINKERPOP-1576 gremlin-python calls non-existent methods

### DIFF
--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
@@ -159,6 +159,7 @@ under the License.
         __.class.getMethods().
                 findAll { GraphTraversal.class.equals(it.returnType) }.
                 findAll { Modifier.isStatic(it.getModifiers()) }.
+                findAll { !it.name.equals("__") && !it.name.equals("start") }.
                 collect { SymbolHelper.toPython(it.name) }.
                 unique().
                 sort { a, b -> a <=> b }.
@@ -174,7 +175,7 @@ under the License.
         __.class.getMethods().
                 findAll { GraphTraversal.class.equals(it.returnType) }.
                 findAll { Modifier.isStatic(it.getModifiers()) }.
-                findAll { !it.name.equals("__") }.
+                findAll { !it.name.equals("__") && !it.name.equals("start") }.
                 collect { SymbolHelper.toPython(it.name) }.
                 unique().
                 sort { a, b -> a <=> b }.

--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
@@ -155,7 +155,15 @@ under the License.
 ////////////////////////
 // AnonymousTraversal //
 ////////////////////////
-        pythonClass.append("class __(object):\n");
+        pythonClass.append(
+                """class __(object):
+  @staticmethod
+  def start():
+    return GraphTraversal(None, None, Bytecode())
+  @staticmethod
+  def __(*args):
+    return __.inject(*args)
+""")
         __.class.getMethods().
                 findAll { GraphTraversal.class.equals(it.returnType) }.
                 findAll { Modifier.isStatic(it.getModifiers()) }.
@@ -175,7 +183,7 @@ under the License.
         __.class.getMethods().
                 findAll { GraphTraversal.class.equals(it.returnType) }.
                 findAll { Modifier.isStatic(it.getModifiers()) }.
-                findAll { !it.name.equals("__") && !it.name.equals("start") }.
+                findAll { !it.name.equals("__") }.
                 collect { SymbolHelper.toPython(it.name) }.
                 unique().
                 sort { a, b -> a <=> b }.

--- a/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
+++ b/gremlin-python/src/main/groovy/org/apache/tinkerpop/gremlin/python/GraphTraversalSourceGenerator.groovy
@@ -183,7 +183,7 @@ under the License.
         __.class.getMethods().
                 findAll { GraphTraversal.class.equals(it.returnType) }.
                 findAll { Modifier.isStatic(it.getModifiers()) }.
-                findAll { !it.name.equals("__") }.
+                findAll { !it.name.equals("__") && !it.name.equals("start") }.
                 collect { SymbolHelper.toPython(it.name) }.
                 unique().
                 sort { a, b -> a <=> b }.

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -392,6 +392,12 @@ class GraphTraversal(Traversal):
 
 class __(object):
   @staticmethod
+  def start():
+    return GraphTraversal(None, None, Bytecode())
+  @staticmethod
+  def __(*args):
+    return __.inject(*args)
+  @staticmethod
   def V(*args):
     return GraphTraversal(None, None, Bytecode()).V(*args)
   @staticmethod
@@ -1035,6 +1041,11 @@ def simplePath(*args):
       return __.simplePath(*args)
 
 statics.add_static('simplePath', simplePath)
+
+def start(*args):
+      return __.start(*args)
+
+statics.add_static('start', start)
 
 def store(*args):
       return __.store(*args)

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -1042,11 +1042,6 @@ def simplePath(*args):
 
 statics.add_static('simplePath', simplePath)
 
-def start(*args):
-      return __.start(*args)
-
-statics.add_static('start', start)
-
 def store(*args):
       return __.store(*args)
 

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -395,9 +395,6 @@ class __(object):
   def V(*args):
     return GraphTraversal(None, None, Bytecode()).V(*args)
   @staticmethod
-  def __(*args):
-    return GraphTraversal(None, None, Bytecode()).__(*args)
-  @staticmethod
   def addE(*args):
     return GraphTraversal(None, None, Bytecode()).addE(*args)
   @staticmethod
@@ -616,9 +613,6 @@ class __(object):
   @staticmethod
   def simplePath(*args):
     return GraphTraversal(None, None, Bytecode()).simplePath(*args)
-  @staticmethod
-  def start(*args):
-    return GraphTraversal(None, None, Bytecode()).start(*args)
   @staticmethod
   def store(*args):
     return GraphTraversal(None, None, Bytecode()).store(*args)
@@ -1041,11 +1035,6 @@ def simplePath(*args):
       return __.simplePath(*args)
 
 statics.add_static('simplePath', simplePath)
-
-def start(*args):
-      return __.start(*args)
-
-statics.add_static('start', start)
 
 def store(*args):
       return __.store(*args)

--- a/gremlin-python/src/main/jython/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/jython/tests/process/test_traversal.py
@@ -73,6 +73,19 @@ class TestTraversal(TestCase):
         assert "and(or(lt(b),gt(c)),or(neq(d),gte(e)))" == str(
             P.lt("b").or_(P.gt("c")).and_(P.neq("d").or_(P.gte("e"))))
 
+    def test_anonymous_traversal(self):
+        bytecode = __.__(1).bytecode
+        assert 0 == len(bytecode.bindings.keys())
+        assert 0 == len(bytecode.source_instructions)
+        assert 1 == len(bytecode.step_instructions)
+        assert "inject" == bytecode.step_instructions[0][0]
+        assert 1 == bytecode.step_instructions[0][1]
+        ##
+        bytecode = __.start().bytecode
+        assert 0 == len(bytecode.bindings.keys())
+        assert 0 == len(bytecode.source_instructions)
+        assert 0 == len(bytecode.step_instructions)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1576

This removes the methods `__.__()` and `__.start()` from gremlin-python as they called the respective methods on `GraphTraversal` which doesn't have those methods.