### PR TITLE
TINKERPOP-1303 Adds help option to :remote config command

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added "help" command option on `:remote config` for plugins that support that feature in the Gremlin Console.
 * Added various metrics to the `GremlinGroovyScriptEngine` around script compilation and exposed them in Gremlin Server.
 * Moved the `caffeine` dependency down to `gremlin-groovy` and out of `gremlin-server`.
 * Improved script compilation in `GremlinGroovyScriptEngine to use better caching, log long compile times and prevent failed compilations from recompiling on future requests.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/jsr223/GephiRemoteAcceptor.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/jsr223/GephiRemoteAcceptor.groovy
@@ -99,8 +99,11 @@ class GephiRemoteAcceptor implements RemoteAcceptor {
 
     @Override
     Object configure(final List<String> args) throws RemoteException {
-        if (args.size() < 2)
+        if (args.size() < 2 && args[0] != "help")
             throw new RemoteException("Invalid config arguments - check syntax")
+
+        if (args[0] == "help")
+            return ":remote config [host <host>|port <port>|workspace <name>|stepDelay <ms>|startRGBColor <0.0,0.0,0.0>|colorToFade [r|g|b]|colorFadeRate <0.0>|sizeDecrementRate <0.0>|startSize <0.0>|visualTraversal <graph>|help]"
 
         if (args[0] == "host")
             host = args[1]

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/plugin/GephiRemoteAcceptor.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/plugin/GephiRemoteAcceptor.groovy
@@ -104,8 +104,11 @@ class GephiRemoteAcceptor implements RemoteAcceptor {
 
     @Override
     Object configure(final List<String> args) throws RemoteException {
-        if (args.size() < 2)
+        if (args.size() < 2 && args[0] != "help")
             throw new RemoteException("Invalid config arguments - check syntax")
+
+        if (args[0] == "help")
+            return ":remote config [host <host>|port <port>|workspace <name>|stepDelay <ms>|startRGBColor <0.0,0.0,0.0>|colorToFade [r|g|b]|colorFadeRate <0.0>|sizeDecrementRate <0.0>|startSize <0.0>|visualTraversal <graph>|help]"
 
         if (args[0] == "host")
             host = args[1]

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptor.java
@@ -75,7 +75,8 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
     private static final String TOKEN_ALIAS = "alias";
     private static final String TOKEN_SESSION = "session";
     private static final String TOKEN_SESSION_MANAGED = "session-managed";
-    private static final List<String> POSSIBLE_TOKENS = Arrays.asList(TOKEN_TIMEOUT, TOKEN_ALIAS);
+    private static final String TOKEN_HELP = "help";
+    private static final List<String> POSSIBLE_TOKENS = Arrays.asList(TOKEN_TIMEOUT, TOKEN_ALIAS, TOKEN_HELP);
 
     private final Groovysh shell;
 
@@ -117,7 +118,9 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
 
         final List<String> arguments = args.subList(1, args.size());
 
-        if (option.equals(TOKEN_TIMEOUT)) {
+        if (option.equals(TOKEN_HELP)) {
+            return ":remote config [timeout [<ms>|none]|alias [reset|show|<alias> <actual>]|help]";
+        } else if (option.equals(TOKEN_TIMEOUT)) {
             final String errorMessage = "The timeout option expects a positive integer representing milliseconds or 'none' as an argument";
             if (arguments.size() != 1) throw new RemoteException(errorMessage);
             try {

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -73,7 +73,8 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
     private static final String TOKEN_ALIAS = "alias";
     private static final String TOKEN_SESSION = "session";
     private static final String TOKEN_SESSION_MANAGED = "session-managed";
-    private static final List<String> POSSIBLE_TOKENS = Arrays.asList(TOKEN_TIMEOUT, TOKEN_ALIAS);
+    private static final String TOKEN_HELP = "help";
+    private static final List<String> POSSIBLE_TOKENS = Arrays.asList(TOKEN_TIMEOUT, TOKEN_ALIAS, TOKEN_HELP);
 
     private final GremlinShellEnvironment shellEnvironment;
 
@@ -115,7 +116,9 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
 
         final List<String> arguments = args.subList(1, args.size());
 
-        if (option.equals(TOKEN_TIMEOUT)) {
+        if (option.equals(TOKEN_HELP)) {
+            return ":remote config [timeout [<ms>|none]|alias [reset|show|<alias> <actual>]|help]";
+        } else if (option.equals(TOKEN_TIMEOUT)) {
             final String errorMessage = "The timeout option expects a positive integer representing milliseconds or 'none' as an argument";
             if (arguments.size() != 1) throw new RemoteException(errorMessage);
             try {

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/groovy/plugin/HadoopRemoteAcceptor.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/groovy/plugin/HadoopRemoteAcceptor.java
@@ -46,6 +46,7 @@ public final class HadoopRemoteAcceptor implements RemoteAcceptor {
 
     private static final String USE_SUGAR = "useSugar";
     private static final String USE_TRAVERSAL_SOURCE = "useTraversalSource";
+    private static final String HELP = "help";
     private static final String SPACE = " ";
 
     private HadoopGraph hadoopGraph;
@@ -76,6 +77,9 @@ public final class HadoopRemoteAcceptor implements RemoteAcceptor {
 
     @Override
     public Object configure(final List<String> args) throws RemoteException {
+        if (args.size() == 1 && args.get(0).equals(HELP))
+            return ":remote config [useSugar [true|false]|useTraversalSource <traversalSourceName>|help]";
+
         for (int i = 0; i < args.size(); i = i + 2) {
             if (args.get(i).equals(USE_SUGAR))
                 this.useSugar = Boolean.valueOf(args.get(i + 1));

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/jsr223/HadoopRemoteAcceptor.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/jsr223/HadoopRemoteAcceptor.java
@@ -44,6 +44,7 @@ public final class HadoopRemoteAcceptor implements RemoteAcceptor {
 
     private static final String USE_SUGAR = "useSugar";
     private static final String USE_TRAVERSAL_SOURCE = "useTraversalSource";
+    private static final String HELP = "help";
     private static final String SPACE = " ";
 
     private HadoopGraph hadoopGraph;
@@ -74,6 +75,9 @@ public final class HadoopRemoteAcceptor implements RemoteAcceptor {
 
     @Override
     public Object configure(final List<String> args) throws RemoteException {
+        if (args.size() == 1 && args.get(0).equals(HELP))
+            return ":remote config [useSugar [true|false]|useTraversalSource <traversalSourceName>|help]";
+
         for (int i = 0; i < args.size(); i = i + 2) {
             if (args.get(i).equals(USE_SUGAR))
                 this.useSugar = Boolean.valueOf(args.get(i + 1));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1303

Here's the output for "help" in the plugins that support `:remote` as an option in the console:

```text
gremlin> :remote connect tinkerpop.gephi
==>Connection to Gephi - http://localhost:8080/workspace1 with stepDelay:1000, startRGBColor:[0.0, 1.0, 0.5], colorToFade:g, colorFadeRate:0.7, startSize:10.0,sizeDecrementRate:0.33
gremlin> :remote config help
==>:remote config [host <host>|port <port>|workspace <name>|stepDelay <ms>|startRGBColor <0.0,0.0,0.0>|colorToFade [r|g|b]|colorFadeRate <0.0>|sizeDecrementRate <0.0>|startSize <0.0>|visualTraversal <graph>|help]
gremlin> :remote connect tinkerpop.server conf/remote.yaml
==>Configured localhost/127.0.0.1:8182
gremlin> :remote config help
==>:remote config [timeout [<ms>|none]|alias [reset|show|<alias> <actual>]|help]
gremlin> :remote connect tinkerpop.hadoop graph g
==>useTraversalSource=graphtraversalsource[hadoopgraph[gryoinputformat->gryooutputformat], sparkgraphcomputer]
==>useSugar=false
gremlin> :remote config help
==>:remote config [useSugar [true|false]|useTraversalSource <traversalSourceName>|help]
```

This was a pretty simple change, but since @pluradj added this ticket, I opted submit this to vote so that he could review before merge instead of just doing a CTR.

VOTE +1