### PR TITLE
TINKERPOP-834: Remove deprecated sack() method

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Removed previously deprecated `GraphTraversal.sack(BiFunction,String)`.
 * Established the Gryo 3.0 format.
 * `GryoVersion` now includes a default `ClassResolver` to supply to the `GryoMapper`.
 * `GryoClassResolver` renamed to `GryoClassResolverV1d0` which has an abstract class that for providers to extend in `AbstractGryoClassResolver`.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -216,6 +216,7 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.OrP(P...)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptFunction`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper`
+** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#sack(BiFunction,String)`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#supportsAddProperty()`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#FEATURE_ADD_PROPERTY`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.OptIn#SUITE_GROOVY_PROCESS_STANDARD`
@@ -309,7 +310,8 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-1612[TINKERPOP-1612],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1622[TINKERPOP-1622],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1651[TINKERPOP-1651],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1694[TINKERPOP-1694],
-link:https://issues.apache.org/jira/browse/TINKERPOP-1700[TINKERPOP-1700]
+link:https://issues.apache.org/jira/browse/TINKERPOP-1700[TINKERPOP-1700],
+link:https://issues.apache.org/jira/browse/TINKERPOP-834[TINKERPOP-834]
 
 Gremlin-server.sh and Init Scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -2034,15 +2034,6 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     /**
-     * @since 3.0.0-incubating
-     * @deprecated As of release 3.1.0, replaced by {@link #sack(BiFunction)} with {@link #by(String)}.
-     */
-    @Deprecated
-    public default <V, U> GraphTraversal<S, E> sack(final BiFunction<V, U, V> sackOperator, final String elementPropertyKey) {
-        return this.sack(sackOperator).by(elementPropertyKey);
-    }
-
-    /**
      * Lazily aggregates objects in the stream into a side-effect collection.
      *
      * @param sideEffectKey the name of the side-effect key that will hold the aggregate

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -968,14 +968,6 @@ public class __ {
     }
 
     /**
-     * @deprecated As of release 3.1.0, replaced by {@link #sack(BiFunction)}.
-     */
-    @Deprecated
-    public static <A, V, U> GraphTraversal<A, A> sack(final BiFunction<V, U, V> sackOperator, final String elementPropertyKey) {
-        return __.<A>start().sack(sackOperator, elementPropertyKey);
-    }
-
-    /**
      * @see GraphTraversal#store(String)
      */
     public static <A> GraphTraversal<A, A> store(final String sideEffectKey) {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackTest.java
@@ -56,12 +56,6 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Double> get_g_withSackX0X_V_repeatXoutE_sackXsumX_byXweightX_inVX_timesX2X_sack();
 
-    @Deprecated
-    public abstract Traversal<Vertex, Double> get_g_withSackX0X_V_outE_sackXsum_weightX_inV_sack_sum();
-
-    @Deprecated
-    public abstract Traversal<Vertex, Double> get_g_withSackX0X_V_repeatXoutE_sackXsum_weightX_inVX_timesX2X_sack();
-
     public abstract Traversal<Vertex, Map> get_g_withSackXmap__map_cloneX_V_out_out_sackXmap_a_nameX_sack();
 
     public abstract Traversal<Vertex, Double> get_g_withSackX1_sumX_VX1X_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack(final Object v1Id);
@@ -90,27 +84,8 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    @Deprecated
-    public void g_withSackX0X_V_outE_sackXsum_weightX_inV_sack_sum() {
-        final Traversal<Vertex, Double> traversal = get_g_withSackX0X_V_outE_sackXsum_weightX_inV_sack_sum();
-        printTraversalForm(traversal);
-        assertEquals(3.5d, traversal.next(), 0.00001d);
-        assertFalse(traversal.hasNext());
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
     public void g_withSackX0X_V_repeatXoutE_sackXsumX_byXweightX_inVX_timesX2X_sack() {
         final Traversal<Vertex, Double> traversal = get_g_withSackX0X_V_repeatXoutE_sackXsumX_byXweightX_inVX_timesX2X_sack();
-        printTraversalForm(traversal);
-        checkResults(Arrays.asList(2.0d, 1.4d), traversal);
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
-    @Deprecated
-    public void g_withSackX0X_V_repeatXoutE_sackXsum_weightX_inVX_timesX2X_sack() {
-        final Traversal<Vertex, Double> traversal = get_g_withSackX0X_V_repeatXoutE_sackXsum_weightX_inVX_timesX2X_sack();
         printTraversalForm(traversal);
         checkResults(Arrays.asList(2.0d, 1.4d), traversal);
     }
@@ -183,16 +158,6 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Double> get_g_withSackX0X_V_repeatXoutE_sackXsumX_byXweightX_inVX_timesX2X_sack() {
             return g.withSack(0.0d).V().repeat(outE().sack(sum).by("weight").inV()).times(2).sack();
-        }
-
-        @Override
-        public Traversal<Vertex, Double> get_g_withSackX0X_V_outE_sackXsum_weightX_inV_sack_sum() {
-            return g.withSack(0.0d).V().outE().sack(sum, "weight").inV().sack().sum();
-        }
-
-        @Override
-        public Traversal<Vertex, Double> get_g_withSackX0X_V_repeatXoutE_sackXsum_weightX_inVX_timesX2X_sack() {
-            return g.withSack(0.0d).V().repeat(outE().sack(sum, "weight").inV()).times(2).sack();
         }
 
         @Override

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -144,35 +144,6 @@ public class TinkerGraphPlayTest {
 
     }
 
-    @Test
-    @Ignore
-    public void testPlay() {
-        Graph g = TinkerGraph.open();
-        Vertex v1 = g.addVertex(T.id, "1", "animal", "males");
-        Vertex v2 = g.addVertex(T.id, "2", "animal", "puppy");
-        Vertex v3 = g.addVertex(T.id, "3", "animal", "mama");
-        Vertex v4 = g.addVertex(T.id, "4", "animal", "puppy");
-        Vertex v5 = g.addVertex(T.id, "5", "animal", "chelsea");
-        Vertex v6 = g.addVertex(T.id, "6", "animal", "low");
-        Vertex v7 = g.addVertex(T.id, "7", "animal", "mama");
-        Vertex v8 = g.addVertex(T.id, "8", "animal", "puppy");
-        Vertex v9 = g.addVertex(T.id, "9", "animal", "chula");
-
-        v1.addEdge("link", v2, "weight", 2f);
-        v2.addEdge("link", v3, "weight", 3f);
-        v2.addEdge("link", v4, "weight", 4f);
-        v2.addEdge("link", v5, "weight", 5f);
-        v3.addEdge("link", v6, "weight", 1f);
-        v4.addEdge("link", v6, "weight", 2f);
-        v5.addEdge("link", v6, "weight", 3f);
-        v6.addEdge("link", v7, "weight", 2f);
-        v6.addEdge("link", v8, "weight", 3f);
-        v7.addEdge("link", v9, "weight", 1f);
-        v8.addEdge("link", v9, "weight", 7f);
-
-        g.traversal().withSack(Float.MIN_VALUE).V(v1).repeat(outE().sack(Operator.max, "weight").inV()).times(5).sack().forEachRemaining(x -> logger.info(x.toString()));
-    }
-
    /* @Test
     public void testTraversalDSL() throws Exception {
         Graph g = TinkerFactory.createClassic();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-834

It has been done.

VOTE +1