### PR TITLE
TINKERPOP-1704: XXXTranslators are not being respective of BulkSet and Tree.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
+* `JavaTranslator` is now smart about handling `BulkSet` and `Tree`.
 * Added annotations to the traversal metrics pretty print.
 * `EdgeVertexStep` is no longer final and can be extended by providers.
 * Fixed `HADOOP_GREMLIN_LIBS` parsing for Windows.

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
@@ -135,7 +135,7 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
                         append(convertToString(entry.getValue())).
                         append("),");
             }
-            map.deleteCharAt(map.length()-1);
+            map.deleteCharAt(map.length() - 1);
             return map.append("]").toString();
         } else if (object instanceof Long)
             return object + "L";


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1704

`JavaTranslator` would convert `Tree` to `HashMap` and `BulkSet` to `HashSet`. While passing in such objects through `Bytecode` is low probability, it is still good to cover this corner case (especially for `Tree`, where the semantics are a bit different than `Map`).

VOTE +1