### PR TITLE
TINKERPOP-1736 Sack step evaluated by groovy interprets numbers in an unexpected way

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,12 @@ TinkerPop 3.1.8 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Fixed a `MessageScope` bug in `TinkerGraphComputer`.
+* Fixed a bug in `BigDecimal` divisions in `NumberHelper` that potentially threw an `ArithmeticException`.
+
+Bugs
+^^^^
+
+* TINKERPOP-1736 Sack step evaluated by Groovy interprets numbers in an unexpected way
 
 [[release-3-1-7]]
 TinkerPop 3.1.7 (Release Date: June 12, 2017)

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySackTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySackTest.groovy
@@ -74,5 +74,10 @@ public abstract class GroovySackTest {
         Traversal<Vertex, BigDecimal> get_g_withSackXBigInteger_TEN_powX1000X_assignX_V_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack() {
             TraversalScriptHelper.compute("g.withSack(BigInteger.TEN.pow(1000), assign).V.local(out('knows').barrier(normSack)).in('knows').barrier.sack", g)
         }
+
+        @Override
+        Traversal<Vertex, BigDecimal> get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack() {
+            TraversalScriptHelper.compute("g.withSack(2).V.sack(div).by(constant(3.0)).sack", g)
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackTest.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.constant;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.junit.Assert.assertEquals;
@@ -67,6 +68,8 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Integer> get_g_withBulkXfalseX_withSackX1_sumX_V_out_barrier_sack();
 
     public abstract Traversal<Vertex, BigDecimal> get_g_withSackXBigInteger_TEN_powX1000X_assignX_V_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack();
+
+    public abstract Traversal<Vertex, BigDecimal> get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -156,6 +159,19 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
         assertFalse(traversal.hasNext());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack() {
+        final Traversal<Vertex, BigDecimal> traversal = get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack();
+        printTraversalForm(traversal);
+        final double expected = 2.0 / 3.0;
+        for (int i = 0; i < 6; i++) {
+            assertTrue(traversal.hasNext());
+            assertEquals(expected, traversal.next().doubleValue(), 0.0001);
+        }
+        assertFalse(traversal.hasNext());
+    }
+
     public static class Traversals extends SackTest {
 
         @Override
@@ -204,6 +220,11 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, BigDecimal> get_g_withSackXBigInteger_TEN_powX1000X_assignX_V_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack() {
             return g.withSack(BigInteger.TEN.pow(1000), Operator.assign).V().local(out("knows").barrier(SackFunctions.Barrier.normSack)).in("knows").barrier().sack();
+        }
+
+        @Override
+        public Traversal<Vertex, BigDecimal> get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack() {
+            return g.withSack(2).V().sack(Operator.div).by(constant(BigDecimal.valueOf(3))).sack();
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1736

Fixed a bug in `BigDecimal` divisions in `NumberHelper` that potentially threw an `ArithmeticException`.

`docker/build.sh -t -i` succeeded.

VOTE: +1