### PR TITLE
TINKERPOP-1743: LambdaRestrictionStrategy does not catch lambdas passed to sack()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
+* Fixed a lambda-leak in `SackValueStep` where `BiFunction` must be tested for true lambda status.
 * Allowed access to `InjectStep.injections` for `TraversalStrategy` analysis.
 * Exceptions that occur during result iteration in Gremlin Server will now return `SCRIPT_EVALUATION_EXCEPTION` rather than `SERVER_ERROR`.
 * `AddEdgeStep` attaches detached vertices prior to edge creation.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
@@ -70,6 +70,10 @@ public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements T
         return super.hashCode() ^ this.sackFunction.hashCode() ^ ((null == this.sackTraversal) ? "null".hashCode() : this.sackTraversal.hashCode());
     }
 
+    public BiFunction<A,B,A> getSackFunction() {
+        return this.sackFunction;
+    }
+
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return getSelfAndChildRequirements(TraverserRequirement.SACK);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ComparatorHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackValueStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.javatuples.Pair;
 
@@ -64,6 +65,8 @@ public final class LambdaRestrictionStrategy extends AbstractTraversalStrategy<T
                         throw new VerificationException("The provided step contains a lambda comparator: " + step, traversal);
                 }
             }
+            if (step instanceof SackValueStep && (((SackValueStep) step).getSackFunction().toString().contains("$$Lambda$")))
+                throw new VerificationException("The provided step contains a lambda comparator: " + step, traversal);
         }
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
@@ -61,12 +61,16 @@ public final class LambdaRestrictionStrategy extends AbstractTraversalStrategy<T
                 throw new VerificationException("The provided traversal contains a lambda step: " + step, traversal);
             if (step instanceof ComparatorHolder) {
                 for (final Pair<Traversal.Admin<Object, Comparable>, Comparator<Comparable>> comparator : ((ComparatorHolder<Object, Comparable>) step).getComparators()) {
-                    if (comparator.toString().contains("$$Lambda$"))
+                    final String comparatorString = comparator.toString();
+                    if (comparatorString.contains("$") || comparatorString.contains("@"))
                         throw new VerificationException("The provided step contains a lambda comparator: " + step, traversal);
                 }
             }
-            if (step instanceof SackValueStep && (((SackValueStep) step).getSackFunction().toString().contains("$$Lambda$")))
-                throw new VerificationException("The provided step contains a lambda comparator: " + step, traversal);
+            if (step instanceof SackValueStep) {
+                final String sackString = ((SackValueStep) step).getSackFunction().toString();
+                if (sackString.contains("$") || sackString.contains("@"))
+                    throw new VerificationException("The provided step contains a lambda bi-function: " + step, traversal);
+            }
         }
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
@@ -33,6 +33,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.Operator.sum;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -59,6 +60,9 @@ public class LambdaRestrictionStrategyTest {
                 {"order(local).by(values,decr)", __.order(Scope.local).by(Column.values, Order.decr), true},
                 {"order().by(label,decr)", __.order().by(T.label, Order.decr), true},
                 {"groupCount().by(label)", __.groupCount().by(T.label), true},
+                //
+                {"sack(sum).by('age')", __.sack(sum).by("age"), true},
+                {"sack{a,b -> a+b}.by('age')", __.sack((a, b) -> (int) a + (int) b).by("age"), false},
         });
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1743

Fixed a lambda-leak in `SackValueStep` where `BiFunction` must be tested for true lambda status.