### PR TITLE
TINKERPOP-1681 Multiple hasId's are or'd into GraphStep

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed folding of multiple `hasId()`'s into `GraphStep`.
 * Added string performance options to `StarGraph`.
 * Fixed a bug in `until(predicate)` where it was actually calling `emit(predicate)`.
 * Fixed inconsistency in GraphSON serialization of `Path` where properties of graph elements were being included when serialized.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -181,7 +181,8 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
      * @return true if the {@link HasContainer} updated ids and thus, was processed.
      */
     public static boolean processHasContainerIds(final GraphStep<?, ?> graphStep, final HasContainer hasContainer) {
-        if (hasContainer.getKey().equals(T.id.getAccessor()) && (hasContainer.getBiPredicate() == Compare.eq || hasContainer.getBiPredicate() == Contains.within)) {
+        if (hasContainer.getKey().equals(T.id.getAccessor()) && graphStep.ids.length == 0 &&
+                (hasContainer.getBiPredicate() == Compare.eq || hasContainer.getBiPredicate() == Contains.within)) {
             graphStep.addIds(hasContainer.getValue());
             return true;
         }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
@@ -159,5 +159,15 @@ public abstract class GroovyHasTest {
         public Traversal<Vertex, String> get_g_V_hasNotXageX_name() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasNot('age').name");
         }
+
+        @Override
+        public Traversal<Vertex, Vertex>  get_g_V_hasIdX1X_hasIdX2X(final Object v1Id, final Object v2Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(v1Id).hasId(v2Id)", "v1Id", v1Id, "v2Id", v2Id)
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_hasLabelXsoftwareX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').hasLabel('software')")
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
@@ -104,6 +104,10 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, String> get_g_V_hasNotXageX_name();
 
+    public abstract Traversal<Vertex, Vertex> get_g_V_hasIdX1X_hasIdX2X(final Object v1Id, final Object v2Id);
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_hasLabelXsoftwareX();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_outXcreatedX_hasXname__mapXlengthX_isXgtX3XXX_name() {
@@ -427,6 +431,23 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         checkResults(Arrays.asList("lop", "ripple"), traversal);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasIdX1X_hasIdX2X() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_hasIdX1X_hasIdX2X(
+                convertToVertexId("marko"), convertToVertexId("vadas")
+        );
+        printTraversalForm(traversal);
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasLabelXpersonX_hasLabelXsoftwareX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_hasLabelXpersonX_hasLabelXsoftwareX();
+        printTraversalForm(traversal);
+        assertFalse(traversal.hasNext());
+    }
 
     public static class Traversals extends HasTest {
         @Override
@@ -557,6 +578,16 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, String> get_g_V_hasNotXageX_name() {
             return g.V().hasNot("age").values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex>  get_g_V_hasIdX1X_hasIdX2X(final Object v1Id, final Object v2Id) {
+            return g.V().hasId(v1Id).hasId(v2Id);
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_hasLabelXsoftwareX() {
+            return g.V().hasLabel("person").hasLabel("software");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1681

Fixed folding of multiple `hasId()`'s into `GraphStep`.

VOTE: +1