### PR TITLE
TINKERPOP-1727: Bytecode object shallow copied when traversals are cloned

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ This release also includes changes from <<release-3-1-8, 3.1.8>>.
 * Improved GraphSON serialization performance around `VertexProperty`.
 * Changed some tests in `EventStrategyProcessTest` which were enforcing some unintended semantics around transaction state.
 * Added WsAndHttpChannelizer and SaslAndHttpBasicAuthenticationHandler to be allow for servicing Http and Websocket requests to the same server
+* Added deep copy of `Bytecode` to `DefaultTraversal.clone()`.
 
 [[release-3-2-5]]
 TinkerPop 3.2.5 (Release Date: June 12, 2017)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -62,7 +62,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     protected transient TraverserGenerator generator;
     protected Set<TraverserRequirement> requirements;
     protected boolean locked = false;
-    protected final Bytecode bytecode; // TODO: perhaps make transient until 3.3.0?
+    protected Bytecode bytecode; // TODO: perhaps make transient until 3.3.0?
 
 
     private DefaultTraversal(final Graph graph, final TraversalStrategies traversalStrategies, final Bytecode bytecode) {
@@ -247,6 +247,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
             clone.unmodifiableSteps = Collections.unmodifiableList(clone.steps);
             clone.sideEffects = this.sideEffects.clone();
             clone.strategies = this.strategies;
+            clone.bytecode = this.bytecode.clone();
             for (final Step<?, ?> step : this.steps) {
                 final Step<?, ?> clonedStep = step.clone();
                 clonedStep.setTraversal(clone);

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -102,6 +103,7 @@ public class DefaultTraversalTest {
         clone.getSideEffects().set("m", 2);
         assertEquals(1, original.getSideEffects().<Integer>get("m").intValue());
         assertEquals(2, clone.getSideEffects().<Integer>get("m").intValue());
+        assertNotSame(original.bytecode, clone.bytecode);
     }
 
     @Test


### PR DESCRIPTION
Added an explicit deep copy of `bytecode` in `DefaultTraversal.clone()`

VOTE: +1

```
[INFO] Apache TinkerPop ................................... SUCCESS [  7.372 s]
[INFO] Apache TinkerPop :: Gremlin Shaded ................. SUCCESS [  3.981 s]
[INFO] Apache TinkerPop :: Gremlin Core ................... SUCCESS [01:56 min]
[INFO] Apache TinkerPop :: Gremlin Test ................... SUCCESS [ 18.989 s]
[INFO] Apache TinkerPop :: Gremlin Groovy ................. SUCCESS [04:20 min]
[INFO] Apache TinkerPop :: Gremlin Groovy Test ............ SUCCESS [ 10.580 s]
[INFO] Apache TinkerPop :: TinkerGraph Gremlin ............ SUCCESS [03:51 min]
[INFO] Apache TinkerPop :: Gremlin Benchmark .............. SUCCESS [  9.258 s]
[INFO] Apache TinkerPop :: Gremlin Driver ................. SUCCESS [ 17.654 s]
[INFO] Apache TinkerPop :: Neo4j Gremlin .................. SUCCESS [  4.002 s]
[INFO] Apache TinkerPop :: Gremlin Server ................. SUCCESS [01:03 min]
[INFO] Apache TinkerPop :: Gremlin Python ................. SUCCESS [ 11.328 s]
[INFO] Apache TinkerPop :: Hadoop Gremlin ................. SUCCESS [04:17 min]
[INFO] Apache TinkerPop :: Spark Gremlin .................. SUCCESS [01:45 min]
[INFO] Apache TinkerPop :: Giraph Gremlin ................. SUCCESS [ 11.786 s]
[INFO] Apache TinkerPop :: Gremlin Console ................ SUCCESS [ 30.369 s]
[INFO] Apache TinkerPop :: Gremlin Archetype .............. SUCCESS [  0.167 s]
[INFO] Apache TinkerPop :: Archetype - TinkerGraph ........ SUCCESS [  6.686 s]
[INFO] Apache TinkerPop :: Archetype - Server ............. SUCCESS [ 13.698 s]
[INFO] Apache TinkerPop :: Archetype - DSL ................ SUCCESS [  7.444 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```