### PR TITLE
TINKERPOP-1289: Remove deprecated ConnectiveP, AndP, and OrP constructors.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Removed previously deprecated `ConnectiveP`, `AndP`, `OrP` constructors.
 * Graphite and Ganglia are no longer packaged with the Gremlin Server distribution.
 * `TransactionException` is no longer a class of `AbstractTransaction` and it extends `RuntimeException`.
 * Included an ellipse on long property names that are truncated.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -202,6 +202,9 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.jsr223.SingleGremlinScriptEngineManager#getInstance()`
 ** `org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineManager#addModule(GremlinModule)`
 ** `org.apache.tinkerpop.gremlin.jsr223.console.PluginAcceptor`
+** `org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP(P...)`
+** `org.apache.tinkerpop.gremlin.process.traversal.util.AndP(P...)`
+** `org.apache.tinkerpop.gremlin.process.traversal.util.OrP(P...)`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#supportsAddProperty()`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#FEATURE_ADD_PROPERTY`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.OptIn#SUITE_GROOVY_PROCESS_STANDARD`

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/AndP.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/AndP.java
@@ -40,14 +40,6 @@ public final class AndP<V> extends ConnectiveP<V> {
         this.biPredicate = new AndBiPredicate(this);
     }
 
-    @Deprecated
-    /**
-     * @deprecated As of release 3.2.0-incubating, replaced by {@link AndP(List)}
-     */
-    public AndP(final P<V>... predicates) {
-        this(Arrays.asList(predicates));
-    }
-
     @Override
     public P<V> and(final Predicate<? super V> predicate) {
         if (!(predicate instanceof P))

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ConnectiveP.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ConnectiveP.java
@@ -39,14 +39,6 @@ public abstract class ConnectiveP<V> extends P<V> {
             throw new IllegalArgumentException("The provided " + this.getClass().getSimpleName() + " array must have at least two arguments: " + predicates.size());
     }
 
-    @Deprecated
-    /**
-     * @deprecated As of release 3.2.0-incubating, replaced by {@link ConnectiveP(List)}
-     */
-    public ConnectiveP(final P<V>... predicates) {
-        this(Arrays.asList(predicates));
-    }
-
     public List<P<V>> getPredicates() {
         return Collections.unmodifiableList(this.predicates);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/OrP.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/OrP.java
@@ -40,14 +40,6 @@ public final class OrP<V> extends ConnectiveP<V> {
         this.biPredicate = new OrBiPredicate(this);
     }
 
-    @Deprecated
-    /**
-     * @deprecated As of release 3.2.0-incubating, replaced by {@link OrP(List)}
-     */
-    public OrP(final P<V>... predicates) {
-        this(Arrays.asList(predicates));
-    }
-
     @Override
     public P<V> or(final Predicate<? super V> predicate) {
         if (!(predicate instanceof P))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1289

Removed deprecated constructors. (for TinkerPop 3.3.0).

VOTE +1