### PR TITLE
TINKERPOP-1764: Generalize MatchStep to localize all barriers, not just reducing barriers.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Generalized `MatchStep` to locally compute all clauses with barriers (not just reducing barriers).
 * Ensured that plugins were applied in the order they were configured.
 * Fixed a bug in `Neo4jGremlinPlugin` that prevented it from loading properly in the `GremlinPythonScriptEngine`.
 * Fixed a bug in `ComputerVerificationStrategy` where child traversals were being analyzed prior to compilation.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -22,6 +22,45 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *Nine Inch Gremlins*
 
+TinkerPop 3.2.7
+---------------
+
+*NOT OFFICIALLY RELEASED YET*
+
+Upgrading for Users
+~~~~~~~~~~~~~~~~~~~
+
+The `match()`-step has been generalized to suppor the local scoping of all barrier steps, not just reducing barrier steps.
+Previously, the `order().limit()` clause would have worked globally yielding:
+
+[source,groovy]
+----
+gremlin> g.V().match(
+......1>   __.as('a').outE('created').order().by('weight',decr).limit(1).inV().as('b'),
+......2>   __.as('b').has('lang','java')
+......3> ).select('a','b').by('name')
+==>[a:marko,b:lop]
+----
+
+However, now, `order()` (and all other barriers) are treated as local computations to the pattern and thus, the result set is:
+
+[source,groovy]
+----
+gremlin> g.V().match(
+......1>   __.as('a').outE('created').order().by('weight',decr).limit(1).inV().as('b'),
+......2>   __.as('b').has('lang','java')
+......3> ).select('a','b').by('name')
+==>[a:marko,b:lop]
+==>[a:josh,b:ripple]
+==>[a:peter,b:lop]
+----
+
+Note that this is not that intense of a breaking change as all of the reducing barriers behaved in this manner previously.
+This includes steps like `count()`, `min()`, `max()`, `sum()`, `group()`, `groupCount()`, etc. This update has now
+generalized this behavior to all barriers and thus, adds `aggregate()`, `dedup()`, `range()`, `limit()`, `tail()`, and `order()`
+to the list of locally computed clauses.
+
+
 TinkerPop 3.2.6
 ---------------
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
@@ -154,7 +154,8 @@ public final class MatchStep<S, E> extends ComputerAwareStep<S, Map<String, E>> 
         matchTraversal.asAdmin().addStep(matchEndStep);
 
         // this turns barrier computations into locally computable traversals
-        if (TraversalHelper.hasStepOfAssignableClass(Barrier.class, matchTraversal)) {
+        if (TraversalHelper.getStepsOfAssignableClass(Barrier.class, matchTraversal).stream().
+                filter(s -> !(s instanceof NoOpBarrierStep)).findAny().isPresent()) { // exclude NoOpBarrierSteps from the determination as they are optimization barriers
             final Traversal.Admin newTraversal = new DefaultTraversal<>();
             TraversalHelper.removeToTraversal(matchTraversal.getStartStep().getNextStep(), matchTraversal.getEndStep(), newTraversal);
             TraversalHelper.insertAfterStep(new TraversalFlatMapStep<>(matchTraversal, newTraversal), matchTraversal.getStartStep(), matchTraversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
@@ -20,10 +20,12 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -36,7 +38,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ComputerAwareStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathRetractionStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
@@ -153,7 +154,7 @@ public final class MatchStep<S, E> extends ComputerAwareStep<S, Map<String, E>> 
         matchTraversal.asAdmin().addStep(matchEndStep);
 
         // this turns barrier computations into locally computable traversals
-        if (!TraversalHelper.getStepsOfAssignableClass(ReducingBarrierStep.class, matchTraversal).isEmpty()) {
+        if (TraversalHelper.hasStepOfAssignableClass(Barrier.class, matchTraversal)) {
             final Traversal.Admin newTraversal = new DefaultTraversal<>();
             TraversalHelper.removeToTraversal(matchTraversal.getStartStep().getNextStep(), matchTraversal.getEndStep(), newTraversal);
             TraversalHelper.insertAfterStep(new TraversalFlatMapStep<>(matchTraversal, newTraversal), matchTraversal.getStartStep(), matchTraversal);

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMatchTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMatchTest.groovy
@@ -24,6 +24,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import org.junit.Before
 
+import static org.apache.tinkerpop.gremlin.process.traversal.Order.decr
+
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
@@ -375,6 +377,16 @@ public abstract class GroovyMatchTest {
              g.V.match(
                     __.as("a").out("followedBy").count.is(gt(10)).as("b"),
                     __.as("a").in("followedBy").count().is(gt(10)).as("b")).count;
+            """)
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_outEXcreatedX_order_byXweight_decrX_limitX1X_inV_b__b_hasXlang_javaXX_selectXa_bX_byXnameX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", """
+             g.V.match(
+                    __.as("a").outE("created").order.by("weight", decr).limit(1).inV.as("b"),
+                    __.as("b").has("lang", "java")).
+                select("a", "b").by("name")
             """)
         }
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.GRATEFUL;
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.Order.decr;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.and;
@@ -158,6 +159,9 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
 
     // test inline counts
     public abstract Traversal<Vertex, Long> get_g_V_matchXa_followedBy_count_isXgtX10XX_b__a_0followedBy_count_isXgtX10XX_bX_count();
+
+    // test order barriers
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_matchXa_outEXcreatedX_order_byXweight_decrX_limitX1X_inV_b__b_hasXlang_javaXX_selectXa_bX_byXnameX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -566,6 +570,17 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
         checkResults(Collections.singletonList(6L), traversal);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_matchXa_outEXcreatedX_order_byXweight_decrX_limitX1X_inV_b__b_hasXlang_javaXX_selectXa_bX_byXnameX() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_matchXa_outEXcreatedX_order_byXweight_decrX_limitX1X_inV_b__b_hasXlang_javaXX_selectXa_bX_byXnameX();
+        printTraversalForm(traversal);
+        checkResults(makeMapList(2,
+                "a", "marko", "b", "lop",
+                "a", "peter", "b", "lop",
+                "a", "josh", "b", "ripple"), traversal);
+    }
+
     public static class GreedyMatchTraversals extends Traversals {
         @Before
         public void setupTest() {
@@ -849,6 +864,14 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
             return g.V().match(
                     as("a").out("followedBy").count().is(P.gt(10)).as("b"),
                     as("a").in("followedBy").count().is(P.gt(10)).as("b")).count();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_outEXcreatedX_order_byXweight_decrX_limitX1X_inV_b__b_hasXlang_javaXX_selectXa_bX_byXnameX() {
+            return g.V().match(
+                    as("a").outE("created").order().by("weight", decr).limit(1).inV().as("b"),
+                    as("b").has("lang", "java")).
+                    <String>select("a", "b").by("name");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1764

Prior to this moment, only reducing barrier steps in a `match()`-clause forced the clause to be computed locally (via a `flatMap()`-wrap). However, it has been deemed important to generalize this behavior to all barriers (e.g. `order()`, `limit()`, etc.) as identified by @doanduyhai (Gremlin power user). As such, the generalization has been done, but at the expense of a breaking change. However, realize that this breaking change would only be breaking behavior that is "random" (and most users should not be doing anyways -- but you never know).

*PREVIOUSLY*

```
gremlin> g.V().match(
......1>   __.as('a').outE('created').order().by('weight',decr).limit(1).inV().as('b'),
......2>   __.as('b').has('lang','java')
......3> ).select('a','b').by('name')
==>[a:marko,b:lop]
```

*CURRENTLY*

```
gremlin> g.V().match(
......1>   __.as('a').outE('created').order().by('weight',decr).limit(1).inV().as('b'),
......2>   __.as('b').has('lang','java')
......3> ).select('a','b').by('name')
==>[a:marko,b:lop]
==>[a:josh,b:ripple]
==>[a:peter,b:lop]
```

VOTE +1