### PR TITLE
TINKERPOP-1762: Make MatchStep analyze mid-clause variables for executing ordering purposes.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a bug in `MatchStep` where mid-traversal `where()` variables were not being considered in start-scope.
 * Ensured that plugins were applied in the order they were configured.
 * Fixed a bug in `Neo4jGremlinPlugin` that prevented it from loading properly in the `GremlinPythonScriptEngine`.
 * Fixed a bug that prevented Gremlin from ordering lists and streams made of mixed number types.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
@@ -513,8 +513,15 @@ public final class MatchStep<S, E> extends ComputerAwareStep<S, Map<String, E>> 
                 this.scopeKeys = new HashSet<>();
                 if (null != this.selectKey)
                     this.scopeKeys.add(this.selectKey);
-                if (this.getNextStep() instanceof WhereTraversalStep || this.getNextStep() instanceof WherePredicateStep)
-                    this.scopeKeys.addAll(((Scoping) this.getNextStep()).getScopeKeys());
+                final Set<String> endLabels = ((MatchStep<?, ?>) this.getTraversal().getParent()).getMatchEndLabels();
+                Stream.concat(
+                        TraversalHelper.getStepsOfAssignableClassRecursively(WherePredicateStep.class, this.getTraversal()).stream(),
+                        TraversalHelper.getStepsOfAssignableClassRecursively(WhereTraversalStep.class, this.getTraversal()).stream()).
+                        flatMap(s -> s.getScopeKeys().stream()).filter(endLabels::contains).forEach(this.scopeKeys::add);
+                // this is the old way but it only checked for where() as the next step, not arbitrarily throughout traversal
+                // just going to keep this in case something pops up in the future and this is needed as an original reference.
+                /* if (this.getNextStep() instanceof WhereTraversalStep || this.getNextStep() instanceof WherePredicateStep)
+                   this.scopeKeys.addAll(((Scoping) this.getNextStep()).getScopeKeys());*/
                 this.scopeKeys = Collections.unmodifiableSet(this.scopeKeys);
             }
             return this.scopeKeys;

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMatchTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMatchTest.groovy
@@ -377,5 +377,17 @@ public abstract class GroovyMatchTest {
                     __.as("a").in("followedBy").count().is(gt(10)).as("b")).count;
             """)
         }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_matchXa_hasXsong_name_sunshineX__a_mapX0followedBy_weight_meanX_b__a_0followedBy_c__c_filterXweight_whereXgteXbXXX_outV_dX_selectXdX_byXnameX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", """
+              g.V().match(
+                  __.as("a").has("song", "name", "HERE COMES SUNSHINE"),
+                  __.as("a").map(inE("followedBy").weight.mean()).as("b"),
+                  __.as("a").inE("followedBy").as("c"),
+                  __.as("c").filter(values("weight").where(gte("b"))).outV.as("d")).
+                select("d").by("name");
+            """)
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchTest.java
@@ -46,11 +46,13 @@ import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.and;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.inE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.match;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.not;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.or;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.repeat;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.values;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.where;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -158,6 +160,10 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
 
     // test inline counts
     public abstract Traversal<Vertex, Long> get_g_V_matchXa_followedBy_count_isXgtX10XX_b__a_0followedBy_count_isXgtX10XX_bX_count();
+
+    // test mid-clause variables
+    public abstract Traversal<Vertex, String> get_g_V_matchXa_hasXsong_name_sunshineX__a_mapX0followedBy_weight_meanX_b__a_0followedBy_c__c_filterXweight_whereXgteXbXXX_outV_dX_selectXdX_byXnameX();
+
 
     @Test
     @LoadGraphWith(MODERN)
@@ -566,6 +572,16 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
         checkResults(Collections.singletonList(6L), traversal);
     }
 
+    @Test
+    @LoadGraphWith(GRATEFUL)
+    public void g_V_matchXa_hasXsong_name_sunshineX__a_mapX0followedBy_weight_meanX_b__a_0followedBy_c__c_filterXweight_whereXgteXbXXX_outV_dX_selectXdX_byXnameX() {
+        final Traversal<Vertex, String> traversal = get_g_V_matchXa_hasXsong_name_sunshineX__a_mapX0followedBy_weight_meanX_b__a_0followedBy_c__c_filterXweight_whereXgteXbXXX_outV_dX_selectXdX_byXnameX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList("THE MUSIC NEVER STOPPED", "PROMISED LAND", "PLAYING IN THE BAND",
+                "CASEY JONES", "BIG RIVER", "EL PASO", "LIBERTY", "LOOKS LIKE RAIN"), traversal);
+    }
+
+
     public static class GreedyMatchTraversals extends Traversals {
         @Before
         public void setupTest() {
@@ -849,6 +865,16 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
             return g.V().match(
                     as("a").out("followedBy").count().is(P.gt(10)).as("b"),
                     as("a").in("followedBy").count().is(P.gt(10)).as("b")).count();
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_matchXa_hasXsong_name_sunshineX__a_mapX0followedBy_weight_meanX_b__a_0followedBy_c__c_filterXweight_whereXgteXbXXX_outV_dX_selectXdX_byXnameX() {
+            return g.V().match(
+                    as("a").has("song", "name", "HERE COMES SUNSHINE"),
+                    as("a").map(inE("followedBy").values("weight").mean()).as("b"),
+                    as("a").inE("followedBy").as("c"),
+                    as("c").filter(values("weight").where(P.gte("b"))).outV().as("d")).
+                    <String>select("d").by("name");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1762

There was a bug in `MatchStep` where if you had a mid-clause `where()`, its variable was not being considered as part of the determination of the matching start-variables. This led to traversers going down clause paths when they didn't have all the subsequent data.

```
gremlin> graph = TinkerGraph.open()
==>tinkergraph[vertices:0 edges:0]
gremlin> graph.io(graphml()).readGraph("data/grateful-dead.xml")
==>null
gremlin> g = graph.traversal()
==>graphtraversalsource[tinkergraph[vertices:808 edges:8049], standard]
gremlin> g.V().match(
......1>     __.as("sunshine").has("song", "name", "HERE COMES SUNSHINE"),
......2>     __.as("sunshine").map(inE("followedBy").values("weight").mean()).as("avg_weight"),
......3>     __.as("sunshine").inE("followedBy").as("x"),
......4>     __.as("x").filter(values("weight").where(gte("avg_weight"))).outV().as("followers")).
......5>   select("followers").by("name");
==>LOOKS LIKE RAIN
==>PROMISED LAND
==>LIBERTY
==>EL PASO
==>PLAYING IN THE BAND
==>BIG RIVER
==>CASEY JONES
==>THE MUSIC NEVER STOPPED
gremlin>
```

VOTE +1