### PR TITLE
TINKERPOP-1675 Throw underlying unchecked exception in processNextStart

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/step/map/RemoteStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/step/map/RemoteStep.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -57,7 +58,23 @@ public final class RemoteStep<S, E> extends AbstractStep<S, E> {
 
     @Override
     protected Traverser.Admin<E> processNextStart() throws NoSuchElementException {
-        if (null == this.remoteTraversal) promise().join();
+        if (null == this.remoteTraversal) {
+            try {
+                promise().join();
+            } catch (CompletionException e) {
+                Throwable cause = e.getCause();
+                // If the underlying future failed, join() will throw a CompletionException, for consistency
+                // with previous behavior:
+                // - Throw underlying exception if it was unchecked (RuntimeException or Error).
+                // - Wrap in IllegalStateException otherwise.
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                } else if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                throw new IllegalStateException(cause);
+            }
+        }
         return this.remoteTraversal.nextTraverser();
     }
 


### PR DESCRIPTION
For consistency with previous behavior, if an unchecked exception is set on the returned future throw that instead of the wrapped CompletionException.

For [TINKERPOP-1675](https://issues.apache.org/jira/browse/TINKERPOP-1675).