### PR TITLE
TINKERPOP-1583: PathRetractionStrategy retracts keys that are actually needed

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.4 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug where `keepLabels` were not being pushed down into child traversals by `PathRetractionStrategy`.
 * Fixed a bug associated with user-provided maps and `GroupSideEffectStep`.
 * `GroupBiOperator` no longer maintains a detached traversal and thus, no more side-effect related OLAP inconsistencies.
 * Added `ProjectedTraverser` which wraps a traverser with a `List<Object>` of projected data.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
@@ -27,8 +27,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectOneStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
@@ -95,7 +99,10 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
             // add the keep labels to the path processor
             if (currentStep instanceof PathProcessor) {
                 final PathProcessor pathProcessor = (PathProcessor) currentStep;
-                if (currentStep instanceof MatchStep && (currentStep.getNextStep().equals(EmptyStep.instance()) || currentStep.getNextStep() instanceof DedupGlobalStep)) {
+                if (currentStep instanceof MatchStep &&
+                        (currentStep.getNextStep().equals(EmptyStep.instance()) ||
+                            currentStep.getNextStep() instanceof DedupGlobalStep ||
+                            currentStep.getNextStep() instanceof SelectOneStep && currentStep.getNextStep().getNextStep() instanceof FilterStep)) {
                     pathProcessor.setKeepLabels(((MatchStep) currentStep).getMatchStartLabels());
                     pathProcessor.getKeepLabels().addAll(((MatchStep) currentStep).getMatchEndLabels());
                 } else {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
 import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchStep;
@@ -33,6 +34,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.PathUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.javatuples.Pair;
 
 import java.util.ArrayList;
@@ -96,8 +98,12 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
                 if (currentStep instanceof MatchStep && (currentStep.getNextStep().equals(EmptyStep.instance()) || currentStep.getNextStep() instanceof DedupGlobalStep)) {
                     pathProcessor.setKeepLabels(((MatchStep) currentStep).getMatchStartLabels());
                     pathProcessor.getKeepLabels().addAll(((MatchStep) currentStep).getMatchEndLabels());
-                } else
-                    pathProcessor.setKeepLabels(new HashSet<>(keepLabels));
+                } else {
+                    if (pathProcessor.getKeepLabels() == null)
+                        pathProcessor.setKeepLabels(new HashSet<>(keepLabels));
+                    else
+                        pathProcessor.getKeepLabels().addAll(new HashSet<>(keepLabels));
+                }
 
                 if (currentStep.getTraversal().getParent() instanceof MatchStep) {
                     pathProcessor.setKeepLabels(((MatchStep) currentStep.getTraversal().getParent().asStep()).getMatchStartLabels());
@@ -111,6 +117,7 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
                         !(currentStep.getNextStep() instanceof Barrier) &&
                         !(currentStep.getTraversal().getParent() instanceof MatchStep) &&
                         (!(currentStep.getNextStep() instanceof EmptyStep) || TraversalHelper.isGlobalChild(currentStep.getTraversal())))
+
                     TraversalHelper.insertAfterStep(new NoOpBarrierStep<>(traversal, this.standardBarrierSize), currentStep, traversal);
             }
         }
@@ -141,16 +148,29 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
                 hasRepeat = true;
             }
 
+            // if parent step is a TraversalParent itself and it has more than 1 child traversal
+            // propagate labels to children
+            if (step instanceof TraversalParent) {
+                final List<Traversal.Admin<Object, Object>> children = new ArrayList<>();
+                children.addAll(((TraversalParent) step).getGlobalChildren());
+                children.addAll(((TraversalParent) step).getLocalChildren());
+                // if this is the only child traversal, do not re-push labels
+                if (children.size() > 1)
+                    applyToChildren(keepLabels, children);
+            }
+
             // propagate requirements of keep labels back through the traversal's previous steps
             // to ensure that the label is not dropped before it reaches the step(s) that require it
             step = step.getPreviousStep();
             while (!(step.equals(EmptyStep.instance()))) {
                 if (step instanceof PathProcessor) {
-                    if (((PathProcessor) step).getKeepLabels() == null) {
-                        ((PathProcessor) step).setKeepLabels(new HashSet<>(keepLabels));
-                    } else {
-                        ((PathProcessor) step).getKeepLabels().addAll(new HashSet<>(keepLabels));
-                    }
+                    addLabels((PathProcessor) step, keepLabels);
+                }
+                if (step instanceof TraversalParent) {
+                    final List<Traversal.Admin<Object, Object>> children = new ArrayList<>();
+                    children.addAll(((TraversalParent) step).getGlobalChildren());
+                    children.addAll(((TraversalParent) step).getLocalChildren());
+                    applyToChildren(keepLabels, children);
                 }
                 step = step.getPreviousStep();
             }
@@ -187,6 +207,28 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
                     ((PathProcessor) currentStep).getKeepLabels().addAll(keepLabels);
                 }
             }
+        }
+    }
+
+    private void applyToChildren(Set<String> keepLabels, List<Traversal.Admin<Object, Object>> children) {
+        for (Traversal.Admin<Object, Object> child : children) {
+            TraversalHelper.applyTraversalRecursively(trav -> addLabels(trav, keepLabels), child);
+        }
+    }
+
+    private void addLabels(final Traversal.Admin traversal, final Set<String> keepLabels) {
+        for (Object s : traversal.getSteps()) {
+            if (s instanceof PathProcessor) {
+                addLabels((PathProcessor) s, keepLabels);
+            }
+        }
+    }
+
+    private void addLabels(PathProcessor s, Set<String> keepLabels) {
+        if (s.getKeepLabels() == null) {
+            s.setKeepLabels(new HashSet<>(keepLabels));
+        } else {
+            s.getKeepLabels().addAll(new HashSet<>(keepLabels));
         }
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
@@ -132,7 +132,7 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
         Step<?, ?> parent = traversal.getParent().asStep();
         final List<Pair<Step, Set<String>>> parentKeeperPairs = new ArrayList<>();
         while (!parent.equals(EmptyStep.instance())) {
-            Set<String> parentKeepLabels = new HashSet<>(PathUtil.getReferencedLabels(parent));
+            final Set<String> parentKeepLabels = new HashSet<>(PathUtil.getReferencedLabels(parent));
             parentKeepLabels.addAll(PathUtil.getReferencedLabelsAfterStep(parent));
             parentKeeperPairs.add(new Pair<>(parent, parentKeepLabels));
             parent = parent.getTraversal().getParent().asStep();
@@ -214,21 +214,21 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
         }
     }
 
-    private void applyToChildren(Set<String> keepLabels, List<Traversal.Admin<Object, Object>> children) {
-        for (Traversal.Admin<Object, Object> child : children) {
+    private void applyToChildren(final Set<String> keepLabels, final List<Traversal.Admin<Object, Object>> children) {
+        for (final Traversal.Admin<Object, Object> child : children) {
             TraversalHelper.applyTraversalRecursively(trav -> addLabels(trav, keepLabels), child);
         }
     }
 
     private void addLabels(final Traversal.Admin traversal, final Set<String> keepLabels) {
-        for (Object s : traversal.getSteps()) {
+        for (final Object s : traversal.getSteps()) {
             if (s instanceof PathProcessor) {
                 addLabels((PathProcessor) s, keepLabels);
             }
         }
     }
 
-    private void addLabels(PathProcessor s, Set<String> keepLabels) {
+    private void addLabels(final PathProcessor s, final Set<String> keepLabels) {
         if (s.getKeepLabels() == null) {
             s.setKeepLabels(new HashSet<>(keepLabels));
         } else {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
@@ -28,8 +28,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectOneStep;
@@ -38,7 +36,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.PathUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.javatuples.Pair;
 
 import java.util.ArrayList;

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
@@ -37,8 +37,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.P.*;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.gte;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.without;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.project;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.store;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.values;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.where;
 import static org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathRetractionStrategy.MAX_BARRIER_SIZE;
 import static org.junit.Assert.assertEquals;
 
@@ -109,8 +120,8 @@ public class PathRetractionStrategyTest {
                 {__.V().as("a").out().where(out().where(neq("a"))).out(), "[[[]]]", null},
                 {__.V().as("a").out().where(neq("a")).out().select("a"), "[[a], []]", null},
                 {__.V().as("a").out().as("b").where(neq("a")).out().select("a", "b").out().select("b"), "[[a, b], [b], []]", null},
-                {__.V().match(__.as("a").out().as("b")), "[[a, b]]", null},
-                {__.V().match(__.as("a").out().as("b")).select("a"), "[[a], []]", null},
+                {__.V().match(as("a").out().as("b")), "[[a, b]]", null},
+                {__.V().match(as("a").out().as("b")).select("a"), "[[a], []]", null},
                 {__.V().out().out().match(
                         as("a").in("created").as("b"),
                         as("b").in("knows").as("c")).select("c").out("created").where(neq("a")).values("name"),

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
@@ -179,7 +179,7 @@ public class PathRetractionStrategyTest {
                         "[[[z, seen]], [[z, seen]]]", null},
                 {__.V().as("a").optional(bothE().dedup().as("b")).
                         choose(select("b"), select("a","b"), project("a").by(select("a"))),
-                        "[[[a, b]], [[a, b]], [[a, b]], [[[a, b]]], [[a, b]]]", null}
+                        "[[[a, b]], [[a, b]], [[a, b]], [[[a, b]]], [[a, b]]]", null},
         });
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
@@ -37,14 +37,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
-import static org.apache.tinkerpop.gremlin.process.traversal.P.gte;
-import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.values;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.*;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 import static org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathRetractionStrategy.MAX_BARRIER_SIZE;
 import static org.junit.Assert.assertEquals;
 
@@ -153,7 +147,7 @@ public class PathRetractionStrategyTest {
                         as("c").out().as("d", "e").select("c", "e").out().select("c"),
                         as("c").out().as("d", "e").select("c", "e").out().select("c")).
                         out().select("c"),
-                        "[[b, c, e], [c, e], [[c], [c]], [[c], [c]], []]", null},
+                        "[[b, c, e], [c, e], [[c, e], [c, e]], [[c, e], [c, e]], []]", null},
                 {__.V().as("a").out().as("b").select("a").select("b").
                         local(as("c").out().as("d", "e").select("c", "e").out().select("c")).
                         out().select("c"),
@@ -180,7 +174,12 @@ public class PathRetractionStrategyTest {
                 {__.V().out("created").project("a", "b").by("name").by(__.in("created").count()).order().by(select("b")).select("a"), "[[[a]], []]", null},
                 {__.order().by("weight", Order.decr).store("w").by("weight").filter(values("weight").as("cw").
                         select("w").by(limit(Scope.local, 1)).as("mw").where("cw", eq("mw"))).project("from", "to", "weight").by(__.outV()).by(__.inV()).by("weight"),
-                        "[[[cw, mw], []]]", null}
+                        "[[[cw, mw], []]]", null},
+                {__.V().limit(1).as("z").out().repeat(store("seen").out().where(without("seen"))).until(where(eq("z"))),
+                        "[[[z, seen]], [[z, seen]]]", null},
+                {__.V().as("a").optional(bothE().dedup().as("b")).
+                        choose(select("b"), select("a","b"), project("a").by(select("a"))),
+                        "[[[a, b]], [[a, b]], [[a, b]], [[[a, b]]], [[a, b]]]", null}
         });
     }
 }


### PR DESCRIPTION
`PathRetractionStrategy` was not pushing `keepLabels` down into sibling traversals of children with label requirements.  Labels were also not being pushed down into `TraversalParents` earlier in the traversal.

@okram I saw you had a `PathRetractionStrategy` issue while doing some other work.  Do you have a traversal you were getting a failure on?  I can make sure this fixes it and adds a test case if so.

`./docker/build.sh -t -i` success
```
[INFO] Apache TinkerPop .................................. SUCCESS [30.949s]
[INFO] Apache TinkerPop :: Gremlin Shaded ................ SUCCESS [9.462s]
[INFO] Apache TinkerPop :: Gremlin Core .................. SUCCESS [56.670s]
[INFO] Apache TinkerPop :: Gremlin Test .................. SUCCESS [4.887s]
[INFO] Apache TinkerPop :: Gremlin Groovy ................ SUCCESS [2:09.535s]
[INFO] Apache TinkerPop :: Gremlin Groovy Test ........... SUCCESS [4.935s]
[INFO] Apache TinkerPop :: TinkerGraph Gremlin ........... SUCCESS [3:32.013s]
[INFO] Apache TinkerPop :: Gremlin Benchmark ............. SUCCESS [32:23.091s]
[INFO] Apache TinkerPop :: Gremlin Driver ................ SUCCESS [15:56.763s]
[INFO] Apache TinkerPop :: Neo4j Gremlin ................. SUCCESS [15:53.728s]
[INFO] Apache TinkerPop :: Gremlin Server ................ SUCCESS [30:15.950s]
[INFO] Apache TinkerPop :: Gremlin Python ................ SUCCESS [32:02.364s]
[INFO] Apache TinkerPop :: Hadoop Gremlin ................ SUCCESS [22:03.412s]
[INFO] Apache TinkerPop :: Spark Gremlin ................. SUCCESS [52:17.578s]
[INFO] Apache TinkerPop :: Giraph Gremlin ................ SUCCESS [2:52:20.792s]
[INFO] Apache TinkerPop :: Gremlin Console ............... SUCCESS [32:59.765s]
[INFO] Apache TinkerPop :: Gremlin Archetype ............. SUCCESS [0.085s]
[INFO] Apache TinkerPop :: Archetype - TinkerGraph ....... SUCCESS [16:05.156s]
[INFO] Apache TinkerPop :: Archetype - Server ............ SUCCESS [10.964s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

VOTE: +1