### PR TITLE
TINKERPOP-1701: HaltedTraverserStrategy should recurse into collections for detachment.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
@@ -19,6 +19,8 @@
 package org.apache.tinkerpop.gremlin.structure.util.detached;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
@@ -86,6 +88,12 @@ public class DetachedFactory {
                 list.add(DetachedFactory.detach(item, withProperties));
             }
             return (D) list;
+        } else if (object instanceof BulkSet) {
+            final BulkSet set = new BulkSet();
+            for (Map.Entry<Object, Long> entry : ((BulkSet<Object>) object).asBulk().entrySet()) {
+                set.add(DetachedFactory.detach(entry.getKey(),withProperties),entry.getValue());
+            }
+            return (D) set;
         } else if (object instanceof Set) {
             final Set set = object instanceof LinkedHashSet ? new LinkedHashSet() : new HashSet();
             for (final Object item : (Set) object) {
@@ -93,7 +101,7 @@ public class DetachedFactory {
             }
             return (D) set;
         } else if (object instanceof Map) {
-            final Map map = object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
+            final Map map = object instanceof Tree ? new Tree() : object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
             for (final Map.Entry<Object, Object> entry : ((Map<Object, Object>) object).entrySet()) {
                 map.put(DetachedFactory.detach(entry.getKey(), withProperties), DetachedFactory.detach(entry.getValue(), withProperties));
             }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
@@ -83,7 +83,7 @@ public class DetachedFactory {
         } else if (object instanceof Path) {
             return (D) DetachedFactory.detach((Path) object, withProperties);
         } else if (object instanceof List) {
-            final List list = new ArrayList();
+            final List list = new ArrayList(((List) object).size());
             for (final Object item : (List) object) {
                 list.add(DetachedFactory.detach(item, withProperties));
             }
@@ -95,13 +95,18 @@ public class DetachedFactory {
             }
             return (D) set;
         } else if (object instanceof Set) {
-            final Set set = object instanceof LinkedHashSet ? new LinkedHashSet() : new HashSet();
+            final Set set = object instanceof LinkedHashSet ?
+                    new LinkedHashSet(((Set) object).size()) :
+                    new HashSet(((Set) object).size());
             for (final Object item : (Set) object) {
                 set.add(DetachedFactory.detach(item, withProperties));
             }
             return (D) set;
         } else if (object instanceof Map) {
-            final Map map = object instanceof Tree ? new Tree() : object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
+            final Map map = object instanceof Tree ? new Tree() :
+                    object instanceof LinkedHashMap ?
+                            new LinkedHashMap(((Map) object).size()) :
+                            new HashMap(((Map) object).size());
             for (final Map.Entry<Object, Object> entry : ((Map<Object, Object>) object).entrySet()) {
                 map.put(DetachedFactory.detach(entry.getKey(), withProperties), DetachedFactory.detach(entry.getValue(), withProperties));
             }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
@@ -91,7 +91,7 @@ public class DetachedFactory {
         } else if (object instanceof BulkSet) {
             final BulkSet set = new BulkSet();
             for (Map.Entry<Object, Long> entry : ((BulkSet<Object>) object).asBulk().entrySet()) {
-                set.add(DetachedFactory.detach(entry.getKey(),withProperties),entry.getValue());
+                set.add(DetachedFactory.detach(entry.getKey(), withProperties), entry.getValue());
             }
             return (D) set;
         } else if (object instanceof Set) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactory.java
@@ -25,6 +25,15 @@ import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
@@ -71,6 +80,24 @@ public class DetachedFactory {
             return (D) DetachedFactory.detach((Property) object);
         } else if (object instanceof Path) {
             return (D) DetachedFactory.detach((Path) object, withProperties);
+        } else if (object instanceof List) {
+            final List list = new ArrayList();
+            for (final Object item : (List) object) {
+                list.add(DetachedFactory.detach(item, withProperties));
+            }
+            return (D) list;
+        } else if (object instanceof Set) {
+            final Set set = object instanceof LinkedHashSet ? new LinkedHashSet() : new HashSet();
+            for (final Object item : (Set) object) {
+                set.add(DetachedFactory.detach(item, withProperties));
+            }
+            return (D) set;
+        } else if (object instanceof Map) {
+            final Map map = object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
+            for (final Map.Entry<Object, Object> entry : ((Map<Object, Object>) object).entrySet()) {
+                map.put(DetachedFactory.detach(entry.getKey(), withProperties), DetachedFactory.detach(entry.getValue(), withProperties));
+            }
+            return (D) map;
         } else {
             return (D) object;
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactory.java
@@ -25,6 +25,15 @@ import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
@@ -71,6 +80,24 @@ public class ReferenceFactory {
             return (D) ReferenceFactory.detach((Property) object);
         } else if (object instanceof Path) {
             return (D) ReferenceFactory.detach((Path) object);
+        } else if (object instanceof List) {
+            final List list = new ArrayList();
+            for (final Object item : (List) object) {
+                list.add(ReferenceFactory.detach(item));
+            }
+            return (D) list;
+        } else if (object instanceof Set) {
+            final Set set = object instanceof LinkedHashSet ? new LinkedHashSet() : new HashSet();
+            for (final Object item : (Set) object) {
+                set.add(ReferenceFactory.detach(item));
+            }
+            return (D) set;
+        } else if (object instanceof Map) {
+            final Map map = object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
+            for (final Map.Entry<Object, Object> entry : ((Map<Object, Object>) object).entrySet()) {
+                map.put(ReferenceFactory.detach(entry.getKey()), ReferenceFactory.detach(entry.getValue()));
+            }
+            return (D) map;
         } else {
             return (D) object;
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactory.java
@@ -19,6 +19,8 @@
 package org.apache.tinkerpop.gremlin.structure.util.reference;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
@@ -86,6 +88,12 @@ public class ReferenceFactory {
                 list.add(ReferenceFactory.detach(item));
             }
             return (D) list;
+        } else if (object instanceof BulkSet) {
+            final BulkSet set = new BulkSet();
+            for (Map.Entry<Object, Long> entry : ((BulkSet<Object>) object).asBulk().entrySet()) {
+                set.add(ReferenceFactory.detach(entry.getKey()), entry.getValue());
+            }
+            return (D) set;
         } else if (object instanceof Set) {
             final Set set = object instanceof LinkedHashSet ? new LinkedHashSet() : new HashSet();
             for (final Object item : (Set) object) {
@@ -93,7 +101,7 @@ public class ReferenceFactory {
             }
             return (D) set;
         } else if (object instanceof Map) {
-            final Map map = object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
+            final Map map = object instanceof Tree ? new Tree() : object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
             for (final Map.Entry<Object, Object> entry : ((Map<Object, Object>) object).entrySet()) {
                 map.put(ReferenceFactory.detach(entry.getKey()), ReferenceFactory.detach(entry.getValue()));
             }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactory.java
@@ -83,7 +83,7 @@ public class ReferenceFactory {
         } else if (object instanceof Path) {
             return (D) ReferenceFactory.detach((Path) object);
         } else if (object instanceof List) {
-            final List list = new ArrayList();
+            final List list = new ArrayList(((List) object).size());
             for (final Object item : (List) object) {
                 list.add(ReferenceFactory.detach(item));
             }
@@ -95,13 +95,18 @@ public class ReferenceFactory {
             }
             return (D) set;
         } else if (object instanceof Set) {
-            final Set set = object instanceof LinkedHashSet ? new LinkedHashSet() : new HashSet();
+            final Set set = object instanceof LinkedHashSet ?
+                    new LinkedHashSet(((Set) object).size()) :
+                    new HashSet(((Set) object).size());
             for (final Object item : (Set) object) {
                 set.add(ReferenceFactory.detach(item));
             }
             return (D) set;
         } else if (object instanceof Map) {
-            final Map map = object instanceof Tree ? new Tree() : object instanceof LinkedHashMap ? new LinkedHashMap() : new HashMap();
+            final Map map = object instanceof Tree ? new Tree() :
+                    object instanceof LinkedHashMap ?
+                            new LinkedHashMap(((Map) object).size()) :
+                            new HashMap(((Map) object).size());
             for (final Map.Entry<Object, Object> entry : ((Map<Object, Object>) object).entrySet()) {
                 map.put(ReferenceFactory.detach(entry.getKey()), ReferenceFactory.detach(entry.getValue()));
             }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
@@ -189,38 +189,33 @@ public class ReferenceVertexTest extends AbstractGremlinTest {
         final List<Vertex> vertices = ReferenceFactory.detach(g.V().hasLabel("software").fold().next());
         for (final Vertex v : vertices) {
             assertTrue(v instanceof ReferenceVertex);
-            assertEquals("java", v.value("lang"));
         }
         // double nested list
         final List<List<Vertex>> lists = ReferenceFactory.detach(g.V().hasLabel("software").fold().fold().next());
         for (final Vertex v : lists.get(0)) {
             assertTrue(v instanceof ReferenceVertex);
-            assertEquals("java", v.value("lang"));
         }
         // double nested list to set
         final Set<List<Vertex>> set = ReferenceFactory.detach(g.V().hasLabel("software").fold().toSet());
         for (final Vertex v : set.iterator().next()) {
             assertTrue(v instanceof ReferenceVertex);
-            assertEquals("java", v.value("lang"));
         }
         // map keys and values
         Map<Vertex, List<Edge>> map = ReferenceFactory.detach(g.V().hasLabel("software").group().by().by(inE().fold()).next());
         for (final Map.Entry<Vertex, List<Edge>> entry : map.entrySet()) {
             assertTrue(entry.getKey() instanceof ReferenceVertex);
-            assertEquals("java", entry.getKey().value("lang"));
             for (final Edge edge : entry.getValue()) {
                 assertTrue(edge instanceof ReferenceEdge);
-                assertTrue(edge.property("weight").isPresent());
+                assertFalse(edge.property("weight").isPresent());
             }
         }
         // map keys and values as sideEffect
         map = ReferenceFactory.detach(g.V().hasLabel("software").group("m").by().by(inE().fold()).identity().cap("m").next());
         for (final Map.Entry<Vertex, List<Edge>> entry : map.entrySet()) {
             assertTrue(entry.getKey() instanceof ReferenceVertex);
-            assertEquals("java", entry.getKey().value("lang"));
             for (final Edge edge : entry.getValue()) {
                 assertTrue(edge instanceof ReferenceEdge);
-                assertTrue(edge.property("weight").isPresent());
+                assertFalse(edge.property("weight").isPresent());
             }
         }
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
@@ -23,17 +23,23 @@ import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.inE;
 import static org.junit.Assert.*;
 
 /**
@@ -170,5 +176,52 @@ public class ReferenceVertexTest extends AbstractGremlinTest {
     public void shouldNotHaveAnyVertices() {
         final ReferenceVertex rv = ReferenceFactory.detach(g.V(convertToVertexId("marko")).next());
         assertFalse(rv.vertices(Direction.BOTH).hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+    @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
+    public void shouldDetachCollections() {
+        // single element
+        final Vertex vertex = ReferenceFactory.detach(g.V().has("name", "marko").next());
+        assertTrue(vertex instanceof ReferenceVertex);
+        // list nest
+        final List<Vertex> vertices = ReferenceFactory.detach(g.V().hasLabel("software").fold().next());
+        for (final Vertex v : vertices) {
+            assertTrue(v instanceof ReferenceVertex);
+            assertEquals("java", v.value("lang"));
+        }
+        // double nested list
+        final List<List<Vertex>> lists = ReferenceFactory.detach(g.V().hasLabel("software").fold().fold().next());
+        for (final Vertex v : lists.get(0)) {
+            assertTrue(v instanceof ReferenceVertex);
+            assertEquals("java", v.value("lang"));
+        }
+        // double nested list to set
+        final Set<List<Vertex>> set = ReferenceFactory.detach(g.V().hasLabel("software").fold().toSet());
+        for (final Vertex v : set.iterator().next()) {
+            assertTrue(v instanceof ReferenceVertex);
+            assertEquals("java", v.value("lang"));
+        }
+        // map keys and values
+        Map<Vertex, List<Edge>> map = ReferenceFactory.detach(g.V().hasLabel("software").group().by().by(inE().fold()).next());
+        for (final Map.Entry<Vertex, List<Edge>> entry : map.entrySet()) {
+            assertTrue(entry.getKey() instanceof ReferenceVertex);
+            assertEquals("java", entry.getKey().value("lang"));
+            for (final Edge edge : entry.getValue()) {
+                assertTrue(edge instanceof ReferenceEdge);
+                assertTrue(edge.property("weight").isPresent());
+            }
+        }
+        // map keys and values as sideEffect
+        map = ReferenceFactory.detach(g.V().hasLabel("software").group("m").by().by(inE().fold()).identity().cap("m").next());
+        for (final Map.Entry<Vertex, List<Edge>> entry : map.entrySet()) {
+            assertTrue(entry.getKey() instanceof ReferenceVertex);
+            assertEquals("java", entry.getKey().value("lang"));
+            for (final Edge edge : entry.getValue()) {
+                assertTrue(edge instanceof ReferenceEdge);
+                assertTrue(edge.property("weight").isPresent());
+            }
+        }
     }
 }

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializerIntegrateTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializerIntegrateTest.java
@@ -72,7 +72,7 @@ public class GryoSerializerIntegrateTest extends AbstractSparkTest {
         Graph graph = GraphFactory.open(configuration);
         final GraphTraversal.Admin<Vertex, Map<Vertex, Collection<Vertex>>> traversal = graph.traversal().withComputer(SparkGraphComputer.class).V().group("m").<Map<Vertex, Collection<Vertex>>>cap("m").asAdmin();
         assertTrue(traversal.hasNext());
-        assertTrue(traversal.next() == traversal.getSideEffects().get("m"));
+        assertEquals(traversal.next(), traversal.getSideEffects().get("m"));
         assertFalse(traversal.hasNext());
         assertTrue(traversal.getSideEffects().exists("m"));
         assertTrue(traversal.getSideEffects().get("m") instanceof Map);

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/HaltedTraverserStrategyTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/HaltedTraverserStrategyTest.java
@@ -76,6 +76,8 @@ public class HaltedTraverserStrategyTest {
         g.V().out().out().path().forEachRemaining(path -> assertEquals(DetachedPath.class, path.getClass()));
         g.V().out().pageRank().forEachRemaining(vertex -> assertEquals(DetachedVertex.class, vertex.getClass()));
         g.V().out().pageRank().out().forEachRemaining(vertex -> assertEquals(DetachedVertex.class, vertex.getClass()));
+        // should handle nested collections
+        g.V().out().fold().next().forEach(vertex -> assertEquals(DetachedVertex.class, vertex.getClass()));
     }
 
     @Test
@@ -104,6 +106,8 @@ public class HaltedTraverserStrategyTest {
         g.V().out().out().path().forEachRemaining(path -> assertEquals(ReferencePath.class, path.getClass()));
         g.V().out().pageRank().forEachRemaining(vertex -> assertEquals(ReferenceVertex.class, vertex.getClass()));
         g.V().out().pageRank().out().forEachRemaining(vertex -> assertEquals(ReferenceVertex.class, vertex.getClass()));
+        // should handle nested collections
+        g.V().out().fold().next().forEach(vertex -> assertEquals(ReferenceVertex.class, vertex.getClass()));
     }
 
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1701

`HaltedTraverserStrategy` is used by serializing systems (e.g. GremlinServer, OLAP) to decide how to format the result set. For instance, are the objects `DetachedXXX` or `ReferenceXXX`. In order to make this functionality generalized to objects within collections, `DetachedFactory` and `ReferenceFactory` were updated to handle `Tree`, `Map`, `BulkSet`, `Set`,  and `List` (in any arbitrarily nested configuration). Test cases added, and stuff passes.

VOTE +1.