### PR TITLE
TINKERPOP-1665 Remove unittest from Gremlin-Python tests

### DIFF
--- a/gremlin-console/src/test/python/tests/test_console.py
+++ b/gremlin-console/src/test/python/tests/test_console.py
@@ -17,11 +17,10 @@ specific language governing permissions and limitations
 under the License.
 '''
 
-import unittest
-from unittest import TestCase
 import pexpect
 
-class TestConsole(TestCase):
+
+class TestConsole(object):
 
     # the base command must pass -C because if colors are enabled pexpect gets garbled input and tests won't pass
     gremlinsh = "bash gremlin-console/bin/gremlin.sh -C "
@@ -90,6 +89,3 @@ class TestConsole(TestCase):
     @staticmethod
     def _close(child):
         child.sendline(":x")
-
-
-

--- a/gremlin-python/src/main/jython/tests/process/test_strategies.py
+++ b/gremlin-python/src/main/jython/tests/process/test_strategies.py
@@ -19,15 +19,12 @@ under the License.
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
-import unittest
-from unittest import TestCase
-
 from gremlin_python.structure.graph import Graph
 from gremlin_python.process.strategies import *
 from gremlin_python.process.graph_traversal import __
 
 
-class TestTraversalStrategies(TestCase):
+class TestTraversalStrategies(object):
     def test_singletons(self):
         g = Graph().traversal()
         bytecode = g.withStrategies(ReadOnlyStrategy()).bytecode
@@ -101,6 +98,3 @@ class TestTraversalStrategies(TestCase):
         strategy = bytecode.source_instructions[0][1]
         assert 1 == len(strategy.configuration)
         assert __.has("name","marko") == strategy.configuration["vertices"]
-
-if __name__ == '__main__':
-    unittest.main()

--- a/gremlin-python/src/main/jython/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/jython/tests/process/test_traversal.py
@@ -19,16 +19,13 @@ under the License.
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
-import unittest
-from unittest import TestCase
-
 from gremlin_python.structure.graph import Graph
 from gremlin_python.process.traversal import P
 from gremlin_python.process.traversal import Binding
 from gremlin_python.process.graph_traversal import __
 
 
-class TestTraversal(TestCase):
+class TestTraversal(object):
     def test_bytecode(self):
         g = Graph().traversal()
         bytecode = g.V().out("created").bytecode
@@ -85,7 +82,3 @@ class TestTraversal(TestCase):
         assert 0 == len(bytecode.bindings.keys())
         assert 0 == len(bytecode.source_instructions)
         assert 0 == len(bytecode.step_instructions)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
@@ -21,8 +21,6 @@ __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
 import json
 from mock import Mock
-import unittest
-from unittest import TestCase
 
 import six
 
@@ -36,7 +34,7 @@ from gremlin_python.process.strategies import SubgraphStrategy
 from gremlin_python.process.graph_traversal import __
 
 
-class TestGraphSONReader(TestCase):
+class TestGraphSONReader(object):
     graphson_reader = GraphSONReader()
 
     def test_number_input(self):
@@ -124,7 +122,7 @@ class TestGraphSONReader(TestCase):
         assert o is serdes.objectify()
 
 
-class TestGraphSONWriter(TestCase):
+class TestGraphSONWriter(object):
 
     graphson_writer = GraphSONWriter()
 
@@ -205,7 +203,3 @@ class TestGraphSONWriter(TestCase):
         mapping = self.graphson_writer.toDict(long(1))
         assert mapping['@type'] == 'g:Int64'
         assert mapping['@value'] == 1
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/gremlin-python/src/main/jython/tests/structure/test_graph.py
+++ b/gremlin-python/src/main/jython/tests/structure/test_graph.py
@@ -19,9 +19,6 @@ under the License.
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
-import unittest
-from unittest import TestCase
-
 import six
 
 from gremlin_python.statics import long
@@ -32,7 +29,7 @@ from gremlin_python.structure.graph import VertexProperty
 from gremlin_python.structure.graph import Path
 
 
-class TestGraph(TestCase):
+class TestGraph(object):
     def test_graph_objects(self):
         vertex = Vertex(1)
         assert "v[1]" == str(vertex)
@@ -114,7 +111,3 @@ class TestGraph(TestCase):
         assert hash(path) == hash(path2)
         assert path != Path([set(["a"]), set(["c", "b"]), set([])], [1, Vertex(1), "hello"])
         assert path != Path([set(["a", "b"]), set(["c", "b"]), set([])], [3, Vertex(1), "hello"])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/gremlin-python/src/main/jython/tests/test_statics.py
+++ b/gremlin-python/src/main/jython/tests/test_statics.py
@@ -19,16 +19,13 @@ under the License.
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
-import unittest
-from unittest import TestCase
-
 from gremlin_python import statics
 from gremlin_python.process.traversal import Cardinality
 from gremlin_python.process.traversal import P
 from gremlin_python.process.traversal import Pop
 
 
-class TestStatics(TestCase):
+class TestStatics(object):
     def test_enums(self):
         statics.load_statics(globals())
         assert isinstance(list_, Cardinality)
@@ -40,7 +37,3 @@ class TestStatics(TestCase):
         assert isinstance(first, Pop)
         assert first == Pop.first
         statics.unload_statics(globals())
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
A simple PR that removes unnecessary `unittest` code from the Gremlin-Python test suite. 

VOTE +1