### PR TITLE
TINKERPOP-1720: Remove deprecated Hadoop code

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Removed previously deprecated `Constants` in Hadoop.
+* Removed previously deprecated `VertexComputing.generateComputer(Graph)`.
 * Established the Gryo 3.0 format.
 * `GryoVersion` now includes a default `ClassResolver` to supply to the `GryoMapper`.
 * `GryoClassResolver` renamed to `GryoClassResolverV1d0` which has an abstract class that for providers to extend in `AbstractGryoClassResolver`.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -216,6 +216,7 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.OrP(P...)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptFunction`
 ** `org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper`
+** `org.apache.tinkerpop.gremlin.process.computer.traversal.step.VertexComputing#generateComputer(Graph)`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#supportsAddProperty()`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures#FEATURE_ADD_PROPERTY`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.OptIn#SUITE_GROOVY_PROCESS_STANDARD`
@@ -275,6 +276,13 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.server.op.AbstractEvalOpProcessor.validBindingName`
 ** `org.apache.tinkerpop.gremlin.server.op.session.Session.kill()`
 ** `org.apache.tinkerpop.gremlin.server.op.session.Session.manualkill()`
+* `hadoop-gremlin`
+** `org.apache.tinkerpop.gremlin.hadoop.Constants#GREMLIN_HADOOP_GRAPH_INPUT_FORMAT`
+** `org.apache.tinkerpop.gremlin.hadoop.Constants#GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT`
+** `org.apache.tinkerpop.gremlin.hadoop.Constants#GREMLIN_HADOOP_GRAPH_INPUT_FORMAT_HAS_EDGES`
+** `org.apache.tinkerpop.gremlin.hadoop.Constants#GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES`
+** `org.apache.tinkerpop.gremlin.hadoop.Constants#GREMLIN_SPARK_GRAPH_INPUT_RDD`
+** `org.apache.tinkerpop.gremlin.hadoop.Constants#GREMLIN_SPARK_GRAPH_OUTPUT_RDD`
 * `spark-gremlin`
 ** `org.apache.tinkerpop.gremlin.spark.groovy.plugin.SparkGremlinPlugin`
 * `tinkergraph-gremlin`
@@ -309,7 +317,8 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-1612[TINKERPOP-1612],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1622[TINKERPOP-1622],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1651[TINKERPOP-1651],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1694[TINKERPOP-1694],
-link:https://issues.apache.org/jira/browse/TINKERPOP-1700[TINKERPOP-1700]
+link:https://issues.apache.org/jira/browse/TINKERPOP-1700[TINKERPOP-1700],
+link:https://issues.apache.org/jira/browse/TINKERPOP-1720[TINKERPOP-1720]
 
 Gremlin-server.sh and Init Scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
@@ -54,12 +54,4 @@ public interface VertexComputing {
      * @return the generated vertex program instance.
      */
     public VertexProgram generateProgram(final Graph graph, final Memory memory);
-
-    /**
-     * @deprecated As of release 3.2.1. Please use {@link VertexComputing#getComputer()}.
-     */
-    @Deprecated
-    public default GraphComputer generateComputer(final Graph graph) {
-        return this.getComputer().apply(graph);
-    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -88,14 +88,6 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
     }
 
     @Override
-    public GraphComputer generateComputer(final Graph graph) {
-        final GraphComputer graphComputer = this.computer.apply(graph);
-        if (!this.isEndStep())
-            graphComputer.persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW);
-        return graphComputer;
-    }
-
-    @Override
     public TraversalVertexProgramStep clone() {
         final TraversalVertexProgramStep clone = (TraversalVertexProgramStep) super.clone();
         clone.computerTraversal = this.computerTraversal.clone();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
@@ -72,7 +72,7 @@ public abstract class VertexProgramStep extends AbstractStep<ComputerResult, Com
                 final Traverser.Admin<ComputerResult> traverser = this.starts.next();
                 final Graph graph = traverser.get().graph();
                 final Memory memory = traverser.get().memory();
-                future = this.generateComputer(graph).program(this.generateProgram(graph, memory)).submit();
+                future = this.getComputer().apply(graph).program(this.generateProgram(graph, memory)).submit();
                 final ComputerResult result = future.get();
                 this.processMemorySideEffects(result.memory());
                 return traverser.split(result, this);

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
@@ -80,19 +80,4 @@ public final class Constants {
         else
             return Optional.empty();
     }
-
-    ///////////////////////
-    @Deprecated
-    public static final String GREMLIN_HADOOP_GRAPH_INPUT_FORMAT = "gremlin.hadoop.graphInputFormat";
-    @Deprecated
-    public static final String GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT = "gremlin.hadoop.graphOutputFormat";
-    @Deprecated
-    public static final String GREMLIN_HADOOP_GRAPH_INPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphInputFormat.hasEdges";
-    @Deprecated
-    public static final String GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphOutputFormat.hasEdges";
-    @Deprecated
-    public static final String GREMLIN_SPARK_GRAPH_INPUT_RDD = "gremlin.spark.graphInputRDD";
-    @Deprecated
-    public static final String GREMLIN_SPARK_GRAPH_OUTPUT_RDD = "gremlin.spark.graphOutputRDD";
-    //////////////////////
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopConfiguration.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopConfiguration.java
@@ -52,12 +52,12 @@ public final class HadoopConfiguration extends AbstractConfiguration implements 
 
     @Override
     protected void addPropertyDirect(final String key, final Object value) {
-        this.properties.put(convertKey(key), value);
+        this.properties.put(key, value);
     }
 
     @Override
     protected void clearPropertyDirect(final String key) {
-        this.properties.remove(convertKey(key));
+        this.properties.remove(key);
     }
 
     @Override
@@ -67,35 +67,17 @@ public final class HadoopConfiguration extends AbstractConfiguration implements 
 
     @Override
     public boolean containsKey(final String key) {
-        return this.properties.containsKey(convertKey(key));
+        return this.properties.containsKey(key);
     }
 
     @Override
     public Object getProperty(final String key) {
-        return this.properties.get(convertKey(key));
+        return this.properties.get(key);
     }
 
     @Override
     public Iterator<String> getKeys() {
         return this.properties.keySet().iterator();
-    }
-
-    @Deprecated
-    private static String convertKey(final String key) {
-        if (key.equals(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT))
-            return Constants.GREMLIN_HADOOP_GRAPH_READER;
-        else if (key.equals(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT))
-            return Constants.GREMLIN_HADOOP_GRAPH_WRITER;
-        else if (key.equals(Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD))
-            return Constants.GREMLIN_HADOOP_GRAPH_READER;
-        else if (key.equals(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD))
-            return Constants.GREMLIN_HADOOP_GRAPH_WRITER;
-        else if (key.equals(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT_HAS_EDGES))
-            return Constants.GREMLIN_HADOOP_GRAPH_READER_HAS_EDGES;
-        else if (key.equals(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES))
-            return Constants.GREMLIN_HADOOP_GRAPH_WRITER_HAS_EDGES;
-        else
-            return key;
     }
 
     ///////

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
@@ -70,13 +70,13 @@ public class SparkHadoopGraphProvider extends HadoopGraphProvider {
                 !test.equals(FileSystemStorageCheck.class) &&
                 !testMethodName.equals("shouldSupportJobChaining") &&  // GraphComputerTest.shouldSupportJobChaining
                 RANDOM.nextBoolean()) {
-            config.put(RANDOM.nextBoolean() ? Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD : Constants.GREMLIN_HADOOP_GRAPH_READER, ToyGraphInputRDD.class.getCanonicalName());
+            config.put(Constants.GREMLIN_HADOOP_GRAPH_READER, ToyGraphInputRDD.class.getCanonicalName());
         }
 
         // tests persisted RDDs
         if (test.equals(SparkContextStorageCheck.class)) {
-            config.put(RANDOM.nextBoolean() ? Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD : Constants.GREMLIN_HADOOP_GRAPH_READER, ToyGraphInputRDD.class.getCanonicalName());
-            config.put(RANDOM.nextBoolean() ? Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD : Constants.GREMLIN_HADOOP_GRAPH_WRITER, PersistedOutputRDD.class.getCanonicalName());
+            config.put(Constants.GREMLIN_HADOOP_GRAPH_READER, ToyGraphInputRDD.class.getCanonicalName());
+            config.put(Constants.GREMLIN_HADOOP_GRAPH_WRITER, PersistedOutputRDD.class.getCanonicalName());
         }
 
         config.put(Constants.GREMLIN_HADOOP_DEFAULT_GRAPH_COMPUTER, SparkGraphComputer.class.getCanonicalName());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1720

Removed Constants and VertexComputing method. Created another ticket for the `ScriptElementFactory` deprecation (@dkuppitz area of work).

VOTE +1.