### PR TITLE
TINKERPOP-999 Removed generics from ServerGremlinExecutor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Added "attachment requisite" `VertexProperty.element()` and `Property.element()` data in GraphSON serialization.
 * GraphSON 3.0 is now the default serialization format in TinkerGraph and Gremlin Server.
 * Established the GraphSON 3.0 format.
+* Changed `ServerGremlinExecutor` to not use generics since there really is no flexibility in the kind of `ScheduledExecutorService` that will be used.
 * Removed previously deprecated `OpSelectorHandler.errorMeter` and `AbstractEvalOpProcessor.errorMeter` fields.
 * Removed previously deprecated `AbstractEvalOpProcessor.validBindingName` field.
 * Removed previously deprecated `SimpleAuthenticator.CONFIG_CREDENTIALS_LOCATION` field.

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
-import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -53,7 +52,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Stream;
-import java.util.Iterator;
 
 /**
  * A base implementation for the {@code Channelizer} which does a basic configuration of the pipeline, one that
@@ -110,7 +108,7 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
     }
 
     @Override
-    public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
+    public void init(final ServerGremlinExecutor serverGremlinExecutor) {
         settings = serverGremlinExecutor.getSettings();
         gremlinExecutor = serverGremlinExecutor.getGremlinExecutor();
         graphManager = serverGremlinExecutor.getGraphManager();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Channelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Channelizer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.server;
 
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.EventLoopGroup;
 import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
 
 /**
@@ -35,5 +34,5 @@ public interface Channelizer extends ChannelHandler {
     /**
      * This method is called just after the {@code Channelizer} is initialized.
      */
-    public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor);
+    public void init(final ServerGremlinExecutor serverGremlinExecutor);
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
@@ -18,12 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.server.channel;
 
-import io.netty.channel.EventLoopGroup;
 import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
 import org.apache.tinkerpop.gremlin.server.Channelizer;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
-import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
 import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpBasicAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
@@ -48,7 +46,7 @@ public class HttpChannelizer extends AbstractChannelizer {
     private AbstractAuthenticationHandler authenticationHandler;
 
     @Override
-    public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
+    public void init(final ServerGremlinExecutor serverGremlinExecutor) {
         super.init(serverGremlinExecutor);
         httpGremlinEndpointHandler = new HttpGremlinEndpointHandler(serializers, gremlinExecutor, graphManager, settings);
     }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/NioChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/NioChannelizer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.server.channel;
 
-import io.netty.channel.EventLoopGroup;
 import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
 import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
 import org.apache.tinkerpop.gremlin.server.handler.GremlinResponseFrameEncoder;
@@ -46,7 +45,7 @@ public class NioChannelizer extends AbstractChannelizer {
     private NioGremlinResponseFrameEncoder nioGremlinResponseFrameEncoder;
 
     @Override
-    public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
+    public void init(final ServerGremlinExecutor serverGremlinExecutor) {
         super.init(serverGremlinExecutor);
 
         // configure authentication - null means don't bother to add authentication to the pipeline

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.server.channel;
 
-import io.netty.channel.EventLoopGroup;
 import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
 import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
 import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
@@ -57,7 +56,7 @@ public class WebSocketChannelizer extends AbstractChannelizer {
     private AbstractAuthenticationHandler authenticationHandler;
 
     @Override
-    public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
+    public void init(final ServerGremlinExecutor serverGremlinExecutor) {
         super.init(serverGremlinExecutor);
 
         gremlinResponseFrameEncoder = new GremlinResponseFrameEncoder();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-999

Pretty simple - I probably could have CTR'd this but since it was a breaking change on 3.3.0 I wanted folks to be more aware of it in case someone was using this class in some way I'm not imagining.

Builds with `mvn clean install -DskipTests && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1