### PR TITLE
TINKERPOP-1653 Allow multiple scripts to be passed to gremlin.sh

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Allowed for multiple scripts and related arguments to be passed to `gremlin.sh` via `-i` and `-e`.
 * Added various metrics to the `GremlinGroovyScriptEngine` around script compilation and exposed them in Gremlin Server.
 * Moved the `caffeine` dependency down to `gremlin-groovy` and out of `gremlin-server`.
 * Improved script compilation in `GremlinGroovyScriptEngine to use better caching, log long compile times and prevent failed compilations from recompiling on future requests.

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -77,6 +77,14 @@ which enables the "glv-python" Maven profile or in a more automated fashion simp
 `gremlin-python` module which will signify to Maven that the environment is Python-ready. The `.glv` file need not have
 any contents and is ignored by Git. A standard `mvn clean install` will then build `gremlin-python` in full.
 
+As of TinkerPop 3.2.5, the build also requires Python to execute `gremlin-console` integration tests. The integration
+test is configured by a "console-integration-tests" Maven profile. This profile can be activated manually or can more
+simply piggy-back on the `.glv` file in `gremlin-python`. Note that unlike `gremlin-python` the tests are actually
+integration tests and therefore must be actively switched on with `-DskipIntegrationTests=false`:
+
+[source,text
+mvn clean install -pl gremlin-console -DskipIntegrationTests=false
+
 [[release-environment]]
 Release Environment
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -303,6 +303,16 @@ $ bin/gremlin.sh -e gremlin.groovy vadas
 v[2]
 ----
 
+It is also possible to pass multiple scripts by specifying multiple `-e` options. The scripts will execute in the order
+that they are specified. Note that only the arguments from the last script executed will be preserved in the console.
+Finally, if the arguments conflict with the reserved flags that `gremlin.sh` responds double quotes can be used to
+wrap all the arugments to the option:
+
+[source,bash]
+----
+$ bin/gremlin.sh -e "gremlin.groovy -e -i --color"
+----
+
 [[interactive-mode]]
 Interactive Mode
 ~~~~~~~~~~~~~~~~
@@ -346,6 +356,9 @@ gremlin> g.V()
 
 Note that the user can now reference `g` (and `graph` for that matter) at startup without having to directly type that
 variable initialization code into the console.
+
+Like, execution mode, it is also possible to pass multiple scripts by specifying multiple `-i` options. See the
+<<execution-mode, Execution Mode Section>> for more information on the specfics of that capability.
 
 [[gremlin-server]]
 Gremlin Server

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -42,6 +42,21 @@ set. Note that metrics are captured for both sessionless requests as well as for
 
 See: https://issues.apache.org/jira/browse/TINKERPOP-1644[TINKERPOP-1644]
 
+Gremlin Console Scripting
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `gremlin.sh` command has two flags, `-i` and `-e`, which are used to pass a script and arguments into the Gremlin
+Console for execution. Those flags now allow for passing multiple scripts and related arguments to be supplied which
+can yield greater flexibilty in automation tasks.
+
+[source,bash]
+----
+$ bin/gremlin.sh -i y.groovy 1 2 3 -i x.groovy
+$ bin/gremlin.sh -e y.groovy 1 2 3 -e x.groovy
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1653[TINKERPOP-1653]
+
 Gremlin-Python Driver
 ^^^^^^^^^^^^^^^^^^^^^
 Gremlin-Python now offers a more complete driver implementation that uses connection pooling and

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -206,4 +206,121 @@ limitations under the License.
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- activates the building of python components and requires that python be installed on the system. use
+             the .glv file in gremlin-python as an indicator to activate -->
+        <profile>
+            <id>console-integration-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <file>
+                    <!-- can't use variable here - maven no likey -->
+                    <exists>../gremlin-python/.glv</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-python-reports-directory</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipIntegrationTests}</skip>
+                                    <tasks>
+                                        <mkdir dir="${project.build.directory}/python-reports"/>
+                                        <mkdir dir="${project.build.directory}/python/env"/>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                            <!-- copy files in python directory to target/python and run virtual env to sandbox python.
+                                 there is no need to "activate" the virtualenv because all calls to python occur
+                                 directly from bin/ -->
+                            <execution>
+                                <id>setup-py-env</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipIntegrationTests}</skip>
+                                    <tasks>
+                                        <copy todir="${project.build.directory}/python">
+                                            <fileset dir="src/test/python"/>
+                                        </copy>
+                                        <exec dir="${project.build.directory}/python" executable="virtualenv"
+                                              failonerror="true">
+                                            <arg line="--python=python env"/>
+                                        </exec>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>native-python-build</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipIntegrationTests}</skip>
+                                    <target>
+                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
+                                              failonerror="true">
+                                            <env key="PYTHONPATH" value=""/>
+                                            <arg line="setup.py build --build-lib ${project.build.outputDirectory}/Lib"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>copy-gremlinsh</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipIntegrationTests}</skip>
+                                    <tasks>
+                                        <copy todir="${project.build.directory}/python/gremlin-console">
+                                            <fileset dir="${project.build.directory}/apache-tinkerpop-gremlin-console-${project.version}-standalone"/>
+                                        </copy>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+
+                            <!--
+                            use pytest to execute native python tests - output of xunit output is configured in setup.cfg.
+                            must run on integration tests because package phase has to execute to get the console binaries
+                            available for testing
+                            -->
+                            <execution>
+                                <id>native-python-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipIntegrationTests}</skip>
+                                    <target>
+                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
+                                              failonerror="true">
+                                            <env key="PYTHONPATH" value=""/>
+                                            <arg line="setup.py test"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -69,10 +69,10 @@ class Console {
      */
     @Deprecated
     public Console(final String initScriptFile) {
-        this(new IO(System.in, System.out, System.err), initScriptFile.size() != null ? [initScriptFile]: null, true)
+        this(new IO(System.in, System.out, System.err), initScriptFile.size() != null ? [[initScriptFile]]: null, true)
     }
 
-    public Console(final IO io, final List<String> scriptAndArgs, final boolean interactive) {
+    public Console(final IO io, final List<List<String>> scriptsAndArgs, final boolean interactive) {
         this.io = io
         this.interactive = interactive
 
@@ -158,7 +158,7 @@ class Console {
         try {
             // if the init script contains :x command it will throw an ExitNotification so init script execution
             // needs to appear in the try/catch
-            if (scriptAndArgs != null && scriptAndArgs.size() > 0) executeInShell(scriptAndArgs)
+            if (scriptsAndArgs != null && !scriptsAndArgs.isEmpty()) executeInShell(scriptsAndArgs)
 
             // start iterating results to show as output
             showShellEvaluationOutput(true)
@@ -364,49 +364,51 @@ class Console {
         return Preferences.resultPrompt
     }
 
-    private void executeInShell(final List<String> scriptAndArgs) {
-        final String scriptFile = scriptAndArgs[0]
-        try {
-            // check if this script comes with arguments. if so then set them up in an "args" bundle
-            if (scriptAndArgs.size() > 1) {
-                List<String> args = scriptAndArgs.subList(1, scriptAndArgs.size())
-                groovy.execute("args = [\"" + args.join('\",\"') + "\"]")
-            } else {
-                groovy.execute("args = []")
-            }
-
-            File file = new File(scriptFile)
-            if (!file.exists() && !file.isAbsolute()) {
-                final String userWorkingDir = System.getProperty("user.working_dir");
-                if (userWorkingDir != null) {
-                    file = new File(userWorkingDir, scriptFile);
+    private void executeInShell(final List<List<String>> scriptsAndArgs) {
+        scriptsAndArgs.each { scriptAndArgs ->
+            final String scriptFile = scriptAndArgs[0]
+            try {
+                // check if this script comes with arguments. if so then set them up in an "args" bundle
+                if (scriptAndArgs.size() > 1) {
+                    List<String> args = scriptAndArgs.subList(1, scriptAndArgs.size())
+                    groovy.execute("args = [\"" + args.join('\",\"') + "\"]")
+                } else {
+                    groovy.execute("args = []")
                 }
-            }
-            int lineNumber = 0
-            def lines = file.readLines()
-            for (String line : lines) {
-                try {
-                    lineNumber++
-                    groovy.execute(line)
-                } catch (Exception ex) {
-                    io.err.println(Colorizer.render(Preferences.errorColor, "Error in $scriptFile at [$lineNumber: $line] - ${ex.message}"))
-                    if (interactive)
-                        break
-                    else {
-                        ex.printStackTrace(io.err)
-                        System.exit(1)
+
+                File file = new File(scriptFile)
+                if (!file.exists() && !file.isAbsolute()) {
+                    final String userWorkingDir = System.getProperty("user.working_dir");
+                    if (userWorkingDir != null) {
+                        file = new File(userWorkingDir, scriptFile);
                     }
-
                 }
-            }
+                int lineNumber = 0
+                def lines = file.readLines()
+                for (String line : lines) {
+                    try {
+                        lineNumber++
+                        groovy.execute(line)
+                    } catch (Exception ex) {
+                        io.err.println(Colorizer.render(Preferences.errorColor, "Error in $scriptFile at [$lineNumber: $line] - ${ex.message}"))
+                        if (interactive)
+                            break
+                        else {
+                            ex.printStackTrace(io.err)
+                            System.exit(1)
+                        }
 
-            if (!interactive) System.exit(0)
-        } catch (FileNotFoundException ignored) {
-            io.err.println(Colorizer.render(Preferences.errorColor, "Gremlin file not found at [$scriptFile]."))
-            if (!interactive) System.exit(1)
-        } catch (Exception ex) {
-            io.err.println(Colorizer.render(Preferences.errorColor, "Failure processing Gremlin script [$scriptFile] - ${ex.message}"))
-            if (!interactive) System.exit(1)
+                    }
+                }
+
+                if (!interactive) System.exit(0)
+            } catch (FileNotFoundException ignored) {
+                io.err.println(Colorizer.render(Preferences.errorColor, "Gremlin file not found at [$scriptFile]."))
+                if (!interactive) System.exit(1)
+            } catch (Exception ex) {
+                io.err.println(Colorizer.render(Preferences.errorColor, "Failure processing Gremlin script [$scriptFile] - ${ex.message}"))
+                if (!interactive) System.exit(1)
+            }
         }
     }
 
@@ -414,11 +416,7 @@ class Console {
 
         Preferences.expandoMagic()
 
-        // need to do some up front processing to try to support "bin/gremlin.sh init.groovy" until this deprecated
-        // feature can be removed. ultimately this should be removed when a breaking change can go in
         IO io = new IO(System.in, System.out, System.err)
-        if (args.length == 1 && !args[0].startsWith("-"))
-            new Console(io, [args[0]], true)
 
         final CliBuilder cli = new CliBuilder(usage: 'gremlin.sh [options] [...]', formatter: new HelpFormatter(), stopAtNonOption: false)
 
@@ -452,6 +450,8 @@ class Console {
         }
 
         if (options.v) {
+        if (args.length == 1 && !args[0].startsWith("-"))
+            new Console(io, [args[0]], true)
             println("gremlin " + Gremlin.version())
             System.exit(0)
         }
@@ -469,9 +469,50 @@ class Console {
             System.exit(0)
         }
 
-        List<String> scriptAndArgs = options.e ?
-                (options.es != null && options.es ? options.es : null) :
-                (options.is != null && options.is ? options.is : null)
-        new Console(io, scriptAndArgs, !options.e)
+        // need to do some up front processing to try to support "bin/gremlin.sh init.groovy" until this deprecated
+        // feature can be removed. ultimately this should be removed when a breaking change can go in
+        if (args.length == 1 && !args[0].startsWith("-")) {
+            new Console(io, [[args[0]]], true)
+        } else {
+            def scriptAndArgs = parseArgs(options.e ? "-e" : "-i", args, cli)
+            new Console(io, scriptAndArgs, !options.e)
+        }
+    }
+
+    /**
+     * Provides a bit of a hack around the limitations of the {@code CliBuilder}. This method directly parses the
+     * argument list to allow for multiple {@code -e} and {@code -i} values and parses such parameters into a list
+     * of lists where the inner list is a script file and its arguments.
+     */
+    private static List<List<String>> parseArgs(final String option, final String[] args, final CliBuilder cli) {
+        def parsed = []
+        for (int ix = 0; ix < args.length; ix++) {
+            if (args[ix] == option) {
+                // increment the counter to move past the option that was found. should now be positioned on the
+                // first argument to that option
+                ix++
+
+                def parsedSet = []
+                for (ix; ix < args.length; ix++) {
+                    // this is a do nothing as there's no arguments to the option or it's the start of a new option
+                    if (cli.options.options.any { "-" + it.opt == args[ix] || "--" + it.longOpt == args[ix] }) {
+                        // rollback the counter now that we hit the next option
+                        ix--
+                        break;
+                    }
+                    parsedSet << args[ix]
+                }
+
+                if (!parsedSet.isEmpty()) {
+                    // check if the params were passed in with double quotes such that they arrive as a single arg
+                    if (parsedSet.size() == 1)
+                        parsed << parsedSet[0].toString().split(" ").toList()
+                    else
+                        parsed << parsedSet
+                }
+            }
+        }
+
+        return parsed
     }
 }

--- a/gremlin-console/src/test/python/setup.cfg
+++ b/gremlin-console/src/test/python/setup.cfg
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --junitxml=../python-reports/TEST-native-python.xml
+norecursedirs = '.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg' lib lib64

--- a/gremlin-console/src/test/python/setup.py
+++ b/gremlin-console/src/test/python/setup.py
@@ -1,0 +1,36 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+'''
+import codecs
+import os
+import sys
+import time
+from setuptools import setup
+
+setup(
+    name='gremlinconsoletest',
+    test_suite="tests",
+    setup_requires=[
+        'pytest-runner',
+    ],
+    tests_require=[
+        'pytest',
+        'mock',
+        'pexpect'
+    ]
+)

--- a/gremlin-console/src/test/python/tests/__init__.py
+++ b/gremlin-console/src/test/python/tests/__init__.py
@@ -1,0 +1,20 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+'''
+
+__author__ = 'Stephen Mallette (http://stephen.genoprime.com)'

--- a/gremlin-console/src/test/python/tests/test_console.py
+++ b/gremlin-console/src/test/python/tests/test_console.py
@@ -1,0 +1,95 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+'''
+
+import unittest
+from unittest import TestCase
+import pexpect
+
+class TestConsole(TestCase):
+
+    # the base command must pass -C because if colors are enabled pexpect gets garbled input and tests won't pass
+    gremlinsh = "bash gremlin-console/bin/gremlin.sh -C "
+
+    def test_basic_console_operations(self):
+        child = pexpect.spawn(TestConsole.gremlinsh)
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "1-1")
+        child.expect("==>0\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
+    def test_just_dash_i(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "-i x.groovy")
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "x")
+        child.expect("==>2\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
+    def test_dash_i_with_args(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "-i y.groovy 1 2 3")
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "y")
+        child.expect("==>6\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
+    def test_dash_i_multiple_scripts(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "-i y.groovy 1 2 3 -i x.groovy -i \"z.groovy x -i --color -D\"")
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "y")
+        child.expect("==>6\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._send(child, "x")
+        child.expect("==>2\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._send(child, "z")
+        child.expect("==>argument=\[x, -i, --color, -D\]\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
+    def test_no_mix_dash_i_and_dash_e(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "-i y.groovy 1 2 3 -i x.groovy -e \"z.groovy x -i --color -D\"")
+        child.expect("-i and -e options are mutually exclusive - provide one or the other")
+        child.expect(pexpect.EOF)
+
+    @staticmethod
+    def _expect_gremlin_header(child):
+        # skip/read the Gremlin graphics
+        child.expect("\r\n")
+        child.expect(["plugin activated: tinkerpop.server", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
+        child.expect(["plugin activated: tinkerpop.server", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
+        child.expect(["plugin activated: tinkerpop.server", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
+        TestConsole._expect_prompt(child)
+
+    @staticmethod
+    def _send(child, line):
+        child.sendline(line)
+        child.expect(line + "\r\n")
+
+    @staticmethod
+    def _expect_prompt(child):
+        child.expect("gremlin> ")
+
+    @staticmethod
+    def _close(child):
+        child.sendline(":x")
+
+
+

--- a/gremlin-console/src/test/python/x.groovy
+++ b/gremlin-console/src/test/python/x.groovy
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+x = 1 + 1

--- a/gremlin-console/src/test/python/y.groovy
+++ b/gremlin-console/src/test/python/y.groovy
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+y = args.collect{Integer.parseInt(it)}.sum()

--- a/gremlin-console/src/test/python/z.groovy
+++ b/gremlin-console/src/test/python/z.groovy
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+z = "argument=" + args


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1653

This is a non-breaking change and simply allows multiple `-i` and `-e` options on gremlin.sh. The old method for passing a single script name to gremlin.sh remains intact as well. Had to write a custom parser for the command line arguments to do this because it doesn't appear that `CliBuilder` is capable of parsing the in the manner necessary to support this feature unfortunately.

Here's some example usage given these three scripts:

```text
$ more *.groovy
::::::::::::::
x.groovy
::::::::::::::
x = 1 + 1
::::::::::::::
y.groovy
::::::::::::::
y = args.collect{Integer.parseInt(it)}.sum()
::::::::::::::
z.groovy
::::::::::::::
z = "argument=" + args
```

This is old, now deprecated, method that is still supported:

```
$ bin/gremlin.sh x.groovy 

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
gremlin> x
==>2
```

Next with `-i` as usual:

```text
$ bin/gremlin.sh -i x.groovy

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
gremlin> x
==>2
```

then with arguments:

```text
$ bin/gremlin.sh -i y.groovy 1 2 3

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
gremlin> y
==>6
```

Next with multiple scripts:

```text
$ bin/gremlin.sh -i y.groovy 1 2 3 -i x.groovy

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
gremlin> y
==>6
gremlin> x
==>2
```

Then with multiple scripts with other `gremlin.sh` options mixed in

```text
$ bin/gremlin.sh -i y.groovy 1 2 3 --color -i x.groovy -i "z.groovy x -i --color -D"

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
gremlin> x
==>2
gremlin> y
==>6
gremlin> z
==>argument=[x, -i, --color, -D]
```

Finally, note that you still can't mix/match `-i` and `-e` commands - `CliBuilder` still rejects bad stuff like that:

```text
$ bin/gremlin.sh -i y.groovy 1 2 3 --color -i x.groovy -e "z.groovy x -i --color -D"
-i and -e options are mutually exclusive - provide one or the other
```

VOTE +1