### PR TITLE
TINKERPOP-1659 Docker uses custom maven settings.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ doc/out
 docs/*.asciidoc
 ext/
 .glv
+settings.xml

--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -63,6 +63,13 @@ if [ -d "/usr/src/tinkermem" ]; then
   cd /usr/src/tinkermem
 fi
 
+# use a custom maven settings.xml
+if [ -r "settings.xml" ]; then
+  echo "Copying settings.xml"
+  mkdir -p ~/.m2
+  cp settings.xml ~/.m2/
+fi
+
 mvn clean install process-resources ${TINKERPOP_BUILD_OPTIONS} || exit 1
 [ -z "${BUILD_JAVA_DOCS}" ] || mvn process-resources -Djavadoc || exit 1
 


### PR DESCRIPTION
This lets docker use a local maven proxy for faster download.  Speeds up build time for those of us out in the boonies with slow internet.