### PR TITLE
TINKERPOP-741 Deprecated Transaction.submit(Function)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
+* Deprecated `Transaction.submit(Function)`.
 * Fixed `HADOOP_GREMLIN_LIBS` parsing for Windows.
 * Improved GraphSON serialization performance around `VertexProperty`.
 

--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -280,26 +280,6 @@ NOTE: It may be important to consult the documentation of the `Graph` implementa
 specifics of how transactions will behave.  TinkerPop allows some latitude in this area and implementations may not have
 the exact same behaviors and link:https://en.wikipedia.org/wiki/ACID[ACID] guarantees.
 
-Retries
-~~~~~~~
-
-There are times when transactions fail.  Failure may be indicative of some permanent condition, but other failures
-might simply require the transaction to be retried for possible future success. The `Transaction` object also exposes
-a method for executing automatic transaction retries:
-
-[gremlin-groovy]
-----
-graph = Neo4jGraph.open('/tmp/neo4j')
-graph.tx().submit {it.addVertex("name","josh")}.retry(10)
-graph.tx().submit {it.addVertex("name","daniel")}.exponentialBackoff(10)
-graph.close()
-----
-
-As shown above, the `submit` method takes a `Function<Graph, R>` which is the unit of work to execute and possibly
-retry on failure.  The method returns a `Transaction.Workload` object which has a number of default methods for common
-retry strategies.  It is also possible to supply a custom retry function if a default one does not suit the required
-purpose.
-
 Threaded Transactions
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Transaction.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Transaction.java
@@ -63,7 +63,9 @@ public interface Transaction extends AutoCloseable {
     /**
      * Submit a unit of work that represents a transaction returning a {@link Workload} that can be automatically
      * retried in the event of failure.
+     * @deprecated As of release 3.2.6, not replaced.
      */
+    @Deprecated
     public <R> Workload<R> submit(final Function<Graph, R> work);
 
     /**
@@ -228,7 +230,9 @@ public interface Transaction extends AutoCloseable {
      * or the unit of work succeeds with a commit operation.
      *
      * @param <R> The type of the result from the unit of work.
+     * @deprecated As of release 3.2.6, not replaced.
      */
+    @Deprecated
     public static class Workload<R> {
         public static final long DEFAULT_DELAY_MS = 20;
         public static final int DEFAULT_TRIES = 8;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/AbstractTransaction.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/AbstractTransaction.java
@@ -125,8 +125,10 @@ public abstract class AbstractTransaction implements Transaction {
 
     /**
      * {@inheritDoc}
+     * @deprecated As of release 3.2.6, not replaced.
      */
     @Override
+    @Deprecated
     public <R> Workload<R> submit(final Function<Graph, R> work) {
         return new Workload<>(g, work);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-741

Deprecated  methods related to transaction retry in preparation for removal in 3.3.0.  Builds with `mvn clean install`.

VOTE +1