### PR TITLE
TINKERPOP-1633 use official jbcrypt 0.4 in maven central

### DIFF
--- a/gremlin-console/src/main/static/LICENSE
+++ b/gremlin-console/src/main/static/LICENSE
@@ -235,4 +235,4 @@ Other Licenses
 
 The Apache TinkerPop project bundles the following components under the ISC License:
 
-     jBCrypt (com.github.jeremyh:jBCrypt:0.4 - https://github.com/jeremyh/jBCrypt) - for details, see licenses/jbcrypt
+     jBCrypt (org.mindrot:jbcrypt:0.4 - https://github.com/djmdjm/jBCrypt) - for details, see licenses/jbcrypt

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -61,9 +61,9 @@ limitations under the License.
             <classifier>indy</classifier>
         </dependency>
         <dependency>
-            <groupId>com.github.jeremyh</groupId>
-            <artifactId>jBCrypt</artifactId>
-            <version>jbcrypt-0.4</version>
+            <groupId>org.mindrot</groupId>
+            <artifactId>jbcrypt</artifactId>
+            <version>0.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/dsl/credential/CredentialGraph.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/dsl/credential/CredentialGraph.java
@@ -23,7 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.mindrot.BCrypt;
+import org.mindrot.jbcrypt.BCrypt;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.drop;
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/plugin/dsl/credential/CredentialGraph.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/plugin/dsl/credential/CredentialGraph.java
@@ -23,7 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.mindrot.BCrypt;
+import org.mindrot.jbcrypt.BCrypt;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.drop;
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/SimpleAuthenticator.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/SimpleAuthenticator.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.IoCore;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
-import org.mindrot.BCrypt;
+import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/gremlin-server/src/main/static/LICENSE
+++ b/gremlin-server/src/main/static/LICENSE
@@ -239,4 +239,4 @@ The Apache TinkerPop project bundles the following components under the BSD/MIT 
 
 The Apache TinkerPop project bundles the following components under the ISC License:
 
-     jBCrypt (com.github.jeremyh:jBCrypt:0.4 - https://github.com/jeremyh/jBCrypt) - for details, see licenses/jbcrypt
+     jBCrypt (org.mindrot:jbcrypt:0.4 - https://github.com/djmdjm/jBCrypt) - for details, see licenses/jbcrypt


### PR DESCRIPTION
This removes the hurdle of requiring extra steps to get the artifacts of jbcrypt 0.4, which can now be found in maven central: https://repo1.maven.org/maven2/org/mindrot/jbcrypt/0.4/