### PR TITLE
Make ElementHelper.areEqual(Property, Object) handle nulls…

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelper.java
@@ -467,10 +467,8 @@ public final class ElementHelper {
      * @return true if equal and false otherwise
      */
     public static boolean areEqual(final Property a, final Object b) {
-        if (null == a)
-            throw Graph.Exceptions.argumentCanNotBeNull("a");
-        if (null == b)
-            throw Graph.Exceptions.argumentCanNotBeNull("b");
+        if (null == b || null == a)
+            return false;
 
         if (a == b)
             return true;

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelperTest.java
@@ -262,6 +262,23 @@ public class ElementHelperTest {
     }
 
     @Test
+    public void shouldDetermineElementsAreNotEqualWhenBothNull() {
+        assertFalse(ElementHelper.areEqual((Element) null, null));
+    }
+
+    @Test
+    public void shouldDetermineElementsAreNotEqualBecauseFirstArgumentIsNull() {
+        Element v = mock(Element.class);
+        assertFalse(ElementHelper.areEqual((Element) null, v));
+    }
+
+    @Test
+    public void shouldDetermineElementsAreNotEqualBecauseSecondArgumentIsNull() {
+        Element v = mock(Element.class);
+        assertFalse(ElementHelper.areEqual(v, null));
+    }
+
+    @Test
     public void shouldDetermineEdgesAreEqual() {
         final Element mockEdgeA = mock(Edge.class);
         final Element mockEdgeB = mock(Edge.class);
@@ -280,24 +297,19 @@ public class ElementHelperTest {
     }
 
     @Test
-    public void shouldFailPropertyAreEqualTestBecauseFirstArgumentIsNull() {
-        try {
-            ElementHelper.areEqual((Property) null, "some object");
-            fail("Should throw exception since the first argument is null");
-        } catch (IllegalArgumentException iae) {
-            assertEquals(Graph.Exceptions.argumentCanNotBeNull("a").getMessage(), iae.getMessage());
-        }
+    public void shouldDeterminePropertiesAreNotEqualBecauseBothAreNull() {
+        assertFalse(ElementHelper.areEqual((Property) null, null));
     }
 
     @Test
-    public void shouldFailPropertyAreEqualTestBecauseSecondArgumentIsNull() {
+    public void shouldDeterminePropertiesAreNotEqualBecauseFirstArgumentIsNull() {
+        assertFalse(ElementHelper.areEqual((Property) null, "some object"));
+    }
+
+    @Test
+    public void shouldDeterminePropertiesAreNotEqualTestBecauseSecondArgumentIsNull() {
         final Property mockProperty = mock(Property.class);
-        try {
-            ElementHelper.areEqual(mockProperty, null);
-            fail("Should throw exception since the second argument is null");
-        } catch (IllegalArgumentException iae) {
-            assertEquals(Graph.Exceptions.argumentCanNotBeNull("b").getMessage(), iae.getMessage());
-        }
+        assertFalse(ElementHelper.areEqual(mockProperty, null));
     }
 
     @Test
@@ -406,6 +418,39 @@ public class ElementHelperTest {
         when(mockPropertyB.value()).thenReturn("v1");
 
         assertFalse(ElementHelper.areEqual(mockPropertyA, mockPropertyB));
+    }
+
+    @Test
+    public void shouldDetermineAbsentPropertiesEqual() {
+        Property<?> p1 = mock(Property.class);
+        Property<?> p2 = mock(Property.class);
+
+        when(p1.isPresent()).thenReturn(false);
+        when(p2.isPresent()).thenReturn(false);
+
+        assertTrue(ElementHelper.areEqual(p1, p2));
+    }
+
+    @Test
+    public void shouldDetermineAbsentPropertyNotEqualToPresent() {
+        Property<?> p1 = mock(Property.class);
+        Property<?> p2 = mock(Property.class);
+
+        when(p1.isPresent()).thenReturn(false);
+        when(p2.isPresent()).thenReturn(true);
+
+        assertFalse(ElementHelper.areEqual(p1, p2));
+    }
+
+    @Test
+    public void shouldDeterminePresentPropertyNotEqualToAbsent() {
+        Property<?> p1 = mock(Property.class);
+        Property<?> p2 = mock(Property.class);
+
+        when(p1.isPresent()).thenReturn(true);
+        when(p2.isPresent()).thenReturn(false);
+
+        assertFalse(ElementHelper.areEqual(p1, p2));
     }
 
     @Test


### PR DESCRIPTION
… so that it can be used correctly in equals() methods of Property impls.

Added test methods for additional equality "scenarios" in ElementHelper.

Note that it is not possible to add tests for equals on `Vertex`, `Edge`, `Property` and `VertexProperty` directly as they are interfaces, not concrete classes. Instead I've added additional test methods for `ElementHelper` to test various case of properties and elements. `ElementHelper.areEqual()` methods are suggested to be used for `equals` of implementations of those interfaces.
