### PR TITLE
TINKERPOP-1663 Validation for maximum number of parameters on a request

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1136,6 +1136,7 @@ run Gremlin Server with Ganglia monitoring, download the `org.acplt:oncrpc` jar 
 link:http://repo1.maven.org/maven2/org/acplt/oncrpc/1.0.7/[here] and copy it to the Gremlin Server `/lib` directory
 before starting the server.
 
+[[opprocessor-configurations]]
 OpProcessor Configurations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1161,7 +1162,21 @@ The `SessionOpProcessor` provides a way to interact with Gremlin Server over a <
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Name |Description |Default
+|maxParameters |Maximum number of parameters that can be passed on the request. |16
+|perGraphCloseTimeout |Time in milliseconds to wait for each configured graph to close any open transactions when the session is killed. |10000
 |sessionTimeout |Time in milliseconds before a session will time out. |28800000
+|=========================================================
+
+StandardOpProcessor
+++++++++++++++++++
+
+The `StandardOpProcessor` provides a way to interact with Gremlin Server without use of sessions and is the default
+method for processing script evaluation requests.
+
+[width="100%",cols="3,10,^2",options="header"]
+|=========================================================
+|Name |Description |Default
+|maxParameters |Maximum number of parameters that can be passed on the request. |16
 |=========================================================
 
 [[traversalopprocessor]]
@@ -1635,6 +1650,12 @@ Map<String,Object> params = new HashMap<>();
 params.put("x",4);
 client.submit("[1,2,3,x]", params);
 ----
+
+The more parameters that are used in a script the more expensive the compilation step becomes. Gremlin Server has a
+`OpProcessor` setting called `maxParameters`, which is mentioned in the <<opprocess-configuration,OpProcessor Configuration>>
+section. It controls the maximum number of parameters that can be passed to the server for script evaluation purposes.
+Use of this setting can prevent accidental long run compilations, which individually are not terribly oppressive to
+the server, but taken as a group under high concurrency would be considered detrimental.
 
 Cache Management
 ^^^^^^^^^^^^^^^^

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -32,6 +32,28 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.2.5/CHANGELOG.asc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+Default Maximum Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It was learned that compilation for scripts with large numbers of parameters is more expensive than those with less
+parameters. It therefore becomes possible to make some mistakes with how Gremlin Server is used. A new setting on
+the `StandardOpProcessor` and `SessionOpProcessor` called `maxParameters` controls the number of parameters that can
+be passed in on a request. This setting is defaulted to sixteen.
+
+Users upgrading to this version may notice errors in their applications if they use more than sixteen parameters. To
+fix this problem simply reconfigure Gremlin Server with a configuration as follows:
+
+[source,yaml]
+----
+processors:
+  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { maxParameters: 64 }}
+  - { className: org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor, config: { maxParameters: 64 }}
+----
+
+The above configuration allows sixty-four parameters to be passed on each request.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1663[TINKERPOP-1663]
+
 GremlinScriptEngine Metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
 import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
 import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
 import info.ganglia.gmetric4j.gmetric.GMetric;
+import org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor;
 import org.apache.tinkerpop.gremlin.server.util.LifeCycleHook;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.yaml.snakeyaml.TypeDescription;
@@ -217,6 +218,16 @@ public class Settings {
      * {@link ServiceLoader} but custom configurations can be supplied through this configuration.
      */
     public List<ProcessorSettings> processors = new ArrayList<>();
+
+    /**
+     * Find the {@link ProcessorSettings} related to the specified class. If there are multiple entries then only the
+     * first is returned.
+     */
+    public Optional<ProcessorSettings> optionalProcessor(final Class<? extends OpProcessor> clazz) {
+        return processors.stream()
+                .filter(p -> p.className.equals(clazz.getCanonicalName()))
+                .findFirst();
+    }
 
     public Optional<ServerMetrics> optionalMetrics() {
         return Optional.ofNullable(metrics);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -41,13 +41,11 @@ import org.apache.tinkerpop.gremlin.server.util.MetricManager;
 import org.apache.tinkerpop.gremlin.util.function.ThrowingConsumer;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import io.netty.channel.ChannelHandlerContext;
-import org.codehaus.groovy.control.ErrorCollector;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.script.Bindings;
-import javax.script.ScriptException;
 import javax.script.SimpleBindings;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -71,6 +69,18 @@ import static com.codahale.metrics.MetricRegistry.name;
 public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
     private static final Logger logger = LoggerFactory.getLogger(AbstractEvalOpProcessor.class);
     public static final Timer evalOpTimer = MetricManager.INSTANCE.getTimer(name(GremlinServer.class, "op", "eval"));
+
+    /**
+     * The maximum number of parameters that can be passed on a script evaluation request.
+     */
+    public static final String CONFIG_MAX_PARAMETERS = "maxParameters";
+
+    /**
+     * Default number of parameters allowed on a script evaluation request.
+     */
+    public static final int DEFAULT_MAX_PARAMETERS = 16;
+
+    protected int maxParameters = DEFAULT_MAX_PARAMETERS;
 
     /**
      * Captures the "error" count as a reportable metric for Gremlin Server.
@@ -178,7 +188,7 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
 
         if (message.optionalArgs(Tokens.ARGS_BINDINGS).isPresent()) {
             final Map bindings = (Map) message.getArgs().get(Tokens.ARGS_BINDINGS);
-            if (bindings.keySet().stream().anyMatch(k -> null == k || !(k instanceof String))) {
+            if (IteratorUtils.anyMatch(bindings.keySet().iterator(), k -> null == k || !(k instanceof String))) {
                 final String msg = String.format("The [%s] message is using one or more invalid binding keys - they must be of type String and cannot be null", Tokens.OPS_EVAL);
                 throw new OpProcessorException(msg, ResponseMessage.build(message).code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).statusMessage(msg).create());
             }
@@ -186,6 +196,13 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
             final Set<String> badBindings = IteratorUtils.set(IteratorUtils.<String>filter(bindings.keySet().iterator(), INVALID_BINDINGS_KEYS::contains));
             if (!badBindings.isEmpty()) {
                 final String msg = String.format("The [%s] message supplies one or more invalid parameters key of [%s] - these are reserved names.", Tokens.OPS_EVAL, badBindings);
+                throw new OpProcessorException(msg, ResponseMessage.build(message).code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).statusMessage(msg).create());
+            }
+
+            // ignore control bindings that get passed in with the "#jsr223" prefix - those aren't used in compilation
+            if (IteratorUtils.count(IteratorUtils.filter(bindings.keySet().iterator(), k -> !k.toString().startsWith("#jsr223"))) > maxParameters) {
+                final String msg = String.format("The [%s] message contains %s bindings which is more than is allowed by the server %s configuration",
+                        Tokens.OPS_EVAL, bindings.size(), maxParameters);
                 throw new OpProcessorException(msg, ResponseMessage.build(message).code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).statusMessage(msg).create());
             }
         }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/OpLoader.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/OpLoader.java
@@ -78,4 +78,12 @@ public final class OpLoader {
     public static Map<String, OpProcessor> getProcessors() {
         return Collections.unmodifiableMap(processors);
     }
+
+    /**
+     * Reset the processors so that they can be re-initialized with different settings which is useful in testing
+     * scenarios.
+     */
+    public synchronized static void reset() {
+        initialized = false;
+    }
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
@@ -89,9 +89,8 @@ public class Session {
         this.scheduledExecutorService = context.getScheduledExecutorService();
         this.sessions = sessions;
 
-        final Settings.ProcessorSettings processorSettings = this.settings.processors.stream()
-                .filter(p -> p.className.equals(SessionOpProcessor.class.getCanonicalName()))
-                .findAny().orElse(SessionOpProcessor.DEFAULT_SETTINGS);
+        final Settings.ProcessorSettings processorSettings = this.settings.optionalProcessor(SessionOpProcessor.class).
+                orElse(SessionOpProcessor.DEFAULT_SETTINGS);
         this.configuredSessionTimeout = Long.parseLong(processorSettings.config.getOrDefault(
                 SessionOpProcessor.CONFIG_SESSION_TIMEOUT, SessionOpProcessor.DEFAULT_SESSION_TIMEOUT).toString());
         this.configuredPerGraphCloseTimeout = Long.parseLong(processorSettings.config.getOrDefault(

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -94,6 +94,7 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
         DEFAULT_SETTINGS.config = new HashMap<String, Object>() {{
             put(CONFIG_SESSION_TIMEOUT, DEFAULT_SESSION_TIMEOUT);
             put(CONFIG_PER_GRAPH_CLOSE_TIMEOUT, DEFAULT_PER_GRAPH_CLOSE_TIMEOUT);
+            put(CONFIG_MAX_PARAMETERS, DEFAULT_MAX_PARAMETERS);
         }};
     }
 
@@ -104,6 +105,12 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
     @Override
     public String getName() {
         return OP_PROCESSOR_NAME;
+    }
+
+    @Override
+    public void init(final Settings settings) {
+        this.maxParameters = (int) settings.optionalProcessor(SessionOpProcessor.class).orElse(DEFAULT_SETTINGS).config.
+                getOrDefault(CONFIG_MAX_PARAMETERS, DEFAULT_MAX_PARAMETERS);
     }
 
     /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/standard/StandardOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/standard/StandardOpProcessor.java
@@ -25,8 +25,10 @@ import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.server.Context;
 import org.apache.tinkerpop.gremlin.server.OpProcessor;
+import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.op.AbstractEvalOpProcessor;
 import org.apache.tinkerpop.gremlin.server.op.OpProcessorException;
+import org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.util.function.ThrowingConsumer;
 import org.slf4j.Logger;
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.script.Bindings;
 import javax.script.SimpleBindings;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -51,6 +54,15 @@ public class StandardOpProcessor extends AbstractEvalOpProcessor {
 
     protected final Function<Context, BindingSupplier> bindingMaker;
 
+    static final Settings.ProcessorSettings DEFAULT_SETTINGS = new Settings.ProcessorSettings();
+
+    static {
+        DEFAULT_SETTINGS.className = StandardOpProcessor.class.getCanonicalName();
+        DEFAULT_SETTINGS.config = new HashMap<String, Object>() {{
+            put(CONFIG_MAX_PARAMETERS, DEFAULT_MAX_PARAMETERS);
+        }};
+    }
+
     public StandardOpProcessor() {
         super(true);
         bindingMaker = getBindingMaker();
@@ -59,6 +71,12 @@ public class StandardOpProcessor extends AbstractEvalOpProcessor {
     @Override
     public String getName() {
         return OP_PROCESSOR_NAME;
+    }
+
+    @Override
+    public void init(final Settings settings) {
+        this.maxParameters = (int) settings.optionalProcessor(StandardOpProcessor.class).orElse(DEFAULT_SETTINGS).config.
+                getOrDefault(CONFIG_MAX_PARAMETERS, DEFAULT_MAX_PARAMETERS);
     }
 
     @Override

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import org.apache.tinkerpop.gremlin.server.op.OpLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -82,6 +83,10 @@ public abstract class AbstractGremlinServerIntegrationTest {
 
     public void stopServer() throws Exception {
         server.stop().join();
+
+        // reset the OpLoader processors so that they can get reconfigured on startup - Settings may have changed
+        // between tests
+        OpLoader.reset();
     }
 
     public static boolean deleteDirectory(final File directory) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1663

Provides a configuration option to validate the number of parameters that gremlin server will accept on a request for script evaluation.

Ran integration tests for gremlin-server and console.

vOTE +1