### PR TITLE
TINKERPOP-1581 Gremlin-Python driver connection is not thread safe.

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
@@ -39,7 +39,9 @@ class DriverRemoteConnection(RemoteConnection):
         self._url = url
         self._username = username
         self._password = password
-        if loop is None: self._loop = ioloop.IOLoop.current()
+        if loop is None:
+            loop = ioloop.IOLoop.current()
+        self._loop = loop
         self._websocket = self._loop.run_sync(lambda: websocket.websocket_connect(self.url))
         self._graphson_reader = graphson_reader or GraphSONReader()
         self._graphson_writer = graphson_writer or GraphSONWriter()

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
@@ -1,0 +1,69 @@
+import sys
+from queue import Queue
+from threading import Thread
+
+import pytest
+
+from tornado import ioloop
+
+from gremlin_python.driver.driver_remote_connection import (
+    DriverRemoteConnection)
+from gremlin_python.structure.graph import Graph
+
+
+skip = False
+try:
+    connection = DriverRemoteConnection('ws://localhost:8182/gremlin', 'g')
+    connection.close()
+except:
+    skip = True
+
+
+@pytest.mark.skipif(skip, reason='Gremlin Server is not running')
+class TestDriverRemoteConnectionThreaded:
+
+    def test_threaded_client(self):
+        q = Queue()
+        # Here if we give each thread its own loop there is no problem.
+        loop1 = ioloop.IOLoop()
+        loop2 = ioloop.IOLoop()
+        child = Thread(target=self._executor, args=(q, loop1))
+        child2 = Thread(target=self._executor, args=(q, loop2))
+        child.start()
+        child2.start()
+        for x in range(2):
+            success = q.get()
+            assert success == 'success!'
+        child.join()
+        child2.join()
+
+    def test_threaded_client_error(self):
+        q = Queue()
+        # This scenario fails because both threads try to access the main
+        # thread event loop - bad - each thread needs its own loop.
+        # This is what happens when you can't manually set the loop.
+        child = Thread(target=self._executor, args=(q, None))
+        child2 = Thread(target=self._executor, args=(q, None))
+        child.start()
+        child2.start()
+        with pytest.raises(RuntimeError):
+            try:
+                for x in range(2):
+                    exc = q.get()
+                    if issubclass(exc, Exception):
+                        raise exc()
+            finally:
+                child.join()
+                child2.join()
+
+    def _executor(self, q, loop):
+        try:
+            connection = DriverRemoteConnection(
+                'ws://localhost:8182/gremlin', 'g', loop=loop)
+            g = Graph().traversal().withRemote(connection)
+            assert len(g.V().toList()) == 6
+        except:
+            q.put(sys.exc_info()[0])
+        else:
+            q.put('success!')
+            connection.close()

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
@@ -1,3 +1,26 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+'''
+
+
+__author__ = 'David M. Brown (davebshow@gmail.com)'
+
+
 import sys
 from threading import Thread
 

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
@@ -1,9 +1,9 @@
 import sys
-from queue import Queue
 from threading import Thread
 
 import pytest
 
+from six.moves import queue
 from tornado import ioloop
 
 from gremlin_python.driver.driver_remote_connection import (
@@ -13,7 +13,7 @@ from gremlin_python.structure.graph import Graph
 
 skip = False
 try:
-    connection = DriverRemoteConnection('ws://localhost:8182/gremlin', 'g')
+    connection = DriverRemoteConnection('ws://localhost:45940/gremlin', 'g')
     connection.close()
 except:
     skip = True
@@ -23,7 +23,7 @@ except:
 class TestDriverRemoteConnectionThreaded:
 
     def test_threaded_client(self):
-        q = Queue()
+        q = queue.Queue()
         # Here if we give each thread its own loop there is no problem.
         loop1 = ioloop.IOLoop()
         loop2 = ioloop.IOLoop()
@@ -38,7 +38,7 @@ class TestDriverRemoteConnectionThreaded:
         child2.join()
 
     def test_threaded_client_error(self):
-        q = Queue()
+        q = queue.Queue()
         # This scenario fails because both threads try to access the main
         # thread event loop - bad - each thread needs its own loop.
         # This is what happens when you can't manually set the loop.
@@ -59,7 +59,7 @@ class TestDriverRemoteConnectionThreaded:
     def _executor(self, q, loop):
         try:
             connection = DriverRemoteConnection(
-                'ws://localhost:8182/gremlin', 'g', loop=loop)
+                'ws://localhost:45940/gremlin', 'g', loop=loop)
             g = Graph().traversal().withRemote(connection)
             assert len(g.V().toList()) == 6
         except:

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
@@ -60,25 +60,6 @@ class TestDriverRemoteConnectionThreaded:
         child.join()
         child2.join()
 
-    def test_threaded_client_error(self):
-        q = queue.Queue()
-        # This scenario fails because both threads try to access the main
-        # thread event loop - bad - each thread needs its own loop.
-        # This is what happens when you can't manually set the loop.
-        child = Thread(target=self._executor, args=(q, None))
-        child2 = Thread(target=self._executor, args=(q, None))
-        child.start()
-        child2.start()
-        with pytest.raises(RuntimeError):
-            try:
-                for x in range(2):
-                    exc = q.get()
-                    if issubclass(exc, Exception):
-                        raise exc()
-            finally:
-                child.join()
-                child2.join()
-
     def _executor(self, q, loop):
         try:
             connection = DriverRemoteConnection(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1581

This was a simple fix. The `DriverRemoteConnection.__init__` method no longer ignores the `loop` kwarg passed by user. I added two tests using threads as well. One demonstrates how not passing an `IOLoop`, which was in effect the behavior before this PR, will cause a `RuntimeError`. The other shows how you can now pass an `IOLoop` for each thread to avoid this problem.

VOTE +1