### PR TITLE
TINKERPOP-1724 Remove deprecated ScriptElementFactory

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Removed previously deprecated `ScriptElementFactory`.
 * Bumped to support Giraph 1.2.0.
 * Bumped to support Spark 2.2.0.
 * Detected if type checking was required in `GremlinGroovyScriptEngine` and disabled related infrastructure if not.

--- a/data/script-input.groovy
+++ b/data/script-input.groovy
@@ -16,9 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-def parse(line, factory) {
-    // "factory" should no longer be used, as ScriptElementFactory is now deprecated
-    // instead use the global "graph" variable which is the local star graph for the current element
+def parse(line) {
     def parts = line.split(/ /)
     def (id, label, name, x) = parts[0].split(/:/).toList()
     def v1 = graph.addVertex(T.id, id, T.label, label)

--- a/docs/src/reference/implementations-hadoop-end.asciidoc
+++ b/docs/src/reference/implementations-hadoop-end.asciidoc
@@ -91,16 +91,15 @@ As such, `ScriptInputFormat` can be used. With `ScriptInputFormat` a script is s
 mapper in the Hadoop job. The script must have the following method defined:
 
 [source,groovy]
-def parse(String line, ScriptElementFactory factory) { ... }
+def parse(String line) { ... }
 
-`ScriptElementFactory` is a legacy from previous versions and, although it's still functional, it should no longer be used.
 In order to create vertices and edges, the `parse()` method gets access to a global variable named `graph`, which holds
 the local `StarGraph` for the current line/vertex.
 
 An appropriate `parse()` for the above adjacency list file is:
 
 [source,groovy]
-def parse(line, factory) {
+def parse(line) {
     def parts = line.split(/ /)
     def (id, label, name, x) = parts[0].split(/:/).toList()
     def v1 = graph.addVertex(T.id, id, T.label, label)

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/script/script-input-grateful-dead.groovy
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/script/script-input-grateful-dead.groovy
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-def parse(line, factory) {
+def parse(line) {
     def (vertex, outEdges, inEdges) = line.split(/\t/, 3)
     def (v1id, v1label, v1props) = vertex.split(/,/, 3)
-    def v1 = factory.vertex(v1id.toInteger(), v1label)
+    def v1 = graph.addVertex(T.id, v1id.toInteger(), T.label, v1label)
     switch (v1label) {
         case "song":
             def (name, songType, performances) = v1props.split(/,/)
@@ -43,8 +43,8 @@ def parse(line, factory) {
             } else {
                 (eLabel, otherV, weight) = parts
             }
-            def v2 = factory.vertex(otherV.toInteger())
-            def e = factory.edge(out ? v1 : v2, out ? v2 : v1, eLabel)
+            def v2 = graph.addVertex(T.id, otherV.toInteger())
+            def e = out ? v1.addOutEdge(eLabel, v2) : v1.addInEdge(eLabel, v2)
             if (weight != null) e.property("weight", weight.toInteger())
         }
     }

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/script/script-input.groovy
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/script/script-input.groovy
@@ -18,7 +18,7 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty
  * specific language governing permissions and limitations
  * under the License.
  */
-def parse(line, factory) {
+def parse(line) {
     def parts = line.split(/\t/)
     def (id, label, name, x) = parts[0].split(/:/).toList()
     def v1 = graph.addVertex(T.id, id, T.label, label)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1724

Removed previously deprecated `ScriptElementFactory`.

`mvn clean install -DskipIntegrationTests=false` succeeded. (Docker ran out of memory for some reason, but I'm sure that was not related to my changes)

VOTE: +1