### PR TITLE
TINKERPOP-1605 gremlin-console 3.2.3 -e can no longer take paths relative to current working directory

### DIFF
--- a/gremlin-console/src/main/bin/gremlin.sh
+++ b/gremlin-console/src/main/bin/gremlin.sh
@@ -22,6 +22,8 @@
 set -e
 set -u
 
+USER_DIR=`pwd`
+
 cd $(dirname $0)
 DIR=`pwd`
 
@@ -90,7 +92,7 @@ while getopts ":l" opt; do
     esac
 done
 
-JAVA_OPTIONS="${JAVA_OPTIONS} -Dtinkerpop.ext=${USER_EXT_DIR:-${SYSTEM_EXT_DIR}} -Dlog4j.configuration=conf/log4j-console.properties -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL"
+JAVA_OPTIONS="${JAVA_OPTIONS} -Duser.working_dir=${USER_DIR} -Dtinkerpop.ext=${USER_EXT_DIR:-${SYSTEM_EXT_DIR}} -Dlog4j.configuration=conf/log4j-console.properties -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL"
 JAVA_OPTIONS=$(awk -v RS=' ' '!/^$/ {if (!x[$0]++) print}' <<< "${JAVA_OPTIONS}" | grep -v '^$' | paste -sd ' ' -)
 
 if [ -n "$SCRIPT_DEBUG" ]; then

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -378,7 +378,13 @@ class Console {
                 groovy.execute("args = []")
             }
 
-            final File file = new File(scriptFile)
+            File file = new File(scriptFile)
+            if (!file.exists() && !file.isAbsolute()) {
+                final String userWorkingDir = System.getProperty("user.working_dir");
+                if (userWorkingDir != null) {
+                    file = new File(userWorkingDir, scriptFile);
+                }
+            }
             int lineNumber = 0
             def lines = file.readLines()
             for (String line : lines) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1605

```
daniel@cube /tmp $ ls *.groovy
test.groovy

daniel@cube /tmp $ /projects/apache/tinkerpop/bin/gremlin.sh -e test.groovy 
2
4
6

daniel@cube /tmp $ /projects/apache/tinkerpop/bin/gremlin.sh -e test2.groovy 
Gremlin file not found at [test2.groovy].

daniel@cube /tmp $  /projects/apache/tinkerpop/bin/gremlin.sh

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
gremlin> graph = TinkerGraph.open()
==>tinkergraph[vertices:0 edges:0]
gremlin> graph.io(graphml()).readGraph('data/grateful-dead.xml')
==>null
gremlin> g = graph.traversal()
==>graphtraversalsource[tinkergraph[vertices:808 edges:8049], standard]
```

VOTE: +1