### PR TITLE
Fix numbers deserialization for GraphSON2.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
@@ -237,6 +237,10 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
             addDeserializer(TraversalMetrics.class, new GraphSONSerializersV2d0.TraversalMetricsJacksonDeserializer());
             addDeserializer(Tree.class, new GraphSONSerializersV2d0.TreeJacksonDeserializer());
 
+            // numbers
+            addDeserializer(Integer.class, new GraphSONSerializersV2d0.IntegerJackonsDeserializer());
+            addDeserializer(Double.class, new GraphSONSerializersV2d0.DoubleJackonsDeserializer());
+
             // traversal
             addDeserializer(Bytecode.class, new GraphSONTraversalSerializersV2d0.BytecodeJacksonDeserializer());
             addDeserializer(Bytecode.Binding.class, new GraphSONTraversalSerializersV2d0.BindingJacksonDeserializer());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2d0.java
@@ -556,6 +556,30 @@ class GraphSONSerializersV2d0 {
             return t;
         }
     }
+
+    static class IntegerJackonsDeserializer extends StdDeserializer<Integer> {
+
+        protected IntegerJackonsDeserializer() {
+            super(Integer.class);
+        }
+
+        @Override
+        public Integer deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+            return jsonParser.getIntValue();
+        }
+    }
+
+    static class DoubleJackonsDeserializer extends StdDeserializer<Double> {
+
+        protected DoubleJackonsDeserializer() {
+            super(Double.class);
+        }
+
+        @Override
+        public Double deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+            return jsonParser.getDoubleValue();
+        }
+    }
 }
 
 


### PR DESCRIPTION
Issue:
There was a small issue with `ObjectMapper` that was preventing one from doing `objectMapper.readValue(jsonString, Integer.class/Double.class)`. Turns out the issue come from the fact that Jackson normally doesn't uses the `GraphSONTypeResolverBuilder` hook I've introduced for the typing system - and calls directly the default deserializers - for numbers values like `Integer` or `Double`, which led the default deserializers to fail since they are facing a Typed object (`{"@type":..., "@value":....}`) and not simply the value.

Fix: 
Adding simple deserializers for `Integer` and `Double` causes Jackson to use the hook for the typing system and hence deserialization works normally.