### PR TITLE
TINKERPOP-1584 Made Gryo support a number of classes GraphSON supported.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,8 @@ TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Lessened the severity of Gremlin Server logging when it encounters two or more serializers addressing the same mime type.
 * Bumped to Netty 4.0.42.final.
+* Added `ByteBuffer`, `InetAddress`, `Timestamp` to the list of Gryo supported classes.
+* Fixed Gryo serialization of `Class`.
 * Fixed a bug in Gremlin-Python around `__.__()` and `__.start()`.
 * Fixed a bug around long serialization in Gremlin-Python when using Python3.
 * Deprecated `TraversalSource.withBindings()` as it is no longer needed in Gremlin-Java and never was needed for other variants.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoClassResolver.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoClassResolver.java
@@ -44,6 +44,9 @@ import org.apache.tinkerpop.shaded.kryo.util.IdentityObjectIntMap;
 import org.apache.tinkerpop.shaded.kryo.util.IntMap;
 import org.apache.tinkerpop.shaded.kryo.util.ObjectMap;
 
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+
 import static org.apache.tinkerpop.shaded.kryo.util.Util.getWrapperClass;
 
 /**
@@ -108,6 +111,12 @@ public class GryoClassResolver implements ClassResolver {
             type = Path.class;
         else if (Lambda.class.isAssignableFrom(clazz))
             type = Lambda.class;
+        else if (ByteBuffer.class.isAssignableFrom(clazz))
+            type = ByteBuffer.class;
+        else if (Class.class.isAssignableFrom(clazz))
+            type = Class.class;
+        else if (InetAddress.class.isAssignableFrom(clazz))
+            type = InetAddress.class;
         else
             type = clazz;
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
@@ -96,7 +96,9 @@ import org.javatuples.Pair;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.InetAddress;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -274,7 +276,7 @@ public final class GryoMapper implements Mapper<Kryo> {
             add(GryoTypeReg.of(BigInteger.class, 34));
             add(GryoTypeReg.of(BigDecimal.class, 35));
             add(GryoTypeReg.of(Calendar.class, 39));
-            add(GryoTypeReg.of(Class.class, 41));
+            add(GryoTypeReg.of(Class.class, 41, new UtilSerializers.ClassSerializer()));
             add(GryoTypeReg.of(Collection.class, 37));
             add(GryoTypeReg.of(Collections.EMPTY_LIST.getClass(), 51));
             add(GryoTypeReg.of(Collections.EMPTY_MAP.getClass(), 52));
@@ -313,6 +315,9 @@ public final class GryoMapper implements Mapper<Kryo> {
             add(GryoTypeReg.of(VertexTerminator.class, 13));
             add(GryoTypeReg.of(AbstractMap.SimpleEntry.class, 120));
             add(GryoTypeReg.of(AbstractMap.SimpleImmutableEntry.class, 121));
+            add(GryoTypeReg.of(java.sql.Timestamp.class, 138));
+            add(GryoTypeReg.of(InetAddress.class, 139, new UtilSerializers.InetAddressSerializer()));
+            add(GryoTypeReg.of(ByteBuffer.class, 140, new UtilSerializers.ByteBufferSerializer()));  // ***LAST ID***
 
             add(GryoTypeReg.of(ReferenceEdge.class, 81));
             add(GryoTypeReg.of(ReferenceVertexProperty.class, 82));
@@ -350,7 +355,7 @@ public final class GryoMapper implements Mapper<Kryo> {
             add(GryoTypeReg.of(Column.class, 132));
             add(GryoTypeReg.of(Pop.class, 133));
             add(GryoTypeReg.of(SackFunctions.Barrier.class, 135));
-            add(GryoTypeReg.of(TraversalOptionParent.Pick.class, 137)); // ***LAST ID***
+            add(GryoTypeReg.of(TraversalOptionParent.Pick.class, 137));
             add(GryoTypeReg.of(HashSetSupplier.class, 136, new UtilSerializers.HashSetSupplierSerializer()));
 
             add(GryoTypeReg.of(TraverserSet.class, 58));

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapperTest.java
@@ -40,6 +40,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -336,6 +339,30 @@ public class GryoMapperTest {
     public void shouldHandleBytecode() throws Exception {
         final Bytecode bytecode = __().out().outV().outE().asAdmin().getBytecode();
         assertEquals(bytecode.toString(), serializeDeserialize(bytecode, Bytecode.class).toString());
+    }
+
+    @Test
+    public void shouldHandleClass() throws Exception {
+        final Class clazz = java.io.File.class;
+        assertEquals(clazz, serializeDeserialize(clazz, Class.class));
+    }
+
+    @Test
+    public void shouldHandleTimestamp() throws Exception {
+        final Timestamp ts = new java.sql.Timestamp(1481750076295L);
+        assertEquals(ts, serializeDeserialize(ts, java.sql.Timestamp.class));
+    }
+
+    @Test
+    public void shouldHandleINetAddress() throws Exception {
+        final InetAddress addy = InetAddress.getByName("localhost");
+        assertEquals(addy, serializeDeserialize(addy, InetAddress.class));
+    }
+
+    @Test
+    public void shouldHandleByteBuffer() throws Exception {
+        final ByteBuffer bb = ByteBuffer.wrap("some bytes for you".getBytes());
+        assertEquals(bb, serializeDeserialize(bb, ByteBuffer.class));
     }
 
     public <T> T serializeDeserialize(final Object o, final Class<T> clazz) throws Exception {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1584

Added `ByteBuffer`, `Timestamp`, `InetAddress` and fixed serialization of `Class` (which never worked in the first place).

VOTE +1