### PR TITLE
TINKERPOP-1682 by-modulator optimization strategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -110,8 +110,8 @@ This release also includes changes from <<release-3-2-6, 3.2.6>>.
 * Removed access to previously deprecated `CoreGremlinPlugin#INSTANCE` field.
 * `gremlin.sh` and `gremln.bat` no longer support the option to pass a script as an argument for execution mode without using the `-i` option.
 * Graphite and Ganglia are no longer packaged with the Gremlin Server distribution.
-* `TransactionException` is no longer a class of `AbstractTransaction` and it extends `RuntimeException`.
 * Included an ellipse on long property names that are truncated.
+* Added `TraversalParent.replaceTraversal()` which can replace a direct child traversal.
 * Added `ByModulatorOptimizationStrategy` which replaces certain standard traversals w/ optimized traversals (e.g. `TokenTraversal`).
 * Renamed `RangeByIsCountStrategy` to `CountStrategy`.
 * Added more specific typing to various `__` traversal steps. E.g. `<A,Vertex>out()` is `<Vertex,Vertex>out()`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -112,6 +112,7 @@ This release also includes changes from <<release-3-2-6, 3.2.6>>.
 * Graphite and Ganglia are no longer packaged with the Gremlin Server distribution.
 * `TransactionException` is no longer a class of `AbstractTransaction` and it extends `RuntimeException`.
 * Included an ellipse on long property names that are truncated.
+* Added `ByModulatorOptimizationStrategy` which replaces certain standard traversals w/ optimized traversals (e.g. `TokenTraversal`).
 * Renamed `RangeByIsCountStrategy` to `CountStrategy`.
 * Added more specific typing to various `__` traversal steps. E.g. `<A,Vertex>out()` is `<Vertex,Vertex>out()`.
 * Updated Docker build scripts to include Python dependencies (NOTE: users should remove any previously generated TinkerPop Docker images).

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-2-8, 3.2.8>>.
 
+* Added `TraversalParent.replaceTraversal()` which can replace a direct child traversal.
+* Added `ByModulatorOptimizationStrategy` which replaces certain standard traversals w/ optimized traversals (e.g. `TokenTraversal`).
 * Fixed regression issue where the HTTPChannelizer doesn't instantiate the specified AuthenticationHandler.
 * Bumped to Netty 4.1.21.Final.
 * Defaulted GLV tests for gremlin-python to run for GraphSON 3.0.
@@ -111,8 +113,6 @@ This release also includes changes from <<release-3-2-6, 3.2.6>>.
 * `gremlin.sh` and `gremln.bat` no longer support the option to pass a script as an argument for execution mode without using the `-i` option.
 * Graphite and Ganglia are no longer packaged with the Gremlin Server distribution.
 * Included an ellipse on long property names that are truncated.
-* Added `TraversalParent.replaceTraversal()` which can replace a direct child traversal.
-* Added `ByModulatorOptimizationStrategy` which replaces certain standard traversals w/ optimized traversals (e.g. `TokenTraversal`).
 * Renamed `RangeByIsCountStrategy` to `CountStrategy`.
 * Added more specific typing to various `__` traversal steps. E.g. `<A,Vertex>out()` is `<Vertex,Vertex>out()`.
 * Updated Docker build scripts to include Python dependencies (NOTE: users should remove any previously generated TinkerPop Docker images).

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -112,6 +112,7 @@ This release also includes changes from <<release-3-2-6, 3.2.6>>.
 * Removed access to previously deprecated `CoreGremlinPlugin#INSTANCE` field.
 * `gremlin.sh` and `gremln.bat` no longer support the option to pass a script as an argument for execution mode without using the `-i` option.
 * Graphite and Ganglia are no longer packaged with the Gremlin Server distribution.
+* `TransactionException` is no longer a class of `AbstractTransaction` and it extends `RuntimeException`.
 * Included an ellipse on long property names that are truncated.
 * Renamed `RangeByIsCountStrategy` to `CountStrategy`.
 * Added more specific typing to various `__` traversal steps. E.g. `<A,Vertex>out()` is `<Vertex,Vertex>out()`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
@@ -73,6 +73,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.Subgra
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.MatchAlgorithmStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.AdjacentToIncidentStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.ByModulatorOptimizationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.FilterRankingStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IdentityRemovalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy;
@@ -225,13 +226,14 @@ public final class CoreImports {
         CLASS_IMPORTS.add(MatchAlgorithmStrategy.class);
         CLASS_IMPORTS.add(ProfileStrategy.class);
         CLASS_IMPORTS.add(AdjacentToIncidentStrategy.class);
+        CLASS_IMPORTS.add(ByModulatorOptimizationStrategy.class);
+        CLASS_IMPORTS.add(CountStrategy.class);
         CLASS_IMPORTS.add(FilterRankingStrategy.class);
         CLASS_IMPORTS.add(IdentityRemovalStrategy.class);
         CLASS_IMPORTS.add(IncidentToAdjacentStrategy.class);
         CLASS_IMPORTS.add(MatchPredicateStrategy.class);
         CLASS_IMPORTS.add(OrderLimitStrategy.class);
         CLASS_IMPORTS.add(PathProcessorStrategy.class);
-        CLASS_IMPORTS.add(CountStrategy.class);
         CLASS_IMPORTS.add(ComputerVerificationStrategy.class);
         CLASS_IMPORTS.add(LambdaRestrictionStrategy.class);
         CLASS_IMPORTS.add(ReadOnlyStrategy.class);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.optimiza
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.AdjacentToIncidentStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.ByModulatorOptimizationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.FilterRankingStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.InlineFilterStrategy;
@@ -215,7 +216,8 @@ public interface TraversalStrategies extends Serializable, Cloneable {
                     PathRetractionStrategy.instance(),
                     LazyBarrierStrategy.instance(),
                     ProfileStrategy.instance(),
-                    StandardVerificationStrategy.instance());
+                    StandardVerificationStrategy.instance(),
+                    ByModulatorOptimizationStrategy.instance());
             GRAPH_CACHE.put(Graph.class, graphStrategies);
             GRAPH_CACHE.put(EmptyGraph.class, new DefaultTraversalStrategies());
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -209,6 +209,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
                     InlineFilterStrategy.instance(),
                     IncidentToAdjacentStrategy.instance(),
                     AdjacentToIncidentStrategy.instance(),
+                    ByModulatorOptimizationStrategy.instance(),
                     FilterRankingStrategy.instance(),
                     MatchPredicateStrategy.instance(),
                     RepeatUnrollStrategy.instance(),
@@ -216,8 +217,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
                     PathRetractionStrategy.instance(),
                     LazyBarrierStrategy.instance(),
                     ProfileStrategy.instance(),
-                    StandardVerificationStrategy.instance(),
-                    ByModulatorOptimizationStrategy.instance());
+                    StandardVerificationStrategy.instance());
             GRAPH_CACHE.put(Graph.class, graphStrategies);
             GRAPH_CACHE.put(EmptyGraph.class, new DefaultTraversalStrategies());
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TraversalParent.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TraversalParent.java
@@ -57,6 +57,10 @@ public interface TraversalParent extends AutoCloseable {
         throw new IllegalStateException("This traversal parent does not support the removal of global traversals: " + this.getClass().getCanonicalName());
     }
 
+    public default void replaceLocalChild(final Traversal.Admin<?, ?> oldTrversal, final Traversal.Admin<?, ?> newTrversal) {
+        throw new IllegalStateException("This traversal parent does not support the replacement of local traversals: " + this.getClass().getCanonicalName());
+    }
+
     public default Set<TraverserRequirement> getSelfAndChildRequirements(final TraverserRequirement... selfRequirements) {
         final Set<TraverserRequirement> requirements = EnumSet.noneOf(TraverserRequirement.class);
         Collections.addAll(requirements, selfRequirements);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
@@ -116,6 +116,12 @@ public final class DedupGlobalStep<S> extends FilterStep<S> implements Traversal
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.dedupTraversal && this.dedupTraversal.equals(oldTraversal))
+            this.dedupTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     public DedupGlobalStep<S> clone() {
         final DedupGlobalStep<S> clone = (DedupGlobalStep<S>) super.clone();
         clone.duplicateSet = new HashSet<>();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
@@ -110,14 +110,9 @@ public final class PathFilterStep<S> extends FilterStep<S> implements FromToModu
 
     @Override
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
-        int i = 0;
-        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
-            if (null != traversal && traversal.equals(oldTraversal)) {
-                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
-                break;
-            }
-            i++;
-        }
+        this.traversalRing.replaceTraversal(
+                (Traversal.Admin<Object, Object>) oldTraversal,
+                (Traversal.Admin<Object, Object>) newTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
@@ -109,6 +109,18 @@ public final class PathFilterStep<S> extends FilterStep<S> implements FromToModu
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
+                break;
+            }
+            i++;
+        }
+    }
+
+    @Override
     public void reset() {
         super.reset();
         this.traversalRing.reset();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
@@ -60,6 +60,12 @@ public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implemen
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.probabilityTraversal && this.probabilityTraversal.equals(oldTraversal))
+            this.probabilityTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     public String toString() {
         return StringFactory.stepString(this, this.amountToSample, this.probabilityTraversal);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
@@ -28,7 +28,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
@@ -163,5 +162,17 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
     @Override
     public void modulateBy(final Traversal.Admin<?, ?> traversal) throws UnsupportedOperationException {
         this.traversalRing.addTraversal(this.integrateChild(traversal));
+    }
+
+    @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
+                break;
+            }
+            i++;
+        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
@@ -166,13 +166,8 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
 
     @Override
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
-        int i = 0;
-        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
-            if (null != traversal && traversal.equals(oldTraversal)) {
-                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
-                break;
-            }
-            i++;
-        }
+        this.traversalRing.replaceTraversal(
+                (Traversal.Admin) oldTraversal,
+                (Traversal.Admin) newTraversal);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
@@ -79,6 +79,12 @@ public final class GroupCountStep<S, E> extends ReducingBarrierStep<S, Map<E, Lo
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.keyTraversal && this.keyTraversal.equals(oldTraversal))
+            this.keyTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     public GroupCountStep<S, E> clone() {
         final GroupCountStep<S, E> clone = (GroupCountStep<S, E>) super.clone();
         if (null != this.keyTraversal)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
@@ -79,6 +79,14 @@ public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>> 
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.keyTraversal && this.keyTraversal.equals(oldTraversal))
+            this.keyTraversal = this.integrateChild(newTraversal);
+        else if (null != this.valueTraversal && this.valueTraversal.equals(oldTraversal))
+            this.valueTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     public Map<K, V> projectTraverser(final Traverser.Admin<S> traverser) {
         final Map<K, V> map = new HashMap<>(1);
         this.valueTraversal.reset();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
@@ -99,6 +99,19 @@ public final class OrderGlobalStep<S, C extends Comparable> extends CollectingBa
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Pair<Traversal.Admin<S, C>, Comparator<C>> pair : this.comparators) {
+            final Traversal.Admin<S, C> traversal = pair.getValue0();
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.comparators.set(i, Pair.with(this.integrateChild(newTraversal), pair.getValue1()));
+                break;
+            }
+            i++;
+        }
+    }
+
+    @Override
     public List<Pair<Traversal.Admin<S, C>, Comparator<C>>> getComparators() {
         return this.comparators.isEmpty() ? Collections.singletonList(new Pair<>(new IdentityTraversal(), (Comparator) Order.incr)) : Collections.unmodifiableList(this.comparators);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStep.java
@@ -81,6 +81,19 @@ public final class OrderLocalStep<S, C extends Comparable> extends MapStep<S, S>
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Pair<Traversal.Admin<S, C>, Comparator<C>> pair : this.comparators) {
+            final Traversal.Admin<S, C> traversal = pair.getValue0();
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.comparators.set(i, Pair.with(this.integrateChild(newTraversal), pair.getValue1()));
+                break;
+            }
+            i++;
+        }
+    }
+
+    @Override
     public List<Pair<Traversal.Admin<S, C>, Comparator<C>>> getComparators() {
         return this.comparators.isEmpty() ? Collections.singletonList(new Pair<>(new IdentityTraversal(), (Comparator) Order.incr)) : Collections.unmodifiableList(this.comparators);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
@@ -99,6 +99,18 @@ public final class PathStep<S> extends MapStep<S, Path> implements TraversalPare
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
+                break;
+            }
+            i++;
+        }
+    }
+
+    @Override
     public String toString() {
         return StringFactory.stepString(this, this.traversalRing);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
@@ -100,14 +100,9 @@ public final class PathStep<S> extends MapStep<S, Path> implements TraversalPare
 
     @Override
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
-        int i = 0;
-        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
-            if (null != traversal && traversal.equals(oldTraversal)) {
-                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
-                break;
-            }
-            i++;
-        }
+        this.traversalRing.replaceTraversal(
+                (Traversal.Admin<Object, Object>) oldTraversal,
+                (Traversal.Admin<Object, Object>) newTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
@@ -97,6 +97,18 @@ public final class ProjectStep<S, E> extends MapStep<S, Map<String, E>> implemen
         this.traversalRing.addTraversal(this.integrateChild(selectTraversal));
     }
 
+    @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
+                break;
+            }
+            i++;
+        }
+    }
+
     public List<String> getProjectKeys() {
         return this.projectKeys;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
@@ -99,14 +99,9 @@ public final class ProjectStep<S, E> extends MapStep<S, Map<String, E>> implemen
 
     @Override
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
-        int i = 0;
-        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
-            if (null != traversal && traversal.equals(oldTraversal)) {
-                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
-                break;
-            }
-            i++;
-        }
+        this.traversalRing.replaceTraversal(
+                (Traversal.Admin<S, E>) oldTraversal,
+                (Traversal.Admin<S, E>) newTraversal);
     }
 
     public List<String> getProjectKeys() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
@@ -100,6 +99,12 @@ public final class SelectOneStep<S, E> extends MapStep<S, E> implements Traversa
     @Override
     public void modulateBy(final Traversal.Admin<?, ?> selectTraversal) {
         this.selectTraversal = this.integrateChild(selectTraversal);
+    }
+
+    @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.selectTraversal && this.selectTraversal.equals(oldTraversal))
+            this.selectTraversal = this.integrateChild(newTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
@@ -116,6 +115,18 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
     @Override
     public void modulateBy(final Traversal.Admin<?, ?> selectTraversal) {
         this.traversalRing.addTraversal(this.integrateChild(selectTraversal));
+    }
+
+    @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
+                break;
+            }
+            i++;
+        }
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -119,14 +119,9 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
 
     @Override
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
-        int i = 0;
-        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
-            if (null != traversal && traversal.equals(oldTraversal)) {
-                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
-                break;
-            }
-            i++;
-        }
+        this.traversalRing.replaceTraversal(
+                (Traversal.Admin<Object, E>) oldTraversal,
+                (Traversal.Admin<Object, E>) newTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -65,14 +65,9 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements T
 
     @Override
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
-        int i = 0;
-        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
-            if (null != traversal && traversal.equals(oldTraversal)) {
-                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
-                break;
-            }
-            i++;
-        }
+        this.traversalRing.replaceTraversal(
+                (Traversal.Admin<Object, Object>) oldTraversal,
+                (Traversal.Admin<Object, Object>) newTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -64,6 +64,18 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements T
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
+                break;
+            }
+            i++;
+        }
+    }
+
+    @Override
     public Set<TraverserRequirement> getRequirements() {
         return this.getSelfAndChildRequirements(TraverserRequirement.PATH, TraverserRequirement.SIDE_EFFECTS);
     }
@@ -82,7 +94,6 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements T
         this.traversalRing.reset();
         return topTree;
     }
-
 
     @Override
     public TreeStep<S> clone() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateStep.java
@@ -72,6 +72,12 @@ public final class AggregateStep<S> extends AbstractStep<S, S> implements SideEf
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.aggregateTraversal && this.aggregateTraversal.equals(oldTraversal))
+            this.aggregateTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     public List<Traversal.Admin<S, Object>> getLocalChildren() {
         return null == this.aggregateTraversal ? Collections.emptyList() : Collections.singletonList(this.aggregateTraversal);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
@@ -106,4 +106,10 @@ public final class GroupCountSideEffectStep<S, E> extends SideEffectStep<S> impl
     public void modulateBy(final Traversal.Admin<?, ?> keyTraversal) throws UnsupportedOperationException {
         this.keyTraversal = this.integrateChild(keyTraversal);
     }
+
+    @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.keyTraversal && this.keyTraversal.equals(oldTraversal))
+            this.keyTraversal = this.integrateChild(newTraversal);
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
@@ -81,6 +81,14 @@ public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implem
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.keyTraversal && this.keyTraversal.equals(oldTraversal))
+            this.keyTraversal = this.integrateChild(newTraversal);
+        else if (null != this.valueTraversal && this.valueTraversal.equals(oldTraversal))
+            this.valueTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     protected void sideEffect(final Traverser.Admin<S> traverser) {
         final Map<K, V> map = new HashMap<>(1);
         this.valueTraversal.reset();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
@@ -52,6 +52,12 @@ public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements T
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.sackTraversal && this.sackTraversal.equals(oldTraversal))
+            this.sackTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     public List<Traversal.Admin<S, B>> getLocalChildren() {
         return null == this.sackTraversal ? Collections.emptyList() : Collections.singletonList(this.sackTraversal);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreStep.java
@@ -78,6 +78,12 @@ public final class StoreStep<S> extends SideEffectStep<S> implements SideEffectC
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        if (null != this.storeTraversal && this.storeTraversal.equals(oldTraversal))
+            this.storeTraversal = this.integrateChild(newTraversal);
+    }
+
+    @Override
     public Set<TraverserRequirement> getRequirements() {
         return this.getSelfAndChildRequirements(TraverserRequirement.SIDE_EFFECTS, TraverserRequirement.BULK);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
@@ -119,6 +119,18 @@ public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements Si
     }
 
     @Override
+    public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
+        int i = 0;
+        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
+            if (null != traversal && traversal.equals(oldTraversal)) {
+                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
+                break;
+            }
+            i++;
+        }
+    }
+
+    @Override
     public Set<TraverserRequirement> getRequirements() {
         return this.getSelfAndChildRequirements(TraverserRequirement.PATH, TraverserRequirement.SIDE_EFFECTS);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
@@ -120,14 +120,9 @@ public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements Si
 
     @Override
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
-        int i = 0;
-        for (final Traversal.Admin<?, ?> traversal : this.traversalRing.getTraversals()) {
-            if (null != traversal && traversal.equals(oldTraversal)) {
-                this.traversalRing.setTraversal(i, this.integrateChild(newTraversal));
-                break;
-            }
-            i++;
-        }
+        this.traversalRing.replaceTraversal(
+                (Traversal.Admin<Object, Object>) oldTraversal,
+                (Traversal.Admin<Object, Object>) newTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/ByModulatorOptimizationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/ByModulatorOptimizationStrategy.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.IdStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.LabelStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.IdentityStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.structure.PropertyType;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This strategy looks for standard traversals in by-modulators and replaces them with more optimized traversals
+ * (e.g. {@code TokenTraversal}) if possible.
+ * <p/>
+ *
+ * @author Daniel Kuppitz (http://gremlin.guru)
+ * @example <pre>
+ * __.path().by(id())            // is replaced by __.path().by(id)
+ * __.dedup().by(label())        // is replaced by __.dedup().by(label)
+ * __.group().by(key())          // is replaced by __.group().by(key)
+ * __.group().by(value())        // is replaced by __.group().by(value)
+ * __.order().by(values("name")) // is replaced by __.order().by("name")
+ * </pre>
+ */
+public final class ByModulatorOptimizationStrategy extends AbstractTraversalStrategy<TraversalStrategy.OptimizationStrategy>
+        implements TraversalStrategy.OptimizationStrategy {
+
+    private static final ByModulatorOptimizationStrategy INSTANCE = new ByModulatorOptimizationStrategy();
+    private static final Set<Class<? extends OptimizationStrategy>> PRIORS = new HashSet<>(Collections.singletonList(IdentityRemovalStrategy.class));
+
+    private ByModulatorOptimizationStrategy() {
+    }
+
+    public static ByModulatorOptimizationStrategy instance() {
+        return INSTANCE;
+    }
+
+    private void optimizeByModulatingTraversal(final TraversalParent step, final Traversal.Admin<?, ?> traversal) {
+        if (traversal == null) return;
+        final List<Step> steps = traversal.asAdmin().getSteps();
+        if (steps.size() == 1) {
+            final Step singleStep = steps.get(0);
+            if (singleStep instanceof PropertiesStep) {
+                final PropertiesStep ps = (PropertiesStep) singleStep;
+                if (ps.getReturnType().equals(PropertyType.VALUE) && ps.getPropertyKeys().length == 1) {
+                    step.replaceLocalChild(traversal, new ElementValueTraversal<>(ps.getPropertyKeys()[0]));
+                }
+            } else if (singleStep instanceof IdStep) {
+                step.replaceLocalChild(traversal, new TokenTraversal<>(T.id));
+            } else if (singleStep instanceof LabelStep) {
+                step.replaceLocalChild(traversal, new TokenTraversal<>(T.label));
+/* todo: this fails for `Property`s (e.g. outE().property().as("a").select("a").by(key/value))
+            } else if (singleStep instanceof PropertyKeyStep) {
+                step.setModulateByTraversal(n, new TokenTraversal<>(T.key));
+            } else if (singleStep instanceof PropertyValueStep) {
+                step.setModulateByTraversal(n, new TokenTraversal<>(T.value));
+*/
+            } else if (singleStep instanceof IdentityStep) {
+                step.replaceLocalChild(traversal, new IdentityTraversal<>());
+            }
+        }
+    }
+
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        final Step step = traversal.getParent().asStep();
+        if (step instanceof ByModulating && step instanceof TraversalParent) {
+            final TraversalParent byModulatingStep = (TraversalParent) step;
+            for (final Traversal.Admin<?, ?> byModulatingTraversal : byModulatingStep.getLocalChildren()) {
+                optimizeByModulatingTraversal(byModulatingStep, byModulatingTraversal);
+            }
+        }
+    }
+
+    @Override
+    public Set<Class<? extends OptimizationStrategy>> applyPrior() {
+        return PRIORS;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/ByModulatorOptimizationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/ByModulatorOptimizationStrategy.java
@@ -48,8 +48,6 @@ import java.util.Set;
  * @example <pre>
  * __.path().by(id())            // is replaced by __.path().by(id)
  * __.dedup().by(label())        // is replaced by __.dedup().by(label)
- * __.group().by(key())          // is replaced by __.group().by(key)
- * __.group().by(value())        // is replaced by __.group().by(value)
  * __.order().by(values("name")) // is replaced by __.order().by("name")
  * </pre>
  */

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
@@ -62,6 +62,10 @@ public final class TraversalRing<A, B> implements Serializable, Cloneable {
         this.traversals.add(traversal);
     }
 
+    public void setTraversal(final int index, final Traversal.Admin<A, B> traversal) {
+        this.traversals.set(index, traversal);
+    }
+
     public List<Traversal.Admin<A, B>> getTraversals() {
         return Collections.unmodifiableList(this.traversals);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -62,8 +63,13 @@ public final class TraversalRing<A, B> implements Serializable, Cloneable {
         this.traversals.add(traversal);
     }
 
-    public void setTraversal(final int index, final Traversal.Admin<A, B> traversal) {
-        this.traversals.set(index, traversal);
+    public void replaceTraversal(final Traversal.Admin<A, B> oldTraversal, final Traversal.Admin<A, B> newTraversal) {
+        for (int i = 0, j = this.traversals.size(); i < j; i++) {
+            if (Objects.equals(oldTraversal, this.traversals.get(i))) {
+                this.traversals.set(i, newTraversal);
+                break;
+            }
+        }
     }
 
     public List<Traversal.Admin<A, B>> getTraversals() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
@@ -41,6 +41,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.Partit
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.MatchAlgorithmStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.AdjacentToIncidentStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.ByModulatorOptimizationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.FilterRankingStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IdentityRemovalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy;
@@ -166,6 +167,8 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                             LazyBarrierStrategy.class,
                             MatchAlgorithmStrategy.class,
                             AdjacentToIncidentStrategy.class,
+                            ByModulatorOptimizationStrategy.class,
+                            CountStrategy.class,
                             FilterRankingStrategy.class,
                             IdentityRemovalStrategy.class,
                             IncidentToAdjacentStrategy.class,
@@ -174,7 +177,6 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                             OrderLimitStrategy.class,
                             PathProcessorStrategy.class,
                             PathRetractionStrategy.class,
-                            CountStrategy.class,
                             RepeatUnrollStrategy.class,
                             ComputerVerificationStrategy.class,
                             LambdaRestrictionStrategy.class,
@@ -282,6 +284,8 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                     LazyBarrierStrategy.class,
                     MatchAlgorithmStrategy.class,
                     AdjacentToIncidentStrategy.class,
+                    ByModulatorOptimizationStrategy.class,
+                    CountStrategy.class,
                     FilterRankingStrategy.class,
                     IdentityRemovalStrategy.class,
                     IncidentToAdjacentStrategy.class,
@@ -290,7 +294,6 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                     OrderLimitStrategy.class,
                     PathProcessorStrategy.class,
                     PathRetractionStrategy.class,
-                    CountStrategy.class,
                     RepeatUnrollStrategy.class,
                     ComputerVerificationStrategy.class,
                     LambdaRestrictionStrategy.class,
@@ -380,6 +383,8 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                             LazyBarrierStrategy.class,
                             MatchAlgorithmStrategy.class,
                             AdjacentToIncidentStrategy.class,
+                            ByModulatorOptimizationStrategy.class,
+                            CountStrategy.class,
                             FilterRankingStrategy.class,
                             IdentityRemovalStrategy.class,
                             IncidentToAdjacentStrategy.class,
@@ -388,7 +393,6 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                             OrderLimitStrategy.class,
                             PathProcessorStrategy.class,
                             PathRetractionStrategy.class,
-                            CountStrategy.class,
                             RepeatUnrollStrategy.class,
                             ComputerVerificationStrategy.class,
                             LambdaRestrictionStrategy.class,
@@ -488,6 +492,8 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                     LazyBarrierStrategy.class,
                     MatchAlgorithmStrategy.class,
                     AdjacentToIncidentStrategy.class,
+                    ByModulatorOptimizationStrategy.class,
+                    CountStrategy.class,
                     FilterRankingStrategy.class,
                     IdentityRemovalStrategy.class,
                     IncidentToAdjacentStrategy.class,
@@ -496,7 +502,6 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
                     OrderLimitStrategy.class,
                     PathProcessorStrategy.class,
                     PathRetractionStrategy.class,
-                    CountStrategy.class,
                     RepeatUnrollStrategy.class,
                     ComputerVerificationStrategy.class,
                     LambdaRestrictionStrategy.class,

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
@@ -320,7 +320,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(MatchAlgorithmStrategy.class, 143));
             add(GryoTypeReg.of(MatchStep.GreedyMatchAlgorithm.class, 144));
             add(GryoTypeReg.of(AdjacentToIncidentStrategy.class, 145));
-            add(GryoTypeReg.of(ByModulatorOptimizationStrategy.class, 170));  // ***LAST ID***
+            add(GryoTypeReg.of(ByModulatorOptimizationStrategy.class, 174));  // ***LAST ID***
             add(GryoTypeReg.of(CountStrategy.class, 155));
             add(GryoTypeReg.of(FilterRankingStrategy.class, 146));
             add(GryoTypeReg.of(IdentityRemovalStrategy.class, 147));
@@ -375,7 +375,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(RangeGlobalStep.RangeBiOperator.class, 114));
             add(GryoTypeReg.of(OrderGlobalStep.OrderBiOperator.class, 118));
             add(GryoTypeReg.of(ProfileStep.ProfileBiOperator.class, 119));
-            add(GryoTypeReg.of(IndexedTraverserSet.VertexIndexedTraverserSet.class, 173));                 // ***LAST ID***
+            add(GryoTypeReg.of(IndexedTraverserSet.VertexIndexedTraverserSet.class, 173));
 
             // placeholder serializers for classes that don't live here in core. this will allow them to be used if
             // present  or ignored if the class isn't available. either way the registration numbers are held as
@@ -537,7 +537,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(MatchAlgorithmStrategy.class, 143));
             add(GryoTypeReg.of(MatchStep.GreedyMatchAlgorithm.class, 144));
             add(GryoTypeReg.of(AdjacentToIncidentStrategy.class, 145));
-            add(GryoTypeReg.of(ByModulatorOptimizationStrategy.class, 170)); // ***LAST ID***
+            add(GryoTypeReg.of(ByModulatorOptimizationStrategy.class, 174)); // ***LAST ID***
             add(GryoTypeReg.of(CountStrategy.class, 155));
             add(GryoTypeReg.of(FilterRankingStrategy.class, 146));
             add(GryoTypeReg.of(IdentityRemovalStrategy.class, 147));
@@ -555,7 +555,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(MatchStep.CountMatchAlgorithm.class, 160));
             add(GryoTypeReg.of(MatchStep.GreedyMatchAlgorithm.class, 167));
             // skip 171, 172 to sync with tp33
-            add(GryoTypeReg.of(IndexedTraverserSet.VertexIndexedTraverserSet.class, 173));                 // ***LAST ID***
+            add(GryoTypeReg.of(IndexedTraverserSet.VertexIndexedTraverserSet.class, 173));
         }};
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
@@ -51,6 +51,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.Partit
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.MatchAlgorithmStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.AdjacentToIncidentStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.ByModulatorOptimizationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.FilterRankingStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IdentityRemovalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy;
@@ -319,6 +320,8 @@ public enum GryoVersion {
             add(GryoTypeReg.of(MatchAlgorithmStrategy.class, 143));
             add(GryoTypeReg.of(MatchStep.GreedyMatchAlgorithm.class, 144));
             add(GryoTypeReg.of(AdjacentToIncidentStrategy.class, 145));
+            add(GryoTypeReg.of(ByModulatorOptimizationStrategy.class, 170));  // ***LAST ID***
+            add(GryoTypeReg.of(CountStrategy.class, 155));
             add(GryoTypeReg.of(FilterRankingStrategy.class, 146));
             add(GryoTypeReg.of(IdentityRemovalStrategy.class, 147));
             add(GryoTypeReg.of(IncidentToAdjacentStrategy.class, 148));
@@ -328,7 +331,6 @@ public enum GryoVersion {
             add(GryoTypeReg.of(OrderLimitStrategy.class, 152));
             add(GryoTypeReg.of(PathProcessorStrategy.class, 153));
             add(GryoTypeReg.of(PathRetractionStrategy.class, 154));
-            add(GryoTypeReg.of(CountStrategy.class, 155));
             add(GryoTypeReg.of(RepeatUnrollStrategy.class, 156));
             add(GryoTypeReg.of(GraphFilterStrategy.class, 157));
             add(GryoTypeReg.of(LambdaRestrictionStrategy.class, 158));
@@ -535,6 +537,8 @@ public enum GryoVersion {
             add(GryoTypeReg.of(MatchAlgorithmStrategy.class, 143));
             add(GryoTypeReg.of(MatchStep.GreedyMatchAlgorithm.class, 144));
             add(GryoTypeReg.of(AdjacentToIncidentStrategy.class, 145));
+            add(GryoTypeReg.of(ByModulatorOptimizationStrategy.class, 170)); // ***LAST ID***
+            add(GryoTypeReg.of(CountStrategy.class, 155));
             add(GryoTypeReg.of(FilterRankingStrategy.class, 146));
             add(GryoTypeReg.of(IdentityRemovalStrategy.class, 147));
             add(GryoTypeReg.of(IncidentToAdjacentStrategy.class, 148));
@@ -544,7 +548,6 @@ public enum GryoVersion {
             add(GryoTypeReg.of(OrderLimitStrategy.class, 152));
             add(GryoTypeReg.of(PathProcessorStrategy.class, 153));
             add(GryoTypeReg.of(PathRetractionStrategy.class, 154));
-            add(GryoTypeReg.of(CountStrategy.class, 155));
             add(GryoTypeReg.of(RepeatUnrollStrategy.class, 156));
             add(GryoTypeReg.of(GraphFilterStrategy.class, 157));
             add(GryoTypeReg.of(LambdaRestrictionStrategy.class, 158));

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/ByModulatorOptimizationStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/ByModulatorOptimizationStrategyTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.Operator.assign;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Daniel Kuppitz (http://gremlin.guru)
+ */
+@RunWith(Parameterized.class)
+public class ByModulatorOptimizationStrategyTest {
+
+    @Parameterized.Parameter
+    public Traversal original;
+
+    @Parameterized.Parameter(value = 1)
+    public Traversal optimized;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> generateTestParameters() {
+
+        final List<Object[]> result = new ArrayList<>();
+        final GraphTraversal[] baseTraversals = new GraphTraversal[]{
+                __.aggregate("x"),
+                __.dedup(),
+                __.dedup("a"),
+                __.group(),
+                __.group("x"),
+                __.groupCount(),
+                __.groupCount("x"),
+                __.order(),
+                __.order(Scope.local),
+                __.project("a"),
+                __.path(),
+                __.path().from("a").to("b"),
+                __.sack(assign),
+                __.sample(10),
+                __.select("a"),
+                __.select("a", "b"),
+                __.store("x"),
+                __.tree(),
+                __.tree("x"),
+                __.where(P.eq("a")),
+                __.where("a", P.eq("b"))
+        };
+
+        for (final Traversal traversal : baseTraversals) {
+            result.add(new Traversal[]{
+                    ((GraphTraversal<?, ?>) traversal.asAdmin().clone()).by(__.values("name")),
+                    ((GraphTraversal) traversal.asAdmin().clone()).by("name"),
+            });
+            result.add(new Traversal[]{
+                    ((GraphTraversal<?, ?>) traversal.asAdmin().clone()).by(__.id()),
+                    ((GraphTraversal) traversal.asAdmin().clone()).by(T.id),
+            });
+            result.add(new Traversal[]{
+                    ((GraphTraversal<?, ?>) traversal.asAdmin().clone()).by(__.label()),
+                    ((GraphTraversal) traversal.asAdmin().clone()).by(T.label),
+            });
+            /*result.add(new Traversal[]{
+                    ((GraphTraversal<?, ?>) traversal.asAdmin().clone()).by(__.key()),
+                    ((GraphTraversal) traversal.asAdmin().clone()).by(T.key),
+            });
+            result.add(new Traversal[]{
+                    ((GraphTraversal<?, ?>) traversal.asAdmin().clone()).by(__.value()),
+                    ((GraphTraversal) traversal.asAdmin().clone()).by(T.value),
+            });*/
+            result.add(new Traversal[]{
+                    ((GraphTraversal<?, ?>) traversal.asAdmin().clone()).by(__.identity()),
+                    ((GraphTraversal) traversal.asAdmin().clone()).by(),
+            });
+        }
+
+        result.add(new Traversal[]{
+                __.project("a", "b", "c", "d", "e")
+                        .by(__.values("name"))
+                        .by(__.id())
+                        .by(__.label())
+                        .by(__.identity())
+                        .by(__.outE().count()),
+                __.project("a", "b", "c", "d", "e")
+                        .by("name")
+                        .by(T.id)
+                        .by(T.label)
+                        .by()
+                        .by(__.outE().count())
+        });
+
+        return result;
+    }
+
+    private void applyByModulatorOptimizationStrategy(final Traversal traversal) {
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(ByModulatorOptimizationStrategy.instance());
+        traversal.asAdmin().setStrategies(strategies);
+        traversal.asAdmin().applyStrategies();
+    }
+
+    @Test
+    public void doTest() {
+        applyByModulatorOptimizationStrategy(original);
+        assertEquals(optimized, original);
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathProcessorStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathProcessorStrategyTest.java
@@ -84,7 +84,7 @@ public class PathProcessorStrategyTest {
                 {__.select("a").by(__.outE().count()), __.select("a").map(__.outE().count()), Collections.emptyList()},
                 {__.select("a").by("name"), __.select("a").map(new ElementValueTraversal<>("name")), Collections.emptyList()},
                 {__.select("a").out(), __.select("a").out(), Collections.emptyList()},
-                {__.select(Pop.all, "a").by(__.values("name")), __.select(Pop.all, "a").by(__.values("name")), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
+                {__.select(Pop.all, "a").by(__.values("name")), __.select(Pop.all, "a").by("name"), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
                 {__.select(Pop.last, "a").by(__.values("name")), __.select(Pop.last, "a").map(__.values("name")), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
                 {__.select(Pop.first, "a").by(__.values("name")), __.select(Pop.first, "a").map(__.values("name")), TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
                 // select("a","b")

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanationTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanationTest.java
@@ -123,7 +123,7 @@ public class TraversalExplanationTest {
         assertEquals(4, found);
         //
         found = 0;
-        for (final String line : traversal.explain().prettyPrint(158).split("]\n")) { // need to split cause of word wrap
+        for (final String line : traversal.explain().prettyPrint(160).split("]\n")) { // need to split cause of word wrap
             if (line.contains("IncidentToAdjacentStrategy") && line.contains("[VertexStep(IN,vertex)"))
                 found++;
             if (line.contains("IncidentToAdjacentStrategy") && line.contains("[VertexStep(OUT,vertex)"))

--- a/gremlin-python/src/main/jython/gremlin_python/process/strategies.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/strategies.py
@@ -109,6 +109,16 @@ class AdjacentToIncidentStrategy(TraversalStrategy):
         TraversalStrategy.__init__(self)
 
 
+class ByModulatorOptimizationStrategy(TraversalStrategy):
+    def __init__(self):
+        TraversalStrategy.__init__(self)
+
+
+class CountStrategy(TraversalStrategy):
+    def __init__(self):
+        TraversalStrategy.__init__(self)
+
+
 class FilterRankingStrategy(TraversalStrategy):
     def __init__(self):
         TraversalStrategy.__init__(self)
@@ -150,11 +160,6 @@ class PathProcessorStrategy(TraversalStrategy):
 
 
 class PathRetractionStrategy(TraversalStrategy):
-    def __init__(self):
-        TraversalStrategy.__init__(self)
-
-
-class CountStrategy(TraversalStrategy):
     def __init__(self):
         TraversalStrategy.__init__(self)
 

--- a/gremlin-test/features/sideEffect/Group.feature
+++ b/gremlin-test/features/sideEffect/Group.feature
@@ -242,3 +242,25 @@ Feature: Step - group()
     Then the result should be unordered
       | result |
       | m[{"ripple":[], "peter":["created"], "noone":["blah"], "vadas":[], "josh":["created", "created"], "lop":[], "marko":[666, "created", "knows", "knows"]}] |
+
+  Scenario: g_V_group_byXlabelX_byXlabel_countX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().group().by(__.label()).by(__.label().count())
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"software":"d[2].l", "person":"d[4].l"}] |
+
+  Scenario: g_V_groupXmX_byXlabelX_byXlabel_countX_capXmX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().group("m").by(__.label()).by(__.label().count()).cap("m")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"software":"d[2].l", "person":"d[4].l"}] |

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
@@ -99,6 +100,10 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Map<String, Number>> get_g_V_hasLabelXpersonX_group_byXnameX_byXoutE_weight_sumX_orderXlocalX_byXvaluesX();
 
     public abstract Traversal<Vertex, Map.Entry<String, Number>> get_g_V_hasLabelXpersonX_group_byXnameX_byXoutE_weight_sumX_unfold_order_byXvalues_decrX();
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_order_byXlabelX();
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_order_byXlabel_decrX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -400,6 +405,21 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         entry = iterator.next();
         assertEquals("marko", entry.getKey());
         assertEquals(1.9, entry.getValue().doubleValue(), 0.0001);
+
+    public void g_V_order_byXlabelX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_order_byXlabelX();
+        printTraversalForm(traversal);
+        for (int i = 0; i < 4; i++) {
+            assertTrue(traversal.hasNext());
+            final Vertex v = traversal.next();
+            assertEquals("person", v.label());
+        }
+        for (int i = 0; i < 2; i++) {
+            assertTrue(traversal.hasNext());
+            final Vertex v = traversal.next();
+            assertEquals("software", v.label());
+        }
+        assertFalse(traversal.hasNext());
     }
 
     @Test
@@ -420,6 +440,20 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         entry = traversal.next();
         assertEquals("vadas", entry.getKey());
         assertEquals(0.0, entry.getValue().doubleValue(), 0.0001);
+
+    public void g_V_order_byXlabel_decrX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_order_byXlabel_decrX();
+        printTraversalForm(traversal);
+        for (int i = 0; i < 2; i++) {
+            assertTrue(traversal.hasNext());
+            final Vertex v = traversal.next();
+            assertEquals("software", v.label());
+        }
+        for (int i = 0; i < 4; i++) {
+            assertTrue(traversal.hasNext());
+            final Vertex v = traversal.next();
+            assertEquals("person", v.label());
+        }
         assertFalse(traversal.hasNext());
     }
 
@@ -542,6 +576,14 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map.Entry<String, Number>> get_g_V_hasLabelXpersonX_group_byXnameX_byXoutE_weight_sumX_unfold_order_byXvalues_decrX() {
             return g.V().hasLabel("person").group().by("name").by(outE().values("weight").sum()).<Map.Entry<String, Number>>unfold().order().by(Column.values, Order.decr);
+
+        public Traversal<Vertex, Vertex> get_g_V_order_byXlabelX() {
+            return g.V().order().by(__.label());
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_order_byXlabel_decrX() {
+            return g.V().order().by(__.label(), Order.decr);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
@@ -405,6 +405,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         entry = iterator.next();
         assertEquals("marko", entry.getKey());
         assertEquals(1.9, entry.getValue().doubleValue(), 0.0001);
+    }
 
     public void g_V_order_byXlabelX() {
         final Traversal<Vertex, Vertex> traversal = get_g_V_order_byXlabelX();
@@ -440,6 +441,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         entry = traversal.next();
         assertEquals("vadas", entry.getKey());
         assertEquals(0.0, entry.getValue().doubleValue(), 0.0001);
+    }
 
     public void g_V_order_byXlabel_decrX() {
         final Traversal<Vertex, Vertex> traversal = get_g_V_order_byXlabel_decrX();
@@ -576,6 +578,7 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map.Entry<String, Number>> get_g_V_hasLabelXpersonX_group_byXnameX_byXoutE_weight_sumX_unfold_order_byXvalues_decrX() {
             return g.V().hasLabel("person").group().by("name").by(outE().values("weight").sum()).<Map.Entry<String, Number>>unfold().order().by(Column.values, Order.decr);
+        }
 
         public Traversal<Vertex, Vertex> get_g_V_order_byXlabelX() {
             return g.V().order().by(__.label());

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupTest.java
@@ -99,6 +99,10 @@ public abstract class GroupTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_withSideEffectXa__marko_666_noone_blahX_V_groupXaX_byXnameX_byXoutE_label_foldX_capXaX(final Map<String, List<Object>> m);
 
+    public abstract Traversal<Vertex, Map<String, Long>> get_g_V_group_byXlabelX_byXlabel_countX();
+
+    public abstract Traversal<Vertex, Map<String, Long>> get_g_V_groupXmX_byXlabelX_byXlabel_countX_capXmX();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_group_byXnameX() {
@@ -488,6 +492,32 @@ public abstract class GroupTest extends AbstractGremlinProcessTest {
         checkSideEffects(traversal.asAdmin().getSideEffects(), "a", HashMap.class);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_group_byXlabelX_byXlabel_countX() {
+        final Traversal<Vertex, Map<String, Long>> traversal = get_g_V_group_byXlabelX_byXlabel_countX();
+        printTraversalForm(traversal);
+        final Map<String, Long> map = traversal.next();
+        assertEquals(2, map.size());
+        assertTrue(map.containsKey("person"));
+        assertTrue(map.containsKey("software"));
+        assertEquals(4L, map.get("person").longValue());
+        assertEquals(2L, map.get("software").longValue());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_groupXmX_byXlabelX_byXlabel_countX_capXmX() {
+        final Traversal<Vertex, Map<String, Long>> traversal = get_g_V_groupXmX_byXlabelX_byXlabel_countX_capXmX();
+        printTraversalForm(traversal);
+        final Map<String, Long> map = traversal.next();
+        assertEquals(2, map.size());
+        assertTrue(map.containsKey("person"));
+        assertTrue(map.containsKey("software"));
+        assertEquals(4L, map.get("person").longValue());
+        assertEquals(2L, map.get("software").longValue());
+    }
+
     public static class Traversals extends GroupTest {
 
         @Override
@@ -593,6 +623,16 @@ public abstract class GroupTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, List<Object>>> get_g_withSideEffectXa__marko_666_noone_blahX_V_groupXaX_byXnameX_byXoutE_label_foldX_capXaX(final Map<String, List<Object>> m) {
             return g.withSideEffect("a", m).V().group("a").by("name").by(outE().label().fold()).cap("a");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Long>> get_g_V_group_byXlabelX_byXlabel_countX() {
+            return g.V().<String, Long>group().by(__.label()).by(__.label().count());
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Long>> get_g_V_groupXmX_byXlabelX_byXlabel_countX_capXmX() {
+            return g.V().group("m").by(__.label()).by(__.label().count()).cap("m");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1682

Implemented `ByModulatorOptimizationStrategy` which replaces certain standard traversals w/ optimized traversals (e.g. `TokenTraversal`).

`docker/build.sh -t -i` succeeded.

VOTE: +1

I wouldn't mind to wait for [TINKERPOP-1689](https://issues.apache.org/jira/browse/TINKERPOP-1689) to fix the [todo](https://github.com/apache/tinkerpop/commit/c5a1bdebf02538dda19fa73c26e1aa350aa8c32f#diff-116d9ef1d2f03e342eef281717bc5f39R83) though.