### PR TITLE
TINKERPOP-1644 Improve script compilation syncronisation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Script compilation is synchronised.
+* Script compilation times are placed in to logs.
+* Failed scripts will not be recompiled.
+* Scripts that take over 5 seconds to compile are logged as a warning.
 * Split `ComputerVerificationStrategy` into two strategies: `ComputerVerificationStrategy` and `ComputerFinalizationStrategy`.
 * Removed `HasTest.g_V_hasId_compilationEquality` from process test suite as it makes too many assumptions about provider compilation.
 * Deprecated `CustomizerProvider` infrastructure.

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -70,6 +70,11 @@ limitations under the License.
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.3.1</version>
+        </dependency>
         <!-- TEST -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
@@ -174,7 +174,7 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
                     return loader.parseClass(script, generateScriptName());
                 } catch (CompilationFailedException e) {
                     long finish = System.currentTimeMillis();
-                    log.error("Script compilation FAILED {} took {}ms {}", script, finish - start, e.getCause());
+                    log.error("Script compilation FAILED {} took {}ms {}", script, finish - start, e);
                     throw e;
                 } finally {
                     long time = System.currentTimeMillis() - start;


### PR DESCRIPTION
Script compilation is synchronised.
Script compilation times are placed in to logs.
Failed scripts will not be recompiled.
Scripts that take over 5 seconds to compile are logged as a warning.