### PR TITLE
TINKERPOP-1635 Fix duplicate serialization of element property in PropertySerializer

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -225,7 +225,7 @@ class PropertySerializer(_GraphSONTypeIO):
                 del valueDict["value"]
         return GraphSONUtil.typedValue("Property", {"key": writer.toDict(property.key),
                                                     "value": writer.toDict(property.value),
-                                                    "element": writer.toDict(elementDict)})
+                                                    "element": elementDict})
 
 
 class TraversalStrategySerializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
@@ -211,10 +211,10 @@ class TestGraphSONWriter(TestCase):
                 "@value": {"key": "name", "value": "marko", "element": {"@type": "g:VertexProperty",
                                                                         "@value": {
                                                                             "vertex": "vertexId",
-                                                                            "id": "anId",
+                                                                            "id": {"@type": "g:Int32", "@value": 1234},
                                                                             "label": "aKey"}}}} == json.loads(
             self.graphson_writer.writeObject(
-                Property("name", "marko", VertexProperty("anId", "aKey", 21345, Vertex("vertexId")))))
+                Property("name", "marko", VertexProperty(1234, "aKey", 21345, Vertex("vertexId")))))
 
     def test_custom_mapping(self):
         # extended mapping


### PR DESCRIPTION
This fixes the duplicate serialization issue in gremlin-python's PropertySerializer:
[https://issues.apache.org/jira/browse/TINKERPOP-1635](https://issues.apache.org/jira/browse/TINKERPOP-1635)

This pull requests removes the second call to `writer.toDict()` and changes a property value in the respective unit test to an int. That makes the test fail with the duplicate serialization and pass with the fixed version.