### PR TITLE
TINKERPOP-1747 Streamline inheritance for gremlin-python GraphSON serializer classes

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/serializer.py
@@ -89,8 +89,8 @@ class GraphSONMessageSerializer(object):
     """
 
     # KEEP TRACK OF CURRENT DEFAULTS
-    DEFAULT_READER = graphsonV3d0.GraphSONReader()
-    DEFAULT_WRITER = graphsonV3d0.GraphSONWriter()
+    DEFAULT_READER_CLASS = graphsonV3d0.GraphSONReader
+    DEFAULT_WRITER_CLASS = graphsonV3d0.GraphSONWriter
     DEFAULT_VERSION = b"application/vnd.gremlin-v3.0+json"
 
     def __init__(self, reader=None, writer=None, version=None):
@@ -98,10 +98,10 @@ class GraphSONMessageSerializer(object):
             version = self.DEFAULT_VERSION
         self._version = version
         if not reader:
-            reader = self.DEFAULT_READER
+            reader = self.DEFAULT_READER_CLASS()
         self._graphson_reader = reader
         if not writer:
-            writer = self.DEFAULT_WRITER
+            writer = self.DEFAULT_WRITER_CLASS()
         self.standard = Standard(writer)
         self.traversal = Traversal(writer)
 

--- a/gremlin-python/src/main/jython/tests/conftest.py
+++ b/gremlin-python/src/main/jython/tests/conftest.py
@@ -27,7 +27,9 @@ from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import (
     DriverRemoteConnection)
 from gremlin_python.driver.protocol import GremlinServerWSProtocol
-from gremlin_python.driver.serializer import GraphSONMessageSerializer
+from gremlin_python.driver.serializer import (
+    GraphSONMessageSerializer, GraphSONSerializersV2d0,
+    GraphSONSerializersV3d0)
 from gremlin_python.driver.tornado.transport import TornadoTransport
 
 
@@ -86,3 +88,13 @@ def remote_connection_v2(request):
             remote_conn.close()
         request.addfinalizer(fin)
         return remote_conn
+
+
+@pytest.fixture
+def graphson_serializer_v2(request):
+    return GraphSONSerializersV2d0()
+
+
+@pytest.fixture
+def graphson_serializer_v3(request):
+    return GraphSONSerializersV3d0()

--- a/gremlin-python/src/main/jython/tests/driver/test_serializer.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_serializer.py
@@ -1,0 +1,37 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+'''
+from gremlin_python.structure.io import graphsonV2d0
+from gremlin_python.structure.io import graphsonV3d0
+
+
+__author__ = 'David M. Brown'
+
+
+def test_graphson_serialzier_v2(graphson_serializer_v2):
+    assert graphson_serializer_v2.version == b"application/vnd.gremlin-v2.0+json"
+    assert isinstance(graphson_serializer_v2._graphson_reader, graphsonV2d0.GraphSONReader)
+    assert isinstance(graphson_serializer_v2.standard._graphson_writer, graphsonV2d0.GraphSONWriter)
+    assert isinstance(graphson_serializer_v2.traversal._graphson_writer, graphsonV2d0.GraphSONWriter)
+
+
+def test_graphson_serialzier_v3(graphson_serializer_v3):
+    assert graphson_serializer_v3.version == b"application/vnd.gremlin-v3.0+json"
+    assert isinstance(graphson_serializer_v3._graphson_reader, graphsonV3d0.GraphSONReader)
+    assert isinstance(graphson_serializer_v3.standard._graphson_writer, graphsonV3d0.GraphSONWriter)
+    assert isinstance(graphson_serializer_v3.traversal._graphson_writer, graphsonV3d0.GraphSONWriter)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1747

This PR cleans up the code used to define GraphSON serializer classes in gremlin-python. 

`GraphSONMessageSerializer` acts as a base class for `GraphSONSerializersV2d0` and `GraphSONSerializersV3d0` in a similar fashion, but with this change:

1. While `GraphSONMessageSerializer` can accept custom reader, writer, and version implementations in order to create a custom serializer,  `GraphSONSerializersV2d0` and `GraphSONSerializersV3d0` cannot.

2. Instead `GraphSONSerializersV3d0` and `GraphSONSerializersV2d0` are in a sense implementations of custom serializers, and they always use `graphsonV2d0.GraphSONReader()`/`graphsonV2d0.GraphSONWriter()` and `graphsonV3d0.GraphSONReader()`/`graphsonV3d0.GraphSONWriter()` respectively.

As before, `GraphSONMessageSerializer` will default to the current version of GraphSON (v3 for TP 3.3.0) if no custom reader/writer implementation is passed. Defaults are now specified in a highly visible class attribute position using uppercase naming like class CONSTANTS.

All other changes, like using `super` to call parent class's init methods, are more stylistic, reflecting current Python standards for best practice.

I also added a couple small tests to make sure each serializer was assigned proper reader, writer classes as well as version information. 