### PR TITLE
TINKERPOP-1142: Remove deprecated valueIncr, valueDecr, keyIncr, keyDecr.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Removed previously deprecatd `Order` enums of `keyIncr`, `keyDecr`, `valueIncr`, and `valueDecr.`
 * Removed previously deprecated `TraversalSource.Builder` class.
 * Removed previously deprecated `ConnectiveP`, `AndP`, `OrP` constructors.
 * Removed previously deprecated `TraversalScriptFunction` class.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -211,6 +211,10 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.OrP(P...)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptFunction`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper`
+** `org.apache.tinkerpop.gremlin.process.traversal.Order.keyIncr`
+** `org.apache.tinkerpop.gremlin.process.traversal.Order.valueIncr`
+** `org.apache.tinkerpop.gremlin.process.traversal.Order.keyDecr`
+** `org.apache.tinkerpop.gremlin.process.traversal.Order.valueIncr`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#supportsAddProperty()`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#FEATURE_ADD_PROPERTY`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.OptIn#SUITE_GROOVY_PROCESS_STANDARD`

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Order.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Order.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.process.traversal;
 
 import java.util.Comparator;
-import java.util.Map;
 import java.util.Random;
 
 /**
@@ -46,66 +45,6 @@ public enum Order implements Comparator<Object> {
         @Override
         public Order reversed() {
             return incr;
-        }
-    },
-    /**
-     * @deprecated Use {@link org.apache.tinkerpop.gremlin.structure.Column#keys};
-     */
-    @Deprecated
-    keyIncr {
-        @Override
-        public int compare(final Object first, final Object second) {
-            return Comparator.<Comparable>naturalOrder().compare(((Map.Entry<Comparable, ?>) first).getKey(), ((Map.Entry<Comparable, ?>) second).getKey());
-        }
-
-        @Override
-        public Order reversed() {
-            return keyDecr;
-        }
-    },
-    /**
-     * @deprecated Use {@link org.apache.tinkerpop.gremlin.structure.Column#values};
-     */
-    @Deprecated
-    valueIncr {
-        @Override
-        public int compare(final Object first, final Object second) {
-            return Comparator.<Comparable>naturalOrder().compare(((Map.Entry<?, Comparable>) first).getValue(), ((Map.Entry<?, Comparable>) second).getValue());
-        }
-
-        @Override
-        public Order reversed() {
-            return valueDecr;
-        }
-    },
-    /**
-     * @deprecated Use {@link org.apache.tinkerpop.gremlin.structure.Column#keys};
-     */
-    @Deprecated
-    keyDecr {
-        @Override
-        public int compare(final Object first, final Object second) {
-            return Comparator.<Comparable>reverseOrder().compare(((Map.Entry<Comparable, ?>) first).getKey(), ((Map.Entry<Comparable, ?>) second).getKey());
-        }
-
-        @Override
-        public Order reversed() {
-            return keyIncr;
-        }
-    },
-    /**
-     * @deprecated Use {@link org.apache.tinkerpop.gremlin.structure.Column#values};
-     */
-    @Deprecated
-    valueDecr {
-        @Override
-        public int compare(final Object first, final Object second) {
-            return Comparator.<Comparable>reverseOrder().compare(((Map.Entry<?, Comparable>) first).getValue(), ((Map.Entry<?, Comparable>) second).getValue());
-        }
-
-        @Override
-        public Order reversed() {
-            return valueIncr;
         }
     }, shuffle {
         @Override

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -148,14 +148,10 @@ statics.add_static('or_', Operator.or_)
 statics.add_static('addAll', Operator.addAll)
 statics.add_static('sumLong', Operator.sumLong)
 
-Order = Enum('Order', ' decr incr keyDecr keyIncr shuffle valueDecr valueIncr')
+Order = Enum('Order', ' decr incr shuffle')
 
 statics.add_static('incr', Order.incr)
 statics.add_static('decr', Order.decr)
-statics.add_static('keyIncr', Order.keyIncr)
-statics.add_static('valueIncr', Order.valueIncr)
-statics.add_static('keyDecr', Order.keyDecr)
-statics.add_static('valueDecr', Order.valueDecr)
 statics.add_static('shuffle', Order.shuffle)
 
 Pick = Enum('Pick', ' any none')


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1142

Removed deprecated `valueIncr`, `valueDecr`, `keyIncr`, and `keyDecr`. These were deprecated long ago and replaced with `Column.values` and `Column.keys` along with the use of `Order.incr` and `Order.decr` accordingly.

VOTE +1