### PR TITLE
TINKERPOP-1582 - Encode Bytecode as a dict, not a string

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
@@ -66,7 +66,7 @@ class DriverRemoteConnection(RemoteConnection):
             "op": "bytecode",
             "processor": "traversal",
             "args": {
-                "gremlin": self._graphson_writer.writeObject(bytecode),
+                "gremlin": self._graphson_writer.toDict(bytecode),
                 "aliases": {"g": self.traversal_source}
             }
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1582

Remote connection driver was encoding the Gremlin Bytecode as a json string, rather than as a dict.  This caused the TraversalOpProcessor to not use the gremlin-server configured deserializers, but rather a non-configurable statically declared serializer to decode the Bytecode string.