### PR TITLE
TINKERPOP-1577 Building gremlin-python with python 2/3

### DIFF
--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -359,17 +359,28 @@
                                              specifically). note that the commands to install wheel are largely for
                                              safety in case someone is using an older version of virtualenv (which
                                              doesn't install wheel by default) -->
-                                        <copy todir="${project.build.directory}/python">
+                                        <copy todir="${project.build.directory}/python3">
+                                            <fileset dir="src/main/jython"/>
+                                        </copy>
+                                        <copy todir="${project.build.directory}/python2">
                                             <fileset dir="src/main/jython"/>
                                         </copy>
                                         <copy todir="${project.build.directory}/python-packaged">
                                             <fileset dir="src/main/jython"/>
                                         </copy>
-                                        <exec dir="${project.build.directory}/python" executable="virtualenv"
+                                        <exec dir="${project.build.directory}/python2" executable="virtualenv"
                                               failonerror="true">
                                             <arg line="--python=python env"/>
                                         </exec>
-                                        <exec dir="${project.build.directory}/python" executable="env/bin/pip"
+                                        <exec dir="${project.build.directory}/python2" executable="env/bin/pip"
+                                              failonerror="true">
+                                            <arg line="install wheel"/>
+                                        </exec>
+                                        <exec dir="${project.build.directory}/python3" executable="virtualenv"
+                                              failonerror="true">
+                                            <arg line="--python=python env"/>
+                                        </exec>
+                                        <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
                                               failonerror="true">
                                             <arg line="install wheel"/>
                                         </exec>
@@ -388,14 +399,30 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>native-python-build</id>
+                                <id>native-python2-build</id>
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
+                                        <exec executable="env/bin/python" dir="${project.build.directory}/python2"
+                                              failonerror="true">
+                                            <env key="PYTHONPATH" value=""/>
+                                            <arg line="setup.py build --build-lib ${project.build.outputDirectory}/Lib"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>native-python3-build</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <exec executable="env/bin/python" dir="${project.build.directory}/python3"
                                               failonerror="true">
                                             <env key="PYTHONPATH" value=""/>
                                             <arg line="setup.py build --build-lib ${project.build.outputDirectory}/Lib"/>
@@ -433,7 +460,7 @@
                             test phase doesn't have a pre/post event like integration-test does.
                             -->
                             <execution>
-                                <id>native-python-test</id>
+                                <id>native-python2-test</id>
                                 <phase>integration-test</phase>
                                 <goals>
                                     <goal>run</goal>
@@ -441,7 +468,24 @@
                                 <configuration>
                                     <skip>${skipTests}</skip>
                                     <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
+                                        <exec executable="env/bin/python" dir="${project.build.directory}/python2"
+                                              failonerror="true">
+                                            <env key="PYTHONPATH" value=""/>
+                                            <arg line="setup.py test"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>native-python3-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <target>
+                                        <exec executable="env/bin/python" dir="${project.build.directory}/python3"
                                               failonerror="true">
                                             <env key="PYTHONPATH" value=""/>
                                             <arg line="setup.py test"/>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -370,7 +370,7 @@
                                         </copy>
                                         <exec dir="${project.build.directory}/python2" executable="virtualenv"
                                               failonerror="true">
-                                            <arg line="--python=python env"/>
+                                            <arg line="--python=python2 env"/>
                                         </exec>
                                         <exec dir="${project.build.directory}/python2" executable="env/bin/pip"
                                               failonerror="true">
@@ -378,7 +378,7 @@
                                         </exec>
                                         <exec dir="${project.build.directory}/python3" executable="virtualenv"
                                               failonerror="true">
-                                            <arg line="--python=python env"/>
+                                            <arg line="--python=python3 env"/>
                                         </exec>
                                         <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
                                               failonerror="true">


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1577

I'd forgotten that I'd long ago made this change to the python build. It basically sets up two separate python environments with virtualenv - one for python 2.x and one for 3.x - so that we can test both versions against our code. 

VOTE +1