### PR TITLE
Neo4j upgrade to 3.2.2 - TINKERPOP-1692

### DIFF
--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -89,7 +89,7 @@ limitations under the License.
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.3-2.3.3
+                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.7-3.2.2-SNAPSHOT
                             </Gremlin-Plugin-Dependencies>
                         </manifestEntries>
                     </archive>
@@ -117,16 +117,28 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.3-2.3.3</version>
+                    <version>0.7-3.2.2-SNAPSHOT</version>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>
-                            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                            <artifactId>concurrentlinkedhashmap-lru</artifactId>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.github.ben-manes.caffeine</groupId>
+                            <artifactId>caffeine</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.neo4j</groupId>
+                            <artifactId>neo4j</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>org.scala-lang</groupId>
                             <artifactId>scala-library</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.scala-lang</groupId>
+                            <artifactId>scala-reflect</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>org.slf4j</groupId>
@@ -137,13 +149,25 @@ limitations under the License.
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
-                    <version>2.11.6</version>
+                    <version>2.11.8</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                    <artifactId>concurrentlinkedhashmap-lru</artifactId>
-                    <version>1.4.2</version>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-reflect</artifactId>
+                    <version>2.11.8</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                    <version>2.3.1</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j</artifactId>
+                    <version>3.2.2</version>
                     <scope>test</scope>
                 </dependency>
                 <!-- *** WARNING *** -->

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/NativeNeo4jCypherCheck.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/NativeNeo4jCypherCheck.java
@@ -111,7 +111,7 @@ public class NativeNeo4jCypherCheck extends AbstractNeo4jGremlinTest {
         this.graph.addVertex("name", "marko", "age", 30, "color", "orange");
         this.graph.tx().commit();
 
-        final List<Object> result = this.getGraph().cypher("MATCH n WHERE id(n) IN [1,2] RETURN n").select("n").id().toList();
+        final List<Object> result = this.getGraph().cypher("MATCH (n) WHERE id(n) IN [1,2] RETURN n").select("n").id().toList();
         assertNotNull(result);
         assertEquals(2, result.size());
         assertTrue(result.contains(1l));
@@ -129,7 +129,7 @@ public class NativeNeo4jCypherCheck extends AbstractNeo4jGremlinTest {
         final List<Object> ids = Arrays.asList(v1.id(), v2.id());
         final Map<String, Object> m = new HashMap<>();
         m.put("ids", ids);
-        final List<Object> result = this.getGraph().cypher("MATCH n WHERE id(n) IN {ids} RETURN n", m).select("n").id().toList();
+        final List<Object> result = this.getGraph().cypher("MATCH (n) WHERE id(n) IN {ids} RETURN n", m).select("n").id().toList();
         assertNotNull(result);
         assertEquals(2, result.size());
         assertTrue(result.contains(v1.id()));

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/structure/NativeNeo4jStructureCheck.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/structure/NativeNeo4jStructureCheck.java
@@ -197,7 +197,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             // assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
 
-            assertEquals(4l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(4l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(2l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(2l, this.getBaseGraph().execute("MATCH (a)-[r]->() WHERE id(a) = " + a.id() + " RETURN COUNT(r)", null).next().get("COUNT(r)"));
             final AtomicInteger counter = new AtomicInteger(0);
@@ -206,8 +206,8 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
                 counter.incrementAndGet();
             });
             assertEquals(2, counter.getAndSet(0));
-            this.getBaseGraph().execute("MATCH (a)-[]->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
-                assertEquals(VertexProperty.DEFAULT_LABEL, ((List<String>) results.get("labels(m)")).get(0));
+            this.getBaseGraph().execute("MATCH (a)-->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
+                assertEquals(true, ((List<String>) results.get("labels(m)")).contains(VertexProperty.DEFAULT_LABEL));
                 counter.incrementAndGet();
             });
             assertEquals(2, counter.getAndSet(0));
@@ -234,7 +234,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             //  assertEquals(1, b.properties("name").count().next().intValue());
             // assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
-            assertEquals(2l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(2l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(0l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
 
             assertEquals(1, IteratorUtils.count(a.getBaseVertex().getKeys()));
@@ -250,7 +250,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             //    assertEquals(0, a.properties().count().next().intValue());
             //   assertEquals(2, b.properties().count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
-            assertEquals(2l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(2l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(0l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(0, IteratorUtils.count(a.getBaseVertex().getKeys()));
             assertEquals(2, IteratorUtils.count(b.getBaseVertex().getKeys()));
@@ -265,7 +265,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             // assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
 
-            assertEquals(3l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(3l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (a)-[r]->() WHERE id(a) = " + a.id() + " RETURN COUNT(r)", null).next().get("COUNT(r)"));
             final AtomicInteger counter = new AtomicInteger(0);
@@ -274,8 +274,8 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));
-            this.getBaseGraph().execute("MATCH (a)-[]->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
-                assertEquals(VertexProperty.DEFAULT_LABEL, ((List<String>) results.get("labels(m)")).get(0));
+            this.getBaseGraph().execute("MATCH (a)-->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
+                assertEquals(true, ((List<String>) results.get("labels(m)")).contains(VertexProperty.DEFAULT_LABEL));
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));
@@ -309,7 +309,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             //assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
 
-            assertEquals(3l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(3l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (a)-[r]->() WHERE id(a) = " + a.id() + " RETURN COUNT(r)", null).next().get("COUNT(r)"));
             final AtomicInteger counter = new AtomicInteger(0);
@@ -318,8 +318,8 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));
-            this.getBaseGraph().execute("MATCH (a)-[]->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
-                assertEquals(VertexProperty.DEFAULT_LABEL, ((List<String>) results.get("labels(m)")).get(0));
+            this.getBaseGraph().execute("MATCH (a)-->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
+                assertEquals(true, ((List<String>) results.get("labels(m)")).contains(VertexProperty.DEFAULT_LABEL));
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));


### PR DESCRIPTION
for review

couldn't get the maven enforcer plugin to work
fixed two tests with Cypher syntax issues
the schema-index-performance test is flaky

see: https://github.com/neo4j-contrib/neo4j-tinkerpop-api-impl/commits/3.2
