### PR TITLE
TINKERPOP-1552 C# GLV: Generics and enum generation

### DIFF
--- a/gremlin-dotnet-generator/src/main/groovy/org/apache/tinkerpop/gremlin/dotnet/EnumGenerator.groovy
+++ b/gremlin-dotnet-generator/src/main/groovy/org/apache/tinkerpop/gremlin/dotnet/EnumGenerator.groovy
@@ -20,20 +20,66 @@
 package org.apache.tinkerpop.gremlin.dotnet
 
 import org.apache.tinkerpop.gremlin.util.CoreImports
+import org.apache.tinkerpop.gremlin.structure.Direction
 
 class EnumGenerator {
 
     public static void create(final String enumDirectory) {
 
+        Map<String, String> enumCSharpToJavaNames = new HashMap<String, String>();
         for (final Class<? extends Enum> enumClass : CoreImports.getClassImports()
                 .findAll { Enum.class.isAssignableFrom(it) }
                 .sort { a, b -> a.getSimpleName() <=> b.getSimpleName() }
                 .collect()) {
-            createEnum(enumDirectory, enumClass)
+            createEnum(enumDirectory, enumClass, enumCSharpToJavaNames)
         }
+
+        // Write a file containing the equivalence in names between Java and C#
+        final String enumCSharpToJavaFile = "$enumDirectory/NamingConversions.cs"
+        final File file = new File(enumCSharpToJavaFile);
+        file.delete();
+        file.append(CommonContentHelper.getLicense());
+        file.append("""
+using System.Collections.Generic;
+
+namespace Gremlin.Net.Process.Traversal
+{
+    internal static class NamingConversions
+    {
+        /// <summary>
+        /// Gets the Java name equivalent for a given enum value
+        /// </summary>
+        internal static string GetEnumJavaName(string typeName, string value)
+        {
+            var key = \$"{typeName}.{value}";
+            string javaName;
+            if (!CSharpToJavaEnums.TryGetValue(key, out javaName))
+            {
+                throw new KeyNotFoundException(\$"Java name for {key} not found");
+            }
+            return javaName;
+        }
+
+        internal static readonly IDictionary<string, string> CSharpToJavaEnums = new Dictionary<string, string>
+        {
+"""     );
+        def lastIndex = (enumCSharpToJavaNames.size() - 1);
+        enumCSharpToJavaNames.eachWithIndex{ node, i ->
+            file.append("""            {"$node.key", "$node.value"}${i == lastIndex ? "" : ","}\n""")
+        }
+        file.append("        };\n    }\n}");
+
     }
 
-    private static void createEnum(final String enumDirectory, final Class<? extends Enum> enumClass){
+    public static String toCSharpName(final Class<? extends Enum> enumClass, String itemName) {
+        if (enumClass.equals(Direction.class)) {
+            itemName = itemName.toLowerCase();
+        }
+        return itemName.substring(0, 1).toUpperCase() + itemName.substring(1);
+    }
+
+    private static void createEnum(final String enumDirectory, final Class<? extends Enum> enumClass,
+                                   final Map<String, String> csharpToJava) {
         final StringBuilder csharpEnum = new StringBuilder()
 
         csharpEnum.append(CommonContentHelper.getLicense())
@@ -45,9 +91,13 @@ namespace Gremlin.Net.Process.Traversal
     public enum ${enumClass.getSimpleName()}
     {
 """)
-        enumClass.getEnumConstants()
-                .sort { a, b -> a.name() <=> b.name() }
-                .each { value -> csharpEnum.append("        ${value.name()},\n"); }
+        enumClass.getEnumConstants().
+                sort { a, b -> a.name() <=> b.name() }.
+                each { value ->
+                    def csharpName = toCSharpName(enumClass, value.name());
+                    csharpEnum.append("        $csharpName,\n");
+                    csharpToJava.put(enumClass.simpleName + "." + csharpName, value.name());
+                }
         csharpEnum.deleteCharAt(csharpEnum.length() - 2)
 
         csharpEnum.append("    }\n")

--- a/gremlin-dotnet-generator/src/main/groovy/org/apache/tinkerpop/gremlin/dotnet/PredicateGenerator.groovy
+++ b/gremlin-dotnet-generator/src/main/groovy/org/apache/tinkerpop/gremlin/dotnet/PredicateGenerator.groovy
@@ -55,8 +55,7 @@ namespace Gremlin.Net.Process.Traversal
         }
 """)
                 }
-        csharpClass.append("\t}\n")
-        csharpClass.append("}")
+        csharpClass.append("    }\n}")
 
         final File file = new File(predicateFile)
         file.delete()

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
@@ -52,11 +52,11 @@ namespace Gremlin.Net.Driver.Remote
         /// </summary>
         /// <param name="bytecode">The <see cref="Bytecode" /> to submit.</param>
         /// <returns>A <see cref="ITraversal" /> allowing to access the results and side-effects.</returns>
-        public async Task<ITraversal> SubmitAsync(Bytecode bytecode)
+        public async Task<ITraversal<S, E>> SubmitAsync<S, E>(Bytecode bytecode)
         {
             var requestId = Guid.NewGuid();
             var resultSet = await SubmitBytecodeAsync(requestId, bytecode).ConfigureAwait(false);
-            return new DriverRemoteTraversal(_client, requestId, resultSet);
+            return new DriverRemoteTraversal<S, E>(_client, requestId, resultSet);
         }
 
         private async Task<IEnumerable<Traverser>> SubmitBytecodeAsync(Guid requestid, Bytecode bytecode)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteTraversal.cs
@@ -27,7 +27,7 @@ using Gremlin.Net.Process.Traversal;
 
 namespace Gremlin.Net.Driver.Remote
 {
-    internal class DriverRemoteTraversal : DefaultTraversal
+    internal class DriverRemoteTraversal<S, E> : DefaultTraversal<S, E>
     {
         public DriverRemoteTraversal(IGremlinClient gremlinClient, Guid requestId,
             IEnumerable<Traverser> traversers)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Remote/IRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Remote/IRemoteConnection.cs
@@ -37,6 +37,6 @@ namespace Gremlin.Net.Process.Remote
         /// </summary>
         /// <param name="bytecode">The <see cref="Bytecode" /> to send.</param>
         /// <returns>The <see cref="ITraversal" /> with the results and optional side-effects.</returns>
-        Task<ITraversal> SubmitAsync(Bytecode bytecode);
+        Task<ITraversal<S, E>> SubmitAsync<S, E>(Bytecode bytecode);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
@@ -44,16 +44,16 @@ namespace Gremlin.Net.Process.Remote
         }
 
         /// <inheritdoc />
-        public void Apply(ITraversal traversal)
+        public void Apply<S, E>(ITraversal<S, E> traversal)
         {
             ApplyAsync(traversal).Wait();
         }
 
         /// <inheritdoc />
-        public async Task ApplyAsync(ITraversal traversal)
+        public async Task ApplyAsync<S, E>(ITraversal<S, E> traversal)
         {
             if (traversal.Traversers != null) return;
-            var remoteTraversal = await _remoteConnection.SubmitAsync(traversal.Bytecode).ConfigureAwait(false);
+            var remoteTraversal = await _remoteConnection.SubmitAsync<S, E>(traversal.Bytecode).ConfigureAwait(false);
             traversal.SideEffects = remoteTraversal.SideEffects;
             traversal.Traversers = remoteTraversal.Traversers;
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Barrier.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Barrier.cs
@@ -25,6 +25,6 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Barrier
     {
-        normSack
+        NormSack
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Cardinality.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Cardinality.cs
@@ -25,8 +25,8 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Cardinality
     {
-        list,
-        set,
-        single
+        List,
+        Set,
+        Single
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Column.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Column.cs
@@ -25,7 +25,7 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Column
     {
-        keys,
-        values
+        Keys,
+        Values
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -30,7 +31,7 @@ namespace Gremlin.Net.Process.Traversal
     /// <summary>
     ///     A traversal represents a directed walk over a graph.
     /// </summary>
-    public abstract class DefaultTraversal : ITraversal
+    public abstract class DefaultTraversal<S, E> : ITraversal<S, E>
     {
         private IEnumerator<Traverser> _traverserEnumerator;
 
@@ -85,7 +86,9 @@ namespace Gremlin.Net.Process.Traversal
         }
 
         /// <inheritdoc />
-        public object Current => TraverserEnumerator.Current?.Object;
+        public E Current => (E)TraverserEnumerator.Current?.Object;
+
+        object IEnumerator.Current => Current;
 
         private IEnumerator<Traverser> GetTraverserEnumerator()
         {
@@ -110,7 +113,7 @@ namespace Gremlin.Net.Process.Traversal
         ///     Gets the next result from the traversal.
         /// </summary>
         /// <returns>The result.</returns>
-        public object Next()
+        public E Next()
         {
             MoveNext();
             return Current;
@@ -121,7 +124,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         /// <param name="amount">The number of results to get.</param>
         /// <returns>The n-results.</returns>
-        public IEnumerable<object> Next(int amount)
+        public IEnumerable<E> Next(int amount)
         {
             for (var i = 0; i < amount; i++)
                 yield return Next();
@@ -131,7 +134,7 @@ namespace Gremlin.Net.Process.Traversal
         ///     Iterates all <see cref="Traverser" /> instances in the traversal.
         /// </summary>
         /// <returns>The fully drained traversal.</returns>
-        public ITraversal Iterate()
+        public ITraversal<S, E> Iterate()
         {
             while (MoveNext())
             {
@@ -153,9 +156,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Puts all the results into a <see cref="List{T}" />.
         /// </summary>
         /// <returns>The results in a list.</returns>
-        public List<object> ToList()
+        public IList<E> ToList()
         {
-            var objs = new List<object>();
+            var objs = new List<E>();
             while (MoveNext())
                 objs.Add(Current);
             return objs;
@@ -165,9 +168,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Puts all the results into a <see cref="HashSet{T}" />.
         /// </summary>
         /// <returns>The results in a set.</returns>
-        public HashSet<object> ToSet()
+        public ISet<E> ToSet()
         {
-            var objs = new HashSet<object>();
+            var objs = new HashSet<E>();
             while (MoveNext())
                 objs.Add(Current);
             return objs;
@@ -186,7 +189,7 @@ namespace Gremlin.Net.Process.Traversal
         /// <typeparam name="TReturn">The return type of the <paramref name="callback" />.</typeparam>
         /// <param name="callback">The function to execute on the current traversal.</param>
         /// <returns>The result of the executed <paramref name="callback" />.</returns>
-        public async Task<TReturn> Promise<TReturn>(Func<ITraversal, TReturn> callback)
+        public async Task<TReturn> Promise<TReturn>(Func<ITraversal<S, E>, TReturn> callback)
         {
             await ApplyStrategiesAsync().ConfigureAwait(false);
             return callback(this);

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Direction.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Direction.cs
@@ -25,8 +25,8 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Direction
     {
-        BOTH,
-        IN,
-        OUT
+        Both,
+        In,
+        Out
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -22,10 +22,11 @@
 #endregion
 
 using System.Collections.Generic;
+using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.Process.Traversal
 {
-    public class GraphTraversal : DefaultTraversal
+    public class GraphTraversal<S, E> : DefaultTraversal<S, E>
     {
         public GraphTraversal()
             : this(new List<ITraversalStrategy>(), new Bytecode())
@@ -38,592 +39,603 @@ namespace Gremlin.Net.Process.Traversal
             Bytecode = bytecode;
         }
 
-        public GraphTraversal V(params object[] args)
+        private static GraphTraversal<S2, E2> Wrap<S2, E2>(GraphTraversal<S, E> traversal)
+        {
+            if (typeof(S2) == typeof(S) && typeof(E2) == typeof(E))
+            {
+                return traversal as GraphTraversal<S2, E2>;
+            }
+            // New wrapper
+            return new GraphTraversal<S2, E2>(traversal.TraversalStrategies, traversal.Bytecode);
+        }
+
+
+        public GraphTraversal<S, Vertex> V(params object[] args)
         {
             Bytecode.AddStep("V", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal AddE(params object[] args)
+        public GraphTraversal<S, Edge> AddE(params object[] args)
         {
             Bytecode.AddStep("addE", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal AddInE(params object[] args)
+        public GraphTraversal<S, Edge> AddInE(params object[] args)
         {
             Bytecode.AddStep("addInE", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal AddOutE(params object[] args)
+        public GraphTraversal<S, Edge> AddOutE(params object[] args)
         {
             Bytecode.AddStep("addOutE", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal AddV(params object[] args)
+        public GraphTraversal<S, Vertex> AddV(params object[] args)
         {
             Bytecode.AddStep("addV", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal Aggregate(params object[] args)
+        public GraphTraversal<S, E> Aggregate(params object[] args)
         {
             Bytecode.AddStep("aggregate", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal And(params object[] args)
+        public GraphTraversal<S, E> And(params object[] args)
         {
             Bytecode.AddStep("and", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal As(params object[] args)
+        public GraphTraversal<S, E> As(params object[] args)
         {
             Bytecode.AddStep("as", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Barrier(params object[] args)
+        public GraphTraversal<S, E> Barrier(params object[] args)
         {
             Bytecode.AddStep("barrier", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Both(params object[] args)
+        public GraphTraversal<S, Vertex> Both(params object[] args)
         {
             Bytecode.AddStep("both", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal BothE(params object[] args)
+        public GraphTraversal<S, Edge> BothE(params object[] args)
         {
             Bytecode.AddStep("bothE", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal BothV(params object[] args)
+        public GraphTraversal<S, Vertex> BothV(params object[] args)
         {
             Bytecode.AddStep("bothV", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal Branch(params object[] args)
+        public GraphTraversal<S, E2> Branch<E2>(params object[] args)
         {
             Bytecode.AddStep("branch", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal By(params object[] args)
+        public GraphTraversal<S, E> By(params object[] args)
         {
             Bytecode.AddStep("by", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Cap(params object[] args)
+        public GraphTraversal<S, E2> Cap<E2>(params object[] args)
         {
             Bytecode.AddStep("cap", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Choose(params object[] args)
+        public GraphTraversal<S, E2> Choose<E2>(params object[] args)
         {
             Bytecode.AddStep("choose", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Coalesce(params object[] args)
+        public GraphTraversal<S, E2> Coalesce<E2>(params object[] args)
         {
             Bytecode.AddStep("coalesce", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Coin(params object[] args)
+        public GraphTraversal<S, E> Coin(params object[] args)
         {
             Bytecode.AddStep("coin", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Constant(params object[] args)
+        public GraphTraversal<S, E2> Constant<E2>(params object[] args)
         {
             Bytecode.AddStep("constant", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Count(params object[] args)
+        public GraphTraversal<S, long> Count(params object[] args)
         {
             Bytecode.AddStep("count", args);
-            return this;
+            return Wrap<S, long>(this);
         }
 
-        public GraphTraversal CyclicPath(params object[] args)
+        public GraphTraversal<S, E> CyclicPath(params object[] args)
         {
             Bytecode.AddStep("cyclicPath", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Dedup(params object[] args)
+        public GraphTraversal<S, E> Dedup(params object[] args)
         {
             Bytecode.AddStep("dedup", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Drop(params object[] args)
+        public GraphTraversal<S, E> Drop(params object[] args)
         {
             Bytecode.AddStep("drop", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Emit(params object[] args)
+        public GraphTraversal<S, E> Emit(params object[] args)
         {
             Bytecode.AddStep("emit", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Filter(params object[] args)
+        public GraphTraversal<S, E> Filter(params object[] args)
         {
             Bytecode.AddStep("filter", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal FlatMap(params object[] args)
+        public GraphTraversal<S, E2> FlatMap<E2>(params object[] args)
         {
             Bytecode.AddStep("flatMap", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Fold(params object[] args)
+        public GraphTraversal<S, E2> Fold<E2>(params object[] args)
         {
             Bytecode.AddStep("fold", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal From(params object[] args)
+        public GraphTraversal<S, E> From(params object[] args)
         {
             Bytecode.AddStep("from", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Group(params object[] args)
+        public GraphTraversal<S, E> Group(params object[] args)
         {
             Bytecode.AddStep("group", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal GroupCount(params object[] args)
+        public GraphTraversal<S, E> GroupCount(params object[] args)
         {
             Bytecode.AddStep("groupCount", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal GroupV3d0(params object[] args)
+        public GraphTraversal<S, E> GroupV3d0(params object[] args)
         {
             Bytecode.AddStep("groupV3d0", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Has(params object[] args)
+        public GraphTraversal<S, E> Has(params object[] args)
         {
             Bytecode.AddStep("has", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal HasId(params object[] args)
+        public GraphTraversal<S, E> HasId(params object[] args)
         {
             Bytecode.AddStep("hasId", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal HasKey(params object[] args)
+        public GraphTraversal<S, E> HasKey(params object[] args)
         {
             Bytecode.AddStep("hasKey", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal HasLabel(params object[] args)
+        public GraphTraversal<S, E> HasLabel(params object[] args)
         {
             Bytecode.AddStep("hasLabel", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal HasNot(params object[] args)
+        public GraphTraversal<S, E> HasNot(params object[] args)
         {
             Bytecode.AddStep("hasNot", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal HasValue(params object[] args)
+        public GraphTraversal<S, E> HasValue(params object[] args)
         {
             Bytecode.AddStep("hasValue", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Id(params object[] args)
+        public GraphTraversal<S, object> Id(params object[] args)
         {
             Bytecode.AddStep("id", args);
-            return this;
+            return Wrap<S, object>(this);
         }
 
-        public GraphTraversal Identity(params object[] args)
+        public GraphTraversal<S, E> Identity(params object[] args)
         {
             Bytecode.AddStep("identity", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal In(params object[] args)
+        public GraphTraversal<S, Vertex> In(params object[] args)
         {
             Bytecode.AddStep("in", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal InE(params object[] args)
+        public GraphTraversal<S, Edge> InE(params object[] args)
         {
             Bytecode.AddStep("inE", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal InV(params object[] args)
+        public GraphTraversal<S, Vertex> InV(params object[] args)
         {
             Bytecode.AddStep("inV", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal Inject(params object[] args)
+        public GraphTraversal<S, E> Inject(params object[] args)
         {
             Bytecode.AddStep("inject", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Is(params object[] args)
+        public GraphTraversal<S, E> Is(params object[] args)
         {
             Bytecode.AddStep("is", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Key(params object[] args)
+        public GraphTraversal<S, string> Key(params object[] args)
         {
             Bytecode.AddStep("key", args);
-            return this;
+            return Wrap<S, string>(this);
         }
 
-        public GraphTraversal Label(params object[] args)
+        public GraphTraversal<S, string> Label(params object[] args)
         {
             Bytecode.AddStep("label", args);
-            return this;
+            return Wrap<S, string>(this);
         }
 
-        public GraphTraversal Limit(params object[] args)
+        public GraphTraversal<S, E2> Limit<E2>(params object[] args)
         {
             Bytecode.AddStep("limit", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Local(params object[] args)
+        public GraphTraversal<S, E2> Local<E2>(params object[] args)
         {
             Bytecode.AddStep("local", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Loops(params object[] args)
+        public GraphTraversal<S, int> Loops(params object[] args)
         {
             Bytecode.AddStep("loops", args);
-            return this;
+            return Wrap<S, int>(this);
         }
 
-        public GraphTraversal Map(params object[] args)
+        public GraphTraversal<S, E2> Map<E2>(params object[] args)
         {
             Bytecode.AddStep("map", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal MapKeys(params object[] args)
+        public GraphTraversal<S, E2> MapKeys<E2>(params object[] args)
         {
             Bytecode.AddStep("mapKeys", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal MapValues(params object[] args)
+        public GraphTraversal<S, E2> MapValues<E2>(params object[] args)
         {
             Bytecode.AddStep("mapValues", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Match(params object[] args)
+        public GraphTraversal<S, IDictionary<string, E2>> Match<E2>(params object[] args)
         {
             Bytecode.AddStep("match", args);
-            return this;
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
-        public GraphTraversal Max(params object[] args)
+        public GraphTraversal<S, E2> Max<E2>(params object[] args)
         {
             Bytecode.AddStep("max", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Mean(params object[] args)
+        public GraphTraversal<S, E2> Mean<E2>(params object[] args)
         {
             Bytecode.AddStep("mean", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Min(params object[] args)
+        public GraphTraversal<S, E2> Min<E2>(params object[] args)
         {
             Bytecode.AddStep("min", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Not(params object[] args)
+        public GraphTraversal<S, E> Not(params object[] args)
         {
             Bytecode.AddStep("not", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Option(params object[] args)
+        public GraphTraversal<S, E> Option(params object[] args)
         {
             Bytecode.AddStep("option", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Optional(params object[] args)
+        public GraphTraversal<S, E2> Optional<E2>(params object[] args)
         {
             Bytecode.AddStep("optional", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Or(params object[] args)
+        public GraphTraversal<S, E> Or(params object[] args)
         {
             Bytecode.AddStep("or", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Order(params object[] args)
+        public GraphTraversal<S, E> Order(params object[] args)
         {
             Bytecode.AddStep("order", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal OtherV(params object[] args)
+        public GraphTraversal<S, Vertex> OtherV(params object[] args)
         {
             Bytecode.AddStep("otherV", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal Out(params object[] args)
+        public GraphTraversal<S, Vertex> Out(params object[] args)
         {
             Bytecode.AddStep("out", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal OutE(params object[] args)
+        public GraphTraversal<S, Edge> OutE(params object[] args)
         {
             Bytecode.AddStep("outE", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal OutV(params object[] args)
+        public GraphTraversal<S, Vertex> OutV(params object[] args)
         {
             Bytecode.AddStep("outV", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal PageRank(params object[] args)
+        public GraphTraversal<S, E> PageRank(params object[] args)
         {
             Bytecode.AddStep("pageRank", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Path(params object[] args)
+        public GraphTraversal<S, Path> Path(params object[] args)
         {
             Bytecode.AddStep("path", args);
-            return this;
+            return Wrap<S, Path>(this);
         }
 
-        public GraphTraversal PeerPressure(params object[] args)
+        public GraphTraversal<S, E> PeerPressure(params object[] args)
         {
             Bytecode.AddStep("peerPressure", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Profile(params object[] args)
+        public GraphTraversal<S, E> Profile(params object[] args)
         {
             Bytecode.AddStep("profile", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Program(params object[] args)
+        public GraphTraversal<S, E> Program(params object[] args)
         {
             Bytecode.AddStep("program", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Project(params object[] args)
+        public GraphTraversal<S, IDictionary<string, E2>> Project<E2>(params object[] args)
         {
             Bytecode.AddStep("project", args);
-            return this;
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
-        public GraphTraversal Properties(params object[] args)
+        public GraphTraversal<S, E2> Properties<E2>(params object[] args)
         {
             Bytecode.AddStep("properties", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Property(params object[] args)
+        public GraphTraversal<S, E> Property(params object[] args)
         {
             Bytecode.AddStep("property", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal PropertyMap(params object[] args)
+        public GraphTraversal<S, IDictionary<string, E2>> PropertyMap<E2>(params object[] args)
         {
             Bytecode.AddStep("propertyMap", args);
-            return this;
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
-        public GraphTraversal Range(params object[] args)
+        public GraphTraversal<S, E2> Range<E2>(params object[] args)
         {
             Bytecode.AddStep("range", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Repeat(params object[] args)
+        public GraphTraversal<S, E> Repeat(params object[] args)
         {
             Bytecode.AddStep("repeat", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Sack(params object[] args)
+        public GraphTraversal<S, E> Sack(params object[] args)
         {
             Bytecode.AddStep("sack", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Sample(params object[] args)
+        public GraphTraversal<S, E> Sample(params object[] args)
         {
             Bytecode.AddStep("sample", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Select(params object[] args)
+        public GraphTraversal<S, IDictionary<string, E2>> Select<E2>(params object[] args)
         {
             Bytecode.AddStep("select", args);
-            return this;
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
-        public GraphTraversal SideEffect(params object[] args)
+        public GraphTraversal<S, E> SideEffect(params object[] args)
         {
             Bytecode.AddStep("sideEffect", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal SimplePath(params object[] args)
+        public GraphTraversal<S, E> SimplePath(params object[] args)
         {
             Bytecode.AddStep("simplePath", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Store(params object[] args)
+        public GraphTraversal<S, E> Store(params object[] args)
         {
             Bytecode.AddStep("store", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Subgraph(params object[] args)
+        public GraphTraversal<S, Edge> Subgraph(params object[] args)
         {
             Bytecode.AddStep("subgraph", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal Sum(params object[] args)
+        public GraphTraversal<S, E2> Sum<E2>(params object[] args)
         {
             Bytecode.AddStep("sum", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Tail(params object[] args)
+        public GraphTraversal<S, E2> Tail<E2>(params object[] args)
         {
             Bytecode.AddStep("tail", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal TimeLimit(params object[] args)
+        public GraphTraversal<S, E> TimeLimit(params object[] args)
         {
             Bytecode.AddStep("timeLimit", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Times(params object[] args)
+        public GraphTraversal<S, E> Times(params object[] args)
         {
             Bytecode.AddStep("times", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal To(params object[] args)
+        public GraphTraversal<S, Vertex> To(params object[] args)
         {
             Bytecode.AddStep("to", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal ToE(params object[] args)
+        public GraphTraversal<S, Edge> ToE(params object[] args)
         {
             Bytecode.AddStep("toE", args);
-            return this;
+            return Wrap<S, Edge>(this);
         }
 
-        public GraphTraversal ToV(params object[] args)
+        public GraphTraversal<S, Vertex> ToV(params object[] args)
         {
             Bytecode.AddStep("toV", args);
-            return this;
+            return Wrap<S, Vertex>(this);
         }
 
-        public GraphTraversal Tree(params object[] args)
+        public GraphTraversal<S, E> Tree(params object[] args)
         {
             Bytecode.AddStep("tree", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Unfold(params object[] args)
+        public GraphTraversal<S, E2> Unfold<E2>(params object[] args)
         {
             Bytecode.AddStep("unfold", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Union(params object[] args)
+        public GraphTraversal<S, E2> Union<E2>(params object[] args)
         {
             Bytecode.AddStep("union", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Until(params object[] args)
+        public GraphTraversal<S, E> Until(params object[] args)
         {
             Bytecode.AddStep("until", args);
-            return this;
+            return Wrap<S, E>(this);
         }
 
-        public GraphTraversal Value(params object[] args)
+        public GraphTraversal<S, E2> Value<E2>(params object[] args)
         {
             Bytecode.AddStep("value", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal ValueMap(params object[] args)
+        public GraphTraversal<S, IDictionary<string, E2>> ValueMap<E2>(params object[] args)
         {
             Bytecode.AddStep("valueMap", args);
-            return this;
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
-        public GraphTraversal Values(params object[] args)
+        public GraphTraversal<S, E2> Values<E2>(params object[] args)
         {
             Bytecode.AddStep("values", args);
-            return this;
+            return Wrap<S, E2>(this);
         }
 
-        public GraphTraversal Where(params object[] args)
+        public GraphTraversal<S, E> Where(params object[] args)
         {
             Bytecode.AddStep("where", args);
-            return this;
+            return Wrap<S, E>(this);
         }
-	}
+    }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -24,6 +24,7 @@
 using System.Collections.Generic;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
+using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.Process.Traversal
 {
@@ -111,32 +112,25 @@ namespace Gremlin.Net.Process.Traversal
             return WithStrategies(new VertexProgramStrategy(graphComputer, workers, persist, result, vertices, edges, configuration));
         }
 
-        public GraphTraversal E(params object[] args)
+        public GraphTraversal<Edge, Edge> E(params object[] args)
         {
-            var traversal = new GraphTraversal(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Edge, Edge>(TraversalStrategies, new Bytecode(Bytecode));
             traversal.Bytecode.AddStep("E", args);
             return traversal;
         }
 
-        public GraphTraversal V(params object[] args)
+        public GraphTraversal<Vertex, Vertex> V(params object[] args)
         {
-            var traversal = new GraphTraversal(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
             traversal.Bytecode.AddStep("V", args);
             return traversal;
         }
 
-        public GraphTraversal AddV(params object[] args)
+        public GraphTraversal<Vertex, Vertex> AddV(params object[] args)
         {
-            var traversal = new GraphTraversal(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
             traversal.Bytecode.AddStep("addV", args);
             return traversal;
         }
-
-        public GraphTraversal Inject(params object[] args)
-        {
-            var traversal = new GraphTraversal(TraversalStrategies, new Bytecode(Bytecode));
-            traversal.Bytecode.AddStep("inject", args);
-            return traversal;
-        }
-	}
+    }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversal.cs
@@ -29,9 +29,10 @@ using System.Threading.Tasks;
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     A traversal represents a directed walk over a graph.
+    /// Represents the basic information for a walk over a graph.
     /// </summary>
-    public interface ITraversal : IDisposable, IEnumerator
+    /// <seealso cref="ITraversal{SType, EType}"/>
+    public interface ITraversal
     {
         /// <summary>
         ///     Gets the <see cref="Bytecode" /> representation of this traversal.
@@ -47,25 +48,31 @@ namespace Gremlin.Net.Process.Traversal
         ///     Gets or sets the <see cref="Traverser" />'s of this traversal that hold the results of the traversal.
         /// </summary>
         IEnumerable<Traverser> Traversers { get; set; }
+    }
 
+    /// <summary>
+    ///     A traversal represents a directed walk over a graph.
+    /// </summary>
+    public interface ITraversal<S, E> : ITraversal, IEnumerator<E>
+    {
         /// <summary>
         ///     Gets the next result from the traversal.
         /// </summary>
         /// <returns>The result.</returns>
-        object Next();
+        E Next();
 
         /// <summary>
         ///     Gets the next n-number of results from the traversal.
         /// </summary>
         /// <param name="amount">The number of results to get.</param>
         /// <returns>The n-results.</returns>
-        IEnumerable<object> Next(int amount);
+        IEnumerable<E> Next(int amount);
 
         /// <summary>
         ///     Iterates all <see cref="Traverser" /> instances in the traversal.
         /// </summary>
         /// <returns>The fully drained traversal.</returns>
-        ITraversal Iterate();
+        ITraversal<S, E> Iterate();
 
         /// <summary>
         ///     Gets the next <see cref="Traverser" />.
@@ -74,16 +81,16 @@ namespace Gremlin.Net.Process.Traversal
         Traverser NextTraverser();
 
         /// <summary>
-        ///     Puts all the results into a <see cref="List{T}" />.
+        ///     Puts all the results into a <see cref="IList{T}" />.
         /// </summary>
         /// <returns>The results in a list.</returns>
-        List<object> ToList();
+        IList<E> ToList();
 
         /// <summary>
-        ///     Puts all the results into a <see cref="HashSet{T}" />.
+        ///     Puts all the results into a <see cref="ISet{T}" />.
         /// </summary>
         /// <returns>The results in a set.</returns>
-        HashSet<object> ToSet();
+        ISet<E> ToSet();
 
         /// <summary>
         ///     Starts a promise to execute a function on the current traversal that will be completed in the future.
@@ -91,6 +98,6 @@ namespace Gremlin.Net.Process.Traversal
         /// <typeparam name="TReturn">The return type of the <paramref name="callback" />.</typeparam>
         /// <param name="callback">The function to execute on the current traversal.</param>
         /// <returns>The result of the executed <paramref name="callback" />.</returns>
-        Task<TReturn> Promise<TReturn>(Func<ITraversal, TReturn> callback);
+        Task<TReturn> Promise<TReturn>(Func<ITraversal<S, E>, TReturn> callback);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversalStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversalStrategy.cs
@@ -35,12 +35,12 @@ namespace Gremlin.Net.Process.Traversal
         ///     Applies the strategy to the given <see cref="ITraversal" />.
         /// </summary>
         /// <param name="traversal">The <see cref="ITraversal" /> the strategy should be applied to.</param>
-        void Apply(ITraversal traversal);
+        void Apply<S, E>(ITraversal<S, E> traversal);
 
         /// <summary>
         ///     Applies the strategy to the given <see cref="ITraversal" /> asynchronously.
         /// </summary>
         /// <param name="traversal">The <see cref="ITraversal" /> the strategy should be applied to.</param>
-        Task ApplyAsync(ITraversal traversal);
+        Task ApplyAsync<S, E>(ITraversal<S, E> traversal);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/NamingConversions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/NamingConversions.cs
@@ -1,0 +1,86 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Collections.Generic;
+
+namespace Gremlin.Net.Process.Traversal
+{
+    internal static class NamingConversions
+    {
+        /// <summary>
+        /// Gets the Java name equivalent for a given enum value
+        /// </summary>
+        internal static string GetEnumJavaName(string typeName, string value)
+        {
+            var key = $"{typeName}.{value}";
+            string javaName;
+            if (!CSharpToJavaEnums.TryGetValue(key, out javaName))
+            {
+                throw new KeyNotFoundException($"Java name for {key} not found");
+            }
+            return javaName;
+        }
+
+        internal static readonly IDictionary<string, string> CSharpToJavaEnums = new Dictionary<string, string>
+        {
+            {"T.Value", "value"},
+            {"Order.Decr", "decr"},
+            {"Order.KeyDecr", "keyDecr"},
+            {"T.Key", "key"},
+            {"Column.Values", "values"},
+            {"Order.KeyIncr", "keyIncr"},
+            {"Operator.Or", "or"},
+            {"Order.ValueIncr", "valueIncr"},
+            {"Cardinality.List", "list"},
+            {"Order.Incr", "incr"},
+            {"Pop.All", "all"},
+            {"Operator.SumLong", "sumLong"},
+            {"Pop.First", "first"},
+            {"T.Label", "label"},
+            {"Cardinality.Set", "set"},
+            {"Order.Shuffle", "shuffle"},
+            {"Direction.In", "IN"},
+            {"Direction.Both", "BOTH"},
+            {"Scope.Local", "local"},
+            {"Operator.Max", "max"},
+            {"Direction.Out", "OUT"},
+            {"Scope.Global", "global"},
+            {"Pick.Any", "any"},
+            {"Order.ValueDecr", "valueDecr"},
+            {"Column.Keys", "keys"},
+            {"Operator.AddAll", "addAll"},
+            {"Operator.Mult", "mult"},
+            {"Pick.None", "none"},
+            {"Pop.Last", "last"},
+            {"Operator.And", "and"},
+            {"T.Id", "id"},
+            {"Operator.Min", "min"},
+            {"Barrier.NormSack", "normSack"},
+            {"Operator.Minus", "minus"},
+            {"Cardinality.Single", "single"},
+            {"Operator.Assign", "assign"},
+            {"Operator.Div", "div"},
+            {"Operator.Sum", "sum"}
+        };
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Operator.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Operator.cs
@@ -25,16 +25,16 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Operator
     {
-        addAll,
-        and,
-        assign,
-        div,
-        max,
-        min,
-        minus,
-        mult,
-        or,
-        sum,
-        sumLong
+        AddAll,
+        And,
+        Assign,
+        Div,
+        Max,
+        Min,
+        Minus,
+        Mult,
+        Or,
+        Sum,
+        SumLong
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Order.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Order.cs
@@ -25,12 +25,12 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Order
     {
-        decr,
-        incr,
-        keyDecr,
-        keyIncr,
-        shuffle,
-        valueDecr,
-        valueIncr
+        Decr,
+        Incr,
+        KeyDecr,
+        KeyIncr,
+        Shuffle,
+        ValueDecr,
+        ValueIncr
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
@@ -103,5 +103,5 @@ namespace Gremlin.Net.Process.Traversal
             var value = args.Length == 1 ? args[0] : args;
             return new TraversalPredicate("without", value);
         }
-	}
+    }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pick.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pick.cs
@@ -25,7 +25,7 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Pick
     {
-        any,
-        none
+        Any,
+        None
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pop.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pop.cs
@@ -25,8 +25,8 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Pop
     {
-        all,
-        first,
-        last
+        All,
+        First,
+        Last
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Scope.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Scope.cs
@@ -25,7 +25,7 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum Scope
     {
-        global,
-        local
+        Global,
+        Local
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/AbstractTraversalStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/AbstractTraversalStrategy.cs
@@ -52,12 +52,12 @@ namespace Gremlin.Net.Process.Traversal.Strategy
         }
 
         /// <inheritdoc />
-        public virtual void Apply(ITraversal traversal)
+        public virtual void Apply<S, E>(ITraversal<S, E> traversal)
         {
         }
 
         /// <inheritdoc />
-        public virtual Task ApplyAsync(ITraversal traversal)
+        public virtual Task ApplyAsync<S, E>(ITraversal<S, E> traversal)
         {
             return Task.CompletedTask;
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/T.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/T.cs
@@ -25,9 +25,9 @@ namespace Gremlin.Net.Process.Traversal
 {
     public enum T
     {
-        id,
-        key,
-        label,
-        value
+        Id,
+        Key,
+        Label,
+        Value
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
@@ -21,468 +21,471 @@
 
 #endregion
 
+using System.Collections.Generic;
+using Gremlin.Net.Structure;
+
 namespace Gremlin.Net.Process.Traversal
 {
     public static class __
     {
-        public static GraphTraversal Start()
+        public static GraphTraversal<object, object> Start()
         {
-            return new GraphTraversal();
+            return new GraphTraversal<object, object>();
         }
 
-        public static GraphTraversal V(params object[] args)
+        public static GraphTraversal<object, Vertex> V(params object[] args)
         {
-            return new GraphTraversal().V(args);
+            return new GraphTraversal<object, object>().V(args);
         }
 
-        public static GraphTraversal AddE(params object[] args)
+        public static GraphTraversal<object, Edge> AddE(params object[] args)
         {
-            return new GraphTraversal().AddE(args);
+            return new GraphTraversal<object, object>().AddE(args);
         }
 
-        public static GraphTraversal AddInE(params object[] args)
+        public static GraphTraversal<object, Edge> AddInE(params object[] args)
         {
-            return new GraphTraversal().AddInE(args);
+            return new GraphTraversal<object, object>().AddInE(args);
         }
 
-        public static GraphTraversal AddOutE(params object[] args)
+        public static GraphTraversal<object, Edge> AddOutE(params object[] args)
         {
-            return new GraphTraversal().AddOutE(args);
+            return new GraphTraversal<object, object>().AddOutE(args);
         }
 
-        public static GraphTraversal AddV(params object[] args)
+        public static GraphTraversal<object, Vertex> AddV(params object[] args)
         {
-            return new GraphTraversal().AddV(args);
+            return new GraphTraversal<object, object>().AddV(args);
         }
 
-        public static GraphTraversal Aggregate(params object[] args)
+        public static GraphTraversal<object, object> Aggregate(params object[] args)
         {
-            return new GraphTraversal().Aggregate(args);
+            return new GraphTraversal<object, object>().Aggregate(args);
         }
 
-        public static GraphTraversal And(params object[] args)
+        public static GraphTraversal<object, object> And(params object[] args)
         {
-            return new GraphTraversal().And(args);
+            return new GraphTraversal<object, object>().And(args);
         }
 
-        public static GraphTraversal As(params object[] args)
+        public static GraphTraversal<object, object> As(params object[] args)
         {
-            return new GraphTraversal().As(args);
+            return new GraphTraversal<object, object>().As(args);
         }
 
-        public static GraphTraversal Barrier(params object[] args)
+        public static GraphTraversal<object, object> Barrier(params object[] args)
         {
-            return new GraphTraversal().Barrier(args);
+            return new GraphTraversal<object, object>().Barrier(args);
         }
 
-        public static GraphTraversal Both(params object[] args)
+        public static GraphTraversal<object, Vertex> Both(params object[] args)
         {
-            return new GraphTraversal().Both(args);
+            return new GraphTraversal<object, object>().Both(args);
         }
 
-        public static GraphTraversal BothE(params object[] args)
+        public static GraphTraversal<object, Edge> BothE(params object[] args)
         {
-            return new GraphTraversal().BothE(args);
+            return new GraphTraversal<object, object>().BothE(args);
         }
 
-        public static GraphTraversal BothV(params object[] args)
+        public static GraphTraversal<object, Vertex> BothV(params object[] args)
         {
-            return new GraphTraversal().BothV(args);
+            return new GraphTraversal<object, object>().BothV(args);
         }
 
-        public static GraphTraversal Branch(params object[] args)
+        public static GraphTraversal<object, E2> Branch<E2>(params object[] args)
         {
-            return new GraphTraversal().Branch(args);
+            return new GraphTraversal<object, object>().Branch<E2>(args);
         }
 
-        public static GraphTraversal Cap(params object[] args)
+        public static GraphTraversal<object, E2> Cap<E2>(params object[] args)
         {
-            return new GraphTraversal().Cap(args);
+            return new GraphTraversal<object, object>().Cap<E2>(args);
         }
 
-        public static GraphTraversal Choose(params object[] args)
+        public static GraphTraversal<object, E2> Choose<E2>(params object[] args)
         {
-            return new GraphTraversal().Choose(args);
+            return new GraphTraversal<object, object>().Choose<E2>(args);
         }
 
-        public static GraphTraversal Coalesce(params object[] args)
+        public static GraphTraversal<object, E2> Coalesce<E2>(params object[] args)
         {
-            return new GraphTraversal().Coalesce(args);
+            return new GraphTraversal<object, object>().Coalesce<E2>(args);
         }
 
-        public static GraphTraversal Coin(params object[] args)
+        public static GraphTraversal<object, object> Coin(params object[] args)
         {
-            return new GraphTraversal().Coin(args);
+            return new GraphTraversal<object, object>().Coin(args);
         }
 
-        public static GraphTraversal Constant(params object[] args)
+        public static GraphTraversal<object, E2> Constant<E2>(params object[] args)
         {
-            return new GraphTraversal().Constant(args);
+            return new GraphTraversal<object, object>().Constant<E2>(args);
         }
 
-        public static GraphTraversal Count(params object[] args)
+        public static GraphTraversal<object, long> Count(params object[] args)
         {
-            return new GraphTraversal().Count(args);
+            return new GraphTraversal<object, object>().Count(args);
         }
 
-        public static GraphTraversal CyclicPath(params object[] args)
+        public static GraphTraversal<object, object> CyclicPath(params object[] args)
         {
-            return new GraphTraversal().CyclicPath(args);
+            return new GraphTraversal<object, object>().CyclicPath(args);
         }
 
-        public static GraphTraversal Dedup(params object[] args)
+        public static GraphTraversal<object, object> Dedup(params object[] args)
         {
-            return new GraphTraversal().Dedup(args);
+            return new GraphTraversal<object, object>().Dedup(args);
         }
 
-        public static GraphTraversal Drop(params object[] args)
+        public static GraphTraversal<object, object> Drop(params object[] args)
         {
-            return new GraphTraversal().Drop(args);
+            return new GraphTraversal<object, object>().Drop(args);
         }
 
-        public static GraphTraversal Emit(params object[] args)
+        public static GraphTraversal<object, object> Emit(params object[] args)
         {
-            return new GraphTraversal().Emit(args);
+            return new GraphTraversal<object, object>().Emit(args);
         }
 
-        public static GraphTraversal Filter(params object[] args)
+        public static GraphTraversal<object, object> Filter(params object[] args)
         {
-            return new GraphTraversal().Filter(args);
+            return new GraphTraversal<object, object>().Filter(args);
         }
 
-        public static GraphTraversal FlatMap(params object[] args)
+        public static GraphTraversal<object, E2> FlatMap<E2>(params object[] args)
         {
-            return new GraphTraversal().FlatMap(args);
+            return new GraphTraversal<object, object>().FlatMap<E2>(args);
         }
 
-        public static GraphTraversal Fold(params object[] args)
+        public static GraphTraversal<object, E2> Fold<E2>(params object[] args)
         {
-            return new GraphTraversal().Fold(args);
+            return new GraphTraversal<object, object>().Fold<E2>(args);
         }
 
-        public static GraphTraversal Group(params object[] args)
+        public static GraphTraversal<object, object> Group(params object[] args)
         {
-            return new GraphTraversal().Group(args);
+            return new GraphTraversal<object, object>().Group(args);
         }
 
-        public static GraphTraversal GroupCount(params object[] args)
+        public static GraphTraversal<object, object> GroupCount(params object[] args)
         {
-            return new GraphTraversal().GroupCount(args);
+            return new GraphTraversal<object, object>().GroupCount(args);
         }
 
-        public static GraphTraversal GroupV3d0(params object[] args)
+        public static GraphTraversal<object, object> GroupV3d0(params object[] args)
         {
-            return new GraphTraversal().GroupV3d0(args);
+            return new GraphTraversal<object, object>().GroupV3d0(args);
         }
 
-        public static GraphTraversal Has(params object[] args)
+        public static GraphTraversal<object, object> Has(params object[] args)
         {
-            return new GraphTraversal().Has(args);
+            return new GraphTraversal<object, object>().Has(args);
         }
 
-        public static GraphTraversal HasId(params object[] args)
+        public static GraphTraversal<object, object> HasId(params object[] args)
         {
-            return new GraphTraversal().HasId(args);
+            return new GraphTraversal<object, object>().HasId(args);
         }
 
-        public static GraphTraversal HasKey(params object[] args)
+        public static GraphTraversal<object, object> HasKey(params object[] args)
         {
-            return new GraphTraversal().HasKey(args);
+            return new GraphTraversal<object, object>().HasKey(args);
         }
 
-        public static GraphTraversal HasLabel(params object[] args)
+        public static GraphTraversal<object, object> HasLabel(params object[] args)
         {
-            return new GraphTraversal().HasLabel(args);
+            return new GraphTraversal<object, object>().HasLabel(args);
         }
 
-        public static GraphTraversal HasNot(params object[] args)
+        public static GraphTraversal<object, object> HasNot(params object[] args)
         {
-            return new GraphTraversal().HasNot(args);
+            return new GraphTraversal<object, object>().HasNot(args);
         }
 
-        public static GraphTraversal HasValue(params object[] args)
+        public static GraphTraversal<object, object> HasValue(params object[] args)
         {
-            return new GraphTraversal().HasValue(args);
+            return new GraphTraversal<object, object>().HasValue(args);
         }
 
-        public static GraphTraversal Id(params object[] args)
+        public static GraphTraversal<object, object> Id(params object[] args)
         {
-            return new GraphTraversal().Id(args);
+            return new GraphTraversal<object, object>().Id(args);
         }
 
-        public static GraphTraversal Identity(params object[] args)
+        public static GraphTraversal<object, object> Identity(params object[] args)
         {
-            return new GraphTraversal().Identity(args);
+            return new GraphTraversal<object, object>().Identity(args);
         }
 
-        public static GraphTraversal In(params object[] args)
+        public static GraphTraversal<object, Vertex> In(params object[] args)
         {
-            return new GraphTraversal().In(args);
+            return new GraphTraversal<object, object>().In(args);
         }
 
-        public static GraphTraversal InE(params object[] args)
+        public static GraphTraversal<object, Edge> InE(params object[] args)
         {
-            return new GraphTraversal().InE(args);
+            return new GraphTraversal<object, object>().InE(args);
         }
 
-        public static GraphTraversal InV(params object[] args)
+        public static GraphTraversal<object, Vertex> InV(params object[] args)
         {
-            return new GraphTraversal().InV(args);
+            return new GraphTraversal<object, object>().InV(args);
         }
 
-        public static GraphTraversal Inject(params object[] args)
+        public static GraphTraversal<object, object> Inject(params object[] args)
         {
-            return new GraphTraversal().Inject(args);
+            return new GraphTraversal<object, object>().Inject(args);
         }
 
-        public static GraphTraversal Is(params object[] args)
+        public static GraphTraversal<object, object> Is(params object[] args)
         {
-            return new GraphTraversal().Is(args);
+            return new GraphTraversal<object, object>().Is(args);
         }
 
-        public static GraphTraversal Key(params object[] args)
+        public static GraphTraversal<object, string> Key(params object[] args)
         {
-            return new GraphTraversal().Key(args);
+            return new GraphTraversal<object, object>().Key(args);
         }
 
-        public static GraphTraversal Label(params object[] args)
+        public static GraphTraversal<object, string> Label(params object[] args)
         {
-            return new GraphTraversal().Label(args);
+            return new GraphTraversal<object, object>().Label(args);
         }
 
-        public static GraphTraversal Limit(params object[] args)
+        public static GraphTraversal<object, E2> Limit<E2>(params object[] args)
         {
-            return new GraphTraversal().Limit(args);
+            return new GraphTraversal<object, object>().Limit<E2>(args);
         }
 
-        public static GraphTraversal Local(params object[] args)
+        public static GraphTraversal<object, E2> Local<E2>(params object[] args)
         {
-            return new GraphTraversal().Local(args);
+            return new GraphTraversal<object, object>().Local<E2>(args);
         }
 
-        public static GraphTraversal Loops(params object[] args)
+        public static GraphTraversal<object, int> Loops(params object[] args)
         {
-            return new GraphTraversal().Loops(args);
+            return new GraphTraversal<object, object>().Loops(args);
         }
 
-        public static GraphTraversal Map(params object[] args)
+        public static GraphTraversal<object, E2> Map<E2>(params object[] args)
         {
-            return new GraphTraversal().Map(args);
+            return new GraphTraversal<object, object>().Map<E2>(args);
         }
 
-        public static GraphTraversal MapKeys(params object[] args)
+        public static GraphTraversal<object, E2> MapKeys<E2>(params object[] args)
         {
-            return new GraphTraversal().MapKeys(args);
+            return new GraphTraversal<object, object>().MapKeys<E2>(args);
         }
 
-        public static GraphTraversal MapValues(params object[] args)
+        public static GraphTraversal<object, E2> MapValues<E2>(params object[] args)
         {
-            return new GraphTraversal().MapValues(args);
+            return new GraphTraversal<object, object>().MapValues<E2>(args);
         }
 
-        public static GraphTraversal Match(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> Match<E2>(params object[] args)
         {
-            return new GraphTraversal().Match(args);
+            return new GraphTraversal<object, object>().Match<E2>(args);
         }
 
-        public static GraphTraversal Max(params object[] args)
+        public static GraphTraversal<object, E2> Max<E2>(params object[] args)
         {
-            return new GraphTraversal().Max(args);
+            return new GraphTraversal<object, object>().Max<E2>(args);
         }
 
-        public static GraphTraversal Mean(params object[] args)
+        public static GraphTraversal<object, E2> Mean<E2>(params object[] args)
         {
-            return new GraphTraversal().Mean(args);
+            return new GraphTraversal<object, object>().Mean<E2>(args);
         }
 
-        public static GraphTraversal Min(params object[] args)
+        public static GraphTraversal<object, E2> Min<E2>(params object[] args)
         {
-            return new GraphTraversal().Min(args);
+            return new GraphTraversal<object, object>().Min<E2>(args);
         }
 
-        public static GraphTraversal Not(params object[] args)
+        public static GraphTraversal<object, object> Not(params object[] args)
         {
-            return new GraphTraversal().Not(args);
+            return new GraphTraversal<object, object>().Not(args);
         }
 
-        public static GraphTraversal Optional(params object[] args)
+        public static GraphTraversal<object, E2> Optional<E2>(params object[] args)
         {
-            return new GraphTraversal().Optional(args);
+            return new GraphTraversal<object, object>().Optional<E2>(args);
         }
 
-        public static GraphTraversal Or(params object[] args)
+        public static GraphTraversal<object, object> Or(params object[] args)
         {
-            return new GraphTraversal().Or(args);
+            return new GraphTraversal<object, object>().Or(args);
         }
 
-        public static GraphTraversal Order(params object[] args)
+        public static GraphTraversal<object, object> Order(params object[] args)
         {
-            return new GraphTraversal().Order(args);
+            return new GraphTraversal<object, object>().Order(args);
         }
 
-        public static GraphTraversal OtherV(params object[] args)
+        public static GraphTraversal<object, Vertex> OtherV(params object[] args)
         {
-            return new GraphTraversal().OtherV(args);
+            return new GraphTraversal<object, object>().OtherV(args);
         }
 
-        public static GraphTraversal Out(params object[] args)
+        public static GraphTraversal<object, Vertex> Out(params object[] args)
         {
-            return new GraphTraversal().Out(args);
+            return new GraphTraversal<object, object>().Out(args);
         }
 
-        public static GraphTraversal OutE(params object[] args)
+        public static GraphTraversal<object, Edge> OutE(params object[] args)
         {
-            return new GraphTraversal().OutE(args);
+            return new GraphTraversal<object, object>().OutE(args);
         }
 
-        public static GraphTraversal OutV(params object[] args)
+        public static GraphTraversal<object, Vertex> OutV(params object[] args)
         {
-            return new GraphTraversal().OutV(args);
+            return new GraphTraversal<object, object>().OutV(args);
         }
 
-        public static GraphTraversal Path(params object[] args)
+        public static GraphTraversal<object, Path> Path(params object[] args)
         {
-            return new GraphTraversal().Path(args);
+            return new GraphTraversal<object, object>().Path(args);
         }
 
-        public static GraphTraversal Project(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> Project<E2>(params object[] args)
         {
-            return new GraphTraversal().Project(args);
+            return new GraphTraversal<object, object>().Project<E2>(args);
         }
 
-        public static GraphTraversal Properties(params object[] args)
+        public static GraphTraversal<object, E2> Properties<E2>(params object[] args)
         {
-            return new GraphTraversal().Properties(args);
+            return new GraphTraversal<object, object>().Properties<E2>(args);
         }
 
-        public static GraphTraversal Property(params object[] args)
+        public static GraphTraversal<object, object> Property(params object[] args)
         {
-            return new GraphTraversal().Property(args);
+            return new GraphTraversal<object, object>().Property(args);
         }
 
-        public static GraphTraversal PropertyMap(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> PropertyMap<E2>(params object[] args)
         {
-            return new GraphTraversal().PropertyMap(args);
+            return new GraphTraversal<object, object>().PropertyMap<E2>(args);
         }
 
-        public static GraphTraversal Range(params object[] args)
+        public static GraphTraversal<object, E2> Range<E2>(params object[] args)
         {
-            return new GraphTraversal().Range(args);
+            return new GraphTraversal<object, object>().Range<E2>(args);
         }
 
-        public static GraphTraversal Repeat(params object[] args)
+        public static GraphTraversal<object, object> Repeat(params object[] args)
         {
-            return new GraphTraversal().Repeat(args);
+            return new GraphTraversal<object, object>().Repeat(args);
         }
 
-        public static GraphTraversal Sack(params object[] args)
+        public static GraphTraversal<object, object> Sack(params object[] args)
         {
-            return new GraphTraversal().Sack(args);
+            return new GraphTraversal<object, object>().Sack(args);
         }
 
-        public static GraphTraversal Sample(params object[] args)
+        public static GraphTraversal<object, object> Sample(params object[] args)
         {
-            return new GraphTraversal().Sample(args);
+            return new GraphTraversal<object, object>().Sample(args);
         }
 
-        public static GraphTraversal Select(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> Select<E2>(params object[] args)
         {
-            return new GraphTraversal().Select(args);
+            return new GraphTraversal<object, object>().Select<E2>(args);
         }
 
-        public static GraphTraversal SideEffect(params object[] args)
+        public static GraphTraversal<object, object> SideEffect(params object[] args)
         {
-            return new GraphTraversal().SideEffect(args);
+            return new GraphTraversal<object, object>().SideEffect(args);
         }
 
-        public static GraphTraversal SimplePath(params object[] args)
+        public static GraphTraversal<object, object> SimplePath(params object[] args)
         {
-            return new GraphTraversal().SimplePath(args);
+            return new GraphTraversal<object, object>().SimplePath(args);
         }
 
-        public static GraphTraversal Store(params object[] args)
+        public static GraphTraversal<object, object> Store(params object[] args)
         {
-            return new GraphTraversal().Store(args);
+            return new GraphTraversal<object, object>().Store(args);
         }
 
-        public static GraphTraversal Subgraph(params object[] args)
+        public static GraphTraversal<object, Edge> Subgraph(params object[] args)
         {
-            return new GraphTraversal().Subgraph(args);
+            return new GraphTraversal<object, object>().Subgraph(args);
         }
 
-        public static GraphTraversal Sum(params object[] args)
+        public static GraphTraversal<object, E2> Sum<E2>(params object[] args)
         {
-            return new GraphTraversal().Sum(args);
+            return new GraphTraversal<object, object>().Sum<E2>(args);
         }
 
-        public static GraphTraversal Tail(params object[] args)
+        public static GraphTraversal<object, E2> Tail<E2>(params object[] args)
         {
-            return new GraphTraversal().Tail(args);
+            return new GraphTraversal<object, object>().Tail<E2>(args);
         }
 
-        public static GraphTraversal TimeLimit(params object[] args)
+        public static GraphTraversal<object, object> TimeLimit(params object[] args)
         {
-            return new GraphTraversal().TimeLimit(args);
+            return new GraphTraversal<object, object>().TimeLimit(args);
         }
 
-        public static GraphTraversal Times(params object[] args)
+        public static GraphTraversal<object, object> Times(params object[] args)
         {
-            return new GraphTraversal().Times(args);
+            return new GraphTraversal<object, object>().Times(args);
         }
 
-        public static GraphTraversal To(params object[] args)
+        public static GraphTraversal<object, Vertex> To(params object[] args)
         {
-            return new GraphTraversal().To(args);
+            return new GraphTraversal<object, object>().To(args);
         }
 
-        public static GraphTraversal ToE(params object[] args)
+        public static GraphTraversal<object, Edge> ToE(params object[] args)
         {
-            return new GraphTraversal().ToE(args);
+            return new GraphTraversal<object, object>().ToE(args);
         }
 
-        public static GraphTraversal ToV(params object[] args)
+        public static GraphTraversal<object, Vertex> ToV(params object[] args)
         {
-            return new GraphTraversal().ToV(args);
+            return new GraphTraversal<object, object>().ToV(args);
         }
 
-        public static GraphTraversal Tree(params object[] args)
+        public static GraphTraversal<object, object> Tree(params object[] args)
         {
-            return new GraphTraversal().Tree(args);
+            return new GraphTraversal<object, object>().Tree(args);
         }
 
-        public static GraphTraversal Unfold(params object[] args)
+        public static GraphTraversal<object, E2> Unfold<E2>(params object[] args)
         {
-            return new GraphTraversal().Unfold(args);
+            return new GraphTraversal<object, object>().Unfold<E2>(args);
         }
 
-        public static GraphTraversal Union(params object[] args)
+        public static GraphTraversal<object, E2> Union<E2>(params object[] args)
         {
-            return new GraphTraversal().Union(args);
+            return new GraphTraversal<object, object>().Union<E2>(args);
         }
 
-        public static GraphTraversal Until(params object[] args)
+        public static GraphTraversal<object, object> Until(params object[] args)
         {
-            return new GraphTraversal().Until(args);
+            return new GraphTraversal<object, object>().Until(args);
         }
 
-        public static GraphTraversal Value(params object[] args)
+        public static GraphTraversal<object, E2> Value<E2>(params object[] args)
         {
-            return new GraphTraversal().Value(args);
+            return new GraphTraversal<object, object>().Value<E2>(args);
         }
 
-        public static GraphTraversal ValueMap(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> ValueMap<E2>(params object[] args)
         {
-            return new GraphTraversal().ValueMap(args);
+            return new GraphTraversal<object, object>().ValueMap<E2>(args);
         }
 
-        public static GraphTraversal Values(params object[] args)
+        public static GraphTraversal<object, E2> Values<E2>(params object[] args)
         {
-            return new GraphTraversal().Values(args);
+            return new GraphTraversal<object, object>().Values<E2>(args);
         }
 
-        public static GraphTraversal Where(params object[] args)
+        public static GraphTraversal<object, object> Where(params object[] args)
         {
-            return new GraphTraversal().Where(args);
+            return new GraphTraversal<object, object>().Where(args);
         }
-	}
+    }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/EnumSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/EnumSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.Collections.Generic;
+using Gremlin.Net.Process.Traversal;
 
 namespace Gremlin.Net.Structure.IO.GraphSON
 {
@@ -30,8 +31,8 @@ namespace Gremlin.Net.Structure.IO.GraphSON
         public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)
         {
             var enumName = objectData.GetType().Name;
-            var enumValue = objectData.ToString();
-            return GraphSONUtil.ToTypedValue(enumName, enumValue);
+            var valueJavaName = NamingConversions.GetEnumJavaName(enumName, objectData.ToString());
+            return GraphSONUtil.ToTypedValue(enumName, valueJavaName);
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Remote/RemoteStrategyTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Remote/RemoteStrategyTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -66,7 +66,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Remote
             Assert.Equal(expectedResult, actualResult);
         }
 
-        private DefaultTraversal CreateTraversalWithRemoteStrategy(Bytecode bytecode)
+        private DefaultTraversal<object, object> CreateTraversalWithRemoteStrategy(Bytecode bytecode)
         {
             var remoteStrategy =
                 new RemoteStrategy(new DriverRemoteConnection(new GremlinClient(new GremlinServer(TestHost, TestPort))));
@@ -74,7 +74,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Remote
         }
     }
 
-    internal class TestTraversal : DefaultTraversal
+    internal class TestTraversal : DefaultTraversal<object, object>
     {
         public TestTraversal(ITraversalStrategy traversalStrategy, Bytecode bytecode)
         {

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -161,8 +161,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
             Assert.Equal(new SubgraphStrategy(), bytecode.SourceInstructions[0].Arguments[0]);
             SubgraphStrategy strategy = bytecode.SourceInstructions[0].Arguments[0];
             Assert.Equal(1, strategy.Configuration.Count);
-            Assert.Equal(typeof(GraphTraversal), strategy.Configuration["vertices"].GetType());
-            GraphTraversal traversal = strategy.Configuration["vertices"];
+            Assert.Equal(typeof(GraphTraversal<object, object>), strategy.Configuration["vertices"].GetType());
+            ITraversal traversal = strategy.Configuration["vertices"];
             Assert.Equal("has", traversal.Bytecode.StepInstructions[0].OperatorName);
             Assert.Equal(new List<string> {"name", "marko"}, traversal.Bytecode.StepInstructions[0].Arguments);
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
@@ -39,9 +39,9 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = graph.Traversal().WithRemote(connection);
 
-            var orderedAges = g.V().Values("age").Order().By(Order.decr).ToList();
+            var orderedAges = g.V().Values<int>("age").Order().By(Order.Decr).ToList();
 
-            Assert.Equal(new List<object> {35, 32, 29, 27}, orderedAges);
+            Assert.Equal(new List<int> {35, 32, 29, 27}, orderedAges);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = graph.Traversal().WithRemote(connection);
 
-            var personsCount = g.V().Has(T.label, "person").Count().Next();
+            var personsCount = g.V().Has(T.Label, "person").Count().Next();
 
             Assert.Equal((long) 4, personsCount);
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -43,7 +43,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
                 .V(1)
                 .Out("created")
                 .In("created")
-                .Values("name")
+                .Values<string>("name")
                 .Where(P.Within("a"))
                 .ToList();
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -98,13 +98,18 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_HasXname_markoX_ValueMap_Next()
         {
+            //Unable to cast object of type 
+            //'System.Collections.Generic.Dictionary`2[System.String,System.Object]' to type 
+            //'System.Collections.Generic.IDictionary`2[System.String,System.Collections.Generic.IList`1[System.Object]]'.
+
+
             var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = graph.Traversal().WithRemote(connection);
 
-            var receivedValueMap = g.V().Has("name", "marko").ValueMap().Next();
+            var receivedValueMap = g.V().Has("name", "marko").ValueMap<object>().Next();
 
-            var expectedValueMap = new Dictionary<string, dynamic>
+            var expectedValueMap = new Dictionary<string, object>
             {
                 {"age", new List<object> {29}},
                 {"name", new List<object> {"marko"}}
@@ -119,7 +124,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = graph.Traversal().WithRemote(connection);
 
-            var t = g.V().Repeat(__.Out()).Times(2).Values("name");
+            var t = g.V().Repeat(__.Out()).Times(2).Values<string>("name");
             var names = t.ToList();
 
             Assert.Equal((long) 2, names.Count);
@@ -135,7 +140,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var g = graph.Traversal().WithRemote(connection);
 
             var shortestPath =
-                (Path) g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit(1).Path().Next();
+                (Path)g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit<object>(1).Path().Next();
 
             Assert.Equal((long) 4, shortestPath.Count);
             Assert.Equal(new Vertex((long) 6), shortestPath[3]);

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/SideEffectTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/SideEffectTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -123,7 +123,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = graph.Traversal().WithRemote(connection);
 
-            var t = g.V().Out("created").GroupCount("m").By("name").Values("name").Aggregate("n").Iterate();
+            var t = g.V().Out("created").GroupCount("m").By("name").Values<string>("name").Aggregate("n").Iterate();
 
             var keys = t.SideEffects.Keys().ToList();
             Assert.Equal(2, keys.Count);

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -119,7 +119,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var g =
                 graph.Traversal()
                     .WithRemote(connection)
-                    .WithStrategies(new SubgraphStrategy(edgeCriterion: __.Limit(0)));
+                    .WithStrategies(new SubgraphStrategy(edgeCriterion: __.Limit<object>(0)));
 
             var count = g.E().Count().Next();
 
@@ -151,7 +151,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.Has("name", "marko")));
 
-            var name = g.V().Values("name").Next();
+            var name = g.V().Values<string>("name").Next();
 
             Assert.Equal("marko", name);
         }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversal.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversal.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -27,7 +27,7 @@ using Gremlin.Net.Process.Traversal;
 
 namespace Gremlin.Net.UnitTest.Process.Traversal
 {
-    public class TestTraversal : DefaultTraversal
+    public class TestTraversal : DefaultTraversal<object, object>
     {
         public TestTraversal(List<object> traverserObjs)
         {

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversalStrategy.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversalStrategy.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -36,12 +36,12 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
             _traversers = traversersToAddOnApplication;
         }
 
-        public void Apply(ITraversal traversal)
+        public void Apply<S, E>(ITraversal<S, E> traversal)
         {
             traversal.Traversers = _traversers;
         }
 
-        public Task ApplyAsync(ITraversal traversal)
+        public Task ApplyAsync<S, E>(ITraversal<S, E> traversal)
         {
             traversal.Traversers = _traversers;
             return Task.CompletedTask;

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/BytecodeGraphSONSerializerTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/BytecodeGraphSONSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿﻿#region License
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -143,7 +143,7 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
         }
     }
 
-    internal class TestTraversal : DefaultTraversal
+    internal class TestTraversal : DefaultTraversal<object, object>
     {
         public TestTraversal(Bytecode bytecode)
         {

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONWriterTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONWriterTests.cs
@@ -189,9 +189,9 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
         {
             var writer = CreateStandardGraphSONWriter();
 
-            var serializedEnum = writer.WriteObject(T.label);
+            var serializedEnum = writer.WriteObject(Direction.Both);
 
-            var expectedGraphSON = "{\"@type\":\"g:T\",\"@value\":\"label\"}";
+            var expectedGraphSON = "{\"@type\":\"g:Direction\",\"@value\":\"BOTH\"}";
             Assert.Equal(expectedGraphSON, serializedEnum);
         }
 
@@ -310,11 +310,6 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
                 "{\"@type\":\"g:Vertex\",\"@value\":{\"id\":{\"@type\":\"g:Int64\",\"@value\":123},\"label\":\"project\"}}";
             Assert.Equal(expected, graphSON);
         }
-    }
-
-    internal enum T
-    {
-        label
     }
 
     internal class TestGraphSONSerializer : IGraphSONSerializer


### PR DESCRIPTION
Added type safety to traversal interface. For example:

```csharp
Vertex vertex = g.V().Next();
// Compile time error
Edge edge = g.V().Next();
```

As C# generics is more strict than in Java, some methods require the user to specify the expected type:
```csharp
// Specify the type of the value of the property "age"
IList<int> userAgeList = g.V().HasLabel("user").Values<int>("age").ToList();
```

Additionally, I've changed the letter case of the enums generated in C# to match the C# naming convention, ie: `g.V().Values<int>("age").Order().By(Order.Decr)`