### PR TITLE
TINKERPOP-1570 Bumped to Netty 4.0.42

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Bumped to Netty 4.0.42.final.
 * Fixed a bug in Gremlin-Python around `__.__()` and `__.start()`.
 * Fixed a bug around long serialization in Gremlin-Python when using Python3.
 * Deprecated `TraversalSource.withBindings()` as it is no longer needed in Gremlin-Java and never was needed for other variants.

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
     <artifactId>gremlin-driver</artifactId>
     <name>Apache TinkerPop :: Gremlin Driver</name>
     <properties>
-        <netty.version>4.0.40.Final</netty.version>
+        <netty.version>4.0.42.Final</netty.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1570

Pretty simple, but a version bump so worth a VOTE.  Works with `docker/build.sh -t -i -n` and did a local run of gremlin-server integration tests. Seems all good. I don't see any new dependencies in the packaging so no changes to LICENSE/NOTICE.

VOTE +1