### PR TITLE
TINKERPOP-1766 Gremlin.Net: Add handling for closed connections

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -68,6 +68,8 @@ namespace Gremlin.Net.Driver
             await _webSocketConnection.CloseAsync().ConfigureAwait(false);
         }
 
+        public bool IsOpen => _webSocketConnection.IsOpen;
+
         private async Task SendAsync(RequestMessage message)
         {
             var graphsonMsg = _graphSONWriter.WriteObject(message);

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -101,18 +101,15 @@ namespace Gremlin.Net.Driver
 
         private void RemoveAllConnections()
         {
-            while (!_connections.IsEmpty)
+            while (_connections.TryTake(out var connection))
             {
-                _connections.TryTake(out var connection);
                 connection.Dispose();
             }
         }
 
         private async Task TeardownAsync()
         {
-            var closeTasks = new List<Task>(_connections.Count);
-            closeTasks.AddRange(_connections.Select(conn => conn.CloseAsync()));
-            await Task.WhenAll(closeTasks).ConfigureAwait(false);
+            await Task.WhenAll(_connections.Select(c => c.CloseAsync())).ConfigureAwait(false);
         }
 
         #region IDisposable Support

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -55,7 +55,7 @@ namespace Gremlin.Net.Driver
             if (connection == null)
                 connection = await CreateNewConnectionAsync().ConfigureAwait(false);
 
-            return new ProxyConnection(connection, AddConnection);
+            return new ProxyConnection(connection, AddConnectionIfOpen);
         }
 
         private async Task<Connection> CreateNewConnectionAsync()
@@ -66,12 +66,53 @@ namespace Gremlin.Net.Driver
             return newConnection;
         }
 
+        private void AddConnectionIfOpen(Connection connection)
+        {
+            if (!connection.IsOpen)
+            {
+                ConsiderUnavailable();
+                connection.Dispose();
+                return;
+            }
+            AddConnection(connection);
+        }
+
         private void AddConnection(Connection connection)
         {
             lock (_connectionsLock)
             {
                 _connections.Add(connection);
             }
+        }
+
+        private void ConsiderUnavailable()
+        {
+            CloseAndRemoveAllConnections();
+        }
+
+        private void CloseAndRemoveAllConnections()
+        {
+            lock (_connectionsLock)
+            {
+                TeardownAsync().WaitUnwrap();
+                RemoveAllConnections();
+            }
+        }
+
+        private void RemoveAllConnections()
+        {
+            while (!_connections.IsEmpty)
+            {
+                _connections.TryTake(out var connection);
+                connection.Dispose();
+            }
+        }
+
+        private async Task TeardownAsync()
+        {
+            var closeTasks = new List<Task>(_connections.Count);
+            closeTasks.AddRange(_connections.Select(conn => conn.CloseAsync()));
+            await Task.WhenAll(closeTasks).ConfigureAwait(false);
         }
 
         #region IDisposable Support
@@ -89,27 +130,10 @@ namespace Gremlin.Net.Driver
             if (!_disposed)
             {
                 if (disposing)
-                    lock (_connectionsLock)
-                    {
-                        if (_connections != null && !_connections.IsEmpty)
-                        {
-                            TeardownAsync().WaitUnwrap();
-
-                            foreach (var conn in _connections)
-                                conn.Dispose();
-                        }
-                    }
+                    CloseAndRemoveAllConnections();
                 _disposed = true;
             }
         }
-
-        private async Task TeardownAsync()
-        {
-            var closeTasks = new List<Task>(_connections.Count);
-            closeTasks.AddRange(_connections.Select(conn => conn.CloseAsync()));
-            await Task.WhenAll(closeTasks).ConfigureAwait(false);
-        }
-
         #endregion
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -71,6 +71,8 @@ namespace Gremlin.Net.Driver
             }
         }
 
+        public bool IsOpen => _client.State == WebSocketState.Open;
+
         #region IDisposable Support
 
         private bool _disposed;

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1766

This avoids `Connections` from being added back to the `ConnectionPool` when they were closed which happens when the server gets unavailable. In that case all existing `Connections` are removed from the `ConnectionPool` and closed as they are most likely also not `Open` anymore. This is in line with the handling for closed connections in `gremlin-driver`.

Unfortunately, I don't know of a good way to test something like this. We probably would have to make internal classes like `Connection` public which isn't that nice as users shouldn't see them in my opinion.

VOTE +1