### PR TITLE
TINKERPOP-1666 YAML file supplied to FileSandboxExtension can have empty staticVariableTypes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Implemented `DefaultGraphManager` to include previous `GraphManager` functionality and adhere to updated interface.
 * Deprecated `GraphManager.getGraphs()` and added `GraphManager.getGraphNames()`.
 * Deprecated `GraphManager.getTraversalSources()` and added `GraphManager.getTraversalSourceNames()`.
+* Fixed a bug so now users can supply a YAML with an empty `staticVariableTypes` to be used by the `FileSandboxExtension`
 
 [[release-3-2-4]]
 TinkerPop 3.2.4 (Release Date: February 8, 2017)

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineFileSandboxTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineFileSandboxTest.java
@@ -61,6 +61,18 @@ public class GremlinGroovyScriptEngineFileSandboxTest extends AbstractGremlinTes
     }
 
     @Test
+    public void shouldSuccessfullyInstantiateGroovyScriptEngineWithEmptyStaticVariableTyping() throws Exception {
+        final File f = TestHelper.generateTempFileFromResource(graph.getClass(), GremlinGroovyScriptEngineFileSandboxTest.class, "sandbox-empty-static-variable-types.yaml", ".yaml");
+        System.setProperty(FileSandboxExtension.GREMLIN_SERVER_SANDBOX, f.getAbsolutePath());
+        final CompilerCustomizerProvider standardSandbox = new CompileStaticCustomizerProvider(FileSandboxExtension.class.getName());
+        try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {
+            assertEquals(123, engine.eval("java.lang.Math.abs(-123)"));
+            assertThat(engine.eval("new Boolean(true)"), is(true));
+            assertThat(engine.eval("new Boolean(true).toString()"), is("true"));
+        }
+    }
+
+    @Test
     public void shouldEvalAsTheMethodIsWhiteListed() throws Exception {
         final CompilerCustomizerProvider standardSandbox = new CompileStaticCustomizerProvider(FileSandboxExtension.class.getName());
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {

--- a/gremlin-groovy-test/src/main/resources/org/apache/tinkerpop/gremlin/groovy/jsr223/sandbox-empty-static-variable-types.yaml
+++ b/gremlin-groovy-test/src/main/resources/org/apache/tinkerpop/gremlin/groovy/jsr223/sandbox-empty-static-variable-types.yaml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This is an example configuration for the FileSandboxExtension.
+
+autoTypeUnknown: true
+methodWhiteList:
+  - java\.lang\.Boolean.*
+  - java\.lang\.Byte.*
+  - java\.lang\.Character.*
+  - java\.lang\.Double.*
+  - java\.lang\.Enum.*
+  - java\.lang\.Float.*
+  - java\.lang\.Integer.*
+  - java\.lang\.Long.*
+  - java\.lang\.Math.*
+  - java\.lang\.Number.*
+  - java\.lang\.Object.*
+  - java\.lang\.Short.*
+  - java\.lang\.String.*
+  - java\.lang\.StringBuffer.*
+  - java\.lang\.System#currentTimeMillis\(\)
+  - java\.lang\.System#nanoTime\(\)
+  - java\.lang\.Throwable.*
+  - java\.lang\.Void.*
+  - java\.util\..*
+  - org\.codehaus\.groovy\.runtime\.DefaultGroovyMethods.*
+  - org\.codehaus\.groovy\.runtime\.InvokerHelper#runScript\(java\.lang\.Class,java\.lang\.String\[\]\)
+  - org\.codehaus\.groovy\.runtime\.StringGroovyMethods.*
+  - groovy\.lang\.Script#<init>\(groovy.lang.Binding\)
+  - org\.apache\.tinkerpop\.gremlin\.structure\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.bulkloading\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.clustering\.peerpressure\.*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.ranking\.pagerank\.*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.traversal\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\.dsl\.graph\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\.engine\..*
+  - org\.apache\.tinkerpop\.gremlin\.server\.util\.LifeCycleHook.*
+staticVariableTypes:

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/AbstractSandboxExtension.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/AbstractSandboxExtension.groovy
@@ -51,7 +51,7 @@ abstract class AbstractSandboxExtension extends GroovyTypeCheckingExtensionSuppo
         def boolean autoTypeUnknown = allowAutoTypeOfUnknown()
 
         unresolvedVariable { var ->
-            if (staticVariableTyping.containsKey(var.name)) {
+            if ((null != staticVariableTyping) && (staticVariableTyping.containsKey(var.name))) {
                 storeType(var, classNodeFor(staticVariableTyping[var.name]))
                 handled = true
                 return

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/FileSandboxExtension.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/FileSandboxExtension.groovy
@@ -63,12 +63,16 @@ class FileSandboxExtension extends AbstractSandboxExtension {
 
         autoTypeUnknown = settings.autoTypeUnknown
         methodWhiteList = settings.methodWhiteList
-        staticVariableTypes = settings.staticVariableTypes.collectEntries { kv ->
-            try {
-                return [(kv.key): Class.forName(kv.value)]
-            } catch (Exception ex) {
-                logger.error("Could not convert ${kv.value} to a Class for variable ${kv.key}", ex)
-                throw ex
+        if (null == settings.staticVariableTypes) {
+            staticVariableTypes = null
+        } else {
+            staticVariableTypes = settings.staticVariableTypes.collectEntries { kv ->
+                try {
+                    return [(kv.key): Class.forName(kv.value)]
+                } catch (Exception ex) {
+                    logger.error("Could not convert ${kv.value} to a Class for variable ${kv.key}", ex)
+                    throw ex
+                }
             }
         }
     }


### PR DESCRIPTION
Check if variable is null to avoid NPE

If staticVariableTypes is an empty list in the YAML file, then we throw
an NPE by trying to run collectEntries() on a null object or trying to
run containsKey() on a null object.

https://issues.apache.org/jira/browse/TINKERPOP-1666