### PR TITLE
TINKERPOP-1004 Expand usage of TransactionException

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* `TransactionException` is no longer a class of `AbstractTransaction` and it extends `RuntimeException`.
 * Renamed `RangeByIsCountStrategy` to `CountStrategy`.
 * Added more specific typing to various `__` traversal steps. E.g. `<A,Vertex>out()` is `<Vertex,Vertex>out()`.
 * Updated Docker build scripts to include Python dependencies (NOTE: users should remove any previously generated TinkerPop Docker images).

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -255,34 +255,6 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-1420[TINKERPOP-1420], link:
 link:https://issues.apache.org/jira/browse/TINKERPOP-1465[TINKERPOP-1465], link:https://issues.apache.org/jira/browse/TINKERPOP-1526[TINKERPOP-1526],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1612[TINKERPOP-1612], link:https://issues.apache.org/jira/browse/TINKERPOP-1622[TINKERPOP-1622]
 
-Upgrading for Providers
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Graph Database Providers
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Test Suite Removal
-++++++++++++++++++
-
-A number of test suites that were previously deprecated have been removed which should reduce the burden on graph
-providers who are implementing TinkerPop. Test suites related to perfrmance based on `junit-benchmarks` have been
-removed as have the suites in `gremlin-groovy-test` (in fact, this entire module has been removed). Specifically,
-providers should be concerned with breaking changes related to the removal of:
-
-* `StructurePerformanceSuite`
-* `ProcessPerformanceSuite`
-* `GroovyEnvironmentPerformanceSuite`
-* `GroovyProcessStandardSuite`
-* `GroovyProcessComputerSuite`
-* `GroovyEnvironmentSuite`
-* `GroovyEnvironmentIntegrateSuite`
-
-Those graph providers who relied on these tests should simply remove them from their respective test suites. Beware of
-`OptOut` annotations that reference tests in these suites as test failure will occur if those references are not
-removed.
-
-See: link:https://issues.apache.org/jira/browse/TINKERPOP-1235[TINKERPOP-1235], link:https://issues.apache.org/jira/browse/TINKERPOP-1612[TINKERPOP-1612]
-
 Gremlin-server.sh and Init Scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -322,3 +294,41 @@ spark.serializer=org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerial
 ```
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1389
+
+Upgrading for Providers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Graph Database Providers
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Test Suite Removal
+++++++++++++++++++
+
+A number of test suites that were previously deprecated have been removed which should reduce the burden on graph
+providers who are implementing TinkerPop. Test suites related to perfrmance based on `junit-benchmarks` have been
+removed as have the suites in `gremlin-groovy-test` (in fact, this entire module has been removed). Specifically,
+providers should be concerned with breaking changes related to the removal of:
+
+* `StructurePerformanceSuite`
+* `ProcessPerformanceSuite`
+* `GroovyEnvironmentPerformanceSuite`
+* `GroovyProcessStandardSuite`
+* `GroovyProcessComputerSuite`
+* `GroovyEnvironmentSuite`
+* `GroovyEnvironmentIntegrateSuite`
+
+Those graph providers who relied on these tests should simply remove them from their respective test suites. Beware of
+`OptOut` annotations that reference tests in these suites as test failure will occur if those references are not
+removed.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1235[TINKERPOP-1235], link:https://issues.apache.org/jira/browse/TINKERPOP-1612[TINKERPOP-1612]
+
+TransactionException
+++++++++++++++++++++
+
+The `AbstractTransaction.TransactionException` class is now just `TransactionException` which extends `RuntimeExcetpion`
+rather than `Exception`. Providers should consider using this exception to wrap their own on calls to
+`Transaction.commit()` or `Transaction.rollback()`. By throwing this exception, the TinkerPop stack can better respond
+to transaction problems and it allows for more common, generalized error handling for users.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1004[TINKERPOP-1004]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Transaction.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Transaction.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.structure;
 
 import org.apache.tinkerpop.gremlin.structure.util.AbstractTransaction;
+import org.apache.tinkerpop.gremlin.structure.util.TransactionException;
 
 import java.util.Collections;
 import java.util.Set;
@@ -51,12 +52,16 @@ public interface Transaction extends AutoCloseable {
     public void open();
 
     /**
-     * Commits a transaction.
+     * Commits a transaction. This method may optionally throw {@link TransactionException} on error. Providers should
+     * consider wrapping their transaction exceptions in this TinkerPop exception as it will lead to better error
+     * handling with Gremlin Server and other parts of the stack.
      */
     public void commit();
 
     /**
-     * Rolls back a transaction.
+     * Rolls back a transaction. This method may optionally throw {@link TransactionException} on error. Providers should
+     * consider wrapping their transaction exceptions in this TinkerPop exception as it will lead to better error
+     * handling with Gremlin Server and other parts of the stack.
      */
     public void rollback();
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/AbstractTransaction.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/AbstractTransaction.java
@@ -101,12 +101,8 @@ public abstract class AbstractTransaction implements Transaction {
     @Override
     public void commit() {
         readWrite();
-        try {
-            doCommit();
-            fireOnCommit();
-        } catch (TransactionException te) {
-            throw new RuntimeException(te);
-        }
+        doCommit();
+        fireOnCommit();
     }
 
     /**
@@ -115,12 +111,8 @@ public abstract class AbstractTransaction implements Transaction {
     @Override
     public void rollback() {
         readWrite();
-        try {
-            doRollback();
-            fireOnRollback();
-        } catch (TransactionException te) {
-            throw new RuntimeException(te);
-        }
+        doRollback();
+        fireOnRollback();
     }
 
     /**
@@ -152,23 +144,5 @@ public abstract class AbstractTransaction implements Transaction {
     @Override
     public void close() {
         doClose();
-    }
-
-    /**
-     * An "internal" exception thrown by providers when calls to {@link AbstractTransaction#doCommit} or
-     * {@link AbstractTransaction#doRollback} fail.
-     */
-    public static class TransactionException extends Exception {
-        public TransactionException(final String message) {
-            super(message);
-        }
-
-        public TransactionException(final Throwable cause) {
-            super(cause);
-        }
-
-        public TransactionException(final String message, final Throwable cause) {
-            super(message, cause);
-        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/TransactionException.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/TransactionException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.structure.util;
+
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+
+/**
+ * An exception thrown by providers when calls to {@link AbstractTransaction#doCommit} or
+ * {@link AbstractTransaction#doRollback} fail. This exception will be propagated to users on calls to
+ * {@link Transaction#commit()} or {@link Transaction#rollback()}.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class TransactionException extends RuntimeException {
+    public TransactionException(final String message) {
+        super(message);
+    }
+
+    public TransactionException(final Throwable cause) {
+        super(cause);
+    }
+
+    public TransactionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
@@ -39,6 +39,7 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.AbstractThreadLocalTransaction;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.apache.tinkerpop.gremlin.structure.util.TransactionException;
 import org.apache.tinkerpop.gremlin.structure.util.wrapped.WrappedGraph;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.neo4j.tinkerpop.api.Neo4jFactory;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1004

`TransactionException` is no longer bound to usage by `AbstractTransaction`.  Prescribed a more general usage of it with the Transaction interface.

Builds with `mvn clean install -DincludeNeo4j && mvn verify -pl gremlin-server -DskipIntegrationTests=false -DincludeNeo4j`

VOTE +1