### PR TITLE
TINKERPOP-1692 Neo4j 3.2.2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,9 @@ TinkerPop 3.3.1 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
+* Bumped Neo4j 3.2.3
+
+
 [[release-3-3-0]]
 TinkerPop 3.3.0 (Release Date: August 21, 2017)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -256,8 +256,8 @@ graph.close()
 
 gremlin.graph=org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph
 gremlin.neo4j.directory=/tmp/neo4j
-gremlin.neo4j.conf.node_auto_indexing=true
-gremlin.neo4j.conf.relationship_auto_indexing=true
+gremlin.neo4j.conf.dbms.auto_index.nodes.enabled=true
+gremlin.neo4j.conf.dbms.auto_index.relationships.enabled=true
 ----
 
 High Availability Configuration
@@ -283,8 +283,8 @@ gremlin.graph=org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph
 gremlin.neo4j.directory=/tmp/neo4j.server1
 gremlin.neo4j.conf.ha.server_id=1
 gremlin.neo4j.conf.ha.initial_hosts=localhost:5001\,localhost:5002\,localhost:5003
-gremlin.neo4j.conf.ha.cluster_server=localhost:5001
-gremlin.neo4j.conf.ha.server=localhost:6001
+gremlin.neo4j.conf.ha.host.coordination=localhost:5001
+gremlin.neo4j.conf.ha.host.data=localhost:6001
 ----
 
 Assuming the intent is to configure this cluster completely within TinkerPop (perhaps within three separate Gremlin
@@ -296,8 +296,8 @@ gremlin.graph=org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph
 gremlin.neo4j.directory=/tmp/neo4j.server2
 gremlin.neo4j.conf.ha.server_id=2
 gremlin.neo4j.conf.ha.initial_hosts=localhost:5001\,localhost:5002\,localhost:5003
-gremlin.neo4j.conf.ha.cluster_server=localhost:5002
-gremlin.neo4j.conf.ha.server=localhost:6002
+gremlin.neo4j.conf.ha.host.coordination=localhost:5002
+gremlin.neo4j.conf.ha.host.data=localhost:6002
 ----
 
 and the third will be:
@@ -308,8 +308,8 @@ gremlin.graph=org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph
 gremlin.neo4j.directory=/tmp/neo4j.server3
 gremlin.neo4j.conf.ha.server_id=3
 gremlin.neo4j.conf.ha.initial_hosts=localhost:5001\,localhost:5002\,localhost:5003
-gremlin.neo4j.conf.ha.cluster_server=localhost:5003
-gremlin.neo4j.conf.ha.server=localhost:6003
+gremlin.neo4j.conf.ha.host.coordination=localhost:5003
+gremlin.neo4j.conf.ha.host.data=localhost:6003
 ----
 
 IMPORTANT: The backslashes in the values provided to `gremlin.neo4j.conf.ha.initial_hosts` prevent that configuration

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -22,6 +22,32 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *Gremlin Symphony #40 in G Minor*
 
+TinkerPop 3.3.1
+---------------
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.3.1/CHANGELOG.asciidoc#release-3-3-1[changelog] for a complete list of all the modifications that are part of this release.
+
+Upgrading for Users
+~~~~~~~~~~~~~~~~~~~
+
+Upgrade Neo4j
+^^^^^^^^^^^^^
+
+See Neo4j's link:https://neo4j.com/guides/upgrade/[3.2 Upgrade FAQ] for a complete guide on how to upgrade from the previous 2.3.3 version. Also note that many of the configuration settings have link:https://neo4j.com/developer/kb/manually-migrating-configuration-settings-from-neo4j-2x-to-neo4j-3x/[changed from neo4j 2x to 3x]
+
+In particular, these properties referenced in TinkerPop documentation and configuration were renamed:
+
+|=========================================================
+|old (2.3) |new (3.3)
+|node_auto_indexing |dbms.auto_index.nodes.enabled
+|relationship_auto_indexing |dbms.auto_index.relationships.enabled
+|ha.cluster_server |ha.host.coordination
+|ha.server |ha.host.data
+|=========================================================
+
+
 TinkerPop 3.3.0
 ---------------
 

--- a/gremlin-console/conf/neo4j-standalone.properties
+++ b/gremlin-console/conf/neo4j-standalone.properties
@@ -18,5 +18,7 @@
 gremlin.graph=org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph
 
 gremlin.neo4j.directory=/tmp/neo4j
-gremlin.neo4j.conf.node_auto_indexing=true
-gremlin.neo4j.conf.relationship_auto_indexing=true
+gremlin.neo4j.conf.dbms.auto_index.nodes.enabled=true
+#gremlin.neo4j.conf.dbms.auto_index.nodes.keys=
+gremlin.neo4j.conf.dbms.auto_index.relationships.enabled=true
+#gremlin.neo4j.conf.dbms.auto_index.relationships.keys=

--- a/gremlin-server/conf/neo4j-empty.properties
+++ b/gremlin-server/conf/neo4j-empty.properties
@@ -29,5 +29,7 @@
 
 gremlin.graph=org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph
 gremlin.neo4j.directory=/tmp/neo4j
-gremlin.neo4j.conf.node_auto_indexing=true
-gremlin.neo4j.conf.relationship_auto_indexing=true
+gremlin.neo4j.conf.dbms.auto_index.nodes.enabled=true
+#gremlin.neo4j.conf.dbms.auto_index.nodes.keys=
+gremlin.neo4j.conf.dbms.auto_index.relationships.enabled=true
+#gremlin.neo4j.conf.dbms.auto_index.relationships.keys=

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -121,16 +121,16 @@ limitations under the License.
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>
+                            <groupId>org.neo4j</groupId>
+                            <artifactId>neo4j-kernel</artifactId>
+                        </exclusion>
+                        <exclusion>
                             <groupId>org.apache.commons</groupId>
                             <artifactId>commons-lang3</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>com.github.ben-manes.caffeine</groupId>
                             <artifactId>caffeine</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.neo4j</groupId>
-                            <artifactId>neo4j</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>org.scala-lang</groupId>
@@ -164,9 +164,10 @@ limitations under the License.
                     <version>2.3.1</version>
                     <scope>test</scope>
                 </dependency>
+                <!-- self-conflict with neo4j-graph-matching -->
                 <dependency>
                     <groupId>org.neo4j</groupId>
-                    <artifactId>neo4j</artifactId>
+                    <artifactId>neo4j-kernel</artifactId>
                     <version>3.2.2</version>
                     <scope>test</scope>
                 </dependency>

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -89,7 +89,7 @@ limitations under the License.
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.7-3.2.2-SNAPSHOT
+                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.7-3.2.3
                             </Gremlin-Plugin-Dependencies>
                         </manifestEntries>
                     </archive>
@@ -117,7 +117,7 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.7-3.2.2-SNAPSHOT</version>
+                    <version>0.7-3.2.3</version>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>
@@ -168,7 +168,7 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-kernel</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.2.3</version>
                     <scope>test</scope>
                 </dependency>
                 <!-- *** WARNING *** -->

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -89,7 +89,7 @@ limitations under the License.
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.3-2.3.3
+                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.6-3.2.2
                             </Gremlin-Plugin-Dependencies>
                         </manifestEntries>
                     </archive>
@@ -117,16 +117,28 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.3-2.3.3</version>
+                    <version>0.6-3.2.2</version>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>
-                            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                            <artifactId>concurrentlinkedhashmap-lru</artifactId>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.github.ben-manes.caffeine</groupId>
+                            <artifactId>caffeine</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.neo4j</groupId>
+                            <artifactId>neo4j</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>org.scala-lang</groupId>
                             <artifactId>scala-library</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.scala-lang</groupId>
+                            <artifactId>scala-reflect</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>org.slf4j</groupId>
@@ -137,13 +149,25 @@ limitations under the License.
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
-                    <version>2.11.6</version>
+                    <version>2.11.8</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                    <artifactId>concurrentlinkedhashmap-lru</artifactId>
-                    <version>1.4.2</version>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-reflect</artifactId>
+                    <version>2.11.8</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                    <version>2.3.1</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j</artifactId>
+                    <version>3.2.2</version>
                     <scope>test</scope>
                 </dependency>
                 <!-- *** WARNING *** -->

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -89,7 +89,7 @@ limitations under the License.
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.6-3.2.2
+                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.7-3.2.2-SNAPSHOT
                             </Gremlin-Plugin-Dependencies>
                         </manifestEntries>
                     </archive>
@@ -117,7 +117,7 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.6-3.2.2</version>
+                    <version>0.7-3.2.2-SNAPSHOT</version>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/NativeNeo4jCypherCheck.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/NativeNeo4jCypherCheck.java
@@ -111,7 +111,7 @@ public class NativeNeo4jCypherCheck extends AbstractNeo4jGremlinTest {
         this.graph.addVertex("name", "marko", "age", 30, "color", "orange");
         this.graph.tx().commit();
 
-        final List<Object> result = this.getGraph().cypher("MATCH n WHERE id(n) IN [1,2] RETURN n").select("n").id().toList();
+        final List<Object> result = this.getGraph().cypher("MATCH (n) WHERE id(n) IN [1,2] RETURN n").select("n").id().toList();
         assertNotNull(result);
         assertEquals(2, result.size());
         assertTrue(result.contains(1l));
@@ -129,7 +129,7 @@ public class NativeNeo4jCypherCheck extends AbstractNeo4jGremlinTest {
         final List<Object> ids = Arrays.asList(v1.id(), v2.id());
         final Map<String, Object> m = new HashMap<>();
         m.put("ids", ids);
-        final List<Object> result = this.getGraph().cypher("MATCH n WHERE id(n) IN {ids} RETURN n", m).select("n").id().toList();
+        final List<Object> result = this.getGraph().cypher("MATCH (n) WHERE id(n) IN {ids} RETURN n", m).select("n").id().toList();
         assertNotNull(result);
         assertEquals(2, result.size());
         assertTrue(result.contains(v1.id()));

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/structure/NativeNeo4jStructureCheck.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/structure/NativeNeo4jStructureCheck.java
@@ -197,7 +197,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             // assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
 
-            assertEquals(4l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(4l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(2l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(2l, this.getBaseGraph().execute("MATCH (a)-[r]->() WHERE id(a) = " + a.id() + " RETURN COUNT(r)", null).next().get("COUNT(r)"));
             final AtomicInteger counter = new AtomicInteger(0);
@@ -206,8 +206,8 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
                 counter.incrementAndGet();
             });
             assertEquals(2, counter.getAndSet(0));
-            this.getBaseGraph().execute("MATCH (a)-[]->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
-                assertEquals(VertexProperty.DEFAULT_LABEL, ((List<String>) results.get("labels(m)")).get(0));
+            this.getBaseGraph().execute("MATCH (a)-->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
+                assertEquals(true, ((List<String>) results.get("labels(m)")).contains(VertexProperty.DEFAULT_LABEL));
                 counter.incrementAndGet();
             });
             assertEquals(2, counter.getAndSet(0));
@@ -234,7 +234,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             //  assertEquals(1, b.properties("name").count().next().intValue());
             // assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
-            assertEquals(2l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(2l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(0l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
 
             assertEquals(1, IteratorUtils.count(a.getBaseVertex().getKeys()));
@@ -250,7 +250,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             //    assertEquals(0, a.properties().count().next().intValue());
             //   assertEquals(2, b.properties().count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
-            assertEquals(2l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(2l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(0l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(0, IteratorUtils.count(a.getBaseVertex().getKeys()));
             assertEquals(2, IteratorUtils.count(b.getBaseVertex().getKeys()));
@@ -265,7 +265,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             // assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
 
-            assertEquals(3l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(3l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (a)-[r]->() WHERE id(a) = " + a.id() + " RETURN COUNT(r)", null).next().get("COUNT(r)"));
             final AtomicInteger counter = new AtomicInteger(0);
@@ -274,8 +274,8 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));
-            this.getBaseGraph().execute("MATCH (a)-[]->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
-                assertEquals(VertexProperty.DEFAULT_LABEL, ((List<String>) results.get("labels(m)")).get(0));
+            this.getBaseGraph().execute("MATCH (a)-->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
+                assertEquals(true, ((List<String>) results.get("labels(m)")).contains(VertexProperty.DEFAULT_LABEL));
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));
@@ -309,7 +309,7 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
             //assertEquals(1, b.properties("location").count().next().intValue());
             assertEquals(0, g.E().count().next().intValue());
 
-            assertEquals(3l, this.getBaseGraph().execute("MATCH n RETURN COUNT(n)", null).next().get("COUNT(n)"));
+            assertEquals(3l, this.getBaseGraph().execute("MATCH (n) RETURN COUNT(n)", null).next().get("COUNT(n)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (n)-[r]->(m) RETURN COUNT(r)", null).next().get("COUNT(r)"));
             assertEquals(1l, this.getBaseGraph().execute("MATCH (a)-[r]->() WHERE id(a) = " + a.id() + " RETURN COUNT(r)", null).next().get("COUNT(r)"));
             final AtomicInteger counter = new AtomicInteger(0);
@@ -318,8 +318,8 @@ public class NativeNeo4jStructureCheck extends AbstractNeo4jGremlinTest {
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));
-            this.getBaseGraph().execute("MATCH (a)-[]->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
-                assertEquals(VertexProperty.DEFAULT_LABEL, ((List<String>) results.get("labels(m)")).get(0));
+            this.getBaseGraph().execute("MATCH (a)-->(m) WHERE id(a) = " + a.id() + " RETURN labels(m)", null).forEachRemaining(results -> {
+                assertEquals(true, ((List<String>) results.get("labels(m)")).contains(VertexProperty.DEFAULT_LABEL));
                 counter.incrementAndGet();
             });
             assertEquals(1, counter.getAndSet(0));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1692

Bumps to Neo4j 3.2.2 and is the revision to #674 which needed some additional `pom.xml` work. That's the only real change here. Going forward for review/vote purposes, we'll use this PR over the other one.

Running full tests now....will udpate when complete.

