### PR TITLE
TINKERPOP-1640: ComputerVerificationStrategy gives false errors

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Split `ComputerVerificationStrategy` into two strategies: `ComputerVerificationStrategy` and `ComputerFinalizationStrategy`.
 * Removed `HasTest.g_V_hasId_compilationEquality` from process test suite as it makes too many assumptions about provider compilation.
 * Deprecated `CustomizerProvider` infrastructure.
 * Deprecated `PluginAcceptor` infrastructure.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.ComputerResultStep;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.TraversalVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.finalization.ComputerFinalizationStrategy;
 import org.apache.tinkerpop.gremlin.process.computer.util.AbstractVertexProgramBuilder;
 import org.apache.tinkerpop.gremlin.process.computer.util.SingleMessenger;
 import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
@@ -438,7 +439,7 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
                 final Traversal.Admin<?, ?> parentTraversal = new DefaultTraversal<>();
                 traversal.getGraph().ifPresent(parentTraversal::setGraph);
                 final TraversalStrategies strategies = traversal.getStrategies().clone();
-                strategies.addStrategies(ComputerVerificationStrategy.instance(), new VertexProgramStrategy(Computer.compute()));
+                strategies.addStrategies(ComputerFinalizationStrategy.instance(), ComputerVerificationStrategy.instance(), new VertexProgramStrategy(Computer.compute()));
                 parentTraversal.setStrategies(strategies);
                 traversal.setStrategies(strategies);
                 parentTraversal.setSideEffects(memoryTraversalSideEffects);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/finalization/ComputerFinalizationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/finalization/ComputerFinalizationStrategy.java
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.finalization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class ComputerFinalizationStrategy extends AbstractTraversalStrategy<TraversalStrategy.FinalizationStrategy> {
+
+    private static final ComputerFinalizationStrategy INSTANCE = new ComputerFinalizationStrategy();
+
+    private ComputerFinalizationStrategy() {
+    }
+
+    @Override
+    public void apply(Traversal.Admin<?, ?> traversal) {
+        if (!TraversalHelper.onGraphComputer(traversal))
+            return;
+
+        final boolean globalChild = TraversalHelper.isGlobalChild(traversal);
+        for (final Step<?, ?> step : traversal.getSteps()) {
+            // only global children are graph computing
+            if (globalChild && step instanceof GraphComputing)
+                ((GraphComputing) step).onGraphComputer();
+        }
+    }
+
+    public static ComputerFinalizationStrategy instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Set<Class<? extends FinalizationStrategy>> applyPrior() {
+        return Collections.singleton(ProfileStrategy.class);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/finalization/ComputerFinalizationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/finalization/ComputerFinalizationStrategy.java
@@ -42,13 +42,11 @@ public final class ComputerFinalizationStrategy extends AbstractTraversalStrateg
 
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
-        if (!TraversalHelper.onGraphComputer(traversal))
+        if (!TraversalHelper.onGraphComputer(traversal) || !TraversalHelper.isGlobalChild(traversal))
             return;
 
-        final boolean globalChild = TraversalHelper.isGlobalChild(traversal);
         for (final Step<?, ?> step : traversal.getSteps()) {
-            // only global children are graph computing
-            if (globalChild && step instanceof GraphComputing)
+            if (step instanceof GraphComputing)
                 ((GraphComputing) step).onGraphComputer();
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal;
 
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.finalization.ComputerFinalizationStrategy;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.optimization.GraphFilterStrategy;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.optimization.MessagePassingReductionStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
@@ -226,6 +227,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
                     MessagePassingReductionStrategy.instance(),
                     OrderLimitStrategy.instance(),
                     PathProcessorStrategy.instance(),
+                    ComputerFinalizationStrategy.instance(),
                     ComputerVerificationStrategy.instance());
             GRAPH_COMPUTER_CACHE.put(GraphComputer.class, graphComputerStrategies);
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/GraphComputing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/GraphComputing.java
@@ -23,7 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 
 /**
  * A {@code GraphComputing} step is one that will change its behavior whether its on a {@link org.apache.tinkerpop.gremlin.process.computer.GraphComputer} or not.
- * {@link org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy} is responsible for calling the {@link GraphComputing#onGraphComputer()} method.
+ * {@link org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.finalization.ComputerFinalizationStrategy} is responsible for calling the {@link GraphComputing#onGraphComputer()} method.
  * This method is only called for global children steps of a {@link TraversalParent}.
  *
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategy.java
@@ -24,7 +24,6 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.VertexPr
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -61,8 +60,6 @@ public final class ComputerVerificationStrategy extends AbstractTraversalStrateg
         if (!TraversalHelper.onGraphComputer(traversal))
             return;
 
-        final boolean globalChild = TraversalHelper.isGlobalChild(traversal);
-
         if (traversal.getParent() instanceof TraversalVertexProgramStep) {
             if (TraversalHelper.getStepsOfAssignableClassRecursively(GraphStep.class, traversal).size() > 1)
                 throw new VerificationException("Mid-traversal V()/E() is currently not supported on GraphComputer", traversal);
@@ -71,10 +68,6 @@ public final class ComputerVerificationStrategy extends AbstractTraversalStrateg
         }
 
         for (final Step<?, ?> step : traversal.getSteps()) {
-
-            // only global children are graph computing
-            if (globalChild && step instanceof GraphComputing)
-                ((GraphComputing) step).onGraphComputer();
 
             // you can not traverse past the local star graph with localChildren (e.g. by()-modulators).
             if (step instanceof TraversalParent) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
@@ -47,7 +47,8 @@ public final class StandardVerificationStrategy extends AbstractTraversalStrateg
 
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
-        if (!traversal.getStrategies().toList().contains(ComputerFinalizationStrategy.instance())) {
+        if (!traversal.getStrategies().toList().contains(ComputerFinalizationStrategy.instance()) &&
+                !traversal.getStrategies().toList().contains(ComputerVerificationStrategy.instance())) {
             if (!TraversalHelper.getStepsOfAssignableClass(VertexComputing.class, traversal).isEmpty())
                 throw new VerificationException("VertexComputing steps must be executed with a GraphComputer: " + TraversalHelper.getStepsOfAssignableClass(VertexComputing.class, traversal), traversal);
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.verification;
 
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.VertexComputing;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.finalization.ComputerFinalizationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
@@ -31,7 +32,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Set;
 
@@ -47,7 +47,7 @@ public final class StandardVerificationStrategy extends AbstractTraversalStrateg
 
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
-        if (!traversal.getStrategies().toList().contains(ComputerVerificationStrategy.instance())) {
+        if (!traversal.getStrategies().toList().contains(ComputerFinalizationStrategy.instance())) {
             if (!TraversalHelper.getStepsOfAssignableClass(VertexComputing.class, traversal).isEmpty())
                 throw new VerificationException("VertexComputing steps must be executed with a GraphComputer: " + TraversalHelper.getStepsOfAssignableClass(VertexComputing.class, traversal), traversal);
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraver
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
@@ -29,7 +30,6 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
-import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONTokens;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.InputShim;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.KryoShim;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.OutputShim;
@@ -138,7 +138,8 @@ public final class GryoSerializers {
         public <O extends OutputShim> void write(final KryoShim<?, O> kryo, final O output, final Bytecode bytecode) {
             final List<Bytecode.Instruction> sourceInstructions = IteratorUtils.list(
                     IteratorUtils.filter(bytecode.getSourceInstructions().iterator(),
-                            i -> !i.getOperator().equals("withStrategies") && !i.getOperator().equals("withComputer")));
+                            i -> !i.getOperator().equals(TraversalSource.Symbols.withStrategies) &&
+                                    !i.getOperator().equals(TraversalSource.Symbols.withComputer)));
             writeInstructions(kryo, output, sourceInstructions);
             final List<Bytecode.Instruction> stepInstructions = IteratorUtils.list(bytecode.getStepInstructions().iterator());
             writeInstructions(kryo, output, stepInstructions);
@@ -150,7 +151,9 @@ public final class GryoSerializers {
             final int sourceInstructionCount = input.readInt();
             for (int ix = 0; ix < sourceInstructionCount; ix++) {
                 final String operator = input.readString();
-                final Object[] args = kryo.readObject(input, Object[].class);
+                final Object[] args = operator.equals(TraversalSource.Symbols.withoutStrategies) ?
+                        kryo.readObject(input, Class[].class) :
+                        kryo.readObject(input, Object[].class);
                 bytecode.addSource(operator, args);
             }
 
@@ -210,7 +213,7 @@ public final class GryoSerializers {
             try {
                 if (predicate.equals("and") || predicate.equals("or"))
                     return predicate.equals("and") ? new AndP((List<P>) value) : new OrP((List<P>) value);
-                else  if (value instanceof Collection) {
+                else if (value instanceof Collection) {
                     if (predicate.equals("between"))
                         return P.between(((List) value).get(0), ((List) value).get(1));
                     else if (predicate.equals("inside"))

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
@@ -181,6 +181,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(BigDecimal.class, 35));
             add(GryoTypeReg.of(Calendar.class, 39));
             add(GryoTypeReg.of(Class.class, 41, new UtilSerializers.ClassSerializer()));
+            add(GryoTypeReg.of(Class[].class, 166, new UtilSerializers.ClassArraySerializer())); // ***LAST ID***
             add(GryoTypeReg.of(Collection.class, 37));
             add(GryoTypeReg.of(Collections.EMPTY_LIST.getClass(), 51));
             add(GryoTypeReg.of(Collections.EMPTY_MAP.getClass(), 52));
@@ -260,7 +261,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(SackFunctions.Barrier.class, 135));
             add(GryoTypeReg.of(TraversalOptionParent.Pick.class, 137));
             add(GryoTypeReg.of(HashSetSupplier.class, 136, new UtilSerializers.HashSetSupplierSerializer()));
-            add(GryoTypeReg.of(MultiComparator.class, 165));   // ***LAST ID***
+            add(GryoTypeReg.of(MultiComparator.class, 165));
 
             add(GryoTypeReg.of(TraverserSet.class, 58));
             add(GryoTypeReg.of(Tree.class, 61));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/UtilSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/UtilSerializers.java
@@ -45,7 +45,8 @@ import java.util.UUID;
  */
 final class UtilSerializers {
 
-    private UtilSerializers() {}
+    private UtilSerializers() {
+    }
 
     /**
      * Serializer for {@code List} instances produced by {@code Arrays.asList()}.
@@ -100,6 +101,30 @@ final class UtilSerializers {
         }
     }
 
+    public final static class ClassArraySerializer implements SerializerShim<Class[]> {
+        @Override
+        public <O extends OutputShim> void write(final KryoShim<?, O> kryo, final O output, final Class[] object) {
+            output.writeInt(object.length);
+            for (final Class clazz : object) {
+                output.writeString(clazz.getName());
+            }
+        }
+
+        @Override
+        public <I extends InputShim> Class[] read(final KryoShim<I, ?> kryo, final I input, final Class<Class[]> clazz) {
+            final int size = input.readInt();
+            final Class[] clazzes = new Class[size];
+            for (int i = 0; i < size; i++) {
+                try {
+                    clazzes[i] = Class.forName(input.readString());
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+            return clazzes;
+        }
+    }
+
     public final static class InetAddressSerializer implements SerializerShim<InetAddress> {
         @Override
         public <O extends OutputShim> void write(final KryoShim<?, O> kryo, final O output, final InetAddress addy) {
@@ -137,7 +162,8 @@ final class UtilSerializers {
 
     static final class UUIDSerializer implements SerializerShim<UUID> {
 
-        public UUIDSerializer() { }
+        public UUIDSerializer() {
+        }
 
         @Override
         public <O extends OutputShim> void write(final KryoShim<?, O> kryo, final O output, final UUID uuid) {
@@ -158,7 +184,8 @@ final class UtilSerializers {
 
     static final class URISerializer implements SerializerShim<URI> {
 
-        public URISerializer() { }
+        public URISerializer() {
+        }
 
         @Override
         public <O extends OutputShim> void write(final KryoShim<?, O> kryo, final O output, final URI uri) {

--- a/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonProvider.java
+++ b/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonProvider.java
@@ -69,6 +69,7 @@ public class PythonProvider extends AbstractGraphProvider {
             "shouldNeverPropagateANullValuedTraverser",
             "shouldHidePartitionKeyForValues",
             "g_withSackXBigInteger_TEN_powX1000X_assignX_V_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack",
+            "allShortestPaths",
             //
             ProgramTest.Traversals.class.getCanonicalName(),
             TraversalInterruptionTest.class.getCanonicalName(),

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ComplexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ComplexTest.java
@@ -117,7 +117,7 @@ public abstract class ComplexTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, Map<String, Map<String, Object>>>> getCoworkerSummaryOLTP();
 
-    public abstract Traversal<Vertex, List<String>> getAllShortestPaths();
+    public abstract Traversal<Vertex, List<Object>> getAllShortestPaths();
 
     @Test
     @LoadGraphWith(LoadGraphWith.GraphData.GRATEFUL)
@@ -176,39 +176,45 @@ public abstract class ComplexTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void allShortestPaths() {
-        final Traversal<Vertex, List<String>> traversal = getAllShortestPaths();
+        final Traversal<Vertex, List<Object>> traversal = getAllShortestPaths();
         printTraversalForm(traversal);
-        final List<List<String>> allShortestPaths = Arrays.asList(
-                Arrays.asList("josh", "lop"),
-                Arrays.asList("josh", "marko"),
-                Arrays.asList("josh", "ripple"),
-                Arrays.asList("josh", "marko", "vadas"),
-                Arrays.asList("josh", "lop", "peter"),
-                Arrays.asList("lop", "marko"),
-                Arrays.asList("lop", "peter"),
-                Arrays.asList("lop", "josh"),
-                Arrays.asList("lop", "josh", "ripple"),
-                Arrays.asList("lop", "marko", "vadas"),
-                Arrays.asList("marko", "lop"),
-                Arrays.asList("marko", "josh"),
-                Arrays.asList("marko", "vadas"),
-                Arrays.asList("marko", "josh", "ripple"),
-                Arrays.asList("marko", "lop", "peter"),
-                Arrays.asList("peter", "lop"),
-                Arrays.asList("peter", "lop", "marko"),
-                Arrays.asList("peter", "lop", "josh"),
-                Arrays.asList("peter", "lop", "josh", "ripple"),
-                Arrays.asList("peter", "lop", "marko", "vadas"),
-                Arrays.asList("ripple", "josh"),
-                Arrays.asList("ripple", "josh", "lop"),
-                Arrays.asList("ripple", "josh", "marko"),
-                Arrays.asList("ripple", "josh", "marko", "vadas"),
-                Arrays.asList("ripple", "josh", "lop", "peter"),
-                Arrays.asList("vadas", "marko"),
-                Arrays.asList("vadas", "marko", "josh"),
-                Arrays.asList("vadas", "marko", "lop"),
-                Arrays.asList("vadas", "marko", "josh", "ripple"),
-                Arrays.asList("vadas", "marko", "lop", "peter")
+        final Object marko = convertToVertexId(graph, "marko");
+        final Object vadas = convertToVertexId(graph, "vadas");
+        final Object lop = convertToVertexId(graph, "lop");
+        final Object josh = convertToVertexId(graph, "josh");
+        final Object ripple = convertToVertexId(graph, "ripple");
+        final Object peter = convertToVertexId(graph, "peter");
+        final List<List<Object>> allShortestPaths = Arrays.asList(
+                Arrays.asList(josh, lop),
+                Arrays.asList(josh, marko),
+                Arrays.asList(josh, ripple),
+                Arrays.asList(josh, marko, vadas),
+                Arrays.asList(josh, lop, peter),
+                Arrays.asList(lop, marko),
+                Arrays.asList(lop, peter),
+                Arrays.asList(lop, josh),
+                Arrays.asList(lop, josh, ripple),
+                Arrays.asList(lop, marko, vadas),
+                Arrays.asList(marko, lop),
+                Arrays.asList(marko, josh),
+                Arrays.asList(marko, vadas),
+                Arrays.asList(marko, josh, ripple),
+                Arrays.asList(marko, lop, peter),
+                Arrays.asList(peter, lop),
+                Arrays.asList(peter, lop, marko),
+                Arrays.asList(peter, lop, josh),
+                Arrays.asList(peter, lop, josh, ripple),
+                Arrays.asList(peter, lop, marko, vadas),
+                Arrays.asList(ripple, josh),
+                Arrays.asList(ripple, josh, lop),
+                Arrays.asList(ripple, josh, marko),
+                Arrays.asList(ripple, josh, marko, vadas),
+                Arrays.asList(ripple, josh, lop, peter),
+                Arrays.asList(vadas, marko),
+                Arrays.asList(vadas, marko, josh),
+                Arrays.asList(vadas, marko, lop),
+                Arrays.asList(vadas, marko, josh, ripple),
+                Arrays.asList(vadas, marko, lop, peter)
         );
         checkResults(allShortestPaths, traversal);
     }
@@ -252,7 +258,7 @@ public abstract class ComplexTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, List<String>> getAllShortestPaths() {
+        public Traversal<Vertex, List<Object>> getAllShortestPaths() {
             // TODO: remove .withoutStrategies(PathRetractionStrategy.class)
             return g.withoutStrategies(PathRetractionStrategy.class).V().as("v").both().as("v").
                     project("src", "tgt", "p").by(select(first, "v")).
@@ -272,7 +278,7 @@ public abstract class ComplexTest extends AbstractGremlinProcessTest {
                                     filter(select(values).unfold().or(count(local).where(lt("l")), where(eq("p"))))).
                             group("x").by(select("src", "tgt")).
                             by(select("p").fold()).select("tgt").barrier()).
-                    cap("x").select(values).unfold().unfold().map(unfold().<String>values("name").fold());
+                    cap("x").select(values).unfold().unfold().map(unfold().id().fold());
         }
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.ProgramPhase;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.MemoryTraversalSideEffects;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.finalization.ComputerFinalizationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.NumberHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
@@ -75,7 +76,7 @@ public final class SparkStarBarrierInterceptor implements SparkVertexProgramInte
         final ReducingBarrierStep endStep = (ReducingBarrierStep) traversal.getEndStep(); // needed for the final traverser generation
         traversal.removeStep(0);                                    // remove GraphStep
         traversal.removeStep(traversal.getSteps().size() - 1);      // remove ReducingBarrierStep
-        traversal.setStrategies(traversal.clone().getStrategies().removeStrategies(ComputerVerificationStrategy.class)); // no longer a computer job, but parallel standard jobs
+        traversal.setStrategies(traversal.clone().getStrategies().removeStrategies(ComputerVerificationStrategy.class, ComputerFinalizationStrategy.class)); // no longer a computer job, but parallel standard jobs
         traversal.applyStrategies();                                // compile
         boolean identityTraversal = traversal.getSteps().isEmpty(); // if the traversal is empty, just return the vertex (fast)
         ///////////////////////////////

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphNoStrategyProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphNoStrategyProvider.java
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SideEffectStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.TinkerGraphProvider;
 import org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.strategy.optimization.TinkerGraphStepStrategy;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1640

Split `ComputerVerificationStrategy` into two strategies:

    1. `ComputerVerificationStrategy` -- does all the `VerificationException` analyses.
    2. `ComputerFinalizationStrategy` -- does all the `GraphComputing` step configurations.

This was enabled so that users who are certain that the verification logic of `ComputerVerificationStrategy` is too strict for their particular traversal, can turn off verification and still have a proper executing OLAP traversal.

VOTE +1.