### PR TITLE
Remove tests from packages

### DIFF
--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -46,7 +46,7 @@ version = __version__.version
 setup(
     name='gremlinpython',
     version=version,
-    packages=['gremlin_python', 'gremlin_python.driver', 'gremlin_python.process', 'gremlin_python.structure', 'gremlin_python.structure.io', 'tests'],
+    packages=['gremlin_python', 'gremlin_python.driver', 'gremlin_python.process', 'gremlin_python.structure', 'gremlin_python.structure.io'],
     license='Apache 2',
     url='http://tinkerpop.apache.org',
     description='Gremlin-Python for Apache TinkerPop',


### PR DESCRIPTION
Installing your tests package as part of the setup.py is probably not a good idea.

Most every python project has a tests module for unit/integration tests, this is not generally distributed/installed as part of the package. When we install a tests module as part of the gremlinpython package we end up creating a scenario where a namespace collision can occur with projects that wish to leverage the gremlinpython api. The gremlinpython tests module will end up superseding their own local tests directory in the sys.path, this creates problems for them when they go to try to run their own unit/integration tests.  If you do need to install it, i'd recommend giving it a unique name like "gremlinpythontests", so as to prevent a namespace collision with the more commonly used "tests" module.

