### PR TITLE
fix typo in docs of OLTP

### DIFF
--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -54,7 +54,7 @@ Implementing Gremlin-Core
 The classes that a graph system provider should focus on implementing are itemized below. It is a good idea to study
 the link:http://tinkerpop.apache.org/docs/x.y.z/reference/#tinkergraph-gremlin[TinkerGraph] (in-memory OLTP and OLAP
 in `tinkergraph-gremlin`), link:http://tinkerpop.apache.org/docs/x.y.z/reference/#neo4j-gremlin[Neo4jGraph]
-(OTLP w/ transactions in `neo4j-gremlin`) and/or
+(OLTP w/ transactions in `neo4j-gremlin`) and/or
 link:http://tinkerpop.apache.org/docs/x.y.z/reference/#hadoop-gremlin[HadoopGraph] (OLAP in `hadoop-gremlin`)
 implementations for ideas and patterns.
 
@@ -62,7 +62,7 @@ implementations for ideas and patterns.
  .. Structure API: `Graph`, `Element`, `Vertex`, `Edge`, `Property` and `Transaction` (if transactions are supported).
  .. Process API: `TraversalStrategy` instances for optimizing Gremlin traversals to the provider's graph system (i.e. `TinkerGraphStepStrategy`).
 . Online Analytics Processing Graph Systems (*OLAP*)
- .. Everything required of OTLP is required of OLAP (but not vice versa).
+ .. Everything required of OLTP is required of OLAP (but not vice versa).
  .. GraphComputer API: `GraphComputer`, `Messenger`, `Memory`.
 
 Please consider the following implementation notes:

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -20,7 +20,7 @@ The GraphComputer
 
 image:graphcomputer-puffers.png[width=350,float=right] TinkerPop3 provides two primary means of interacting with a
 graph: link:http://en.wikipedia.org/wiki/Online_transaction_processing[online transaction processing] (OLTP) and
-link:http://en.wikipedia.org/wiki/Online_analytical_processing[online analytical processing] (OLAP). OTLP-based
+link:http://en.wikipedia.org/wiki/Online_analytical_processing[online analytical processing] (OLAP). OLTP-based
 graph systems allow the user to query the graph in real-time. However, typically, real-time performance is only
 possible when a local traversal is enacted. A local traversal is one that starts at a particular vertex (or small set
 of vertices) and touches a small set of connected vertices (by any arbitrary path of arbitrary length). In short, OLTP
@@ -447,7 +447,7 @@ TraversalVertexProgram
 
 image:traversal-vertex-program.png[width=250,float=left] The `TraversalVertexProgram` is a "special" VertexProgram in
 that it can be executed via a `Traversal` and a `GraphComputer`. In Gremlin, it is possible to have
-the same traversal executed using either the standard OTLP-engine or the `GraphComputer` OLAP-engine. The difference
+the same traversal executed using either the standard OLTP-engine or the `GraphComputer` OLAP-engine. The difference
 being where the traversal is submitted.
 
 NOTE: This model of graph traversal in a BSP system was first implemented by the


### PR DESCRIPTION
Combine two typo PR's (#580 & #581) to one and do it against tp32.