### PR TITLE
TINKERPOP-1519: tinker graph computer does not handle multiple scopes

### DIFF
--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerMessageBoard.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerMessageBoard.java
@@ -32,8 +32,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 final class TinkerMessageBoard<M> {
 
-    public Map<Vertex, Queue<M>> sendMessages = new ConcurrentHashMap<>();
-    public Map<Vertex, Queue<M>> receiveMessages = new ConcurrentHashMap<>();
+    public Map<MessageScope, Map<Vertex,Queue<M>>> sendMessages = new ConcurrentHashMap<>();
+    public Map<MessageScope, Map<Vertex, Queue<M>>> receiveMessages = new ConcurrentHashMap<>();
     public Set<MessageScope> previousMessageScopes = new HashSet<>();
     public Set<MessageScope> currentMessageScopes = new HashSet<>();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1519

This change modifies the tinker graph computer so that each message sent in a vertex program remembers its scope. Previously when the receiveMessages method on TinkerMessenger was called it would loop through ALL message scopes and then ALL messages, which is incorrect. Now the method loops over each scope, and then each message within that scope.

I have added the regression test suggested in the JIRA ticket and run mvn clean install locally to confirm everything passes OK.

I had a quick look at the latest master, and this bugfix may need to be merged there too.
