### PR TITLE
TINKERPOP-1657 Provide abstraction to easily allow different HttpAuth schemes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+
+* Deprecated `authentication.className` setting in favor of using `authentication.authenticator`
+* Added `authentication.authenticationHandler` setting
+* Added abstraction to authorization to allow users to plug in their own `AbstractAuthorizationHandler` implementations
 * Fixed a `NullPointerException` bug in `B_LP_O_S_SE_SL_Traverser`.
 * `PathRetractionStrategy` now uses the marker-model to reduce recursive lookups of invalidating steps.
 * `ProfileStrategy` now uses the marker-model to reduce recursive lookups of `ProfileSideEffectStep`.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1072,7 +1072,8 @@ The following table describes the various configuration options that Gremlin Ser
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Key |Description |Default
-|authentication.className |The fully qualified classname of an `Authenticator` implementation to use.  If this setting is not present, then authentication is effectively disabled. |`AllowAllAuthenticator`
+|authentication.authenticator |The fully qualified classname of an `Authenticator` implementation to use.  If this setting is not present, then authentication is effectively disabled. |`AllowAllAuthenticator`
+|authentication.authenticationHandler | The fully qualified classname of an `AbstractAuthenticationHandler` implementation to use. If this setting is not present, but the `authentication.authenticator` is, it will use that authenticator with the default `AbstractAuthenticationHandler` implementation for the specified `Channelizer` |_none_
 |authentication.config |A `Map` of configuration settings to be passes to the `Authenticator` when it is constructed.  The settings available are dependent on the implementation. |_none_
 |channelizer |The fully qualified classname of the `Channelizer` implementation to use.  A `Channelizer` is a "channel initializer" which Gremlin Server uses to define the type of processing pipeline to use.  By allowing different `Channelizer` implementations, Gremlin Server can support different communication protocols (e.g. Websockets, Java NIO, etc.). |`WebSocketChannelizer`
 |graphs |A `Map` of `Graph` configuration files where the key of the `Map` becomes the name to which the `Graph` will be bound and the value is the file name of a `Graph` configuration file. |_none_
@@ -1194,7 +1195,7 @@ graph database, which must be provided to it as part of the configuration.
 
 [source,yaml]
 authentication: {
-  className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
+  authenticator: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
   config: {
     credentialsDb: conf/tinkergraph-credentials.properties}}
 

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -32,6 +32,16 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.2.5/CHANGELOG.asc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+Authentication Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The server settings previously used `authentication.className` to set an authenticator for the the two provided
+authentication handler and channelizer classes to use. This has been deprecated in favor of `authentication.authenticator`.
+A class that extends `AbstractAuthenticationHandler` may also now be provided as `authentication.authenticationHandler`
+to be used in either of the provided channelizer classes to handle the provided authenticator
+
+See: https://issues.apache.org/jira/browse/TINKERPOP-1657[TINKERPOP-1657]
+
 GremlinScriptEngine Metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -965,6 +975,7 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.2.0-incubating/CH
 
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
+
 
 Hadoop FileSystem Variable
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gremlin-python/src/test/resources/org/apache/tinkerpop/gremlin/python/driver/gremlin-server-modern-secure-py.yaml
+++ b/gremlin-python/src/test/resources/org/apache/tinkerpop/gremlin/python/driver/gremlin-server-modern-secure-py.yaml
@@ -58,7 +58,7 @@ maxContentLength: 65536
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 authentication: {
-  className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
+  authenticator: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
   config: {
     credentialsDb: src/test/resources/org/apache/tinkerpop/gremlin/python/driver/tinkergraph-credentials.properties}}
 

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -65,7 +65,7 @@ resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536
 authentication: {
-  className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
+  authenticator: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
   config: {
     credentialsDb: conf/tinkergraph-credentials.properties}}
 ssl: {

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -68,7 +68,7 @@ resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536
 authentication: {
-  className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
+  authenticator: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
   config: {
     credentialsDb: conf/tinkergraph-credentials.properties}}
 ssl: {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -384,7 +384,23 @@ public class Settings {
          * used to load the implementation from the classpath. Defaults to {@link AllowAllAuthenticator} when
          * not specified.
          */
+        public String authenticator = AllowAllAuthenticator.class.getName();
+
+        /**
+         * The fully qualified class name of the {@link Authenticator} implementation. This class name will be
+         * used to load the implementation from the classpath. Defaults to {@link AllowAllAuthenticator} when
+         * not specified.
+         * @deprecated As of release 3.2.5, replaced by {@link authenticator}.
+         */
+        @Deprecated
         public String className = AllowAllAuthenticator.class.getName();
+
+        /**
+         * The fully qualified class name of the {@link HttpAuthenticationHandler} implementation.
+         * This class name will be used to load the implementation from the classpath.
+         * Defaults to null when not specified.
+         */
+        public String authenticationHandler = null;
 
         /**
          * A {@link Map} containing {@link Authenticator} specific configurations. Consult the
@@ -424,7 +440,7 @@ public class Settings {
          * contain an X.509 certificate chain in PEM format. {@code null} uses the system default.
          */
         public String trustCertChainFile = null;
-        
+
         /**
          * Require client certificate authentication
          */

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -384,7 +384,7 @@ public class Settings {
          * used to load the implementation from the classpath. Defaults to {@link AllowAllAuthenticator} when
          * not specified.
          */
-        public String authenticator = AllowAllAuthenticator.class.getName();
+        public String authenticator = null;
 
         /**
          * The fully qualified class name of the {@link Authenticator} implementation. This class name will be
@@ -396,7 +396,7 @@ public class Settings {
         public String className = AllowAllAuthenticator.class.getName();
 
         /**
-         * The fully qualified class name of the {@link HttpAuthenticationHandler} implementation.
+         * The fully qualified class name of the {@link AbstractAuthenticationHandler} implementation.
          * This class name will be used to load the implementation from the classpath.
          * Defaults to null when not specified.
          */

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
@@ -71,7 +71,7 @@ public class HttpChannelizer extends AbstractChannelizer {
             // not occur. It may not be a safe assumption that the handler
             // is sharable so create a new handler each time.
             authenticationHandler = authenticator.getClass() == AllowAllAuthenticator.class ?
-                    null : createAuthenticationHandler(settings);
+                    null : instantiateAuthenticationHandler(settings.authentication);
             if (authenticationHandler != null)
                 pipeline.addLast(PIPELINE_AUTHENTICATOR, authenticationHandler);
         }
@@ -85,15 +85,7 @@ public class HttpChannelizer extends AbstractChannelizer {
             //Keep things backwards compatible
             return new HttpBasicAuthenticationHandler(authenticator);
         } else {
-            try {
-                final Class<?> clazz = Class.forName(handlerClassName);
-                final Class[] constructorArgs = new Class[1];
-                constructorArgs[0] = Authenticator.class;
-                return (HttpAuthenticationHandler) clazz.getDeclaredConstructor(constructorArgs).newInstance(authenticator);
-            } catch (Exception ex) {
-                logger.warn(ex.getMessage());
-                throw new IllegalStateException(String.format("Could not create/configure HttpAuthenticationHandler %s", handlerClassName), ex);
-            }
+            return createAuthenticationHandler(authSettings);
         }
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractAuthenticationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractAuthenticationHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
+
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * Provides an abstraction point to allow for http auth schemes beyond basic auth.
+ */
+public abstract class AbstractAuthenticationHandler extends ChannelInboundHandlerAdapter {
+    protected final Authenticator authenticator;
+
+    public AbstractAuthenticationHandler(final Authenticator authenticator) {
+        this.authenticator = authenticator;
+    }
+
+}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpBasicAuthenticationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpBasicAuthenticationHandler.java
@@ -42,13 +42,12 @@ import static org.apache.tinkerpop.gremlin.groovy.plugin.dsl.credential.Credenti
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public class HttpBasicAuthenticationHandler extends ChannelInboundHandlerAdapter {
-    private final Authenticator authenticator;
+public class HttpBasicAuthenticationHandler extends AbstractAuthenticationHandler {
 
     private final Base64.Decoder decoder = Base64.getUrlDecoder();
 
     public HttpBasicAuthenticationHandler(final Authenticator authenticator) {
-        this.authenticator = authenticator;
+        super(authenticator);
     }
 
     @Override

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAuthenticationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAuthenticationHandler.java
@@ -51,15 +51,13 @@ import org.slf4j.LoggerFactory;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 @ChannelHandler.Sharable
-public class SaslAuthenticationHandler extends ChannelInboundHandlerAdapter {
+public class SaslAuthenticationHandler extends AbstractAuthenticationHandler {
     private static final Logger logger = LoggerFactory.getLogger(SaslAuthenticationHandler.class);
     private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
     private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
 
-    private final Authenticator authenticator;
-
     public SaslAuthenticationHandler(final Authenticator authenticator) {
-        this.authenticator = authenticator;
+        super(authenticator);
     }
 
     @Override


### PR DESCRIPTION
Abstracting over the http authentication allows for easy extensibility
for users/implementors to provide their own classes for http auth beyond
basic auth. The general issue is that there is a fixed overhead to
hashing passwords securely. This change allows for implementing things
like HMAC token auth and plugging them in easily to the gremlin server.