### PR TITLE
TINKERPOP-1748 Callout comments break code snippets

### DIFF
--- a/docs/postprocessor/processor.awk
+++ b/docs/postprocessor/processor.awk
@@ -19,13 +19,33 @@
 
 BEGIN {
   firstMatch=1
+  styled=0
 }
 
 /Licensed to the Apache Software Foundation/ {
   isHeader=1
 }
 
-firstMatch || !isHeader
+/<\/style>/ {
+  if (!styled) {
+    print ".invisible {position: absolute; left: 9999px}"
+    styled=1
+  }
+}
+
+!/<span class="comment">/ {
+  if (firstMatch || !isHeader) {
+    print gensub(/(<b class="conum">)\(([0-9]+)\)(<\/b>)/,
+                 "<span class=\"invisible\">//</span>\\1\\2\\3", "g")
+  }
+}
+
+/<span class="comment">/ {
+  if (firstMatch || !isHeader) {
+    print gensub(/<span class="comment">\/\/<\/span>(<b class="conum">)\(([0-9]+)\)(<\/b>)/,
+                 "<span class=\"invisible\">//</span>\\1\\2\\3<span class=\"invisible\">\\\\<\/span>", "g")
+  }
+}
 
 /under the License\./ {
   firstMatch=0


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1748

Made callouts in docs prettier and copy+paste friendly.

Tested with `docker/build.sh -d`. Looks great and all snippets can now be pasted into the console w/o producing any syntax errors due to callout comments.

VOTE: +1