### PR TITLE
TINKERPOP-1445 Add ellipses for long property values

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Included an ellipse on long property names that are truncated.
 * Renamed `RangeByIsCountStrategy` to `CountStrategy`.
 * Added more specific typing to various `__` traversal steps. E.g. `<A,Vertex>out()` is `<Vertex,Vertex>out()`.
 * Updated Docker build scripts to include Python dependencies (NOTE: users should remove any previously generated TinkerPop Docker images).

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.structure.util;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
@@ -68,12 +69,8 @@ public final class StringFactory {
     private static final String L_BRACKET = "[";
     private static final String R_BRACKET = "]";
     private static final String COMMA_SPACE = ", ";
-    private static final String COLON = ":";
-    private static final String EMPTY_MAP = "{}";
-    private static final String DOTS = "...";
     private static final String DASH = "-";
     private static final String ARROW = "->";
-    private static final String STAR = "*";
     private static final String EMPTY_PROPERTY = "p[empty]";
     private static final String EMPTY_VERTEX_PROPERTY = "vp[empty]";
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
@@ -106,11 +103,11 @@ public final class StringFactory {
         if (property instanceof VertexProperty) {
             if (!property.isPresent()) return EMPTY_VERTEX_PROPERTY;
             final String valueString = String.valueOf(property.value());
-            return VP + L_BRACKET + property.key() + ARROW + valueString.substring(0, Math.min(valueString.length(), 20)) + R_BRACKET;
+            return VP + L_BRACKET + property.key() + ARROW + StringUtils.abbreviate(valueString, 20) + R_BRACKET;
         } else {
             if (!property.isPresent()) return EMPTY_PROPERTY;
             final String valueString = String.valueOf(property.value());
-            return P + L_BRACKET + property.key() + ARROW + valueString.substring(0, Math.min(valueString.length(), 20)) + R_BRACKET;
+            return P + L_BRACKET + property.key() + ARROW + StringUtils.abbreviate(valueString, 20) + R_BRACKET;
         }
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
@@ -59,9 +59,35 @@ public class PropertyTest {
     public static class BasicPropertyTest extends AbstractGremlinTest {
         @Test
         @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
-        public void shouldHaveStandardStringRepresentation() {
+        public void shouldHaveStandardStringRepresentationForVertexProperty() {
             final Vertex v = graph.addVertex("name", "marko");
             final Property p = v.property("name");
+            assertEquals(StringFactory.propertyString(p), p.toString());
+        }
+
+        @Test
+        @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
+        public void shouldHaveTruncatedStringRepresentationForVertexProperty() {
+            final Vertex v = graph.addVertex("name", "maria de la santa cruz rosalina agnelia rodriguez cuellar rene");
+            final Property p = v.property("name");
+            assertEquals(StringFactory.propertyString(p), p.toString());
+        }
+
+        @Test
+        @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        public void shouldHaveStandardStringRepresentationForEdgeProperty() {
+            final Vertex v = graph.addVertex();
+            final Edge e = v.addEdge("self", v, "short", "s");
+            final Property p = e.property("short");
+            assertEquals(StringFactory.propertyString(p), p.toString());
+        }
+
+        @Test
+        @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        public void shouldHaveTruncatedStringRepresentationForEdgeProperty() {
+            final Vertex v = graph.addVertex();
+            final Edge e = v.addEdge("self", v, "long", "s");
+            final Property p = e.property("long", "this is a really long property to truncate");
             assertEquals(StringFactory.propertyString(p), p.toString());
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1445

This was an easy change but I decided to do this as a PR so that the change would be noted as it does affect something that is user facing. I did this change for 3.3.0 only in case someone is depending on the `toString()` value of `Property` for some reason.

```text
gremlin> graph = TinkerGraph.open()
==>tinkergraph[vertices:0 edges:0]
gremlin> g = graph.traversal()
==>graphtraversalsource[tinkergraph[vertices:0 edges:0], standard]
gremlin> g.addV().property('short','pretty short').property('long','this one is much longer so it is going to get truncated a bit').as('a').
......1>   addE('self').property('short','pretty short').property('long', 'this one is much longer so it is going to get truncated a bit').from('a').to('a')
==>e[3][0-self->0]
gremlin> g.V().properties()
==>vp[short->pretty short]
==>vp[long->this one is much ...]
gremlin> g.E().properties()
==>p[short->pretty short]
==>p[long->this one is much ...]
```

Builds with `mvn clean install`

VOTE +1