### PR TITLE
Fix the serializers lookup to handle the type first, then the class inheritance

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -293,11 +293,7 @@ class Int32IO(_NumberIO):
     def dictify(cls, n, writer):
         if isinstance(n, bool):
             return n
-        if isinstance(n, LongType):
-            graphson_base_type = Int64IO.graphson_base_type
-        else:
-            graphson_base_type = cls.graphson_base_type
-        return GraphSONUtil.typedValue(graphson_base_type, n)
+        return GraphSONUtil.typedValue(cls.graphson_base_type, n)
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -75,9 +75,13 @@ class GraphSONWriter(object):
         """
         Encodes python objects in GraphSON type-tagged dict values
         """
-        for key, serializer in self.serializers.items():
-            if isinstance(obj, key):
-                return serializer.dictify(obj, self)
+        try:
+            return self.serializers[type(obj)].dictify(obj, self)
+        except KeyError:
+            for key, serializer in self.serializers.items():
+                if isinstance(obj, key):
+                    return serializer.dictify(obj, self)
+
         # list and map are treated as normal json objs (could be isolated serializers)
         if isinstance(obj, (list, set)):
             return [self.toDict(o) for o in obj]


### PR DESCRIPTION
A good example of the need for this fix is with these types:

    datetime.date
    datetime.datetime

Since a datetime is a subclass of a date and that a dict is unordered... it might happen that the wrong serializer is selected. (since isinstance(my_datetime_instance, datetime.date) == True)