### PR TITLE
Restore 5 second cutoff time in TraversalInterruptionComputerTest

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalInterruptionComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalInterruptionComputerTest.java
@@ -95,9 +95,9 @@ public class TraversalInterruptionComputerTest extends AbstractGremlinProcessTes
 
         t.start();
 
-        // total time for test should not exceed 1 second - this prevents the test from just hanging and allows
+        // total time for test should not exceed 5 seconds - this prevents the test from just hanging and allows
         // it to finish with failure
-        assertThat(startedIterating.await(1000, TimeUnit.MILLISECONDS), CoreMatchers.is(true));
+        assertThat(startedIterating.await(5000, TimeUnit.MILLISECONDS), CoreMatchers.is(true));
 
         t.interrupt();
         t.join();


### PR DESCRIPTION
The change in https://github.com/apache/tinkerpop/commit/9983fd210872d57750d49191c391ba8e380e6023 included decreasing the maximum total test time threshold from 5 seconds to 1 second in TraversalInterruptionComputerTest. This PR proposes to revert the timeout back to the original 5 seconds to resolve test failures observed in some custom graph computer implementations.