### PR TITLE
TINKERPOP-1749  Bump to Netty 4.0.50

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.2.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-1-8, 3.1.8>>.
 
+* Bump to Netty 4.0.50
 * Registered `HashMap$TreeNode` to Gryo.
 * Fixed a lambda-leak in `SackValueStep` where `BiFunction` must be tested for true lambda status.
 * Fixed a bug in `RangeByIsCountStrategy` that broke any `ConnectiveStep` that included a child traversal with an optimizable pattern.

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ limitations under the License.
         <javadoc-plugin.version>2.10.4</javadoc-plugin.version>
         <jcabi.version>1.1</jcabi.version>
         <metrics.version>3.0.2</metrics.version>
-        <netty.version>4.0.42.Final</netty.version>
+        <netty.version>4.0.50.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1749

Many SSL updates, bug fixes.

`docker/build.sh -i -t -n` SUCCESS

VOTE +1
