### PR TITLE
TINKERPOP-832: Remove deprecated addV/E/InE/OutE methods

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Removed previously deprecated `GraphTraversal#addV(Object...)`
+* Removed previously deprecated `GraphTraversal#addE(Direction, String, String, Object...)`
+* Removed previously deprecated `GraphTraversal#addOutE(String, String, Object...)`
+* Removed previously deprecated `GraphTraversal#addInV(String, String, Object...)`
 * Removed previously deprecated `TraversalSource.Builder` class.
 * Removed previously deprecated `ConnectiveP`, `AndP`, `OrP` constructors.
 * Removed previously deprecated `TraversalScriptFunction` class.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -308,7 +308,8 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-1612[TINKERPOP-1612],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1622[TINKERPOP-1622],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1651[TINKERPOP-1651],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1694[TINKERPOP-1694],
-link:https://issues.apache.org/jira/browse/TINKERPOP-1700[TINKERPOP-1700]
+link:https://issues.apache.org/jira/browse/TINKERPOP-1700[TINKERPOP-1700],
+link:https://issues.apache.org/jira/browse/TINKERPOP-832[TINKERPOP-832]
 
 Gremlin-server.sh and Init Scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -211,6 +211,10 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.OrP(P...)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptFunction`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper`
+** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#addV(Object...)`
+** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#addE(Direction, String, String, Object...)`
+** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#addOutE(String, String, Object...)`
+** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#addInV(String, String, Object...)`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#supportsAddProperty()`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#FEATURE_ADD_PROPERTY`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.OptIn#SUITE_GROOVY_PROCESS_STANDARD`

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -1025,19 +1025,6 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     /**
-     * @since 3.0.0-incubating
-     * @deprecated As of release 3.1.0, replaced by {@link #addV()}
-     */
-    @Deprecated
-    public default GraphTraversal<S, Vertex> addV(final Object... propertyKeyValues) {
-        this.addV();
-        for (int i = 0; i < propertyKeyValues.length; i = i + 2) {
-            this.property(propertyKeyValues[i], propertyKeyValues[i + 1]);
-        }
-        return (GraphTraversal<S, Vertex>) this;
-    }
-
-    /**
      * Adds an {@link Edge} with the specified edge label.
      *
      * @param edgeLabel the label of the newly added edge
@@ -1106,59 +1093,6 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         this.asAdmin().getBytecode().addStep(Symbols.from, fromVertex);
         ((FromToModulating) this.asAdmin().getEndStep()).addFrom(fromVertex.asAdmin());
         return this;
-    }
-
-    /**
-     * @since 3.0.0-incubating
-     * @deprecated As of release 3.1.0, replaced by {@link #addE(String)}
-     */
-    @Deprecated
-    public default GraphTraversal<S, Edge> addE(final Direction direction, final String firstVertexKeyOrEdgeLabel, final String edgeLabelOrSecondVertexKey, final Object... propertyKeyValues) {
-        if (propertyKeyValues.length % 2 == 0) {
-            // addOutE("createdBy", "a")
-            this.addE(firstVertexKeyOrEdgeLabel);
-            if (direction.equals(Direction.OUT))
-                this.to(edgeLabelOrSecondVertexKey);
-            else
-                this.from(edgeLabelOrSecondVertexKey);
-
-            for (int i = 0; i < propertyKeyValues.length; i = i + 2) {
-                this.property(propertyKeyValues[i], propertyKeyValues[i + 1]);
-            }
-            //((Mutating) this.asAdmin().getEndStep()).addPropertyMutations(propertyKeyValues);
-            return (GraphTraversal<S, Edge>) this;
-        } else {
-            // addInE("a", "codeveloper", "b", "year", 2009)
-            this.addE(edgeLabelOrSecondVertexKey);
-            if (direction.equals(Direction.OUT))
-                this.from(firstVertexKeyOrEdgeLabel).to((String) propertyKeyValues[0]);
-            else
-                this.to(firstVertexKeyOrEdgeLabel).from((String) propertyKeyValues[0]);
-
-            for (int i = 1; i < propertyKeyValues.length; i = i + 2) {
-                this.property(propertyKeyValues[i], propertyKeyValues[i + 1]);
-            }
-            //((Mutating) this.asAdmin().getEndStep()).addPropertyMutations(Arrays.copyOfRange(propertyKeyValues, 1, propertyKeyValues.length));
-            return (GraphTraversal<S, Edge>) this;
-        }
-    }
-
-    /**
-     * @since 3.0.0-incubating
-     * @deprecated As of release 3.1.0, replaced by {@link #addE(String)}
-     */
-    @Deprecated
-    public default GraphTraversal<S, Edge> addOutE(final String firstVertexKeyOrEdgeLabel, final String edgeLabelOrSecondVertexKey, final Object... propertyKeyValues) {
-        return this.addE(Direction.OUT, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);
-    }
-
-    /**
-     * @since 3.0.0-incubating
-     * @deprecated As of release 3.1.0, replaced by {@link #addE(String)}
-     */
-    @Deprecated
-    public default GraphTraversal<S, Edge> addInE(final String firstVertexKeyOrEdgeLabel, final String edgeLabelOrSecondVertexKey, final Object... propertyKeyValues) {
-        return this.addE(Direction.IN, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);
     }
 
     ///////////////////// FILTER STEPS /////////////////////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -259,27 +259,6 @@ public class GraphTraversalSource implements TraversalSource {
 
     //// SPAWNS
 
-    /**
-     * @deprecated As of release 3.1.0, replaced by {@link #addV()}
-     */
-    @Deprecated
-    public GraphTraversal<Vertex, Vertex> addV(final Object... keyValues) {
-        ElementHelper.legalPropertyKeyValueArray(keyValues);
-        if (keyValues.length != 0 && keyValues[0].equals(T.label)) {
-            final GraphTraversal<Vertex, Vertex> traversal = this.addV(keyValues[1].toString());
-            for (int i = 2; i < keyValues.length; i = i + 2) {
-                traversal.property(keyValues[i], keyValues[i + 1]);
-            }
-            return traversal;
-        } else {
-            final GraphTraversal<Vertex, Vertex> traversal = this.addV();
-            for (int i = 0; i < keyValues.length; i = i + 2) {
-                traversal.property(keyValues[i], keyValues[i + 1]);
-            }
-            return traversal;
-        }
-    }
-
     public GraphTraversal<Vertex, Vertex> addV(final String label) {
         final GraphTraversalSource clone = this.clone();
         clone.bytecode.addStep(GraphTraversal.Symbols.addV, label);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -518,38 +518,6 @@ public class __ {
     }
 
     /**
-     * @see GraphTraversal#addV(Object...)
-     */
-    @Deprecated
-    public static <A> GraphTraversal<A, Vertex> addV(final Object... propertyKeyValues) {
-        return __.<A>start().addV(propertyKeyValues);
-    }
-
-    /**
-     * @see GraphTraversal#addE(Direction, String, String, Object...)
-     */
-    @Deprecated
-    public static <A> GraphTraversal<A, Edge> addE(final Direction direction, final String firstVertexKeyOrEdgeLabel, final String edgeLabelOrSecondVertexKey, final Object... propertyKeyValues) {
-        return __.<A>start().addE(direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);
-    }
-
-    /**
-     * @see GraphTraversal#addOutE(String, String, Object...)
-     */
-    @Deprecated
-    public static <A> GraphTraversal<A, Edge> addOutE(final String firstVertexKeyOrEdgeLabel, final String edgeLabelOrSecondVertexKey, final Object... propertyKeyValues) {
-        return __.<A>start().addOutE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);
-    }
-
-    /**
-     * @see GraphTraversal#addInE(String, String, Object...)
-     */
-    @Deprecated
-    public static <A> GraphTraversal<A, Edge> addInE(final String firstVertexKeyOrEdgeLabel, final String edgeLabelOrSecondVertexKey, final Object... propertyKeyValues) {
-        return __.<A>start().addInE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);
-    }
-
-    /**
      * @see GraphTraversal#addE(String)
      */
     public static <A> GraphTraversal<A, Edge> addE(final String edgeLabel) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyTest.java
@@ -48,7 +48,6 @@ public class EventStrategyTest {
                 {"addE(test).to(x)", new DefaultGraphTraversal<>(EmptyGraph.instance()).addE("test").to("x"), 1},
                 {"addE(test).to(x).property(this,that)", new DefaultGraphTraversal<>(EmptyGraph.instance()).addE("test").to("x").property("this", "that"), 1},
                 {"addV()", new DefaultGraphTraversal<>(EmptyGraph.instance()).addV(), 1},
-                {"addV(args)", new DefaultGraphTraversal<>(EmptyGraph.instance()).addV("test", "this"), 1},
                 {"addV().property(k,v)", new DefaultGraphTraversal<>(EmptyGraph.instance()).addV().property("test", "that"), 1},
                 {"properties().drop()", new DefaultGraphTraversal<>(EmptyGraph.instance()).properties().drop(), 1},
                 {"properties(k).drop()", new DefaultGraphTraversal<>(EmptyGraph.instance()).properties("test").drop(), 1},

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -128,14 +128,6 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("addE", *args)
         return self
 
-    def addInE(self, *args):
-        self.bytecode.add_step("addInE", *args)
-        return self
-
-    def addOutE(self, *args):
-        self.bytecode.add_step("addOutE", *args)
-        return self
-
     def addV(self, *args):
         self.bytecode.add_step("addV", *args)
         return self
@@ -540,14 +532,6 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).addE(*args)
 
     @classmethod
-    def addInE(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).addInE(*args)
-
-    @classmethod
-    def addOutE(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).addOutE(*args)
-
-    @classmethod
     def addV(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).addV(*args)
 
@@ -912,14 +896,6 @@ statics.add_static('V', V)
 def addE(*args):
     return __.addE(*args)
 statics.add_static('addE', addE)
-
-def addInE(*args):
-    return __.addInE(*args)
-statics.add_static('addInE', addInE)
-
-def addOutE(*args):
-    return __.addOutE(*args)
-statics.add_static('addOutE', addOutE)
 
 def addV(*args):
     return __.addV(*args)

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -985,7 +985,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final Client client = cluster.connect();
 
         // this line is important because it tests GraphTraversal which has a certain transactional path
-        final Vertex vertexRequest1 = client.submit("g.addV(\"name\",\"stephen\")").all().get().get(0).getVertex();
+        final Vertex vertexRequest1 = client.submit("g.addV().property(\"name\",\"stephen\")").all().get().get(0).getVertex();
         assertEquals("stephen", vertexRequest1.values("name").next());
 
         final Vertex vertexRequest2 = client.submit("graph.vertices().next()").all().get().get(0).getVertex();
@@ -1211,7 +1211,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final Client client = cluster.connect();
 
         try {
-            client.submit("g.addV('name','stephen')").all().get().get(0).getVertex();
+            client.submit("g.addV().property('name','stephen')").all().get().get(0).getVertex();
             fail("Should have tossed an exception because \"g\" is readonly in this context");
         } catch (Exception ex) {
             final Throwable root = ExceptionUtils.getRootCause(ex);
@@ -1222,11 +1222,11 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
         // keep the testing here until "rebind" is completely removed
         final Client clientLegacy = client.rebind("g1");
-        final Vertex vLegacy = clientLegacy.submit("g.addV('name','stephen')").all().get().get(0).getVertex();
+        final Vertex vLegacy = clientLegacy.submit("g.addV().property('name','stephen')").all().get().get(0).getVertex();
         assertEquals("stephen", vLegacy.value("name"));
 
         final Client clientAliased = client.alias("g1");
-        final Vertex v = clientAliased.submit("g.addV('name','jason')").all().get().get(0).getVertex();
+        final Vertex v = clientAliased.submit("g.addV().property('name','jason')").all().get().get(0).getVertex();
         assertEquals("jason", v.value("name"));
 
         cluster.close();
@@ -1267,7 +1267,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final Client client = cluster.connect(name.getMethodName());
 
         try {
-            client.submit("g.addV('name','stephen')").all().get().get(0).getVertex();
+            client.submit("g.addV().property('name','stephen')").all().get().get(0).getVertex();
             fail("Should have tossed an exception because \"g\" is readonly in this context");
         } catch (Exception ex) {
             final Throwable root = ExceptionUtils.getRootCause(ex);
@@ -1279,12 +1279,12 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         // keep the testing here until "rebind" is completely removed
         final Client clientLegacy = client.rebind("g1");
         assertEquals("stephen", clientLegacy.submit("n='stephen'").all().get().get(0).getString());
-        final Vertex vLegacy = clientLegacy.submit("g.addV('name',n)").all().get().get(0).getVertex();
+        final Vertex vLegacy = clientLegacy.submit("g.addV().property('name',n)").all().get().get(0).getVertex();
         assertEquals("stephen", vLegacy.value("name"));
 
         final Client clientAliased = client.alias("g1");
         assertEquals("jason", clientAliased.submit("n='jason'").all().get().get(0).getString());
-        final Vertex v = clientAliased.submit("g.addV('name',n)").all().get().get(0).getVertex();
+        final Vertex v = clientAliased.submit("g.addV().property('name',n)").all().get().get(0).getVertex();
         assertEquals("jason", v.value("name"));
 
         cluster.close();
@@ -1300,7 +1300,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final Client sessionWithoutManagedTx = cluster.connect(name.getMethodName() + "-not-managed");
 
         // this should auto-commit
-        final Vertex vStephen = sessionWithManagedTx.submit("v = g.addV('name','stephen').next()").all().get().get(0).getVertex();
+        final Vertex vStephen = sessionWithManagedTx.submit("v = g.addV().property('name','stephen').next()").all().get().get(0).getVertex();
         assertEquals("stephen", vStephen.value("name"));
 
         // the other clients should see that change because of auto-commit
@@ -1308,7 +1308,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         assertThat(sessionWithoutManagedTx.submit("g.V().has('name','stephen').hasNext()").all().get().get(0).getBoolean(), is(true));
 
         // this should NOT auto-commit
-        final Vertex vDaniel = sessionWithoutManagedTx.submit("v = g.addV('name','daniel').next()").all().get().get(0).getVertex();
+        final Vertex vDaniel = sessionWithoutManagedTx.submit("v = g.addV().property('name','daniel').next()").all().get().get(0).getVertex();
         assertEquals("daniel", vDaniel.value("name"));
 
         // the other clients should NOT see that change because of auto-commit

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
@@ -63,43 +63,6 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Edge> get_g_addV_asXfirstX_repeatXaddEXnextX_toXaddVX_inVX_timesX5X_addEXnextX_toXselectXfirstXX();
 
-    ///////
-
-    @Deprecated
-    public abstract Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_aX(final Object v1Id);
-
-    @Deprecated
-    public abstract Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_a_weight_2X(final Object v1Id);
-
-    @Deprecated
-    public abstract Traversal<Vertex, Edge> get_g_withSideEffectXx__g_V_toListX_addOutEXexistsWith_x_time_nowX();
-
-    @Deprecated
-    public abstract Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_selectXa_bX_addInEXa_codeveloper_b_year_2009X();
-
-    @Deprecated
-    public abstract Traversal<Vertex, Edge> get_g_V_asXaX_inXcreatedX_addInEXcreatedBy_a_year_2009_acl_publicX();
-
-    @Test
-    @LoadGraphWith(MODERN)
-    @Deprecated
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-    public void g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_aX() {
-        final Traversal<Vertex, Edge> traversal = get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_aX(convertToVertexId("marko"));
-        printTraversalForm(traversal);
-        int count = 0;
-        while (traversal.hasNext()) {
-            final Edge edge = traversal.next();
-            assertEquals("createdBy", edge.label());
-            assertEquals(0, IteratorUtils.count(edge.properties()));
-            count++;
-
-        }
-        assertEquals(1, count);
-        assertEquals(7, IteratorUtils.count(g.E()));
-        assertEquals(6, IteratorUtils.count(g.V()));
-    }
-
     @Test
     @LoadGraphWith(MODERN)
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
@@ -112,28 +75,6 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
             assertEquals("createdBy", edge.label());
             assertEquals(0, IteratorUtils.count(edge.properties()));
             count++;
-
-        }
-        assertEquals(1, count);
-        assertEquals(7, IteratorUtils.count(g.E()));
-        assertEquals(6, IteratorUtils.count(g.V()));
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
-    @Deprecated
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-    public void g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_a_weight_2X() {
-        final Traversal<Vertex, Edge> traversal = get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_a_weight_2X(convertToVertexId("marko"));
-        printTraversalForm(traversal);
-        int count = 0;
-        while (traversal.hasNext()) {
-            final Edge edge = traversal.next();
-            assertEquals("createdBy", edge.label());
-            assertEquals(2.0d, edge.<Number>value("weight").doubleValue(), 0.00001d);
-            assertEquals(1, IteratorUtils.count(edge.properties()));
-            count++;
-
 
         }
         assertEquals(1, count);
@@ -163,30 +104,6 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
     }
 
     @Test
-    @Ignore
-    @LoadGraphWith(MODERN)
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-    public void g_withSideEffectXx__g_V_toListX_addOutEXexistsWith_x_time_nowX() {
-        final Traversal<Vertex, Edge> traversal = get_g_withSideEffectXx__g_V_toListX_addOutEXexistsWith_x_time_nowX();
-        printTraversalForm(traversal);
-        int count = 0;
-        while (traversal.hasNext()) {
-            final Edge edge = traversal.next();
-            assertEquals("existsWith", edge.label());
-            assertEquals("now", edge.value("time"));
-            assertEquals(1, IteratorUtils.count(edge.properties()));
-            count++;
-        }
-        assertEquals(36, count);
-        assertEquals(42, IteratorUtils.count(g.E()));
-        for (final Vertex vertex : IteratorUtils.list(g.V())) {
-            assertEquals(6, IteratorUtils.count(vertex.edges(Direction.OUT, "existsWith")));
-            assertEquals(6, IteratorUtils.count(vertex.edges(Direction.IN, "existsWith")));
-        }
-        assertEquals(6, IteratorUtils.count(g.V()));
-    }
-
-    @Test
     @LoadGraphWith(MODERN)
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     public void g_V_aggregateXxX_asXaX_selectXxX_unfold_addEXexistsWithX_toXaX_propertyXtime_nowX() {
@@ -206,32 +123,6 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
             assertEquals(6, IteratorUtils.count(vertex.edges(Direction.OUT, "existsWith")));
             assertEquals(6, IteratorUtils.count(vertex.edges(Direction.IN, "existsWith")));
         }
-        assertEquals(6, IteratorUtils.count(g.V()));
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
-    @Deprecated
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-    public void g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_selectXa_bX_addInEXa_codeveloper_b_year_2009X() {
-        final Traversal<Vertex, Edge> traversal = get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_selectXa_bX_addInEXa_codeveloper_b_year_2009X();
-        printTraversalForm(traversal);
-        int count = 0;
-        while (traversal.hasNext()) {
-            final Edge edge = traversal.next();
-            assertEquals("codeveloper", edge.label());
-            assertEquals(2009, (int) edge.value("year"));
-            assertEquals(1, IteratorUtils.count(edge.properties()));
-            assertEquals("person", edge.inVertex().label());
-            assertEquals("person", edge.outVertex().label());
-            assertFalse(edge.inVertex().value("name").equals("vadas"));
-            assertFalse(edge.outVertex().value("name").equals("vadas"));
-            assertFalse(edge.inVertex().equals(edge.outVertex()));
-            count++;
-
-        }
-        assertEquals(6, count);
-        assertEquals(12, IteratorUtils.count(g.E()));
         assertEquals(6, IteratorUtils.count(g.V()));
     }
 
@@ -257,32 +148,6 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         }
         assertEquals(6, count);
         assertEquals(12, IteratorUtils.count(g.E()));
-        assertEquals(6, IteratorUtils.count(g.V()));
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
-    @Deprecated
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-    public void g_V_asXaX_inXcreatedX_addInEXcreatedBy_a_year_2009_acl_publicX() {
-        final Traversal<Vertex, Edge> traversal = get_g_V_asXaX_inXcreatedX_addInEXcreatedBy_a_year_2009_acl_publicX();
-        printTraversalForm(traversal);
-        int count = 0;
-        while (traversal.hasNext()) {
-            final Edge edge = traversal.next();
-            assertEquals("createdBy", edge.label());
-            assertEquals(2009, (int) edge.value("year"));
-            assertEquals("public", edge.value("acl"));
-            assertEquals(2, IteratorUtils.count(edge.properties()));
-            assertEquals("person", edge.inVertex().label());
-            assertEquals("software", edge.outVertex().label());
-            if (edge.outVertex().value("name").equals("ripple"))
-                assertEquals("josh", edge.inVertex().value("name"));
-            count++;
-
-        }
-        assertEquals(4, count);
-        assertEquals(10, IteratorUtils.count(g.E()));
         assertEquals(6, IteratorUtils.count(g.V()));
     }
 
@@ -352,33 +217,6 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_inXcreatedX_addEXcreatedByX_fromXaX_propertyXyear_2009X_propertyXacl_publicX() {
             return g.V().as("a").in("created").addE("createdBy").from("a").property("year", 2009).property("acl", "public");
-        }
-
-        ///////
-
-        @Override
-        public Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_aX(final Object v1Id) {
-            return g.V(v1Id).as("a").out("created").addOutE("createdBy", "a");
-        }
-
-        @Override
-        public Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_a_weight_2X(final Object v1Id) {
-            return g.V(v1Id).as("a").out("created").addOutE("createdBy", "a", "weight", 2.0d);
-        }
-
-        @Override
-        public Traversal<Vertex, Edge> get_g_withSideEffectXx__g_V_toListX_addOutEXexistsWith_x_time_nowX() {
-            return g.withSideEffect("x", g.V().toList()).V().addOutE("existsWith", "x", "time", "now");
-        }
-
-        @Override
-        public Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_selectXa_bX_addInEXa_codeveloper_b_year_2009X() {
-            return g.V().as("a").out("created").in("created").where(P.neq("a")).as("b").select("a", "b").addInE("a", "codeveloper", "b", "year", 2009);
-        }
-
-        @Override
-        public Traversal<Vertex, Edge> get_g_V_asXaX_inXcreatedX_addInEXcreatedBy_a_year_2009_acl_publicX() {
-            return g.V().as("a").in("created").addInE("createdBy", "a", "year", 2009, "acl", "public");
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexTest.java
@@ -72,13 +72,6 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
 
     public abstract Traversal<Vertex, String> get_g_withSideEffectXa_markoX_addV_propertyXname_selectXaXX_name();
 
-    // 3.0.0 DEPRECATIONS
-    @Deprecated
-    public abstract Traversal<Vertex, Vertex> get_g_V_addVXlabel_animal_age_0X();
-
-    @Deprecated
-    public abstract Traversal<Vertex, Vertex> get_g_addVXlabel_person_name_stephenX();
-
     @Test
     @LoadGraphWith(MODERN)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
@@ -253,40 +246,6 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY)
-    public void g_V_addVXlabel_animal_age_0X() {
-        final Traversal<Vertex, Vertex> traversal = get_g_V_addVXlabel_animal_age_0X();
-        printTraversalForm(traversal);
-        int count = 0;
-        while (traversal.hasNext()) {
-            final Vertex vertex = traversal.next();
-            assertEquals("animal", vertex.label());
-            assertEquals(0, vertex.<Integer>value("age").intValue());
-            count++;
-        }
-        assertEquals(6, count);
-        assertEquals(12, IteratorUtils.count(g.V()));
-
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY)
-    public void g_addVXlabel_person_name_stephenX() {
-        final Traversal<Vertex, Vertex> traversal = get_g_addVXlabel_person_name_stephenX();
-        printTraversalForm(traversal);
-        final Vertex stephen = traversal.next();
-        assertFalse(traversal.hasNext());
-        assertEquals("person", stephen.label());
-        assertEquals("stephen", stephen.value("name"));
-        assertEquals(1, IteratorUtils.count(stephen.properties()));
-        assertEquals(7, IteratorUtils.count(g.V()));
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY)
     public void g_withSideEffectXa_testX_V_hasLabelXsoftwareX_propertyXtemp_selectXaXX_valueMapXname_tempX() {
         final Traversal<Vertex, Map<String, List<String>>> traversal = get_g_withSideEffectXa_testX_V_hasLabelXsoftwareX_propertyXtemp_selectXaXX_valueMapXname_tempX();
@@ -360,16 +319,6 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_addVXanimalX_propertyXname_valuesXnameXX_propertyXname_an_animalX_propertyXvaluesXnameX_labelX() {
             return g.V().addV("animal").property("name", __.values("name")).property("name", "an animal").property(__.values("name"), __.label());
-        }
-
-        @Override
-        public Traversal<Vertex, Vertex> get_g_V_addVXlabel_animal_age_0X() {
-            return g.V().addV(T.label, "animal", "age", 0);
-        }
-
-        @Override
-        public Traversal<Vertex, Vertex> get_g_addVXlabel_person_name_stephenX() {
-            return g.addV(T.label, "person", "name", "stephen");
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategyProcessTest.java
@@ -148,7 +148,7 @@ public class ElementIdStrategyProcessTest extends AbstractGremlinProcessTest {
         sg.addV().next();
         assertEquals(1, IteratorUtils.count(sg.V()));
 
-        final Vertex v = sg.V().addV(T.id, "STEPHEN", "name", "stephen").next();
+        final Vertex v = sg.V().addV().property(T.id, "STEPHEN").property("name", "stephen").next();
         assertEquals("stephen", v.value("name"));
         assertEquals("STEPHEN", sg.V(v).id().next());
         assertEquals("STEPHEN", sg.V("STEPHEN").id().next());
@@ -160,7 +160,7 @@ public class ElementIdStrategyProcessTest extends AbstractGremlinProcessTest {
         final ElementIdStrategy strategy = ElementIdStrategy.build().create();
         final GraphTraversalSource sg = create(strategy);
         final Vertex v = sg.addV().next();
-        final Edge e = sg.withSideEffect("v", v).V(v).addE(Direction.OUT, "self", "v", "test", "value", T.id, "some-id").next();
+        final Edge e = sg.withSideEffect("v", v).V(v).addE("self").to("v").property("test", "value").property(T.id, "some-id").next();
         assertEquals("value", e.value("test"));
         assertEquals("some-id", sg.E(e).id().next());
         assertEquals("some-id", sg.E("some-id").id().next());
@@ -172,7 +172,7 @@ public class ElementIdStrategyProcessTest extends AbstractGremlinProcessTest {
         final ElementIdStrategy strategy = ElementIdStrategy.build().create();
         final GraphTraversalSource sg = create(strategy);
         final Vertex v = sg.addV().next();
-        final Edge e = sg.withSideEffect("v", v).V(v).addE(Direction.OUT, "self", "v", "test", "value").next();
+        final Edge e = sg.withSideEffect("v", v).V(v).addE("self").to("v").property("test", "value").next();
         assertEquals("value", e.value("test"));
         assertNotNull(UUID.fromString(sg.E(e).id().next().toString()));
     }
@@ -183,7 +183,7 @@ public class ElementIdStrategyProcessTest extends AbstractGremlinProcessTest {
         final ElementIdStrategy strategy = ElementIdStrategy.build().idPropertyKey("name").create();
         final GraphTraversalSource sg = create(strategy);
         final Vertex v = sg.addV().next();
-        final Edge e = sg.withSideEffect("v", v).V(v).addE(Direction.OUT, "self", "v", "test", "value", T.id, "some-id").next();
+        final Edge e = sg.withSideEffect("v", v).V(v).addE("self").to("v").property("test", "value").property(T.id, "some-id").next();
         assertEquals("value", e.value("test"));
         assertEquals("some-id", e.value("name"));
         assertEquals("some-id", sg.E(e).id().next());
@@ -196,7 +196,7 @@ public class ElementIdStrategyProcessTest extends AbstractGremlinProcessTest {
         final ElementIdStrategy strategy = ElementIdStrategy.build().idPropertyKey("name").create();
         final GraphTraversalSource sg = create(strategy);
         final Vertex v = sg.addV().next();
-        final Edge e = sg.withSideEffect("v", v).V(v).addE(Direction.OUT, "self", "v", "test", "value", "name", "some-id").next();
+        final Edge e = sg.withSideEffect("v", v).V(v).addE("self").to("v").property("test", "value").property("name", "some-id").next();
         assertEquals("value", e.value("test"));
         assertEquals("some-id", e.value("name"));
         assertEquals("some-id", sg.E(e).id().next());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-832

Removed deprecated `addV()`, `addE()`, `addInE()`, and `addOutE()` methods that are no longer supported given the introduction of the `to()` and `from()` modulators. This is actually a very good deprecation to remove as there is a lot of extraneous testing (and bug proneness) around these methods given the complicated interactions with the desired overloaded methods of the same name -- lots of parameter type checking and validation (gross).

VOTE +1.