### PR TITLE
TINKERPOP-1760: OLAP compilation failing around ConnectiveStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug in `ComputerVerificationStrategy` where child traversals were being analyzed prior to compilation.
 * Fixed a bug that prevented Gremlin from ordering lists and streams made of mixed number types.
 
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategyTest.java
@@ -23,6 +23,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.AdjacentToIncidentStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.util.EmptyTraversal;
 import org.junit.Test;
@@ -34,6 +36,7 @@ import java.util.Arrays;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.max;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.min;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.sum;
 import static org.junit.Assert.fail;
 
@@ -53,6 +56,7 @@ public class ComputerVerificationStrategyTest {
                 {"__.values(\"age\").union(max(), min(), sum())", __.values("age").union(max(), min(), sum()), true},
                 {"__.count().sum()", __.count().sum(), true},
                 {"__.where(\"a\",eq(\"b\")).out()", __.where("a", P.eq("b")).out(), true},
+                {"__.where(and(outE(\"knows\"),outE(\"created\"))).values(\"name\")", __.where(__.and(outE("knows"), outE("created"))).values("name"), true},
 
         });
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1760

The more general problem was in `ComputerVerificationStrategy`. The problem was the nested traversals were being analyzed prior to full strategy compilation. The solution actually simplified the code a bit.

```
gremlin> g = TinkerFactory.createModern().traversal().withComputer()
==>graphtraversalsource[tinkergraph[vertices:6 edges:6], graphcomputer]
gremlin> g.V().where(out("created").and().out("knows")).values("name")
==>marko
```

VOTE +1