### PR TITLE
TINKERPOP-1744 Unwrap AggregateException for sync io operations

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -26,7 +26,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Gremlin.Net.Structure;
+using Gremlin.Net.Process;
 
 namespace Gremlin.Net.Driver
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -26,6 +26,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.Driver
 {
@@ -92,7 +93,7 @@ namespace Gremlin.Net.Driver
                     {
                         if (_connections != null && !_connections.IsEmpty)
                         {
-                            TeardownAsync().Wait();
+                            TeardownAsync().WaitUnwrap();
 
                             foreach (var conn in _connections)
                                 conn.Dispose();

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteTraversalSideEffects.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteTraversalSideEffects.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Process.Traversal;
+using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.Driver.Remote
 {
@@ -112,7 +113,7 @@ namespace Gremlin.Net.Driver.Remote
 
         private void CloseSideEffects()
         {
-            _gremlinClient.SubmitAsync<object>(SideEffectCloseMessage()).Wait();
+            _gremlinClient.SubmitAsync<object>(SideEffectCloseMessage()).WaitUnwrap();
         }
 
         private RequestMessage SideEffectCloseMessage()

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteTraversalSideEffects.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteTraversalSideEffects.cs
@@ -25,8 +25,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Gremlin.Net.Driver.Messages;
+using Gremlin.Net.Process;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.Driver.Remote
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
@@ -23,7 +23,6 @@
 
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.Process.Remote
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
@@ -23,6 +23,7 @@
 
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
+using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.Process.Remote
 {
@@ -46,7 +47,7 @@ namespace Gremlin.Net.Process.Remote
         /// <inheritdoc />
         public void Apply<S, E>(ITraversal<S, E> traversal)
         {
-            ApplyAsync(traversal).Wait();
+            ApplyAsync(traversal).WaitUnwrap();
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
@@ -25,7 +25,7 @@ using System;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
-namespace Gremlin.Net.Structure
+namespace Gremlin.Net.Process
 {
     /// <summary>
     /// Contains useful methods that can be reused across the project. 

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Utils.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Utils.cs
@@ -1,0 +1,55 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+
+namespace Gremlin.Net.Structure
+{
+    /// <summary>
+    /// Contains useful methods that can be reused across the project. 
+    /// </summary>
+    internal static class Utils
+    {
+        /// <summary>
+        /// Waits the completion of the provided Task.
+        /// When an AggregateException is thrown, the inner exception is thrown.
+        /// </summary>
+        public static void WaitUnwrap(this Task task)
+        {
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException ex)
+            {
+                if (ex.InnerExceptions.Count == 1)
+                {
+                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();   
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Remote/RemoteStrategyTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Remote/RemoteStrategyTests.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Exceptions;
 using Gremlin.Net.Driver.Remote;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal;
@@ -49,6 +50,17 @@ namespace Gremlin.Net.IntegrationTest.Process.Remote
             var actualResult = testTraversal.Next();
 
             Assert.Equal(expectedResult, actualResult);
+        }
+        
+        [Fact]
+        public void ShouldThrowOriginalExceptionWhenByteCodeIsInvalid()
+        {
+            var testBytecode = new Bytecode();
+            testBytecode.AddStep("V");
+            testBytecode.AddStep("this_step_does_not_exist", "test");
+            var testTraversal = CreateTraversalWithRemoteStrategy(testBytecode);
+
+            Assert.Throws<ResponseException>(() => testTraversal.Next());
         }
 
         [Fact]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1744

Includes a test expecting the underlying exception (`ResponseException`) to be thrown.

Builds with `mvn clean install -P gremlin-dotnet`