### PR TITLE
[TINKERPOP-915]Add combined handler for Http and Websockets

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -121,6 +121,7 @@ This release also includes changes from <<release-3-1-8, 3.1.8>>.
 * Fixed `HADOOP_GREMLIN_LIBS` parsing for Windows.
 * Improved GraphSON serialization performance around `VertexProperty`.
 * Changed some tests in `EventStrategyProcessTest` which were enforcing some unintended semantics around transaction state.
+* Added WsAndHttpChannelizer and SaslAndHttpBasicAuthenticationHandler to be allow for servicing Http and Websocket requests to the same server
 
 [[release-3-2-5]]
 TinkerPop 3.2.5 (Release Date: June 12, 2017)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -881,13 +881,16 @@ as the API for the endpoint is very similar to Rexster's link:https://github.com
 
 Gremlin Server provides for a single HTTP endpoint - a Gremlin evaluator - which allows the submission of a Gremlin
 script as a request.  For each request, it returns a response containing the serialized results of that script.
-To enable this endpoint, Gremlin Server needs to be configured with the `HttpChannelizer`, which replaces the default
+To enable this endpoint, Gremlin Server needs to be configured with the `HttpChannelizer`, which replaces the default. The `WsAndHttpChannelizer` may also be configured to enable both WebSockets and the REST endpoint.
 `WebSocketChannelizer`, in the configuration file:
 
 [source,yaml]
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 
-This setting is already configured in the `gremlin-server-rest-modern.yaml` file that is packaged with the Gremlin
+[source,yaml]
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+
+The `HttpChannelizer` is already configured in the `gremlin-server-rest-modern.yaml` file that is packaged with the Gremlin
 Server distribution.  To utilize it, start Gremlin Server as follows:
 
 [source,text]

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -39,6 +39,15 @@ it has not been promoted as the primary way to add `IoRegistry` instances to ser
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1694[TINKERPOP-1694]
 
+WsAndHttpChannelizer
+^^^^^^^^^^^^^^^^^^^^
+
+The `WsAndHttpChannelizer` has been added to allow for processing both WebSocket and Http requests on the same
+port and gremlin server. The `SaslAndHttpBasicAuthenticationHandler` has also been added to service
+authentication for both protocols in conjunction with the `SimpleAuthenticator`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-915[TINKERPOP-915]
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -81,10 +81,17 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
     protected ExecutorService gremlinExecutorService;
     protected ScheduledExecutorService scheduledExecutorService;
 
+
+    public static final String PIPELINE_AUTHENTICATOR = "authenticator";
+    public static final String PIPELINE_REQUEST_HANDLER = "request-handler";
+    public static final String PIPELINE_HTTP_RESPONSE_ENCODER = "http-response-encoder";
+
     protected static final String PIPELINE_SSL = "ssl";
     protected static final String PIPELINE_OP_SELECTOR = "op-selector";
     protected static final String PIPELINE_OP_EXECUTOR = "op-executor";
-    protected static final String PIPELINE_AUTHENTICATOR = "authenticator";
+    protected static final String PIPELINE_HTTP_REQUEST_DECODER = "http-request-decoder";
+
+    protected static final String GREMLIN_ENDPOINT = "/gremlin";
 
     protected final Map<String, MessageSerializer> serializers = new HashMap<>();
 
@@ -260,8 +267,6 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
             builder = SslContextBuilder.forServer(keyCertChainFile, keyFile, sslSettings.keyPassword)
                     .trustManager(trustCertChainFile);
         }
-        
-        
 
         builder.clientAuth(sslSettings.needClientAuth).sslProvider(provider);
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
@@ -78,7 +78,7 @@ public class WebSocketChannelizer extends AbstractChannelizer {
 
         logger.debug("HttpRequestDecoder settings - maxInitialLineLength={}, maxHeaderSize={}, maxChunkSize={}",
                 settings.maxInitialLineLength, settings.maxHeaderSize, settings.maxChunkSize);
-        pipeline.addLast("http-request-decoder", new HttpRequestDecoder(settings.maxInitialLineLength, settings.maxHeaderSize, settings.maxChunkSize));
+        pipeline.addLast(PIPELINE_HTTP_REQUEST_DECODER, new HttpRequestDecoder(settings.maxInitialLineLength, settings.maxHeaderSize, settings.maxChunkSize));
 
         if (logger.isDebugEnabled())
             pipeline.addLast(new LoggingHandler("log-decoder-aggregator", LogLevel.DEBUG));
@@ -92,8 +92,9 @@ public class WebSocketChannelizer extends AbstractChannelizer {
         if (logger.isDebugEnabled())
             pipeline.addLast(new LoggingHandler("log-aggregator-encoder", LogLevel.DEBUG));
 
-        pipeline.addLast("http-response-encoder", new HttpResponseEncoder());
-        pipeline.addLast("request-handler", new WebSocketServerProtocolHandler("/gremlin", null, false, settings.maxContentLength));
+        pipeline.addLast(PIPELINE_HTTP_RESPONSE_ENCODER, new HttpResponseEncoder());
+
+        pipeline.addLast(PIPELINE_REQUEST_HANDLER, new WebSocketServerProtocolHandler(GREMLIN_ENDPOINT, null, false, settings.maxContentLength));
 
         if (logger.isDebugEnabled())
             pipeline.addLast(new LoggingHandler("log-aggregator-encoder", LogLevel.DEBUG));

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WsAndHttpChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WsAndHttpChannelizer.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
+import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
+import org.apache.tinkerpop.gremlin.server.handler.WsAndHttpChannelizerHandler;
+import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
+import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *A channelizer for port unification with websockets and http
+ *@author Keith Lohnes lohnesk@gmail.com
+ */
+
+public class WsAndHttpChannelizer extends AbstractChannelizer {
+
+    private static final Logger logger = LoggerFactory.getLogger(WsAndHttpChannelizer.class);
+
+    private WsAndHttpChannelizerHandler handler;
+
+    @Override
+    public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
+        super.init(serverGremlinExecutor);
+        handler = new WsAndHttpChannelizerHandler();
+        handler.init(serverGremlinExecutor, new HttpGremlinEndpointHandler(serializers, gremlinExecutor, graphManager, settings));
+    }
+
+    @Override
+    public void configure(final ChannelPipeline pipeline) {
+        handler.configure(pipeline);
+        pipeline.addAfter(PIPELINE_HTTP_REQUEST_DECODER, "WsAndHttpChannelizerHandler", handler);
+    }
+}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAndHttpBasicAuthenticationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAndHttpBasicAuthenticationHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpMessage;
+import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
+import org.apache.tinkerpop.gremlin.server.handler.HttpBasicAuthenticationHandler;
+import org.apache.tinkerpop.gremlin.server.handler.SaslAuthenticationHandler;
+import org.apache.tinkerpop.gremlin.server.handler.WebSocketHandlerUtil;
+
+import static org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer.PIPELINE_AUTHENTICATOR;
+
+/**
+ *An Authentication Handler for doing WebSocket Sasl and Http Basic auth
+ */
+@ChannelHandler.Sharable
+public class SaslAndHttpBasicAuthenticationHandler extends SaslAuthenticationHandler {
+
+    private final String HTTP_AUTH = "http-authentication";
+
+    public SaslAndHttpBasicAuthenticationHandler(final Authenticator authenticator) {
+        super(authenticator);
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object obj) throws Exception {
+        if (obj instanceof HttpMessage && !WebSocketHandlerUtil.isWebSocket((HttpMessage)obj)) {
+            if (null == ctx.pipeline().get(HTTP_AUTH)) {
+                ctx.pipeline().addAfter(PIPELINE_AUTHENTICATOR, HTTP_AUTH, new HttpBasicAuthenticationHandler(authenticator));
+            }
+            ctx.fireChannelRead(obj);
+        } else {
+            super.channelRead(ctx, obj);
+        }
+    }
+
+}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WebSocketHandlerUtil.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WebSocketHandlerUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.handler.codec.http.HttpMessage;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.UPGRADE;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+
+/**
+ * A class to handle common WebSocket operations
+ * @author Keith Lohnes lohnesk@gmail.com
+ */
+final class WebSocketHandlerUtil {
+
+    static boolean isWebSocket(final HttpMessage msg) {
+        final String connectionHeader = msg.headers().get(CONNECTION);
+        final String upgradeHeader = msg.headers().get(UPGRADE);
+        return (null != connectionHeader && connectionHeader.equalsIgnoreCase("Upgrade")) ||
+               (null != upgradeHeader && upgradeHeader.equalsIgnoreCase("WebSocket"));
+    }
+}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsAndHttpChannelizerHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsAndHttpChannelizerHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.codec.http.HttpServerCodec;
+import org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer;
+import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
+import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
+import org.apache.tinkerpop.gremlin.server.handler.WsAndHttpChannelizerHandler;
+import org.apache.tinkerpop.gremlin.server.handler.WebSocketHandlerUtil;
+import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.UPGRADE;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+import static org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer.PIPELINE_AUTHENTICATOR;
+import static org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer.PIPELINE_REQUEST_HANDLER;
+import static org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer.PIPELINE_HTTP_RESPONSE_ENCODER;
+
+/*
+ * A ChannelInboundHandlerAdapter for use with {@link WsAndHttpChannelizer} that toggles between WebSockets
+ * and http
+ * @author Keith Lohnes lohnesk@gmail.com
+ */
+@ChannelHandler.Sharable
+public class WsAndHttpChannelizerHandler extends ChannelInboundHandlerAdapter {
+
+    private final WebSocketChannelizer wsChannelizer = new WebSocketChannelizer();
+    private HttpGremlinEndpointHandler httpGremlinEndpointHandler;
+
+    public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor, final HttpGremlinEndpointHandler httpGremlinEndpointHandler) {
+        //WebSocketChannelizer has everything needed for the http endpoint to work
+        wsChannelizer.init(serverGremlinExecutor);
+        this.httpGremlinEndpointHandler = httpGremlinEndpointHandler;
+    }
+
+    public void configure(final ChannelPipeline pipeline) {
+        wsChannelizer.configure(pipeline);
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object obj) {
+        final ChannelPipeline pipeline = ctx.pipeline();
+        if (obj instanceof HttpMessage && !WebSocketHandlerUtil.isWebSocket((HttpMessage)obj)) {
+            if (null != pipeline.get(PIPELINE_AUTHENTICATOR)) {
+                pipeline.remove(PIPELINE_REQUEST_HANDLER);
+                final ChannelHandler authenticator = pipeline.get(PIPELINE_AUTHENTICATOR);
+                pipeline.remove(PIPELINE_AUTHENTICATOR);
+                pipeline.addAfter(PIPELINE_HTTP_RESPONSE_ENCODER, PIPELINE_AUTHENTICATOR, authenticator);
+                pipeline.addAfter(PIPELINE_AUTHENTICATOR, PIPELINE_REQUEST_HANDLER, this.httpGremlinEndpointHandler);
+            } else {
+                pipeline.remove(PIPELINE_REQUEST_HANDLER);
+                pipeline.addAfter(PIPELINE_HTTP_RESPONSE_ENCODER, PIPELINE_REQUEST_HANDLER, this.httpGremlinEndpointHandler);
+            }
+        }
+        ctx.fireChannelRead(obj);
+    }
+
+    @Override
+    public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
+        ctx.close();
+    }
+
+
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -54,7 +54,6 @@ import org.apache.tinkerpop.gremlin.server.op.AbstractEvalOpProcessor;
 import org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
-import org.apache.tinkerpop.gremlin.server.channel.NioChannelizer;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
@@ -167,9 +166,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             case "shouldBatchResultsByTwos":
                 settings.resultIterationBatchSize = 2;
                 break;
-            case "shouldWorkOverNioTransport":
-                settings.channelizer = NioChannelizer.class.getName();
-                break;
             case "shouldEnableSsl":
             case "shouldEnableSslButFailIfClientConnectsWithoutIt":
                 settings.ssl = new Settings.SslSettings();
@@ -210,11 +206,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 // Trust ONLY the server cert
                 settings.ssl.trustCertChainFile = SERVER_CRT;
             	break;
-            case "shouldStartWithDefaultSettings":
-                // test with defaults exception for port because we want to keep testing off of 8182
-                final Settings defaultSettings = new Settings();
-                defaultSettings.port = TestClientFactory.PORT;
-                return settings;
             case "shouldUseSimpleSandbox":
                 settings.scriptEngines.get("gremlin-groovy").plugins.put(GroovyCompilerGremlinPlugin.class.getName(), getScriptEngineConfForSimpleSandbox());
                 // remove the script because it isn't used in the test but also because it's not CompileStatic ready
@@ -353,20 +344,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         } finally {
             cluster.close();
         }
-    }
-
-    @Test
-    public void shouldStartWithDefaultSettings() {
-        // just quickly validate that results are returning given defaults. no graphs are config'd with defaults
-        // so just eval a groovy script.
-        final Cluster cluster = TestClientFactory.open();
-        final Client client = cluster.connect();
-
-        final ResultSet results = client.submit("[1,2,3,4,5,6,7,8,9]");
-        final AtomicInteger counter = new AtomicInteger(0);
-        results.stream().map(i -> i.get(Integer.class) * 2).forEach(i -> assertEquals(counter.incrementAndGet() * 2, Integer.parseInt(i.toString())));
-
-        cluster.close();
     }
 
     @Test
@@ -691,20 +668,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             final List<ResponseMessage> msgs = client.submit(request);
             assertEquals(10, msgs.size());
             IntStream.rangeClosed(0, 9).forEach(i -> assertEquals(i, ((List<Integer>) msgs.get(i).getResult().getData()).get(0).intValue()));
-        }
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void shouldWorkOverNioTransport() throws Exception {
-        try (SimpleClient client = TestClientFactory.createNioClient()) {
-            final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
-                    .addArg(Tokens.ARGS_GREMLIN, "[0,1,2,3,4,5,6,7,8,9,]").create();
-
-            final List<ResponseMessage> msg = client.submit(request);
-            assertEquals(1, msg.size());
-            final List<Integer> integers = (List<Integer>) msg.get(0).getResult().getData();
-            IntStream.rangeClosed(0, 9).forEach(i -> assertEquals(i, integers.get(i).intValue()));
         }
     }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/AbstractGremlminServerChannelizerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/AbstractGremlminServerChannelizerIntegrateTest.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import org.apache.tinkerpop.gremlin.driver.AuthProperties;
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.simple.SimpleClient;
+import org.apache.tinkerpop.gremlin.driver.Channelizer;
+import org.apache.tinkerpop.gremlin.server.AbstractGremlinServerIntegrationTest;
+import org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.TestClientFactory;
+
+
+import org.apache.http.Consts;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.util.EntityUtils;
+import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.rules.ExternalResource;
+
+import java.io.File;
+import java.io.InputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.apache.tinkerpop.gremlin.driver.AuthProperties.Property;
+
+abstract class AbstractGremlinServerChannelizerIntegrateTest extends AbstractGremlinServerIntegrationTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Base64.Encoder encoder = Base64.getUrlEncoder();
+
+    protected static final String HTTP = "http";
+    protected static final String WS = "ws";
+    protected static final String HTTPS = "https";
+    protected static final String WSS = "wss";
+    protected static final String WS_AND_HTTP = "wsAndHttp";
+    protected static final String WSS_AND_HTTPS = "wssAndHttps";
+    protected static final String NIO = "nio";
+    protected static final String NIO_SECURE = "nioSecure";
+
+    public abstract String getProtocol();
+    public abstract String getSecureProtocol();
+    public abstract String getChannelizer();
+    public abstract Settings.AuthenticationSettings getAuthSettings();
+
+    /**
+     * Configure specific Gremlin Server settings for specific tests.
+     */
+    @Override
+    public Settings overrideSettings(final Settings settings) {
+        settings.channelizer = getChannelizer();
+        final String nameOfTest = name.getMethodName();
+        Settings.AuthenticationSettings authSettings = getAuthSettings();
+        switch (nameOfTest) {
+            case "shouldReturnResult":
+                break;
+            case "shouldWorkWithSSL":
+                settings.ssl = new Settings.SslSettings();
+                settings.ssl.enabled = true;
+                break;
+            case "shouldWorkWithAuth":
+                if (authSettings != null) {
+                    settings.authentication = getAuthSettings();
+                }
+                break;
+            case "shouldWorkWithSSLAndAuth":
+                settings.ssl = new Settings.SslSettings();
+                settings.ssl.enabled = true;
+                if (authSettings != null) {
+                    settings.authentication = getAuthSettings();
+                }
+                break;
+        }
+        return settings;
+    }
+
+    @Test
+    public void shouldReturnResult() throws Exception {
+        final CombinedTestClient client =  new CombinedTestClient(getProtocol());
+        try {
+            client.sendAndAssert("2+2", 4);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void shouldWorkWithSSL() throws Exception {
+        final CombinedTestClient client =  new CombinedTestClient(getSecureProtocol());
+        try {
+            client.sendAndAssert("2+2", 4);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void shouldWorkWithAuth() throws Exception {
+        CombinedTestClient client =  new CombinedTestClient(getProtocol());
+        try {
+            client.sendAndAssertUnauthorized("2+2", "stephen", "notpassword");
+            client.close();
+            client = new CombinedTestClient(getProtocol());
+            client.sendAndAssert("2+2", 4, "stephen", "password");
+            client.close();
+        } catch (Exception e) {
+            client.close();
+            throw e;
+        }
+    }
+
+    @Test
+    public void shouldWorkWithSSLAndAuth() throws Exception {
+        CombinedTestClient client =  new CombinedTestClient(getSecureProtocol());
+        try {
+            client.sendAndAssertUnauthorized("2+2", "stephen", "incorrect-password");
+            client.close();
+            client = new CombinedTestClient(getSecureProtocol());
+            client.sendAndAssert("2+2", 4, "stephen", "password");
+            client.close();
+        } catch (Exception e) {
+            client.close();
+            throw e;
+        }
+    }
+
+    public class CombinedTestClient {
+        private CloseableHttpClient httpClient = null;
+        private Cluster wsCluster = null;
+        private Cluster.Builder wsBuilder = null;
+        private Cluster nioCluster = null;
+        private Cluster.Builder nioBuilder = null;
+        private Client wsClient = null;
+        private Client.ClusteredClient nioClient = null;
+        private boolean secure = false;
+
+
+        public CombinedTestClient(final String protocol) throws Exception {
+            switch (protocol) {
+                case HTTP:
+                    httpClient = HttpClients.createDefault();
+                    break;
+                case HTTPS:
+                    httpClient = createSslHttpClient();
+                    secure = true;
+                    break;
+                case WS:
+                    this.wsBuilder = TestClientFactory.build();
+                    break;
+                case WSS:
+                    this.wsBuilder = TestClientFactory.build();
+                    secure = true;
+                    break;
+                case WS_AND_HTTP:
+                    httpClient = HttpClients.createDefault();
+                    this.wsBuilder = TestClientFactory.build();
+                    break;
+                case WSS_AND_HTTPS:
+                    httpClient = createSslHttpClient();
+                    secure = true;
+                    this.wsBuilder = TestClientFactory.build();
+                    break;
+                case NIO:
+                    this.nioBuilder = TestClientFactory.build();
+                    break;
+                case NIO_SECURE:
+                    this.nioBuilder = TestClientFactory.build();
+                    secure = true;
+                    break;
+            }
+        }
+
+        private CloseableHttpClient createSslHttpClient() throws Exception {
+            final SSLContextBuilder wsBuilder = new SSLContextBuilder();
+            wsBuilder.loadTrustMaterial(null, new TrustStrategy() {
+                @Override
+                public boolean isTrusted(X509Certificate[] chain,
+                    String authType) throws CertificateException {
+                    return true;
+                }
+            });
+            final SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(wsBuilder.build(),
+                new AllowAllHostnameVerifier());
+            //This winds up using a PoolingHttpClientConnectionManager so need to pass the
+            //RegistryBuilder
+            final Registry<ConnectionSocketFactory> registry = RegistryBuilder
+                .<ConnectionSocketFactory> create().register("https", sslsf)
+                .build();
+            final PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager(registry);
+            return HttpClients
+                .custom()
+                .setConnectionManager(cm)
+                .build();
+
+        }
+
+        public void sendAndAssert(final String gremlin, Object result) throws Exception {
+            sendAndAssert(gremlin, result, null, null);
+        }
+
+        public void close() {
+            if (wsCluster != null) {
+                wsCluster.close();
+            }
+            if (nioCluster != null) {
+                nioCluster.close();
+            }
+        }
+
+        public void sendAndAssertUnauthorized(final String gremlin, final String username, final String password) throws Exception {
+            if (httpClient != null) {
+                final HttpPost httpPost = createPost(gremlin, username, password);
+                try (final CloseableHttpResponse response = httpClient.execute(httpPost)) {
+                    assertEquals(401, response.getStatusLine().getStatusCode());
+                }
+            }
+            if (wsBuilder != null) {
+                setWsClient(username, password);
+                try {
+                    wsClient.submit(gremlin).all().get();
+                    fail("Should not authorize on incorrect auth creds");
+                } catch(Exception e) {
+                    assertEquals("Username and/or password are incorrect", e.getCause().getMessage());
+                }
+            }
+            if (nioBuilder != null) {
+                setNioClient(username, password);
+                try {
+                    nioClient.submit(gremlin);
+                } catch(Exception e) {
+                    assertEquals("Username and/or password are incorrect", e.getCause().getMessage());
+                }
+            }
+
+        }
+
+        public void sendAndAssert(final String gremlin, final Object result, final String username, final String password) throws Exception {
+            if (httpClient != null) {
+                final HttpPost httpPost = createPost(gremlin, username, password);
+                try (final CloseableHttpResponse response = httpClient.execute(httpPost)) {
+                    assertEquals(200, response.getStatusLine().getStatusCode());
+                    assertEquals("application/json", response.getEntity().getContentType().getValue());
+                    final String json = EntityUtils.toString(response.getEntity());
+                    final JsonNode node = mapper.readTree(json);
+                    assertEquals(result, node.get("result").get("data").get(0).intValue());
+                }
+            }
+            if (wsBuilder != null) {
+                setWsClient(username, password);
+                assertEquals(result, wsClient.submit(gremlin).all().get().get(0).getInt());
+            }
+            if (nioClient != null) {
+                assertEquals(result, nioClient.submit(gremlin).all().get().get(0).getInt());
+            }
+        }
+
+        private void setNioClient(final String username, final String password) {
+            nioBuilder.channelizer(Channelizer.NioChannelizer.class.getName());
+            if (username != null && password != null) {
+                final AuthProperties authProps = new AuthProperties()
+                                                .with(Property.USERNAME, username)
+                                                .with(Property.PASSWORD, password);
+
+                nioCluster = nioBuilder.enableSsl(secure).authProperties(authProps).create();
+                nioClient = nioCluster.connect();
+            } else {
+                nioCluster = nioBuilder.enableSsl(secure).create();
+                nioClient = nioCluster.connect();
+            }
+        }
+
+        private void setWsClient(final String username, final String password) {
+            if (username != null && password != null) {
+                final AuthProperties authProps = new AuthProperties()
+                                                .with(Property.USERNAME, username)
+                                                .with(Property.PASSWORD, password);
+
+                wsCluster = wsBuilder.enableSsl(secure).authProperties(authProps).create();
+                wsClient = wsCluster.connect();
+            } else {
+                wsCluster = wsBuilder.enableSsl(secure).create();
+                wsClient = wsCluster.connect();
+            }
+        }
+
+        private HttpPost createPost(final String gremlin, final String username, final String password) {
+            String urlString = TestClientFactory.createURLString();
+            if (secure) {
+                urlString = urlString.replace("http", "https");
+            }
+            final HttpPost httpPost = new HttpPost(urlString);
+            httpPost.addHeader("Content-Type", "application/json");
+            if (username != null && password != null) {
+                final String auth = encoder.encodeToString((username + ":" + password).getBytes());
+                httpPost.addHeader("Authorization", "Basic " + auth);
+            }
+            final String jsonBody = String.format("{\"gremlin\": \"%s\"}", gremlin);
+            httpPost.setEntity(new StringEntity(jsonBody, Consts.UTF_8));
+            return httpPost;
+        }
+    }
+}
+

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizerIntegrateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.apache.tinkerpop.gremlin.server.Settings;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class HttpChannelizerIntegrateTest extends AbstractGremlinServerChannelizerIntegrateTest {
+
+    @Override
+    public String getProtocol() {
+        return HTTP;
+    }
+
+    @Override
+    public String getSecureProtocol() {
+        return HTTPS;
+    }
+
+    @Override
+    public String getChannelizer() {
+        return HttpChannelizer.class.getName();
+    }
+
+    @Override
+    public Settings.AuthenticationSettings getAuthSettings() {
+        final Settings.AuthenticationSettings authSettings = new Settings.AuthenticationSettings();
+        final Map<String,Object> authConfig = new HashMap<>();
+        authSettings.authenticator = SimpleAuthenticator.class.getName();
+        authConfig.put(SimpleAuthenticator.CONFIG_CREDENTIALS_DB, "conf/tinkergraph-credentials.properties");
+        authSettings.config = authConfig;
+
+        return authSettings;
+    }
+
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/NioChannelizerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/NioChannelizerIntegrateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.apache.tinkerpop.gremlin.server.Settings;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class NioChannelizerIntegrateTest extends AbstractGremlinServerChannelizerIntegrateTest {
+
+    @Override
+    public String getProtocol() {
+        return NIO;
+    }
+
+    @Override
+    public String getSecureProtocol() {
+        return NIO_SECURE;
+    }
+
+    @Override
+    public String getChannelizer() {
+        return NioChannelizer.class.getName();
+    }
+
+    @Override
+    public Settings.AuthenticationSettings getAuthSettings() {
+        final Settings.AuthenticationSettings authSettings = new Settings.AuthenticationSettings();
+        final Map<String,Object> authConfig = new HashMap<>();
+        authSettings.authenticator = SimpleAuthenticator.class.getName();
+        authConfig.put(SimpleAuthenticator.CONFIG_CREDENTIALS_DB, "conf/tinkergraph-credentials.properties");
+        authSettings.config = authConfig;
+
+        return authSettings;
+    }
+
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizerIntegrateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.apache.tinkerpop.gremlin.server.Settings;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class WebSocketChannelizerIntegrateTest extends AbstractGremlinServerChannelizerIntegrateTest {
+
+    @Override
+    public String getProtocol() {
+        return WS;
+    }
+
+    @Override
+    public String getSecureProtocol() {
+        return WSS;
+    }
+
+    @Override
+    public String getChannelizer() {
+        return WebSocketChannelizer.class.getName();
+    }
+
+    @Override
+    public Settings.AuthenticationSettings getAuthSettings() {
+        final Settings.AuthenticationSettings authSettings = new Settings.AuthenticationSettings();
+        final Map<String,Object> authConfig = new HashMap<>();
+        authSettings.authenticator = SimpleAuthenticator.class.getName();
+        authConfig.put(SimpleAuthenticator.CONFIG_CREDENTIALS_DB, "conf/tinkergraph-credentials.properties");
+        authSettings.config = authConfig;
+
+        return authSettings;
+    }
+
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WsAndHttpChannelizerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WsAndHttpChannelizerIntegrateTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+
+import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
+import org.apache.tinkerpop.gremlin.server.handler.SaslAndHttpBasicAuthenticationHandler;
+import org.apache.tinkerpop.gremlin.server.Settings;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class WsAndHttpChannelizerIntegrateTest extends AbstractGremlinServerChannelizerIntegrateTest {
+
+    @Override
+    public String getProtocol() {
+        return WS_AND_HTTP;
+    }
+
+    @Override
+    public String getSecureProtocol() {
+        return WSS_AND_HTTPS;
+    }
+
+    @Override
+    public String getChannelizer() {
+        return WsAndHttpChannelizer.class.getName();
+    }
+
+    @Override
+    public Settings.AuthenticationSettings getAuthSettings() {
+        final Settings.AuthenticationSettings authSettings = new Settings.AuthenticationSettings();
+        final Map<String,Object> authConfig = new HashMap<>();
+        authSettings.authenticator = SimpleAuthenticator.class.getName();
+        authSettings.authenticationHandler = SaslAndHttpBasicAuthenticationHandler.class.getName();
+        authConfig.put(SimpleAuthenticator.CONFIG_CREDENTIALS_DB, "conf/tinkergraph-credentials.properties");
+        authSettings.config = authConfig;
+
+        return authSettings;
+    }
+
+}


### PR DESCRIPTION
[TINKERPOP-915](https://issues.apache.org/jira/browse/TINKERPOP-915)

Most of this is tests. I added an integration test that goes over the
functionality of both the http and websocket channelizers using the new
`WsAndHttpChannelizer`. I added an additional test on top of that to
switch between using WebSockets and http.

The change itself leverages the existing `WebSocketChannelizer` to
provide the base pipeline setup. It has everything needed handler-wise
to service both http and ws connections. The
`WsAndHttpChannelizerHandler` then detects whether the incoming request
is a plain http connection or a WebSockets connection. If it's an http
connection, the channelizer handler swaps out the request handler
appropriately for whether or not authentication has been enabled.