### PR TITLE
TINKERPOP-1679: Detached side-effects aren't attached when remoted

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
+* Added graph element GraphSON serializers in Gremlin-Python.
 * Initialization scripts for Gremlin Server will not timeout.
 * Added Gremlin.Net.
 * `ProfileTest` is now less stringent about assertions which will reduce burdens on providers.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
+* `AddEdgeStep` attaches detached vertices prior to edge creation.
 * Added graph element GraphSON serializers in Gremlin-Python.
 * Initialization scripts for Gremlin Server will not timeout.
 * Added Gremlin.Net.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
@@ -65,14 +65,6 @@ import java.util.Iterator;
         method = "*",
         reason = "hmmmm")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectTest",
-        method = "g_V_hasLabelXpersonX_projectXa_bX_byXoutE_countX_byXageX",
-        reason = "Not happy in OLAP.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectTest",
-        method = "g_V_outXcreatedX_projectXa_bX_byXnameX_byXinXcreatedX_countX_order_byXselectXbX__decrX_selectXaX",
-        reason = "Not happy in OLAP.")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.CoreTraversalTest",
         method = "*",
         reason = "The test suite does not support profiling or lambdas and for groovy tests: 'Could not locate method: GraphTraversalSource.withStrategies([{traversalCategory=interface org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy$DecorationStrategy}])'")

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -95,7 +95,7 @@ public final class AddEdgeStep<S> extends MapStep<S, Edge>
         Vertex toVertex = this.parameters.get(traverser, TO, () -> (Vertex) traverser.get()).get(0);
         Vertex fromVertex = this.parameters.get(traverser, FROM, () -> (Vertex) traverser.get()).get(0);
         if (toVertex instanceof Attachable)
-            toVertex = ((Attachable<Vertex>) fromVertex)
+            toVertex = ((Attachable<Vertex>) toVertex)
                     .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
         if (fromVertex instanceof Attachable)
             fromVertex = ((Attachable<Vertex>) fromVertex)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -37,6 +37,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.List;
 import java.util.Set;
@@ -93,13 +94,12 @@ public final class AddEdgeStep<S> extends MapStep<S, Edge>
     protected Edge map(final Traverser.Admin<S> traverser) {
         Vertex toVertex = this.parameters.get(traverser, TO, () -> (Vertex) traverser.get()).get(0);
         Vertex fromVertex = this.parameters.get(traverser, FROM, () -> (Vertex) traverser.get()).get(0);
-        if (this.getTraversal().getGraph().isPresent()) {
-            final Graph graph = this.getTraversal().getGraph().get();
-            if (toVertex instanceof Attachable)
-                toVertex = ((Attachable<Vertex>) toVertex).attach(Attachable.Method.get(graph));
-            if (fromVertex instanceof Attachable)
-                fromVertex = ((Attachable<Vertex>) fromVertex).attach(Attachable.Method.get(graph));
-        }
+        if (toVertex instanceof Attachable)
+            toVertex = ((Attachable<Vertex>) fromVertex)
+                    .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
+        if (fromVertex instanceof Attachable)
+            fromVertex = ((Attachable<Vertex>) fromVertex)
+                    .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
         final String edgeLabel = this.parameters.get(traverser, T.label, () -> Edge.DEFAULT_LABEL).get(0);
 
         final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -34,11 +34,10 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.Attachable;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -81,19 +80,26 @@ public final class AddEdgeStep<S> extends MapStep<S, Edge>
     }
 
     @Override
-    public void addTo(final Traversal.Admin<?,?> toObject) {
+    public void addTo(final Traversal.Admin<?, ?> toObject) {
         this.parameters.set(this, TO, toObject);
     }
 
     @Override
-    public void addFrom(final Traversal.Admin<?,?> fromObject) {
+    public void addFrom(final Traversal.Admin<?, ?> fromObject) {
         this.parameters.set(this, FROM, fromObject);
     }
 
     @Override
     protected Edge map(final Traverser.Admin<S> traverser) {
-        final Vertex toVertex = this.parameters.get(traverser, TO, () -> (Vertex) traverser.get()).get(0);
-        final Vertex fromVertex = this.parameters.get(traverser, FROM, () -> (Vertex) traverser.get()).get(0);
+        Vertex toVertex = this.parameters.get(traverser, TO, () -> (Vertex) traverser.get()).get(0);
+        Vertex fromVertex = this.parameters.get(traverser, FROM, () -> (Vertex) traverser.get()).get(0);
+        if (this.getTraversal().getGraph().isPresent()) {
+            final Graph graph = this.getTraversal().getGraph().get();
+            if (toVertex instanceof Attachable)
+                toVertex = ((Attachable<Vertex>) toVertex).attach(Attachable.Method.get(graph));
+            if (fromVertex instanceof Attachable)
+                fromVertex = ((Attachable<Vertex>) fromVertex).attach(Attachable.Method.get(graph));
+        }
         final String edgeLabel = this.parameters.get(traverser, T.label, () -> Edge.DEFAULT_LABEL).get(0);
 
         final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddEdgeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddEdgeTest.groovy
@@ -86,5 +86,13 @@ public abstract class GroovyAddEdgeTest {
         public Traversal<Vertex, Edge> get_g_addV_asXfirstX_repeatXaddEXnextX_toXaddVX_inVX_timesX5X_addEXnextX_toXselectXfirstXX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.addV().as('first').repeat(addE('next').to(addV()).inV).times(5).addE('next').to(select('first'))")
         }
+
+        @Override
+        public Traversal<Vertex, Edge> get_g_withSideEffectXb_bX_VXaX_addEXknowsX_toXbX_propertyXweight_0_5X() {
+            final Vertex a = g.V().has("name", "marko").next();
+            final Vertex b = g.V().has("name", "peter").next();
+            return new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('b', b).V(a).addE('knows').to('b').property('weight', 0.5d)", "a", a, "b", b)
+        }
+
     }
 }

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -26,7 +26,6 @@ from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, T
 from gremlin_python.process.traversal import Binding, Bytecode, P, Traversal, Traverser, TraversalStrategy
 from gremlin_python.structure.graph import Edge, Property, Vertex, VertexProperty, Path
 
-
 # When we fall back to a superclass's serializer, we iterate over this map.
 # We want that iteration order to be consistent, so we use an OrderedDict,
 # not a dict.
@@ -60,9 +59,9 @@ class GraphSONUtil(object):
     def formatType(cls, prefix, type_name):
         return "%s:%s" % (prefix, type_name)
 
+
 # Read/Write classes split to follow precedence of the Java API
 class GraphSONWriter(object):
-
     def __init__(self, serializer_map=None):
         """
         :param serializer_map: map from Python type to serializer instance implementing `dictify`
@@ -96,7 +95,6 @@ class GraphSONWriter(object):
 
 
 class GraphSONReader(object):
-
     def __init__(self, deserializer_map=None):
         """
         :param deserializer_map: map from GraphSON type tag to deserializer instance implementing `objectify`
@@ -147,7 +145,6 @@ class _GraphSONTypeIO(object):
 
 
 class _BytecodeSerializer(_GraphSONTypeIO):
-
     @classmethod
     def _dictify_instructions(cls, instructions, writer):
         out = []
@@ -167,6 +164,49 @@ class _BytecodeSerializer(_GraphSONTypeIO):
         if bytecode.step_instructions:
             out["step"] = cls._dictify_instructions(bytecode.step_instructions, writer)
         return GraphSONUtil.typedValue("Bytecode", out)
+
+
+class VertexSerializer(_GraphSONTypeIO):
+    python_type = Vertex
+
+    @classmethod
+    def dictify(cls, vertex, writer):
+        v = {"id": writer.toDict(vertex.id),
+             "label": vertex.label}
+        return GraphSONUtil.typedValue("Vertex", v)
+
+
+class EdgeSerializer(_GraphSONTypeIO):
+    python_type = Edge
+
+    @classmethod
+    def dictify(cls, edge, writer):
+        e = {"id": edge.id,
+             "label": edge.label,
+             "inV": writer.toDict(edge.inV.id),
+             "outV": writer.toDict(edge.outV.id)}
+        return GraphSONUtil.typedValue("Edge", e)
+
+
+class VertexPropertySerializer(_GraphSONTypeIO):
+    python_type = VertexProperty
+
+    @classmethod
+    def dictify(cls, vertex_property, writer):
+        vp = {"id": vertex_property.id,
+              "label": vertex_property.label,
+              "value": writer.toDict(vertex_property.value)}
+        return GraphSONUtil.typedValue("VertexProperty", vp)
+
+
+class PropertySerializer(_GraphSONTypeIO):
+    python_type = Property
+
+    @classmethod
+    def dictify(cls, property, writer):
+        p = {"key": writer.toDict(property.key),
+             "value": writer.toDict(property.value)}
+        return GraphSONUtil.typedValue("Property", p)
 
 
 class TraversalSerializer(_BytecodeSerializer):
@@ -216,7 +256,7 @@ class PSerializer(_GraphSONTypeIO):
     def dictify(cls, p, writer):
         out = {"predicate": p.operator,
                "value": [writer.toDict(p.value), writer.toDict(p.other)] if p.other is not None else
-                        writer.toDict(p.value)}
+               writer.toDict(p.value)}
         return GraphSONUtil.typedValue("P", out)
 
 
@@ -259,7 +299,6 @@ class TypeSerializer(_GraphSONTypeIO):
 
 
 class _NumberIO(_GraphSONTypeIO):
-
     @classmethod
     def dictify(cls, n, writer):
         if isinstance(n, bool):  # because isinstance(False, int) and isinstance(True, int)

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -59,7 +59,8 @@ class TestDriverRemoteConnection(object):
         assert 4 == g.V()[2:].count().next()
         assert 2 == g.V()[:2].count().next()
         # #
-        results = g.withSideEffect('a',['josh','peter']).V(1).out('created').in_('created').values('name').where(within('a')).toList()
+        results = g.withSideEffect('a', ['josh', 'peter']).V(1).out('created').in_('created').values('name').where(
+            within('a')).toList()
         assert 2 == len(results)
         assert 'josh' in results
         assert 'peter' in results
@@ -153,6 +154,20 @@ class TestDriverRemoteConnection(object):
         with pytest.raises(Exception):
             x = t.side_effects["x"]
 
+        a = g.V().has("name", "marko").next()
+        b = g.V().has("name", "peter").next()
+        edge = g.withSideEffect("b", b).V(a).addE("knows").to("b").next()
+        assert "knows" == edge.label
+        assert a == edge.outV
+        assert b == edge.inV
+        g.V().has("name","marko").outE("knows").where(__.inV().has("name","peter")).drop().iterate()
+        ##
+        edge = g.withSideEffect("a", a).withSideEffect("b", b).V().limit(1).addE("knows").from_("a").to("b").next()
+        assert "knows" == edge.label
+        assert a == edge.outV
+        assert b == edge.inV
+        g.V().has("name","marko").outE("knows").where(__.inV().has("name","peter")).drop().iterate()
+
     def test_side_effect_close(self, remote_connection):
         g = Graph().traversal().withRemote(remote_connection)
         t = g.V().aggregate('a').aggregate('b')
@@ -191,7 +206,7 @@ class TestDriverRemoteConnection(object):
         t = future.result()
         assert len(t.toList()) == 6
         a, = t.side_effects.keys()
-        assert  a == 'a'
+        assert a == 'a'
         results = t.side_effects.get('a')
         assert results
         results = t.side_effects.close()

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
@@ -274,8 +274,8 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         assertEquals("knows", edge.label());
         assertEquals(1, IteratorUtils.count(edge.properties()));
         assertEquals(0.5d, edge.value("weight"), 0.1d);
-        assertEquals(6, IteratorUtils.count(graph.vertices()));
-        assertEquals(7, IteratorUtils.count(graph.edges()));
+        assertEquals(6L, g.V().count().next().longValue());
+        assertEquals(7L, g.E().count().next().longValue());
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
@@ -63,6 +63,8 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Edge> get_g_addV_asXfirstX_repeatXaddEXnextX_toXaddVX_inVX_timesX5X_addEXnextX_toXselectXfirstXX();
 
+    public abstract Traversal<Vertex, Edge> get_g_withSideEffectXb_bX_VXaX_addEXknowsX_toXbX_propertyXweight_0_5X();
+
     ///////
 
     @Deprecated
@@ -262,6 +264,22 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
+    public void g_withSideEffectXb_bX_VXaX_addEXknowsX_toXbX_propertyXweight_0_5X() {
+        final Traversal<Vertex, Edge> traversal = get_g_withSideEffectXb_bX_VXaX_addEXknowsX_toXbX_propertyXweight_0_5X();
+        final Edge edge = traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals(edge.outVertex(), convertToVertex(graph, "marko"));
+        assertEquals(edge.inVertex(), convertToVertex(graph, "peter"));
+        assertEquals("knows", edge.label());
+        assertEquals(1, IteratorUtils.count(edge.properties()));
+        assertEquals(0.5d, edge.value("weight"), 0.1d);
+        assertEquals(6, IteratorUtils.count(graph.vertices()));
+        assertEquals(7, IteratorUtils.count(graph.edges()));
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
     @Deprecated
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     public void g_V_asXaX_inXcreatedX_addInEXcreatedBy_a_year_2009_acl_publicX() {
@@ -352,6 +370,13 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_inXcreatedX_addEXcreatedByX_fromXaX_propertyXyear_2009X_propertyXacl_publicX() {
             return g.V().as("a").in("created").addE("createdBy").from("a").property("year", 2009).property("acl", "public");
+        }
+
+        @Override
+        public Traversal<Vertex, Edge> get_g_withSideEffectXb_bX_VXaX_addEXknowsX_toXbX_propertyXweight_0_5X() {
+            final Vertex a = g.V().has("name", "marko").next();
+            final Vertex b = g.V().has("name", "peter").next();
+            return g.withSideEffect("b", b).V(a).addE("knows").to("b").property("weight", 0.5d);
         }
 
         ///////


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1679

This was occurring because Gremlin-Python did not have serializers for the Graph elements. I created serializers which are of the `ReferenceXXX` form. I added serializer tests as well as add an `AddEdgeTest` and specific Gremlin-Python test for the traversal specified in the ticket. I also exposed two `ProjectTest` `OPT_OUTs` in `RemoteGraph`. I don't know why those were `OPT_OUT` as OLAP will automatically fail accordingly beyond the star graph.

VOTE +1.