### PR TITLE
TINKERPOP-1729: Remove deprecated select steps.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Removed previously deprecated `GraphTraversal.selectV3d0()` step.
 * Removed previously deprecated `DetachedEdge(Object,String,Map,Pair,Pair)` constructor.
 * Removed previously deprecated `Bindings` constructor. It is now a private constructor.
 * Removed previously deprecated `TraversalSource.withBindings()`.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -235,6 +235,7 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#addE(Direction, String, String, Object...)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#addOutE(String, String, Object...)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#addInV(String, String, Object...)`
+** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#selectV3d2()`
 ** `org.apache.tinkerpop.gremlin.process.traversal.Bindings()`
 ** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource#withBindings(Bindings)`
 ** `org.apache.tinkerpop.gremlin.structure.Transaction.submit(Function)`
@@ -360,7 +361,8 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-1721[TINKERPOP-1721],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1719[TINKERPOP-1719],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1720[TINKERPOP-1720],
 link:https://issues.apache.org/jira/browse/TINKERPOP-880[TINKERPOP-880],
-link:https://issues.apache.org/jira/browse/TINKERPOP-1170[TINKERPOP-1170]
+link:https://issues.apache.org/jira/browse/TINKERPOP-1170[TINKERPOP-1170],
+link:https://issues.apache.org/jira/browse/TINKERPOP-1729[TINKERPOP-1729]
 
 Gremlin-server.sh and Init Scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -732,29 +732,6 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     /**
-     * @deprecated As of release 3.3.0, replaced by {@link GraphTraversal#select(Pop, String)} with {@link Pop#mixed}.
-     */
-    @Deprecated
-    public default <E2> GraphTraversal<S, E2> selectV3d2(final String selectKey) {
-        this.asAdmin().getBytecode().addStep(Symbols.selectV3d2, selectKey);
-        return this.asAdmin().addStep(new SelectOneStep<>(this.asAdmin(), Pop.mixed, selectKey));
-    }
-
-    /**
-     * @deprecated As of release 3.3.0, replaced by {@link GraphTraversal#select(Pop, String, String, String...)} with {@link Pop#mixed}.
-     */
-    @Deprecated
-    public default <E2> GraphTraversal<S, Map<String, E2>> selectV3d2(final String selectKey1, final String selectKey2, String... otherSelectKeys) {
-        final String[] selectKeys = new String[otherSelectKeys.length + 2];
-        selectKeys[0] = selectKey1;
-        selectKeys[1] = selectKey2;
-        System.arraycopy(otherSelectKeys, 0, selectKeys, 2, otherSelectKeys.length);
-        this.asAdmin().getBytecode().addStep(Symbols.selectV3d2, selectKey1, selectKey2, otherSelectKeys);
-        return this.asAdmin().addStep(new SelectStep<>(this.asAdmin(), Pop.mixed, selectKeys));
-    }
-
-
-    /**
      * A version of {@code select} that allows for the extraction of a {@link Column} from objects in the traversal.
      *
      * @param column the column to extract

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -338,14 +338,6 @@ public class __ {
     }
 
     /**
-     * @see GraphTraversal#selectV3d2(String)
-     */
-    @Deprecated
-    public static <A, B> GraphTraversal<A, B> selectV3d2(final String selectKey) {
-        return __.<A>start().selectV3d2(selectKey);
-    }
-
-    /**
      * @see GraphTraversal#select(Pop, String, String, String...)
      */
     public static <A, B> GraphTraversal<A, Map<String, B>> select(final Pop pop, final String selectKey1, final String selectKey2, final String... otherSelectKeys) {
@@ -357,14 +349,6 @@ public class __ {
      */
     public static <A, B> GraphTraversal<A, Map<String, B>> select(final String selectKey1, final String selectKey2, final String... otherSelectKeys) {
         return __.<A>start().select(selectKey1, selectKey2, otherSelectKeys);
-    }
-
-    /**
-     * @see GraphTraversal#selectV3d2(String, String, String...)
-     */
-    @Deprecated
-    public static <A, B> GraphTraversal<A, Map<String, B>> selectV3d2(final String selectKey1, final String selectKey2, final String... otherSelectKeys) {
-        return __.<A>start().selectV3d2(selectKey1, selectKey2, otherSelectKeys);
     }
 
     /**

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -416,10 +416,6 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("select", *args)
         return self
 
-    def selectV3d2(self, *args):
-        self.bytecode.add_step("selectV3d2", *args)
-        return self
-
     def sideEffect(self, *args):
         self.bytecode.add_step("sideEffect", *args)
         return self
@@ -780,10 +776,6 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).select(*args)
 
     @classmethod
-    def selectV3d2(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).selectV3d2(*args)
-
-    @classmethod
     def sideEffect(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).sideEffect(*args)
 
@@ -1132,10 +1124,6 @@ statics.add_static('sample', sample)
 def select(*args):
     return __.select(*args)
 statics.add_static('select', select)
-
-def selectV3d2(*args):
-    return __.selectV3d2(*args)
-statics.add_static('selectV3d2', selectV3d2)
 
 def sideEffect(*args):
     return __.sideEffect(*args)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1729

There is no point is crying over spilled milk. The deed is done. It had to be done.

VOTE +1.