### PR TITLE
TINKERPOP-1552: Minor code cleanup for Gremlin.Net

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversal.cs
@@ -22,7 +22,6 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/NamingConversions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/NamingConversions.cs
@@ -41,7 +41,7 @@ namespace Gremlin.Net.Process.Traversal
             return javaName;
         }
 
-        internal static readonly IDictionary<string, string> CSharpToJavaEnums = new Dictionary<string, string>
+        private static readonly IDictionary<string, string> CSharpToJavaEnums = new Dictionary<string, string>
         {
             {"T.Value", "value"},
             {"Order.Decr", "decr"},

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
@@ -53,7 +53,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var personsCount = g.V().Has(T.Label, "person").Count().Next();
 
-            Assert.Equal((long) 4, personsCount);
+            Assert.Equal(4, personsCount);
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -43,7 +43,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.V().Count().Next();
 
-            Assert.Equal((long) 6, count);
+            Assert.Equal(6, count);
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = graph.Traversal().WithRemote(connection);
 
-            var vertex = (Vertex) g.V(1).Next();
+            var vertex = g.V(1).Next();
 
             Assert.Equal(new Vertex((long) 1), vertex);
             Assert.Equal((long) 1, vertex.Id);
@@ -135,9 +135,9 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var g = graph.Traversal().WithRemote(connection);
 
             var shortestPath =
-                (Path)g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit<object>(1).Path().Next();
+                g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit<object>(1).Path().Next();
 
-            Assert.Equal((long) 4, shortestPath.Count);
+            Assert.Equal(4, shortestPath.Count);
             Assert.Equal(new Vertex((long) 6), shortestPath[3]);
         }
 
@@ -151,7 +151,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var b = new Bindings();
             var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
 
-            Assert.Equal((long) 3, count);
+            Assert.Equal(3, count);
         }
 
         [Fact]
@@ -163,7 +163,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = await g.V().Count().Promise(t => t.Next());
 
-            Assert.Equal((long) 6, count);
+            Assert.Equal(6, count);
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
@@ -40,7 +40,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.V().Has("age", P.Gt(30).And(P.Lt(35))).Count().Next();
 
-            Assert.Equal((long) 1, count);
+            Assert.Equal(1, count);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.V().Has("name", P.Within("josh", "vadas")).Count().Next();
 
-            Assert.Equal((long) 2, count);
+            Assert.Equal(2, count);
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
@@ -47,7 +47,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.V().Count().Next();
 
-            Assert.Equal((long) 4, count);
+            Assert.Equal(4, count);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.E().Count().Next();
 
-            Assert.Equal((long)0, count);
+            Assert.Equal(0, count);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.V().Label().Dedup().Count().Next();
 
-            Assert.Equal((long)1, count);
+            Assert.Equal(1, count);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.V().Count().Next();
 
-            Assert.Equal((long)1, count);
+            Assert.Equal(1, count);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.E().Count().Next();
 
-            Assert.Equal((long)0, count);
+            Assert.Equal(0, count);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.V().Count().Next();
 
-            Assert.Equal((long)6, count);
+            Assert.Equal(6, count);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             var count = g.E().Count().Next();
 
-            Assert.Equal((long)6, count);
+            Assert.Equal(6, count);
         }
 
         [Fact]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1552

This mainly removes explicit type castings that are now obsolete thanks to changes from the pull request #620 from @jorgebay. It also makes the Dictionary CSharpToJavaEnums in NamingConversions private to avoid direct access to it as GetEnumJavaName should be used instead.