### PR TITLE
TINKERPOP-1552: Add support for authentication (Plain SASL) to Gremlin.Net

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Gremlin.Net.Structure.IO.GraphSON;
 
 namespace Gremlin.Net.Driver
@@ -30,18 +29,20 @@ namespace Gremlin.Net.Driver
     {
         private readonly GraphSONReader _graphSONReader;
         private readonly GraphSONWriter _graphSONWriter;
-        private readonly Uri _uri;
+        private readonly GremlinServer _gremlinServer;
 
-        public ConnectionFactory(Uri uri, GraphSONReader graphSONReader, GraphSONWriter graphSONWriter)
+        public ConnectionFactory(GremlinServer gremlinServer, GraphSONReader graphSONReader,
+            GraphSONWriter graphSONWriter)
         {
-            _uri = uri;
+            _gremlinServer = gremlinServer;
             _graphSONReader = graphSONReader;
             _graphSONWriter = graphSONWriter;
         }
 
         public Connection CreateConnection()
         {
-            return new Connection(_uri, _graphSONReader, _graphSONWriter);
+            return new Connection(_gremlinServer.Uri, _gremlinServer.Username, _gremlinServer.Password, _graphSONReader,
+                _graphSONWriter);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -47,7 +47,7 @@ namespace Gremlin.Net.Driver
         {
             var reader = graphSONReader ?? new GraphSONReader();
             var writer = graphSONWriter ?? new GraphSONWriter();
-            var connectionFactory = new ConnectionFactory(gremlinServer.Uri, reader, writer);
+            var connectionFactory = new ConnectionFactory(gremlinServer, reader, writer);
             _connectionPool = new ConnectionPool(connectionFactory);
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
@@ -36,9 +36,13 @@ namespace Gremlin.Net.Driver
         /// <param name="hostname">The hostname of the server.</param>
         /// <param name="port">The port on which Gremlin Server can be reached.</param>
         /// <param name="enableSsl">Specifies whether SSL should be enabled.</param>
-        public GremlinServer(string hostname, int port = 8182, bool enableSsl = false)
+        /// <param name="username">The username to submit on requests that require authentication.</param>
+        /// <param name="password">The password to submit on requests that require authentication.</param>
+        public GremlinServer(string hostname, int port = 8182, bool enableSsl = false, string username = null, string password = null)
         {
             Uri = CreateUri(hostname, port, enableSsl);
+            Username = username;
+            Password = password;
         }
 
         /// <summary>
@@ -46,6 +50,16 @@ namespace Gremlin.Net.Driver
         /// </summary>
         /// <value>The WebSocket <see cref="System.Uri" /> that the Gremlin Server responds to.</value>
         public Uri Uri { get; }
+
+        /// <summary>
+        ///     Gets the username to submit on requests that require authentication.
+        /// </summary>
+        public string Username { get; }
+
+        /// <summary>
+        ///     Gets the password to submit on requests that require authentication.
+        /// </summary>
+        public string Password { get; }
 
         private Uri CreateUri(string hostname, int port, bool enableSsl)
         {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatusCode.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatusCode.cs
@@ -49,9 +49,9 @@ namespace Gremlin.Net.Driver.Messages
                 case ResponseStatusCode.Success:
                 case ResponseStatusCode.NoContent:
                 case ResponseStatusCode.PartialContent:
+                case ResponseStatusCode.Authenticate:
                     return false;
                 case ResponseStatusCode.Unauthorized:
-                case ResponseStatusCode.Authenticate:
                 case ResponseStatusCode.MalformedRequest:
                 case ResponseStatusCode.InvalidRequestArguments:
                 case ResponseStatusCode.ServerError:

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
@@ -31,6 +31,11 @@ namespace Gremlin.Net.Driver
     public class Tokens
     {
         /// <summary>
+        ///     Operation used by the client to authenticate itself.
+        /// </summary>
+        public static string OpsAuthentication = "authentication";
+
+        /// <summary>
         ///     Operation used for a request that contains the Bytecode representation of a Traversal.
         /// </summary>
         public static string OpsBytecode = "bytecode";
@@ -107,6 +112,12 @@ namespace Gremlin.Net.Driver
         ///     execute on the server.
         /// </summary>
         public static string ArgsEvalTimeout = "scriptEvaluationTimeout";
+
+        /// <summary>
+        ///     Argument name for the response to the server authentication challenge. This value is dependent on the SASL
+        ///     authentication mechanism required by the server.
+        /// </summary>
+        public static string ArgsSasl = "sasl";
 
         internal static string ValAggregateToMap = "map";
         internal static string ValAggregateToBulkSet = "bulkset";

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientAuthenticationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientAuthenticationTests.cs
@@ -1,0 +1,86 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Exceptions;
+using Gremlin.Net.IntegrationTest.Util;
+using Xunit;
+
+namespace Gremlin.Net.IntegrationTest.Driver
+{
+    public class GremlinClientAuthenticationTests
+    {
+        private static readonly string TestHost = ConfigProvider.Configuration["TestServerIpAddress"];
+        private static readonly int TestPort = Convert.ToInt32(ConfigProvider.Configuration["TestSecureServerPort"]);
+        private readonly RequestMessageProvider _requestMessageProvider = new RequestMessageProvider();
+
+        [Fact]
+        public async Task ShouldThrowForMissingCredentials()
+        {
+            var gremlinServer = new GremlinServer(TestHost, TestPort);
+            using (var gremlinClient = new GremlinClient(gremlinServer))
+            {
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await gremlinClient.SubmitWithSingleResultAsync<string>(_requestMessageProvider
+                        .GetDummyMessage()));
+
+                Assert.Contains("authentication", exception.Message);
+                Assert.Contains("credentials", exception.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("unknownUser", "passwordDoesntMatter")]
+        [InlineData("stephen", "wrongPassword")]
+        public async Task ShouldThrowForWrongCredentials(string username, string password)
+        {
+            var gremlinServer = new GremlinServer(TestHost, TestPort, username: username, password: password);
+            using (var gremlinClient = new GremlinClient(gremlinServer))
+            {
+                var exception = await Assert.ThrowsAsync<ResponseException>(
+                    async () => await gremlinClient.SubmitWithSingleResultAsync<string>(_requestMessageProvider
+                        .GetDummyMessage()));
+
+                Assert.Contains("Unauthorized", exception.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("'Hello' + 'World'", "HelloWorld")]
+        public async Task ScriptShouldBeEvaluatedAndResultReturnedForCorrectCredentials(string requestMsg,
+            string expectedResponse)
+        {
+            const string username = "stephen";
+            const string password = "password";
+            var gremlinServer = new GremlinServer(TestHost, TestPort, username: username, password: password);
+            using (var gremlinClient = new GremlinClient(gremlinServer))
+            {
+                var response = await gremlinClient.SubmitWithSingleResultAsync<string>(requestMsg);
+
+                Assert.Equal(expectedResponse, response);
+            }
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/appsettings.json
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/appsettings.json
@@ -1,4 +1,5 @@
 ﻿{
   "TestServerIpAddress": "localhost",
-  "TestServerPort": 45950
+  "TestServerPort": 45950,
+  "TestSecureServerPort": 45951
 }

--- a/gremlin-dotnet/test/pom.xml
+++ b/gremlin-dotnet/test/pom.xml
@@ -122,6 +122,19 @@ server.start().join()
 
 project.setContextValue("gremlin.dotnet.server", server)
 log.info("Gremlin Server with no authentication started on port 45950")
+
+def settingsSecure = Settings.read("${gremlin.server.dir}/conf/gremlin-server-modern.yaml")
+settingsSecure.graphs.graph = "${gremlin.server.dir}/conf/tinkergraph-empty.properties"
+settingsSecure.scriptEngines["gremlin-groovy"].scripts = ["${gremlin.server.dir}/scripts/generate-modern.groovy"]
+settingsSecure.port = 45951
+settingsSecure.authentication.className = "org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator"
+settingsSecure.authentication.config = [credentialsDb: "${gremlin.server.dir}/conf/tinkergraph-credentials.properties", credentialsDbLocation: "${gremlin.server.dir}/data/credentials.kryo"]
+
+def serverSecure = new GremlinServer(settingsSecure)
+serverSecure.start().join()
+
+project.setContextValue("gremlin.dotnet.server.secure", serverSecure)
+log.info("Gremlin Server with authentication started on port 45951")
 ]]>
                                         </script>
                                     </scripts>
@@ -146,6 +159,10 @@ log.info("Tests for native gremlin-dotnet complete")
 def server = project.getContextValue("gremlin.dotnet.server")
 log.info("Shutting down $server")
 server.stop().join()
+
+def serverSecure = project.getContextValue("gremlin.dotnet.server.secure")
+log.info("Shutting down $serverSecure")
+serverSecure.stop().join()
 
 log.info("Gremlin Server instance shutdown for gremlin-dotnet")
 ]]>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1552

This adds support for authentication with Plain SASL (username + password) to the Gremlin.Net driver. The functionality was originally implemented for the pre-GLV version of Gremlin.Net by @TigerSun-MS from the @CosmosDB team (see FlorianHockmann/Gremlin.Net#7).

The Gremlin Server instance used for the authentication related integration tests complains during startup about some duplicate metric name, but everything works as expected and all tests pass. This is the beginning of the stack trace:

```
[WARNING] Could not initialize gremlin-groovy GremlinScriptEngine as init script could not be evaluated
java.lang.IllegalArgumentException: A metric named org.apache.tinkerpop.gremlin.server.GremlinServer.gremlin-groovy.sessionless.class-cache.long-run-compilation-count already exists
```