### PR TITLE
TINKERPOP-1645 Bump to groovy 2.4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ limitations under the License.
     </scm>
     <properties>
         <commons.configuration.version>1.10</commons.configuration.version>
-        <groovy.version>2.4.8</groovy.version>
+        <groovy.version>2.4.9</groovy.version>
         <junit.version>4.12</junit.version>
         <metrics.version>3.0.2</metrics.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1645

Just a version bump, but as it is a version bump an explicit vote would be good.  I've only ran tests for 'tp31' at this point, but will run tests on the other branches prior to merge. There really shouldn't be any problems as this release of groovy was pretty small.

VOTE +1