### PR TITLE
TINKERPOP-1710: Add a note on tree() by-modulation and uniqueness of tree branches.

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2283,6 +2283,20 @@ tree['marko']['josh']
 tree.getObjectsAtDepth(3)
 ----
 
+Note that when using `by()`-modulation, tree nodes are combined based on projection uniqueness, not on the
+uniqueness of the original objects being projected. For instance:
+
+[gremlin-groovy,modern]
+----
+g.V().has('name','josh').out('created').values('name').tree() <1>
+g.V().has('name','josh').out('created').values('name').
+  tree().by('name').by(label).by() <2>
+----
+
+<1> When the `tree()` is created, vertex 3 and 5 are unique and thus, form unique branches in the tree structure.
+<2> When the `tree()` is `by()`-modulated by `label`, then vertex 3 and 5 are both "software" and thus are merged to a single node in the tree.
+
+
 [[unfold-step]]
 Unfold Step
 ~~~~~~~~~~~


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1710

There was confusion as to what should happen what `tree()` sees duplicate objects in the same depth of the tree. The behavior is as expected and not a "bug." Tree is constructed using path objects that are "horizontally" linked. If two objects are the same at the same depth, then they are merged into one none in the tree data structure.

VOTE +1