### PR TITLE
TINKERPOP-1589 Re-introduced CloseableIterator

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
+public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements AutoCloseable {
 
     private Traverser.Admin<S> head = null;
     private Iterator<E> iterator = EmptyIterator.instance();
@@ -44,6 +44,7 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
                 return this.head.split(this.iterator.next(), this);
             } else {
                 this.head = this.starts.next();
+                closeIterator();
                 this.iterator = this.flatMap(this.head);
             }
         }
@@ -54,6 +55,25 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
     @Override
     public void reset() {
         super.reset();
-        this.iterator = EmptyIterator.instance();
+        closeIterator();
+    }
+
+    @Override
+    public void close() {
+        closeIterator();
+    }
+
+    private void closeIterator() {
+        if (this.iterator instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) this.iterator).close();
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            finally {
+                this.iterator = EmptyIterator.instance();
+            }
+        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -64,16 +64,16 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements Au
     }
 
     private void closeIterator() {
-        if (this.iterator instanceof AutoCloseable) {
-            try {
+        try {
+            if (this.iterator instanceof AutoCloseable) {
                 ((AutoCloseable) this.iterator).close();
             }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            finally {
-                this.iterator = EmptyIterator.instance();
-            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            this.iterator = EmptyIterator.instance();
         }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -164,13 +164,13 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
     }
 
     /**
-     * Attemps to close an underlying iterator if it is of type {@link CloseableIterator}. Graph providers may choose
+     * Attempts to close an underlying iterator if it is of type {@link CloseableIterator}. Graph providers may choose
      * to return this interface containing their vertices and edges if there are expensive resources that might need to
      * be released at some point.
      */
     @Override
     public void close() throws Exception {
-        if (iterator != null && iterator instanceof CloseableIterator) {
+        if (iterator instanceof CloseableIterator) {
             ((CloseableIterator) iterator).close();
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1589
Add support for the closing of `Iterators` returned from
`Vertex.vertices()` and `Vertex.edges()`.
`Iterators` are closed once they are read to completion.
Make `FlatMapStep` implement `AutoCloseable` in case iterator is not
read to completion, should get closed when `Traversal` is closed.
Remove unnecessary null check (null is never an instanceof).
OLTP mode support only. More extensive changes required for OLAP.
NOTE: Rethrowing checked Exception from `close()` as unchecked
RuntimeException in order to retain `Step.reset()` and
`AbstractStep.processNextStart()` signatures.