### PR TITLE
TINKERPOP-1673: GroovyTranslator produces Gremlin that can't execute on :remote

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Now using Groovy `[...]` map notation in `GroovyTranslator` instead of `new LinkedHashMap(){{ }}`.
 * Maintained type information on `Traversal.promise()`.
 * Propagated exception to `Future` instead of calling thread in `RemoteConnection`.
 * Fixed a bug in `RepeatUnrollStrategy` where `LoopsStep` and `LambdaHolder` should invalidate the strategy's application.

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
@@ -27,7 +27,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
@@ -38,8 +37,9 @@ import org.junit.Test;
 import javax.script.Bindings;
 import javax.script.SimpleBindings;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -114,6 +114,17 @@ public class GroovyTranslatorTest extends AbstractGremlinTest {
         assertEquals(7, sacks.get(5).intValue());
         //
         assertEquals(24, t.getSideEffects().<Number>get("lengthSum").intValue());
+    }
+
+    @Test
+    @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+    public void shouldHandleMaps() {
+        GraphTraversalSource g = graph.traversal();
+        String script = GroovyTranslator.of("g").translate(g.V().id().is(new LinkedHashMap() {{
+            put(3, "32");
+            put(Arrays.asList(1, 2, 3.1d), 4);
+        }}).asAdmin().getBytecode());
+        assertEquals(script, "g.V().id().is([((int) 3):(\"32\"),([(int) 1, (int) 2, 3.1d]):((int) 4)])");
     }
 
     @Test

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
@@ -127,15 +127,16 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
             }
             return list.toString();
         } else if (object instanceof Map) {
-            final StringBuilder map = new StringBuilder("new LinkedHashMap(){{");
+            final StringBuilder map = new StringBuilder("[");
             for (final Map.Entry<?, ?> entry : ((Map<?, ?>) object).entrySet()) {
-                map.append("put(").
+                map.append("(").
                         append(convertToString(entry.getKey())).
-                        append(",").
+                        append("):(").
                         append(convertToString(entry.getValue())).
-                        append(");");
+                        append("),");
             }
-            return map.append("}}").toString();
+            map.deleteCharAt(map.length()-1);
+            return map.append("]").toString();
         } else if (object instanceof Long)
             return object + "L";
         else if (object instanceof Double)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1673

`GroovyTranslator` now uses Groovy `[...]` map notation instead of `new LinkedHashMap(){{ put() }}` notation in order to make the String translation from Bytecode to Gremlin-Groovy cleaner and easier to read.

