### PR TITLE
TINKERPOP-1736 Sack step evaluated by groovy interprets numbers in an unexpected way

### DIFF
--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySackTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySackTest.groovy
@@ -76,7 +76,7 @@ public abstract class GroovySackTest {
         }
 
         @Override
-        Traversal<Vertex, BigDecimal> get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack() {
+        Traversal<Vertex, Double> get_g_withSackX2X_V_sackXdivX_byXconstantX3_0XX_sack() {
             TraversalScriptHelper.compute("g.withSack(2).V.sack(div).by(constant(3.0)).sack", g)
         }
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackTest.java
@@ -69,7 +69,7 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, BigDecimal> get_g_withSackXBigInteger_TEN_powX1000X_assignX_V_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack();
 
-    public abstract Traversal<Vertex, BigDecimal> get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack();
+    public abstract Traversal<Vertex, Double> get_g_withSackX2X_V_sackXdivX_byXconstantX3_0XX_sack();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -161,13 +161,13 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack() {
-        final Traversal<Vertex, BigDecimal> traversal = get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack();
+    public void g_withSackX2X_V_sackXdivX_byXconstantX3_0XX_sack() {
+        final Traversal<Vertex, Double> traversal = get_g_withSackX2X_V_sackXdivX_byXconstantX3_0XX_sack();
         printTraversalForm(traversal);
         final double expected = 2.0 / 3.0;
         for (int i = 0; i < 6; i++) {
             assertTrue(traversal.hasNext());
-            assertEquals(expected, traversal.next().doubleValue(), 0.0001);
+            assertEquals(expected, ((Number) traversal.next()).doubleValue(), 0.0001);
         }
         assertFalse(traversal.hasNext());
     }
@@ -223,8 +223,8 @@ public abstract class SackTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, BigDecimal> get_g_withSackX2X_V_sackXdivX_byXconstantXBigDecimal_valueOfX3XXX_sack() {
-            return g.withSack(2).V().sack(Operator.div).by(constant(BigDecimal.valueOf(3))).sack();
+        public Traversal<Vertex, Double> get_g_withSackX2X_V_sackXdivX_byXconstantX3_0XX_sack() {
+            return g.withSack(2).V().sack(Operator.div).by(constant(3.0)).sack();
         }
     }
 }


### PR DESCRIPTION
Follow-up on #682. This PR fixes the test case that failed in `master/`.

VOTE: +1