### PR TITLE
TINKERPOP-1552: Improve comments in Gremlin-DotNet

### DIFF
--- a/gremlin-dotnet/glv/AnonymousTraversal.template
+++ b/gremlin-dotnet/glv/AnonymousTraversal.template
@@ -24,18 +24,25 @@
 using System.Collections.Generic;
 using Gremlin.Net.Structure;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     An anonymous <see cref="GraphTraversal{SType, EType}" />.
     /// </summary>
     public static class __
     {
+        /// <summary>
+        ///     Starts an empty <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public static GraphTraversal<object, object> Start()
         {
             return new GraphTraversal<object, object>();
         }
 <% anonStepMethods.each { method -> %>
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the <%= method.methodName %> step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, <%= method.t2 %>> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(params object[] args)
         {
             return new GraphTraversal<object, object>().<%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(args);

--- a/gremlin-dotnet/glv/Enum.template
+++ b/gremlin-dotnet/glv/Enum.template
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum <%= enumClass.simpleName %>
     {
         <%= constants %>

--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -24,18 +24,27 @@
 using System.Collections.Generic;
 using Gremlin.Net.Structure;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     Graph traversals are the primary way in which graphs are processed.
     /// </summary>
     public class GraphTraversal<S, E> : DefaultTraversal<S, E>
     {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversal{SType, EType}" /> class.
+        /// </summary>
         public GraphTraversal()
             : this(new List<ITraversalStrategy>(), new Bytecode())
         {
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversal{SType, EType}" /> class.
+        /// </summary>
+        /// <param name="traversalStrategies">The traversal strategies to be used by this graph traversal at evaluation time.</param>
+        /// <param name="bytecode">The <see cref="Bytecode" /> associated with the construction of this graph traversal.</param>
         public GraphTraversal(ICollection<ITraversalStrategy> traversalStrategies, Bytecode bytecode)
         {
             TraversalStrategies = traversalStrategies;
@@ -53,6 +62,9 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 <% graphStepMethods.each { method -> %>
+        /// <summary>
+        ///     Adds the <%= method.methodName %> step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< <%= method.t1 %> , <%= method.t2 %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (params object[] args)
         {
             Bytecode.AddStep("<%= method.methodName %>", args);

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -21,26 +21,48 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     A <see cref="GraphTraversalSource" /> is the primary DSL of the Gremlin traversal machine.
+    ///     It provides access to all the configurations and steps for Turing complete graph computing.
     /// </summary>
     public class GraphTraversalSource
     {
+        /// <summary>
+        ///     Gets or sets the traversal strategies associated with this graph traversal source.
+        /// </summary>
         public ICollection<ITraversalStrategy> TraversalStrategies { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the <see cref="Traversal.Bytecode" /> associated with the current state of this graph traversal
+        ///     source.
+        /// </summary>
         public Bytecode Bytecode { get; set; }
 
-         public GraphTraversalSource()
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversalSource" /> class.
+        /// </summary>
+        public GraphTraversalSource()
             : this(new List<ITraversalStrategy>(), new Bytecode())
         {
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversalSource" /> class.
+        /// </summary>
+        /// <param name="traversalStrategies">The traversal strategies associated with this graph traversal source.</param>
+        /// <param name="bytecode">
+        ///     The <see cref="Traversal.Bytecode" /> associated with the current state of this graph traversal
+        ///     source.
+        /// </param>
         public GraphTraversalSource(ICollection<ITraversalStrategy> traversalStrategies, Bytecode bytecode)
         {
             TraversalStrategies = traversalStrategies;
@@ -56,11 +78,21 @@ namespace Gremlin.Net.Process.Traversal
             return source;
         }
 <% } %>
+        [Obsolete("Use the Bindings class instead.", false)]
         public GraphTraversalSource WithBindings(object bindings)
         {
             return this;
         }
 
+        /// <summary>
+        ///     Configures the <see cref="GraphTraversalSource" /> as a "remote" to issue the
+        ///     <see cref="GraphTraversal{SType, EType}" /> for execution elsewhere.
+        /// </summary>
+        /// <param name="remoteConnection">
+        ///     The <see cref="IRemoteConnection" /> instance to use to submit the
+        ///     <see cref="GraphTraversal{SType, EType}" />.
+        /// </param>
+        /// <returns>A <see cref="GraphTraversalSource" /> configured to use the provided <see cref="IRemoteConnection" />.</returns>
         public GraphTraversalSource WithRemote(IRemoteConnection remoteConnection)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
@@ -69,6 +101,10 @@ namespace Gremlin.Net.Process.Traversal
             return source;
         }
 
+        /// <summary>
+        ///     Add a GraphComputer class used to execute the traversal.
+        ///     This adds a <see cref="VertexProgramStrategy" /> to the strategies.
+        /// </summary>
         public GraphTraversalSource WithComputer(string graphComputer = null, int? workers = null, string persist = null,
             string result = null, ITraversal vertices = null, ITraversal edges = null,
             Dictionary<string, dynamic> configuration = null)
@@ -77,6 +113,10 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 <% sourceSpawnMethods.each { method -> %>
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the <%= method.methodName %> step to that
+        ///     traversal.
+        /// </summary>
         public GraphTraversal< <%= method.typeArguments.join(",") %> > <%= toCSharpMethodName.call(method.methodName) %>(params object[] args)
         {
             var traversal = new GraphTraversal< <%= method.typeArguments.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));

--- a/gremlin-dotnet/glv/NamingConversions.template
+++ b/gremlin-dotnet/glv/NamingConversions.template
@@ -23,15 +23,13 @@
 
 using System.Collections.Generic;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     internal static class NamingConversions
     {
         /// <summary>
-        /// Gets the Java name equivalent for a given enum value
+        ///     Gets the Java name equivalent for a given enum value
         /// </summary>
         internal static string GetEnumJavaName(string typeName, string value)
         {

--- a/gremlin-dotnet/glv/P.template
+++ b/gremlin-dotnet/glv/P.template
@@ -21,10 +21,12 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     A <see cref="P" /> is a predicate of the form Func&lt;object, bool&gt;.
+    ///     That is, given some object, return true or false.
     /// </summary>
     public class P
     {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Barrier.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Barrier.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Barrier
     {
         NormSack

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Bytecode.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Bytecode.cs
@@ -31,7 +31,7 @@ namespace Gremlin.Net.Process.Traversal
     /// <remarks>
     ///     Bytecode is simply a list of ordered instructions.
     ///     Bytecode can be serialized between environments and machines by way of a GraphSON representation.
-    ///     Thus, Gremlin-CSharp can create bytecode in C# and ship it to Gremlin-Java for evaluation in Java.
+    ///     Thus, Gremlin-DotNet can create bytecode in C# and ship it to Gremlin-Java for evaluation in Java.
     /// </remarks>
     public class Bytecode
     {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Cardinality.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Cardinality.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Cardinality
     {
         List,Set,Single

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Column.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Column.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Column
     {
         Keys,Values

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
@@ -36,7 +36,7 @@ namespace Gremlin.Net.Process.Traversal
         private IEnumerator<Traverser> _traverserEnumerator;
 
         /// <summary>
-        ///     Gets the <see cref="Bytecode" /> representation of this traversal.
+        ///     Gets the <see cref="Traversal.Bytecode" /> representation of this traversal.
         /// </summary>
         public Bytecode Bytecode { get; protected set; }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Direction.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Direction.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Direction
     {
         Both,In,Out

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphSONVersion.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphSONVersion.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum GraphSONVersion
     {
         V1_0,V2_0

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -24,18 +24,27 @@
 using System.Collections.Generic;
 using Gremlin.Net.Structure;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     Graph traversals are the primary way in which graphs are processed.
     /// </summary>
     public class GraphTraversal<S, E> : DefaultTraversal<S, E>
     {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversal{SType, EType}" /> class.
+        /// </summary>
         public GraphTraversal()
             : this(new List<ITraversalStrategy>(), new Bytecode())
         {
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversal{SType, EType}" /> class.
+        /// </summary>
+        /// <param name="traversalStrategies">The traversal strategies to be used by this graph traversal at evaluation time.</param>
+        /// <param name="bytecode">The <see cref="Bytecode" /> associated with the construction of this graph traversal.</param>
         public GraphTraversal(ICollection<ITraversalStrategy> traversalStrategies, Bytecode bytecode)
         {
             TraversalStrategies = traversalStrategies;
@@ -53,588 +62,882 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 
+        /// <summary>
+        ///     Adds the V step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > V (params object[] args)
         {
             Bytecode.AddStep("V", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the addE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > AddE (params object[] args)
         {
             Bytecode.AddStep("addE", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the addInE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > AddInE (params object[] args)
         {
             Bytecode.AddStep("addInE", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the addOutE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > AddOutE (params object[] args)
         {
             Bytecode.AddStep("addOutE", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > AddV (params object[] args)
         {
             Bytecode.AddStep("addV", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the aggregate step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Aggregate (params object[] args)
         {
             Bytecode.AddStep("aggregate", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the and step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > And (params object[] args)
         {
             Bytecode.AddStep("and", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the as step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > As (params object[] args)
         {
             Bytecode.AddStep("as", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Barrier (params object[] args)
         {
             Bytecode.AddStep("barrier", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the both step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > Both (params object[] args)
         {
             Bytecode.AddStep("both", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the bothE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > BothE (params object[] args)
         {
             Bytecode.AddStep("bothE", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the bothV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > BothV (params object[] args)
         {
             Bytecode.AddStep("bothV", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the branch step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Branch<E2> (params object[] args)
         {
             Bytecode.AddStep("branch", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > By (params object[] args)
         {
             Bytecode.AddStep("by", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the cap step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Cap<E2> (params object[] args)
         {
             Bytecode.AddStep("cap", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Choose<E2> (params object[] args)
         {
             Bytecode.AddStep("choose", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the coalesce step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Coalesce<E2> (params object[] args)
         {
             Bytecode.AddStep("coalesce", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the coin step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Coin (params object[] args)
         {
             Bytecode.AddStep("coin", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the constant step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Constant<E2> (params object[] args)
         {
             Bytecode.AddStep("constant", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the count step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , long > Count (params object[] args)
         {
             Bytecode.AddStep("count", args);
             return Wrap< S , long >(this);
         }
 
+        /// <summary>
+        ///     Adds the cyclicPath step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > CyclicPath (params object[] args)
         {
             Bytecode.AddStep("cyclicPath", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the dedup step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Dedup (params object[] args)
         {
             Bytecode.AddStep("dedup", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the drop step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Drop (params object[] args)
         {
             Bytecode.AddStep("drop", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Emit (params object[] args)
         {
             Bytecode.AddStep("emit", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the filter step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Filter (params object[] args)
         {
             Bytecode.AddStep("filter", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the flatMap step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > FlatMap<E2> (params object[] args)
         {
             Bytecode.AddStep("flatMap", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the fold step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Fold<E2> (params object[] args)
         {
             Bytecode.AddStep("fold", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the from step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > From (params object[] args)
         {
             Bytecode.AddStep("from", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Group (params object[] args)
         {
             Bytecode.AddStep("group", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the groupCount step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > GroupCount (params object[] args)
         {
             Bytecode.AddStep("groupCount", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the groupV3d0 step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > GroupV3d0 (params object[] args)
         {
             Bytecode.AddStep("groupV3d0", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Has (params object[] args)
         {
             Bytecode.AddStep("has", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the hasId step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > HasId (params object[] args)
         {
             Bytecode.AddStep("hasId", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the hasKey step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > HasKey (params object[] args)
         {
             Bytecode.AddStep("hasKey", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the hasLabel step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > HasLabel (params object[] args)
         {
             Bytecode.AddStep("hasLabel", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the hasNot step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > HasNot (params object[] args)
         {
             Bytecode.AddStep("hasNot", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the hasValue step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > HasValue (params object[] args)
         {
             Bytecode.AddStep("hasValue", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the id step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , object > Id (params object[] args)
         {
             Bytecode.AddStep("id", args);
             return Wrap< S , object >(this);
         }
 
+        /// <summary>
+        ///     Adds the identity step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Identity (params object[] args)
         {
             Bytecode.AddStep("identity", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the in step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > In (params object[] args)
         {
             Bytecode.AddStep("in", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the inE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > InE (params object[] args)
         {
             Bytecode.AddStep("inE", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the inV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > InV (params object[] args)
         {
             Bytecode.AddStep("inV", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the inject step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Inject (params object[] args)
         {
             Bytecode.AddStep("inject", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the is step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Is (params object[] args)
         {
             Bytecode.AddStep("is", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the key step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , string > Key (params object[] args)
         {
             Bytecode.AddStep("key", args);
             return Wrap< S , string >(this);
         }
 
+        /// <summary>
+        ///     Adds the label step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , string > Label (params object[] args)
         {
             Bytecode.AddStep("label", args);
             return Wrap< S , string >(this);
         }
 
+        /// <summary>
+        ///     Adds the limit step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Limit<E2> (params object[] args)
         {
             Bytecode.AddStep("limit", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the local step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Local<E2> (params object[] args)
         {
             Bytecode.AddStep("local", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the loops step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , int > Loops (params object[] args)
         {
             Bytecode.AddStep("loops", args);
             return Wrap< S , int >(this);
         }
 
+        /// <summary>
+        ///     Adds the map step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Map<E2> (params object[] args)
         {
             Bytecode.AddStep("map", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the mapKeys step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > MapKeys<E2> (params object[] args)
         {
             Bytecode.AddStep("mapKeys", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the mapValues step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > MapValues<E2> (params object[] args)
         {
             Bytecode.AddStep("mapValues", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the match step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Match<E2> (params object[] args)
         {
             Bytecode.AddStep("match", args);
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
+        /// <summary>
+        ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Max<E2> (params object[] args)
         {
             Bytecode.AddStep("max", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the mean step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Mean<E2> (params object[] args)
         {
             Bytecode.AddStep("mean", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the min step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Min<E2> (params object[] args)
         {
             Bytecode.AddStep("min", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the not step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Not (params object[] args)
         {
             Bytecode.AddStep("not", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the option step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Option (params object[] args)
         {
             Bytecode.AddStep("option", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the optional step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Optional<E2> (params object[] args)
         {
             Bytecode.AddStep("optional", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the or step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Or (params object[] args)
         {
             Bytecode.AddStep("or", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the order step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Order (params object[] args)
         {
             Bytecode.AddStep("order", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the otherV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > OtherV (params object[] args)
         {
             Bytecode.AddStep("otherV", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the out step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > Out (params object[] args)
         {
             Bytecode.AddStep("out", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the outE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > OutE (params object[] args)
         {
             Bytecode.AddStep("outE", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the outV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > OutV (params object[] args)
         {
             Bytecode.AddStep("outV", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the pageRank step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > PageRank (params object[] args)
         {
             Bytecode.AddStep("pageRank", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the path step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Path > Path (params object[] args)
         {
             Bytecode.AddStep("path", args);
             return Wrap< S , Path >(this);
         }
 
+        /// <summary>
+        ///     Adds the peerPressure step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > PeerPressure (params object[] args)
         {
             Bytecode.AddStep("peerPressure", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Profile (params object[] args)
         {
             Bytecode.AddStep("profile", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the program step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Program (params object[] args)
         {
             Bytecode.AddStep("program", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the project step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Project<E2> (params object[] args)
         {
             Bytecode.AddStep("project", args);
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
+        /// <summary>
+        ///     Adds the properties step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Properties<E2> (params object[] args)
         {
             Bytecode.AddStep("properties", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the property step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Property (params object[] args)
         {
             Bytecode.AddStep("property", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the propertyMap step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > PropertyMap<E2> (params object[] args)
         {
             Bytecode.AddStep("propertyMap", args);
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
+        /// <summary>
+        ///     Adds the range step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Range<E2> (params object[] args)
         {
             Bytecode.AddStep("range", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the repeat step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Repeat (params object[] args)
         {
             Bytecode.AddStep("repeat", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Sack (params object[] args)
         {
             Bytecode.AddStep("sack", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the sample step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Sample (params object[] args)
         {
             Bytecode.AddStep("sample", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (params object[] args)
         {
             Bytecode.AddStep("select", args);
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
+        /// <summary>
+        ///     Adds the sideEffect step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > SideEffect (params object[] args)
         {
             Bytecode.AddStep("sideEffect", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the simplePath step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > SimplePath (params object[] args)
         {
             Bytecode.AddStep("simplePath", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the store step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Store (params object[] args)
         {
             Bytecode.AddStep("store", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the subgraph step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > Subgraph (params object[] args)
         {
             Bytecode.AddStep("subgraph", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the sum step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Sum<E2> (params object[] args)
         {
             Bytecode.AddStep("sum", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Tail<E2> (params object[] args)
         {
             Bytecode.AddStep("tail", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the timeLimit step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > TimeLimit (params object[] args)
         {
             Bytecode.AddStep("timeLimit", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the times step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Times (params object[] args)
         {
             Bytecode.AddStep("times", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > To (params object[] args)
         {
             Bytecode.AddStep("to", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the toE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Edge > ToE (params object[] args)
         {
             Bytecode.AddStep("toE", args);
             return Wrap< S , Edge >(this);
         }
 
+        /// <summary>
+        ///     Adds the toV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , Vertex > ToV (params object[] args)
         {
             Bytecode.AddStep("toV", args);
             return Wrap< S , Vertex >(this);
         }
 
+        /// <summary>
+        ///     Adds the tree step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Tree (params object[] args)
         {
             Bytecode.AddStep("tree", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the unfold step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Unfold<E2> (params object[] args)
         {
             Bytecode.AddStep("unfold", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the union step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Union<E2> (params object[] args)
         {
             Bytecode.AddStep("union", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the until step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Until (params object[] args)
         {
             Bytecode.AddStep("until", args);
             return Wrap< S , E >(this);
         }
 
+        /// <summary>
+        ///     Adds the value step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Value<E2> (params object[] args)
         {
             Bytecode.AddStep("value", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the valueMap step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (params object[] args)
         {
             Bytecode.AddStep("valueMap", args);
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
+        /// <summary>
+        ///     Adds the values step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E2 > Values<E2> (params object[] args)
         {
             Bytecode.AddStep("values", args);
             return Wrap< S , E2 >(this);
         }
 
+        /// <summary>
+        ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal< S , E > Where (params object[] args)
         {
             Bytecode.AddStep("where", args);

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -21,26 +21,48 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     A <see cref="GraphTraversalSource" /> is the primary DSL of the Gremlin traversal machine.
+    ///     It provides access to all the configurations and steps for Turing complete graph computing.
     /// </summary>
     public class GraphTraversalSource
     {
+        /// <summary>
+        ///     Gets or sets the traversal strategies associated with this graph traversal source.
+        /// </summary>
         public ICollection<ITraversalStrategy> TraversalStrategies { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the <see cref="Traversal.Bytecode" /> associated with the current state of this graph traversal
+        ///     source.
+        /// </summary>
         public Bytecode Bytecode { get; set; }
 
-         public GraphTraversalSource()
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversalSource" /> class.
+        /// </summary>
+        public GraphTraversalSource()
             : this(new List<ITraversalStrategy>(), new Bytecode())
         {
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="GraphTraversalSource" /> class.
+        /// </summary>
+        /// <param name="traversalStrategies">The traversal strategies associated with this graph traversal source.</param>
+        /// <param name="bytecode">
+        ///     The <see cref="Traversal.Bytecode" /> associated with the current state of this graph traversal
+        ///     source.
+        /// </param>
         public GraphTraversalSource(ICollection<ITraversalStrategy> traversalStrategies, Bytecode bytecode)
         {
             TraversalStrategies = traversalStrategies;
@@ -96,11 +118,21 @@ namespace Gremlin.Net.Process.Traversal
             return source;
         }
 
+        [Obsolete("Use the Bindings class instead.", false)]
         public GraphTraversalSource WithBindings(object bindings)
         {
             return this;
         }
 
+        /// <summary>
+        ///     Configures the <see cref="GraphTraversalSource" /> as a "remote" to issue the
+        ///     <see cref="GraphTraversal{SType, EType}" /> for execution elsewhere.
+        /// </summary>
+        /// <param name="remoteConnection">
+        ///     The <see cref="IRemoteConnection" /> instance to use to submit the
+        ///     <see cref="GraphTraversal{SType, EType}" />.
+        /// </param>
+        /// <returns>A <see cref="GraphTraversalSource" /> configured to use the provided <see cref="IRemoteConnection" />.</returns>
         public GraphTraversalSource WithRemote(IRemoteConnection remoteConnection)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
@@ -109,6 +141,10 @@ namespace Gremlin.Net.Process.Traversal
             return source;
         }
 
+        /// <summary>
+        ///     Add a GraphComputer class used to execute the traversal.
+        ///     This adds a <see cref="VertexProgramStrategy" /> to the strategies.
+        /// </summary>
         public GraphTraversalSource WithComputer(string graphComputer = null, int? workers = null, string persist = null,
             string result = null, ITraversal vertices = null, ITraversal edges = null,
             Dictionary<string, dynamic> configuration = null)
@@ -117,6 +153,10 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the E step to that
+        ///     traversal.
+        /// </summary>
         public GraphTraversal< Edge,Edge > E(params object[] args)
         {
             var traversal = new GraphTraversal< Edge,Edge >(TraversalStrategies, new Bytecode(Bytecode));
@@ -124,6 +164,10 @@ namespace Gremlin.Net.Process.Traversal
             return traversal;
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the V step to that
+        ///     traversal.
+        /// </summary>
         public GraphTraversal< Vertex,Vertex > V(params object[] args)
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
@@ -131,6 +175,10 @@ namespace Gremlin.Net.Process.Traversal
             return traversal;
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
+        ///     traversal.
+        /// </summary>
         public GraphTraversal< Vertex,Vertex > AddV(params object[] args)
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GryoVersion.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GryoVersion.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum GryoVersion
     {
         V1_0

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/NamingConversions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/NamingConversions.cs
@@ -23,15 +23,13 @@
 
 using System.Collections.Generic;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     internal static class NamingConversions
     {
         /// <summary>
-        /// Gets the Java name equivalent for a given enum value
+        ///     Gets the Java name equivalent for a given enum value
         /// </summary>
         internal static string GetEnumJavaName(string typeName, string value)
         {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Operator.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Operator.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Operator
     {
         AddAll,And,Assign,Div,Max,Min,Minus,Mult,Or,Sum,SumLong

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Order.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Order.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Order
     {
         Decr,Incr,KeyDecr,KeyIncr,Shuffle,ValueDecr,ValueIncr

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
@@ -21,10 +21,12 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     A <see cref="P" /> is a predicate of the form Func&lt;object, bool&gt;.
+    ///     That is, given some object, return true or false.
     /// </summary>
     public class P
     {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pick.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pick.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Pick
     {
         Any,None

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pop.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Pop.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Pop
     {
         All,First,Last

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Scope.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Scope.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum Scope
     {
         Global,Local

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/T.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/T.cs
@@ -21,11 +21,9 @@
 
 #endregion
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
-    /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
-    /// </summary>
     public enum T
     {
         Id,Key,Label,Value

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
@@ -24,468 +24,745 @@
 using System.Collections.Generic;
 using Gremlin.Net.Structure;
 
+// THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
 namespace Gremlin.Net.Process.Traversal
 {
     /// <summary>
-    ///     THIS IS A GENERATED CLASS - DO NOT MODIFY THIS CLASS DIRECTLY - see pom.xml
+    ///     An anonymous <see cref="GraphTraversal{SType, EType}" />.
     /// </summary>
     public static class __
     {
+        /// <summary>
+        ///     Starts an empty <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public static GraphTraversal<object, object> Start()
         {
             return new GraphTraversal<object, object>();
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the V step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> V(params object[] args)
         {
             return new GraphTraversal<object, object>().V(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addE step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> AddE(params object[] args)
         {
             return new GraphTraversal<object, object>().AddE(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addInE step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> AddInE(params object[] args)
         {
             return new GraphTraversal<object, object>().AddInE(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addOutE step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> AddOutE(params object[] args)
         {
             return new GraphTraversal<object, object>().AddOutE(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addV step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> AddV(params object[] args)
         {
             return new GraphTraversal<object, object>().AddV(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the aggregate step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Aggregate(params object[] args)
         {
             return new GraphTraversal<object, object>().Aggregate(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the and step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> And(params object[] args)
         {
             return new GraphTraversal<object, object>().And(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the as step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> As(params object[] args)
         {
             return new GraphTraversal<object, object>().As(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the barrier step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Barrier(params object[] args)
         {
             return new GraphTraversal<object, object>().Barrier(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the both step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> Both(params object[] args)
         {
             return new GraphTraversal<object, object>().Both(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the bothE step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> BothE(params object[] args)
         {
             return new GraphTraversal<object, object>().BothE(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the bothV step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> BothV(params object[] args)
         {
             return new GraphTraversal<object, object>().BothV(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the branch step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Branch<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Branch<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the cap step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Cap<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Cap<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the choose step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Choose<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Choose<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the coalesce step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Coalesce<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Coalesce<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the coin step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Coin(params object[] args)
         {
             return new GraphTraversal<object, object>().Coin(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the constant step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Constant<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Constant<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the count step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, long> Count(params object[] args)
         {
             return new GraphTraversal<object, object>().Count(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the cyclicPath step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> CyclicPath(params object[] args)
         {
             return new GraphTraversal<object, object>().CyclicPath(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the dedup step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Dedup(params object[] args)
         {
             return new GraphTraversal<object, object>().Dedup(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the drop step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Drop(params object[] args)
         {
             return new GraphTraversal<object, object>().Drop(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the emit step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Emit(params object[] args)
         {
             return new GraphTraversal<object, object>().Emit(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the filter step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Filter(params object[] args)
         {
             return new GraphTraversal<object, object>().Filter(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the flatMap step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> FlatMap<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().FlatMap<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the fold step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Fold<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Fold<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the group step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Group(params object[] args)
         {
             return new GraphTraversal<object, object>().Group(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the groupCount step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> GroupCount(params object[] args)
         {
             return new GraphTraversal<object, object>().GroupCount(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the groupV3d0 step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> GroupV3d0(params object[] args)
         {
             return new GraphTraversal<object, object>().GroupV3d0(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Has(params object[] args)
         {
             return new GraphTraversal<object, object>().Has(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasId step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> HasId(params object[] args)
         {
             return new GraphTraversal<object, object>().HasId(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasKey step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> HasKey(params object[] args)
         {
             return new GraphTraversal<object, object>().HasKey(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasLabel step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> HasLabel(params object[] args)
         {
             return new GraphTraversal<object, object>().HasLabel(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasNot step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> HasNot(params object[] args)
         {
             return new GraphTraversal<object, object>().HasNot(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasValue step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> HasValue(params object[] args)
         {
             return new GraphTraversal<object, object>().HasValue(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the id step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Id(params object[] args)
         {
             return new GraphTraversal<object, object>().Id(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the identity step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Identity(params object[] args)
         {
             return new GraphTraversal<object, object>().Identity(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the in step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> In(params object[] args)
         {
             return new GraphTraversal<object, object>().In(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the inE step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> InE(params object[] args)
         {
             return new GraphTraversal<object, object>().InE(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the inV step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> InV(params object[] args)
         {
             return new GraphTraversal<object, object>().InV(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the inject step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Inject(params object[] args)
         {
             return new GraphTraversal<object, object>().Inject(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the is step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Is(params object[] args)
         {
             return new GraphTraversal<object, object>().Is(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the key step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, string> Key(params object[] args)
         {
             return new GraphTraversal<object, object>().Key(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the label step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, string> Label(params object[] args)
         {
             return new GraphTraversal<object, object>().Label(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the limit step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Limit<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Limit<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the local step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Local<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Local<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the loops step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, int> Loops(params object[] args)
         {
             return new GraphTraversal<object, object>().Loops(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the map step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Map<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Map<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the mapKeys step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> MapKeys<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().MapKeys<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the mapValues step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> MapValues<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().MapValues<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the match step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, IDictionary<string, E2>> Match<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Match<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the max step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Max<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Max<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the mean step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Mean<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Mean<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the min step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Min<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Min<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the not step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Not(params object[] args)
         {
             return new GraphTraversal<object, object>().Not(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the optional step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Optional<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Optional<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the or step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Or(params object[] args)
         {
             return new GraphTraversal<object, object>().Or(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the order step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Order(params object[] args)
         {
             return new GraphTraversal<object, object>().Order(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the otherV step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> OtherV(params object[] args)
         {
             return new GraphTraversal<object, object>().OtherV(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the out step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> Out(params object[] args)
         {
             return new GraphTraversal<object, object>().Out(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the outE step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> OutE(params object[] args)
         {
             return new GraphTraversal<object, object>().OutE(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the outV step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> OutV(params object[] args)
         {
             return new GraphTraversal<object, object>().OutV(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the path step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Path> Path(params object[] args)
         {
             return new GraphTraversal<object, object>().Path(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the project step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, IDictionary<string, E2>> Project<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Project<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the properties step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Properties<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Properties<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the property step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Property(params object[] args)
         {
             return new GraphTraversal<object, object>().Property(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the propertyMap step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, IDictionary<string, E2>> PropertyMap<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().PropertyMap<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the range step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Range<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Range<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the repeat step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Repeat(params object[] args)
         {
             return new GraphTraversal<object, object>().Repeat(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sack step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Sack(params object[] args)
         {
             return new GraphTraversal<object, object>().Sack(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sample step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Sample(params object[] args)
         {
             return new GraphTraversal<object, object>().Sample(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the select step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, IDictionary<string, E2>> Select<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Select<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sideEffect step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> SideEffect(params object[] args)
         {
             return new GraphTraversal<object, object>().SideEffect(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the simplePath step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> SimplePath(params object[] args)
         {
             return new GraphTraversal<object, object>().SimplePath(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the store step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Store(params object[] args)
         {
             return new GraphTraversal<object, object>().Store(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the subgraph step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> Subgraph(params object[] args)
         {
             return new GraphTraversal<object, object>().Subgraph(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sum step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Sum<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Sum<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tail step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Tail<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Tail<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the timeLimit step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> TimeLimit(params object[] args)
         {
             return new GraphTraversal<object, object>().TimeLimit(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the times step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Times(params object[] args)
         {
             return new GraphTraversal<object, object>().Times(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the to step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> To(params object[] args)
         {
             return new GraphTraversal<object, object>().To(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the toE step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Edge> ToE(params object[] args)
         {
             return new GraphTraversal<object, object>().ToE(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the toV step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, Vertex> ToV(params object[] args)
         {
             return new GraphTraversal<object, object>().ToV(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tree step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Tree(params object[] args)
         {
             return new GraphTraversal<object, object>().Tree(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the unfold step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Unfold<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Unfold<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the union step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Union<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Union<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the until step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Until(params object[] args)
         {
             return new GraphTraversal<object, object>().Until(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the value step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Value<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Value<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the valueMap step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, IDictionary<string, E2>> ValueMap<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().ValueMap<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the values step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, E2> Values<E2>(params object[] args)
         {
             return new GraphTraversal<object, object>().Values<E2>(args);
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the where step to that traversal.
+        /// </summary>
         public static GraphTraversal<object, object> Where(params object[] args)
         {
             return new GraphTraversal<object, object>().Where(args);

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
@@ -25,8 +25,16 @@ using Gremlin.Net.Process.Traversal;
 
 namespace Gremlin.Net.Structure
 {
+    /// <summary>
+    ///     A <see cref="Graph" /> is a container object for a collection of <see cref="Vertex" />, <see cref="Edge" />,
+    ///     <see cref="VertexProperty" />, and <see cref="Property" /> objects.
+    /// </summary>
     public class Graph
     {
+        /// <summary>
+        ///     Generates a reusable <see cref="GraphTraversalSource" /> instance.
+        /// </summary>
+        /// <returns>A graph traversal source.</returns>
         public GraphTraversalSource Traversal()
         {
             return new GraphTraversalSource();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1552

This change adds many comments to Gremlin-DotNet, especially for the GLV part. Some comments where taken from the respective Java classes. It also adds comments to most of the auto-generated methods to tell the user what the method does.

Example for the anonymous class `__`:
```cs
/// <summary>
///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the out step to that traversal.
/// </summary>
public static GraphTraversal<object, Vertex> Out(params object[] args)
{
    return new GraphTraversal<object, object>().Out(args);
}
```
And for a `GraphTraversal` step:
```cs
/// <summary>
///     Adds the aggregate step to this <see cref="GraphTraversal{SType, EType}" />.
/// </summary>
public GraphTraversal< S , E > Aggregate (params object[] args)
{
    Bytecode.AddStep("aggregate", args);
    return Wrap< S , E >(this);
}
```
Apart from the comment improvements, this also marks `GraphTraversalSource.WithBindings` as obsolete as it is also marked as deprecated in Gremlin-Java.