### PR TITLE
TINKERPOP-1678: until(Predicate) is actually calling emit(Predicate)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug in `until(predicate)` where it was actually calling `emit(predicate)`.
 * Improved error messaging on the `g.addV(Object...)` when passing an invalid arguments.
 * Reduced memory usage for TinkerGraph deserialization in GraphSON by streaming vertices and edges.
 * Now using Groovy `[...]` map notation in `GroovyTranslator` instead of `new LinkedHashMap(){{ }}`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -2335,7 +2335,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      */
     public default GraphTraversal<S, E> until(final Predicate<Traverser<E>> untilPredicate) {
         this.asAdmin().getBytecode().addStep(Symbols.until, untilPredicate);
-        return RepeatStep.addEmitToTraversal(this, (Traversal.Admin<E, ?>) __.filter(untilPredicate));
+        return RepeatStep.addUntilToTraversal(this, (Traversal.Admin<E, ?>) __.filter(untilPredicate));
     }
 
     /**

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyRepeatTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyRepeatTest.groovy
@@ -23,6 +23,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal
 import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both
+
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
@@ -89,6 +91,11 @@ public abstract class GroovyRepeatTest {
         public Traversal<Vertex, Map<Integer, Long>> get_g_VX1X_repeatXgroupCountXmX_byXloopsX_outX_timesX3X_capXmX(
                 final Object v1Id) {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).repeat(groupCount('m').by(loops()).out()).times(3).cap('m')", "v1Id", v1Id)
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXbothX_untilXname_eq_marko_or_loops_gt_1X_groupCount_byXnameX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(both()).until{it.get().value('name').equals('lop') || it.loops() > 1}.groupCount.by('name')")
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatTest.java
@@ -87,6 +87,8 @@ public abstract class RepeatTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, String> get_g_VX1X_repeatXoutX_untilXoutE_count_isX0XX_name(final Object v1Id);
 
+    public abstract Traversal<Vertex, Map<String, Long>> get_g_V_repeatXbothX_untilXname_eq_marko_or_loops_gt_1X_groupCount_byXnameX();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_repeatXoutX_timesX2X_emit_path() {
@@ -259,6 +261,21 @@ public abstract class RepeatTest extends AbstractGremlinProcessTest {
         assertEquals(2L, map.get(2).longValue());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_repeatXbothX_untilXname_eq_marko_or_loops_gt_1X_groupCount_byXnameX() {
+        final Traversal<Vertex, Map<String, Long>> traversal = get_g_V_repeatXbothX_untilXname_eq_marko_or_loops_gt_1X_groupCount_byXnameX();
+        printTraversalForm(traversal);
+        final Map<String, Long> map = traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals(5, map.size());
+        assertEquals(3L, map.get("ripple").longValue());
+        assertEquals(3L, map.get("vadas").longValue());
+        assertEquals(4L, map.get("josh").longValue());
+        assertEquals(10L, map.get("lop").longValue());
+        assertEquals(4L, map.get("marko").longValue());
+    }
+
     public static class Traversals extends RepeatTest {
 
         @Override
@@ -319,6 +336,11 @@ public abstract class RepeatTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<Integer, Long>> get_g_VX1X_repeatXgroupCountXmX_byXloopsX_outX_timesX3X_capXmX(final Object v1Id) {
             return g.V(v1Id).repeat(groupCount("m").by(loops()).out()).times(3).cap("m");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXbothX_untilXname_eq_marko_or_loops_gt_1X_groupCount_byXnameX() {
+            return g.V().repeat(both()).until(t -> t.get().value("name").equals("lop") || t.loops() > 1).<String>groupCount().by("name");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1678

Fixed a typo-bug in `GraphTraversal` where `until(Predicate)` was actually calling `emit(Predicate)`. A very low probability traversal and thus, it was never uncovered until now. However, fixed and added a test case that verifies that the previous behavior was wrong and the new behavior is write.

VOTE +1.

NOTE: This is the work done here https://github.com/apache/tinkerpop/pull/606, but now there is a test case.