### PR TITLE
TINKERPOP-1504 Added the property key to events for new properties.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.1.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed `EventStrategy` so that newly added properties trigger events with the name of the key that was added.
 * Drop use of jitpack for the jbcrypt artifact - using the official one in Maven Central.
 
 [[release-3-1-6]]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
@@ -36,6 +36,8 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedProperty;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 
 import java.util.List;
 import java.util.Set;
@@ -91,11 +93,20 @@ public final class AddPropertyStep<S extends Element> extends SideEffectStep<S> 
             final boolean newProperty = element instanceof Vertex ? currentProperty == VertexProperty.empty() : currentProperty == Property.empty();
             final Event.ElementPropertyChangedEvent evt;
             if (element instanceof Vertex)
-                evt = new Event.VertexPropertyChangedEvent(DetachedFactory.detach((Vertex) element, true), newProperty ? null : DetachedFactory.detach((VertexProperty) currentProperty, true), value, vertexPropertyKeyValues);
+                evt = new Event.VertexPropertyChangedEvent(DetachedFactory.detach((Vertex) element, true),
+                        newProperty ?
+                                new DetachedVertexProperty(null, key, null, null) :
+                                DetachedFactory.detach((VertexProperty) currentProperty, true), value, vertexPropertyKeyValues);
             else if (element instanceof Edge)
-                evt = new Event.EdgePropertyChangedEvent(DetachedFactory.detach((Edge) element, true), newProperty ? null : DetachedFactory.detach(currentProperty), value);
+                evt = new Event.EdgePropertyChangedEvent(DetachedFactory.detach((Edge) element, true),
+                        newProperty ?
+                                new DetachedProperty(key, null) :
+                                DetachedFactory.detach(currentProperty), value);
             else if (element instanceof VertexProperty)
-                evt = new Event.VertexPropertyPropertyChangedEvent(DetachedFactory.detach((VertexProperty) element, true), newProperty ? null : DetachedFactory.detach(currentProperty), value);
+                evt = new Event.VertexPropertyPropertyChangedEvent(DetachedFactory.detach((VertexProperty) element, true),
+                        newProperty ?
+                                new DetachedProperty(key, null):
+                                DetachedFactory.detach(currentProperty), value);
             else
                 throw new IllegalStateException(String.format("The incoming object cannot be processed by change eventing in %s:  %s", AddPropertyStep.class.getName(), element));
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1504

Newly added properties triggered "changed" events when using `EventStrategy` but the specific key that was newly added was not available in the mutation listener. The listener would simply report the new value only. After this change the listener now gets a `DetachedVertexProperty` / `DetachedProperty` with the newly added key and a null value set.

Builds with `mvn clean install` - VOTE +1