### PR TITLE
TINKERPOP-1639 Support simple String operations

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added support for simple String operations. `CountLocalStep`, `RangeLocalStep` and `TailLocalStep` can now imitate `String::length()` and `String::substring()`.
 * Removed `HasTest.g_V_hasId_compilationEquality` from process test suite as it makes too many assumptions about provider compilation.
 * Deprecated `CustomizerProvider` infrastructure.
 * Improved consistency of the application of bindings to `GremlinScriptEngine` implementations in the `BindingsGremlinPlugin`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountLocalStep.java
@@ -43,7 +43,9 @@ public final class CountLocalStep<S> extends MapStep<S, Long> {
         final S item = traverser.get();
         return (item instanceof Collection) ? ((Collection) item).size()
                 : (item instanceof Map) ? ((Map) item).size()
-                : (item instanceof Path) ? ((Path) item).size() : 1L;
+                : (item instanceof Path) ? ((Path) item).size()
+                : (item instanceof Object[]) ? ((Object[]) item).length
+                : (item instanceof CharSequence) ? ((CharSequence) item).length() : 1L;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
@@ -61,6 +61,9 @@ public final class RangeLocalStep<S> extends MapStep<S, S> {
      * Set becomes Set (order-preserving)
      * </li>
      * <li>
+     * String becomes String
+     * </li>
+     * <li>
      * Other Collection types become List
      * </li>
      * </ul>
@@ -70,6 +73,11 @@ public final class RangeLocalStep<S> extends MapStep<S, S> {
             return (S) applyRangeMap((Map) start, low, high);
         } else if (start instanceof Iterable) {
             return (S) applyRangeIterable((Iterable) start, low, high);
+        } else if (start instanceof CharSequence) {
+            final CharSequence seq = (CharSequence) start;
+            final int length = seq.length();
+            return (S) (low >= length ? "" : seq.subSequence((int) Math.max(0, low),
+                    high > length || high == -1 ? length : (int) high).toString());
         }
         return start;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStep.java
@@ -53,8 +53,9 @@ public final class TailLocalStep<S> extends MapStep<S, S> {
                 start instanceof Map ? ((Map) start).size() :
                         start instanceof Collection ? ((Collection) start).size() :
                                 start instanceof Path ? ((Path) start).size() :
-                                        start instanceof Iterable ? IteratorUtils.count((Iterable) start) :
-                                                this.limit;
+                                        start instanceof CharSequence ? ((CharSequence) start).length() :
+                                                start instanceof Iterable ? IteratorUtils.count((Iterable) start) :
+                                                        this.limit;
         final long low = high - this.limit;
         final S result = RangeLocalStep.applyRange(start, low, high);
         return result;

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
@@ -108,5 +108,15 @@ public abstract class GroovyRangeTest {
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').range(local,1,2)")
         }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_name_limitXlocal_3X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.name.limit(local, 3)")
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_name_rangeXlocal_1_4X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.name.range(local, 1, 4)")
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
@@ -88,5 +88,10 @@ public abstract class GroovyTailTest {
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').tail(local, 1)")
         }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_name_tailXlocal_4X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.name.tail(local, 4)")
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCountTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCountTest.groovy
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
+import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
 import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
@@ -66,6 +67,11 @@ public abstract class GroovyCountTest {
         @Override
         public Traversal<Vertex, Long> get_g_V_fold_countXlocalX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.fold.count(local)")
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_name_countXlocalX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.name.count(local)")
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeTest.java
@@ -79,6 +79,10 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X();
 
+    public abstract Traversal<Vertex, String> get_g_V_name_limitXlocal_3X();
+
+    public abstract Traversal<Vertex, String> get_g_V_name_rangeXlocal_1_4X();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_VX1X_out_limitX2X() {
@@ -295,6 +299,22 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_name_limitXlocal_3X() {
+        final Traversal<Vertex, String> traversal = get_g_V_name_limitXlocal_3X();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList("mar", "vad", "lop", "jos", "rip", "pet"), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_name_rangeXlocal_1_4X() {
+        final Traversal<Vertex, String> traversal = get_g_V_name_rangeXlocal_1_4X();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList("ark", "ada", "op", "osh", "ipp", "ete"), traversal);
+    }
+
     public static class Traversals extends RangeTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_limitX2X(final Object v1Id) {
@@ -374,6 +394,16 @@ public abstract class RangeTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X() {
             return g.V().as("a").out().as("b").out().as("c").<Map<String, String>>select("a","b","c").by("name").range(local, 1, 2);
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_name_limitXlocal_3X() {
+            return g.V().values("name").limit(local, 3);
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_name_rangeXlocal_1_4X() {
+            return g.V().values("name").range(local, 1, 4);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
@@ -74,6 +74,8 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X();
 
+    public abstract Traversal<Vertex, String> get_g_V_name_tailXlocal_4X();
+
     /** Scenario: Global scope */
     @Test
     @LoadGraphWith(MODERN)
@@ -206,6 +208,13 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_name_tailXlocal_4X() {
+        final Traversal<Vertex, String> traversal = get_g_V_name_tailXlocal_4X();
+        checkResults(Arrays.asList("arko", "adas", "lop", "josh", "pple", "eter"), traversal);
+    }
+
     public static class Traversals extends TailTest {
 
         @Override
@@ -266,6 +275,11 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X() {
             return g.V().as("a").out().as("b").out().as("c").<String>select("a","b","c").by("name").tail(local, 1);
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_name_tailXlocal_4X() {
+            return g.V().values("name").tail(local, 4);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountTest.java
@@ -27,6 +27,8 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Arrays;
+
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.GRATEFUL;
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
@@ -54,6 +56,8 @@ public abstract class CountTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Long> get_g_V_hasXnoX_count();
 
     public abstract Traversal<Vertex, Long> get_g_V_fold_countXlocalX();
+
+    public abstract Traversal<Vertex, Long> get_g_V_name_countXlocalX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -136,6 +140,14 @@ public abstract class CountTest extends AbstractGremlinProcessTest {
         assertFalse(traversal.hasNext());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_name_countXlocalX() {
+        final Traversal<Vertex, Long> traversal = get_g_V_name_countXlocalX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(5L, 5L, 3L, 4L, 6L, 5L), traversal);
+    }
+
     public static class Traversals extends CountTest {
 
         @Override
@@ -176,6 +188,11 @@ public abstract class CountTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Long> get_g_V_fold_countXlocalX() {
             return g.V().fold().count(Scope.local);
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_name_countXlocalX() {
+            return g.V().values("name").count(Scope.local);
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1639

Added support for simple String operations. `CountLocalStep`, `RangeLocalStep` and `TailLocalStep` can now imitate `String::length()` and `String::substring()`.

A few examples:

```
gremlin> g.V().values("name").count(local)
==>5
==>5
==>3
==>4
==>6
==>5
gremlin> g.V().values("name").limit(local, 3)
==>mar
==>vad
==>lop
==>jos
==>rip
==>pet
gremlin> g.V().values("name").tail(local, 4)
==>arko
==>adas
==>lop
==>josh
==>pple
==>eter
gremlin> g.V().values("name").group().by(range(local, 1, 2)).next()
==>a=[marko, vadas]
==>e=[peter]
==>i=[ripple]
==>o=[lop, josh]
```

VOTE: +1