### PR TITLE
TINKERPOP-1601 LazyBarrierStrategy should not check is.testing

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bytecode.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bytecode.java
@@ -61,13 +61,10 @@ public final class Bytecode implements Cloneable, Serializable {
      */
     public void addSource(final String sourceName, final Object... arguments) {
         if (sourceName.equals(TraversalSource.Symbols.withoutStrategies)) {
-            final Class<TraversalStrategy>[] classes = new Class[arguments.length];
-            for (int i = 0; i < arguments.length; i++) {
-                classes[i] = arguments[i] instanceof TraversalStrategyProxy ?
-                        ((TraversalStrategyProxy) arguments[i]).getStrategyClass() :
-                        (Class) arguments[i];
+            for (final Object argument : arguments) {
+                this.sourceInstructions.add(new Instruction(sourceName, argument instanceof TraversalStrategyProxy
+                        ? ((TraversalStrategyProxy) argument).getStrategyClass() : (Class) argument));
             }
-            this.sourceInstructions.add(new Instruction(sourceName, classes));
         } else
             this.sourceInstructions.add(new Instruction(sourceName, flattenArguments(arguments)));
         Bindings.clear();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/LazyBarrierStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/LazyBarrierStrategy.java
@@ -44,7 +44,6 @@ import java.util.Set;
  */
 public final class LazyBarrierStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy> implements TraversalStrategy.OptimizationStrategy {
 
-    private final boolean IS_TESTING = Boolean.valueOf(System.getProperty("is.testing", "false"));
     private static final LazyBarrierStrategy INSTANCE = new LazyBarrierStrategy();
     private static final Set<Class<? extends OptimizationStrategy>> PRIORS = new HashSet<>(Arrays.asList(
             RangeByIsCountStrategy.class,
@@ -64,9 +63,7 @@ public final class LazyBarrierStrategy extends AbstractTraversalStrategy<Travers
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
         if (TraversalHelper.onGraphComputer(traversal) ||
-                traversal.getTraverserRequirements().contains(TraverserRequirement.PATH) ||
-                (IS_TESTING && ((TraversalHelper.hasStepOfAssignableClass(ProfileStep.class, TraversalHelper.getRootTraversal(traversal)) ||
-                        TraversalHelper.hasStepOfAssignableClass(ProfileSideEffectStep.class, TraversalHelper.getRootTraversal(traversal)))))) // necessary cause ProfileTest analyzes counts
+                traversal.getTraverserRequirements().contains(TraverserRequirement.PATH))
             return;
 
         boolean foundFlatMap = false;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProfileTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProfileTest.java
@@ -32,6 +32,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Profiling;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.RangeByIsCountStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.RepeatUnrollStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
@@ -41,6 +42,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -90,6 +92,11 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, TraversalMetrics> get_g_V_hasLabelXpersonX_pageRank_byXrankX_byXbothEX_rank_profile();
 
     public abstract Traversal<Vertex, TraversalMetrics> get_g_V_groupXmX_profile();
+
+    @Before
+    public void adjustStrategies() {
+        g = g.withoutStrategies(LazyBarrierStrategy.class);
+    }
 
     @Test
     @LoadGraphWith(MODERN)

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProfileTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProfileTest.java
@@ -28,6 +28,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Profiling;
@@ -95,7 +97,12 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
 
     @Before
     public void adjustStrategies() {
-        g = g.withoutStrategies(LazyBarrierStrategy.class);
+        // exclude LazyBarrierStrategy and all provider specific strategies
+        final TraversalStrategies strategies = g.getStrategies();
+        strategies.toList().stream().map(TraversalStrategy::getClass)
+                .filter(clazz -> LazyBarrierStrategy.class.equals(clazz) ||
+                        !clazz.getCanonicalName().startsWith("org.apache.tinkerpop."))
+                .forEach(clazz -> g = g.withoutStrategies(clazz));
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
@@ -363,7 +363,7 @@ public class SerializationTest {
             assertTrue(m.containsKey(GraphSONTokens.METRICS));
 
             final List<Map<String, Object>> metrics = (List<Map<String, Object>>) m.get(GraphSONTokens.METRICS);
-            assertEquals(2, metrics.size());
+            assertEquals(3, metrics.size());
 
             final Map<String, Object> metrics0 = metrics.get(0);
             assertTrue(metrics0.containsKey(GraphSONTokens.ID));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1601

Only a minor improvement (strategies shouldn't behave differently depending on whether we're in testing mode or not). If a test requires that certain strategies don't do anything, then it's the test's job to exclude those strategies.

`docker/build.sh -t -i` succeeded.

VOTE: +1