### PR TITLE
TINKERPOP-1610 Deprecated Groovy test suites

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * SASL negotiation supports both a byte array and Base64 encoded bytes as a string for authentication to Gremlin Server.
+* Deprecated all test suites in `gremlin-groovy-test` - Graph Providers no longer need to implement these.
 * Deprecated `TinkerIoRegistry` replacing it with the more consistently named `TinkerIoRegistryV1d0`.
 * Made error messaging more consistent during result iteration timeouts in Gremlin Server.
 * `PathRetractionStrategy` does not add a `NoOpBarrierStep` to the end of local children as its wasted computation in 99% of traversals.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -199,8 +199,8 @@ multi-properties have more flexibility in describing their graph capabilities.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-919[TINKERPOP-919]
 
-Deprecated Performance OptIn
-++++++++++++++++++++++++++++
+Deprecated OptIn
+++++++++++++++++
 
 In 3.2.1, all `junit-benchmark` performance tests were deprecated. At that time, the `OptIn` representations of these
 tests should have been deprecated as well, but they were not. That omission has been remedied now. Specifically, the
@@ -209,6 +209,19 @@ following fields were deprecated:
 * `OptIn.SUITE_GROOVY_ENVIRONMENT_PERFORMANCE`
 * `OptIn.SUITE_PROCESS_PERFORMANCE`
 * `OptIn.SUITE_STRUCTURE_PERFORMANCE`
+
+As of 3.2.4, the following test suites were also deprecated:
+
+* `OptIn.SUITE_GROOVY_PROCESS_STANDARD`
+* `OptIn.SUITE_GROOVY_PROCESS_COMPUTER`
+* `OptIn.SUITE_GROOVY_ENVIRONMENT`
+* `OptIn.SUITE_GROOVY_ENVIRONMENT_INTEGRATE`
+
+Future testing of `gremlin-groovy` (and language variants in general) will be handled differently and will not require
+a Graph Provider to validate its operations with it. Graph Providers may now choose to remove these tests from their
+test suites, which should reduce the testing burden.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1610[TINKERPOP-1610]
 
 Deprecated getInstance()
 ++++++++++++++++++++++++

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -1226,9 +1226,29 @@ public interface Graph extends AutoCloseable, Host {
          */
         @Deprecated
         public static String SUITE_PROCESS_PERFORMANCE = "org.apache.tinkerpop.gremlin.process.ProcessPerformanceSuite";
+
+        /**
+         * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
+         */
+        @Deprecated
         public static String SUITE_GROOVY_PROCESS_STANDARD = "org.apache.tinkerpop.gremlin.process.GroovyProcessStandardSuite";
+
+        /**
+         * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
+         */
+        @Deprecated
         public static String SUITE_GROOVY_PROCESS_COMPUTER = "org.apache.tinkerpop.gremlin.process.GroovyProcessComputerSuite";
+
+        /**
+         * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
+         */
+        @Deprecated
         public static String SUITE_GROOVY_ENVIRONMENT = "org.apache.tinkerpop.gremlin.groovy.GroovyEnvironmentSuite";
+
+        /**
+         * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
+         */
+        @Deprecated
         public static String SUITE_GROOVY_ENVIRONMENT_INTEGRATE = "org.apache.tinkerpop.gremlin.groovy.GroovyEnvironmentIntegrateSuite";
 
         /**

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/GroovyEnvironmentIntegrateSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/GroovyEnvironmentIntegrateSuite.java
@@ -46,7 +46,9 @@ import java.util.stream.Stream;
  * For more information on the usage of this suite, please see {@link StructureStandardSuite}.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
  */
+@Deprecated
 public class GroovyEnvironmentIntegrateSuite extends AbstractGremlinSuite {
 
     /**

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/GroovyEnvironmentSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/GroovyEnvironmentSuite.java
@@ -47,7 +47,9 @@ import org.junit.runners.model.RunnerBuilder;
  * For more information on the usage of this suite, please see {@link StructureStandardSuite}.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
  */
+@Deprecated
 public class GroovyEnvironmentSuite extends AbstractGremlinSuite {
 
     /**

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
@@ -97,7 +97,9 @@ import org.junit.runners.model.RunnerBuilder;
  * For more information on the usage of this suite, please see {@link StructureStandardSuite}.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
  */
+@Deprecated
 public class GroovyProcessComputerSuite extends ProcessComputerSuite {
 
     /**

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessStandardSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessStandardSuite.java
@@ -94,7 +94,9 @@ import org.junit.runners.model.RunnerBuilder;
  * For more information on the usage of this suite, please see {@link StructureStandardSuite}.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated As of release 3.2.4, not replaced as a test suite that Graph Providers need to implement.
  */
+@Deprecated
 public class GroovyProcessStandardSuite extends ProcessStandardSuite {
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1610

Graph Providers no longer need to implement these going forward. Note that the new model for testing groovy will be similar to the approach taken for gremlin-python (which obviously doesn't have all this tests required of the provider). By making this change, we reduce the testing burden on graph providers as this is a whole body of tests they can just ignore now. This is a non-breaking change and will setup for removal and migration of the `gremlin-groovy-test` classes to `gremlin-groovy` (or potentally `gremlin-test` if the test is general enough to aid in testing the `GremlinScriptEngine` environment).

This is a pretty simple PR at this point, but since it was a major deprecation I wanted to go through the vote process rather than CTR.

VOTE +1