### PR TITLE
TINKERPOP-1549 Implement skip()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Changed `gremlin-benchmark` system property for the report location to `benchmarkReportDir` for consistency.
 * Added SysV and systemd init scripts.
 * `GraphTraversal.valueMap(includeTokens,propertyKeys...)` now returns a `Map<Object,E>` since keys could be `T.id` or `T.label`.
+* Added `skip(long)` and `skip((Scope,long)` which call the `range(low,high)` equivalents with -1 as the high.
 
 TinkerPop 3.2.0 (Nine Inch Gremlins)
 ------------------------------------

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1916,6 +1916,35 @@ g.V(1).both().both().simplePath()
 g.V(1).both().both().simplePath().path()
 ----
 
+[[skip-step]]
+Skip Step
+~~~~~~~~~
+
+The `skip()`-step is analogous to <<range-step,`range()`-step>> save that the higher end range is set to -1.
+
+[gremlin-groovy,modern]
+----
+g.V().skip(2)
+g.V().range(2, -1)
+g.V().skip(2).toString()
+----
+
+The `skip()`-step can also be applied with `Scope.local`, in which case it operates on the incoming collection.
+
+[gremlin-groovy,modern]
+----
+g.V().hasLabel('person').filter(outE('created')).as('p'). <1>
+  map(out('created').values('name').fold()).
+  project('person','primary','other').
+    by(select('p').by('name')).
+    by(limit(local, 1)). <2>
+    by(skip(local, 1)) <3>
+----
+
+<1> For each person who created something...
+<2> ...select the first project (random order) as `primary` and...
+<3> ...select all other projects as `other`.
+
 [[store-step]]
 Store Step
 ~~~~~~~~~~

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -865,7 +865,6 @@ The `limit()`-step is analogous to <<range-step,`range()`-step>> save that the l
 ----
 g.V().limit(2)
 g.V().range(0, 2)
-g.V().limit(2).toString()
 ----
 
 The `limit()`-step can also be applied with `Scope.local`, in which case it operates on the incoming collection.
@@ -1924,9 +1923,9 @@ The `skip()`-step is analogous to <<range-step,`range()`-step>> save that the hi
 
 [gremlin-groovy,modern]
 ----
-g.V().skip(2)
-g.V().range(2, -1)
-g.V().skip(2).toString()
+g.V().values('age').order()
+g.V().values('age').order().skip(2)
+g.V().values('age').order().range(2, -1)
 ----
 
 The `skip()`-step can also be applied with `Scope.local`, in which case it operates on the incoming collection.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -1135,16 +1135,16 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
                 : new RangeLocalStep<>(this.asAdmin(), 0, limit));
     }
 
-    public default GraphTraversal<S, E> skip(final long n) {
-        this.asAdmin().getBytecode().addStep(Symbols.skip, n);
-        return this.asAdmin().addStep(new RangeGlobalStep<>(this.asAdmin(), n, -1));
+    public default GraphTraversal<S, E> skip(final long skip) {
+        this.asAdmin().getBytecode().addStep(Symbols.skip, skip);
+        return this.asAdmin().addStep(new RangeGlobalStep<>(this.asAdmin(), skip, -1));
     }
 
-    public default <E2> GraphTraversal<S, E2> skip(final Scope scope, final long n) {
-        this.asAdmin().getBytecode().addStep(Symbols.skip, scope, n);
+    public default <E2> GraphTraversal<S, E2> skip(final Scope scope, final long skip) {
+        this.asAdmin().getBytecode().addStep(Symbols.skip, scope, skip);
         return this.asAdmin().addStep(scope.equals(Scope.global)
-                ? new RangeGlobalStep<>(this.asAdmin(), n, -1)
-                : new RangeLocalStep<>(this.asAdmin(), n, -1));
+                ? new RangeGlobalStep<>(this.asAdmin(), skip, -1)
+                : new RangeLocalStep<>(this.asAdmin(), skip, -1));
     }
 
     public default GraphTraversal<S, E> tail() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -1135,6 +1135,18 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
                 : new RangeLocalStep<>(this.asAdmin(), 0, limit));
     }
 
+    public default GraphTraversal<S, E> skip(final long n) {
+        this.asAdmin().getBytecode().addStep(Symbols.skip, n);
+        return this.asAdmin().addStep(new RangeGlobalStep<>(this.asAdmin(), n, -1));
+    }
+
+    public default <E2> GraphTraversal<S, E2> skip(final Scope scope, final long n) {
+        this.asAdmin().getBytecode().addStep(Symbols.skip, scope, n);
+        return this.asAdmin().addStep(scope.equals(Scope.global)
+                ? new RangeGlobalStep<>(this.asAdmin(), n, -1)
+                : new RangeLocalStep<>(this.asAdmin(), n, -1));
+    }
+
     public default GraphTraversal<S, E> tail() {
         this.asAdmin().getBytecode().addStep(Symbols.tail);
         return this.asAdmin().addStep(new TailGlobalStep<>(this.asAdmin(), 1));
@@ -1671,6 +1683,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         public static final String not = "not";
         public static final String range = "range";
         public static final String limit = "limit";
+        public static final String skip = "skip";
         public static final String tail = "tail";
         public static final String coin = "coin";
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -810,6 +810,20 @@ public class __ {
     }
 
     /**
+     * @see GraphTraversal#skip(long)
+     */
+    public static <A> GraphTraversal<A, A> skip(final long n) {
+        return __.<A>start().skip(n);
+    }
+
+    /**
+     * @see GraphTraversal#skip(Scope, long)
+     */
+    public static <A> GraphTraversal<A, A> skip(final Scope scope, final long n) {
+        return __.<A>start().skip(scope, n);
+    }
+
+    /**
      * @see GraphTraversal#tail()
      */
     public static <A> GraphTraversal<A, A> tail() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -812,15 +812,15 @@ public class __ {
     /**
      * @see GraphTraversal#skip(long)
      */
-    public static <A> GraphTraversal<A, A> skip(final long n) {
-        return __.<A>start().skip(n);
+    public static <A> GraphTraversal<A, A> skip(final long skip) {
+        return __.<A>start().skip(skip);
     }
 
     /**
      * @see GraphTraversal#skip(Scope, long)
      */
-    public static <A> GraphTraversal<A, A> skip(final Scope scope, final long n) {
-        return __.<A>start().skip(scope, n);
+    public static <A> GraphTraversal<A, A> skip(final Scope scope, final long skip) {
+        return __.<A>start().skip(scope, skip);
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
@@ -23,7 +23,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Bypassing;
-import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Ranging;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
@@ -33,9 +32,7 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BinaryOperator;
@@ -128,6 +125,15 @@ public final class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, 
     }
 
     @Override
+    public boolean equals(final Object other) {
+        if (super.equals(other)) {
+            final RangeGlobalStep typedOther = (RangeGlobalStep) other;
+            return typedOther.low == this.low && typedOther.high == this.high;
+        }
+        return false;
+    }
+
+    @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.BULK);
     }
@@ -178,8 +184,8 @@ public final class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, 
 
         private final long highRange;
 
-        private RangeBiOperator() {
-            this.highRange = Long.MAX_VALUE;
+        public RangeBiOperator() {
+            this(-1);
         }
 
         public RangeBiOperator(final long highRange) {
@@ -188,7 +194,7 @@ public final class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, 
 
         @Override
         public TraverserSet<S> apply(final TraverserSet<S> mutatingSeed, final TraverserSet<S> set) {
-            if (mutatingSeed.size() < this.highRange)
+            if (this.highRange == -1 || mutatingSeed.size() < this.highRange)
                 mutatingSeed.addAll(set);
             return mutatingSeed;
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
@@ -172,7 +172,7 @@ public final class OrderGlobalStep<S, C extends Comparable> extends CollectingBa
         @Override
         public TraverserSet<S> apply(final TraverserSet<S> setA, final TraverserSet<S> setB) {
             setA.addAll(setB);
-            if (Long.MAX_VALUE != this.limit && setA.bulkSize() > this.limit) {
+            if (this.limit != -1 && setA.bulkSize() > this.limit) {
                 if (this.chainedComparator.isShuffle())
                     setA.shuffle();
                 else

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/StepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/StepTest.java
@@ -58,7 +58,6 @@ public abstract class StepTest {
                 final Step instance2 = instances2.get(j);
                 if (i != j) {
                     assertNotEquals(instance1, instance2);
-                    assertNotEquals(instance1.hashCode(), instance2.hashCode());
                 } else {
                     assertEquals(instance1, instance2);
                     assertEquals(instance1.hashCode(), instance2.hashCode());

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStepTest.java
@@ -34,6 +34,7 @@ public class RangeGlobalStepTest extends StepTest {
     protected List<Traversal> getTraversals() {
         return Arrays.asList(
                 __.limit(10L),
+                __.skip(10L),
                 __.range(1L, 10L)
         );
     }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
@@ -115,6 +115,11 @@ public abstract class GroovyRangeTest {
         }
 
         @Override
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_skipX1X_valuesXnameX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').order.by('age').skip(1).values('name')")
+        }
+
+        @Override
         public Traversal<Vertex, List<Double>> get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.values('weight').fold.order(local).skip(local, 2)")
         }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
@@ -110,8 +110,8 @@ public abstract class GroovyRangeTest {
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').order.by('age').skip(1).values('name')")
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_valuesXnameX_skipX1X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').order.by('age').values('name').skip(1)")
         }
 
         @Override

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
@@ -108,5 +108,15 @@ public abstract class GroovyRangeTest {
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').range(local,1,2)")
         }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_skipX2X_count() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.skip(2).count()")
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_fold_skipXlocal_2X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.fold.skip(local, 2)")
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
@@ -110,13 +110,13 @@ public abstract class GroovyRangeTest {
         }
 
         @Override
-        public Traversal<Vertex, Long> get_g_V_skipX2X_count() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.skip(2).count()")
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').order.by('age').skip(1).values('name')")
         }
 
         @Override
-        public Traversal<Vertex, List<Vertex>> get_g_V_fold_skipXlocal_2X() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.fold.skip(local, 2)")
+        public Traversal<Vertex, List<Double>> get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.values('weight').fold.order(local).skip(local, 2)")
         }
     }
 }

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -349,6 +349,9 @@ class GraphTraversal(Traversal):
   def simplePath(self, *args):
     self.bytecode.add_step("simplePath", *args)
     return self
+  def skip(self, *args):
+    self.bytecode.add_step("skip", *args)
+    return self
   def store(self, *args):
     self.bytecode.add_step("store", *args)
     return self
@@ -634,6 +637,9 @@ class __(object):
   @staticmethod
   def simplePath(*args):
     return GraphTraversal(None, None, Bytecode()).simplePath(*args)
+  @staticmethod
+  def skip(*args):
+    return GraphTraversal(None, None, Bytecode()).skip(*args)
   @staticmethod
   def store(*args):
     return GraphTraversal(None, None, Bytecode()).store(*args)
@@ -1061,6 +1067,11 @@ def simplePath(*args):
       return __.simplePath(*args)
 
 statics.add_static('simplePath', simplePath)
+
+def skip(*args):
+      return __.skip(*args)
+
+statics.add_static('skip', skip)
 
 def store(*args):
       return __.store(*args)

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
@@ -81,9 +81,9 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X();
 
-    public abstract Traversal<Vertex, Long> get_g_V_skipX2X_count();
+    public abstract Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX();
 
-    public abstract Traversal<Vertex, List<Vertex>> get_g_V_fold_skipXlocal_2X();
+    public abstract Traversal<Vertex, List<Double>> get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -321,24 +321,21 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_skipX2X_count() {
-        final Traversal<Vertex, Long> traversal = get_g_V_skipX2X_count();
+    public void g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX() {
+        final Traversal<Vertex, String> traversal = get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX();
         printTraversalForm(traversal);
         assertTrue(traversal.hasNext());
-        final Long count = traversal.next();
-        assertFalse(traversal.hasNext());
-        assertEquals(4, count.longValue());
+        assertEquals(Arrays.asList("marko", "josh", "peter"), traversal.toList());
     }
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_fold_skipXlocal_2X() {
-        final Traversal<Vertex, List<Vertex>> traversal = get_g_V_fold_skipXlocal_2X();
+    public void g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X() {
+        final Traversal<Vertex, List<Double>> traversal = get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X();
         printTraversalForm(traversal);
         assertTrue(traversal.hasNext());
-        final List<Vertex> list = traversal.next();
+        assertEquals(Arrays.asList(0.4, 0.5, 1.0, 1.0), traversal.next());
         assertFalse(traversal.hasNext());
-        assertEquals(4, list.size());
     }
 
     public static class Traversals extends RangeTest {
@@ -423,13 +420,13 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, Long> get_g_V_skipX2X_count() {
-            return g.V().skip(2).count();
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX() {
+            return g.V().hasLabel("person").order().by("age").skip(1).values("name");
         }
 
         @Override
-        public Traversal<Vertex, List<Vertex>> get_g_V_fold_skipXlocal_2X() {
-            return g.V().fold().skip(local, 2);
+        public Traversal<Vertex, List<Double>> get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X() {
+            return g.V().outE().values("weight").fold().order(local).skip(local, 2);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
@@ -39,6 +39,7 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -79,6 +80,10 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_3X();
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X();
+
+    public abstract Traversal<Vertex, Long> get_g_V_skipX2X_count();
+
+    public abstract Traversal<Vertex, List<Vertex>> get_g_V_fold_skipXlocal_2X();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -314,6 +319,28 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_skipX2X_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_skipX2X_count();
+        printTraversalForm(traversal);
+        assertTrue(traversal.hasNext());
+        final Long count = traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals(4, count.longValue());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_fold_skipXlocal_2X() {
+        final Traversal<Vertex, List<Vertex>> traversal = get_g_V_fold_skipXlocal_2X();
+        printTraversalForm(traversal);
+        assertTrue(traversal.hasNext());
+        final List<Vertex> list = traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals(4, list.size());
+    }
+
     public static class Traversals extends RangeTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_limitX2X(final Object v1Id) {
@@ -393,6 +420,16 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X() {
             return g.V().as("a").out().as("b").out().as("c").<Map<String, String>>select("a", "b", "c").by("name").range(local, 1, 2);
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_skipX2X_count() {
+            return g.V().skip(2).count();
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_fold_skipXlocal_2X() {
+            return g.V().fold().skip(local, 2);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
@@ -81,7 +81,7 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X();
 
-    public abstract Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX();
+    public abstract Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_valuesXnameX_skipX1X();
 
     public abstract Traversal<Vertex, List<Double>> get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X();
 
@@ -321,8 +321,8 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX() {
-        final Traversal<Vertex, String> traversal = get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX();
+    public void g_V_hasLabelXpersonX_order_byXageX_valuesXnameX_skipX1X() {
+        final Traversal<Vertex, String> traversal = get_g_V_hasLabelXpersonX_order_byXageX_valuesXnameX_skipX1X();
         printTraversalForm(traversal);
         assertTrue(traversal.hasNext());
         assertEquals(Arrays.asList("marko", "josh", "peter"), traversal.toList());
@@ -420,8 +420,8 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageXskipX1X_valuesXnameX() {
-            return g.V().hasLabel("person").order().by("age").skip(1).values("name");
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_valuesXnameX_skipX1X() {
+            return g.V().hasLabel("person").order().by("age").<String>values("name").skip(1);
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
@@ -83,6 +83,8 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_valuesXnameX_skipX1X();
 
+    public abstract Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_skipX1X_valuesXnameX();
+
     public abstract Traversal<Vertex, List<Double>> get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X();
 
     @Test
@@ -330,6 +332,15 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
+    public void g_V_hasLabelXpersonX_order_byXageX_skipX1X_valuesXnameX() {
+        final Traversal<Vertex, String> traversal = get_g_V_hasLabelXpersonX_order_byXageX_skipX1X_valuesXnameX();
+        printTraversalForm(traversal);
+        assertTrue(traversal.hasNext());
+        assertEquals(Arrays.asList("marko", "josh", "peter"), traversal.toList());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
     public void g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X() {
         final Traversal<Vertex, List<Double>> traversal = get_g_V_outE_valuesXweightX_fold_orderXlocalX_skipXlocal_2X();
         printTraversalForm(traversal);
@@ -422,6 +433,11 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_valuesXnameX_skipX1X() {
             return g.V().hasLabel("person").order().by("age").<String>values("name").skip(1);
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXageX_skipX1X_valuesXnameX() {
+            return g.V().hasLabel("person").order().by("age").skip(1).values("name");
         }
 
         @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1549

Added `skip(long)` and `skip((Scope,long)` which call the `range(low,high)` equivalents with -1 as the high.

Also added test cases and fixed the OLAP implementation (which probably never worked before).

Note, that I implemented `equals()` for `RangeGlobalStep`, because hash code collisions are very likely. For the same reason I also removed the hash code inequality check from `StepTest`.

VOTE: +1