### PR TITLE
TINKERPOP-1554: has(propertyKey) should have a corresponding step in Gremlin-Java.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added an optimized `HasPropertyStep` so that `has(key)` no longer compiles to `filter(values(key))`.
 * Refactor `SparkContext` handler to support external kill and stop operations.
 * Fixed an optimization bug in `LazyBarrierStrategy` around appending barriers to the end of a `Traversal`.
 * `TraverserIterator` in GremlinServer is smart to try and bulk traversers prior to network I/O.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -35,12 +35,21 @@ Upgrading for Users
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+HasPropertyStep
++++++++++++++++
+
+`HasPropertyStep` was added in order to alleviate the complexity of the compilation of `has(key)` to `filter(values('key'))`.
+A few of TinkerPop's `TraversalStrategy` test cases had to be tweaked given the new compilation. Nothing too complicated
+and providers may run into similar test case issues with their specific `ProviderTraverserStrategies`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1554[TINKERPOP-1554]
+
 LazyBarrierStrategy No Longer End Appends Barriers
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 
 `LazyBarrierStrategy` was trying to do to much by considering `Traverser` effects on network I/O by appending an
 `NoOpBarrierStrategy` to the end of the root traversal. This should not be accomplished by `LazyBarrierStrategy`,
-but instead by `RemoteStrategy`. `RemoteStrategy` now tries to barrier-append. This may effect the reasoninig logic in
+but instead by `RemoteStrategy`. `RemoteStrategy` now tries to barrier-append. This may effect the reasoning logic in
 some `ProviderStrategies`. Most likely not, but just be aware.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1627[TINKERPOP-1627]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -50,6 +50,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.CyclicPathStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DropStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasPropertyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.IsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.LambdaFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
@@ -963,12 +964,12 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default GraphTraversal<S, E> has(final String propertyKey) {
         this.asAdmin().getBytecode().addStep(Symbols.has, propertyKey);
-        return this.asAdmin().addStep(new TraversalFilterStep<>(this.asAdmin(), __.values(propertyKey)));
+        return this.asAdmin().addStep(new HasPropertyStep(this.asAdmin(), propertyKey, true));
     }
 
     public default GraphTraversal<S, E> hasNot(final String propertyKey) {
         this.asAdmin().getBytecode().addStep(Symbols.hasNot, propertyKey);
-        return this.asAdmin().addStep(new NotStep<>(this.asAdmin(), __.values(propertyKey)));
+        return this.asAdmin().addStep(new HasPropertyStep(this.asAdmin(), propertyKey, false));
     }
 
     public default GraphTraversal<S, E> hasLabel(final String label, final String... otherLabels) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasPropertyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasPropertyStep.java
@@ -1,0 +1,55 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class HasPropertyStep<S extends Element> extends FilterStep<S> {
+
+    private final String propertyKey;
+    private final boolean contains;
+
+    public HasPropertyStep(final Traversal.Admin traversal, final String propertyKey, final boolean contains) {
+        super(traversal);
+        this.propertyKey = propertyKey;
+        this.contains = contains;
+    }
+
+    @Override
+    protected boolean filter(final Traverser.Admin<S> traverser) {
+        return this.contains == traverser.get().properties(this.propertyKey).hasNext();
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.stepString(this, this.contains ? this.propertyKey : "!" + this.propertyKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.propertyKey.hashCode() ^ Boolean.hashCode(this.contains);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategy.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ClassFilterSte
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.CyclicPathStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasPropertyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.IsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
@@ -49,26 +50,6 @@ import java.util.Set;
  * FilterRankingStrategy reorders filter- and order-steps according to their rank. It will also do its best to push
  * step labels as far "right" as possible in order to keep traversers as small and bulkable as possible prior to the
  * absolute need for path-labeling.
- * <p/>
- * <table>
- * <thead>
- * <tr><th>Step</th><th>Rank</th></tr>
- * </thead>
- * <tbody>
- * <tr><td>is(predicate)</td><td>1</td></tr>
- * <tr><td>has(predicate)</td><td>2</td></tr>
- * <tr><td>where(predicate)</td><td>3</td></tr>
- * <tr><td>simplePath()</td><td>4</td></tr>
- * <tr><td>cyclicPath()</td><td>4</td></tr>
- * <tr><td>filter(traversal)</td><td>5</td></tr>
- * <tr><td>not(traversal)</td>td>5</td></tr>
- * <tr><td>where(traversal)</td><td>6</td></tr>
- * <tr><td>or(...)</td><td>7</td></tr>
- * <tr><td>and(...)</td><td>8</td></tr>
- * <tr><td>dedup()</td><td>9</td></tr>
- * <tr><td>order()</td><td>10</td></tr>
- * </tbody>
- * </table>
  *
  * @author Daniel Kuppitz (http://gremlin.guru)
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -127,24 +108,26 @@ public final class FilterRankingStrategy extends AbstractTraversalStrategy<Trave
             rank = 1;
         else if (step instanceof HasStep)
             rank = 2;
-        else if (step instanceof WherePredicateStep && ((WherePredicateStep) step).getLocalChildren().isEmpty())
+        else if (step instanceof HasPropertyStep)
             rank = 3;
-        else if (step instanceof SimplePathStep || step instanceof CyclicPathStep)
+        else if (step instanceof WherePredicateStep && ((WherePredicateStep) step).getLocalChildren().isEmpty())
             rank = 4;
-        else if (step instanceof TraversalFilterStep || step instanceof NotStep)
+        else if (step instanceof SimplePathStep || step instanceof CyclicPathStep)
             rank = 5;
-        else if (step instanceof WhereTraversalStep)
+        else if (step instanceof TraversalFilterStep || step instanceof NotStep)
             rank = 6;
-        else if (step instanceof OrStep)
+        else if (step instanceof WhereTraversalStep)
             rank = 7;
-        else if (step instanceof AndStep)
+        else if (step instanceof OrStep)
             rank = 8;
-        else if (step instanceof WherePredicateStep) // has by()-modulation
+        else if (step instanceof AndStep)
             rank = 9;
-        else if (step instanceof DedupGlobalStep)
+        else if (step instanceof WherePredicateStep) // has by()-modulation
             rank = 10;
-        else if (step instanceof OrderGlobalStep)
+        else if (step instanceof DedupGlobalStep)
             rank = 11;
+        else if (step instanceof OrderGlobalStep)
+            rank = 12;
         else
             return 0;
         ////////////

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasPropertyStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasPropertyStepTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *  
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class HasPropertyStepTest extends StepTest {
+
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Arrays.asList(
+                __.has("name"),
+                __.hasNot("name"),
+                __.hasNot("age"),
+                __.has("age")
+        );
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasStepTest.java
@@ -40,7 +40,6 @@ public class HasStepTest extends StepTest {
     @Override
     protected List<Traversal> getTraversals() {
         return Arrays.asList(
-                __.has("name"),
                 __.has("name", "marko"),
                 __.has("name", out("knows").values("name")),
                 __.hasId(1),
@@ -49,8 +48,6 @@ public class HasStepTest extends StepTest {
                 __.hasKey("age"),
                 __.hasLabel("person"),
                 __.hasLabel("project"),
-                __.hasNot("name"),
-                __.hasNot("age"),
                 __.hasValue("marko"),
                 __.hasValue("josh")
         );

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategyTest.java
@@ -106,7 +106,7 @@ public class FilterRankingStrategyTest {
                 {__.dedup().has("value", 0).or(not(has("age")), has("age", 10)).has("value", 1), __.has("value", 0).has("value", 1).or(not(has("age")), has("age", 10)).dedup(), Collections.singletonList(InlineFilterStrategy.instance())},
                 {__.dedup().filter(out()).has("value", 0), has("value", 0).filter(out()).dedup(), Collections.emptyList()},
                 {filter(out()).dedup().has("value", 0), has("value", 0).filter(out()).dedup(), Collections.emptyList()},
-                {__.as("a").out().has("age").where(P.eq("a")), __.as("a").out().where(P.eq("a")).has("age"), Collections.emptyList()},
+                {__.as("a").out().has("age").where(P.eq("a")), __.as("a").out().has("age").where(P.eq("a")), Collections.emptyList()},
                 {__.as("a").out().has("age").where(P.eq("a")).by("age"), __.as("a").out().has("age").where(P.eq("a")).by("age"), Collections.emptyList()},
                 {__.as("a").out().and(has("age"), has("name")).where(P.eq("a")).by("age"), __.as("a").out().and(has("age"), has("name")).where(P.eq("a")).by("age"), Collections.emptyList()},
                 {__.as("a").out().and(has("age"), has("name")).where(P.eq("a")), __.as("a").out().where(P.eq("a")).and(has("age"), has("name")), Collections.emptyList()},
@@ -118,7 +118,7 @@ public class FilterRankingStrategyTest {
                 {has("value", 0).or(has("name"), has("age")).has("value", 1).dedup(), has("value", 0).has("value", 1).or(has("name"), has("age")).dedup(), Collections.singletonList(InlineFilterStrategy.instance())},
                 {has("value", 0).or(out(), in()).as(Graph.Hidden.hide("x")).has("value", 1).dedup(), has("value", 0).has("value", 1).or(outE(), inE()).dedup(), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
                 {has("value", 0).and(has("age"), has("name", "marko")).is(10), __.is(10).has("value", 0).has("age").has("name", "marko"), Collections.singletonList(InlineFilterStrategy.instance())},
-                {has("value", 0).filter(or(not(has("age")), has("age", 1))).has("value", 1).dedup(), has("value", 0).has("value", 1).or(not(filter(properties("age"))), has("age", 1)).dedup(), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
+                {has("value", 0).filter(or(not(has("age")), has("age", 1))).has("value", 1).dedup(), has("value", 0).has("value", 1).or(not(has("age")), has("age", 1)).dedup(), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
         });
     }
 }

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/strategy/optimization/Neo4jGraphStepStrategyTest.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/strategy/optimization/Neo4jGraphStepStrategyTest.java
@@ -46,10 +46,8 @@ import java.util.Collections;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.gt;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.lt;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.filter;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.not;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.properties;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -122,7 +120,7 @@ public class Neo4jGraphStepStrategyTest {
                 {__.V().as("a").dedup().has("name", "marko").or(has("age", 10), has("age", gt(32))).filter(has("name", "bob")).has("lang", "java"),
                         g_V("name", eq("marko"), "lang", eq("java"), "name", eq("bob"), "age", eq(10).or(gt(32))).dedup().as("a"), TraversalStrategies.GlobalCache.getStrategies(Neo4jGraph.class).toList()},
                 {__.V().has("name", "marko").or(not(has("age")), has("age", gt(32))).has("name", "bob").has("lang", "java"),
-                        g_V("name", eq("marko"), "name", eq("bob"), "lang", eq("java")).or(not(filter(properties("age"))), has("age", gt(32))), TraversalStrategies.GlobalCache.getStrategies(Neo4jGraph.class).toList()},
+                        g_V("name", eq("marko"), "name", eq("bob"), "lang", eq("java")).or(not(has("age")), has("age", gt(32))), TraversalStrategies.GlobalCache.getStrategies(Neo4jGraph.class).toList()},
                 {__.V().has("name", P.eq("marko").or(P.eq("bob").and(P.eq("stephen")))).out("knows"),
                         g_V("name", eq("marko").or(P.eq("bob").and(P.eq("stephen")))).out("knows"), Collections.emptyList()},
                 {__.V().has("name", P.eq("marko").and(P.eq("bob").and(P.eq("stephen")))).out("knows"),

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphStepStrategyTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphStepStrategyTest.java
@@ -123,7 +123,7 @@ public class TinkerGraphStepStrategyTest {
                 {__.V().as("a").dedup().has("name", "marko").or(has("age", 10), has("age", gt(32))).filter(has("name", "bob")).has("lang", "java"),
                         g_V("name", eq("marko"), "lang", eq("java"), "name", eq("bob"), "age", eq(10).or(gt(32))).dedup().as("a"), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
                 {__.V().has("name", "marko").or(not(has("age")), has("age", gt(32))).has("name", "bob").has("lang", "java"),
-                        g_V("name", eq("marko"), "name", eq("bob"), "lang", eq("java")).or(not(filter(properties("age"))), has("age", gt(32))), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
+                        g_V("name", eq("marko"), "name", eq("bob"), "lang", eq("java")).or(not(has("age")), has("age", gt(32))), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
                 {__.V().has("name", P.eq("marko").or(P.eq("bob").and(P.eq("stephen")))).out("knows"),
                         g_V("name", eq("marko").or(P.eq("bob").and(P.eq("stephen")))).out("knows"), Collections.emptyList()},
                 {__.V().has("name", P.eq("marko").and(P.eq("bob").and(P.eq("stephen")))).out("knows"),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1554

Currently `has('name')` compiles to `filter(values('name'))`. Its a used enough "step" that it should really have its own direct step compilation for efficiency, understability, and ease of strategy manipulation.

VOTE +1.