### PR TITLE
TINKERPOP-1703: Make EdgeOtherVertexStep non-final

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
 * Added annotations to the traversal metrics pretty print.
+* `EdgeOtherVertexStep` is no longer final and can be extended by providers.
 * `EdgeVertexStep` is no longer final and can be extended by providers.
 * Fixed `HADOOP_GREMLIN_LIBS` parsing for Windows.
 * Improved GraphSON serialization performance around `VertexProperty`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeOtherVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/EdgeOtherVertexStep.java
@@ -32,7 +32,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class EdgeOtherVertexStep extends MapStep<Edge, Vertex> {
+public class EdgeOtherVertexStep extends MapStep<Edge, Vertex> {
 
     public EdgeOtherVertexStep(final Traversal.Admin traversal) {
         super(traversal);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1703

The ticket really is about making {{EdgeOtherVertexStep}} non-final so providers, like DSEGraph, can extend it accordingly.

Simple fix.

**SIDENOTE**: @dkuppitz -- I wonder if there is a more efficient way to implement this step. I looked into using `Path.get(i)`, but it seems while it makes less data, it is more expensive to execute (at least for `ImmutablePath`).

VOTE +1.