### PR TITLE
TINKERPOP-1625: Improvements to has() related steps

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -797,8 +797,8 @@ It is possible to filter vertices, edges, and vertex properties based on their p
   * `has(key,predicate)`: Remove the traverser if its element does not have a key value that satisfies the bi-predicate. For more information on predicates, please read <<a-note-on-predicates,A Note on Predicates>>.
   * `hasLabel(labels...)`: Remove the traverser if its element does not have any of the labels.
   * `hasId(ids...)`: Remove the traverser if its element does not have any of the ids.
-  * `hasKey(keys...)`: Remove the traverser if its property does not have any of the keys.
-  * `hasValue(values...)`: Remove the traverser if its property does not have any of the values.
+  * `hasKey(keys...)`: Remove the traverser if the property does not have all of the provided keys.
+  * `hasValue(values...)`: Remove the traverser if its property does not have all of the provided values.
   * `has(key)`: Remove the traverser if its element does not have a value for the key.
   * `hasNot(key)`: Remove the traverser if its element has a value for the key.
   * `has(key, traversal)`: Remove the traverser if its object does not yield a result through the traversal off the property value.
@@ -814,6 +814,8 @@ g.V().has('age',outside(20,30)).values('age') <2>
 g.V().has('name',within('josh','marko')).valueMap() <3>
 g.V().has('name',without('josh','marko')).valueMap() <4>
 g.V().has('name',not(within('josh','marko'))).valueMap() <5>
+g.V().properties().hasKey('age').value() <6>
+g.V().hasNot('age').values('name') <7>
 ----
 
 <1> Find all vertices whose ages are between 20 (inclusive) and 30 (exclusive).
@@ -822,6 +824,8 @@ g.V().has('name',not(within('josh','marko'))).valueMap() <5>
 the key,value pairs for those verticies.
 <4> Find all vertices whose names are not in the collection `[josh,marko]`, display all the key,value pairs for those vertices.
 <5> Same as the prior example save using `not` on `within` to yield `without`.
+<6> Find all age-properties and emit their value.
+<7> Find all vertices that do not have an age-property and emit their name.
 
 TinkerPop does not support a regular expression predicate, although specific graph databases that leverage TinkerPop
 may provide a partial match extension.

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
@@ -136,31 +136,6 @@ public abstract class GroovyHasTest {
         }
 
         @Override
-        public Traversal<Vertex, Vertex> get_g_VX1X(final Object v1Id) {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id)", "v1Id", v1Id)
-        }
-
-        @Override
-        public Traversal<Vertex, Vertex> get_g_V_hasIdX1X(final Object v1Id) {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(v1Id)", "v1Id", v1Id)
-        }
-
-        @Override
-        public Traversal<Vertex, Vertex> get_g_VX1_2X(final Object v1Id, final Object v2Id) {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id, v2Id)", "v1Id", v1Id, "v2Id", v2Id)
-        }
-
-        @Override
-        public Traversal<Vertex, Vertex> get_g_V_hasIdX1_2X(final Object v1Id, final Object v2Id) {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(v1Id, v2Id)", "v1Id", v1Id, "v2Id", v2Id)
-        }
-
-        @Override
-        public Traversal<Vertex, Vertex> get_g_V_hasIdXwithinX1_2XX(final Object v1Id, final Object v2Id) {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(within(v1Id, v2Id))", "v1Id", v1Id, "v2Id", v2Id)
-        }
-
-        @Override
         public Traversal<Vertex, Vertex> get_g_V_in_hasIdXneqX1XX(final Object v1Id) {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.in.hasId(neq(v1Id))", "v1Id", v1Id)
         }
@@ -168,6 +143,21 @@ public abstract class GroovyHasTest {
         @Override
         public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_hasXage_notXlteX10X_andXnotXbetweenX11_20XXXX_andXltX29X_orXeqX35XXXX_name() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').has('age', P.not(lte(10).and(P.not(between(11,20)))).and(lt(29).or(eq(35)))).name")
+        }
+
+        @Override
+        public Traversal<Vertex, Integer> get_g_V_both_properties_dedup_hasKeyXageX_value() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.properties().dedup.hasKey('age').value")
+        }
+
+        @Override
+        public Traversal<Vertex, Integer> get_g_V_both_properties_dedup_hasKeyXageX_hasValueXgtX30XX_value() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.properties().dedup.hasKey('age').hasValue(gt(30)).value")
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_hasNotXageX_name() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasNot('age').name");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1625

Added tests for `hasKey()` and `hasValue()`. Also tweaked up `HasTest` which had dangling traversers not being tested. Updated docs with `hasKey()` and `hasValue()` examples. Note that in the documentation we do not use Java var args conventions, but instead try and keep it general to all languages. Thus, the "technique" of `hasKey(String,String...)` is simply `hasKey(keys...)`.

VOTE +1.