### PR TITLE
TINKERPOP-1750: An Object Graph Mapping Framework For Gremlin.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.3.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `gremlin-objects`, an object graph mapping framework for Gremlin.
 * Removed previously deprecated `ScriptElementFactory`.
 * Added `GraphTraversalSource.addE(String)` in support of `g.addE().from().to()`.
 * Added support for `to(Vertex)` and `from(Vertex)` as a shorthand for `to(V(a))` and `from(V(b))`.

--- a/LICENSE
+++ b/LICENSE
@@ -211,3 +211,4 @@ The Apache TinkerPop project bundles the following components under the MIT Lice
      jquery 1.11.0 (https://jquery.com/) - for details, see license/jquery
      normalize.css 2.1.2 (http://necolas.github.io/normalize.css/) - for details, see licenses/normalize
      prism.css/js (http://prismjs.com) - for details, see licenses/prism
+     lombok 1.6.18 (https://projectlombok.org/) - for details, see licenses/lombok

--- a/gremlin-objects/README.asciidoc
+++ b/gremlin-objects/README.asciidoc
@@ -1,0 +1,310 @@
+////
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+////
+An Object Graph Mapping Framework For Gremlin
+---------------------------------------------
+Karthick Sankarachary <http://gihub.com/karthicks>
+[.lead]
+The `gremlin-objects` link:pom.xml[module] defines a framework that puts an object-oriented spin on the gremlin property graph.
+It aims to make it much easier to specify business `domain specific languages` around Gremlin, without any loss of expressive power.
+While it targets the Gremlin-Java variant, the concept itself is language-independent.
+
+=== Introduction
+
+Every element in the property graph, whether it be a vertex (property) or an edge, is made up of properties.
+Each such property is a `String` key and an arbitrary `Java` value.
+It only seems fitting then to try and represent that property as a strongly-typed `Java` field.
+The specific class in which that field is defined then becomes the vertex (property) or edge, which the property describes.
+A `gremlin object model` such as this would need abstractions to query and update the graph in terms of those objects.
+To get the framework that facilitates all of this, add this dependency to your `pom.xml`:
+
+[source, pom]
+----
+<dependency>
+  <groupId>org.apache.tinkerpop</groupId>
+  <artifactId>gremlin-objects</artifactId>
+  <version>3.3.0-SNAPSHOT</version>
+</dependency>
+----
+
+A default reference implementation of this framework is available in the following `tinkergraph-gremlin` module:
+
+[source, pom]
+----
+<dependency>
+  <groupId>org.apache.tinkerpop</groupId>
+  <artifactId>tinkergraph-gremlin</artifactId>
+  <version>3.3.0-SNAPSHOT</version>
+</dependency>
+----
+
+=== The Object Graph
+
+In this section, we go over how gremlin elements may be modeled, and how those models may be queried and stored.
+
+==== Object Model
+
+Let's consider the example of the `person` vertex, taken from the "modern" and "the crew" graphs defined in the link:../tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerFactory.java[TinkerFactory].
+In our object world, it would be defined as a `Person` class that extends link:./src/main/java/org/apache/tinkerpop/gremlin/object/structure/Vertex.java[Vertex].
+By default, the vertex's label matches its simple class name, hence we have to un-capitalize it using the `@Alias` annotation.
+
+The person's `name` and `age` properties become primitive fields in the class.
+The `@PrimaryKey` and `@OrderingKey` annotations on them not only indicate that they are mandatory,
+but also allow the `person` to be found easily through the link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasKeys.java[HasKeys.of(person)] `SubTraversal`.
+Think of the link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/SubTraversal.java[SubTraversal] as a reusable function that takes a `GraphTraversal`, performs a few steps on it, and returns it back (to allow for chaining).
+The `KnowsPeople` field in this class is an example of an in-line `SubTraversal`, albeit a stronger-typed version of it called `ToVertex`, to indicate that it ends up selecting vertices.
+Note that these traversal functions are not stored in the graph.
+
+[source, java]
+----
+@Data
+@Alias(label = "person")
+public class Person extends Vertex {
+
+  public static ToVertex KnowsPeople = traversal -> traversal
+      .out(Label.of(Knows.class))
+      .hasLabel(Label.of(Person.class));
+
+  @PrimaryKey
+  private String name;
+
+  @OrderingKey
+  private int age;
+
+  private Set<String> titles;
+
+  private List<Location> locations;
+}
+----
+
+Next, we look at its `titles` field, which is defined to be a `Set`.
+As you might expect, the cardinality of the underlying property becomes `set`.
+Similarly, the `locations` field takes on the `list` cardinality.
+Further, each element in the `locations` list has it's own meta-properties, and ergo deserves a `Location` class of it's own.
+
+[source, java]
+----
+@Data
+@Alias(label = 'location')
+public class Location extends Element {
+
+  @OrderingKey
+  @PropertyValue
+  private String name;
+  @OrderingKey
+  private Instant startTime;
+  private Instant endTime;
+}
+----
+
+NOTE: The value of the `location` is stored in `name`, due to the placement of the `@PropertyValue` annotation.
+Every other field in the `Location` class becomes the `location`'s meta-property.
+
+An edge is defined much like the vertex, except it extends the `Edge` class.
+By default, an edge's label is it's un-capitalized simple class name, and hence no `@Alias` is needed:
+
+[source, java]
+----
+@Data
+public class Knows extends Edge {
+  private Double weight;
+
+  private Instant since;
+}
+----
+
+You can find more examples of gremlin object vertices link:./src/test/java/org/apache/tinkerpop/gremlin/object/vertices/[here] and edges link:./src/test/java/org/apache/tinkerpop/gremlin/object/edges/[here].
+
+==== Updating Objects
+The `Graph` interface lets you update the graph using `Vertex` or `Edge` objects.
+You can get it via dependency injection:
+
+[source, java]
+----
+@Inject // To use another provider, add it's Qualifier here.
+private Graph graph;
+----
+
+Or, the good old fashioned way, using a `GraphFactory` interface:
+
+[source, java]
+----
+private GraphFactory graphFactory =
+    TinkerFactory.of(); // This gets you the TinkerGraph factory.
+private Graph = graphFactory.graph();
+----
+
+Now that we know how to obtain a `Graph` instance, let's see how to change it using `Java` objects.
+Here, we create `software` vertices for `tinkergraph` and `gremlin`, and add a `traverses` edge from `gremlin` to `tinkergraph`.
+
+[source, java]
+----
+graph
+    .addVertex(Software.of("tinkergraph")).as("tinkergraph")
+    .addVertex(Software.of("gremlin")).as("gremlin")
+    .addEdge(Traverses.of(), "tinkergraph");
+----
+
+Below, a `person` vertex containing a list of `locations` is added, along with three outgoing edges.
+
+[source, java]
+----
+graph
+    .addVertex(
+        Person.of("marko",
+            Location.of("san diego", 1997, 2001),
+            Location.of("santa cruz", 2001, 2004),
+            Location.of("brussels", 2004, 2005),
+            Location.of("santa fe", 2005))).as("marko")
+    .addEdge(Develops.of(2010), "tinkergraph")
+    .addEdge(Uses.of(Proficient), "gremlin")
+    .addEdge(Uses.of(Expert), "tinkergraph")
+----
+
+To see how the `modern` and the `crew` reference graphs may be created using the object `Graph` interface, go link:./src/test/java/org/apache/tinkerpop/gremlin/object/graphs/[here].
+
+TIP: Since the object being added may already exist in the graph, we provide link:./src/main/java/org/apache/tinkerpop/gremlin/object/structure/Graph.java[various options] to resolve "merge conflicts", such as `MERGE`, `REPLACE`, `CREATE`, `IGNORE` AND `INSERT`.
+
+==== Querying Objects
+
+There are two ways to get a handle to the `Query` interface.
+You can inject it, and get the `TinkerGraph` query, like so:
+
+[source, java]
+----
+@Inject
+private Query query;
+----
+
+Otherwise, if you have a handle to a `GraphFactory` class, like the one for `TinkerGraph`, you can create it like so:
+
+[source, java]
+----
+private GraphFactory graphFactory = TinkerFactory.of();
+private Query = graphFactory.query();
+----
+
+Next, let's see how to use the `Query` interface.
+The following snippet queries the graph by chaining two `SubTraversals` (a function denoting a partial traversal), and parses the result into a list of `Person` vertices.
+
+[source, java]
+----
+List<Person> friends = query
+    .by(HasKeys.of(modern.marko), Person.KnowsPeople)
+    .list(Person.class);
+----
+
+Below, we query by an `AnyTraversal` (a function on the `GraphTraversalSource`), and get a single `Person` back.
+
+[source, java]
+----
+Person marko = Person.of("marko");
+Person actual = query
+    .by(g -> g.V().hasLabel(marko.label()).has("name", marko.getName()))
+    .one(Person.class);
+----
+
+The type of the result may be primitives too, and that is handled as shown below.
+
+[source, java]
+----
+long count = query
+    .by(HasPrimaryKey.of(crew.marko), Count.of())
+    .one(Long.class);
+----
+
+Last, we show a traversal involving select steps, which requires special handling as it may return a map.
+
+[source, java]
+----
+Selections selections = query
+    .by(g -> g.V().as("a").
+        properties("locations").as("b").
+        hasNot("endTime").as("c").
+        order().by("startTime").
+        select("a", "b", "c").by("name").by(T.value).by("startTime").dedup())
+    .as("a", String.class)
+    .as("b", String.class)
+    .as("c", Instant.class)
+    .select();
+----
+
+To see more examples showcasing how the object `Query` interface may be used, go link:./src/test/java/org/apache/tinkerpop/gremlin/object/ObjectGraphTest.java[here].
+
+=== Providers
+
+In this section, we talk about how the `gremlin-objects` framework can be adopted by and adapted for a `graph system`.
+
+==== Service Provider Interface
+A provider that wishes to plug into `gremlin-objects` will need to implement the `GraphSystem`, which simply supplies a `GraphTraversalSource`.
+In addition, it must extend the `ObjectGraph` and `ObjectQuery` abstract classes, constructor injecting its implementation of the `GraphSystem`.
+For users that don't use dependency injection, an implementation of the `GraphFactory` (preferably an extension of the `CachedFactory`) must also be provided.
+
+==== Registering Native Types
+Typically, gremlin property values are Java primitives.
+Sometimes, a provider treats a custom type as a primitive.
+For instance, `DataStax` lets you define property keys of the primitive geometric type `Point`.
+Such types can be registered using the `Primitives#registerPrimitiveClass` methods.
+
+==== Registering Custom Parsers
+When a `GraphTraversal` is completed, it usually returns (a list of) gremlin `Element(s)`.
+However, when some providers execute a traversal, the result comprises custom element types.
+For instance, when `DataStax` executes a graph query, it returns a result set made up of `GraphNode(s)`, a proprietary element type.
+We give such providers a way to tell us how to parse such custom elements using the `Parsers#registerElementParser` method.
+
+=== Analysis
+
+While there exist similar frameworks, this one has some key differentiating factors. Now, let's consider the alternatives:
+
+==== GremlinDsl Traversals
+The `gremlin-core` module defines a `GremlinDsl` annotation that lets you define custom traversals by extending the `GraphTraversal` and `GraphTraversalSource`.
+However, it requires some familiarity of `gremlin-core` internals.
+
+==== Peopod for Tinkerpop 3
+Peopod represents elements as annotated interfaces or abstract classes.
+While it generates boilerplate for traversals to adjacent vertices, it doesn't let you co-locate arbitrary traversals.
+This framework is less intrusive and more flexible.
+
+==== User Defined Steps
+An older version of TinkerPop allowed you to define custom steps using `Closures`, not unlike the `AnyTraversal` and `SubTraversal` functions.
+However, they aren't as developer friendly as the functional interfaces provided here.
+Moreover, it doesn't allow for co-locating the traversal logic along with the element model, as we do here.
+
+=== Future Work
+
+So far, we have the `gremlin-objects` framework, and a `TinkerGraph` implementation of it.
+Here, we list a few directions in which we see the framework evolving:
+
+==== Language Variants
+The concept of lifting the property graph into objects is language-independent.
+While `gremlin-objects` currently targets the Gremlin-Java variant, it can be ported to any variant that supports basic reflection.
+Case in point, the Gremlin-Python variant could achieve the object mapping through the `dir`, `getattr`  and `setattr` built-in functions.
+
+==== Provider Support
+In reality, it is fairly easy for a provider to plug-into `gremlin-objects` simply by implementing an interface and extending a few classes.
+The ability to register custom primitive types and traversal result parsers allows for customization.
+Since `neo4j` already has it's own TinkerPop module, it's a good candidate to become a provider. While there exists a `DataStax` implementation, it uses an older TinkerPop version, and hence is not included.
+
+==== DataFrame Support
+Some providers use `GraphFrames` to execute bulk operations and graph algorithms on top of Tinkerpop.
+Assuming they can work with `DataFrames`, one could build a `GraphTraversalSource`,
+which translates the object `Graph` and `Query` operations into `DataFrame` tables,  and adapt's it to the provider's `GraphFrame`.
+
+==== Traversal Storage
+The link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/AnyTraversal.java[AnyTraversal] and link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/SubTraversal.java[SubTraversal]
+interfaces extend `Formattable` so that the steps defined in it's body can be revealed.
+Let's say that we stored the bytecode of these types of functional fields as a hidden property in the element.
+That could potentially allow us to execute `user defined traversals` using a, say, `traversal.invoke('function-name')` step.

--- a/gremlin-objects/README.asciidoc
+++ b/gremlin-objects/README.asciidoc
@@ -58,11 +58,11 @@ In this section, we go over how gremlin elements may be modeled, and how those m
 ==== Object Model
 
 Let's consider the example of the `person` vertex, taken from the "modern" and "the crew" graphs defined in the link:../tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerFactory.java[TinkerFactory].
-In our object world, it would be defined as a `Person` class that extends link:./src/main/java/org/apache/tinkerpop/gremlin/object/structure/Vertex.java[Vertex].
-By default, the vertex's label matches its simple class name, hence we have to un-capitalize it using the `@Alias` annotation.
+In our object world, it would be defined as a link:./src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Person.java[Person] class that extends link:./src/main/java/org/apache/tinkerpop/gremlin/object/structure/Vertex.java[Vertex].
+By default, the vertex's label matches its simple class name, hence we have to un-capitalize it using the link:./src/main/java/org/apache/tinkerpop/gremlin/object/model/Alias.java[@Alias] annotation.
 
 The person's `name` and `age` properties become primitive fields in the class.
-The `@PrimaryKey` and `@OrderingKey` annotations on them not only indicate that they are mandatory,
+The link:./src/main/java/org/apache/tinkerpop/gremlin/object/model/PrimaryKey.java[@PrimaryKey] and link:./src/main/java/org/apache/tinkerpop/gremlin/object/model/OrderingKey.java[@OrderingKey] annotations on them not only indicate that they are mandatory,
 but also allow the `person` to be found easily through the link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasKeys.java[HasKeys.of(person)] `SubTraversal`.
 Think of the link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/SubTraversal.java[SubTraversal] as a reusable function that takes a `GraphTraversal`, performs a few steps on it, and returns it back (to allow for chaining).
 The `KnowsPeople` field in this class is an example of an in-line `SubTraversal`, albeit a stronger-typed version of it called `ToVertex`, to indicate that it ends up selecting vertices.
@@ -93,7 +93,7 @@ public class Person extends Vertex {
 Next, we look at its `titles` field, which is defined to be a `Set`.
 As you might expect, the cardinality of the underlying property becomes `set`.
 Similarly, the `locations` field takes on the `list` cardinality.
-Further, each element in the `locations` list has it's own meta-properties, and ergo deserves a `Location` class of it's own.
+Further, each element in the `locations` list has it's own meta-properties, and ergo deserves a link:./src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Location.java[Location] class of it's own.
 
 [source, java]
 ----
@@ -113,7 +113,7 @@ public class Location extends Element {
 NOTE: The value of the `location` is stored in `name`, due to the placement of the `@PropertyValue` annotation.
 Every other field in the `Location` class becomes the `location`'s meta-property.
 
-An edge is defined much like the vertex, except it extends the `Edge` class.
+An edge is defined much like the vertex, except it extends the link:./src/main/java/org/apache/tinkerpop/gremlin/object/structure/Edge.java[Edge] class.
 By default, an edge's label is it's un-capitalized simple class name, and hence no `@Alias` is needed:
 
 [source, java]
@@ -129,7 +129,7 @@ public class Knows extends Edge {
 You can find more examples of gremlin object vertices link:./src/test/java/org/apache/tinkerpop/gremlin/object/vertices/[here] and edges link:./src/test/java/org/apache/tinkerpop/gremlin/object/edges/[here].
 
 ==== Updating Objects
-The `Graph` interface lets you update the graph using `Vertex` or `Edge` objects.
+The link:./src/main/java/org/apache/tinkerpop/gremlin/object/structure/Graph.java[Graph] interface lets you update the graph using `Vertex` or `Edge` objects.
 You can get it via dependency injection:
 
 [source, java]
@@ -138,7 +138,7 @@ You can get it via dependency injection:
 private Graph graph;
 ----
 
-Or, the good old fashioned way, using a `GraphFactory` interface:
+Or, the good old fashioned way, using a link:./src/main/java/org/apache/tinkerpop/gremlin/object/provider/GraphFactory.java[GraphFactory] interface:
 
 [source, java]
 ----
@@ -180,7 +180,7 @@ TIP: Since the object being added may already exist in the graph, we provide lin
 
 ==== Querying Objects
 
-There are two ways to get a handle to the `Query` interface.
+There are two ways to get a handle to the link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/Query.java[Query] interface.
 You can inject it, and get the `TinkerGraph` query, like so:
 
 [source, java]
@@ -207,7 +207,7 @@ List<Person> friends = query
     .list(Person.class);
 ----
 
-Below, we query by an `AnyTraversal` (a function on the `GraphTraversalSource`), and get a single `Person` back.
+Below, we query by an link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/AnyTraversal.java[AnyTraversal] (a function on the `GraphTraversalSource`), and get a single `Person` back.
 
 [source, java]
 ----
@@ -222,7 +222,7 @@ The type of the result may be primitives too, and that is handled as shown below
 [source, java]
 ----
 long count = query
-    .by(HasPrimaryKey.of(crew.marko), Count.of())
+    .by(HasKeys.of(crew.marko), Count.of())
     .one(Long.class);
 ----
 
@@ -249,9 +249,9 @@ To see more examples showcasing how the object `Query` interface may be used, go
 In this section, we talk about how the `gremlin-objects` framework can be adopted by and adapted for a `graph system`.
 
 ==== Service Provider Interface
-A provider that wishes to plug into `gremlin-objects` will need to implement the `GraphSystem`, which simply supplies a `GraphTraversalSource`.
-In addition, it must extend the `ObjectGraph` and `ObjectQuery` abstract classes, constructor injecting its implementation of the `GraphSystem`.
-For users that don't use dependency injection, an implementation of the `GraphFactory` (preferably an extension of the `CachedFactory`) must also be provided.
+A provider that wishes to plug into `gremlin-objects` will need to implement the link:./src/main/java/org/apache/tinkerpop/gremlin/object/provider/GraphSystem.java[GraphSystem], which simply supplies a `GraphTraversalSource`.
+In addition, it must extend the link:./src/main/java/org/apache/tinkerpop/gremlin/object/structure/ObjectGraph.java[ObjectGraph] and link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/ObjectQuery.java[ObjectQuery] abstract classes, constructor injecting its implementation of the `GraphSystem`.
+For users that don't use dependency injection, an implementation of the `GraphFactory` (preferably an extension of the link:./src/main/java/org/apache/tinkerpop/gremlin/object/provider/CachedFactory.java[CachedFactory]) must also be provided.
 
 ==== Registering Native Types
 Typically, gremlin property values are Java primitives.
@@ -270,11 +270,11 @@ We give such providers a way to tell us how to parse such custom elements using 
 While there exist similar frameworks, this one has some key differentiating factors. Now, let's consider the alternatives:
 
 ==== GremlinDsl Traversals
-The `gremlin-core` module defines a `GremlinDsl` annotation that lets you define custom traversals by extending the `GraphTraversal` and `GraphTraversalSource`.
+The `gremlin-core` module defines a link:../gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDsl.java[GremlinDsl] annotation that lets you define custom traversals by extending the `GraphTraversal` and `GraphTraversalSource`.
 However, it requires some familiarity of `gremlin-core` internals.
 
 ==== Peopod for Tinkerpop 3
-Peopod represents elements as annotated interfaces or abstract classes.
+https://github.com/bayofmany/peapod[Peopod] represents elements as annotated interfaces or abstract classes.
 While it generates boilerplate for traversals to adjacent vertices, it doesn't let you co-locate arbitrary traversals.
 This framework is less intrusive and more flexible.
 
@@ -291,20 +291,20 @@ Here, we list a few directions in which we see the framework evolving:
 ==== Language Variants
 The concept of lifting the property graph into objects is language-independent.
 While `gremlin-objects` currently targets the Gremlin-Java variant, it can be ported to any variant that supports basic reflection.
-Case in point, the Gremlin-Python variant could achieve the object mapping through the `dir`, `getattr`  and `setattr` built-in functions.
+Case in point, the Gremlin-Python variant could achieve the object mapping through the https://docs.python.org/2/library/functions.html#dir[dir], https://docs.python.org/2/library/functions.html#getattr[getattr]  and https://docs.python.org/2/library/functions.html#setattr[setattr] built-in functions.
 
 ==== Provider Support
 In reality, it is fairly easy for a provider to plug-into `gremlin-objects` simply by implementing an interface and extending a few classes.
 The ability to register custom primitive types and traversal result parsers allows for customization.
-Since `neo4j` already has it's own TinkerPop module, it's a good candidate to become a provider. While there exists a `DataStax` implementation, it uses an older TinkerPop version, and hence is not included.
+Since `neo4j` already has it's own link:../neo4j-gremlin/pom.xml[TinkerPop module], it's a good candidate to become a provider. While there exists a `DataStax` implementation, it uses an older TinkerPop version, and hence is not included.
 
 ==== DataFrame Support
-Some providers use `GraphFrames` to execute bulk operations and graph algorithms on top of Tinkerpop.
-Assuming they can work with `DataFrames`, one could build a `GraphTraversalSource`,
+Some providers use http://graphframes.github.io/[GraphFrames] to execute bulk operations and graph algorithms on top of Tinkerpop.
+Assuming they can work with https://spark.apache.org/docs/1.6.3/api/java/org/apache/spark/sql/DataFrame.html[DataFrames], one could build a `GraphTraversalSource`,
 which translates the object `Graph` and `Query` operations into `DataFrame` tables,  and adapt's it to the provider's `GraphFrame`.
 
 ==== Traversal Storage
 The link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/AnyTraversal.java[AnyTraversal] and link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/SubTraversal.java[SubTraversal]
-interfaces extend `Formattable` so that the steps defined in it's body can be revealed.
+interfaces extend https://docs.oracle.com/javase/7/docs/api/java/util/Formattable.html[Formattable] so that the steps defined in it's body can be revealed.
 Let's say that we stored the bytecode of these types of functional fields as a hidden property in the element.
 That could potentially allow us to execute `user defined traversals` using a, say, `traversal.call('function-name')` step.

--- a/gremlin-objects/README.asciidoc
+++ b/gremlin-objects/README.asciidoc
@@ -16,7 +16,7 @@
 ////
 An Object Graph Mapping Framework For Gremlin
 ---------------------------------------------
-Karthick Sankarachary <http://gihub.com/karthicks>
+Karthick Sankarachary <http://github.com/karthicks>
 [.lead]
 The `gremlin-objects` link:pom.xml[module] defines a framework that puts an object-oriented spin on the gremlin property graph.
 It aims to make it much easier to specify business `domain specific languages` around Gremlin, without any loss of expressive power.
@@ -307,4 +307,4 @@ which translates the object `Graph` and `Query` operations into `DataFrame` tabl
 The link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/AnyTraversal.java[AnyTraversal] and link:./src/main/java/org/apache/tinkerpop/gremlin/object/traversal/SubTraversal.java[SubTraversal]
 interfaces extend `Formattable` so that the steps defined in it's body can be revealed.
 Let's say that we stored the bytecode of these types of functional fields as a hidden property in the element.
-That could potentially allow us to execute `user defined traversals` using a, say, `traversal.invoke('function-name')` step.
+That could potentially allow us to execute `user defined traversals` using a, say, `traversal.call('function-name')` step.

--- a/gremlin-objects/pom.xml
+++ b/gremlin-objects/pom.xml
@@ -1,0 +1,100 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.tinkerpop</groupId>
+    <artifactId>tinkerpop</artifactId>
+    <version>3.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>gremlin-objects</artifactId>
+  <name>Apache TinkerPop :: Gremlin Objects</name>
+  <properties>
+      <hamcrest.version>1.3</hamcrest.version>
+      <lombok.version>1.16.18</lombok.version>
+  </properties>
+  <dependencies>
+      <dependency>
+          <groupId>org.apache.tinkerpop</groupId>
+          <artifactId>gremlin-core</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.javatuples</groupId>
+          <artifactId>javatuples</artifactId>
+          <version>${java.tuples.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+          <version>${hamcrest.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.projectlombok</groupId>
+          <artifactId>lombok</artifactId>
+          <version>${lombok.version}</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>${slf4j.version}</version>
+      </dependency>
+  </dependencies>
+  <build>
+      <directory>${basedir}/target</directory>
+      <finalName>${project.artifactId}-${project.version}</finalName>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <version>3.0.2</version>
+              <executions>
+                  <execution>
+                      <goals>
+                          <goal>test-jar</goal>
+                      </goals>
+                  </execution>
+              </executions>
+          </plugin>
+      </plugins>
+  </build>
+</project>

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/Alias.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/Alias.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An {@link Alias} annotation on a field is used to override the key of the corresponding property
+ * through the {@link #key()} method.
+ *
+ * <p>
+ * When used on an {@link org.apache.tinkerpop.gremlin.object.structure.Element}, it is used to
+ * override it's label, through the {@link #label()} method.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Alias {
+
+  String key() default "";
+
+  String label() default "";
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/DefaultValue.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/DefaultValue.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A field annotated with {@link DefaultValue} will inherit it's value if it has none.
+ *
+ * <p>
+ * In the following example, if the {@code name} field has no value, then when we write it, it will be set
+ * to {@code "noname"}.
+ *
+ * <p>
+ * {@code @DefaultValue("noname") private String name; }
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DefaultValue {
+
+  String value();
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/Hidden.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/Hidden.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@link Hidden} annotation on a field indicates that it does not map to any specific property
+ * in the underlying graph element.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Hidden {
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/OrderingKey.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/OrderingKey.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A field annotated with {@link OrderingKey} represents a mandatory property in the underlying
+ * graph element by which ordering occurs.
+ *
+ * <p>
+ * If the graph supports user supplied ids, then such fields will be included in the id generated
+ * when objects are created in the graph.
+ *
+ * <p>
+ * This annotation also serves as a reminder that it's okay to order by the property that fields
+ * annotated with {@link OrderingKey} represent.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OrderingKey {
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/PrimaryKey.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/PrimaryKey.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.model;
+
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasKeys;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A field annotated with {@link PrimaryKey} represents a property in the underlying graph element
+ * by which identification should occur. Ideally, the set of fields with this annotation should be a
+ * minimal superkey, which is both necessary and sufficient to identity the element.
+ *
+ * <p>
+ * If the graph supports user supplied ids, then such fields will be included in the id
+ * generated when objects are created in the graph. If not, then such fields help us find objects in
+ * the graph whose ids are unknown, through the {@link HasKeys} sub-traversal.
+ *
+ * <p>
+ * While most objects have one primary key field, they may have more than one. To facilitate
+ * fast lookups, there must be at least one primary key field, especially if element ids are not
+ * user supplied, in which case we may not always have those ids handy.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PrimaryKey {
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/PropertyValue.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/model/PropertyValue.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@link PropertyValue} annotation is applied on a unique field of an element class that
+ * represents a vertex property, in case it has meta-properties of it's own.
+ *
+ * <p>
+ * Specifically, the field where that element object appears in the vertex class denotes the key
+ * of that vertex property. And, the field annotated with {@link PropertyValue} holds the value of
+ * that vertex property. The rest of the fields in the (vertex property) element class appear as
+ * meta-properties tied to the vertex property.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PropertyValue {
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/provider/CachedFactory.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/provider/CachedFactory.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.provider;
+
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The {@link CachedFactory} implements the {@link GraphFactory} such that its provided instances
+ * may be optionally cached, as specified by the {@link #shouldCache} value.
+ *
+ * <p>
+ * The expectation is that the graph system provider's implementation of {@link GraphFactory} will
+ * extend this class, and will turn caching on, so as to reduce the number of resources it holds.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@RequiredArgsConstructor
+public abstract class CachedFactory<C> implements GraphFactory<C> {
+
+  public enum ShouldCache {
+    /**
+     * Cache the instances returned by {@link #graph()}, {@link #query()}, and {@link #system()}.
+     *
+     * <p>
+     * This mode may be used in single-threaded applications, if you want to avoid the overhead of
+     * creating the state of the {@link #graph()} and {@link #query()} instances. The caller must
+     * remember to finally invoke {@link Graph#reset()} after every use.
+     */
+    EVERYTHING,
+    /**
+     * Cache the instances returned by {@link #graph()}, {@link #query()}, and {@link #system()}.
+     *
+     * <p>
+     * This mode should be used in multi-threaded applications, where the resources underlying the
+     * {@link #system()} can handle concurrent requests. Since the {@link #graph()} } and {@link
+     * #query()} instances need to be thread-safe, their states will be stored in a thread-local.
+     * The caller thread must remember to finally invoke {@link Graph#reset()} after every use.
+     */
+    GRAPH_SYSTEM,
+    /**
+     * Do not cache instances returned by {@link #graph()}, {@link #query()}, and {@link
+     * #system()}.
+     *
+     * <p>
+     * This mode may be used in multi-threaded applications, when the resources underlying the
+     * {@link #system()} cannot handle concurrent requests, or it is preferable to create new
+     * "system" resources per caller, or if the caller needs to employ custom caching schemes. Since
+     * the {@link #graph()}  and {@link #query()} instances are not cached, there's no need to
+     * {@link Graph#reset} them after every use, unless of source, the caller keeps a copy of it.
+     */
+    NOTHING
+  }
+
+  protected final ShouldCache shouldCache;
+
+  private static Graph cachedGraph;
+  private static Query cachedQuery;
+
+  private static ThreadLocal<Graph> threadGraph = new ThreadLocal<>();
+  private static ThreadLocal<Query> threadQuery = new ThreadLocal<>();
+
+  private static GraphSystem<?> cachedSystem;
+
+  protected abstract Graph makeGraph();
+
+  protected abstract Query makeQuery();
+
+  protected abstract GraphSystem<C> makeSystem();
+
+  @Override
+  public final Graph graph() {
+    switch (shouldCache) {
+      case EVERYTHING:
+        if (cachedGraph != null) {
+          return cachedGraph;
+        }
+        break;
+      case GRAPH_SYSTEM:
+        if (threadGraph.get() != null) {
+          return threadGraph.get();
+        }
+        break;
+      case NOTHING:
+        break;
+      default:
+        break;
+    }
+    synchronized (CachedFactory.class) {
+      if (cachedGraph != null) {
+        cachedGraph.reset();
+        return cachedGraph;
+      }
+      Graph graph = makeGraph();
+      switch (shouldCache) {
+        case EVERYTHING:
+          cachedGraph = graph;
+          break;
+        case GRAPH_SYSTEM:
+          threadGraph.set(graph);
+          break;
+        case NOTHING:
+        default:
+      }
+      graph.reset();
+      return graph;
+    }
+  }
+
+  @Override
+  public final Query query() {
+    switch (shouldCache) {
+      case EVERYTHING:
+        if (cachedQuery != null) {
+          return cachedQuery;
+        }
+        break;
+      case GRAPH_SYSTEM:
+        if (threadQuery.get() != null) {
+          return threadQuery.get();
+        }
+        break;
+      case NOTHING:
+        break;
+      default:
+        break;
+    }
+    synchronized (CachedFactory.class) {
+      if (cachedQuery != null) {
+        return cachedQuery;
+      }
+      Query query = makeQuery();
+      switch (shouldCache) {
+        case EVERYTHING:
+          cachedQuery = query;
+          break;
+        case GRAPH_SYSTEM:
+          threadQuery.set(query);
+          break;
+        case NOTHING:
+        default:
+          break;
+      }
+      return query;
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final GraphSystem<C> system() {
+    switch (shouldCache) {
+      case EVERYTHING:
+      case GRAPH_SYSTEM:
+        if (cachedSystem != null) {
+          return (GraphSystem<C>) cachedSystem;
+        }
+        break;
+      case NOTHING:
+      default:
+        break;
+    }
+    synchronized (CachedFactory.class) {
+      if (cachedSystem != null) {
+        return (GraphSystem<C>) cachedSystem;
+      }
+      GraphSystem<C> system = makeSystem();
+      switch (shouldCache) {
+        case EVERYTHING:
+        case GRAPH_SYSTEM:
+          cachedSystem = system;
+          break;
+        case NOTHING:
+        default:
+          break;
+      }
+      return system;
+    }
+  }
+
+  public void clear() {
+    cachedGraph = null;
+    cachedQuery = null;
+    cachedSystem = null;
+    threadGraph.remove();
+    threadQuery.remove();
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/provider/GraphFactory.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/provider/GraphFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.provider;
+
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+/**
+ * The {@link GraphFactory} is an interface that provides instances of the {@link Graph} and {@link
+ * Query} specific to a given {@link GraphSystem}.
+ *
+ * <p>
+ * For write-access to the object {@link Graph}, use the {@link #graph()} method. For read-access to
+ * the object graph, use the {@link #query()} method.
+ *
+ * <p>
+ * If dependency injection is enabled, you will get the {@code TinkerGraph} implementation, by default.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public interface GraphFactory<C> {
+
+  Graph graph();
+
+  Query query();
+
+  GraphSystem<C> system();
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/provider/GraphSystem.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/provider/GraphSystem.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.provider;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+import javax.script.Bindings;
+
+/**
+ * A {@link GraphSystem} represents an tinkerpop-based graph system. In essence, it's job is to
+ * supply an implementation-defined {@link GraphTraversalSource}.
+ *
+ * <p>
+ * Think of this as a service provider interface intended to be implemented by a graph system, such
+ * as {@code TinkerGraph}, which at a minimum, knows how to define a {@link GraphTraversalSource}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings("rawtypes")
+public interface GraphSystem<C> {
+
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  /**
+   * Provide an instance of the {@link GraphTraversalSource}.
+   */
+  GraphTraversalSource g();
+
+  /**
+   * How is this instance configured?
+   */
+  C configuration();
+
+  /**
+   * Complete the given gremlin traversal statement, and return a results iterable.
+   */
+  Iterable execute(String statement);
+
+  /**
+   * Complete the given gremlin traversal statement, and return a results iterable.
+   */
+  Iterable execute(String statement, Bindings bindings);
+
+  /**
+   * Release any resources associated with the system.
+   */
+  void close();
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Classes.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Classes.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import lombok.SneakyThrows;
+
+/**
+ * {@link Classes} helps you introspect classes easily.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public final class Classes {
+
+  private Classes() {}
+
+  /**
+   * Does the given class inherits from {@link Element}?
+   */
+  public static boolean isElement(Class<?> type) {
+    return is(type, Element.class);
+  }
+
+  /**
+   * Is the given object a {@link Vertex}?
+   */
+  public static boolean isVertex(Object object) {
+    return object != null && isVertex(object.getClass());
+  }
+
+  /**
+   * Is the given class a {@link Vertex}?
+   */
+  public static boolean isVertex(Class<?> type) {
+    return is(type, Vertex.class);
+  }
+
+  /**
+   * Is the given object an {@link Edge}?
+   */
+  public static boolean isEdge(Object object) {
+    return object != null && isEdge(object.getClass());
+  }
+
+  /**
+   * Is the given type an {@link Edge}?
+   */
+  public static boolean isEdge(Class<?> type) {
+    return is(type, Edge.class);
+  }
+
+  /**
+   * Is the given object a {@link List}?
+   */
+  public static boolean isList(Object object) {
+    return object != null && isList(object.getClass());
+  }
+
+  /**
+   * Is the given class a {@link List}?
+   */
+  public static boolean isList(Class<?> type) {
+    return is(type, List.class);
+  }
+
+  /**
+   * Is the given object a {@link Set}?
+   */
+  public static boolean isSet(Object object) {
+    return object != null && isSet(object.getClass());
+  }
+
+  /**
+   * Is the given class a {@link Set}?
+   */
+  public static boolean isSet(Class<?> type) {
+    return is(type, Set.class);
+  }
+
+  /**
+   * Is the given object a {@link List} or a {@link Set}?
+   */
+  public static boolean isCollection(Object object) {
+    return object != null && isCollection(object.getClass());
+  }
+
+  /**
+   * Is the given class a {@link List} or a {@link Set}?
+   */
+  public static boolean isCollection(Class<?> type) {
+    return isList(type) || isSet(type);
+  }
+
+  /**
+   * Is the given class a {@link Function}?
+   */
+  public static boolean isFunctional(Class<?> type) {
+    return is(type, Function.class);
+  }
+
+  /**
+   * Is the given class that of the given object?
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static boolean is(Class<?> type, Object that) {
+    return that != null && is(type, that.getClass());
+  }
+
+  /**
+   * Is the given object of the given class?
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static boolean is(Object object, Class<?> that) {
+    return object != null && is(object.getClass(), that);
+  }
+
+  /**
+   * Is the type class assignable from that class?
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static boolean is(Class<?> type, Class<?> that) {
+    return that.isAssignableFrom(type);
+  }
+
+  /**
+   * Sort the collection, if it's a list.
+   */
+  @SuppressWarnings("unchecked")
+  public static void sortCollection(Class<?> clazz, Collection<?> collection) {
+    if (isList(clazz)) {
+      Collections.sort((List) collection);
+    }
+  }
+
+  /**
+   * Create a new collection of the given type.
+   */
+  @SneakyThrows
+  @SuppressWarnings("rawtypes")
+  public static Collection newCollection(Class<?> clazz) {
+    if (isList(clazz)) {
+      return new ArrayList<>();
+    }
+    if (isSet(clazz)) {
+      return new HashSet<>();
+    }
+    throw Element.Exceptions.invalidCollectionType(clazz);
+  }
+
+  /**
+   * Return the simple name of the given class.
+   */
+  public static String name(Class<?> type) {
+    return type.getSimpleName();
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Fields.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Fields.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.model.Alias;
+import org.apache.tinkerpop.gremlin.object.model.DefaultValue;
+import org.apache.tinkerpop.gremlin.object.model.Hidden;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.javatuples.Pair;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import static java.lang.reflect.Modifier.isStatic;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.reflect.FieldUtils.getAllFields;
+import static org.apache.commons.lang3.reflect.FieldUtils.getField;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isFunctional;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isList;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.isKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.isOrderingKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.isPrimaryKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.asPrimitiveType;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isPrimitive;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isPrimitiveDefault;
+
+/**
+ * {@link Fields} defines ways to get the key and value of a field that represents a property,
+ * retrieve fields for certain kinds of properties, and see if it has object specific annotations.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@SuppressWarnings({"unchecked", "rawtypes", "PMD.TooManyStaticImports"})
+public final class Fields {
+
+  // How many element types do we want to cache?
+  public static long elementCacheSize = 10L;
+
+  // A LRU cache of element types to their fields.
+  private static final Map<Pair<Class, Predicate<Field>>, Map<String, Field>> ELEMENT_CACHE =
+      new LinkedHashMap() {
+        public static final long serialVersionUID = 1L;
+
+        @Override
+        public Object get(Object key) {
+          return elementCacheSize > 0L ? super.get(key) : null;
+        }
+
+        @Override
+        public Object computeIfAbsent(Object key, Function mappingFunction) {
+          return elementCacheSize > 0L ? super.computeIfAbsent(key, mappingFunction)
+              : mappingFunction.apply(key);
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry eldest) {
+          return super.size() > elementCacheSize;
+        }
+      };
+
+  public static final Comparator<Field> BY_NAME = (left, right) ->
+      left.getName().compareTo(right.getName());
+
+  /**
+   * A comparator, that considers the primary keys first, ordering keys next, and then the rest.
+   */
+  public static final Comparator<Field> BY_KEYS = (left, right) -> {
+    if (isPrimaryKey(left)) {
+      if (isPrimaryKey(right)) {
+        return BY_NAME.compare(left, right);
+      } else {
+        return -1;
+      }
+    } else if (isOrderingKey(left)) {
+      if (isPrimaryKey(right)) {
+        return 1;
+      } else if (isOrderingKey(right)) {
+        return BY_NAME.compare(left, right);
+      } else {
+        return -1;
+      }
+    } else {
+      if (isKey(right)) {
+        return 1;
+      } else {
+        return BY_NAME.compare(left, right);
+      }
+    }
+  };
+
+  private static final Set<String> SYSTEM_PROPERTIES = new HashSet<>();
+  private static final Set<Class> SYSTEM_CLASSES = new HashSet<>();
+
+  static {
+    SYSTEM_PROPERTIES.add(T.id.getAccessor());
+    SYSTEM_PROPERTIES.add(T.label.getAccessor());
+
+    SYSTEM_CLASSES.add(Element.class);
+    SYSTEM_CLASSES.add(Vertex.class);
+    SYSTEM_CLASSES.add(Edge.class);
+  }
+
+  private Fields() {}
+
+  /**
+   * Does the field have the given annotation?
+   */
+  public static boolean has(Field field, Class<? extends Annotation> annotationType) {
+    return field.getAnnotation(annotationType) != null;
+  }
+
+  /**
+   * If the given field or class have an {@link Alias}, what is it's value?
+   */
+  public static String alias(AnnotatedElement element, Function<Alias, String> property) {
+    Alias alias = element.getAnnotation(Alias.class);
+    if (alias == null) {
+      return null;
+    }
+    String value = property.apply(alias);
+    return isNotEmpty(value) ? value : null;
+  }
+
+  /**
+   * What is the property key corresponding to this field?
+   */
+  public static String propertyKey(Field field) {
+    String key = alias(field, Alias::key);
+    return key != null ? key : field.getName();
+  }
+
+  /**
+   * What is the property value corresponding to this field?
+   */
+  @SneakyThrows
+  public static Object propertyValue(Field field, Object instance) {
+    Object value = field.get(instance);
+    if (isPrimitiveDefault(field, value)) {
+      DefaultValue defaultValue = field.getAnnotation(DefaultValue.class);
+      if (defaultValue != null) {
+        return asPrimitiveType(field, defaultValue.value());
+      }
+    }
+    return value;
+  }
+
+  /**
+   * Find the field of the given name in the given element.
+   */
+  public static <E extends Element> Field field(E element, String fieldName) {
+    return field(element.getClass(), fieldName);
+  }
+
+  /**
+   * Find the field of the given name from the given class.
+   */
+
+  public static <E extends Element> Field field(Class<E> elementType, String fieldName) {
+    Field matchingField = null;
+    Map<String, Field> fieldCache = ELEMENT_CACHE.get(elementType);
+    if (fieldCache != null) {
+      matchingField = fieldCache.get(fieldName);
+    }
+    if (matchingField == null) {
+      matchingField = getField(elementType, fieldName, true);
+    }
+    return matchingField;
+  }
+
+  /**
+   * Find the fields of the element.
+   */
+  public static <E extends Element> List<Field> fields(E element) {
+    return fields(element.getClass());
+  }
+
+  /**
+   * Find the fields of the element that satisfy the given predicate.
+   */
+  public static <E extends Element> List<Field> fields(E element, Predicate<Field> predicate) {
+    return fields(element.getClass(), predicate);
+  }
+
+  /**
+   * Find the fields of the given element class.
+   */
+  public static <E extends Element> List<Field> fields(Class<E> elementType) {
+    return fields(elementType, field -> true);
+  }
+
+  private static <E extends Element> Map<String, Field> fieldsByName(Pair<Class, Predicate<Field>>
+      predicatedType) {
+    Class<E> elementType = predicatedType.getValue0();
+    Predicate<Field> predicate = predicatedType.getValue1();
+    List<Field> allFields = Arrays.asList(getAllFields(elementType));
+    allFields.forEach(field -> {
+      field.setAccessible(true);
+    });
+    Map<String, Field> fieldMap = allFields.stream()
+        .filter(field -> predicate.test(field) && !isHiddenField(field))
+        .collect(Collectors.toMap(Field::getName, Function.identity()));
+    return fieldMap;
+  }
+
+  /**
+   * Find the fields of the given element type, and field predicate.
+   */
+  public static <E extends Element> List<Field> fields(Class<E> elementType,
+      Predicate<Field> predicate) {
+    Pair<Class, Predicate<Field>> predicatedType = Pair.with(elementType, predicate);
+    Map<String, Field> cachedFields =
+        ELEMENT_CACHE.computeIfAbsent(
+            predicatedType, Fields::fieldsByName);
+    List<Field> matchingFields = cachedFields.values().stream()
+        .collect(Collectors.toList());
+    Collections.sort(matchingFields, BY_KEYS);
+    return matchingFields;
+  }
+
+  /**
+   * Get the type of the list field.
+   */
+  public static Class<?> listType(Field field) {
+    return (Class) ((ParameterizedType) field.getAnnotatedType().getType())
+        .getActualTypeArguments()[0];
+  }
+
+  /**
+   * Does this field to a simple property with no meta-properties?
+   */
+  public static boolean isSimple(Field field) {
+    return isPrimitive(field) || (isList(field) && isPrimitive(listType(field)));
+  }
+
+  /**
+   * Is this field to be hidden from the graph?
+   */
+  private static boolean isHiddenField(Field field) {
+    if (field.isSynthetic() || has(field, Hidden.class) || isStatic(field.getModifiers())) {
+      return true;
+    }
+    return SYSTEM_PROPERTIES.contains(propertyKey(field)) ||
+        SYSTEM_CLASSES.contains(field.getDeclaringClass()) ||
+        isFunctional(field.getType());
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Keys.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Keys.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.model.OrderingKey;
+import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isVertex;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.fields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.has;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyValue;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isMissing;
+
+/**
+ * {@link Keys} helps find fields in the object that denote special properties in the underlying
+ * graph element, such as those marked as a {@link PrimaryKey} or {@link OrderingKey}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings("PMD.TooManyStaticImports")
+public final class Keys {
+
+  private Keys() {}
+
+  /**
+   * Is the given field annotated with either {@link PrimaryKey} or {@link OrderingKey}?
+   */
+  public static boolean isKey(Field field) {
+    return isPrimaryKey(field) || isOrderingKey(field);
+  }
+
+  public static boolean isPrimaryKey(Field field) {
+    return has(field, PrimaryKey.class);
+  }
+
+  public static boolean isOrderingKey(Field field) {
+    return has(field, OrderingKey.class);
+  }
+
+  /**
+   * Find fields annotated with either {@link PrimaryKey} or {@link OrderingKey} in the element.
+   */
+  public static List<Field> keyFields(Element element) {
+    return keyFields(element.getClass());
+  }
+
+  /**
+   * Find fields annotated with either {@link PrimaryKey} or {@link OrderingKey} in the given type.
+   */
+  public static List<Field> keyFields(Class<? extends Element> elementType) {
+    return fields(elementType).stream().filter(Keys::isKey)
+        .collect(Collectors.toList());
+  }
+
+  public static List<Field> primaryKeyFields(Element element) {
+    return primaryKeyFields(element.getClass());
+  }
+
+  public static List<Field> primaryKeyFields(Class<? extends Element> elementType) {
+    return fields(elementType).stream().filter(Keys::isPrimaryKey)
+        .collect(Collectors.toList());
+  }
+
+  public static boolean hasPrimaryKeys(Element element) {
+    return hasPrimaryKeys(element.getClass());
+  }
+
+  public static boolean hasPrimaryKeys(Class<? extends Element> elementType) {
+    return !primaryKeyFields(elementType).isEmpty();
+  }
+
+  public static List<Field> orderingKeyFields(Element element) {
+    return orderingKeyFields(element.getClass());
+  }
+
+  public static List<Field> orderingKeyFields(Class<? extends Element> elementType) {
+    return fields(elementType).stream().filter(Keys::isOrderingKey)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Get the names of the fields annotated with {@link PrimaryKey} in the given element
+   */
+  public static List<String> primaryKeyNames(Element element) {
+    return primaryKeyNames(element);
+  }
+
+  public static List<String> primaryKeyNames(Class<? extends Element> elementType) {
+    return primaryKeyFields(elementType).stream()
+        .map(Fields::propertyKey)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Supply an id for the given element, in terms of a {@link Map} that contains its label, and all
+   * of it's {@link PrimaryKey} and {@link OrderingKey}s.
+   */
+  @SneakyThrows
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static <E extends Element> Object id(E element) {
+    if (element == null) {
+      return null;
+    }
+    Object elementId = element.id();
+    if (elementId != null) {
+      return elementId;
+    }
+    Map<String, Object> mappedId = new HashMap<>();
+    if (isVertex(element)) {
+      mappedId.put(T.label.getAccessor(), element.label());
+    }
+    Consumer<Field> addKey = field -> {
+      Object propertyValue = propertyValue(field, element);
+      if (isMissing(propertyValue)) {
+        throw Element.Exceptions.requiredKeysMissing(element.getClass(), propertyKey(field));
+      }
+      mappedId.put(propertyKey(field), propertyValue);
+    };
+    primaryKeyFields(element).forEach(addKey);
+    orderingKeyFields(element).forEach(addKey);
+    return mappedId.isEmpty() ? null : mappedId;
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Label.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Label.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.commons.lang3.text.WordUtils;
+import org.apache.tinkerpop.gremlin.object.model.Alias;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.is;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.name;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.alias;
+
+/**
+ * The label of a vertex (or edge) object can be obtained through the {@link Label#of} methods.
+ *
+ * <p>
+ * By default, the label of a vertex is the same as it's object's simple class name, and that of an
+ * edge is the same, except it's uncapitalized. If you wish to override this default naming
+ * convention, you may annotate the class with a {@link Alias#label()} value.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public final class Label {
+
+  private Label() {}
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static String of(Element element) {
+    return of(element.getClass());
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static String of(Class<? extends Element> elementType) {
+    String label = alias(elementType, Alias::label);
+    if (label == null) {
+      label = name(elementType);
+      if (is(elementType, Edge.class)) {
+        label = WordUtils.uncapitalize(label);
+      }
+    }
+    return label;
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Parser.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Parser.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.model.PropertyValue;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedProperty;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import lombok.SneakyThrows;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.is;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isCollection;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.newCollection;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.sortCollection;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.fields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.has;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.listType;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isPrimitive;
+
+/**
+ * The {@link Parser}'s job is to take an element returned by a traversal and convert it into its
+ * corresponding class' object, through the {@link #as(Object, Class)} method.
+ *
+ * <p>
+ * It specifies a {@link ElementParser} interface, which has similar {@code #as} method. A default
+ * implementation of that contract is defined in {@link GremlinElementParser}.
+ *
+ * <p>
+ * Some graph systems may complete a traversal as an iterator of implementation-defined elements. To
+ * support such non-standard elements, the graph system may register a custom {@link ElementParser}
+ * with this class during it's construction phase.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings({"rawtypes", "unchecked", "PMD.TooManyStaticImports"})
+public final class Parser {
+
+  private static final List<ElementParser<?>> ELEMENT_PARSERS = new ArrayList<>();
+
+  static {
+    registerElementParser(GremlinElementParser.getInstance());
+  }
+
+  private Parser() {}
+
+  /**
+   * Register a {@link ElementParser} that takes a element from a result set, and maps it to an
+   * object.
+   */
+  public static void registerElementParser(ElementParser<?> elementParser) {
+    ELEMENT_PARSERS.add(elementParser);
+  }
+
+  /**
+   * Does the given field hold the value of a vertex property, that has meta-properties of it's
+   * own?
+   */
+  public static boolean isPropertyValue(Field field) {
+    return has(field, PropertyValue.class);
+  }
+
+  @SneakyThrows
+  @SuppressWarnings({"PMD.ShortMethodName", "rawtypes"})
+  public static <T> T as(Object element, Class<T> objectClass) {
+    Class<?> elementType = element.getClass();
+    if (is(elementType, objectClass)) {
+      return (T) element;
+    }
+    for (ElementParser elementParser : ELEMENT_PARSERS) {
+      if (is(elementType, elementParser.elementType())) {
+        return (T) elementParser.as(element, objectClass);
+      }
+    }
+    if (objectClass.isEnum()) {
+      return (T) Enum.valueOf((Class<Enum>) objectClass, (String) element);
+    }
+    throw Query.Exceptions.invalidObjectType(element, objectClass);
+  }
+
+  /**
+   * The {@link ElementParser} takes an abstract element and constructs an instance of the given
+   * object type.
+   */
+  public interface ElementParser<E> {
+
+    Class<E> elementType();
+
+    @SuppressWarnings("PMD.ShortMethodName")
+    <O> O as(E element, Class<O> objectType);
+  }
+
+  /**
+   * This is an implementation of {@link ElementParser} baaed on the {@link
+   * org.apache.tinkerpop.gremlin.structure.Element} type.
+   */
+  public static class GremlinElementParser
+      implements ElementParser<org.apache.tinkerpop.gremlin.structure.Element> {
+
+    private static final GremlinElementParser INSTANCE = new GremlinElementParser();
+
+    public static GremlinElementParser getInstance() {
+      return INSTANCE;
+    }
+
+    @Override
+    public Class<org.apache.tinkerpop.gremlin.structure.Element> elementType() {
+      return org.apache.tinkerpop.gremlin.structure.Element.class;
+    }
+
+    @SneakyThrows
+    @Override
+    @SuppressWarnings({"PMD.ShortMethodName"})
+    public <T> T as(org.apache.tinkerpop.gremlin.structure.Element element, Class<T> objectType) {
+      Element instance = (Element) objectType.newInstance();
+      Object elementId = element.id();
+      instance.setUserSuppliedId(elementId);
+      instance.setDelegate(element);
+      for (Field field : fields(instance)) {
+        String propertyName = propertyKey(field);
+        Class propertyType = field.getType();
+
+        List<Property> properties = properties(element, propertyName);
+        if (properties.isEmpty()) {
+          continue;
+        }
+        if (isCollection(propertyType)) {
+          Collection collection = (Collection) field.get(instance);
+          if (collection == null) {
+            collection = newCollection(propertyType);
+            field.set(instance, collection);
+          }
+          for (Property property : properties) {
+            Class elementType = listType(field);
+            collection.add(value(elementType, property));
+          }
+          sortCollection(propertyType, collection);
+        } else {
+          Property property = properties.get(0);
+          field.set(instance, value(propertyType, property));
+        }
+      }
+      return (T) instance;
+    }
+
+    private List<Property> properties(org.apache.tinkerpop.gremlin.structure.Element element,
+        String propertyName) {
+      List<Property> properties = new ArrayList<>();
+      Object elementId = element.id();
+      if (elementId instanceof Map) {
+        Object idValue = ((Map) elementId).get(propertyName);
+        if (idValue != null) {
+          properties.add(new DetachedProperty(propertyName, idValue));
+        }
+      }
+      Iterator<? extends Property> iterator = element.properties(propertyName);
+      if (iterator != null) {
+        iterator.forEachRemaining(property -> {
+          if (property.isPresent()) {
+            properties.add(property);
+          }
+        });
+      }
+      return properties;
+    }
+
+    @SneakyThrows
+    private Object value(Class propertyType, Property property) {
+      if (isPrimitive(propertyType)) {
+        return value(propertyType, property.value());
+      }
+      Element propertyValue = (Element) propertyType.newInstance();
+      VertexProperty vertexProperty = (VertexProperty) property;
+      for (Field field : fields(propertyValue)) {
+        if (isPropertyValue(field)) {
+          Object value = vertexProperty.value();
+          if (value instanceof Object[]) {
+            Object[] values = (Object[]) value;
+            field.set(propertyValue, value(field.getType(), values[0]));
+          } else {
+            field.set(propertyValue, value(field.getType(), value));
+          }
+        } else {
+          Object value = vertexProperty.value();
+          if (value instanceof Object[]) {
+            Object[] values = (Object[]) value;
+            String fieldName = propertyKey(field);
+            for (int i = 1; i < values.length; i = i + 2) {
+              if (fieldName.equals(values[i])) {
+                field.set(propertyValue, value(field.getType(), values[i + 1]));
+              }
+            }
+          } else {
+            Iterator values = vertexProperty.values(propertyKey(field));
+            if (values.hasNext()) {
+              field.set(propertyValue, value(field.getType(), values.next()));
+            }
+          }
+        }
+      }
+      return propertyValue;
+    }
+
+    private Object value(Class propertyType, Object propertyValue) {
+      Object modifiedValue = propertyValue;
+      if (Primitives.isTimeType(propertyType)) {
+        modifiedValue = Primitives.toTimeType(propertyValue, propertyType);
+      } else if (propertyType.isEnum()) {
+        modifiedValue = Enum.valueOf((Class<Enum>) propertyType, (String) propertyValue);
+      }
+      return modifiedValue;
+    }
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Primitives.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Primitives.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.model.DefaultValue;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+import org.javatuples.Pair;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import lombok.SneakyThrows;
+
+/**
+ * {@link Primitives} helps us work with properties whose type is a primitive, or a wrapper thereof.
+ * It also handles conversions between various formats of time-based properties, and default values
+ * for various primitive types.
+ *
+ * <p>
+ * It is important to know which properties are treated as primitive by the graph system, so that
+ * the object graph can pass them as-is to the traversal. If a graph system defines custom primitive
+ * types, they may register them here using the {@link #registerPrimitiveClass} method.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings({"rawtypes", "PMD.AvoidUsingShortType"})
+public final class Primitives {
+
+  /**
+   * If false, then primitive fields that are {@code PrimaryKey} or {@code OrderingKey} cannot be
+   * stored using the primitive default values.
+   */
+  public static boolean allowDefaultKeys = true;
+
+  /**
+   * What is the primitive value for the primitive classes that we know of?
+   */
+  private static final Map<Class, Object> PRIMITIVE_DEFAULTS = new HashMap<>();
+
+  /**
+   * How can one parse a primitive value from the string specified in {@link DefaultValue#value()}?
+   */
+  private static final Map<Class, Function<String, ?>> STRING_CONVERTERS = new HashMap<>();
+
+  /**
+   * How do we go from one type of time class to another?
+   */
+  private static final Map<Pair<Class, Class>, Function<Object, Object>> TIME_CONVERTERS =
+      new HashMap<>();
+
+  static {
+    // Register the known primitive types and default values thereof.
+    registerPrimitiveClass(boolean.class, false);
+    registerPrimitiveClass(byte.class, 0xB);
+    registerPrimitiveClass(char.class, '\u0000');
+    registerPrimitiveClass(double.class, 0D);
+    registerPrimitiveClass(float.class, 0F);
+    registerPrimitiveClass(int.class, 0);
+    registerPrimitiveClass(long.class, 0L);
+    registerPrimitiveClass(short.class, 0);
+    registerPrimitiveClass(Boolean.class, false);
+    registerPrimitiveClass(Byte.class, 0xB);
+    registerPrimitiveClass(Character.class, '\u0000');
+    registerPrimitiveClass(Double.class, 0D);
+    registerPrimitiveClass(Float.class, 0F);
+    registerPrimitiveClass(Integer.class, 0);
+    registerPrimitiveClass(Long.class, 0L);
+    registerPrimitiveClass(Short.class, 0);
+    registerPrimitiveClass(Void.class);
+    registerPrimitiveClass(String.class, "");
+    registerPrimitiveClass(Date.class, new Date(0));
+    registerPrimitiveClass(Instant.class, Instant.ofEpochMilli(0));
+
+    // Register the string parsers for the known primitive types.
+    registerStringConverters(byte.class, Byte::parseByte);
+    registerStringConverters(char.class, string -> string.charAt(0));
+    registerStringConverters(double.class, Double::parseDouble);
+    registerStringConverters(float.class, Float::parseFloat);
+    registerStringConverters(int.class, Integer::parseInt);
+    registerStringConverters(long.class, Long::parseLong);
+    registerStringConverters(short.class, Short::parseShort);
+    registerStringConverters(Byte.class, Byte::parseByte);
+    registerStringConverters(Character.class, string -> string.charAt(0));
+    registerStringConverters(Double.class, Double::parseDouble);
+    registerStringConverters(Float.class, Float::parseFloat);
+    registerStringConverters(Integer.class, Integer::parseInt);
+    registerStringConverters(Long.class, Long::parseLong);
+    registerStringConverters(Short.class, Short::parseShort);
+    registerStringConverters(String.class, Function.identity());
+
+    // Register the time converters for the know time types.
+    registerTimeConverters(Date.class, Date.class, Function.identity());
+    registerTimeConverters(Date.class, Instant.class, value -> toInstant((Date) value));
+    registerTimeConverters(Instant.class, Date.class, value -> toDate((Instant) value));
+    registerTimeConverters(Instant.class, Instant.class, Function.identity());
+    registerTimeConverters(Long.class, Date.class, value -> toDate((Long) value));
+    registerTimeConverters(Long.class, Instant.class, value -> toInstant((Long) value));
+    registerTimeConverters(Date.class, Long.class, value -> toEpoch((Date) value));
+    registerTimeConverters(Instant.class, Long.class, value -> toEpoch((Instant) value));
+  }
+
+  private Primitives() {}
+
+  public static void registerPrimitiveClass(Class primitiveClass) {
+    registerPrimitiveClass(primitiveClass, null);
+  }
+
+  @SneakyThrows
+  public static void registerPrimitiveClass(Class primitiveClass, Object primitiveDefault) {
+    PRIMITIVE_DEFAULTS.put(primitiveClass, primitiveDefault);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <P> void registerStringConverters(Class<P> primitiveClass,
+      Function<String, P> stringConverter) {
+    STRING_CONVERTERS.put(primitiveClass, stringConverter);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void registerTimeConverters(Class sourceTimeClass, Class targetTimeClass,
+      Function<Object, Object> timeConverter) {
+    TIME_CONVERTERS.put(new Pair(sourceTimeClass, targetTimeClass), timeConverter);
+  }
+
+  public static boolean isPrimitive(Field field) {
+    return isPrimitive(field.getType());
+  }
+
+
+  public static boolean isPrimitive(Class clazz) {
+    return clazz.isEnum() || clazz.isPrimitive() || PRIMITIVE_DEFAULTS.containsKey(clazz);
+  }
+
+  public static boolean isPrimitiveDefault(Field field, Object value) {
+    return value == null || (isPrimitive(field) && PRIMITIVE_DEFAULTS.get(field.getType())
+        .equals(value));
+  }
+
+  public static Object asPrimitiveType(Field field, String defaultValue) {
+    Function<String, ?> stringConverter = STRING_CONVERTERS.get(field.getType());
+    return (stringConverter != null) ? stringConverter.apply(defaultValue) : null;
+  }
+
+  /**
+   * The given object is considered to be "missing", in the sense that it does not have a value, if
+   * it is {@code null} or it's a default primitive value, and {@link #allowDefaultKeys} is false.
+   */
+  public static boolean isMissing(Object object) {
+    if (object == null) {
+      return true;
+    }
+    if (allowDefaultKeys) {
+      return false;
+    }
+    Class objectClass = object.getClass();
+    Object defaultValue = PRIMITIVE_DEFAULTS.get(objectClass);
+    return object.equals(defaultValue);
+  }
+
+  public static boolean isTimeType(Class clazz) {
+    return clazz.equals(Date.class) || clazz.equals(Instant.class) || clazz.equals(Long.class);
+  }
+
+  public static Date toDate(long epoch) {
+    return toDate(epoch, TimeUnit.MILLISECONDS);
+  }
+
+  public static Date toDate(long epoch, TimeUnit timeUnit) {
+    return new Date(timeUnit.toMillis(epoch));
+  }
+
+  public static long toEpoch(Date date) {
+    return date.getTime();
+  }
+
+  public static Instant toInstant(long epoch) {
+    return Instant.ofEpochMilli(epoch);
+  }
+
+  public static long toEpoch(Instant instant) {
+    return instant.toEpochMilli();
+  }
+
+  public static Instant toInstant(Date date) {
+    return date.toInstant();
+  }
+
+  public static Date toDate(Instant instant) {
+    return Date.from(instant);
+  }
+
+  /**
+   * Convert the given time value to an instance of the target time type.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T toTimeType(Object timeValue, Class<T> targetTimeType) {
+    Class valueClass = timeValue.getClass();
+    Function<Object, Object> timeConverter =
+        TIME_CONVERTERS.get(new Pair(valueClass, targetTimeType));
+    if (timeConverter == null) {
+      throw Element.Exceptions.invalidTimeType(targetTimeType, timeValue);
+    }
+    return (T) timeConverter.apply(timeValue);
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Properties.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/Properties.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedProperty;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isElement;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isList;
+import static org.apache.tinkerpop.gremlin.object.reflect.Parser.isPropertyValue;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.fields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.isSimple;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyValue;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.isKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isMissing;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isPrimitive;
+
+/**
+ * {@link Properties} help outline the properties of an object element, that match a specific
+ * predicate. When creating elements, one is interested in {@link #all} the properties, including
+ * the immutable primary and ordering keys. However, when updating elements, one should only change
+ * the properties {@link #of} the element that are mutable.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@SuppressWarnings({"rawtypes", "PMD.TooManyStaticImports", "PMD.AvoidDuplicateLiterals"})
+public final class Properties {
+
+  private Properties() {}
+
+  /**
+   * Get the id of the given element, as a key value list of it's key fields.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static <E extends Element> Object[] id(E element) {
+    return of(element, Keys::isKey);
+  }
+
+  /**
+   * Get the key value array of all fields of the given element.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static <E extends Element> Object[] all(E element) {
+    return of(element, field -> true);
+  }
+
+  /**
+   * Get the key value array of fields of the element that match the given predicate, including the
+   * given system properties.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static <E extends Element> Object[] all(E element, Predicate<Field> predicate, T... ts) {
+    List<Object> properties = new ArrayList<>();
+    for (T t : ts) {
+      switch (t) {
+        case id:
+          if (element.id() != null) {
+            properties.add(T.id);
+            properties.add(element.id());
+          }
+          break;
+        case label:
+          properties.add(T.label);
+          properties.add(element.label());
+          break;
+        default:
+          break;
+      }
+    }
+    properties.addAll(some(element, predicate));
+    return properties.toArray(new Object[] {});
+  }
+
+  /**
+   * Get the key value array of non-key fields of the given vertex.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static <V extends Vertex> Object[] of(V vertex) {
+    return of(vertex, field -> !isKey(field));
+  }
+
+  /**
+   * Get the key value array of all fields of the given edge.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static <E extends Edge> Object[] of(E edge) {
+    return of(edge, field -> true);
+  }
+
+  /**
+   * Get the key value array of matching fields of the given element.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public static <E extends Element> Object[] of(E element, Predicate<Field> predicate) {
+    return some(element, predicate).toArray(new Object[] {});
+  }
+
+  /**
+   * Get the key value array of simple fields of the given element, including given system ones.
+   */
+  public static <E extends Element> Object[] simple(E element, T... ts) {
+    return all(element, Fields::isSimple, T.id, T.label);
+  }
+
+  /**
+   * Get the key value array of the complex fields of the given element.
+   */
+  public static <E extends Element> Object[] complex(E element) {
+    return all(element, field -> !isSimple(field));
+  }
+
+  /**
+   * Given an {@link Element}, {@link #some} filter's its fields using the given predicate, creates
+   * a property key and value for each field, flattens them, and returns it as a {@link List}.
+   *
+   * @throws IllegalArgumentException, if it finds a property that doesn't have a value, and that
+   *                                   property corresponds to a {@link org.apache.tinkerpop.gremlin.object.model.PrimaryKey}
+   *                                   or {@link org.apache.tinkerpop.gremlin.object.model.OrderingKey}
+   *                                   field.
+   */
+  @SneakyThrows
+  public static <E extends Element> List<Object> some(E element, Predicate<Field> predicate) {
+    List<Object> properties = new ArrayList<>();
+    for (Field field : fields(element, predicate)) {
+      Object propertyValue = FieldUtils.readField(field, element);
+      if (isMissing(propertyValue)) {
+        if (isKey(field)) {
+          throw Element.Exceptions.requiredKeysMissing(element.getClass(), propertyKey(field));
+        }
+        continue;
+      }
+      String propertyName = propertyKey(field);
+      properties.add(propertyName);
+      if (isPrimitive(field)) {
+        if (field.getType().isEnum()) {
+          properties.add(((Enum) propertyValue).name());
+        } else {
+          properties.add(propertyValue);
+        }
+      } else {
+        properties.add(propertyValue);
+      }
+    }
+    return properties;
+  }
+
+  /**
+   * Get the names of the keys of the given element.
+   */
+  public static <E extends Element> List<String> names(E element) {
+    return names(element, field -> true);
+  }
+
+  /**
+   * Get the names of the element matching the given field predicate.
+   */
+  public static <E extends Element> List<String> names(E element, Predicate<Field> predicate) {
+    List<String> names = new ArrayList<>();
+
+    for (Field field : fields(element)) {
+      if (!predicate.test(field)) {
+        continue;
+      }
+      names.add(propertyKey(field));
+    }
+    return names;
+  }
+
+  /**
+   * Get the list of non-null property key values in the given object.
+   */
+  @SneakyThrows
+  @SuppressWarnings("unchecked")
+  public static List<Object> values(Object object) {
+    List<Object> properties = new ArrayList<>();
+    Class<?> objectClass = object.getClass();
+    if (isPrimitive(objectClass)) {
+      properties.add(object);
+    } else if (isElement(objectClass)) {
+      for (Field field : fields((Class<? extends Element>) objectClass)) {
+        Object value = propertyValue(field, object);
+        if (isMissing(value)) {
+          continue;
+        }
+        String propertyName = propertyKey(field);
+        // add property name iff this field is not the meta-properties value field
+        if (isPropertyValue(field)) {
+          properties.add(0, value);
+        } else {
+          properties.add(propertyName);
+          properties.add(value);
+        }
+      }
+    }
+    return properties;
+  }
+
+  /**
+   * Convert the key value array into a list of {@link Property}s.
+   */
+  public static List<Property> list(Object... objects) {
+    List<Property> properties = new ArrayList<>();
+    for (int i = 0; i < objects.length; i = i + 2) {
+      String key = (String) objects[i];
+      Object value = objects[i + 1];
+      properties.add(new DetachedProperty<>(key, value));
+    }
+    return properties;
+  }
+
+  /**
+   * Get the keys of the element that have missing values.
+   */
+  @SneakyThrows
+  public static <E extends Element> List<String> nullKeys(E element) {
+    List<String> keys = new ArrayList<>();
+    for (Field field : fields(element)) {
+      Object propertyValue = FieldUtils.readField(field, element);
+      if (isMissing(propertyValue)) {
+        String propertyName = propertyKey(field);
+        keys.add(propertyName);
+      }
+    }
+    return keys;
+  }
+
+  /**
+   * Get the keys of the element that are lists.
+   */
+  @SneakyThrows
+  public static <E extends Element> List<String> listKeys(E element) {
+    List<String> keys = new ArrayList<>();
+    for (Field field : fields(element)) {
+      Class fieldType = field.getType();
+      if (isList(fieldType)) {
+        String propertyName = propertyKey(field);
+        keys.add(propertyName);
+      }
+    }
+    return keys;
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/UpdateBy.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/reflect/UpdateBy.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import static org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality;
+
+/**
+ * The {@link UpdateBy} class updates the property of an {@link Element}, using either the {@link
+ * Element#property(String, Object)} methods or the {@link GraphTraversal#property} methods.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings({"rawtypes"})
+public enum UpdateBy {
+  /**
+   * Defines an {@link Updater} that relies on the {@link Element#property} method.
+   */
+  ELEMENT(new ElementBasedUpdater()),
+  /**
+   * Defines an {@link Updater} that relies on the {@link GraphTraversal#property} method.
+   */
+  TRAVERSAL(new TraversalBasedUpdater());
+
+  private Updater updater;
+
+  UpdateBy(Updater updater) {
+    this.updater = updater;
+  }
+
+  public Updater updater() {
+    return updater;
+  }
+
+  /**
+   * A function that given a property update, applies it on the given updatable object.
+   */
+  @FunctionalInterface
+  @SuppressWarnings("PMD.UnusedModifier")
+  public interface Updater<U> {
+
+    U property(U updatable, Update update);
+  }
+
+  /**
+   * An abstraction that captures an update on a property.
+   */
+  @Data
+  @AllArgsConstructor
+  @RequiredArgsConstructor(staticName = "of")
+  public static class Update {
+
+    private final String key;
+    private final Object value;
+    private Cardinality cardinality;
+    private Object[] keyValues;
+
+    @SuppressWarnings("PMD.ShortMethodName")
+    public static Update of(Cardinality cardinality, String key, Object value,
+        Object... keyValues) {
+      return new Update(key, value, cardinality, keyValues);
+    }
+  }
+
+  /**
+   * A property updater that goes through the {@link Element#property} methods.
+   */
+  static class ElementBasedUpdater implements Updater<Element> {
+
+    @Override
+    public Element property(Element element, Update update) {
+      if (update.getKeyValues() != null) {
+        ((Vertex) element).property(update.getCardinality(),
+            update.getKey(),
+            update.getValue(),
+            update.getKeyValues());
+      } else {
+        element.property(update.getKey(), update.getValue());
+      }
+      return element;
+    }
+  }
+
+  /**
+   * A property updater that goes through the {@link GraphTraversal#property} methods.
+   */
+  static class TraversalBasedUpdater implements Updater<GraphTraversal> {
+
+    @Override
+    public GraphTraversal property(GraphTraversal traversal, Update update) {
+      if (update.getCardinality() != null) {
+        traversal.property(update.getCardinality(),
+            update.getKey(),
+            update.getValue(),
+            update.getKeyValues());
+      } else {
+        traversal.property(update.getKey(),
+            update.getValue());
+      }
+      return traversal;
+    }
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Connection.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Connection.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Connection} specifies the type of vertices that an edge goes out from and in to.
+ *
+ * <p>
+ * If one tries to create an edge for an unknown connection, an object exception will be thrown.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Connection {
+
+  private final Class<? extends Vertex> fromVertex;
+  private final Class<? extends Vertex> toVertex;
+
+  public static List<Connection> list(Class<? extends Vertex> fromVertexClass,
+      Class<? extends Vertex> toVertexClass) {
+    return list(of(fromVertexClass, toVertexClass));
+  }
+
+  public static List<Connection> list(Connection... connections) {
+    return Arrays.asList(connections);
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Edge.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Edge.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.model.Hidden;
+import org.apache.tinkerpop.gremlin.object.traversal.AnyTraversal;
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * An {@link Edge} is an {@link Element} that is an object-oriented manifestation of an underlying
+ * tinkerpop gremlin edge.
+ *
+ * <p>
+ * Classes that extend the {@link Edge} will have it's fields seamlessly map to the underlying
+ * edge's property. The label of the edge is its sub-classes uncapitalized simple name.
+ *
+ * <p>
+ * The sub-class of an {@link Edge} must specify it's {@link #connections} upfront, at design time.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@ToString
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true,
+    exclude = {"from", "to", "fromId", "toId", "cachedConnections"})
+public abstract class Edge extends Element {
+
+  /**
+   * The object representation of the "from" vertex.
+   */
+  @Hidden
+  private Vertex from;
+  /**
+   * The object representation of the "to" vertex.
+   */
+  @Hidden
+  private Vertex to;
+
+  /**
+   * The id of the "from" vertex.
+   */
+  @Hidden
+  private Object fromId;
+  /**
+   * The id of the "to" vertex.
+   */
+  @Hidden
+  private Object toId;
+
+  @Hidden
+  private List<Connection> cachedConnections;
+
+  protected abstract List<Connection> connections();
+
+  /**
+   * Does the edge have a connection between the given vertices?
+   */
+  @SuppressWarnings("PMD.CloseResource")
+  public boolean connects(Vertex from, Vertex to) {
+    return connects(from.getClass(), to.getClass());
+  }
+
+  /**
+   * Does the edge have a connection between the given vertex types?
+   */
+  @SuppressWarnings("PMD.CloseResource")
+  public boolean connects(Class<? extends Vertex> fromClass, Class<? extends Vertex> toClass) {
+    Connection connection = Connection.of(fromClass, toClass);
+    if (cachedConnections == null) {
+      cachedConnections = connections();
+    }
+    return cachedConnections.contains(connection);
+  }
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at edges, and ends at vertices.
+   */
+  public interface ToVertex extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Edge,
+      org.apache.tinkerpop.gremlin.structure.Vertex> {
+
+  }
+
+  public static class Exceptions extends Element.Exceptions {
+
+    private Exceptions() {}
+
+    public static IllegalStateException missingEdgeVertex(
+        Direction direction, Edge edge, org.apache.tinkerpop.gremlin.structure.Vertex vertex) {
+      return missingEdgeVertex(direction, edge, vertex.toString());
+    }
+
+    public static IllegalStateException missingEdgeVertex(
+        Direction direction, Edge edge, AnyTraversal anyTraversal) {
+      return missingEdgeVertex(direction, edge, anyTraversal.toString());
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static IllegalStateException missingEdgeVertex(
+        Direction direction, Edge edge, SubTraversal... subTraversals) {
+      return missingEdgeVertex(direction, edge, Arrays.asList(subTraversals).toString());
+    }
+
+    public static IllegalStateException missingEdgeVertex(Direction direction, Edge edge,
+        String vertexString) {
+      return new IllegalStateException(
+          String.format("%s vertex (%s) doesn't exist for edge %s",
+              direction.equals(Direction.OUT) ? "Outgoing" : "Incoming", vertexString,
+              edge));
+    }
+
+    public static IllegalStateException invalidEdgeConnection(Edge edge) {
+      return new IllegalStateException(
+          String.format("Edge connects an invalid pair of vertices", edge));
+    }
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/EdgeGraph.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/EdgeGraph.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Parser;
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.apache.tinkerpop.gremlin.object.traversal.AnyTraversal;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@link EdgeGraph} performs add and remove edge operations on the underlying {@link
+ * GraphTraversal} or {@link org.apache.tinkerpop.gremlin.structure.Graph}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@SuppressWarnings("rawtypes")
+public class EdgeGraph extends ElementGraph {
+
+  private final Query query;
+  private Graph.O observers = Graph.O.get();
+
+  private Edge edge;
+  private Map<Object, org.apache.tinkerpop.gremlin.structure.Edge> delegates = new HashMap<>();
+
+  public EdgeGraph(Graph graph, Query query, GraphTraversalSource g) {
+    super(graph, g);
+    this.query = query;
+  }
+
+  public org.apache.tinkerpop.gremlin.structure.Edge delegate(Edge edge) {
+    return edge.id() != null ? this.delegates.get(edge) : null;
+  }
+
+  /**
+   * Add the given edge, from the given gremlin vertex, to the vertices selected by the given {@link
+   * AnyTraversal}.
+   */
+  public <E extends Edge> Edge addEdge(E edge, org.apache.tinkerpop.gremlin.structure.Vertex from,
+      AnyTraversal anyTraversal) {
+    if (from == null) {
+      throw Edge.Exceptions.missingEdgeVertex(Direction.OUT, edge, from);
+    }
+    List<Vertex> tos = query.by(anyTraversal).list(Vertex.class);
+    if (tos == null || tos.isEmpty()) {
+      throw Edge.Exceptions.missingEdgeVertex(Direction.IN, edge, anyTraversal);
+    }
+    tos.forEach(to -> {
+      edge.setTo(to);
+      addEdge(edge, from, to.delegate());
+    });
+    return edge;
+  }
+
+  /**
+   * Add the given edge, from the given gremlin vertex, to the vertices selected by the given {@link
+   * SubTraversal}s.
+   */
+  public <E extends Edge> Edge addEdge(E edge, org.apache.tinkerpop.gremlin.structure.Vertex from,
+      SubTraversal... subTraversals) {
+    if (from == null) {
+      throw Edge.Exceptions.missingEdgeVertex(Direction.OUT, edge, from);
+    }
+    List<Vertex> tos = query.by(subTraversals).list(Vertex.class);
+    if (tos == null || tos.isEmpty()) {
+      throw Edge.Exceptions.missingEdgeVertex(Direction.IN, edge, subTraversals);
+    }
+    tos.forEach(to -> {
+      edge.setTo(to);
+      addEdge(edge, from, to.delegate());
+    });
+    return edge;
+  }
+
+  /**
+   * Add the given edge from and to the given gremlin vertices.
+   *
+   * Based on the value of {@link #should()}, it will either: <ol> <li>Create the edge with no
+   * checks.</li> <li>Merge the edge with any existing one.</li> <li>Replace the existing edge, if
+   * present, otherwise insert.</li> <li>Insert the edge, only if it doesn't exist.</li> <li>Ignore
+   * the addition if one already exists.</li> </ol>
+   */
+  @SuppressWarnings("unchecked")
+  <E extends Edge> Edge addEdge(E edge, org.apache.tinkerpop.gremlin.structure.Vertex fromVertex,
+      org.apache.tinkerpop.gremlin.structure.Vertex toVertex) {
+    if (fromVertex == null) {
+      throw Edge.Exceptions.missingEdgeVertex(Direction.OUT, edge);
+    }
+    if (toVertex == null) {
+      throw Edge.Exceptions.missingEdgeVertex(Direction.IN, edge);
+    }
+    org.apache.tinkerpop.gremlin.structure.Element delegate;
+    Object fromId = fromVertex.id();
+    Object toId = toVertex.id();
+    switch (should()) {
+      case CREATE:
+        delegate = complete(create(edge, fromId, toId));
+        break;
+      case MERGE:
+        delegate = complete(g.inject(1).coalesce(
+            update(edge, fromId, toId), create(edge, fromId, toId)));
+        break;
+      case REPLACE:
+        delegate = complete(g.inject(1).coalesce(
+            clear(edge, fromId, toId), update(edge, fromId, toId), create(edge, fromId, toId)));
+        break;
+      case INSERT:
+        delegate = insert(edge, fromVertex, toVertex);
+        break;
+      case IGNORE:
+      default:
+        delegate = complete(g.inject(1).coalesce(
+            find(edge, fromId, toId), create(edge, fromId, toId)));
+        break;
+    }
+    edge.setDelegate(delegate);
+    edge.setFromId(fromId);
+    edge.setToId(toId);
+    delegates.put(edge.id(), (org.apache.tinkerpop.gremlin.structure.Edge) delegate);
+    this.edge = Parser.as(delegate, edge.getClass());
+    this.edge.setFrom(edge.getFrom());
+    this.edge.setTo(edge.getTo());
+    this.edge.setFromId(edge.getFromId());
+    this.edge.setToId(edge.getToId());
+    observers.notifyAll(observer -> observer.edgeAdded(edge, this.edge));
+    return this.edge;
+  }
+
+  /**
+   * Remove the given edge.
+   */
+  public <E extends Edge> Edge removeEdge(E edge) {
+    if (edge.getFromId() == null || edge.getToId() == null) {
+      throw Element.Exceptions.removingDetachedElement(edge);
+    }
+    GraphTraversal traversal = find(edge, edge.getFromId(), edge.getToId());
+    log.info("Executing 'remove edge' traversal {}", traversal);
+    traversal.select("edge").drop().toList();
+    if (edge.id() != null) {
+      delegates.remove(edge);
+    }
+    observers.notifyAll(observer -> observer.edgeRemoved(edge));
+    return edge;
+  }
+
+  <E extends Edge> GraphTraversal clear(E edge, Object fromId, Object toId) {
+    GraphTraversal traversal = find(edge, fromId, toId);
+    List<String> clearKeys = Properties.nullKeys(edge);
+    traversal.properties(clearKeys.toArray(new String[] {})).drop();
+    return traversal;
+  }
+
+  <E extends Edge> GraphTraversal update(E edge, Object fromId, Object toId) {
+    GraphTraversal traversal = find(edge, fromId, toId);
+    return update(traversal, edge, Properties::of);
+  }
+
+  <E extends Edge> GraphTraversal check(E edge, Object fromId, Object toId) {
+    return fail(find(edge, fromId, toId));
+  }
+
+  <E extends Edge> GraphTraversal create(E edge, Object fromId, Object toId) {
+    GraphTraversal traversal = g
+        .V().hasId(fromId).as("from")
+        .V().hasId(toId).as("to")
+        .addE(edge.label()).as("edge").from("from");
+    Object edgeId = maybeSupplyId(edge);
+    if (edgeId != null) {
+      traversal.property(T.id, edgeId);
+    }
+    return update(traversal, edge, Properties::all);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected org.apache.tinkerpop.gremlin.structure.Edge insert(
+      Edge edge, org.apache.tinkerpop.gremlin.structure.Vertex fromVertex,
+      org.apache.tinkerpop.gremlin.structure.Vertex toVertex) {
+    try {
+      if (useGraph(edge)) {
+        return fromVertex.addEdge(edge.label(), toVertex, Properties.of(edge));
+      } else {
+        Object fromId = fromVertex.id();
+        Object toId = toVertex.id();
+        return complete(g.inject(1).coalesce(
+            check(edge, fromId, toId), create(edge, fromId, toId)));
+      }
+    } catch (Exception e) {
+      log.warn("An {} edge between these two vertices already exists", edge, fromVertex, toVertex);
+      throw Element.Exceptions.elementAlreadyExists(edge);
+    }
+  }
+
+  <E extends Edge> GraphTraversal find(E edge, Object fromId, Object toId) {
+    return g.V().hasId(fromId).as("from").out(edge.label()).hasId(toId).as("to")
+        .inE(edge.label()).as("edge");
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected org.apache.tinkerpop.gremlin.structure.Edge complete(GraphTraversal traversal) {
+    log.info("Executing '{} edge' traversal {} ", should().label(), traversal);
+    return (org.apache.tinkerpop.gremlin.structure.Edge) super.complete(traversal);
+  }
+
+  public void reset() {
+    this.delegates.clear();
+    this.edge = null;
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Element.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Element.java
@@ -143,6 +143,16 @@ public class Element implements Comparable<Element> {
     elementCacheSize = numberOfElements;
   }
 
+  /**
+   * Classes that extend the {@link Element} should use the {@code @EqualsAndHashCode(of={},
+   * callSuper=true)} annotation, so that we can ignore any fields marked as {@code Hidden}.
+   *
+   * By including {@code of={}} in that annotation, the derived class essentially excludes all of
+   * it's fields, so as to avoid double-checking each field. If {@code of={}} is not present, and if
+   * the derived class contains any instance-specific {@link SubTraversal}s or {@code
+   * AnyTraversal}s, then they will need to either be marked as {@code transient} or start with a
+   * {@code $} symbol, so that the {@code lombok} processor can ignore those lambda objects.
+   */
   @Override
   public boolean equals(Object other) {
     if (this == other) {

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Element.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Element.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.model.Alias;
+import org.apache.tinkerpop.gremlin.object.reflect.Keys;
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Has;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.name;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.elementCacheSize;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.field;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.fields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyValue;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.keyFields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.primaryKeyFields;
+
+/**
+ * The element that {@code gremlin-core} uses to represent a vertex and edge is much like a property
+ * map, which can be hard to read and write. The {@link Element} class allows for representations of
+ * the underlying  element as first-class objects, whose fields correspond to its properties.
+ *
+ * <p>
+ * Both the {@link Vertex} and {@link Edge} classes inherit from the {@link Element} class. It
+ * contains sub-traversals such as {@link #withLabel} and {@link #s}, that are applicable to all
+ * elements. In addition, it implements the {@link Comparable} interface, ordering elements by their
+ * {@code PrimaryKey}s and {@code OrderingKey}s first.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@ToString
+@NoArgsConstructor
+@SuppressWarnings({"rawtypes", "PMD.TooManyStaticImports"})
+public class Element implements Comparable<Element> {
+
+  public static final long serialVersionUID = 1L;
+  public final ElementTo.Element withLabel = traversal -> traversal.hasLabel(label());
+  @Setter
+  protected org.apache.tinkerpop.gremlin.structure.Element delegate;
+  @Getter
+  @Setter
+  @Alias(key = "id")
+  private Object userSuppliedId;
+  public final ElementTo.Element withId = traversal -> traversal.hasId(id());
+
+  public Element(Element other) {
+    this.setUserSuppliedId(other.id());
+  }
+
+  /**
+   * Compose the given {@link SubTraversal} in the given order.
+   */
+  @SuppressWarnings("unchecked")
+  protected static <E> ElementTo<E> compose(SubTraversal<?, ?>... subTraversals) {
+    return traversal -> {
+      for (SubTraversal subTraversal : subTraversals) {
+        traversal = (GraphTraversal<
+            org.apache.tinkerpop.gremlin.structure.Element,
+            org.apache.tinkerpop.gremlin.structure.Element>) subTraversal.apply(traversal);
+      }
+      return (GraphTraversal) traversal;
+    };
+  }
+
+  /**
+   * This is final since you can override the label through the {@link Alias} annotation
+   */
+  public final String label() {
+    return Label.of(getClass());
+  }
+
+  /**
+   * If the graph supports user supplied ids, then we will derive the id based on the primary and
+   * ordering key fields of the element, ergo this is final.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public final Object id() {
+    if (userSuppliedId != null) {
+      return userSuppliedId;
+    }
+    if (delegate != null) {
+      return delegate.id();
+    }
+    return null;
+  }
+
+  /**
+   * Generate a {@link SubTraversal} that matches the value of the given key in this element.
+   */
+  @SneakyThrows
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public ElementTo.Element s(String key) {
+    Field propertyField = field(getClass(), key);
+    return Has.of(label(), propertyKey(propertyField), propertyValue(propertyField, this));
+  }
+
+  /**
+   * @throws {@link Exceptions#requiredKeysMissing(Class, String)} if a key is missing
+   */
+  public void validate() {
+    Keys.id(this);
+  }
+
+  /**
+   * Changes the maximum number of elements for which reflection metadata will be cached. If the
+   * limit is hit, the least recently used element is kicked out.
+   */
+  public static void cache(long numberOfElements) {
+    elementCacheSize = numberOfElements;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Element)) {
+      return false;
+    }
+    Element that = (Element) other;
+    if (this.id() != null && that.id() != null && !this.id().equals(that.id())) {
+      return false;
+    }
+    return compareTo(that) == 0;
+  }
+
+  @Override
+  @SneakyThrows
+  public int hashCode() {
+    List<Field> primaryKeyFields = primaryKeyFields(getClass());
+    int hashCode = 0;
+    for (Field primaryKeyField : primaryKeyFields) {
+      Object value = primaryKeyField.get(this);
+      if (value == null) {
+        continue;
+      }
+      hashCode += value.hashCode();
+    }
+    return hashCode;
+  }
+
+  /**
+   * Compare against the given element, using the values of the fields, in {@link
+   * org.apache.tinkerpop.gremlin.object.reflect.Fields#BY_KEYS} order.
+   */
+  @Override
+  public int compareTo(Element that) {
+    return valuesOf(fields(getClass())).compare(this, that);
+  }
+
+  /**
+   * Check if this element exists in the given collection. If it defines {@code PrimaryKey}s or
+   * {@code OrderingKey}s, then those are compared. If not, then all fields are considered.
+   */
+  public boolean existsIn(Collection<? extends Element> elements) {
+    final List<Field> fields = keyFields(getClass());
+    if (fields.isEmpty()) {
+      fields.addAll(fields(getClass()));
+    }
+    return elements.stream()
+        .anyMatch(element -> valuesOf(fields).compare(element, this) == 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static final Comparator<Element> valuesOf(List<Field> fields) {
+    return (left, right) -> {
+      if (!left.getClass().equals(right.getClass())) {
+        return -1;
+      }
+      for (Field field : fields) {
+        try {
+          Object thisValue = field.get(left);
+          Object thatValue = field.get(right);
+
+          if (thisValue == null) {
+            if (thatValue != null) {
+              return -1;
+            }
+          } else {
+            if (thatValue == null) {
+              return 1;
+            }
+            int difference;
+            if (thisValue instanceof Comparable) {
+              difference = ((Comparable) thisValue).compareTo(thatValue);
+            } else {
+              difference = thisValue.hashCode() - thatValue.hashCode();
+            }
+            if (difference != 0) {
+              return difference;
+            }
+          }
+        } catch (IllegalAccessException iae) {
+          return -1;
+        }
+      }
+      return 0;
+    };
+  }
+
+  public static class Exceptions {
+
+    protected Exceptions() {
+      // The protected access modifier allows for sub-classing.
+    }
+
+    public static IllegalStateException elementAlreadyExists(Element element) {
+      return new IllegalStateException(
+          String.format("The element '%s' with the id '%s' already exists",
+              element.label(), Properties.id(element)));
+    }
+
+    public static IllegalStateException removingDetachedElement(Element element) {
+      return new IllegalStateException(
+          String.format("Cannot remove detached element: %s", element));
+    }
+
+    public static IllegalArgumentException requiredKeysMissing(Class<? extends Element> elementType,
+        String fieldName) {
+      return new IllegalArgumentException(
+          String.format("The mandatory key '%s' for element '%s' is null",
+              fieldName, name(elementType)));
+    }
+
+    public static IllegalArgumentException invalidAnnotationType(Class<?> type) {
+      return new IllegalArgumentException(
+          String.format("The annotation type '%s' is not supported", name(type)));
+    }
+
+    public static InstantiationException invalidCollectionType(Class<?> type) {
+      return new InstantiationException(
+          String.format("The collection type '%s' is not supported", name(type)));
+    }
+
+    public static InstantiationException unknownElementType(Class<?> type) {
+      return new InstantiationException(
+          String.format("The collection type '%s' is not supported", name(type)));
+    }
+
+    public static ClassCastException invalidTimeType(Class targetClass, Object timeValue) {
+      return new ClassCastException(
+          String.format("The time value '%s' is not of the desired '%s' type", targetClass,
+              timeValue));
+    }
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/ElementGraph.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/ElementGraph.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Keys;
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.apache.tinkerpop.gremlin.object.reflect.UpdateBy;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isCollection;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isList;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isSet;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.list;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.values;
+import static org.apache.tinkerpop.gremlin.object.reflect.UpdateBy.Update;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.REPLACE;
+import static org.apache.tinkerpop.gremlin.object.structure.HasFeature.supportsGraphAdd;
+import static org.apache.tinkerpop.gremlin.object.structure.HasFeature.supportsUserSuppliedIds;
+import static org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality;
+
+/**
+ * The {@link ElementGraph} provides ways to find and update gremlin {@link
+ * org.apache.tinkerpop.gremlin.structure.Element}s.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@AllArgsConstructor
+@SuppressWarnings({"rawtypes", "PMD.TooManyStaticImports"})
+public class ElementGraph {
+
+  protected Graph graph;
+  protected GraphTraversalSource g;
+
+  /**
+   * What should we do if the element we are trying to add already exists?
+   */
+  protected Graph.Should should() {
+    return graph.should();
+  }
+
+  /**
+   * Does the gremlin graph API support add elements (vertices/edges)?
+   */
+  protected <E extends Element> boolean useGraph(E element) {
+    return graph.verify(supportsGraphAdd(element));
+  }
+
+  /**
+   * Find the given element using it's id, if it has one, or all of it's properties.
+   */
+  protected <E extends Element> GraphTraversal find(E element) {
+    GraphTraversal traversal = g.V();
+    if (element.id() != null) {
+      traversal = traversal.hasId(element.id());
+    } else {
+      traversal = traversal.hasLabel(element.label());
+      Object[] properties = Properties.id(element);
+      if (properties == null || properties.length == 0) {
+        properties = Properties.all(element);
+      }
+      for (Property property : list(properties)) {
+        traversal = traversal.has(property.key(), property.value());
+      }
+    }
+    return traversal;
+  }
+
+  /**
+   * Update the element, using a traversal, and the properties provided by the lister.
+   */
+  protected <E extends Element> GraphTraversal update(
+      GraphTraversal traversal, E element, Function<E, Object[]> lister) {
+    return update(traversal, UpdateBy.TRAVERSAL, element, lister);
+  }
+
+  /**
+   * Update the attached element, using it's own methods, and the listed properties.
+   */
+  protected <E extends Element> org.apache.tinkerpop.gremlin.structure.Element update(
+      org.apache.tinkerpop.gremlin.structure.Element delegate, E element,
+      Function<E, Object[]> lister) {
+    return update(delegate, UpdateBy.ELEMENT, element, lister);
+  }
+
+  /**
+   * Generate the list of {@link Update}s corresponding to the listed properties. Then, apply then
+   * against either the given {@link GraphTraversal} or {@link Element}.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected <E extends Element, M> M update(M updatable, UpdateBy updateBy, E element,
+      Function<E, Object[]> lister) {
+    Object[] properties = lister.apply(element);
+    updates(properties).forEach(
+        mutation -> updateBy.updater().property(updatable, mutation));
+    return updatable;
+  }
+
+  /**
+   * For single-valued properties, create a <key, value> update. For multi- or vertex-properties
+   * with meta-properties, create a <key, value, values> update.
+   */
+  protected List<Update> updates(Object... properties) {
+    List<Update> updates = new ArrayList<>();
+    for (Property property : list(properties)) {
+      String key = property.key();
+      Object value = property.value();
+      Class<?> valueClass = value.getClass();
+      if (isCollection(valueClass)) {
+        Collection collection = (Collection) value;
+        Cardinality cardinality = null;
+        for (Object item : collection) {
+          cardinality = collectionCardinality(valueClass, cardinality);
+          append(updates, cardinality, key, item);
+        }
+      } else {
+        append(updates, VertexProperty.Cardinality.single, key, value);
+      }
+    }
+    return updates;
+  }
+
+  /**
+   * What {@link Cardinality} should we use for the given type of value, depending on what the
+   * previous update's {@link Cardinality}, and what {@link #should()}  is.
+   *
+   * In particular, if we're in the replace mode, we want the first update on a given list or set to
+   * have a {@link Cardinality#single} value.
+   */
+  @SneakyThrows
+  private Cardinality collectionCardinality(Class<?> valueType, Cardinality lastOne) {
+    if (lastOne == null) {
+      if (should().equals(REPLACE)) {
+        return Cardinality.single;
+      }
+    } else {
+      if (!Cardinality.single.equals(lastOne)) {
+        return lastOne;
+      }
+    }
+    if (isList(valueType)) {
+      return Cardinality.list;
+    }
+    if (isSet(valueType)) {
+      return Cardinality.set;
+    }
+    throw Element.Exceptions.invalidCollectionType(valueType);
+  }
+
+  /**
+   * Append an update with key, value and possibly an array of values, depending on whether it's a
+   * single-, multi-, or complex-property (that has meta-properties).
+   */
+  protected void append(List<Update> updates, Cardinality cardinality,
+      String key, Object value) {
+    List<Object> values = values(value);
+    switch (values.size()) {
+      case 0:
+        break;
+      case 1:
+        // this is a single valued property.
+        updates.add(Update.of(key, values.get(0)));
+        break;
+      default:
+        // this is either a multi- or meta-property
+        updates.add(Update.of(cardinality, key, values.remove(0),
+            values.toArray(new Object[] {})));
+        break;
+    }
+  }
+
+  /**
+   * If the underlying graph supports user supplied ids, supply one.
+   */
+  protected Object maybeSupplyId(Element element) {
+    if (!graph.verify(supportsUserSuppliedIds(element))) {
+      return null;
+    }
+    element.setUserSuppliedId(Keys.id(element));
+    return element.id();
+  }
+
+  /**
+   * Force the traversal to fail.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected GraphTraversal fail(GraphTraversal traversal) {
+    traversal.choose(__.value());
+    return traversal;
+  }
+
+  /**
+   * Complete the traversal by returning the next (and only) element.
+   */
+  protected <E> E complete(GraphTraversal<?, E> traversal) {
+    return traversal.next();
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Graph.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Graph.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.traversal.AnyTraversal;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+
+import java.util.function.Consumer;
+
+/**
+ * In order to write objects to the property graph, you'll need an instance of the {@link Graph}.
+ *
+ * <p>
+ * Typically, you would create it using an implementation-specific graph factory. However, if the
+ * implementation supports it, then it may be dependency inject'ed. The default qualifier is
+ * provider by a reference {@code TinkerGraph} system.
+ *
+ * <p>
+ * The {@link #addVertex(Vertex)} and {@link #removeVertex(Vertex)} take a user-defined vertex
+ * object. Similarly, the {@link #addEdge} methods take a user-defined edge object, and it's
+ * connecting vertex objects, specified as-is, or through aliases, or even traversals.
+ *
+ * <p>
+ * Speaking of aliases, one may define it using the {@link #as} methods, which let you capture the
+ * last vertex or edge object that was added under the parameter passed to that method. An aliased
+ * object may be retrieved later using the {@link #get} method.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public interface Graph {
+
+  /**
+   * Add an given {@link Vertex} to the graph.
+   */
+  <V extends Vertex> Graph addVertex(V vertex);
+
+  /**
+   * Remove the given {@link Vertex} from the graph.
+   */
+  <V extends Vertex> Graph removeVertex(V vertex);
+
+  /**
+   * Add an {@link Edge} from the current vertex to the vertex referenced by the given alias.
+   */
+  <E extends Edge,
+      V extends Vertex> Graph addEdge(E edge, String toVertexAlias);
+
+  /**
+   * Add an {@link Edge} from the current vertex to the given {@link Vertex}
+   */
+  <E extends Edge,
+      V extends Vertex> Graph addEdge(E edge, V toVertex);
+
+  /**
+   * Add an {@link Edge} from the given from and to vertices specified by their aliases.
+   */
+  <E extends Edge,
+      V extends Vertex> Graph addEdge(E edge, String fromVertexAlias, String toVertexAlias);
+
+  /**
+   * Add an {@link Edge} between the given vertices.
+   */
+  <E extends Edge,
+      V extends Vertex> Graph addEdge(E edge, V fromVertex, V toVertex);
+
+  /**
+   * Add an {@link Edge} form the aliased vertex to the given vertex.
+   */
+  <E extends Edge,
+      V extends Vertex> Graph addEdge(E edge, String fromVertexAlias, V toVertex);
+
+  /**
+   * Add an {@link Edge} from the given vertex to the aliased vertex.
+   */
+  <E extends Edge,
+      V extends Vertex> Graph addEdge(E edge, Vertex fromVertex, String toVertexAlias);
+
+  /**
+   * Add an {@link Edge} from the given vertex to the vertices returned by the {@link
+   * AnyTraversal}.
+   */
+  <E extends Edge,
+      V extends Vertex> Graph addEdge(E edge, Vertex fromVertex, AnyTraversal toAnyTraversal);
+
+  /**
+   * Add an {@link Edge} to the vertices returned by the given {@link AnyTraversal}.
+   */
+  <E extends Edge> Graph addEdge(E edge, AnyTraversal toAnyTraversal);
+
+  /**
+   * Add an {@link Edge} to the vertices returned by the given {@link SubTraversal}s.
+   */
+  @SuppressWarnings("rawtypes")
+  <E extends Edge> Graph addEdge(E edge, SubTraversal... toVertexQueries);
+
+  /**
+   * Remove the given edge.
+   */
+  <E extends Edge> Graph removeEdge(E edge);
+
+  /**
+   * Get the {@link Element} tied to the given alias.
+   *
+   * This is a materialization of the element provided to this graph, and may not reflect what's
+   * actually in the graph. To see the actual element, use the {@link Query} interface.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  Graph as(String alias);
+
+  /**
+   * Supply the {@link Element} tied to the given consumer.
+   *
+   * This is a materialization of the element provided to this graph, and may not reflect what's
+   * actually in the graph. To see the actual element, use the {@link Query} interface.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  <E extends Element> Graph as(Consumer<E> consumer);
+
+  /**
+   * Get the last added {@link Element} in the form of the given type.
+   *
+   * This is a materialization of the element provided to this graph, and may not reflect what's
+   * actually in the graph. To see the actual element, use the {@link Query} interface.
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  <E extends Element> E as(Class<E> elementType);
+
+  /**
+   * How {@link Should} the {@link Graph} try to add vertices and edges?
+   */
+  Graph should(Should should);
+
+  /**
+   * What is the {@link Should} mode currently set to?
+   */
+  Should should();
+
+  /**
+   * Should primitive required keys be allowed to have their primitive default values?
+   */
+  Graph defaultKeys(boolean allow);
+
+  /**
+   * Verify if the graph has the given feature.
+   */
+  boolean verify(HasFeature hasFeature);
+
+  /**
+   * Get the element of the given type stored against the given alias.
+   */
+  <E extends Element> E get(String alias, Class<E> elementType);
+
+  /**
+   * Return the associated {@link Query} instance.
+   */
+  Query query();
+
+  /**
+   * Return the associated {@link GraphSystem} instance.
+   */
+  @SuppressWarnings("rawtypes")
+  GraphSystem system();
+
+  /**
+   * Drop the elements in the graph.
+   */
+  void drop();
+
+  /**
+   * Release the resources in the graph.
+   */
+  void close();
+
+  /**
+   * Reset the state of the graph, including any aliases, and element mappings.
+   */
+  void reset();
+
+  /**
+   * How should the graph add elements, considering that an element with that id or key might
+   * already exist?
+   */
+  enum Should {
+    /**
+     * The default, which is to merge properties of the new and existing element, if any.
+     */
+    MERGE,
+    /**
+     * If it exists, replace all its (mutable) properties. Otherwise {@link #INSERT}.
+     */
+    REPLACE,
+    /**
+     * If the graph supports user ids, then {@link #INSERT}. Otherwise, {@link #MERGE}.
+     */
+    CREATE,
+    /**
+     * Add the element if and only if there is no existing element.
+     */
+    IGNORE,
+    /**
+     * Add the element, raising an exception if it already exists, and a key violation occurs.
+     */
+    INSERT;
+
+    public String label() {
+      return name().toLowerCase();
+    }
+  }
+
+  /**
+   * An interface that defines graph update events.
+   */
+  interface Observer {
+
+    <V extends Vertex> void vertexAdded(V given, V stored);
+
+    <V extends Vertex> void vertexRemoved(V given);
+
+    <E extends Edge> void edgeAdded(E given, E stored);
+
+    <E extends Edge> void edgeRemoved(E given);
+  }
+
+  /**
+   * {@link Observer}s can register interest in the graph through this class.
+   */
+  @SuppressWarnings("PMD.ShortClassName")
+  class O extends Observable<Observer> {
+
+    private static final O INSTANCE = new O();
+
+    public static O get() {
+      return INSTANCE;
+    }
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/HasFeature.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/HasFeature.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+
+import java.util.function.Predicate;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.is;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isVertex;
+
+/**
+ * {@link HasFeature} is a predicate that given the {@link org.apache.tinkerpop.gremlin.structure.Graph.Features}
+ * of the gremlin graph, determines whether a particular feature is available.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@FunctionalInterface
+public interface HasFeature extends Predicate<Graph.Features> {
+
+  /**
+   * The {@link Verifier} tests the given {@link HasFeature} against the features obtained from a
+   * {@link GraphTraversalSource}. If it contains an {@link EmptyGraph}, then the feature is assumed
+   * to be unavailable.
+   */
+  @Data
+  @RequiredArgsConstructor(staticName = "of")
+  class Verifier {
+
+    private final GraphTraversalSource g;
+
+    public boolean verify(HasFeature hasFeature) {
+      return g.getGraph() != null && !is(g.getGraph(), EmptyGraph.class) &&
+          hasFeature.test(g.getGraph().features());
+    }
+  }
+
+  static HasFeature supportsUserSuppliedIds(Element element) {
+    return features -> (isVertex(element) ? features.vertex() : features.edge())
+        .supportsUserSuppliedIds();
+  }
+
+  static HasFeature supportsGraphAdd(Element element) {
+    return features -> isVertex(element) ? features.vertex().supportsAddVertices()
+        : features.edge().supportsAddEdges();
+  }
+
+  static HasFeature supportsGraphAddVertex() {
+    return features -> features.vertex().supportsAddVertices();
+  }
+
+  static HasFeature supportsGraphAddEdge() {
+    return features -> features.edge().supportsAddEdges();
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/ObjectGraph.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/ObjectGraph.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.reflect.Primitives;
+import org.apache.tinkerpop.gremlin.object.traversal.AnyTraversal;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.CREATE;
+
+/**
+ * The {@link ObjectGraph} implements the {@link Graph} interface using the provided {@link
+ * GraphSystem} and {@link Query} instances.
+ *
+ * <p>
+ * It delegates the {@link #addVertex} and {@link #removeVertex} methods to the {@link VertexGraph}
+ * class. Similarly, it passes on the {@link #addEdge} and {@link #removeEdge} methods to the {@link
+ * EdgeGraph}. Both of those delegates extend the {@link ElementGraph}, which provides ways to find
+ * and update elements of any kind.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@SuppressWarnings({"unchecked", "rawtypes", "PMD.TooManyStaticImports"})
+public abstract class ObjectGraph implements Graph {
+
+  @SuppressWarnings({"PMD.AvoidFieldNameMatchingMethodName"})
+  protected final GraphSystem system;
+  @SuppressWarnings({"PMD.AvoidFieldNameMatchingMethodName"})
+  protected final Query query;
+  protected GraphTraversalSource g;
+
+  @SuppressWarnings({"PMD.AvoidFieldNameMatchingMethodName"})
+  /**
+   * How should the object graph handle "merge conflicts"?
+   */
+  protected Should should;
+  /**
+   * An element graph that handles vertex operations.
+   */
+  protected VertexGraph vertexGraph;
+  /*
+   * An element graph that handles edge operations.
+   */
+  protected EdgeGraph edgeGraph;
+
+  /**
+   * The last element added to the object graph
+   */
+  protected Element object;
+  /**
+   * The objects that have been aliased so far in this graph.
+   */
+  protected Map<String, Element> aliases = new HashMap<>();
+  /**
+   * A feature verified based on this graph's {@link #g}.
+   */
+  protected HasFeature.Verifier verifier;
+
+  public ObjectGraph(GraphSystem system, Query query) {
+    this.system = system;
+    this.query = query;
+    should = CREATE;
+    g = system.g();
+    verifier = HasFeature.Verifier.of(g);
+    vertexGraph = new VertexGraph(this, g);
+    edgeGraph = new EdgeGraph(this, query, g);
+  }
+
+  @Override
+  public <V extends Vertex> ObjectGraph addVertex(V vertex) {
+    this.object = vertexGraph.addVertex(vertex);
+    return this;
+  }
+
+  @Override
+  public <V extends Vertex> ObjectGraph removeVertex(V vertex) {
+    vertexGraph.removeVertex(vertex);
+    return this;
+  }
+
+  @Override
+  public <E extends Edge, V extends Vertex> Graph addEdge(E edge, String toVertexAlias) {
+    addEdge(edge, (V) aliases.get(toVertexAlias));
+    return this;
+  }
+
+  @Override
+  public <E extends Edge, V extends Vertex> Graph addEdge(E edge,
+      String fromVertexAlias,
+      String toVertexAlias) {
+    return addEdge(edge, (V) aliases.get(fromVertexAlias), (V) aliases.get(toVertexAlias));
+  }
+
+  @Override
+  public <E extends Edge, V extends Vertex> Graph addEdge(E edge, Vertex fromVertex,
+      String toVertexAlias) {
+    return addEdge(edge, fromVertex, (V) aliases.get(toVertexAlias));
+  }
+
+  @Override
+  public <E extends Edge, V extends Vertex> Graph addEdge(E edge, String fromVertexAlias,
+      V toVertex) {
+    return addEdge(edge, (V) aliases.get(fromVertexAlias), toVertex);
+  }
+
+  @Override
+  public <E extends Edge, V extends Vertex> Graph addEdge(E edge, V toVertex) {
+    return addEdge(edge, vertexGraph.getVertex(), toVertex);
+  }
+
+  @Override
+  public <E extends Edge, V extends Vertex> Graph addEdge(E edge, V fromVertex, V toVertex) {
+    if (!edge.connects(fromVertex, toVertex)) {
+      throw Edge.Exceptions.invalidEdgeConnection(edge);
+    }
+    edge.setFrom(fromVertex);
+    edge.setTo(toVertex);
+    this.object = edgeGraph.addEdge(
+        edge, vertexGraph.delegate(fromVertex), vertexGraph.delegate(toVertex));
+    return this;
+  }
+
+  @Override
+  public <E extends Edge, V extends Vertex> Graph addEdge(E edge, Vertex fromVertex,
+      AnyTraversal toAnyTraversal) {
+    edge.setFrom(fromVertex);
+    this.object = edgeGraph.addEdge(edge, vertexGraph.delegate(fromVertex), toAnyTraversal);
+    return this;
+  }
+
+  @Override
+  public <E extends Edge> Graph addEdge(E edge, AnyTraversal toAnyTraversal) {
+    return addEdge(edge, vertexGraph.getVertex(), toAnyTraversal);
+  }
+
+  @Override
+  public <E extends Edge> Graph addEdge(E edge, SubTraversal... subTraversals) {
+    Vertex fromVertex = vertexGraph.getVertex();
+    edge.setFrom(fromVertex);
+    this.object = edgeGraph.addEdge(edge, vertexGraph.delegate(fromVertex), subTraversals);
+    return this;
+  }
+
+  @Override
+  public <E extends Edge> Graph removeEdge(E edge) {
+    edgeGraph.removeEdge(edge);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public ObjectGraph as(String alias) {
+    this.aliases.put(alias, object);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public <E extends Element> Graph as(Consumer<E> consumer) {
+    consumer.accept((E) object);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public <E extends Element> E as(Class<E> elementType) {
+    return (E) object;
+  }
+
+  @Override
+  public <E extends Element> E get(String alias, Class<E> elementType) {
+    return (E) this.aliases.get(alias);
+  }
+
+  @Override
+  public Graph should(Should should) {
+    this.should = should;
+    return this;
+  }
+
+  @Override
+  public Should should() {
+    return this.should;
+  }
+
+
+  @Override
+  public Graph defaultKeys(boolean allow) {
+    Primitives.allowDefaultKeys = allow;
+    return this;
+  }
+
+  @Override
+  public boolean verify(HasFeature hasFeature) {
+    return verifier.verify(hasFeature);
+  }
+
+  @Override
+  public Query query() {
+    return query;
+  }
+
+  @Override
+  public GraphSystem system() {
+    return system;
+  }
+
+  @Override
+  public void drop() {
+    query.by(g -> g.V().drop()).none();
+  }
+
+  @Override
+  public void reset() {
+    aliases.clear();
+    vertexGraph.reset();
+    edgeGraph.reset();
+    object = null;
+  }
+
+  @Override
+  public void close() {
+    if (system != null) {
+      system.close();
+    }
+    if (query != null) {
+      query.close();
+    }
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Observable.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Observable.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * {@link Observable} manages the observers that implement the interface defined by the {@link O}
+ * type parameter.
+ *
+ * <p>
+ * The {@link Graph} is an example of an {@link Observable}, in that updates to it can be observed
+ * through its {@code Observer} interface.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class Observable<O> {
+
+  private final List<O> observers = Collections.synchronizedList(new ArrayList<>());
+
+  public void register(O observer) {
+    observers.add(observer);
+  }
+
+  public void unregister(O observer) {
+    observers.remove(observer);
+  }
+
+  public void notifyAll(Consumer<O> change) {
+    observers.forEach(change);
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/SubGraph.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/SubGraph.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import java.util.function.Function;
+
+/**
+ * The {@link SubGraph} is a function, which given a {@link Graph}, lets one chain the addition and
+ * removal of object vertices and edges. This comes in handy, when one wants to update the {@link
+ * Graph}, without necessarily knowing when or how it will be provided.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@FunctionalInterface
+public interface SubGraph extends Function<Graph, Graph> {
+
+  /**
+   * Returns a composed function that first applies the {@code this} function to its input, and then
+   * applies {@code that} function to the result. If evaluation of either function throws an
+   * exception, it is relayed to the caller of the chained function.
+   *
+   * It works in the reverse order of the {@link #compose(Function)} method.
+   */
+  default SubGraph chain(SubGraph that) {
+    return graph -> that.apply(apply(graph));
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Vertex.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/Vertex.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.model.PropertyValue;
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * A {@link Vertex} is an {@link Element} that is the object-oriented manifestation of the
+ * underlying graph vertex.
+ *
+ * <p>
+ * Classes that extend the {@link Vertex} will have it's fields seamlessly map to the underlying
+ * edge's property. The label of the edge is derived as the simple name of the sub-class.
+ *
+ * <p>
+ * Typically, a vertex property is a primitive type, which manifests itself as a primitive field of
+ * the user defined sub-class. Sometimes, a vertex property can have properties of its own, known as
+ * meta-properties. Such vertex properties manifest themselves as fields that are {@link Element}s
+ * in their own right. The value of the vertex property is mapped to the field of it's {@link
+ * Element} that is annotated with {@link PropertyValue}. The rest of the fields in that element
+ * correspond to the vertex property's meta-properties.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@ToString
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuppressWarnings("PMD.CommentSize")
+public class Vertex extends Element {
+
+  public Vertex(Element element) {
+    super(element);
+  }
+
+  /**
+   * Return the underlying gremlin vertex.
+   */
+  public org.apache.tinkerpop.gremlin.structure.Vertex delegate() {
+    return (org.apache.tinkerpop.gremlin.structure.Vertex) delegate;
+  }
+
+  /**
+   * Remove this vertex, if attached.
+   */
+  public void remove() {
+    org.apache.tinkerpop.gremlin.structure.Vertex delegate = delegate();
+    if (delegate == null) {
+      throw Element.Exceptions.removingDetachedElement(this);
+    }
+    delegate.remove();
+  }
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at vertices, and ends at vertices.
+   */
+  public interface ToVertex extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Vertex,
+      org.apache.tinkerpop.gremlin.structure.Vertex> {
+
+  }
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at vertices, and ends at edges.
+   */
+  interface ToEdge extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Vertex, Edge> {
+
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/VertexGraph.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/structure/VertexGraph.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Parser;
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.hasPrimaryKeys;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.simple;
+
+/**
+ * The {@link VertexGraph} performs add and remove vertex operations on the underlying {@link
+ * GraphTraversal} or {@link org.apache.tinkerpop.gremlin.structure.Graph}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class VertexGraph extends ElementGraph {
+
+  @Getter
+  private Vertex vertex;
+  private Graph.O observers = Graph.O.get();
+  private Map<Object, org.apache.tinkerpop.gremlin.structure.Vertex> delegates = new HashMap<>();
+
+  public VertexGraph(Graph graph, GraphTraversalSource g) {
+    super(graph, g);
+  }
+
+  public <V extends Vertex> org.apache.tinkerpop.gremlin.structure.Vertex delegate(V vertex) {
+    return vertex.id() != null ? delegates.get(vertex.id()) : null;
+  }
+
+  /**
+   * Add the given vertex.
+   *
+   * Based on the value of {@link #should()}, it will either:
+   * <p/>
+   * <ul>
+   *   <li>Create the vertex with no checks.</li>
+   *   <li>Merge the vertex with any existing one.</li>
+   *   <li>Replace an existing vertex, if present, else insert.</li>
+   *   <li>Insert the vertex, only if it doesn't exist.</li>
+   *   <li>Ignore the addition if it already exists.</li>
+   * </ul>
+   */
+  public <V extends Vertex> Vertex addVertex(V vertex) {
+    vertex.validate();
+    org.apache.tinkerpop.gremlin.structure.Vertex delegate;
+    switch (should()) {
+      case CREATE:
+        delegate = complete(create(vertex));
+        break;
+      case MERGE:
+        delegate = complete(g.inject(1).coalesce(
+            update(vertex), create(vertex)));
+        break;
+      case REPLACE:
+        delegate = complete(g.inject(1).coalesce(
+            clear(vertex), update(vertex), create(vertex)));
+        break;
+      case INSERT:
+        delegate = insert(vertex);
+        break;
+      case IGNORE:
+      default:
+        delegate = complete(g.inject(1).coalesce(find(vertex), create(vertex)));
+        break;
+    }
+    vertex.setDelegate(delegate);
+    vertex.setUserSuppliedId(delegate.id());
+    delegates.put(vertex.id(), delegate);
+    this.vertex = Parser.as(delegate, vertex.getClass());
+    observers.notifyAll(observer -> observer.vertexAdded(vertex, this.vertex));
+    return this.vertex;
+  }
+
+  /**
+   * Remove the given vertex.
+   */
+  public <V extends Vertex> Vertex removeVertex(V vertex) {
+    GraphTraversal traversal = find(vertex);
+    log.info("Executing 'remove vertex' traversal {} ", traversal);
+    traversal.drop().toList();
+    if (vertex.id() != null) {
+      delegates.remove(vertex);
+    }
+    observers.notifyAll(observer -> observer.vertexRemoved(vertex));
+    return vertex;
+  }
+
+  protected <V extends Vertex> GraphTraversal clear(V vertex) {
+    GraphTraversal traversal = find(vertex);
+    List<String> clearKeys = Properties.nullKeys(vertex);
+    clearKeys.addAll(Properties.listKeys(vertex));
+    traversal.properties(clearKeys.toArray(new String[] {})).drop();
+    return traversal;
+  }
+
+  protected <V extends Vertex> GraphTraversal update(V vertex) {
+    GraphTraversal traversal = find(vertex);
+    return update(traversal, vertex, Properties::of);
+  }
+
+  protected <V extends Vertex> GraphTraversal check(V vertex) {
+    return fail(find(vertex));
+  }
+
+  protected <V extends Vertex> GraphTraversal create(V vertex) {
+    GraphTraversal traversal = g
+        .addV(vertex.label());
+    Object vertexId = maybeSupplyId(vertex);
+    if (vertexId != null) {
+      traversal.property(T.id, vertexId);
+    }
+    return update(traversal, vertex, Properties::all);
+  }
+
+  protected org.apache.tinkerpop.gremlin.structure.Vertex insert(Vertex vertex) {
+    try {
+      org.apache.tinkerpop.gremlin.structure.Vertex delegate;
+      if (useGraph(vertex)) {
+        Object vertexId = maybeSupplyId(vertex);
+        delegate = g.getGraph().addVertex(
+            vertexId != null ? simple(vertex, T.id, T.label) : simple(vertex, T.label));
+        update(delegate, vertex, Properties::complex);
+      } else {
+        delegate = complete(hasPrimaryKeys(vertex) ? g.inject(1).coalesce(
+            check(vertex), create(vertex)) : create(vertex));
+      }
+      return delegate;
+    } catch (Exception e) {
+      log.warn("The vertex {} already exists", vertex);
+      throw Element.Exceptions.elementAlreadyExists(vertex);
+    }
+  }
+
+  @Override
+  protected org.apache.tinkerpop.gremlin.structure.Vertex complete(GraphTraversal traversal) {
+    log.info("Executing '{} vertex' traversal {} ", should().label(), traversal);
+    return (org.apache.tinkerpop.gremlin.structure.Vertex) super.complete(traversal);
+  }
+
+  public void reset() {
+    this.delegates.clear();
+    this.vertex = null;
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/AnyTraversal.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/AnyTraversal.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+
+import java.util.Formattable;
+import java.util.Formatter;
+import java.util.function.Function;
+
+import lombok.SneakyThrows;
+
+
+/**
+ * {@link AnyTraversal} denotes an arbitrary yet complete walk through over the graph, which returns
+ * a {@link GraphTraversal} whose results are ready to be consumed.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@FunctionalInterface
+public interface AnyTraversal extends Function<GraphTraversalSource, GraphTraversal<?, ?>>,
+    Formattable {
+  /**
+   * Reveal the steps in the {@link SubTraversal} by passing a {@link DefaultGraphTraversal} to it,
+   * and outputting it's string representation.
+   */
+  @Override
+  @SneakyThrows
+  default void formatTo(Formatter formatter, int flags, int width, int precision) {
+    GraphTraversalSource g = new GraphTraversalSource(EmptyGraph.instance());
+    GraphTraversal<?, ?> graphTraversal = apply(g);
+    formatter.out().append(graphTraversal.toString());
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/ElementTo.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/ElementTo.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+/**
+ * Given that most {@link SubTraversal}s start at a gremlin element, it behooves us to define
+ * specializations around that. The name of this class is indicative of the start type of the
+ * sub-traversals defined here. The name of the inner class defined here is indicative of the end
+ * type of the sub-traversal.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@FunctionalInterface
+public interface ElementTo<O> extends SubTraversal<Element, O> {
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at elements, and ends at elements.
+   */
+  @FunctionalInterface
+  interface Element extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Element,
+      org.apache.tinkerpop.gremlin.structure.Element> {
+
+  }
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at elements, and ends at vertices.
+   */
+  @FunctionalInterface
+  interface Vertex extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Element,
+      org.apache.tinkerpop.gremlin.structure.Vertex> {
+
+  }
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at elements, and ends at strings.
+   */
+  @FunctionalInterface
+  interface String extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Element,
+      java.lang.String> {
+
+  }
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at elements, and ends at longs.
+   */
+  @FunctionalInterface
+  interface Long extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Element,
+      java.lang.Long> {
+
+  }
+
+  /**
+   * A function denoting a {@code GraphTraversal} that starts at elements, and ends anywhere.
+   */
+  @FunctionalInterface
+  @SuppressWarnings("PMD.ShortClassName")
+  interface Any extends SubTraversal<
+      org.apache.tinkerpop.gremlin.structure.Element,
+      java.lang.Object> {
+
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/ObjectQuery.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/ObjectQuery.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.reflect.Parser;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
+
+/**
+ * The {@link ObjectQuery} implements the {@link Query} interface using the provided {@link
+ * GraphSystem}.
+ *
+ * <p>
+ * Upon initialization, it gets a handle to the {@link GraphTraversalSource}. As traversal
+ * functions, of various forms, are defined using the {@link #by} methods, it remembers them. When a
+ * result is asked for through the {@link #one}, {@link #list}, or {@link #none} methods, it
+ * constitutes a {@link GraphTraversal} using the given {@link SubTraversal}s. The resulting set of
+ * property-based elements are mapped to corresponding object-based elements using the {@link
+ * Parser#as} method, which does most of the heavy-lifting.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@SuppressWarnings({"unchecked", "rawtypes", "PMD.AvoidDuplicateLiterals"})
+public abstract class ObjectQuery implements Query {
+
+  @SuppressWarnings({"PMD.AvoidFieldNameMatchingMethodName"})
+  private final GraphSystem system;
+  private GraphTraversalSource g;
+
+  private AnyTraversal anyTraversal;
+  private List<? extends SubTraversal> subTraversals;
+  private String nativeTraversal;
+  private Bindings bindings = new SimpleBindings();
+
+  private List<StepType> disabledSteps = new ArrayList<>();
+  private Selections selections;
+  private Function<GraphTraversalSource, GraphTraversal> traversalFactory = g -> g.V();
+
+  public ObjectQuery(GraphSystem system) {
+    this.system = system;
+    this.g = this.system.g();
+  }
+
+  @Override
+  public void disable(StepType... disabledSteps) {
+    this.disabledSteps = Arrays.asList(disabledSteps);
+  }
+
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public ObjectQuery by(String nativeTraversal) {
+    this.nativeTraversal = nativeTraversal;
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public ObjectQuery by(AnyTraversal anyTraversal) {
+    this.anyTraversal = anyTraversal;
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public Query by(SubTraversal... subTraversals) {
+    this.subTraversals = Arrays.asList(subTraversals);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public ObjectQuery bind(String name, String value) {
+    bindings.put(name, value);
+    return this;
+  }
+
+  /**
+   * Select one element of the given type, from the {@link #resultSet}.
+   */
+  @Override
+  public <T> T one(Class<T> type) {
+    try {
+      List<T> resultSet = resultSet(g, type);
+      if (resultSet == null || resultSet.size() != 1) {
+        throw Query.Exceptions.unexpectedMultipleResults(this);
+      }
+      return resultSet.get(0);
+    } finally {
+      resetState();
+    }
+  }
+
+  /**
+   * Return the list of elements of the given type, using {@link #resultSet}.
+   */
+  @Override
+  public <T> List<T> list(Class<T> type) {
+    try {
+      return resultSet(g, type);
+    } finally {
+      resetState();
+    }
+  }
+
+  /**
+   * Specify the element type for the alias referenced in a {@link GraphTraversal#select(Column)}.
+   */
+  @Override
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  public Query as(String alias, Class elementType) {
+    if (selections == null) {
+      selections = Selections.of();
+    }
+    selections.as(alias, elementType);
+    return this;
+  }
+
+  /**
+   * Object a list of {@link org.apache.tinkerpop.gremlin.object.traversal.Selections.Selection}s,
+   * one for each "row" in the {@link #resultSet}. From a selection, one can obtain the element
+   * corresponding to the alias selected in the traversal.
+   */
+  @Override
+  public Selections select() {
+    try {
+      return resultSet(g, selections);
+    } finally {
+      resetState();
+    }
+  }
+
+  /**
+   * Don't return anything, but do evaluate the {@link #resultSet}. This comes in handy when {@link
+   * GraphTraversal#drop}s are involved.
+   */
+  @Override
+  public void none() {
+    try {
+      resultSet(g, Object.class);
+    } finally {
+      resetState();
+    }
+  }
+
+  @Override
+  public Query source(Source source) {
+    traversalFactory = source.get();
+    return this;
+  }
+
+  @Override
+  public GraphSystem system() {
+    return system;
+  }
+
+  @Override
+  public void close() {
+    if (system != null) {
+      system.close();
+    }
+  }
+
+  /**
+   * For each row mapping returned by the {@link #resultSet}, convert the vertex/edge corresponding
+   * to each {@link GraphTraversal#select}'ed alias, into corresponding object representations.
+   */
+  private Selections resultSet(GraphTraversalSource g, Selections selections) {
+    Stream<Map<String, Object>> resultStream = (Stream<Map<String, Object>>) resultSet(g);
+    List<Map<String, Object>> resultRows = resultStream.collect(Collectors.toList());
+    for (Map<String, Object> resultRow : resultRows) {
+      Selections.Selection selection = Selections.Selection.of();
+      selections.add(selection);
+      for (Map.Entry<String, Object> entry : resultRow.entrySet()) {
+        String alias = entry.getKey();
+        selection.put(alias, Parser.as(entry.getValue(), selections.as(alias)));
+      }
+    }
+    return selections;
+  }
+
+  /**
+   * Given the traversal source, generate the desired traversal. Then, given that the traversal is
+   * already connected, do a {@code toBulkSet} to retrive the results. Finally, map each element in
+   * the result to the desired type of element.
+   */
+  private <T> List<T> resultSet(GraphTraversalSource g, Class<T> elementType) {
+    Stream<?> resultStream = resultSet(g);
+    return resultStream
+        .map(element -> Parser.as(element, elementType))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Given a {@link GraphTraversalSource}, generate a {@link Stream} of results, by applying it on
+   * either the {@link #nativeTraversal}, {@link #anyTraversal}, or {@link #subTraversals} provided
+   * by the {@link #by} method.
+   */
+  @SuppressWarnings("unchecked")
+  private Stream<?> resultSet(GraphTraversalSource g) {
+    Stream<?> resultStream;
+    if (nativeTraversal != null) {
+      if (hasDisabledSteps(nativeTraversal)) {
+        throw Query.Exceptions.disabledStepQueried(disabledSteps);
+      }
+      Iterable<?> iterable =
+          !bindings.isEmpty() ? system.execute(nativeTraversal, bindings)
+              : system.execute(nativeTraversal);
+      resultStream = StreamSupport.stream(iterable.spliterator(), false);
+      log.info("Executing native graph traversal: {}", nativeTraversal);
+    } else if (anyTraversal != null) {
+      GraphTraversal traversal = anyTraversal.apply(g);
+      if (hasDisabledSteps(traversal)) {
+        throw Query.Exceptions.disabledStepQueried(disabledSteps);
+      }
+      log.info("Executing any graph traversal: {}", traversal);
+      resultStream = traversal.toBulkSet().stream();
+    } else if (subTraversals != null) {
+      GraphTraversal<Vertex, Vertex> traversal = traversalFactory.apply(g);
+      for (SubTraversal subTraversal : subTraversals) {
+        traversal = (GraphTraversal) subTraversal.apply(traversal);
+      }
+      if (hasDisabledSteps(traversal)) {
+        throw Query.Exceptions.disabledStepQueried(disabledSteps);
+      }
+      log.info("Executing chain of graph sub-traversals: {}", traversal);
+      resultStream = traversal.toBulkSet().stream();
+    } else {
+      throw Query.Exceptions.noTraversalSpecified(this);
+    }
+    return resultStream;
+  }
+
+  /**
+   * Check if the traversal has any disabled steps.
+   */
+  private boolean hasDisabledSteps(GraphTraversal traversal) {
+    return hasDisabledSteps(traversal.toString());
+  }
+
+  /**
+   * For each disabled step, check if it appears in the given statement.
+   */
+  private boolean hasDisabledSteps(final String statement) {
+    return disabledSteps.stream().anyMatch(
+        disabledStep -> containsIgnoreCase(statement, disabledStep.name()));
+  }
+
+  private void resetState() {
+    this.source(Source.V);
+    this.nativeTraversal = null;
+    this.subTraversals = null;
+    this.anyTraversal = null;
+    this.selections = null;
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/Query.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/Query.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.name;
+
+/**
+ * In order to read objects from the property graph, you'll need an instance of the {@link Query}.
+ *
+ * <p>
+ * Typically, you would create it using an implementation-specific graph factory. However, if the
+ * implementation supports it, then it may be dependency inject'ed. The default qualifier is
+ * provider by a reference {@code TinkerGraph} system.
+ *
+ * <p>
+ * In general, the following steps are involved in completing a query:
+ * <p>
+ * <ul>
+ *   <li>Specify the traversal you want to apply in the {@link #by} method.</li>
+ *   <li>Retrieve a list of objects output by the traversal through the {@link #list} method.</li>
+ *   <li>Retrieve a single object output by the traversal through the {@link #one} method.</li>
+ * </ul>
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings({"rawtypes", "PMD.AvoidDuplicateLiterals"})
+public interface Query {
+
+  /**
+   * Specify a traversal in terms of a scripted string.
+   *
+   * @return this {@link Query}
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  Query by(String traversal);
+
+  /**
+   * Specify a traversal as an {@link AnyTraversal} deemed to be complete.
+   *
+   * @return this {@link Query}
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  Query by(AnyTraversal traversal);
+
+  /**
+   * Specify a chain of {@link SubTraversal}s that will be applied one in order.
+   *
+   * @return this {@link Query}
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  Query by(SubTraversal... subTraversals);
+
+  /**
+   * Bind a value to a name referenced in the scripted traversal used in {@link #by(String)}.
+   *
+   * @return this {@link Query}
+   */
+  Query bind(String name, String value);
+
+  /**
+   * Define an alias for the object referenced in a {@link GraphTraversal#select} step.
+   *
+   * @return this {@link Query}
+   */
+  @SuppressWarnings({"PMD.ShortMethodName"})
+  Query as(String alias, Class elementType);
+
+  /**
+   * Set the source of the query to either the vertex ({@link Source#V} or edge ({@link Source#E}}
+   * graph.
+   *
+   * @return this {@link Query}
+   */
+  Query source(Source source);
+
+  /**
+   * Complete the query by retrieving the result as an object of the given element type.
+   *
+   * Typically, the @{link #type} represents an object element. However, it may also denote the type
+   * of a property value.
+   *
+   * @return an object of the given type
+   */
+  <T> T one(Class<T> type);
+
+  /**
+   * Complete the query by retrieving the result as a list of objects of the given element type.
+   *
+   * Typically, the @{link #type} represents an object element. However, it may also denote the type
+   * of a property value.
+   *
+   * @return the list of objects of the given type
+   */
+  <T> List<T> list(Class<T> type);
+
+  /**
+   * Complete the traversal specified by the query. This comes in handy when drop steps are
+   * involved.
+   */
+  void none();
+
+  /**
+   * Complete the traversal by selecting the aliases specified by {@link Query#as} into their
+   * corresponding types of object.
+   */
+  Selections select();
+
+  /**
+   * Return the underlying implementation-specific graph system.
+   */
+  GraphSystem system();
+
+  /**
+   * Release the resources held by the underlying graph system.
+   */
+  void close();
+
+  /**
+   * Disable the specified types of steps.
+   */
+  void disable(StepType... stepTypes);
+
+  /**
+   * Enforce the given mode, by disabling the steps disallowed by it.
+   */
+  default void enforce(Mode mode) {
+    disable(mode.get());
+  }
+
+  /**
+   * {@link Source} lets you specify whether the starting point of the traversal.
+   */
+  enum Source implements Supplier<Function<GraphTraversalSource, GraphTraversal>> {
+    /**
+     * Specifies a traversal of the vertex graph.
+     */
+    V {
+      @Override
+      public Function<GraphTraversalSource, GraphTraversal> get() {
+        return g -> g.V();
+      }
+    },
+    /**
+     * Specifies a traversal of the edge graph.
+     */
+    E {
+      @Override
+      public Function<GraphTraversalSource, GraphTraversal> get() {
+        return g -> g.E();
+      }
+    };
+  }
+
+  /**
+   * {@link Mode} dictates which steps are permitted (or not) by the {@link Query}.
+   */
+  enum Mode implements Supplier<StepType[]> {
+    /**
+     * Block steps that can change the graph in this mode.
+     */
+    READ_ONLY {
+      @Override
+      public StepType[] get() {
+        return new StepType[] {StepType.DROP, StepType.ADDV, StepType.ADDE, StepType.PROPERTY};
+      }
+    },
+    /**
+     * Allow both read and write queries in this mode.
+     */
+    READ_WRITE {
+      @Override
+      public StepType[] get() {
+        return new StepType[] {};
+      }
+    };
+  }
+
+  /**
+   * {@link StepType} outlines the steps that the {@link Query} may have to filter for.
+   */
+  enum StepType {
+    DROP, ADDV, ADDE, PROPERTY
+  }
+
+  /**
+   * Exceptions that might come up during the lifecycle of a query.
+   */
+  class Exceptions {
+
+    private Exceptions() {}
+
+    public static ClassCastException invalidObjectType(Object element, Class objectClass) {
+      return new ClassCastException(
+          String.format("The resulting object %s is not of the desired %s type",
+              element, name(objectClass)));
+    }
+
+    public static IllegalArgumentException unexpectedMultipleResults(Query query) {
+      return new IllegalArgumentException(
+          String.format("Must specify a traversal that returns a single element: %s", query));
+    }
+
+    public static IllegalArgumentException noTraversalSpecified(Query query) {
+      return new IllegalArgumentException(
+          String.format("Must specify a traversal before completing it: %s", query));
+    }
+
+    public static IllegalArgumentException disabledStepQueried(List<StepType> stepTypes) {
+      return new IllegalArgumentException(
+          String.format("Must specify a traversal without these disabled steps: %s", stepTypes));
+    }
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/Selections.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/Selections.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The {@link Selection} captures the result of a {@link Query} that involves a select step. For
+ * each alias selected, the corresponding {@link Query#as(String, Class)} must be called to specify
+ * the type of the selected alias.
+ *
+ * <p>
+ * The {@link Selection} returned by {@link Query#select()} is a list of {@link Selection}s. Each
+ * {@link Selection} in turn is a map of the alias to it's corresponding object, whose type is as
+ * was specified by the {@link Query#as(String, Class)} method.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@RequiredArgsConstructor(staticName = "of")
+@EqualsAndHashCode(callSuper = true, exclude = {"classes"})
+@SuppressWarnings({"PMD.ShortMethodName", "rawtypes"})
+public class Selections extends ArrayList<Selections.Selection> {
+
+  public static final long serialVersionUID = 1L;
+  private Map<String, Class> classes = new HashMap<>();
+
+  public static Selections of(Selection... selectionList) {
+    Selections selections = Selections.of();
+    selections.addAll(Arrays.asList(selectionList));
+    return selections;
+  }
+
+  public void as(String alias, Class clazz) {
+    classes.put(alias, clazz);
+  }
+
+  public Class as(String alias) {
+    return classes.get(alias);
+  }
+
+  @RequiredArgsConstructor(staticName = "of")
+  public static class Selection extends HashMap<String, Object> {
+
+    public static final long serialVersionUID = 1L;
+
+
+    public Selection add(String alias, Object object) {
+      this.put(alias, object);
+      return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T as(String alias, Class<T> elementType) {
+      return (T) this.get(alias);
+    }
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/SubTraversal.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/SubTraversal.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import java.util.Formattable;
+import java.util.Formatter;
+import java.util.function.Function;
+
+import lombok.SneakyThrows;
+
+/**
+ * {@link SubTraversal} represents a partial walk through of the graph. Given a @{link
+ * GraphTraversal}, it applies an arbitrary number of steps on it, and returns the traversal back.
+ *
+ * <p> The {@link I} type parameter denotes the type of the selected graph elements at the start of
+ * the sub-traversal, which we will refer to as its start type. Similarly, the {@link O} parameter
+ * specifies the type at the end of the sub-traversal, referred to as its end type.
+ *
+ * <p> This allows you think of traversals in terms of reusing building blocks, which can then be
+ * combined in one of two ways:
+ *
+ * <p/> <ul> <li>By passing a chain of these to the {@link Query#by(SubTraversal[])} method</li>
+ * <li>By passing a chain of these to the object {@code Element#compose(SubTraversal[])} method</li>
+ * </ul>
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@FunctionalInterface
+public interface SubTraversal<I, O>
+    extends Function<GraphTraversal<Element, I>, GraphTraversal<Element, O>>, Formattable {
+
+  /**
+   * Reveal the steps in the {@link SubTraversal} by passing a {@link DefaultGraphTraversal} to it,
+   * and outputting it's string representation.
+   */
+  @Override
+  @SneakyThrows
+  default void formatTo(Formatter formatter, int flags, int width, int precision) {
+    DefaultGraphTraversal defaultGraphTraversal = new DefaultGraphTraversal();
+    apply(defaultGraphTraversal);
+    formatter.out().append(defaultGraphTraversal.toString());
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/AddV.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/AddV.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.structure.HasFeature;
+import org.apache.tinkerpop.gremlin.object.traversal.AnyTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.lang.reflect.Field;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyValue;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.keyFields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isMissing;
+import static org.apache.tinkerpop.gremlin.object.structure.HasFeature.supportsUserSuppliedIds;
+
+/**
+ * {@link AddV} attempts to add a vertex with the keys of the given element.
+ *
+ * <p>
+ * In the case of graphs that don't support user supplied ids, if a vertex with that key(s) already
+ * exists, it will be returned as-is. Otherwise, a vertex will be created with the given key(s), and
+ * returned.
+ *
+ * <p>
+ * If user supplied ids is supported, then this will add the vertex if it's missing, and raise an
+ * exception if it already exists.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@SuppressWarnings({"unchecked", "rawtypes", "PMD.TooManyStaticImports"})
+public class AddV implements AnyTraversal {
+
+  private final org.apache.tinkerpop.gremlin.object.structure.Element element;
+
+  @Override
+  @SneakyThrows
+  public GraphTraversal<Element, Element> apply(GraphTraversalSource g) {
+    GraphTraversal traversal = g.addV(element.label());
+    if (element.id() != null && HasFeature.Verifier.of(g)
+        .verify(supportsUserSuppliedIds(element))) {
+      traversal.property(T.id, element.id());
+    }
+    for (Field field : keyFields(element)) {
+      String key = propertyKey(field);
+      Object value = propertyValue(field, element);
+      if (isMissing(value)) {
+        throw org.apache.tinkerpop.gremlin.object.structure.Element.Exceptions.requiredKeysMissing(
+            element.getClass(), key);
+      }
+      traversal.property(key, value);
+    }
+    return traversal;
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Count.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Count.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Count} applies the {@link GraphTraversal#count} step on the current traversal.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Count implements ElementTo.Long {
+
+  @Override
+  public GraphTraversal<Element, Long> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.count();
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Has.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Has.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Has} constrains the current traversal by a specific element property.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@SuppressWarnings("PMD.ShortClassName")
+public class Has implements ElementTo.Element {
+
+  private final String label;
+  private final String key;
+  private final Object value;
+
+  @Override
+  public GraphTraversal<Element, Element> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.has(label, key, value);
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasId.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasId.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Keys;
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link HasId} finds an adjacent graph element with the specific id of the supplied element.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class HasId implements ElementTo.Element {
+
+  private final org.apache.tinkerpop.gremlin.object.structure.Element element;
+
+  @Override
+  public GraphTraversal<Element, Element> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.hasId(Keys.id(element));
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasKeys.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasKeys.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.model.OrderingKey;
+import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.is;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyValue;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.keyFields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.orderingKeyFields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.primaryKeyFields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isMissing;
+
+/**
+ * {@link HasKeys} finds adjacent graph elements whose primary key properties correspond to that of
+ * the given element.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@SuppressWarnings("PMD.TooManyStaticImports")
+public class HasKeys implements ElementTo.Element {
+
+  private final org.apache.tinkerpop.gremlin.object.structure.Element element;
+
+  private Class<? extends Annotation> keyType;
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static HasKeys of(org.apache.tinkerpop.gremlin.object.structure.Element element,
+      Class<? extends Annotation> keyType) {
+    return HasKeys.builder()
+        .element(element)
+        .keyType(keyType)
+        .build();
+  }
+
+  @Override
+  @SneakyThrows
+  public GraphTraversal<Element, Element> apply(GraphTraversal<Element, Element> traversal) {
+    traversal.hasLabel(element.label());
+    List<Field> fields;
+    if (keyType != null) {
+      if (is(keyType, PrimaryKey.class)) {
+        fields = primaryKeyFields(element);
+      } else if (is(keyType, OrderingKey.class)) {
+        fields = orderingKeyFields(element);
+      } else {
+        throw org.apache.tinkerpop.gremlin.object.structure.Element.Exceptions
+            .invalidAnnotationType(keyType);
+      }
+    } else {
+      fields = keyFields(element);
+    }
+    for (Field field : fields) {
+      String key = propertyKey(field);
+      Object value = propertyValue(field, element);
+      if (isMissing(value)) {
+        throw org.apache.tinkerpop.gremlin.object.structure.Element.Exceptions.requiredKeysMissing(
+            element.getClass(), key);
+      }
+      traversal.has(key, value);
+    }
+    return traversal;
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasLabel.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasLabel.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link HasLabel} finds adjacent graph elements whose label matches that of the given element.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class HasLabel implements ElementTo.Element {
+
+  private final String label;
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static HasLabel of(org.apache.tinkerpop.gremlin.object.structure.Element element) {
+    return of(element.getClass());
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static HasLabel of(
+      Class<? extends org.apache.tinkerpop.gremlin.object.structure.Element> elementType) {
+    return of(org.apache.tinkerpop.gremlin.object.reflect.Label.of(elementType));
+  }
+
+  @Override
+  public GraphTraversal<Element, Element> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.hasLabel(label);
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Id.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Id.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Id} extracts the id(s) of the currently selected elements in the traversal.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@SuppressWarnings("PMD.ShortClassName")
+public class Id implements ElementTo.Any {
+
+  @Override
+  public GraphTraversal<Element, Object> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.id();
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Keys.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Keys.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.primaryKeyNames;
+
+/**
+ * {@link Keys} extracts the values of the primary key properties of the given element type.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Keys implements ElementTo.Any {
+
+  private final Class<? extends org.apache.tinkerpop.gremlin.object.structure.Element> elementType;
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static Keys of(org.apache.tinkerpop.gremlin.object.structure.Element element) {
+    return of(element.getClass());
+  }
+
+  @Override
+  public GraphTraversal<Element, Object> apply(GraphTraversal<Element, Element> traversal) {
+    return Values.of(primaryKeyNames(elementType)).apply(traversal);
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Label.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Label.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Label} extracts the label(s) of the currently selected elements in the traversal.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Label implements ElementTo.String {
+
+  @Override
+  public GraphTraversal<Element, String> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.label();
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Order.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Order.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Order} orders the traversal by the supplied property key.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "by")
+public class Order implements ElementTo.Element {
+
+  private final String property;
+
+  @Override
+  public GraphTraversal<Element, Element> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.order().by(property);
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Out.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Out.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Out} selects outgoing adjacent vertices that can be reached through the given edge label.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@SuppressWarnings({"PMD.ShortClassName"})
+public class Out implements SubTraversal<Element, Vertex> {
+
+  private final String label;
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static Out of(org.apache.tinkerpop.gremlin.object.structure.Element element) {
+    return of(org.apache.tinkerpop.gremlin.object.reflect.Label.of(element));
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static Out of(
+      Class<? extends org.apache.tinkerpop.gremlin.object.structure.Element> elementType) {
+    return of(org.apache.tinkerpop.gremlin.object.reflect.Label.of(elementType));
+  }
+
+  @Override
+  public GraphTraversal<Element, Vertex> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.out(label);
+  }
+
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Page.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Page.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+/**
+ * {@link Page} finds a page of elements of a given type.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Page implements ElementTo.Element {
+
+  private final Class<? extends org.apache.tinkerpop.gremlin.object.structure.Element> elementType;
+  private final long low;
+  private final long high;
+
+  @Override
+  @SneakyThrows
+  public GraphTraversal<Element, Element> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal
+        .hasLabel(org.apache.tinkerpop.gremlin.object.reflect.Label.of(elementType))
+        .range(low, high);
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Range.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Range.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link Range} limits the count of the traversal such that it falls between the given {@link #low}
+ * and {@link #high} numbers.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Range implements ElementTo.Element {
+
+  private final int low;
+  private final int high;
+
+  @Override
+  public GraphTraversal<Element, Element> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.range(low, high);
+  }
+}

--- a/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Values.java
+++ b/gremlin-objects/src/main/java/org/apache/tinkerpop/gremlin/object/traversal/library/Values.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Element;
+
+import java.util.List;
+
+import lombok.Data;
+
+/**
+ * {@link Values} extracts the values of the given property keys, and removes duplicates thereof.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+public class Values implements ElementTo.Any {
+
+  private final String[] propertyKeys;
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static Values of(org.apache.tinkerpop.gremlin.object.structure.Element element) {
+    return of(Properties.names(element));
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static Values of(List<String> propertyKeys) {
+    return of(propertyKeys.toArray(new String[] {}));
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static Values of(String... propertyKeys) {
+    return new Values(propertyKeys);
+  }
+
+  @Override
+  public GraphTraversal<Element, Object> apply(GraphTraversal<Element, Element> traversal) {
+    return traversal.values(propertyKeys).dedup();
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/ObjectGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/ObjectGraphTest.java
@@ -99,8 +99,8 @@ public abstract class ObjectGraphTest extends GraphTest {
         .bind("property", "name")
         .list(String.class);
     assertNotNull(names);
-    assertTrue(names.contains(modern.vadas.getName()));
-    assertTrue(names.contains(modern.marko.getName()));
+    assertTrue(names.contains(modern.vadas.name()));
+    assertTrue(names.contains(modern.marko.name()));
   }
 
   @Test
@@ -111,7 +111,7 @@ public abstract class ObjectGraphTest extends GraphTest {
         .list(String.class);
     assertNotNull(names);
     Collections.sort(names);
-    assertEquals(Arrays.asList(modern.josh.getName(), modern.vadas.getName()), names);
+    assertEquals(Arrays.asList(modern.josh.name(), modern.vadas.name()), names);
   }
 
   @Test
@@ -154,7 +154,7 @@ public abstract class ObjectGraphTest extends GraphTest {
         .list(Person.class);
     assertNotNull(friends);
     Collections.sort(friends);
-    friends.forEach(friend -> Collections.sort(friend.getLocations()));
+    friends.forEach(friend -> Collections.sort(friend.locations()));
     assertEquals(Arrays.asList(crew.marko, crew.matthias, crew.stephen), friends);
   }
 
@@ -173,11 +173,11 @@ public abstract class ObjectGraphTest extends GraphTest {
         .select();
     assertNotNull(selections);
     assertEquals(Selections.of(
-        Selection.of().add("a", crew.marko.getName()).add("b", "santa fe").add("c", year(2005)),
-        Selection.of().add("a", crew.stephen.getName()).add("b", "purcellville")
+        Selection.of().add("a", crew.marko.name()).add("b", "santa fe").add("c", year(2005)),
+        Selection.of().add("a", crew.stephen.name()).add("b", "purcellville")
             .add("c", year(2006)),
-        Selection.of().add("a", crew.daniel.getName()).add("b", "aachen").add("c", year(2009)),
-        Selection.of().add("a", crew.matthias.getName()).add("b", "seattle").add("c", year(2014))
+        Selection.of().add("a", crew.daniel.name()).add("b", "aachen").add("c", year(2009)),
+        Selection.of().add("a", crew.matthias.name()).add("b", "seattle").add("c", year(2014))
         ), selections);
   }
 
@@ -196,10 +196,10 @@ public abstract class ObjectGraphTest extends GraphTest {
         .select();
     assertNotNull(selections);
     assertEquals(Selections.of(
-        Selection.of().add("a", Expert).add("b", crew.daniel.getName()),
-        Selection.of().add("a", Proficient).add("b", crew.marko.getName()),
-        Selection.of().add("a", Competent).add("b", crew.matthias.getName()),
-        Selection.of().add("a", Expert).add("b", crew.stephen.getName())), selections);
+        Selection.of().add("a", Expert).add("b", crew.daniel.name()),
+        Selection.of().add("a", Proficient).add("b", crew.marko.name()),
+        Selection.of().add("a", Competent).add("b", crew.matthias.name()),
+        Selection.of().add("a", Expert).add("b", crew.stephen.name())), selections);
   }
 
   @Test
@@ -221,7 +221,7 @@ public abstract class ObjectGraphTest extends GraphTest {
       graph.addVertex(Person.of("marko", "engineer",
           Location.of("los angeles", 1996, 1997)));
       Person marko = query.by(HasKeys.of(crew.marko)).one(Person.class);
-      Collections.sort(marko.getLocations());
+      Collections.sort(marko.locations());
       long count = query
           .by(HasKeys.of(marko), Count.of())
           .one(Long.class);

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/ObjectGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/ObjectGraphTest.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object;
+
+import org.apache.tinkerpop.gremlin.object.graphs.Modern;
+import org.apache.tinkerpop.gremlin.object.graphs.TheCrew;
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.edges.Knows;
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.edges.Uses;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.structure.GraphTest;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+import org.apache.tinkerpop.gremlin.object.traversal.Selections;
+import org.apache.tinkerpop.gremlin.object.traversal.library.AddV;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Count;
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasId;
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasLabel;
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasKeys;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Order;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Out;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Range;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Values;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.tinkerpop.gremlin.object.vertices.Location.year;
+import static org.apache.tinkerpop.gremlin.object.edges.Uses.Skill.Competent;
+import static org.apache.tinkerpop.gremlin.object.edges.Uses.Skill.Expert;
+import static org.apache.tinkerpop.gremlin.object.edges.Uses.Skill.Proficient;
+import static org.apache.tinkerpop.gremlin.object.structure.HasFeature.supportsGraphAddEdge;
+import static org.apache.tinkerpop.gremlin.object.structure.HasFeature.supportsUserSuppliedIds;
+import static org.apache.tinkerpop.gremlin.object.traversal.Selections.Selection;
+import static org.apache.tinkerpop.gremlin.process.traversal.Order.incr;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This acts as the base of all provider specific implementations of the {@link Graph} and {@link
+ * Query} interfaces. It uses the {@link Modern} and {@link TheCrew} factories to create sample
+ * graphs, and runs a gauntlet of queries against them.
+ *
+ * <p>
+ * The providers of the object graph are expected to extend this class, and pass the
+ * implementation-defined instances of the {@link Graph} and {@link Query} to this class.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = false)
+public abstract class ObjectGraphTest extends GraphTest {
+
+  protected Query query;
+
+  protected ObjectGraphTest(Graph graph, Query query) {
+    super(graph);
+    this.query = query;
+  }
+
+  protected abstract boolean supportsScripts();
+
+  @Test
+  public void testGetFirstNames() {
+    if (!supportsScripts()) {
+      return;
+    }
+    Modern modern = Modern.of(graph);
+    List<String> names = query
+        .by("g.V().values(property)")
+        .bind("property", "name")
+        .list(String.class);
+    assertNotNull(names);
+    assertTrue(names.contains(modern.vadas.getName()));
+    assertTrue(names.contains(modern.marko.getName()));
+  }
+
+  @Test
+  public void testGetKnownPeopleNames() {
+    Modern modern = Modern.of(graph);
+    List<String> names = query
+        .by(Person.KnowsPeople, Values.of("name"))
+        .list(String.class);
+    assertNotNull(names);
+    Collections.sort(names);
+    assertEquals(Arrays.asList(modern.josh.getName(), modern.vadas.getName()), names);
+  }
+
+  @Test
+  public void testDoesNotKnowPeople() {
+    Modern modern = Modern.of(graph);
+    List<Person> friends = query
+        .by(modern.vadas.s("name"), Person.KnowsPeople)
+        .list(Person.class);
+    assertNotNull(friends);
+    assertTrue(friends.isEmpty());
+  }
+
+  @Test
+  public void testKnowsSomePeople() {
+    Modern modern = Modern.of(graph);
+    List<Person> friends = query
+        .by(HasKeys.of(modern.marko), Person.KnowsPeople)
+        .list(Person.class);
+    assertNotNull(friends);
+    Collections.sort(friends);
+    assertEquals(Arrays.asList(modern.josh, modern.vadas), friends);
+  }
+
+  @Test
+  public void testGetRangeOfPeople() {
+    Modern modern = Modern.of(graph);
+    List<Person> friends = query
+        .by(HasLabel.of(Person.class), Range.of(0, 5))
+        .list(Person.class);
+    assertNotNull(friends);
+    Collections.sort(friends);
+    assertEquals(Arrays.asList(modern.josh, modern.marko, modern.peter, modern.vadas), friends);
+  }
+
+  @Test
+  public void testFindGremlinDevelopers() {
+    TheCrew crew = TheCrew.of(graph);
+    List<Person> friends = query
+        .by(HasKeys.of(crew.gremlin), Develops.Developers, Order.by("name"))
+        .list(Person.class);
+    assertNotNull(friends);
+    Collections.sort(friends);
+    friends.forEach(friend -> Collections.sort(friend.getLocations()));
+    assertEquals(Arrays.asList(crew.marko, crew.matthias, crew.stephen), friends);
+  }
+
+  @Test
+  public void testDetermineCurrentLocation() {
+    TheCrew crew = TheCrew.of(graph);
+    Selections selections = query
+        .by(g -> g.V().as("a").
+            properties("locations").as("b").
+            hasNot("endTime").as("c").
+            order().by("startTime").
+            select("a", "b", "c").by("name").by(T.value).by("startTime").dedup())
+        .as("a", String.class)
+        .as("b", String.class)
+        .as("c", Instant.class)
+        .select();
+    assertNotNull(selections);
+    assertEquals(Selections.of(
+        Selection.of().add("a", crew.marko.getName()).add("b", "santa fe").add("c", year(2005)),
+        Selection.of().add("a", crew.stephen.getName()).add("b", "purcellville")
+            .add("c", year(2006)),
+        Selection.of().add("a", crew.daniel.getName()).add("b", "aachen").add("c", year(2009)),
+        Selection.of().add("a", crew.matthias.getName()).add("b", "seattle").add("c", year(2014))
+        ), selections);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testRankUsersBySkill() {
+    TheCrew crew = TheCrew.of(graph);
+    Selections selections = query
+        .by(g -> g.V().has("name", "gremlin").inE("uses").
+            order().by("skill", incr).as("a").
+            outV().as("b").
+            order().by("name").
+            select("a", "b").by("skill").by("name").dedup())
+        .as("a", Uses.Skill.class)
+        .as("b", String.class)
+        .select();
+    assertNotNull(selections);
+    assertEquals(Selections.of(
+        Selection.of().add("a", Expert).add("b", crew.daniel.getName()),
+        Selection.of().add("a", Proficient).add("b", crew.marko.getName()),
+        Selection.of().add("a", Competent).add("b", crew.matthias.getName()),
+        Selection.of().add("a", Expert).add("b", crew.stephen.getName())), selections);
+  }
+
+  @Test
+  public void testRemoveVertex() {
+    TheCrew crew = TheCrew.of(graph);
+
+    graph.removeVertex(crew.marko);
+    long count = query
+        .by(HasKeys.of(crew.marko), Count.of())
+        .one(Long.class);
+    assertEquals(0l, count);
+  }
+
+  @Test
+  public void testAddExistingVertex() {
+    TheCrew crew = TheCrew.of(graph);
+
+    try {
+      graph.addVertex(Person.of("marko", "engineer",
+          Location.of("los angeles", 1996, 1997)));
+      Person marko = query.by(HasKeys.of(crew.marko)).one(Person.class);
+      Collections.sort(marko.getLocations());
+      long count = query
+          .by(HasKeys.of(marko), Count.of())
+          .one(Long.class);
+      switch (should) {
+        case MERGE:
+        case CREATE:
+          assertEquals(Person.of("marko", "engineer",
+              Location.of("brussels", 2004, 2005),
+              Location.of("los angeles", 1996, 1997),
+              Location.of("san diego", 1997, 2001),
+              Location.of("santa cruz", 2001, 2004),
+              Location.of("santa fe", 2005)
+              ), marko);
+          assertEquals(1, count);
+          break;
+        case REPLACE:
+          assertEquals(Person.of("marko", "engineer",
+              Location.of("los angeles", 1996, 1997)), marko);
+          assertEquals(1, count);
+          break;
+        case IGNORE:
+          assertEquals(Person.of("marko",
+              Location.of("brussels", 2004, 2005),
+              Location.of("san diego", 1997, 2001),
+              Location.of("santa cruz", 2001, 2004),
+              Location.of("santa fe", 2005)
+              ), marko);
+          assertEquals(1, count);
+          break;
+        case INSERT:
+          fail("Insert should have failed since vertex already exists");
+          break;
+        default:
+          break;
+      }
+    } catch (IllegalStateException eae) {
+      switch (should) {
+        case INSERT:
+          break;
+        default:
+          throw eae;
+      }
+    } catch (IllegalArgumentException eae) {
+      switch (should) {
+        case CREATE:
+          if (!graph.verify(supportsUserSuppliedIds(crew.marko))) {
+            throw eae;
+          }
+          break;
+        default:
+          throw eae;
+      }
+    }
+  }
+
+  @Test
+  public void testAddExistingKey() {
+    TheCrew crew = TheCrew.of(graph);
+
+    AddV addV = AddV.of(crew.marko);
+
+    if (graph.verify(supportsUserSuppliedIds(crew.marko))) {
+      try {
+        graph
+            .addEdge(Knows.of(10D), crew.daniel, addV);
+        fail("Should not have been able to add existing vertex");
+      } catch (IllegalArgumentException iae) {}
+    } else {
+      graph
+          .addEdge(Knows.of(10D), crew.daniel, addV);
+      Person marko = query.by(
+          HasKeys.of(crew.daniel),
+          Out.of(Knows.class),
+          HasKeys.of(crew.marko))
+          .one(Person.class);
+      assertEquals(crew.marko, marko);
+    }
+  }
+
+  @Test
+  public void testAddMissingKey() {
+    TheCrew crew = TheCrew.of(graph);
+
+    Person intern = Person.of("intern");
+    AddV addV = AddV.of(intern);
+
+    graph
+        .addEdge(Knows.of(10D), crew.daniel, addV);
+    Person actual = query.by(
+        HasKeys.of(crew.daniel),
+        Out.of(Knows.class),
+        HasKeys.of(intern))
+        .one(Person.class);
+    assertEquals(intern, actual);
+  }
+
+  @Test
+  public void testRemoveEdge() {
+    TheCrew crew = TheCrew.of(graph);
+
+    graph.removeEdge(crew.markoDevelopsGremlin);
+    long count = query
+        .source(Query.Source.E)
+        .by(HasId.of(crew.markoDevelopsGremlin), Count.of())
+        .one(Long.class);
+    assertEquals(0l, count);
+  }
+
+  @Test
+  public void testAddExistingEdge() {
+    Modern modern = Modern.of(graph);
+
+    try {
+      Instant now = Instant.now();
+      Knows knows = graph
+          .addEdge(Knows.of(now), modern.marko, modern.vadas)
+          .as(Knows.class);
+      long count = query
+          .by(modern.marko.s("name"), Knows.KnowsWho, modern.vadas.s("name"), Count.of())
+          .one(Long.class);
+
+      switch (should) {
+        case MERGE:
+          assertEquals(Knows.of(0.5d, now), knows);
+          assertEquals(1, count);
+          break;
+        case REPLACE:
+          assertEquals(Knows.of(now), knows);
+          assertEquals(1, count);
+          break;
+        case INSERT:
+          if (!graph.verify(supportsGraphAddEdge())) {
+            fail("Insert should have failed since edge already exists");
+          }
+          break;
+        case IGNORE:
+          assertEquals(Knows.of(0.5d), knows);
+          assertEquals(1, count);
+          break;
+        default:
+          break;
+      }
+    } catch (IllegalStateException eae) {
+      if (!should.equals(Graph.Should.INSERT)) {
+        throw eae;
+      }
+    }
+  }
+
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Created.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Created.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.edges;
+
+import org.apache.tinkerpop.gremlin.object.structure.Connection;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Created} class represents the "created" edge.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class Created extends Edge {
+
+  private double weight;
+
+  public static Created of(double weight) {
+    return Created.builder().weight(weight).build();
+  }
+
+  @Override
+  protected List<Connection> connections() {
+    return Connection.list(Person.class, Software.class);
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Created.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Created.java
@@ -30,6 +30,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Created} class represents the "created" edge.
@@ -40,7 +41,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Created extends Edge {
 
   private double weight;

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Develops.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Develops.java
@@ -33,6 +33,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Develops} class represents the "develops" edge.
@@ -43,7 +44,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Develops extends Edge {
 
   /**

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Develops.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Develops.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.edges;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.structure.Connection;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Develops} class represents the "develops" edge.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class Develops extends Edge {
+
+  /**
+   * Go to the {@link Person} who develop the currently selected {@link Software}s.
+   */
+  public final static ToVertex Developers = traversal -> traversal
+      .in(Label.of(Develops.class))
+      .hasLabel(Label.of(Person.class));
+  public final static ToVertex Softwares = traversal -> traversal
+      .out(Label.of(Develops.class))
+      .hasLabel(Label.of(Software.class));
+  private Instant since;
+
+  public static Develops of(Instant since) {
+    return Develops.builder().since(since).build();
+  }
+
+  public static Develops of(int year) {
+    return of(Location.year(year));
+  }
+
+  @Override
+  protected List<Connection> connections() {
+    return Connection.list(Person.class, Software.class);
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Knows.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Knows.java
@@ -32,6 +32,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Knows} class represents the "knows" edge.
@@ -42,7 +43,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Knows extends Edge {
 
   /**

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Knows.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Knows.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.edges;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.structure.Connection;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Knows} class represents the "knows" edge.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class Knows extends Edge {
+
+  /**
+   * Go to the {@link Person}s you know, assuming you're currently selected.
+   */
+  public final static ToVertex KnowsWho = traversal -> traversal
+      .outE(Label.of(Knows.class))
+      .toV(Direction.IN);
+  /**
+   * Go to  to the {@link Person}s who know of you, assuming you're currently selected.
+   */
+  public final static ToVertex KnownBy = traversal -> traversal
+      .inE(Label.of(Knows.class))
+      .toV(Direction.OUT);
+
+  private Double weight;
+
+  private Instant since;
+
+  public static Knows of(double weight) {
+    return of(weight, null);
+  }
+
+  public static Knows of(Instant since) {
+    return of(null, since);
+  }
+
+  public static Knows of(Double weight, Instant since) {
+    return Knows.builder().weight(weight).since(since).build();
+  }
+
+  @Override
+  protected List<Connection> connections() {
+    return Connection.list(Person.class, Person.class);
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Traverses.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Traverses.java
@@ -28,6 +28,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Traverses} class represents the "traverses" edge.
@@ -37,7 +38,8 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Traverses extends Edge {
 
   public static Traverses of() {

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Traverses.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Traverses.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.edges;
+
+import org.apache.tinkerpop.gremlin.object.structure.Connection;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Traverses} class represents the "traverses" edge.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class Traverses extends Edge {
+
+  public static Traverses of() {
+    return Traverses.builder().build();
+  }
+
+  @Override
+  protected List<Connection> connections() {
+    return Connection.list(Software.class, Software.class);
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Uses.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Uses.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.edges;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.structure.Connection;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Uses} class represents the "uses" edge.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class Uses extends Edge {
+
+  /**
+   * Go to the {@link Software}s used by the currently selected {@link Person}s.
+   */
+  public final static ToVertex Softwares = traversal -> traversal
+      .outE(Label.of(Uses.class))
+      .toV(Direction.IN);
+  /**
+   * Go to the {@link Person}s using the currently selected {@link Software}s.
+   */
+  public final static ToVertex People = traversal -> traversal
+      .inE(Label.of(Uses.class))
+      .toV(Direction.OUT);
+
+  /**
+   * An enum field whose name is used as the value of the "skill" property.
+   */
+  private Skill skill;
+
+  public static Uses of(Skill skill) {
+    return Uses.builder().skill(skill).build();
+  }
+
+  @Override
+  protected List<Connection> connections() {
+    return Connection.list(Person.class, Software.class);
+  }
+
+  public enum Skill {
+    Novice, Beginner, Competent, Proficient, Expert,
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Uses.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/edges/Uses.java
@@ -32,6 +32,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Uses} class represents the "uses" edge.
@@ -42,7 +43,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Uses extends Edge {
 
   /**

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/graphs/Modern.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/graphs/Modern.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.graphs;
+
+import org.apache.tinkerpop.gremlin.object.edges.Created;
+import org.apache.tinkerpop.gremlin.object.edges.Knows;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+
+import lombok.Data;
+
+/**
+ * An object oriented representation of the {@link org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory#createTheCrew}
+ * graph.
+ *
+ * <p>
+ * Note that the "person" and "software" vertices are defined using the {@link Person} and {@link
+ * Software} classes, as opposed to outlining their properties in-line. The "knows" and "created"
+ * edges are represented as the {@link Knows} and {@link Created} classes respectively.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+public class Modern {
+
+  private final Graph graph;
+
+  public Person marko, vadas, josh, peter;
+  public Software lop, ripple, gremlin;
+
+  public static Modern of(Graph graph) {
+    Modern modern = new Modern(graph);
+    modern.generateModern();
+    return modern;
+  }
+
+  private void generateModern() {
+    graph
+        .addVertex(Person.of("marko", 29)).as(this::setMarko)
+        .addVertex(Person.of("vadas", 27)).as(this::setVadas)
+        .addVertex(Software.of("lop")).as("lop")
+        .addVertex(Software.of("ripple")).as("ripple")
+        .addVertex(Person.of("josh", 32)).as("josh")
+        .addEdge(Created.of(1.0d), "ripple")
+        .addEdge(Created.of(0.4d), "lop")
+        .addVertex(Person.of("peter", 35)).as("peter")
+        .addEdge(Created.of(0.2d), "lop");
+    graph
+        .addEdge(Knows.of(0.5d), marko, vadas)
+        .addEdge(Knows.of(1.0d), marko, "josh")
+        .addEdge(Created.of(0.4d), marko, "lop");
+
+    josh = graph.get("josh", Person.class);
+    peter = graph.get("peter", Person.class);
+
+    lop = graph.get("lop", Software.class);
+    ripple = graph.get("ripple", Software.class);
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/graphs/TheCrew.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/graphs/TheCrew.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.graphs;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+import org.apache.tinkerpop.gremlin.object.edges.Traverses;
+import org.apache.tinkerpop.gremlin.object.edges.Uses;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+
+import lombok.Data;
+
+import static org.apache.tinkerpop.gremlin.object.edges.Uses.Skill.Competent;
+import static org.apache.tinkerpop.gremlin.object.edges.Uses.Skill.Expert;
+import static org.apache.tinkerpop.gremlin.object.edges.Uses.Skill.Proficient;
+
+/**
+ * An object oriented representation of the {@link org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory#createModern}
+ * graph.
+ *
+ * <p>
+ * Note that the "person" vertices are defined using the {@link Person} class, as opposed to
+ * outlining them in-line. Edges such as "develops" and "uses" have classes of their own.
+ *
+ * <p>
+ * Last, but not the least, the "locations" property on the {@link Person} vertex gets a class of
+ * it's own. The value of "locations" is stored in {@link Location#name}, as it's qualified with
+ * {@link org.apache.tinkerpop.gremlin.object.model.PropertyValue}. The rest of the fields in the
+ * {@link Location} class, such as {@link Location#startTime} become its meta-properties.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+public class TheCrew {
+
+  private final Graph graph;
+
+  public Person marko, stephen, matthias, daniel;
+  public Software tinkergraph, gremlin;
+
+  public Develops markoDevelopsGremlin;
+
+  public static TheCrew of(Graph graph) {
+    TheCrew crew = new TheCrew(graph);
+    crew.generateTheCrew();
+    return crew;
+  }
+
+  public void generateTheCrew() {
+    graph
+        .addVertex(Software.of("tinkergraph")).as("tinkergraph")
+        .addVertex(Software.of("gremlin")).as("gremlin")
+        .addEdge(Traverses.of(), "tinkergraph");
+    graph
+        .addVertex(
+            Person.of("marko",
+                Location.of("san diego", 1997, 2001),
+                Location.of("santa cruz", 2001, 2004),
+                Location.of("brussels", 2004, 2005),
+                Location.of("santa fe", 2005))).as("marko")
+        .addEdge(Develops.of(2009), "gremlin").as(this::setMarkoDevelopsGremlin)
+        .addEdge(Develops.of(2010), "tinkergraph")
+        .addEdge(Uses.of(Proficient), "gremlin")
+        .addEdge(Uses.of(Expert), "tinkergraph")
+        .addVertex(
+            Person.of("stephen",
+                Location.of("centreville", 1990, 2000),
+                Location.of("dulles", 2000, 2006),
+                Location.of("purcellville", 2006))).as("stephen")
+        .addEdge(Develops.of(2010), "gremlin")
+        .addEdge(Develops.of(2011), "tinkergraph")
+        .addEdge(Uses.of(Expert), "gremlin")
+        .addEdge(Uses.of(Proficient), "tinkergraph")
+        .addVertex(
+            Person.of("matthias",
+                Location.of("bremen", 2004, 2007),
+                Location.of("baltimore", 2007, 2011),
+                Location.of("oakland", 2011, 2014),
+                Location.of("seattle", 2014))).as("matthias")
+        .addEdge(Develops.of(2012), "gremlin")
+        .addEdge(Uses.of(Competent), "gremlin")
+        .addEdge(Uses.of(Competent), "tinkergraph")
+        .addVertex(
+            Person.of("daniel",
+                Location.of("spremberg", 1982, 2005),
+                Location.of("kaiserslautern", 2005, 2009),
+                Location.of("aachen", 2009))).as("daniel")
+        .addEdge(Uses.of(Expert), "gremlin")
+        .addEdge(Uses.of(Competent), "tinkergraph");
+
+    marko = graph.get("marko", Person.class);
+    stephen = graph.get("stephen", Person.class);
+    matthias = graph.get("matthias", Person.class);
+    daniel = graph.get("daniel", Person.class);
+
+    gremlin = graph.get("gremlin", Software.class);
+    tinkergraph = graph.get("tinkergraph", Software.class);
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/provider/CachedFactoryTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/provider/CachedFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.provider;
+
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Run the {@link GraphFactoryTest} using mocked {@link Graph} and {@link Query} instances.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class CachedFactoryTest extends GraphFactoryTest<Void> {
+
+  @Override
+  protected GraphFactory<Void> factory(CachedFactory.ShouldCache shouldCache) {
+    return new MockedFactory(shouldCache);
+  }
+
+  @Override
+  public void testSystemIsEmpty() {}
+
+  @Override
+  public void testGraphHasObjects() {}
+
+  public static class MockedFactory extends CachedFactory<Void> {
+
+    public MockedFactory(ShouldCache shouldCache) {
+      super(shouldCache);
+    }
+
+    @Override
+    protected Graph makeGraph() {
+      return mock(Graph.class);
+    }
+
+    @Override
+    protected Query makeQuery() {
+      return mock(Query.class);
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected GraphSystem<Void> makeSystem() {
+      return mock(GraphSystem.class);
+    }
+
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/provider/GraphFactoryTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/provider/GraphFactoryTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.provider;
+
+import org.apache.tinkerpop.gremlin.object.graphs.TheCrew;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Count;
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasLabel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+
+import lombok.SneakyThrows;
+
+import static org.apache.tinkerpop.gremlin.object.provider.CachedFactory.ShouldCache.EVERYTHING;
+import static org.apache.tinkerpop.gremlin.object.provider.CachedFactory.ShouldCache.GRAPH_SYSTEM;
+import static org.apache.tinkerpop.gremlin.object.provider.CachedFactory.ShouldCache.NOTHING;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * The {@link GraphFactoryTest} defines sanity tests to ensure that the {@link Graph} and {@link
+ * Query} instances provided by the {@link #factory()} method work.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@RunWith(Parameterized.class)
+@SuppressWarnings("rawtypes")
+public abstract class GraphFactoryTest<C> {
+
+  @Parameterized.Parameter
+  public CachedFactory.ShouldCache shouldCache;
+  private Graph graph;
+  private Query query;
+  private GraphSystem<C> system;
+  private GraphFactory<C> factory;
+  private ExecutorService executorService;
+
+  @Parameterized.Parameters(name = "ShouldCache({0})")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        {EVERYTHING}, {GRAPH_SYSTEM}, {NOTHING}
+    });
+  }
+
+  protected abstract GraphFactory<C> factory(CachedFactory.ShouldCache shouldCache);
+
+  protected GraphFactory<C> factory() {
+    if (factory == null) {
+      factory = factory(shouldCache);
+      if (is(factory, CachedFactory.class)) {
+        ((CachedFactory) factory).clear();
+      }
+    }
+    return factory;
+  }
+
+  @Before
+  public void setUp() {
+    executorService = new ForkJoinPool();
+    graph = factory().graph();
+    query = factory().query();
+    system = factory().system();
+    graph.drop();
+  }
+
+  @After
+  public void tearDown() {
+    factory = null;
+    graph.drop();
+    graph.close();
+    query.close();
+    system.close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void testCacheBehavior() {
+    switch (shouldCache) {
+      case EVERYTHING:
+        assertEquals(factory().graph(), graph);
+        assertEquals(factory().query(), query);
+        assertEquals(factory().system(), system);
+        break;
+      case GRAPH_SYSTEM:
+        executorService.submit(() -> {
+          assertNotEquals(factory().graph(), graph);
+          assertNotEquals(factory().query(), query);
+        }).get();
+        assertEquals(factory().graph(), graph);
+        assertEquals(factory().query(), query);
+        assertEquals(factory().system(), system);
+        break;
+      case NOTHING:
+      default:
+        assertNotEquals(factory().graph(), graph);
+        assertNotEquals(factory().query(), query);
+        assertNotEquals(factory().system(), system);
+        break;
+    }
+  }
+
+  @Test
+  public void testSystemIsEmpty() {
+    long count = system.g().V().count().next();
+    assertEquals(0l, count);
+  }
+
+  @Test
+  public void testGraphHasObjects() {
+    TheCrew crew = TheCrew.of(graph);
+    assertNotNull(crew.marko);
+    assertNotNull(crew.gremlin);
+
+    long persons = query
+        .by(
+            HasLabel.of(Person.class),
+            Count.of())
+        .one(Long.class);
+    assertEquals(4l, persons);
+
+    long softwares = query
+        .by(
+            HasLabel.of(Software.class),
+            Count.of())
+        .one(Long.class);
+    assertEquals(2l, softwares);
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ClassesTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ClassesTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasKeys;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.PriorityQueue;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.is;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isCollection;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isEdge;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isElement;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isFunctional;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isList;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isSet;
+import static org.apache.tinkerpop.gremlin.object.reflect.Classes.isVertex;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Assert that the {@link Classes#is*} methods behave as expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class ClassesTest extends ReflectTest {
+
+  @Test
+  public void testIsElement() {
+    assertTrue(isElement(Person.class));
+    assertTrue(isElement(Develops.class));
+  }
+
+  @Test
+  public void testIsVertex() {
+    assertTrue(isVertex(Person.class));
+    assertFalse(isVertex(Develops.class));
+  }
+
+  @Test
+  public void testIsEdge() {
+    assertFalse(isEdge(Person.class));
+    assertTrue(isEdge(Develops.class));
+  }
+
+  @Test
+  public void testIsList() {
+    assertFalse(isList(Person.class));
+    assertTrue(isList(Arrays.asList(develops)));
+  }
+
+  @Test
+  public void testIsSet() {
+    assertTrue(isSet(new HashSet<>()));
+    assertFalse(isSet(Person.class));
+  }
+
+  @Test
+  public void testIsCollection() {
+    assertTrue(isCollection(new ArrayList<>()));
+    assertFalse(isCollection(new PriorityQueue<>()));
+    assertFalse(isCollection(Person.class));
+  }
+
+  @Test
+  public void testIsFunctional() {
+    assertTrue(isFunctional(HasKeys.class));
+    assertFalse(isFunctional(Person.class));
+  }
+
+  @Test
+  public void testIsSomething() {
+    assertTrue(is(Develops.class, Edge.class));
+    assertTrue(is(develops, Edge.class));
+    assertTrue(is(Develops.class, develops));
+    assertFalse(is(Develops.class, Vertex.class));
+    assertFalse(is(develops, Vertex.class));
+    assertFalse(is(Develops.class, marko));
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/FieldsTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/FieldsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.model.Alias;
+import org.apache.tinkerpop.gremlin.object.model.DefaultValue;
+import org.apache.tinkerpop.gremlin.object.model.OrderingKey;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.alias;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.field;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.fields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.has;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.propertyValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Assert that {@link Fields} finds the object fields corresponding to element properties as
+ * expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class FieldsTest extends ReflectTest {
+
+  @Test
+  public void testHasAnnotation() {
+    assertTrue(has(name, PrimaryKey.class));
+    assertFalse(has(name, OrderingKey.class));
+  }
+
+  @Test
+  public void testAliasProperty() {
+    assertEquals("person", alias(Person.class, Alias::label));
+    assertNull(alias(locations, Alias::key));
+  }
+
+  @Test
+  public void testPropertyKey() {
+    assertEquals("name", propertyKey(name));
+  }
+
+  @Test
+  public void testPropertyValue() {
+    assertEquals("marko", propertyValue(name, marko));
+  }
+
+  @Test
+  public void testGetField() {
+    assertEquals("age", field(marko, "age").getName());
+  }
+
+  @Test
+  public void testGetAllFields() {
+    assertEquals(
+        Arrays.asList("name", "age", "locations", "titles"),
+        fields(marko).stream().map(Field::getName).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testFieldCacheEnabled() {
+    assertEquals(fields(marko), fields(marko));
+    List<Field> first = fields(marko);
+    List<Field> second = fields(marko);
+    assertEquals(first.size(), second.size());
+    for (int index = 0; index < first.size(); index++) {
+      assertTrue(first.get(index) == second.get(index));
+    }
+  }
+
+  @Test
+  public void testFieldCacheDisabled() {
+    try {
+      Fields.elementCacheSize = 0;
+      List<Field> first = fields(marko);
+      List<Field> second = fields(marko);
+      assertEquals(first.size(), second.size());
+      for (int index = 0; index < first.size(); index++) {
+        assertFalse(first.get(index) == second.get(index));
+      }
+    } finally {
+      Fields.elementCacheSize = 100L;
+    }
+  }
+
+  @Test
+  public void testGetPrimaryKeyFields() {
+    assertEquals(
+        Arrays.asList("name"),
+        fields(marko, Keys::isPrimaryKey).stream()
+            .map(Field::getName).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testGetNonKeyFields() {
+    assertEquals(
+        Arrays.asList("locations", "titles"),
+        fields(marko, field -> !Keys.isKey(field)).stream()
+            .map(Field::getName).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testGetDefaultValue() {
+    DefaultValues defaultValues = new DefaultValues();
+    Function<String, Object> valueOf = fieldName ->
+        propertyValue(field(defaultValues, fieldName), defaultValues);
+    assertEquals("default", valueOf.apply("stringField"));
+    assertEquals(10, valueOf.apply("intField"));
+    assertEquals(20L, valueOf.apply("longField"));
+    assertEquals(30.2D, valueOf.apply("doubleField"));
+  }
+
+  @Data
+  @EqualsAndHashCode(callSuper = true)
+  private static class DefaultValues extends Vertex {
+
+    @DefaultValue("default")
+    private String stringField;
+    @DefaultValue("10")
+    private int intField;
+    @DefaultValue("20")
+    private Long longField;
+    @DefaultValue("30.2")
+    private Double doubleField;
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/KeysTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/KeysTest.java
@@ -99,14 +99,14 @@ public class KeysTest extends ReflectTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testNullPrimaryKey() {
-    marko.setName(null);
+    marko.name(null);
     id(marko);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNullOrderingKey() {
     Primitives.allowDefaultKeys = false;
-    marko.setAge(0);
+    marko.age(0);
     id(marko);
   }
 

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/KeysTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/KeysTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.field;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.hasPrimaryKeys;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.id;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.isOrderingKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.isPrimaryKey;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.orderingKeyFields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.primaryKeyFields;
+import static org.apache.tinkerpop.gremlin.object.reflect.Keys.primaryKeyNames;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Assert that {@link Keys} finds the fields annotated
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class KeysTest extends ReflectTest {
+
+  private Field personName;
+  private Field personAge;
+  private Field personTitles;
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    personName = field(Person.class, "name");
+    personAge = field(Person.class, "age");
+    personTitles = field(Person.class, "titles");
+  }
+
+  @Test
+  public void testIsPrimaryKey() {
+    assertTrue(isPrimaryKey(personName));
+    assertFalse(isPrimaryKey(personAge));
+    assertFalse(isPrimaryKey(personTitles));
+  }
+
+  @Test
+  public void testIsOrderingKey() {
+    assertFalse(isOrderingKey(personName));
+    assertTrue(isOrderingKey(personAge));
+    assertFalse(isOrderingKey(personTitles));
+  }
+
+  @Test
+  public void testPrimaryKeyFields() {
+    assertEquals(Arrays.asList(personName), primaryKeyFields(Person.class));
+    assertTrue(primaryKeyFields(Develops.class).isEmpty());
+  }
+
+  @Test
+  public void testHasPrimaryKey() {
+    assertTrue(hasPrimaryKeys(Person.class));
+    assertFalse(hasPrimaryKeys(Develops.class));
+  }
+
+  @Test
+  public void testOrderingKeyFields() {
+    assertEquals(Arrays.asList(personAge), orderingKeyFields(Person.class));
+    assertTrue(orderingKeyFields(Develops.class).isEmpty());
+  }
+
+  @Test
+  public void testPrimaryKeyNames() {
+    assertEquals(Arrays.asList("name"), primaryKeyNames(Person.class));
+    assertTrue(primaryKeyNames(Develops.class).isEmpty());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullPrimaryKey() {
+    marko.setName(null);
+    id(marko);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullOrderingKey() {
+    Primitives.allowDefaultKeys = false;
+    marko.setAge(0);
+    id(marko);
+  }
+
+  @Test
+  @SuppressWarnings("serial")
+  public void testIdIsInternalOrGenerated() {
+    assertEquals(new HashMap<String, Object>() {
+      {
+        put(T.label.getAccessor(), marko.label());
+        put("name", "marko");
+        put("age", 29);
+      }
+    }, id(marko));
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/LabelTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/LabelTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.junit.Test;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Label.of;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Assert that {@link Label} determines the label of the element as expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class LabelTest extends ReflectTest {
+
+  @Test
+  public void testVertexLabelWithAlias() {
+    assertEquals("person", of(Person.class));
+    assertEquals("person", of(marko));
+  }
+
+  @Test
+  public void testEdgeLabelWithoutAlias() {
+    assertEquals("develops", of(Develops.class));
+    assertEquals("develops", of(develops));
+  }
+
+  @Test
+  public void testVertexLabelWithoutAlias() {
+    assertEquals("City", of(City.class));
+  }
+
+  private static class City extends Vertex {
+
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ParserTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ParserTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Parser.as;
+import static org.apache.tinkerpop.gremlin.object.reflect.Parser.isPropertyValue;
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.field;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.MERGE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Assert that {@link Parser} materializes {@link org.apache.tinkerpop.gremlin.object.structure.Element}
+ * objects from underlying {@link org.apache.tinkerpop.gremlin.structure.Element} structures as
+ * expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings({"unchecked", "serial"})
+public class ParserTest extends ReflectTest {
+
+  @Test
+  public void testIsPropertyValue() {
+    assertTrue(isPropertyValue(field(location, "name")));
+    assertFalse(isPropertyValue(field(marko, "age")));
+  }
+
+  @Test
+  public void testAsEnum() {
+    assertEquals(MERGE, as("MERGE", Should.class));
+  }
+
+  @Test
+  public void testAsItself() {
+    assertEquals(MERGE, as(MERGE, Should.class));
+  }
+
+  @Test(expected = ClassCastException.class)
+  public void testAsUnhandled() {
+    assertEquals(Collections.emptyList(), as(new ArrayList<>(), Person.class));
+  }
+
+  @Test
+  public void testAsVertex() {
+    assertEquals(marko, as(new DetachedVertex(
+        1, "person", new HashMap<String, Object>() {
+          {
+            put("name", Arrays.asList(new HashMap<String, Object>() {
+              {
+                put("value", "marko");
+              }
+            }));
+            put("age", Arrays.asList(new HashMap<String, Object>() {
+              {
+                put("value", 29);
+              }
+            }));
+          }
+        }), Person.class));
+  }
+
+  @Test
+  public void testAsEdge() {
+    assertEquals(develops, as(new DetachedEdge(
+        null, Label.of(Develops.class), new HashMap<String, Object>() {
+          {
+            put("since", develops.getSince());
+          }
+        }, null, null, null, null), Develops.class));
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ParserTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ParserTest.java
@@ -93,7 +93,7 @@ public class ParserTest extends ReflectTest {
     assertEquals(develops, as(new DetachedEdge(
         null, Label.of(Develops.class), new HashMap<String, Object>() {
           {
-            put("since", develops.getSince());
+            put("since", develops.since());
           }
         }, null, null, null, null), Develops.class));
   }

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/PrimitivesTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/PrimitivesTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Set;
+
+import static org.apache.tinkerpop.gremlin.object.vertices.Location.year;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isPrimitive;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.isTimeType;
+import static org.apache.tinkerpop.gremlin.object.reflect.Primitives.toTimeType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Assert that {@link Primitives} identifies the registered primitive types properly. It also tests
+ * that time properties can be converted between compatible types.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class PrimitivesTest extends ReflectTest {
+
+  private Instant now;
+
+  @Before
+  public void setUp() {
+    now = year(2017);
+  }
+
+  @Test
+  public void testIsPrimitiveType() {
+    assertTrue(isPrimitive(String.class));
+    assertTrue(isPrimitive(Graph.Should.class));
+    assertFalse(isPrimitive(Set.class));
+  }
+
+  @Test
+  public void testIsTimeType() {
+    assertTrue(isTimeType(Instant.class));
+    assertFalse(isTimeType(Integer.class));
+  }
+
+  @Test
+  public void testToDateTime() {
+    assertEquals(Date.from(now), toTimeType(now, Date.class));
+    assertEquals(Date.from(now), toTimeType(now.toEpochMilli(), Date.class));
+  }
+
+  @Test
+  public void testToInstantTime() {
+    assertEquals(now, toTimeType(Date.from(now), Instant.class));
+    assertEquals(now, toTimeType(now.toEpochMilli(), Instant.class));
+  }
+
+  @Test
+  public void testToEpochTime() {
+    assertEquals(Long.valueOf(now.toEpochMilli()), toTimeType(now, Long.class));
+    assertEquals(Long.valueOf(now.toEpochMilli()), toTimeType(Date.from(now), Long.class));
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/PropertiesTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/PropertiesTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import static org.apache.tinkerpop.gremlin.object.vertices.Location.year;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.all;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.id;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.list;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.names;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.of;
+import static org.apache.tinkerpop.gremlin.object.reflect.Properties.values;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Assert that {@link Properties} lists the key and value of properties of any given kind.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class PropertiesTest extends ReflectTest {
+
+  @Test
+  public void testPropertyId() {
+    assertArrayEquals(new Object[] {"name", "marko", "age", 29}, id(marko));
+    assertArrayEquals(new Object[] {}, id(develops));
+  }
+
+  @Test
+  public void testPropertyAll() {
+    assertArrayEquals(new Object[] {"name", "marko", "age", 29}, all(marko));
+    assertArrayEquals(new Object[] {"since", year(2000)}, all(develops));
+  }
+
+  @Test
+  public void testPropertyOf() {
+    assertArrayEquals(new Object[] {}, of(marko));
+    assertArrayEquals(new Object[] {"since", year(2000)}, of(develops));
+  }
+
+  @Test
+  public void testPropertyNames() {
+    assertEquals(Arrays.asList("name", "age", "locations", "titles"), names(marko));
+    assertEquals(Arrays.asList("since"), names(develops));
+  }
+
+  @Test
+  public void testPropertyValues() {
+    assertEquals(Arrays.asList("san diego", "startTime", year(2000)), values(location));
+    assertEquals(Arrays.asList("since", year(2000)), values(develops));
+
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testPropertyLists() {
+    Property<Instant> since = list(of(develops)).get(0);
+    assertEquals("since", since.key());
+    assertEquals(year(2000), since.value());
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ReflectTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/reflect/ReflectTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.reflect;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.junit.Before;
+
+import java.lang.reflect.Field;
+
+import static org.apache.tinkerpop.gremlin.object.reflect.Fields.field;
+
+/**
+ * This acts as a base of all tests in the reflect package.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public abstract class ReflectTest {
+
+  protected Person marko;
+  protected Develops develops;
+  protected Location location;
+
+  protected Field name;
+  protected Field locations;
+
+  @Before
+  public void setUp() {
+    marko = Person.of("marko", 29);
+    develops = Develops.of(2000);
+    location = Location.of("san diego", 2000);
+    name = field(marko, "name");
+    locations = field(marko, "locations");
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/EdgeGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/EdgeGraphTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.apache.tinkerpop.gremlin.object.traversal.AnyTraversal;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+import org.apache.tinkerpop.gremlin.object.traversal.SubTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Assert that the edge graph adds, updates and removes edges as expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings("unchecked")
+public class EdgeGraphTest extends ElementGraphTest<Develops> {
+
+  private EdgeGraph edgeGraph;
+
+  private Query query;
+
+  private Vertex marko, vadas;
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    marko = mock(Vertex.class);
+    vadas = mock(Vertex.class);
+    when(marko.id()).thenReturn(1);
+    when(vadas.id()).thenReturn(2);
+    query = mock(Query.class);
+    edgeGraph = new EdgeGraph(graph, query, g);
+    when(traversal.next()).thenReturn(
+        new DetachedEdge(null, Label.of(Develops.class), null,
+            null, null, null, null));
+  }
+
+  @Override
+  protected Develops createElement() {
+    return Develops.of(2000);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAddEdgeWithMissingVertex() {
+    Develops develops = createElement();
+    edgeGraph.addEdge(develops, null, marko);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAddEdgeWithEmptyTraversal() {
+    Develops develops = createElement();
+
+    when(query.by((AnyTraversal) any())).thenReturn(query);
+    when(query.by((SubTraversal) any())).thenReturn(query);
+    when(query.list((Class) any())).thenReturn(null);
+    edgeGraph.addEdge(develops, marko, g -> null);
+  }
+
+  @Test
+  public void testFindElement() {
+    Develops develops = createElement();
+
+    edgeGraph.find(develops);
+
+    InOrder inOrder = inOrder(traversal);
+    inOrder.verify(traversal, times(1)).hasLabel(develops.label());
+    inOrder.verify(traversal, times(1)).has("since", develops.getSince());
+  }
+
+  @Test
+  public void testUpdateElement() {
+    Develops develops = createElement();
+
+    edgeGraph.update(traversal, develops, Properties::all);
+
+    verify(traversal, times(1)).property("since", develops.getSince());
+  }
+
+  @Test
+  public void testAddEdge() {
+    Develops develops = createElement();
+
+    edgeGraph.addEdge(develops, marko, vadas);
+
+    InOrder inOrder = inOrder(g, traversal);
+
+    switch (should) {
+      case CREATE:
+        inOrder.verify(g, times(1)).V();
+        inOrder.verify(traversal, times(1)).hasId(marko.id());
+        inOrder.verify(traversal, times(1)).as("from");
+        inOrder.verify(traversal, times(1)).V();
+        inOrder.verify(traversal, times(1)).hasId(vadas.id());
+        inOrder.verify(traversal, times(1)).as("to");
+        inOrder.verify(traversal, times(1)).addE(develops.label());
+        inOrder.verify(traversal, times(1)).as("edge");
+        inOrder.verify(traversal, times(1)).from("from");
+        verify(traversal, times(1)).property("since", develops.getSince());
+        break;
+      case MERGE:
+        inOrder.verify(g, times(1)).inject(1);
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal);
+        break;
+      case REPLACE:
+        inOrder.verify(g, times(1)).inject(1);
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal, traversal);
+        break;
+      case INSERT:
+        // coalesce and complete the insert
+        inOrder.verify(g, times(1)).inject(1);
+
+        // try to find the edge, and fail if found
+        inOrder.verify(traversal, times(1)).hasId(marko.id());
+        inOrder.verify(traversal, times(1)).as("from");
+        inOrder.verify(traversal, times(1)).out(develops.label());
+        inOrder.verify(traversal, times(1)).hasId(vadas.id());
+        inOrder.verify(traversal, times(1)).as("to");
+        inOrder.verify(traversal, times(1)).inE(develops.label());
+        inOrder.verify(traversal, times(1)).as("edge");
+        inOrder.verify(traversal, times(1)).choose(__.value());
+
+        // try to insert the edge
+        inOrder.verify(g, times(1)).V();
+        inOrder.verify(traversal, times(1)).hasId(marko.id());
+        inOrder.verify(traversal, times(1)).as("from");
+        inOrder.verify(traversal, times(1)).V();
+        inOrder.verify(traversal, times(1)).hasId(vadas.id());
+        inOrder.verify(traversal, times(1)).as("to");
+        inOrder.verify(traversal, times(1)).addE(develops.label());
+        inOrder.verify(traversal, times(1)).as("edge");
+        inOrder.verify(traversal, times(1)).from("from");
+        verify(traversal, times(1)).property("since", develops.getSince());
+
+        // coalesce the find and insert
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal);
+        break;
+      case IGNORE:
+        inOrder.verify(g, times(1)).inject(1);
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal);
+        break;
+      default:
+        break;
+    }
+  }
+
+  @Test
+  public void testRemoveEdge() {
+    Develops develops = createElement();
+    develops.setFromId(marko.id());
+    develops.setToId(vadas.id());
+
+    edgeGraph.removeEdge(develops);
+
+    InOrder inOrder = inOrder(g, traversal);
+    inOrder.verify(g, times(1)).V();
+    inOrder.verify(traversal, times(1)).hasId(marko.id());
+    inOrder.verify(traversal, times(1)).as("from");
+    inOrder.verify(traversal, times(1)).out(develops.label());
+    inOrder.verify(traversal, times(1)).hasId(vadas.id());
+    inOrder.verify(traversal, times(1)).as("to");
+    inOrder.verify(traversal, times(1)).inE(develops.label());
+    inOrder.verify(traversal, times(1)).as("edge");
+    inOrder.verify(traversal, times(1)).select("edge");
+    inOrder.verify(traversal, times(1)).toList();
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/EdgeGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/EdgeGraphTest.java
@@ -95,7 +95,7 @@ public class EdgeGraphTest extends ElementGraphTest<Develops> {
 
     InOrder inOrder = inOrder(traversal);
     inOrder.verify(traversal, times(1)).hasLabel(develops.label());
-    inOrder.verify(traversal, times(1)).has("since", develops.getSince());
+    inOrder.verify(traversal, times(1)).has("since", develops.since());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class EdgeGraphTest extends ElementGraphTest<Develops> {
 
     edgeGraph.update(traversal, develops, Properties::all);
 
-    verify(traversal, times(1)).property("since", develops.getSince());
+    verify(traversal, times(1)).property("since", develops.since());
   }
 
   @Test
@@ -126,7 +126,7 @@ public class EdgeGraphTest extends ElementGraphTest<Develops> {
         inOrder.verify(traversal, times(1)).addE(develops.label());
         inOrder.verify(traversal, times(1)).as("edge");
         inOrder.verify(traversal, times(1)).from("from");
-        verify(traversal, times(1)).property("since", develops.getSince());
+        verify(traversal, times(1)).property("since", develops.since());
         break;
       case MERGE:
         inOrder.verify(g, times(1)).inject(1);
@@ -160,7 +160,7 @@ public class EdgeGraphTest extends ElementGraphTest<Develops> {
         inOrder.verify(traversal, times(1)).addE(develops.label());
         inOrder.verify(traversal, times(1)).as("edge");
         inOrder.verify(traversal, times(1)).from("from");
-        verify(traversal, times(1)).property("since", develops.getSince());
+        verify(traversal, times(1)).property("since", develops.since());
 
         // coalesce the find and insert
         inOrder.verify(traversal, times(1)).coalesce(traversal, traversal);

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/EdgeTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/EdgeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.edges.Develops;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Assert that the {@link Edge#connects} methods work.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class EdgeTest extends ElementTest<Develops> {
+
+  @Override
+  protected Develops createElement() {
+    return Develops.of(2010);
+  }
+
+  @Override
+  protected Develops anotherElement() {
+    return Develops.of(2017);
+  }
+
+  @Test
+  public void testConnectsProperly() {
+    Develops develops = createElement();
+
+    assertTrue(develops.connects(Person.class, Software.class));
+    assertFalse(develops.connects(Person.class, Person.class));
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/ElementGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/ElementGraphTest.java
@@ -119,8 +119,8 @@ public class ElementGraphTest<O extends Element> extends GraphTest {
 
     InOrder inOrder = inOrder(traversal);
     inOrder.verify(traversal, times(1)).hasLabel(location.label());
-    inOrder.verify(traversal, times(1)).has("name", location.getName());
-    inOrder.verify(traversal, times(1)).has("startTime", location.getStartTime());
+    inOrder.verify(traversal, times(1)).has("name", location.name());
+    inOrder.verify(traversal, times(1)).has("startTime", location.startTime());
   }
 
   @Test
@@ -131,6 +131,6 @@ public class ElementGraphTest<O extends Element> extends GraphTest {
 
     InOrder inOrder = inOrder(traversal);
     inOrder.verify(traversal, times(1)).property("name", "San Francisco");
-    inOrder.verify(traversal, times(1)).property("startTime", location.getStartTime());
+    inOrder.verify(traversal, times(1)).property("startTime", location.startTime());
   }
 }

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/ElementGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/ElementGraphTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.InOrder;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.CREATE;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.IGNORE;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.INSERT;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.MERGE;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.REPLACE;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ *  Assert that the element graph finds and updates elements as expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@RunWith(Parameterized.class)
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class ElementGraphTest<O extends Element> extends GraphTest {
+
+  @Parameterized.Parameter
+  public Graph.Should should;
+  protected GraphTraversalSource g;
+  protected GraphTraversal traversal;
+  private ElementGraph elementGraph;
+
+  public ElementGraphTest() {
+    super(mock(Graph.class));
+  }
+
+  @Parameterized.Parameters(name = "should({0})")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        {CREATE}, {MERGE}, {REPLACE}, {IGNORE}, {INSERT}
+    });
+  }
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setUp() {
+    super.setUp();
+
+    when(graph.should()).thenReturn(should);
+
+    traversal = mock(GraphTraversal.class);
+    when(traversal.V()).thenReturn(traversal);
+    when(traversal.has(anyString(), anyString())).thenReturn(traversal);
+    when(traversal.has(anyVararg())).thenReturn(traversal);
+    when(traversal.hasLabel(anyString())).thenReturn(traversal);
+    when(traversal.hasId(anyString())).thenReturn(traversal);
+    when(traversal.as(anyString())).thenReturn(traversal);
+    when(traversal.out(anyString())).thenReturn(traversal);
+    when(traversal.inE(anyString())).thenReturn(traversal);
+    when(traversal.addE(anyString())).thenReturn(traversal);
+    when(traversal.addV(anyString())).thenReturn(traversal);
+    when(traversal.from(anyString())).thenReturn(traversal);
+    when(traversal.coalesce(anyVararg())).thenReturn(traversal);
+    when(traversal.select(anyString())).thenReturn(traversal);
+    when(traversal.property(anyString(), any())).thenReturn(traversal);
+    when(traversal.property(any(), anyString(), any(), anyVararg())).thenReturn(traversal);
+    when(traversal.properties(anyVararg())).thenReturn(traversal);
+    when(traversal.drop()).thenReturn(traversal);
+    when(traversal.choose(__.value())).thenReturn(traversal);
+
+    g = mock(GraphTraversalSource.class);
+    when(g.V()).thenReturn(traversal);
+    when(g.addV(anyString())).thenReturn(traversal);
+    when(g.inject(anyVararg())).thenReturn(traversal);
+
+    elementGraph = new ElementGraph(graph, g);
+  }
+
+  protected O createElement() {
+    return (O) Location.of("San Francisco", 2000);
+  }
+
+  @Test
+  public void testFindElement() {
+    Location location = (Location) createElement();
+
+    elementGraph.find(location);
+
+    InOrder inOrder = inOrder(traversal);
+    inOrder.verify(traversal, times(1)).hasLabel(location.label());
+    inOrder.verify(traversal, times(1)).has("name", location.getName());
+    inOrder.verify(traversal, times(1)).has("startTime", location.getStartTime());
+  }
+
+  @Test
+  public void testUpdateElement() {
+    Location location = (Location) createElement();
+
+    elementGraph.update(traversal, location, Properties::all);
+
+    InOrder inOrder = inOrder(traversal);
+    inOrder.verify(traversal, times(1)).property("name", "San Francisco");
+    inOrder.verify(traversal, times(1)).property("startTime", location.getStartTime());
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/ElementTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/ElementTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.traversal.ElementTo;
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.object.traversal.library.Count;
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasLabel;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.tinkerpop.gremlin.object.structure.Element.compose;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that the sub-traversals defined in the {@link Element} class works as expected. In
+ * addition, it also checks the {@link #equals} method.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class ElementTest<O extends Element> extends TraversalTest<O> {
+
+  @SuppressWarnings("unchecked")
+  protected O createElement() {
+    return (O) Location.of("San Francisco", 2000);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected O anotherElement() {
+    return (O) Location.of("New York", 2000);
+  }
+
+  @Test
+  public void testWithIdTraversal() {
+    Element element = createElement();
+
+    traverse(element.withId);
+
+    verify(traversal, times(1)).hasId(element.id());
+  }
+
+  @Test
+  public void testWithLabelTraversal() {
+    Element element = createElement();
+
+    traverse(element.withLabel);
+
+    verify(traversal, times(1)).hasLabel(element.label());
+  }
+
+  @Test
+  public void testComposeTraversals() {
+    Element element = createElement();
+    ElementTo<Object> counter = compose(
+        HasLabel.of(element),
+        Count.of());
+
+    traverse(counter);
+
+    verify(traversal, times(1)).hasLabel(element.label());
+    verify(traversal, times(1)).count();
+  }
+
+  @Test
+  public void testLabelExists() {
+    Element element = createElement();
+
+    assertEquals(Label.of(element), element.label());
+  }
+
+  @Test
+  public void testExistsIn() {
+    Element element = createElement();
+    Element other = anotherElement();
+
+    assertTrue(element.existsIn(Arrays.asList(element)));
+    assertFalse(element.existsIn(Arrays.asList(other)));
+  }
+
+  @Test
+  public void testPossessionApostrophe() {
+    Element element = createElement();
+    List<Long> userSuppliedId = Arrays.asList(1L, 2L, 3L);
+    element.setUserSuppliedId(userSuppliedId);
+    assertEquals(userSuppliedId, element.id());
+
+    traverse(element.s("userSuppliedId"));
+
+    verify(traversal, times(1)).has(element.label(), "id", element.id());
+  }
+
+  @Test
+  public void testEqualsByEverything() {
+    Element original = createElement();
+    Element duplicate = createElement();
+
+    assertEquals(duplicate, original);
+
+    original.setUserSuppliedId("the original identity");
+    duplicate.setUserSuppliedId("a duplicate identity");
+    assertNotEquals(duplicate, original);
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/GraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/GraphTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.CREATE;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.IGNORE;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.INSERT;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.MERGE;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.REPLACE;
+
+/**
+ * This acts as a base class for all {@link Graph} related tests. It parameterizes the {@link
+ * #should} variable, and runs all tests for each of the possible values of {@link Graph.Should}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Slf4j
+@RunWith(Parameterized.class)
+public abstract class GraphTest {
+
+  protected final Graph graph;
+  @Parameterized.Parameter
+  public Graph.Should should;
+
+  protected GraphTest(Graph graph) {
+    this.graph = graph;
+  }
+
+  @Parameterized.Parameters(name = "should({0})")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        {CREATE}, {MERGE}, {REPLACE}, {IGNORE}, {INSERT}
+    });
+  }
+
+  @Before
+  public void setUp() {
+    this.graph.should(should);
+    graph.drop();
+  }
+
+  @After
+  public void tearDown() {
+    graph.reset();
+    graph.drop();
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/SubGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/SubGraphTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.graphs.Modern;
+import org.apache.tinkerpop.gremlin.object.graphs.TheCrew;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.vertices.Software;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verify that the sub-graphs can be defined and composed as expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class SubGraphTest {
+
+  private Graph graph;
+  private Person person;
+  private Software software;
+
+  @Before
+  public void setUp() {
+    graph = mock(Graph.class);
+    person = mock(Person.class);
+    software = mock(Software.class);
+
+    when(graph.addVertex(any())).thenReturn(graph);
+    when(graph.addEdge(any(Edge.class), anyString())).thenReturn(graph);
+    when(graph.addEdge(any(Edge.class), any(Vertex.class), any(Vertex.class))).thenReturn(graph);
+    when(graph.addEdge(any(Edge.class), any(Vertex.class), anyString())).thenReturn(graph);
+    when(graph.as(anyString())).thenReturn(graph);
+    when(graph.as(any(Consumer.class))).thenReturn(graph);
+
+    when(graph.get(eq("marko"), any(Class.class))).thenReturn(person);
+    when(graph.get(eq("stephen"), any(Class.class))).thenReturn(person);
+    when(graph.get(eq("matthias"), any(Class.class))).thenReturn(person);
+    when(graph.get(eq("daniel"), any(Class.class))).thenReturn(person);
+
+    when(graph.get(eq("gremlin"), any(Class.class))).thenReturn(software);
+    when(graph.get(eq("tinkergraph"), any(Class.class))).thenReturn(software);
+  }
+
+  @Test
+  public void testSubGraphChange() {
+    SubGraph createCrew = graph ->
+        TheCrew.of(graph).getGraph();
+
+    createCrew.apply(graph);
+
+    verify(graph, times(6)).addVertex(any(Vertex.class));
+    verify(graph, times(14)).addEdge(any(Edge.class), anyString());
+    verify(graph, times(6)).as(anyString());
+    verify(graph, times(6)).get(anyString(), any(Class.class));
+  }
+
+  @Test
+  public void testSubGraphCompose() {
+    SubGraph createCrew = graph ->
+        TheCrew.of(graph).getGraph();
+    SubGraph createModern = graph ->
+        Modern.of(graph).getGraph();
+
+    createCrew.chain(createModern).apply(graph);
+
+    verify(graph, times(12)).addVertex(any(Vertex.class));
+    verify(graph, times(17)).addEdge(any(Edge.class), anyString());
+    verify(graph, times(2)).addEdge(any(Edge.class), any(Vertex.class), anyString());
+    verify(graph, times(1)).addEdge(any(Edge.class), any(Vertex.class), any(Vertex.class));
+    verify(graph, times(10)).as(anyString());
+    verify(graph, times(10)).get(anyString(), any(Class.class));
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/VertexGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/VertexGraphTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.reflect.Properties;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.apache.tinkerpop.gremlin.object.vertices.Location.year;
+import static org.apache.tinkerpop.gremlin.object.structure.Graph.Should.REPLACE;
+import static org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality.list;
+import static org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality.single;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+/**
+ * * Assert that the vertex graph adds, updates and removes vertex as expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings("unchecked")
+public class VertexGraphTest extends ElementGraphTest<Person> {
+
+  private VertexGraph vertexGraph;
+
+  private org.apache.tinkerpop.gremlin.structure.Vertex marko, vadas;
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    marko = mock(org.apache.tinkerpop.gremlin.structure.Vertex.class);
+    vadas = mock(org.apache.tinkerpop.gremlin.structure.Vertex.class);
+    when(marko.id()).thenReturn(1);
+    when(vadas.id()).thenReturn(2);
+    vertexGraph = new VertexGraph(graph, g);
+    when(traversal.next()).thenReturn(
+        mock(org.apache.tinkerpop.gremlin.structure.Vertex.class));
+    when(traversal.property(any(), anyString(), anyVararg())).thenReturn(traversal);
+  }
+
+  @Override
+  protected Person createElement() {
+    return Person.of("marko", 29,
+        Location.of("san diego", 1997, 2001),
+        Location.of("santa cruz", 2001, 2004));
+  }
+
+  @Test
+  public void testFindElement() {
+    Person marko = createElement();
+
+    vertexGraph.find(marko);
+
+    InOrder inOrder = inOrder(traversal);
+    inOrder.verify(traversal, times(1)).hasLabel(marko.label());
+    inOrder.verify(traversal, times(1)).has("name", marko.getName());
+  }
+
+  @Test
+  public void testUpdateElement() {
+    Person marko = createElement();
+
+    vertexGraph.update(traversal, marko, Properties::of);
+
+    InOrder inOrder = inOrder(traversal);
+    inOrder.verify(traversal, times(1))
+        .property(should.equals(REPLACE) ? single : list,
+            "locations",
+            "san diego",
+            new Object[] {
+                "startTime",
+                year(1997),
+                "endTime",
+                year(2001)});
+    inOrder.verify(traversal, times(1))
+        .property(list,
+            "locations",
+            "santa cruz",
+            new Object[] {
+                "startTime",
+                year(2001),
+                "endTime",
+                year(2004)
+            }
+
+        );
+  }
+
+  @Test
+  public void testAddVertex() {
+    Person marko = createElement();
+
+    vertexGraph.addVertex(marko);
+
+    InOrder inOrder = inOrder(g, traversal);
+
+    switch (should) {
+      case MERGE:
+        inOrder.verify(g, times(1)).inject(1);
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal);
+        break;
+      case REPLACE:
+        inOrder.verify(g, times(1)).inject(1);
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal, traversal);
+        break;
+      case INSERT:
+        inOrder.verify(g, times(1)).V();
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal);
+        break;
+      case IGNORE:
+        inOrder.verify(g, times(1)).inject(1);
+        inOrder.verify(traversal, times(1)).coalesce(traversal, traversal);
+        break;
+      default:
+        break;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddInvalidVertex() {
+    Person marko = createElement();
+    marko.setName(null);
+
+    vertexGraph.addVertex(marko);
+  }
+
+  @Test
+  public void testRemoveVertex() {
+    Person marko = createElement();
+
+    vertexGraph.removeVertex(marko);
+
+    InOrder inOrder = inOrder(g, traversal);
+    inOrder.verify(g, times(1)).V();
+    inOrder.verify(traversal, times(1)).hasLabel(marko.label());
+    inOrder.verify(traversal, times(1)).has("name", marko.getName());
+    inOrder.verify(traversal, times(1)).drop();
+    inOrder.verify(traversal, times(1)).toList();
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/VertexGraphTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/VertexGraphTest.java
@@ -77,7 +77,7 @@ public class VertexGraphTest extends ElementGraphTest<Person> {
 
     InOrder inOrder = inOrder(traversal);
     inOrder.verify(traversal, times(1)).hasLabel(marko.label());
-    inOrder.verify(traversal, times(1)).has("name", marko.getName());
+    inOrder.verify(traversal, times(1)).has("name", marko.name());
   }
 
   @Test
@@ -143,7 +143,7 @@ public class VertexGraphTest extends ElementGraphTest<Person> {
   @Test(expected = IllegalArgumentException.class)
   public void testAddInvalidVertex() {
     Person marko = createElement();
-    marko.setName(null);
+    marko.name(null);
 
     vertexGraph.addVertex(marko);
   }
@@ -157,7 +157,7 @@ public class VertexGraphTest extends ElementGraphTest<Person> {
     InOrder inOrder = inOrder(g, traversal);
     inOrder.verify(g, times(1)).V();
     inOrder.verify(traversal, times(1)).hasLabel(marko.label());
-    inOrder.verify(traversal, times(1)).has("name", marko.getName());
+    inOrder.verify(traversal, times(1)).has("name", marko.name());
     inOrder.verify(traversal, times(1)).drop();
     inOrder.verify(traversal, times(1)).toList();
   }

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/VertexTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/structure/VertexTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.structure;
+
+import org.apache.tinkerpop.gremlin.object.vertices.Location;
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.junit.Test;
+
+/**
+ * Verify that the helper methods in the {@link Vertex} class work as expected.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class VertexTest extends ElementTest<Person> {
+
+  @Override
+  protected Person createElement() {
+    return Person.of("marko", 29, Location.of("san diego", 1997, 2001),
+        Location.of("santa cruz", 2001, 2004),
+        Location.of("brussels", 2004, 2005),
+        Location.of("santa fe", 2005));
+  }
+
+  @Override
+  protected Person anotherElement() {
+    return Person.of("daniel",
+        Location.of("spremberg", 1982, 2005),
+        Location.of("kaiserslautern", 2005, 2009),
+        Location.of("aachen", 2009));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testCannotDeleteDetachedVertex() {
+    Person person = createElement();
+    person.remove();
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/ObjectQueryTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/ObjectQueryTest.java
@@ -114,7 +114,7 @@ public class ObjectQueryTest {
     when(traversal.toBulkSet()).thenReturn(bulkSet);
 
     Person actual = query
-        .by(g -> g.V().hasLabel(marko.label()).has("name", marko.getName()))
+        .by(g -> g.V().hasLabel(marko.label()).has("name", marko.name()))
         .one(Person.class);
 
     assertEquals(marko, actual);

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/ObjectQueryTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/ObjectQueryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import org.apache.tinkerpop.gremlin.object.vertices.Person;
+import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.traversal.library.HasKeys;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+import org.apache.tinkerpop.gremlin.util.function.BulkSetSupplier;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verify that the {@link ObjectQuery} executes queries and returns objects as expected. The
+ * provider of the {@link GraphSystem} is mocked, as are the gremlin {@link Vertex}s.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Slf4j
+@NoArgsConstructor
+@SuppressWarnings({"unchecked", "rawtypes", "serial"})
+public class ObjectQueryTest {
+
+  protected GraphSystem system;
+
+  protected ObjectQuery query;
+
+  protected GraphTraversalSource g;
+
+  protected GraphTraversal traversal;
+
+  protected Person marko;
+
+  protected Vertex vertex;
+
+  @Before
+  public void setUp() {
+    marko = Person.of("marko");
+    vertex = new DetachedVertex(
+        1, "person", new HashMap<String, Object>() {
+          {
+            put("name", Arrays.asList(new HashMap() {
+              {
+                put("value", "marko");
+              }
+            }));
+          }
+        });
+
+    system = mock(GraphSystem.class);
+    g = mock(GraphTraversalSource.class);
+    traversal = mock(GraphTraversal.class);
+
+    when(g.V()).thenReturn(traversal);
+    when(system.g()).thenReturn(g);
+
+    query = new ObjectQuery(system) {};
+  }
+
+  @Test
+  public void testQueryByNativeTraversal() {
+    when(system.execute(anyString())).thenReturn((List) Arrays.asList(vertex));
+
+    Person actual = query
+        .by("g.V().has('person', 'name', 'marko')")
+        .one(Person.class);
+
+    assertEquals(marko, actual);
+  }
+
+  @Test
+  @SuppressWarnings("cast")
+  public void testQueryByAnyTraversal() {
+    when(traversal.hasLabel(anyString())).thenReturn(traversal);
+    when(traversal.has(anyString(), (Object) any())).thenReturn(traversal);
+    BulkSet<Vertex> bulkSet = BulkSetSupplier.<Vertex>instance().get();
+    bulkSet.add(vertex);
+    when(traversal.toBulkSet()).thenReturn(bulkSet);
+
+    Person actual = query
+        .by(g -> g.V().hasLabel(marko.label()).has("name", marko.getName()))
+        .one(Person.class);
+
+    assertEquals(marko, actual);
+  }
+
+  @Test
+  @SuppressWarnings("cast")
+  public void testQueryBySubTraversals() {
+    when(traversal.hasLabel(anyString())).thenReturn(traversal);
+    when(traversal.has(anyString(), (Object) any())).thenReturn(traversal);
+    BulkSet<Vertex> bulkSet = BulkSetSupplier.<Vertex>instance().get();
+    bulkSet.add(vertex);
+    when(traversal.toBulkSet()).thenReturn(bulkSet);
+
+    List<Person> actuals = query
+        .by(HasKeys.of(marko, PrimaryKey.class))
+        .list(Person.class);
+
+    assertEquals(Arrays.asList(marko), actuals);
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/TraversalTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/TraversalTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal;
+
+import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
+import org.apache.tinkerpop.gremlin.object.structure.Connection;
+import org.apache.tinkerpop.gremlin.object.structure.Edge;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Before;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * An abstraction that serves as the base for all test cases under the library package. It provides
+ * a mocked {@link GraphTraversal}, with certain {@link org.mockito.Mockito#when}s applied.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings("unchecked")
+public abstract class TraversalTest<O> {
+
+  protected GraphTraversalSource g;
+  protected GraphTraversal<Element, O> traversal;
+
+  protected City sanFrancisco;
+
+  @Before
+  public void setUp() {
+    sanFrancisco = City.of("San Francisco");
+    traversal = (GraphTraversal<Element, O>) mock(GraphTraversal.class);
+    when(traversal.property(anyString(), any())).thenReturn(traversal);
+    when(traversal.hasLabel(anyString())).thenReturn(traversal);
+    when(traversal.count()).thenReturn((GraphTraversal) traversal);
+    g = mock(GraphTraversalSource.class);
+    when(g.V()).thenReturn((GraphTraversal) traversal);
+    when(g.addV(anyString())).thenReturn((GraphTraversal) traversal);
+  }
+
+  protected GraphTraversal<Element, O> traverse(AnyTraversal anyTraversal) {
+    return (GraphTraversal<Element, O>) anyTraversal.apply(g);
+  }
+
+  @SuppressWarnings("rawtypes")
+  protected GraphTraversal<Element, O> traverse(SubTraversal subTraversal) {
+    return (GraphTraversal<Element, O>) subTraversal.apply(traversal);
+  }
+
+  @Data
+  @Builder
+  @AllArgsConstructor
+  @EqualsAndHashCode(callSuper = true)
+  public static class City extends Vertex {
+
+    @PrimaryKey
+    private String name;
+    private int population;
+
+    public static City of(String name) {
+      return City.builder().name(name).build();
+    }
+  }
+
+  @Data
+  @Builder
+  @EqualsAndHashCode(callSuper = true)
+  @RequiredArgsConstructor(staticName = "of")
+  public static class Highway extends Edge {
+
+    @PrimaryKey
+    private final String name;
+
+    @Override
+    protected List<Connection> connections() {
+      return Connection.list(City.class, City.class);
+    }
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/AddVTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/AddVTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link HasKeys} steps through the given element's label, followed by it's
+ * primary key property(s).
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class AddVTest extends TraversalTest<Element> {
+
+  @Test
+  public void testAddKeyTraversal() {
+    AddV addV = AddV.of(sanFrancisco);
+
+    traverse(addV);
+
+    verify(g, times(1)).addV(sanFrancisco.label());
+    verify(traversal, times(1)).property("name", "San Francisco");
+    assertEquals(sanFrancisco, addV.getElement());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddNullKeyTraversal() {
+    City nowhere = City.of(null);
+    AddV addV = AddV.of(nowhere);
+
+    traverse(addV);
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/CountTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/CountTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.junit.Test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link Count} invokes the {@link org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal#count}
+ * step.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class CountTest extends TraversalTest<Long> {
+
+  @Test
+  public void testCountTraversal() {
+    Count count = Count.of();
+    traverse(count);
+    verify(traversal, times(1)).count();
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasIdTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasIdTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link HasId} checks if the traversal has the generated id, since its {@link City#id}
+ * is missing.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@SuppressWarnings("serial")
+public class HasIdTest extends TraversalTest<Element> {
+
+  @Test
+  public void testHasIdTraversal() {
+    HasId hasId = HasId.of(sanFrancisco);
+
+    traverse(hasId);
+
+    verify(traversal, times(1)).hasId(new HashMap<String, Object>() {
+      {
+        put(T.label.getAccessor(), sanFrancisco.label());
+        put("name", "San Francisco");
+      }
+    });
+    assertEquals(sanFrancisco, hasId.getElement());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasKeysTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasKeysTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link HasKeys} steps through the given element's label, followed by it's
+ * primary key property(s).
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class HasKeysTest extends TraversalTest<Element> {
+
+  @Test
+  public void testHasPrimaryKeyTraversal() {
+    HasKeys hasKeys = HasKeys.of(sanFrancisco);
+
+    traverse(hasKeys);
+
+    verify(traversal, times(1)).hasLabel("City");
+    verify(traversal, times(1)).has("name", "San Francisco");
+    assertEquals(sanFrancisco, hasKeys.getElement());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullPrimaryKeyTraversal() {
+    sanFrancisco.setName(null);
+    HasKeys hasKeys = HasKeys.of(sanFrancisco);
+
+    traverse(hasKeys);
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasLabelTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasLabelTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link HasLabel} checks for the label of the provided element.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class HasLabelTest extends TraversalTest<Element> {
+
+  @Test
+  public void testHasLabelTraversal() {
+    HasLabel hasLabel = HasLabel.of(sanFrancisco);
+
+    traverse(hasLabel);
+
+    verify(traversal, times(1)).hasLabel("City");
+    assertEquals(Label.of(sanFrancisco), hasLabel.getLabel());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/HasTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link HasTest} traverses the has step with the provided arguments.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class HasTest extends TraversalTest<Element> {
+
+  @Test
+  public void testHasTraversal() {
+    Has has = Has.of("label", "key", "value");
+
+    traverse(has);
+
+    verify(traversal, times(1)).has("label", "key", "value");
+    assertEquals("label", has.getLabel());
+    assertEquals("key", has.getKey());
+    assertEquals("value", has.getValue());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/IdTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/IdTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.junit.Test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link Id} traverses the id step.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class IdTest extends TraversalTest<Object> {
+
+  @Test
+  public void testIdTraversal() {
+    Id id = Id.of();
+
+    traverse(id);
+
+    verify(traversal, times(1)).id();
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/KeysTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/KeysTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verify that {@link Keys} retrieves the values of the primary key(s) of the given element.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class KeysTest extends TraversalTest<Object> {
+
+  @Test
+  public void testKeysTraversal() {
+    Keys keys = Keys.of(sanFrancisco);
+    when(traversal.values(anyVararg())).thenReturn(traversal);
+
+    traverse(keys);
+
+    verify(traversal, times(1)).values("name");
+    verify(traversal, times(1)).dedup();
+    assertEquals(City.class, keys.getElementType());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/LabelTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/LabelTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link Label} retrieves the labels from the traversal.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class LabelTest extends TraversalTest<Element> {
+
+  @Test
+  public void testLabelTraversal() {
+    Label label = Label.of();
+
+    traverse(label);
+
+    verify(traversal, times(1)).label();
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/OrderTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/OrderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verify that {@link Order} orders by the given property.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class OrderTest extends TraversalTest<Element> {
+
+  @Test
+  public void testOrderTraversal() {
+    Order order = Order.by("population");
+
+    when(traversal.order()).thenReturn(traversal);
+    traverse(order);
+
+    verify(traversal, times(1)).order();
+    verify(traversal, times(1)).by("population");
+    assertEquals("population", order.getProperty());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/OutTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/OutTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link Out} goes along the outgoing edges of the given element.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class OutTest extends TraversalTest<Element> {
+
+  @Test
+  public void testOutTraversal() {
+    Out out = Out.of(sanFrancisco);
+
+    traverse(out);
+
+    verify(traversal, times(1)).out("City");
+    assertEquals(sanFrancisco.label(), out.getLabel());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/RangeTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/RangeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verify that {@link Range} limits the traversal using the given bounds.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class RangeTest extends TraversalTest<Element> {
+
+  @Test
+  public void testRangeTraversal() {
+    Range range = Range.of(10, 20);
+
+    traverse(range);
+
+    verify(traversal, times(1)).range(10, 20);
+    assertEquals(10, range.getLow());
+    assertEquals(20, range.getHigh());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/ValuesTest.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/traversal/library/ValuesTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.traversal.library;
+
+import org.apache.tinkerpop.gremlin.object.traversal.TraversalTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verify that {@link Values} gets the values of all the properties of the given element, de-duped.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class ValuesTest extends TraversalTest<Object> {
+
+  @Test
+  public void testValuesTraversal() {
+    City sanFrancisco = City.of("San Francisco");
+    Values values = Values.of(sanFrancisco);
+
+    when(traversal.values(anyVararg())).thenReturn(traversal);
+    traverse(values);
+
+    verify(traversal, times(1)).values("name", "population");
+    verify(traversal, times(1)).dedup();
+    assertArrayEquals(new String[] {"name", "population"}, values.getPropertyKeys());
+  }
+
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Location.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Location.java
@@ -34,6 +34,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Location} class represents the "locations" vertex property, whose value is kept in the
@@ -47,7 +48,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Alias(label = "location")
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Location extends Element {
 
   @OrderingKey

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Location.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Location.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.vertices;
+
+import org.apache.tinkerpop.gremlin.object.model.Alias;
+import org.apache.tinkerpop.gremlin.object.model.OrderingKey;
+import org.apache.tinkerpop.gremlin.object.model.PropertyValue;
+import org.apache.tinkerpop.gremlin.object.structure.Element;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Location} class represents the "locations" vertex property, whose value is kept in the
+ * {@link #name} field that is annotated with {@link PropertyValue}. The rest of the fields become
+ * its meta-properties.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Alias(label = "location")
+@EqualsAndHashCode(callSuper = true)
+public class Location extends Element {
+
+  @OrderingKey
+  @PropertyValue
+  private String name;
+  @OrderingKey
+  private Instant startTime;
+  private Instant endTime;
+
+  public static Location of(String name, int startYear) {
+    return of(name, year(startYear));
+  }
+
+  public static Location of(String name, Instant startTime) {
+    return of(name, startTime, null);
+  }
+
+  public static Location of(String name, int startYear, int endYear) {
+    return of(name, year(startYear), year(endYear));
+  }
+
+  public static Location of(String name, Instant startTime, Instant endTime) {
+    return Location.builder().name(name).startTime(startTime).endTime(endTime).build();
+  }
+
+  private static Map<Integer, Instant> years = new HashMap<>();
+
+  public static Instant year(int value) {
+    Instant instant = years.get(value);
+    if (instant != null) {
+      return instant;
+    }
+    instant = LocalDate.parse(String.format("%s-01-01", value)).atStartOfDay()
+        .toInstant(ZoneOffset.UTC);
+    years.put(value, instant);
+    return instant;
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Person.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Person.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.vertices;
+
+import org.apache.tinkerpop.gremlin.object.edges.Knows;
+import org.apache.tinkerpop.gremlin.object.model.Alias;
+import org.apache.tinkerpop.gremlin.object.model.OrderingKey;
+import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
+import org.apache.tinkerpop.gremlin.object.reflect.Label;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Person} class represents the "person" vertex. Its label has been overridden to be
+ * "person", based on its class-level {@link Alias} annotation.
+ *
+ * <p>
+ * It has a {@link #name} property which we'll assume uniquely identifies it in the "person" vertex,
+ * and hence is annotated with {@link PrimaryKey}. It has a required {@link #age} property, by which
+ * persons are assumed to be ordered, in the graph system, and hence a candidate for a {@link
+ * GraphTraversal#order()} by clause.
+ *
+ * <p>
+ * Whereas both of the above properties are primitive, the {@link #titles} property is a
+ * multi-property, and furthermore a set as opposed to a list. Similarly, the {@link #locations}
+ * property is a multi-property, only it's a list, *and* it has meta-properties of it's own. To
+ * represent the value of the location property, as well as it's meta-properties, a {@link Location}
+ * class is defined.
+ *
+ * <p>
+ * Finally, the person vertex defines a sub-traversal, which tells us how to go from this person to
+ * the other people that it knows. Other person-related traversal logic may be co-located here.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Alias(label = "person")
+@EqualsAndHashCode(callSuper = true)
+public class Person extends Vertex {
+
+  public static ToVertex KnowsPeople = traversal -> traversal
+      .out(Label.of(Knows.class))
+      .hasLabel(Label.of(Person.class));
+
+  @PrimaryKey
+  private String name;
+
+  @OrderingKey
+  private int age;
+
+  /**
+   * This is a multi-property of primitive types.
+   */
+  private Set<String> titles;
+
+  /**
+   * This is a multi-property of a vertex property, each of which has meta-properties of its own.
+   */
+  private List<Location> locations;
+
+  public static Person of(String name, Location... locations) {
+    return of(name, 0, locations);
+  }
+
+  public static Person of(String name, int age) {
+    return of(name, age, (Location[]) null);
+  }
+
+  public static Person of(String name, int age, Location... locations) {
+    return of(name, age, null, locations);
+  }
+
+  public static Person of(String name, String title, Location... locations) {
+    return of(name, 0, title, locations);
+  }
+
+  public static Person of(String name, int age, String title, Location... locations) {
+    Set<String> titleSet = null;
+    if (title != null) {
+      titleSet = new HashSet<>();
+      Collections.addAll(titleSet, title);
+    }
+    List<Location> locationList = null;
+    if (locations != null && locations.length > 0) {
+      locationList = Arrays.asList(locations);
+    }
+    return of(name, age, titleSet, locationList);
+  }
+
+  public static Person of(String name, int age, Set<String> titles, List<Location> locations) {
+    Person.PersonBuilder builder = Person.builder().name(name).age(age);
+    if (locations != null) {
+      builder.locations(locations);
+    }
+    if (titles != null) {
+      builder.titles(titles);
+    }
+    return builder.build();
+  }
+}

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Person.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Person.java
@@ -38,6 +38,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Person} class represents the "person" vertex. Its label has been overridden to be
@@ -67,7 +68,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Alias(label = "person")
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Person extends Vertex {
 
   public static ToVertex KnowsPeople = traversal -> traversal

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Person.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Person.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.object.model.OrderingKey;
 import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
 import org.apache.tinkerpop.gremlin.object.reflect.Label;
 import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+import org.apache.tinkerpop.gremlin.object.traversal.AnyTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 
 import java.util.Arrays;
@@ -78,6 +79,17 @@ public class Person extends Vertex {
 
   @OrderingKey
   private int age;
+
+  /**
+   * Since the lambda object below is instance-specific, it needs to either have it's name start
+   * with a {@code $} symbol, or be marked as {@code transient}. If you have a lot of such
+   * instance-specific lambda fields, then you could ignore them all for the purposes of {@link
+   * #equals(Object)} and {@link #hashCode()}, by including {@code of={}} in the {@link
+   * EqualsAndHashCode} annotation above.
+   */
+  public final AnyTraversal $sameAge = g -> g.V()
+      .hasLabel(Label.of(Knows.class))
+      .has("age", age);
 
   /**
    * This is a multi-property of primitive types.

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Software.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Software.java
@@ -27,6 +27,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * The {@link Software} class represents the "software" vertex.
@@ -38,7 +39,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Alias(label = "software")
-@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true, chain = true)
+@EqualsAndHashCode(of = {}, callSuper = true)
 public class Software extends Vertex {
 
   @PrimaryKey

--- a/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Software.java
+++ b/gremlin-objects/src/test/java/org/apache/tinkerpop/gremlin/object/vertices/Software.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.object.vertices;
+
+import org.apache.tinkerpop.gremlin.object.model.Alias;
+import org.apache.tinkerpop.gremlin.object.model.PrimaryKey;
+import org.apache.tinkerpop.gremlin.object.structure.Vertex;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * The {@link Software} class represents the "software" vertex.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Alias(label = "software")
+@EqualsAndHashCode(callSuper = true)
+public class Software extends Vertex {
+
+  @PrimaryKey
+  private String name;
+
+  public static Software of(String name) {
+    return Software.builder().name(name).build();
+  }
+}

--- a/licenses/lombok
+++ b/licenses/lombok
@@ -1,0 +1,19 @@
+Copyright (C) 2009-2015 The Project Lombok Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@ limitations under the License.
     <modules>
         <module>gremlin-shaded</module>
         <module>gremlin-core</module>
+        <module>gremlin-objects</module>
         <module>gremlin-test</module>
         <module>gremlin-groovy</module>
         <module>tinkergraph-gremlin</module>

--- a/tinkergraph-gremlin/pom.xml
+++ b/tinkergraph-gremlin/pom.xml
@@ -25,6 +25,9 @@ limitations under the License.
     </parent>
     <artifactId>tinkergraph-gremlin</artifactId>
     <name>Apache TinkerPop :: TinkerGraph Gremlin</name>
+    <properties>
+        <lombok.version>1.16.18</lombok.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
@@ -32,8 +35,30 @@ limitations under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-objects</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-objects</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactory.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.CachedFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * * The {@link TinkerFactory} class is a cache-able implementation of the {@link GraphFactory}
+ * interface. It is to be used as a fallback when dependency injection is not available.
+ *
+ * Note that tinkergraph is the default implementation of the object {@link Graph} and {@link Query}
+ * interfaces, hence no explicit qualifier is needed to {@link javax.inject.Inject} it.
+ *
+ * For writes to the object {@link Graph}, use the {@link #graph()} method. For reads from the
+ * object graph, use the {@link #query()} method.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class TinkerFactory extends CachedFactory<Configuration> {
+
+  private Configuration configuration;
+
+  public TinkerFactory(ShouldCache shouldCache) {
+    super(shouldCache);
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static TinkerFactory of() {
+    return of(ShouldCache.GRAPH_SYSTEM);
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static TinkerFactory of(ShouldCache shouldCache) {
+    return new TinkerFactory(shouldCache);
+  }
+
+  @Override
+  protected Graph makeGraph() {
+    return new TinkerGraph(system(), query());
+  }
+
+  @Override
+  protected Query makeQuery() {
+    return makeQuery(system());
+  }
+
+  @Override
+  public GraphSystem<Configuration> makeSystem() {
+    return new TinkerSystem(configuration);
+  }
+
+  private Query makeQuery(GraphSystem<Configuration> system) {
+    return new TinkerQuery(system);
+  }
+}

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraph.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.structure.ObjectGraph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import javax.inject.Inject;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@link TinkerGraph} is the default implementation of the {@link ObjectGraph}, which lets you
+ * write to the object {@link org.apache.tinkerpop.gremlin.object.structure.Graph}. If dependency
+ * injection is not enabled, use the {@link TinkerFactory}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = true)
+public class TinkerGraph extends ObjectGraph {
+
+  @Inject
+  public TinkerGraph(GraphSystem<Configuration> system, Query query) {
+    super(system, query);
+  }
+}

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerQuery.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerQuery.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.traversal.ObjectQuery;
+
+import javax.inject.Inject;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@link TinkerQuery} is the default implementation of the {@link ObjectQuery}, which lets you
+ * {@link org.apache.tinkerpop.gremlin.object.traversal.Query} objects created using the {@link
+ * org.apache.tinkerpop.gremlin.object.structure.Graph}. If dependency injection is not enabled, use
+ * the {@link TinkerFactory}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = true)
+public class TinkerQuery extends ObjectQuery {
+
+  @Inject
+  public TinkerQuery(GraphSystem<Configuration> system) {
+    super(system);
+  }
+}

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystem.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystem.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+import javax.script.Bindings;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@link TinkerSystem} is an {@link GraphSystem} based on the  tinkergraph reference
+ * implementation. It obtains a {@link GraphTraversalSource} by opening a {@link TinkerGraph}, using
+ * the provided {@link Configuration}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@Singleton
+public class TinkerSystem implements GraphSystem<Configuration> {
+
+  /**
+   * A cache of unique configurations and their corresponding tinker graphs.
+   */
+  static Map<Configuration, TinkerGraph> tinkerGraphs = new LinkedHashMap<>();
+
+  /**
+   * The default configuration to use, if none is provided.
+   */
+  static final Configuration EMPTY_CONFIGURATION;
+
+  static {
+    EMPTY_CONFIGURATION = new BaseConfiguration();
+    EMPTY_CONFIGURATION.setProperty(Graph.GRAPH, TinkerGraph.class.getName());
+  }
+
+  /**
+   * The configuration activated in this instance.
+   */
+  private Configuration configurationActivated;
+
+  /**
+   * Create an instance using the default configuration.
+   */
+  public TinkerSystem() {
+    this(EMPTY_CONFIGURATION);
+  }
+
+  /**
+   * Make an instance for the given configuration, and save it in the {@link #tinkerGraphs} cache.
+   */
+  public TinkerSystem(Configuration configuration) {
+    configurationActivated = configuration != null ? configuration : EMPTY_CONFIGURATION;
+    tinkerGraphs.computeIfAbsent(configurationActivated, TinkerGraph::open);
+  }
+
+  @Override
+  public Configuration configuration() {
+    return configurationActivated;
+  }
+
+  /**
+   * Supply a {@link GraphTraversalSource} by applying {@link TinkerGraph#traversal()} on this
+   * instance's configuration.
+   */
+  @Override
+  @SuppressWarnings("PMD.ShortMethodName")
+  public GraphTraversalSource g() {
+    return tinkerGraphs.get(configurationActivated).traversal();
+  }
+
+  @Override
+  public Iterable<?> execute(String statement) {
+    throw new UnsupportedOperationException("Tinker graph script execution not supported");
+  }
+
+  @Override
+  public Iterable<?> execute(String statement, Bindings bindings) {
+    throw new UnsupportedOperationException("Tinker graph script execution not supported");
+  }
+
+  @Override
+  @PreDestroy
+  @SneakyThrows
+  public void close() {
+    tinkerGraphs.values().forEach(TinkerGraph::close);
+    tinkerGraphs.clear();
+  }
+}

--- a/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactory.java
+++ b/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.CachedFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * * The {@link TinkerFactory} class is a cache-able implementation of the {@link GraphFactory}
+ * interface. It is to be used as a fallback when dependency injection is not available.
+ *
+ * Note that tinkergraph is the default implementation of the object {@link Graph} and {@link Query}
+ * interfaces, hence no explicit qualifier is needed to {@link javax.inject.Inject} it.
+ *
+ * For writes to the object {@link Graph}, use the {@link #graph()} method. For reads from the
+ * object graph, use the {@link #query()} method.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class TinkerFactory extends CachedFactory<Configuration> {
+
+  private Configuration configuration;
+
+  public TinkerFactory(ShouldCache shouldCache) {
+    super(shouldCache);
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static TinkerFactory of() {
+    return of(ShouldCache.GRAPH_SYSTEM);
+  }
+
+  @SuppressWarnings("PMD.ShortMethodName")
+  public static TinkerFactory of(ShouldCache shouldCache) {
+    return new TinkerFactory(shouldCache);
+  }
+
+  @Override
+  protected Graph makeGraph() {
+    return new TinkerGraph(system(), query());
+  }
+
+  @Override
+  protected Query makeQuery() {
+    return makeQuery(system());
+  }
+
+  @Override
+  public GraphSystem<Configuration> makeSystem() {
+    return new TinkerSystem(configuration);
+  }
+
+  private Query makeQuery(GraphSystem<Configuration> system) {
+    return new TinkerQuery(system);
+  }
+}

--- a/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraph.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.structure.ObjectGraph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import javax.inject.Inject;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@link TinkerGraph} is the default implementation of the {@link ObjectGraph}, which lets you
+ * write to the object {@link org.apache.tinkerpop.gremlin.object.structure.Graph}. If dependency
+ * injection is not enabled, use the {@link TinkerFactory}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = true)
+public class TinkerGraph extends ObjectGraph {
+
+  @Inject
+  public TinkerGraph(GraphSystem<Configuration> system, Query query) {
+    super(system, query);
+  }
+}

--- a/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerQuery.java
+++ b/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerQuery.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.object.traversal.ObjectQuery;
+
+import javax.inject.Inject;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@link TinkerQuery} is the default implementation of the {@link ObjectQuery}, which lets you
+ * {@link org.apache.tinkerpop.gremlin.object.traversal.Query} objects created using the {@link
+ * org.apache.tinkerpop.gremlin.object.structure.Graph}. If dependency injection is not enabled, use
+ * the {@link TinkerFactory}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = true)
+public class TinkerQuery extends ObjectQuery {
+
+  @Inject
+  public TinkerQuery(GraphSystem<Configuration> system) {
+    super(system);
+  }
+}

--- a/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystem.java
+++ b/tinkergraph-gremlin/src/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystem.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.GraphSystem;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.inject.Singleton;
+import javax.script.Bindings;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@link TinkerSystem} is an {@link GraphSystem} based on the  tinkergraph reference
+ * implementation. It obtains a {@link GraphTraversalSource} by opening a {@link TinkerGraph}, using
+ * the provided {@link Configuration}.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+@Singleton
+public class TinkerSystem implements GraphSystem<Configuration> {
+
+  /**
+   * A cache of unique configurations and their corresponding tinker graphs.
+   */
+  static Map<Configuration, TinkerGraph> tinkerGraphs = new LinkedHashMap<>();
+
+  /**
+   * The default configuration to use, if none is provided.
+   */
+  static final Configuration EMPTY_CONFIGURATION;
+
+  static {
+    EMPTY_CONFIGURATION = new BaseConfiguration();
+    EMPTY_CONFIGURATION.setProperty(Graph.GRAPH, TinkerGraph.class.getName());
+  }
+
+  /**
+   * The configuration activated in this instance.
+   */
+  private Configuration configurationActivated;
+
+  /**
+   * Create an instance using the default configuration.
+   */
+  public TinkerSystem() {
+    this(EMPTY_CONFIGURATION);
+  }
+
+  /**
+   * Make an instance for the given configuration, and save it in the {@link #tinkerGraphs} cache.
+   */
+  public TinkerSystem(Configuration configuration) {
+    configurationActivated = configuration != null ? configuration : EMPTY_CONFIGURATION;
+    tinkerGraphs.computeIfAbsent(configurationActivated, TinkerGraph::open);
+  }
+
+  @Override
+  public Configuration configuration() {
+    return configurationActivated;
+  }
+
+  /**
+   * Supply a {@link GraphTraversalSource} by applying {@link TinkerGraph#traversal()} on this
+   * instance's configuration.
+   */
+  @Override
+  @SuppressWarnings("PMD.ShortMethodName")
+  public GraphTraversalSource g() {
+    return tinkerGraphs.get(configurationActivated).traversal();
+  }
+
+  @Override
+  public Iterable<?> execute(String statement) {
+    throw new UnsupportedOperationException("Tinker graph script execution not supported");
+  }
+
+  @Override
+  public Iterable<?> execute(String statement, Bindings bindings) {
+    throw new UnsupportedOperationException("Tinker graph script execution not supported");
+  }
+
+  @Override
+  @SneakyThrows
+  public void close() {
+    tinkerGraphs.values().forEach(TinkerGraph::close);
+    tinkerGraphs.clear();
+  }
+}

--- a/tinkergraph-gremlin/src/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactoryTest.java
+++ b/tinkergraph-gremlin/src/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.CachedFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactoryTest;
+
+/**
+ * This is a sanity test for the {@link TinkerFactory}. While all of the testing is defined in
+ * {@link GraphFactoryTest}, this class is responsible for providing a {@link TinkerFactory} based
+ * on the parameterized {@code ShouldCache} value.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class TinkerFactoryTest extends GraphFactoryTest<Configuration> {
+
+  @Override
+  protected GraphFactory<Configuration> factory(CachedFactory.ShouldCache shouldCache) {
+    return TinkerFactory.of(shouldCache);
+  }
+}

--- a/tinkergraph-gremlin/src/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraphTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.ObjectGraphTest;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactory;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is a test suite for the {@link TinkerGraph} and {@link TinkerQuery} alike. While all of the
+ * testing is defined in {@link ObjectGraphTest}, this class is responsible for providing a
+ * tinkergraph-specific version of the {@link Graph} and {@link Query} to it.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+public class TinkerGraphTest extends ObjectGraphTest {
+
+  private static final GraphFactory<Configuration> FACTORY = TinkerFactory.of();
+
+  public TinkerGraphTest() {
+    super(FACTORY.graph(), FACTORY.query());
+  }
+
+  @Override
+  protected boolean supportsScripts() {
+    return false;
+  }
+}

--- a/tinkergraph-gremlin/src/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystemTest.java
+++ b/tinkergraph-gremlin/src/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystemTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Ensure that the {@link TinkerSystem} is configurable and traversable.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+public class TinkerSystemTest {
+
+  private TinkerSystem tinkerSystem;
+
+  @After
+  public void tearDown() {
+    if (tinkerSystem != null) {
+      tinkerSystem.close();
+    }
+  }
+
+  @Test
+  public void testDefaultConfiguration() {
+    tinkerSystem = new TinkerSystem();
+    Set<Configuration> configurations = TinkerSystem.tinkerGraphs.keySet();
+    assertEquals(1, configurations.size());
+    assertEquals(TinkerSystem.EMPTY_CONFIGURATION, configurations.iterator().next());
+    assertEquals(TinkerSystem.EMPTY_CONFIGURATION, tinkerSystem.configuration());
+  }
+
+  @Test
+  public void testCustomConfiguration() {
+    Configuration configuration = new BaseConfiguration();
+    tinkerSystem = new TinkerSystem(configuration);
+    Set<Configuration> configurations = TinkerSystem.tinkerGraphs.keySet();
+    assertEquals(1, configurations.size());
+    assertEquals(configuration, configurations.iterator().next());
+    assertEquals(configuration, tinkerSystem.configuration());
+  }
+
+  @Test
+  public void testMultipleConfigurations() {
+    Configuration someConfiguration = new BaseConfiguration();
+    tinkerSystem = new TinkerSystem(someConfiguration);
+
+    Configuration otherConfiguration = new BaseConfiguration();
+    TinkerSystem otherSystem = new TinkerSystem(otherConfiguration);
+
+    Set<Configuration> configurations = TinkerSystem.tinkerGraphs.keySet();
+    assertEquals(2, configurations.size());
+    Iterator<Configuration> iterator = configurations.iterator();
+    assertEquals(someConfiguration, iterator.next());
+    assertEquals(someConfiguration, tinkerSystem.configuration());
+    assertEquals(otherConfiguration, iterator.next());
+    assertEquals(otherConfiguration, otherSystem.configuration());
+  }
+
+  @Test
+  public void testTraversalObtainable() {
+    tinkerSystem = new TinkerSystem();
+    GraphTraversalSource g = tinkerSystem.g();
+    System.out.println("" + g.V().toBulkSet());
+    assertEquals(Long.valueOf(0L), g.V().count().next());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testExecuteStatementFails() {
+    tinkerSystem = new TinkerSystem();
+    tinkerSystem.execute("g.V().count().next()");
+  }
+}

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactoryTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.provider.CachedFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactory;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactoryTest;
+
+/**
+ * This is a sanity test for the {@link TinkerFactory}. While all of the testing is defined in
+ * {@link GraphFactoryTest}, this class is responsible for providing a {@link TinkerFactory} based
+ * on the parameterized {@code ShouldCache} value.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+public class TinkerFactoryTest extends GraphFactoryTest<Configuration> {
+
+  @Override
+  protected GraphFactory<Configuration> factory(CachedFactory.ShouldCache shouldCache) {
+    return TinkerFactory.of(shouldCache);
+  }
+}

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerGraphTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.object.ObjectGraphTest;
+import org.apache.tinkerpop.gremlin.object.provider.GraphFactory;
+import org.apache.tinkerpop.gremlin.object.structure.Graph;
+import org.apache.tinkerpop.gremlin.object.traversal.Query;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is a test suite for the {@link TinkerGraph} and {@link TinkerQuery} alike. While all of the
+ * testing is defined in {@link ObjectGraphTest}, this class is responsible for providing a
+ * tinkergraph-specific version of the {@link Graph} and {@link Query} to it.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+public class TinkerGraphTest extends ObjectGraphTest {
+
+  private static final GraphFactory<Configuration> FACTORY = TinkerFactory.of();
+
+  public TinkerGraphTest() {
+    super(FACTORY.graph(), FACTORY.query());
+  }
+
+  @Override
+  protected boolean supportsScripts() {
+    return false;
+  }
+}

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystemTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/object/TinkerSystemTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.object;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Ensure that the {@link TinkerSystem} is configurable and traversable.
+ *
+ * @author Karthick Sankarachary (http://github.com/karthicks)
+ */
+@Slf4j
+public class TinkerSystemTest {
+
+  private TinkerSystem tinkerSystem;
+
+  @After
+  public void tearDown() {
+    if (tinkerSystem != null) {
+      tinkerSystem.close();
+    }
+  }
+
+  @Test
+  public void testDefaultConfiguration() {
+    tinkerSystem = new TinkerSystem();
+    Set<Configuration> configurations = TinkerSystem.tinkerGraphs.keySet();
+    assertEquals(1, configurations.size());
+    assertEquals(TinkerSystem.EMPTY_CONFIGURATION, configurations.iterator().next());
+    assertEquals(TinkerSystem.EMPTY_CONFIGURATION, tinkerSystem.configuration());
+  }
+
+  @Test
+  public void testCustomConfiguration() {
+    Configuration configuration = new BaseConfiguration();
+    tinkerSystem = new TinkerSystem(configuration);
+    Set<Configuration> configurations = TinkerSystem.tinkerGraphs.keySet();
+    assertEquals(1, configurations.size());
+    assertEquals(configuration, configurations.iterator().next());
+    assertEquals(configuration, tinkerSystem.configuration());
+  }
+
+  @Test
+  public void testMultipleConfigurations() {
+    Configuration someConfiguration = new BaseConfiguration();
+    tinkerSystem = new TinkerSystem(someConfiguration);
+
+    Configuration otherConfiguration = new BaseConfiguration();
+    TinkerSystem otherSystem = new TinkerSystem(otherConfiguration);
+
+    Set<Configuration> configurations = TinkerSystem.tinkerGraphs.keySet();
+    assertEquals(2, configurations.size());
+    Iterator<Configuration> iterator = configurations.iterator();
+    assertEquals(someConfiguration, iterator.next());
+    assertEquals(someConfiguration, tinkerSystem.configuration());
+    assertEquals(otherConfiguration, iterator.next());
+    assertEquals(otherConfiguration, otherSystem.configuration());
+  }
+
+  @Test
+  public void testTraversalObtainable() {
+    tinkerSystem = new TinkerSystem();
+    GraphTraversalSource g = tinkerSystem.g();
+    System.out.println("" + g.V().toBulkSet());
+    assertEquals(Long.valueOf(0L), g.V().count().next());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testExecuteStatementFails() {
+    tinkerSystem = new TinkerSystem();
+    tinkerSystem.execute("g.V().count().next()");
+  }
+}


### PR DESCRIPTION
This pull request implements the object-graph mapping framework proposed in [TINKERPOP-1750](https://issues.apache.org/jira/browse/TINKERPOP-1750).

In addition to the proposed framework, a reference implementation based on `TinkerGraph` is included. It comes with test cases, and is `javadoc` friendly. A license for `lombok` was added to the `LICENSE` file.

For more details, please see the [README](https://github.com/karthicks/tinkerpop/blob/e9b1ac506900008dd52d12754c75ecf3ddbef01c/gremlin-objects/README.asciidoc) under the `gremlin-objects` module.