### PR TITLE
TINKERPOP-1589 Re-introduced CloseableIterator

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> {
+public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> implements AutoCloseable {
 
     private Direction direction;
 
@@ -68,5 +68,10 @@ public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> {
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> {
+public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> implements AutoCloseable {
 
     private Direction direction;
 
@@ -68,5 +68,10 @@ public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> {
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public void close() {
+        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> implements AutoCloseable {
+public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> {
 
     private Direction direction;
 
@@ -68,10 +68,5 @@ public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> implements A
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
-    }
-
-    @Override
-    public void close() {
-        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -21,7 +21,6 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
-import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
 
 import java.util.Iterator;
@@ -29,10 +28,10 @@ import java.util.Iterator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
+public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements AutoCloseable {
 
     private Traverser.Admin<S> head = null;
-    protected Iterator<E> iterator = EmptyIterator.instance();
+    private Iterator<E> iterator = EmptyIterator.instance();
 
     public FlatMapStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -57,10 +56,24 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
     public void reset() {
         super.reset();
         closeIterator();
-        this.iterator = EmptyIterator.instance();
     }
 
-    protected void closeIterator() {
-        CloseableIterator.closeIterator(this.iterator);
+    @Override
+    public void close() {
+        closeIterator();
+    }
+
+    private void closeIterator() {
+        try {
+            if (this.iterator instanceof AutoCloseable) {
+                ((AutoCloseable) this.iterator).close();
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            this.iterator = EmptyIterator.instance();
+        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -44,8 +44,8 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
             if (this.iterator.hasNext()) {
                 return this.head.split(this.iterator.next(), this);
             } else {
-                this.head = this.starts.next();
                 closeIterator();
+                this.head = this.starts.next();
                 this.iterator = this.flatMap(this.head);
             }
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
 
 import java.util.Iterator;
@@ -28,10 +29,10 @@ import java.util.Iterator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements AutoCloseable {
+public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
 
     private Traverser.Admin<S> head = null;
-    private Iterator<E> iterator = EmptyIterator.instance();
+    protected Iterator<E> iterator = EmptyIterator.instance();
 
     public FlatMapStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -56,24 +57,10 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements Au
     public void reset() {
         super.reset();
         closeIterator();
+        this.iterator = EmptyIterator.instance();
     }
 
-    @Override
-    public void close() {
-        closeIterator();
-    }
-
-    private void closeIterator() {
-        try {
-            if (this.iterator instanceof AutoCloseable) {
-                ((AutoCloseable) this.iterator).close();
-            }
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        finally {
-            this.iterator = EmptyIterator.instance();
-        }
+    protected void closeIterator() {
+        CloseableIterator.closeIterator(this.iterator);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
+public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements AutoCloseable {
 
     private Traverser.Admin<S> head = null;
     private Iterator<E> iterator = EmptyIterator.instance();
@@ -44,6 +44,7 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
                 return this.head.split(this.iterator.next(), this);
             } else {
                 this.head = this.starts.next();
+                closeIterator();
                 this.iterator = this.flatMap(this.head);
             }
         }
@@ -54,6 +55,25 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
     @Override
     public void reset() {
         super.reset();
-        this.iterator = EmptyIterator.instance();
+        closeIterator();
+    }
+
+    @Override
+    public void close() {
+        closeIterator();
+    }
+
+    private void closeIterator() {
+        if (this.iterator instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) this.iterator).close();
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            finally {
+                this.iterator = EmptyIterator.instance();
+            }
+        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -64,16 +64,16 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements Au
     }
 
     private void closeIterator() {
-        if (this.iterator instanceof AutoCloseable) {
-            try {
+        try {
+            if (this.iterator instanceof AutoCloseable) {
                 ((AutoCloseable) this.iterator).close();
             }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            finally {
-                this.iterator = EmptyIterator.instance();
-            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            this.iterator = EmptyIterator.instance();
         }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
 
 import java.util.Iterator;
@@ -28,7 +29,7 @@ import java.util.Iterator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements AutoCloseable {
+public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
 
     private Traverser.Admin<S> head = null;
     private Iterator<E> iterator = EmptyIterator.instance();
@@ -56,24 +57,10 @@ public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> implements Au
     public void reset() {
         super.reset();
         closeIterator();
+        this.iterator = EmptyIterator.instance();
     }
 
-    @Override
-    public void close() {
-        closeIterator();
-    }
-
-    private void closeIterator() {
-        try {
-            if (this.iterator instanceof AutoCloseable) {
-                ((AutoCloseable) this.iterator).close();
-            }
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        finally {
-            this.iterator = EmptyIterator.instance();
-        }
+    protected void closeIterator() {
+        CloseableIterator.closeIterator(iterator);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -169,10 +169,8 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
      * be released at some point.
      */
     @Override
-    public void close() throws Exception {
-        if (iterator instanceof CloseableIterator) {
-            ((CloseableIterator) iterator).close();
-        }
+    public void close() {
+        CloseableIterator.closeIterator(iterator);
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -164,13 +164,13 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
     }
 
     /**
-     * Attemps to close an underlying iterator if it is of type {@link CloseableIterator}. Graph providers may choose
+     * Attempts to close an underlying iterator if it is of type {@link CloseableIterator}. Graph providers may choose
      * to return this interface containing their vertices and edges if there are expensive resources that might need to
      * be released at some point.
      */
     @Override
     public void close() throws Exception {
-        if (iterator != null && iterator instanceof CloseableIterator) {
+        if (iterator instanceof CloseableIterator) {
             ((CloseableIterator) iterator).close();
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class PropertiesStep<E> extends FlatMapStep<Element, E> implements AutoCloseable {
+public class PropertiesStep<E> extends FlatMapStep<Element, E> {
 
     protected final String[] propertyKeys;
     protected final PropertyType returnType;
@@ -76,10 +76,5 @@ public class PropertiesStep<E> extends FlatMapStep<Element, E> implements AutoCl
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
-    }
-
-    @Override
-    public void close() {
-        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class PropertiesStep<E> extends FlatMapStep<Element, E> {
+public class PropertiesStep<E> extends FlatMapStep<Element, E> implements AutoCloseable {
 
     protected final String[] propertyKeys;
     protected final PropertyType returnType;
@@ -76,5 +76,10 @@ public class PropertiesStep<E> extends FlatMapStep<Element, E> {
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public void close() {
+        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class PropertiesStep<E> extends FlatMapStep<Element, E> {
+public class PropertiesStep<E> extends FlatMapStep<Element, E> implements AutoCloseable {
 
     protected final String[] propertyKeys;
     protected final PropertyType returnType;
@@ -76,5 +76,10 @@ public class PropertiesStep<E> extends FlatMapStep<Element, E> {
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
@@ -35,7 +35,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> implements AutoCloseable {
+public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> {
 
     private final String[] edgeLabels;
     private Direction direction;
@@ -96,10 +96,5 @@ public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> implem
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
-    }
-
-    @Override
-    public void close() {
-        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
@@ -35,7 +35,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> {
+public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> implements AutoCloseable {
 
     private final String[] edgeLabels;
     private Direction direction;
@@ -96,5 +96,10 @@ public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> {
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public void close() {
+        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
@@ -35,7 +35,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> {
+public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> implements AutoCloseable {
 
     private final String[] edgeLabels;
     private Direction direction;
@@ -96,5 +96,10 @@ public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> {
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeIterator();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/CloseableIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/CloseableIterator.java
@@ -46,15 +46,4 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
     public default void close() {
         // do nothing by default
     }
-
-    public static <T> void closeIterator(Iterator<T> iterator) {
-        if (iterator instanceof AutoCloseable) {
-            try {
-                ((AutoCloseable) iterator).close();
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/CloseableIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/CloseableIterator.java
@@ -46,4 +46,15 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
     public default void close() {
         // do nothing by default
     }
+
+    public static <T> void closeIterator(Iterator<T> iterator) {
+        if (iterator instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) iterator).close();
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1589
Add support for the closing of Iterators returned from
`Vertex.vertices()` and `Vertex.edges()`.
Make `FlatMapStep` close iterator after read to completion.
Make `EdgeVertexStep`, `PropertiesStep`, `VertexStep`
`AutoCloseable` in case iterator is not read to completion
to ensure closed when Traversal is closed.
Add unchecked `close()` helper method to `CloseableIterator`.
OLTP mode support only. More extensive changes required for OLAP.
