### PR TITLE
TINKERPOP-1535: Bump to support Giraph 1.2.0.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Bumped to support Giraph 1.2.0.
 * Bumped to support Spark 2.2.0.
 * Detected if type checking was required in `GremlinGroovyScriptEngine` and disabled related infrastructure if not.
 * Removed previously deprecated `GraphTraversal.selectV3d0()` step.

--- a/giraph-gremlin/pom.xml
+++ b/giraph-gremlin/pom.xml
@@ -64,7 +64,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.giraph</groupId>
             <artifactId>giraph-core</artifactId>
-            <version>1.1.0-hadoop2</version>
+            <version>1.2.0-hadoop2</version>
             <exclusions>
                 <!-- self conflicts -->
                 <exclusion>

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphMessageCombiner.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphMessageCombiner.java
@@ -30,7 +30,7 @@ import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GiraphMessageCombiner extends org.apache.giraph.combiner.MessageCombiner<ObjectWritable, ObjectWritable> implements ImmutableClassesGiraphConfigurable {
+public final class GiraphMessageCombiner implements org.apache.giraph.combiner.MessageCombiner<ObjectWritable, ObjectWritable>, ImmutableClassesGiraphConfigurable {
 
     private MessageCombiner messageCombiner;
     private ImmutableClassesGiraphConfiguration configuration;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1535

I bumped Giraph from 1.1.0 to 1.20. It was a pretty straight forward upgrade. There was only a single class that needed some tweaking -- `MessageCombiner` is now an interface in Giraph instead of a class.

VOTE +1.