### PR TITLE
TINKERPOP-1669: EdgeVertexStep should be designed for extension

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
+* `EdgeVertexStep` is no longer final and can be extended by providers.
 * Fixed `HADOOP_GREMLIN_LIBS` parsing for Windows.
 * Improved GraphSON serialization performance around `VertexProperty`.
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
@@ -35,7 +35,7 @@ import java.util.Set;
  */
 public class EdgeVertexStep extends FlatMapStep<Edge, Vertex> implements AutoCloseable {
 
-    private Direction direction;
+    protected Direction direction;
 
     public EdgeVertexStep(final Traversal.Admin traversal, final Direction direction) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeVertexStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class EdgeVertexStep extends FlatMapStep<Edge, Vertex> implements AutoCloseable {
+public class EdgeVertexStep extends FlatMapStep<Edge, Vertex> implements AutoCloseable {
 
     private Direction direction;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1669

`EdgeVertexStep` is no longer final and can be extended by providers.

VOTE +1.