### PR TITLE
Honor the equals() contract on Property impls by allowing nulls as valid comparisons.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedProperty.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedProperty.java
@@ -96,7 +96,7 @@ public class DetachedProperty<V> implements Property<V>, Serializable, Attachabl
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     @Override
     public boolean equals(final Object object) {
-        return ElementHelper.areEqual(this, object);
+        return object != null && ElementHelper.areEqual(this, object);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertexProperty.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertexProperty.java
@@ -117,12 +117,6 @@ public class DetachedVertexProperty<V> extends DetachedElement<VertexProperty<V>
         return StringFactory.propertyString(this);
     }
 
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(final Object object) {
-        return ElementHelper.areEqual(this, object);
-    }
-
     @Override
     public <U> Iterator<Property<U>> properties(final String... propertyKeys) {
         return (Iterator) super.properties(propertyKeys);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceProperty.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceProperty.java
@@ -64,7 +64,7 @@ public class ReferenceProperty<V> implements Attachable<Property<V>>, Serializab
 
     @Override
     public boolean equals(final Object object) {
-        return ElementHelper.areEqual(this, object);
+        return object != null && ElementHelper.areEqual(this, object);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -819,7 +819,7 @@ public final class StarGraph implements Graph, Serializable {
 
         @Override
         public boolean equals(final Object object) {
-            return ElementHelper.areEqual(this, object);
+            return object != null && ElementHelper.areEqual(this, object);
         }
 
         @Override

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jProperty.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jProperty.java
@@ -84,7 +84,7 @@ public final class Neo4jProperty<V> implements Property<V> {
 
     @Override
     public boolean equals(final Object object) {
-        return ElementHelper.areEqual(this, object);
+        return object != null && ElementHelper.areEqual(this, object);
     }
 
     @Override

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerProperty.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerProperty.java
@@ -66,7 +66,7 @@ public final class TinkerProperty<V> implements Property<V> {
 
     @Override
     public boolean equals(final Object object) {
-        return ElementHelper.areEqual(this, object);
+        return object != null && ElementHelper.areEqual(this, object);
     }
 
     @Override


### PR DESCRIPTION
If user code put the properties into some kind of collection together with `null` values, things would blow up.

Note that `ElementHelper.areEqual(Element, Object)` allows for `null` values, but `ElementHelper.areEqual(Property, Object)` does not. I assume the reason for this discrepancy is that properties are never supposed to be null but merely not present.

While this assumption is valid in Tinkerpop impl, I think it cannot be imposed on the user code, which assumes a valid implementation of `equals()` which *should not* blow up on null arguments.
