### PR TITLE
TINKERPOP-1767 Added Io.requiresVersion(Object)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,9 @@ TinkerPop 3.3.1 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
+* Added `Io.requiresVersion(Object)` to allow graph providers a way to check the `Io` type and version being constructed.
+* Defaulted `IoCore.gryo()` and `IoCore.graphson()` to both use their 3.0 formats which means that `Graph.io()` will use those by default.
+
 [[release-3-3-0]]
 TinkerPop 3.3.0 (Release Date: August 21, 2017)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -476,11 +476,13 @@ called `tinkerpop-modern.json` and then how to read that file back into a differ
 [source,java]
 ----
 final Graph graph = TinkerFactory.createModern();
-graph.io(IoCore.graphson()).writeGraph("tinkerpop-modern.json");
+graph.io(graphson()).writeGraph("tinkerpop-modern.json");
 
 final Graph newGraph = TinkerGraph.open();
-newGraph.io(IoCore.graphson()).readGraph("tinkerpop-modern.json");
+newGraph.io(graphson()).readGraph("tinkerpop-modern.json");
 ----
+
+NOTE: Using `graphson()`, which is a static helper method of `IoCore`, will default to the most current version of GraphSON which is 3.0.
 
 If a custom configuration is required, then have the `Graph` generate a `GraphReader` or `GraphWriter` "builder" instance:
 
@@ -489,19 +491,16 @@ If a custom configuration is required, then have the `Graph` generate a `GraphRe
 final Graph graph = TinkerFactory.createModern();
 try (final OutputStream os = new FileOutputStream("tinkerpop-modern.json")) {
     final GraphSONMapper mapper = graph.io(IoCore.graphson()).mapper().normalize(true).create()
-    graph.io(IoCore.graphson()).writer().mapper(mapper).create().writeGraph(os, graph)
+    graph.io(graphson()).writer().mapper(mapper).create().writeGraph(os, graph)
 }
 
 final Graph newGraph = TinkerGraph.open();
 try (final InputStream stream = new FileInputStream("tinkerpop-modern.json")) {
-    newGraph.io(IoCore.graphson()).reader().create().readGraph(stream, newGraph);
+    newGraph.io(graphson()).reader().create().readGraph(stream, newGraph);
 }
 ----
 
-One of the important configuration options of the `GraphSONReader` and `GraphSONWriter` is the ability to embed type
-information into the output.  By embedding the types, it becomes possible to serialize a graph without losing type
-information that might be important when being consumed by another source.  The importance of this concept is
-demonstrated in the following example where a single `Vertex` is written to GraphSON using the Gremlin Console:
+The following example shows how a single `Vertex` is written to GraphSON using the Gremlin Console:
 
 [gremlin-groovy]
 ----
@@ -517,289 +516,101 @@ The following GraphSON example shows the output of `GraphSONWriter.writeVertex()
 [source,json]
 ----
 {
-    "id": 1,
-    "label": "person",
-    "outE": {
-        "created": [
-            {
-                "id": 9,
-                "inV": 3,
-                "properties": {
-                    "weight": 0.4
-                }
-            }
-        ],
-        "knows": [
-            {
-                "id": 7,
-                "inV": 2,
-                "properties": {
-                    "weight": 0.5
-                }
-            },
-            {
-                "id": 8,
-                "inV": 4,
-                "properties": {
-                    "weight": 1
-                }
-            }
-        ]
-    },
-    "properties": {
-        "name": [
-            {
-                "id": 0,
-                "value": "marko"
-            }
-        ],
-        "age": [
-            {
-                "id": 1,
-                "value": 29
-            }
-        ]
-    }
+	"id": {
+		"@type": "g:Int32",
+		"@value": 1
+	},
+	"label": "person",
+	"outE": {
+		"created": [{
+			"id": {
+				"@type": "g:Int32",
+				"@value": 9
+			},
+			"inV": {
+				"@type": "g:Int32",
+				"@value": 3
+			},
+			"properties": {
+				"weight": {
+					"@type": "g:Double",
+					"@value": 0.4
+				}
+			}
+		}],
+		"knows": [{
+			"id": {
+				"@type": "g:Int32",
+				"@value": 7
+			},
+			"inV": {
+				"@type": "g:Int32",
+				"@value": 2
+			},
+			"properties": {
+				"weight": {
+					"@type": "g:Double",
+					"@value": 0.5
+				}
+			}
+		}, {
+			"id": {
+				"@type": "g:Int32",
+				"@value": 8
+			},
+			"inV": {
+				"@type": "g:Int32",
+				"@value": 4
+			},
+			"properties": {
+				"weight": {
+					"@type": "g:Double",
+					"@value": 1.0
+				}
+			}
+		}]
+	},
+	"properties": {
+		"name": [{
+			"id": {
+				"@type": "g:Int64",
+				"@value": 0
+			},
+			"value": "marko"
+		}],
+		"age": [{
+			"id": {
+				"@type": "g:Int64",
+				"@value": 1
+			},
+			"value": {
+				"@type": "g:Int32",
+				"@value": 29
+			}
+		}]
+	}
 }
 ----
 
-The vertex properly serializes to valid JSON but note that a consuming application will not automatically know how to
-interpret the numeric values.  In coercing those Java values to JSON, such information is lost.
-
-NOTE: Additional documentation for GraphSON can be found in the link:http://tinkerpop.apache.org/docs/x.y.z/dev/io/#graphson[IO Reference].
-
-[[graphson-types-embedding]]
-Types embedding
-^^^^^^^^^^^^^^^
-
-With a minor change to the construction of the `GraphSONWriter` the lossy nature of GraphSON can be avoided.
-
-[[graphson-1-0-types]]
-Types with GraphSON 1.0
-+++++++++++++++++++++++
-
-GraphSON 1.0 is the version enabled by default when creating a GraphSON Mapper. Here is how to enable types with
-GraphSON 1.0:
+GraphSON has several versions and each has differences that prevent complete compatibility with one another. While the
+default version provided by `IoCore.graphson()` is recommended, it is possible to make changes to revert to an earlier
+version. The following shows an example of how to use 1.0 (with type embedding):
 
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createModern()
 g = graph.traversal()
 f = new ByteArrayOutputStream()
-mapper = graph.io(graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()
-graph.io(graphson()).writer().mapper(mapper).create().writeVertex(f, g.V(1).next(), BOTH)
+mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()
+graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().mapper(mapper).create().writeVertex(f, g.V(1).next(), BOTH)
 f.close()
 ----
 
-In the above code, the `typeInfo` option is set to `true` and the output below shows the difference in the output:
-
-[source,json]
-----
-{
-    "@class": "java.util.HashMap",
-    "id": 1,
-    "label": "person",
-    "outE": {
-        "@class": "java.util.HashMap",
-        "created": [
-            "java.util.ArrayList",
-            [
-                {
-                    "@class": "java.util.HashMap",
-                    "id": 9,
-                    "inV": 3,
-                    "properties": {
-                        "@class": "java.util.HashMap",
-                        "weight": 0.4
-                    }
-                }
-            ]
-        ],
-        "knows": [
-            "java.util.ArrayList",
-            [
-                {
-                    "@class": "java.util.HashMap",
-                    "id": 7,
-                    "inV": 2,
-                    "properties": {
-                        "@class": "java.util.HashMap",
-                        "weight": 0.5
-                    }
-                },
-                {
-                    "@class": "java.util.HashMap",
-                    "id": 8,
-                    "inV": 4,
-                    "properties": {
-                        "@class": "java.util.HashMap",
-                        "weight": 1
-                    }
-                }
-            ]
-        ]
-    },
-    "properties": {
-        "@class": "java.util.HashMap",
-        "name": [
-            "java.util.ArrayList",
-            [
-                {
-                    "@class": "java.util.HashMap",
-                    "id": [
-                        "java.lang.Long",
-                        0
-                    ],
-                    "value": "marko"
-                }
-            ]
-        ],
-        "age": [
-            "java.util.ArrayList",
-            [
-                {
-                    "@class": "java.util.HashMap",
-                    "id": [
-                        "java.lang.Long",
-                        1
-                    ],
-                    "value": 29
-                }
-            ]
-        ]
-    }
-}
-----
-
-The ambiguity of components of the GraphSON is now removed by the `@class` property, which contains Java class
-information for the data it is associated with.  The `@class` property is used for all non-final types, with the
-exception of a small number of "natural" types (String, Boolean, Integer, and Double) which can be correctly inferred
-from JSON typing.  While the output is more verbose, it comes with the security of not losing type information.  While
-non-JVM languages won't be able to consume this information automatically, at least there is a hint as to how the
-values should be coerced back into the correct types in the target language.
-
-[[graphson-2-0-types]]
-GraphSON 2.0
-++++++++++++
-
-GraphSON 2.0 has been introduced to improve the format of the typed values from GraphSON 1.0. It provides non-Java
-centric types information in a consistent format.
-
-With GraphSON 2.0, types are enabled by default.
-
-The type format is:
-
-* Non typed value - `value`
-* Typed value     - `{"@type":"typeID", "@value":value}`
-
-TypeIDs are composed of 2 parts, a namespace, and a type name, in the format `"namespace:typename"`.
-A namespace gives the possibility for TinkerPop implementors to categorize custom types they may implement
-and avoid collision with existing TinkerPop types. By default, TinkerPop types will have the
-namespace `g`.
-
-GraphSON 2.0 will provide type information for any value that is not `String`, `Boolean`, `Map` or `Collection`.
-TinkerPop includes types for graph elements:
-
-* Vertex - `g:Vertex`
-* Edge - `g:Edge`
-* VertexPropery - `g:VertexProperty`
-* Property - `g:Property`
-* Path - `g:Path`
-* Tree - `g:Tree`
-* Graph - `g:Graph`
-* Metrics - `g:Metrics`
-* TraversalMetrics - `g:TraversalMetrics`
-
-GraphSON 2.0 can also be configured with "extended" types that build on top of the core types in the "g" namespace.
-The extended types are in the "gx" namespace as exposed by `GraphSONXModuleV2d0` and includes additional types like
-mappings to Java's `java.time.*` classes, `BigInteger`, `BigDecimal` and others. This module can be added when building
-a `GraphSONMapper` by calling the `addCustomModule()` method on the `Builder`.
+NOTE: Additional documentation for GraphSON can be found in the link:http://tinkerpop.apache.org/docs/x.y.z/dev/io/#graphson[IO Reference].
 
 IMPORTANT: When using the extended type system in Gremlin Server, support for these types when used in the context of
 Gremlin Language Variants is dependent on the programming language, the driver and its serializers. These
 implementations are only required to support the core types and not the extended ones.
-
-Here's the same previous example of GraphSON 1.0, but with GraphSON 2.0:
-
-[gremlin-groovy]
-----
-graph = TinkerFactory.createModern()
-g = graph.traversal()
-f = new ByteArrayOutputStream()
-mapper = graph.io(graphson()).mapper().version(GraphSONVersion.V2_0).create()
-graph.io(graphson()).writer().mapper(mapper).create().writeVertex(f, g.V(1).next(), BOTH)
-f.close()
-----
-
-Creating a GraphSON 2.0 mapper is done by calling `.version(GraphSONVersion.V2_0)` on the mapper builder. Here's is the
-example output from the code above:
-
-[source, json]
-----
-{
-    "@type": "g:Vertex",
-    "@value": {
-        "id": {
-            "@type": "g:Int32",
-            "@value": 1
-        },
-        "label": "person",
-        "properties": {
-            "name": [{
-                "@type": "g:VertexProperty",
-                "@value": {
-                    "id": {
-                        "@type": "g:Int64",
-                        "@value": 0
-                    },
-                    "value": "marko",
-                    "label": "name"
-                }
-            }],
-            "uuid": [{
-                "@type": "g:VertexProperty",
-                "@value": {
-                    "id": {
-                        "@type": "g:Int64",
-                        "@value": 12
-                    },
-                    "value": {
-                        "@type": "g:UUID",
-                        "@value": "829c7ddb-3831-4687-a872-e25201230cd3"
-                    },
-                    "label": "uuid"
-                }
-            }],
-            "age": [{
-                "@type": "g:VertexProperty",
-                "@value": {
-                    "id": {
-                        "@type": "g:Int64",
-                        "@value": 1
-                    },
-                    "value": {
-                        "@type": "g:Int32",
-                        "@value": 29
-                    },
-                    "label": "age"
-                }
-            }]
-        }
-    }
-}
-----
-
-Types can be disabled when creating a GraphSON 2.0 `Mapper` with:
-
-[source,groovy]
-----
-graph.io(graphson()).mapper().
-      version(GraphSONVersion.V2_0).
-      typeInfo(GraphSONMapper.TypeInfo.NO_TYPES).create()
-----
-
-By disabling types, the JSON payload produced will lack the extra information that is written for types. Please note,
-disabling types can be unsafe with regards to the written data in that types can be lost.
 
 [[gryo-reader-writer]]
 Gryo Reader/Writer
@@ -825,11 +636,13 @@ Kryo supports all of the `GraphReader` and `GraphWriter` interface methods and c
 [source,java]
 ----
 final Graph graph = TinkerFactory.createModern();
-graph.io(IoCore.gryo()).writeGraph("tinkerpop-modern.kryo");
+graph.io(gryo()).writeGraph("tinkerpop-modern.kryo");
 
 final Graph newGraph = TinkerGraph.open();
-newGraph.io(IoCore.gryo()).readGraph("tinkerpop-modern.kryo");
+newGraph.io(gryo()).readGraph("tinkerpop-modern.kryo");
 ----
+
+NOTE: Using `gryo()`, which is a static helper method of `IoCore`, will default to the most current version of Gryo which is 3.0.
 
 If a custom configuration is required, then have the `Graph` generate a `GraphReader` or `GraphWriter` "builder" instance:
 
@@ -837,12 +650,12 @@ If a custom configuration is required, then have the `Graph` generate a `GraphRe
 ----
 final Graph graph = TinkerFactory.createModern();
 try (final OutputStream os = new FileOutputStream("tinkerpop-modern.kryo")) {
-    graph.io(IoCore.gryo()).writer().create().writeGraph(os, graph);
+    graph.io(GryoIo.build(GryoVersion.V1_0)).writer().create().writeGraph(os, graph);
 }
 
 final Graph newGraph = TinkerGraph.open();
 try (final InputStream stream = new FileInputStream("tinkerpop-modern.kryo")) {
-    newGraph.io(IoCore.gryo()).reader().create().readGraph(stream, newGraph);
+    newGraph.io(GryoIo.build(GryoVersion.V1_0)).reader().create().readGraph(stream, newGraph);
 }
 ----
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -22,6 +22,53 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *Gremlin Symphony #40 in G Minor*
 
+TinkerPop 3.3.1
+---------------
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.3.1/CHANGELOG.asciidoc#release-3-3-1[changelog] for a complete list of all the modifications that are part of this release.
+
+Upgrading for Users
+~~~~~~~~~~~~~~~~~~~
+
+IO Defaults
+^^^^^^^^^^^
+
+While 3.3.0 released Gryo 3.0 and GraphSON 3.0 and these versions were defaulted in a number of places, it seems that
+some key defaults were missed. Specifically, calls to `Graph.io(graphson())` and `Graph.io(gryo())` were still using
+the old versions. The defaults have now been changed to ensure 3.0 is properly referenced in those cases.
+
+Upgrading for Providers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+IMPORTANT: It is recommended that providers also review all the upgrade instructions specified for users. Many of the
+changes there may prove important for the provider's implementation.
+
+Graph Database Providers
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+IO Version Check
+++++++++++++++++
+
+In the `Graph.io()` method, providers are to bootstrap the `Io` instance returned with their own custom serializers
+typically provided through a custom `IoRegistry` instance. Prior to this change it was not possible to easily determine
+the version of `Io` that was expected (nor was it especially necessary as TinkerPop didn't have breaking format changes
+between versions). As of 3.3.0 however, there could be IO test incompatibilities for some providers who need to
+register a different `IoRegistry` instance depending on the version the user wants.
+
+To allow for that check, the `Io` interface now has the following method:
+
+[source,java]
+----
+public <V> boolean requiresVersion(final V version);
+----
+
+which allows the graph provider to check if a specific `GryoVersion` or `GraphSONVersion` is required. Using that
+information, the provider could then assign the right `IoRegistry` to match that.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1767[TINKERPOP-1767]
+
 TinkerPop 3.3.0
 ---------------
 

--- a/gremlin-core/api-changes.json
+++ b/gremlin-core/api-changes.json
@@ -1,28 +1,16 @@
-// Example:
-// {
-//   "3.3.0": {
-//      "revapi": {
-//       "ignore": [
-//         {
-//           "code": "java.method.addedToInterface",
-//           "new": "method void org.apache.tinkerpop.gremlin.structure.Graph::solveWorldHunger()",
-//           "justification": "Gremlin became sentient and self-aware. This is what it/she/he did first."
-//         }
-//       ]
-//     }
-//   },
-//   "3.3.1": {
-//     "revapi": {
-//       "ignore": [
-//         {
-//           "code": "java.method.removed",
-//           "old": "method void org.apache.tinkerpop.gremlin.structure.Graph::solveWorldHunger()",
-//           "justification": "Gremlin has a strange sense of humour."
-//         }
-//       ]
-//     }
-//   },
-//   ...
-// }
 {
+  "3.3.1": {
+    "revapi": {
+      "ignore": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method <V> boolean org.apache.tinkerpop.gremlin.structure.io.Io.Builder<I extends org.apache.tinkerpop.gremlin.structure.io.Io>::requiresVersion(V)",
+          "package": "org.apache.tinkerpop.gremlin.structure.io",
+          "classSimpleName": "Builder",
+          "methodName": "requiresVersion",
+          "justification": "Graph providers may run into problems with the test suite if they do not have a way to detect the version and type of IO being requested of them so that they can provide the right version of their IoRegistry instances."
+        }
+      ]
+    }
+  }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/Io.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/Io.java
@@ -103,6 +103,12 @@ public interface Io<R extends GraphReader.ReaderBuilder, W extends GraphWriter.W
         public Builder<? extends Io> graph(final Graph g);
 
         /**
+         * Determines if the version matches the one configured for this builder. Graph providers can use this in
+         * calls to {@link Graph#io(Builder)} to figure out the correct versions of registries to add.
+         */
+        public <V> boolean requiresVersion(final V version);
+
+        /**
          * Providers call this method in the {@link Graph#io(Io.Builder)} method to construct the {@link Io} instance
          * and return the value.  End-users will typically not call this method.
          */

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLIo.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLIo.java
@@ -114,6 +114,16 @@ public final class GraphMLIo implements Io<GraphMLReader.Builder, GraphMLWriter.
             return this;
         }
 
+        /**
+         * GraphML does not have a version and therefore always returns false. This default return also makes sense
+         * because GraphML does not use custom {@link IoRegistry} instances anyway which is the primary reason for
+         * calling this method by a graph provider.
+         */
+        @Override
+        public <V> boolean requiresVersion(final V version) {
+            return false;
+        }
+
         @Override
         public GraphMLIo create() {
             if (null == graph) throw new IllegalArgumentException("The graph argument was not specified");

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONIo.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONIo.java
@@ -95,10 +95,10 @@ public final class GraphSONIo implements Io<GraphSONReader.Builder, GraphSONWrit
     }
 
     /**
-     * Create a new builder using the default version of GraphSON.
+     * Create a new builder using the default version of GraphSON - v3.
      */
     public static Io.Builder<GraphSONIo> build() {
-        return build(GraphSONVersion.V2_0);
+        return build(GraphSONVersion.V3_0);
     }
 
     /**
@@ -128,6 +128,11 @@ public final class GraphSONIo implements Io<GraphSONReader.Builder, GraphSONWrit
         public Io.Builder<GraphSONIo> graph(final Graph g) {
             this.graph = g;
             return this;
+        }
+
+        @Override
+        public <V> boolean requiresVersion(final V version) {
+            return this.version == version;
         }
 
         @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoIo.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoIo.java
@@ -41,10 +41,12 @@ public final class GryoIo implements Io<GryoReader.Builder, GryoWriter.Builder, 
 
     private final Graph graph;
     private Optional<Consumer<Mapper.Builder>> onMapper;
+    private final GryoVersion version;
 
     private GryoIo(final Builder builder) {
         this.graph = builder.graph;
         this.onMapper = Optional.ofNullable(builder.onMapper);
+        this.version = builder.version;
     }
 
     /**
@@ -54,6 +56,7 @@ public final class GryoIo implements Io<GryoReader.Builder, GryoWriter.Builder, 
     public GryoReader.Builder reader() {
         return GryoReader.build().mapper(mapper().create());
     }
+
     /**
      * {@inheritDoc}
      */
@@ -67,7 +70,7 @@ public final class GryoIo implements Io<GryoReader.Builder, GryoWriter.Builder, 
      */
     @Override
     public GryoMapper.Builder mapper() {
-        final GryoMapper.Builder builder = GryoMapper.build();
+        final GryoMapper.Builder builder = GryoMapper.build().version(version);
         onMapper.ifPresent(c -> c.accept(builder));
         return builder;
     }
@@ -92,13 +95,28 @@ public final class GryoIo implements Io<GryoReader.Builder, GryoWriter.Builder, 
         }
     }
 
+    /**
+     * Create a new builder using the default version of Gryo - v3.
+     */
     public static Io.Builder<GryoIo> build() {
-        return new Builder();
+        return build(GryoVersion.V3_0);
+    }
+
+    /**
+     * Create a new builder using the specified version of Gryo.
+     */
+    public static Io.Builder<GryoIo> build(final GryoVersion version) {
+        return new Builder(version);
     }
 
     public final static class Builder implements Io.Builder<GryoIo> {
         private Graph graph;
         private Consumer<Mapper.Builder> onMapper = null;
+        private final GryoVersion version;
+
+        Builder(final GryoVersion version) {
+            this.version = version;
+        }
 
         @Override
         public Io.Builder<? extends Io> onMapper(final Consumer<Mapper.Builder> onMapper) {
@@ -110,6 +128,11 @@ public final class GryoIo implements Io<GryoReader.Builder, GryoWriter.Builder, 
         public Io.Builder<GryoIo> graph(final Graph g) {
             this.graph = g;
             return this;
+        }
+
+        @Override
+        public <V> boolean requiresVersion(final V version) {
+            return this.version == version;
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONTokens;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoReader;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoWriter;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedPath;
@@ -67,11 +68,11 @@ import static org.junit.Assert.fail;
  */
 @RunWith(Enclosed.class)
 public class SerializationTest {
-    public static class GryoTest extends AbstractGremlinTest {
+    public static class GryoV1d0Test extends AbstractGremlinTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeVertexAsDetached() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -91,7 +92,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeEdgeAsDetached() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -110,7 +111,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializePropertyAsDetached() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -128,7 +129,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeVertexPropertyAsDetached() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -147,7 +148,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.CREW)
         public void shouldSerializeVertexPropertyWithPropertiesAsDetached() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -171,7 +172,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializePathAsDetached() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -217,7 +218,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeTraversalMetrics() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -236,7 +237,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeTree() throws Exception {
-            final GryoIo gryoIo = graph.io(GryoIo.build());
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V1_0));
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
@@ -254,14 +255,201 @@ public class SerializationTest {
         }
     }
 
-    public static class GraphSONTest extends AbstractGremlinTest {
+    public static class GryoV3d0Test extends AbstractGremlinTest {
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeVertexAsDetached() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final Vertex v = graph.vertices(convertToVertexId("marko")).next();
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, v);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final Vertex detached = gryoReader.readObject(inputStream, DetachedVertex.class);
+            assertNotNull(detached);
+            assertEquals(v.label(), detached.label());
+            assertEquals(v.id(), detached.id());
+            assertEquals(v.value("name").toString(), detached.value("name"));
+            assertEquals((Integer) v.value("age"), detached.value("age"));
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeEdgeAsDetached() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final Edge e = g.E(convertToEdgeId("marko", "knows", "vadas")).next();
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, e);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final Edge detached = gryoReader.readObject(inputStream, DetachedEdge.class);
+            assertNotNull(detached);
+            assertEquals(e.label(), detached.label());
+            assertEquals(e.id(), detached.id());
+            assertEquals((Double) e.value("weight"), detached.value("weight"));
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializePropertyAsDetached() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final Property property = g.E(convertToEdgeId("marko", "knows", "vadas")).next().property("weight");
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, property);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final Property detached = gryoReader.readObject(inputStream, DetachedProperty.class);
+            assertNotNull(detached);
+            assertEquals(property.key(), detached.key());
+            assertEquals(property.value(), detached.value());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeVertexPropertyAsDetached() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final VertexProperty vertexProperty = graph.vertices(convertToVertexId("marko")).next().property("name");
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, vertexProperty);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final VertexProperty detached = gryoReader.readObject(inputStream, DetachedVertexProperty.class);
+            assertNotNull(detached);
+            assertEquals(vertexProperty.label(), detached.label());
+            assertEquals(vertexProperty.id(), detached.id());
+            assertEquals(vertexProperty.value(), detached.value());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.CREW)
+        public void shouldSerializeVertexPropertyWithPropertiesAsDetached() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final VertexProperty<?> vertexProperty = IteratorUtils.filter(graph.vertices(convertToVertexId("marko")).next().properties("location"), p -> p.value().equals("brussels")).next();
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, vertexProperty);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final VertexProperty<?> detached = gryoReader.readObject(inputStream, DetachedVertexProperty.class);
+
+            assertNotNull(detached);
+            assertEquals(vertexProperty.label(), detached.label());
+            assertEquals(vertexProperty.id(), detached.id());
+            assertEquals(vertexProperty.value(), detached.value());
+            assertEquals(vertexProperty.values("startTime").next(), detached.values("startTime").next());
+            assertEquals(vertexProperty.properties("startTime").next().key(), detached.properties("startTime").next().key());
+            assertEquals(vertexProperty.values("endTime").next(), detached.values("endTime").next());
+            assertEquals(vertexProperty.properties("endTime").next().key(), detached.properties("endTime").next().key());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializePathAsDetached() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final Path p = g.V(convertToVertexId("marko")).as("a").outE().as("b").inV().as("c").path()
+                    .filter(t -> ((Vertex) t.get().objects().get(2)).value("name").equals("lop")).next();
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, p);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final Path detached = gryoReader.readObject(inputStream, DetachedPath.class);
+            assertNotNull(detached);
+            assertEquals(p.labels().size(), detached.labels().size());
+            assertEquals(p.labels().get(0).size(), detached.labels().get(0).size());
+            assertEquals(p.labels().get(1).size(), detached.labels().get(1).size());
+            assertEquals(p.labels().get(2).size(), detached.labels().get(2).size());
+            assertTrue(p.labels().stream().flatMap(Collection::stream).allMatch(detached::hasLabel));
+
+            final Vertex vOut = p.get("a");
+            final Vertex detachedVOut = detached.get("a");
+            assertEquals(vOut.label(), detachedVOut.label());
+            assertEquals(vOut.id(), detachedVOut.id());
+
+            // this is a SimpleTraverser so no properties are present in detachment
+            assertFalse(detachedVOut.properties().hasNext());
+
+            final Edge e = p.get("b");
+            final Edge detachedE = detached.get("b");
+            assertEquals(e.label(), detachedE.label());
+            assertEquals(e.id(), detachedE.id());
+
+            // this is a SimpleTraverser so no properties are present in detachment
+            assertFalse(detachedE.properties().hasNext());
+
+            final Vertex vIn = p.get("c");
+            final Vertex detachedVIn = detached.get("c");
+            assertEquals(vIn.label(), detachedVIn.label());
+            assertEquals(vIn.id(), detachedVIn.id());
+
+            // this is a SimpleTraverser so no properties are present in detachment
+            assertFalse(detachedVIn.properties().hasNext());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeTraversalMetrics() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final TraversalMetrics before = (TraversalMetrics) g.V().both().profile().next();
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, before);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final TraversalMetrics after = gryoReader.readObject(inputStream, TraversalMetrics.class);
+            assertNotNull(after);
+            assertEquals(before.getMetrics().size(), after.getMetrics().size());
+            assertEquals(before.getDuration(TimeUnit.MILLISECONDS), after.getDuration(TimeUnit.MILLISECONDS));
+            assertEquals(before.getMetrics(0).getCounts(), after.getMetrics().stream().findFirst().get().getCounts());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeTree() throws Exception {
+            final GryoIo gryoIo = graph.io(GryoIo.build(GryoVersion.V3_0));
+            final GryoWriter gryoWriter = gryoIo.writer().create();
+            final GryoReader gryoReader = gryoIo.reader().create();
+
+            final Tree before = g.V(convertToVertexId("marko")).out().properties("name").tree().next();
+
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            gryoWriter.writeObject(outputStream, before);
+
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            final Tree after = gryoReader.readObject(inputStream, Tree.class);
+            assertNotNull(after);
+            //The following assertions should be sufficent.
+            assertThat("Type does not match", after, instanceOf(Tree.class));
+            assertEquals("The objects differ", after, before);
+        }
+    }
+
+    public static class GraphSONV1d0Test extends AbstractGremlinTest {
         private final TypeReference<HashMap<String, Object>> mapTypeReference = new TypeReference<HashMap<String, Object>>() {
         };
 
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeVertex() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final Vertex v = graph.vertices(convertToVertexId("marko")).next();
             final String json = mapper.writeValueAsString(v);
             final Map<String, Object> m = mapper.readValue(json, mapTypeReference);
@@ -280,7 +468,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeEdge() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final Edge e = g.E(convertToEdgeId("marko", "knows", "vadas")).next();
             final String json = mapper.writeValueAsString(e);
             final Map<String, Object> m = mapper.readValue(json, mapTypeReference);
@@ -294,7 +482,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeProperty() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final Property p = g.E(convertToEdgeId("marko", "knows", "vadas")).next().property("weight");
             final String json = mapper.writeValueAsString(p);
             final Map<String, Object> m = mapper.readValue(json, mapTypeReference);
@@ -306,7 +494,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeVertexProperty() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final VertexProperty vp = graph.vertices(convertToVertexId("marko")).next().property("name");
             final String json = mapper.writeValueAsString(vp);
             final Map<String, Object> m = mapper.readValue(json, mapTypeReference);
@@ -319,7 +507,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.CREW)
         public void shouldSerializeVertexPropertyWithProperties() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final VertexProperty vp = IteratorUtils.filter(graph.vertices(convertToVertexId("marko")).next().properties("location"), p -> p.value().equals("brussels")).next();
             final String json = mapper.writeValueAsString(vp);
             final Map<String, Object> m = mapper.readValue(json, mapTypeReference);
@@ -334,7 +522,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializePath() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final Path p = g.V(convertToVertexId("marko")).as("a").outE().as("b").inV().as("c").path()
                     .filter(t -> ((Vertex) t.get().objects().get(2)).value("name").equals("lop")).next();
             final String json = mapper.writeValueAsString(p);
@@ -362,7 +550,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeTraversalMetrics() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final TraversalMetrics tm = g.V().both().profile().next();
             final String json = mapper.writeValueAsString(tm);
             final Map<String, Object> m = mapper.readValue(json, mapTypeReference);
@@ -383,7 +571,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeTree() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V1_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().version(GraphSONVersion.V1_0).create().createMapper();
             final Tree t = g.V(convertToVertexId("marko")).out().properties("name").tree().next();
             final String json = mapper.writeValueAsString(t);
             
@@ -442,7 +630,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeVertex() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
             final Vertex v = graph.vertices(convertToVertexId("marko")).next();
             final String json = mapper.writeValueAsString(v);
             final Vertex detached = mapper.readValue(json, Vertex.class);
@@ -457,7 +645,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeEdge() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
             final Edge e = g.E(convertToEdgeId("marko", "knows", "vadas")).next();
             final String json = mapper.writeValueAsString(e);
             final Edge detached = mapper.readValue(json, Edge.class);
@@ -471,7 +659,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeProperty() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
             final Property p = g.E(convertToEdgeId("marko", "knows", "vadas")).next().property("weight");
             final String json = mapper.writeValueAsString(p);
             final Property detached = mapper.readValue(json, Property.class);
@@ -484,7 +672,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeVertexProperty() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
             final VertexProperty vp = graph.vertices(convertToVertexId("marko")).next().property("name");
             final String json = mapper.writeValueAsString(vp);
             final VertexProperty detached = mapper.readValue(json, VertexProperty.class);
@@ -498,7 +686,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.CREW)
         public void shouldSerializeVertexPropertyWithProperties() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
             final VertexProperty vp = IteratorUtils.filter(graph.vertices(convertToVertexId("marko")).next().properties("location"), p -> p.value().equals("brussels")).next();
             final String json = mapper.writeValueAsString(vp);
             final VertexProperty<?> detached = mapper.readValue(json, VertexProperty.class);
@@ -516,7 +704,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializePath() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
             final Path p = g.V(convertToVertexId("marko")).as("a").outE().as("b").inV().as("c").path()
                     .filter(t -> ((Vertex) t.get().objects().get(2)).value("name").equals("lop")).next();
             final String json = mapper.writeValueAsString(p);
@@ -560,7 +748,7 @@ public class SerializationTest {
         @Test
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeTraversalMetrics() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
             final TraversalMetrics before = g.V().both().profile().next();
             final String json = mapper.writeValueAsString(before);
             final TraversalMetrics after = mapper.readValue(json, TraversalMetrics.class);
@@ -588,7 +776,212 @@ public class SerializationTest {
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         @org.junit.Ignore("TINKERPOP-1509")
         public void shouldSerializeTree() throws Exception {
-            final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().version(GraphSONVersion.V2_0).create().createMapper();
+            final Tree t = g.V(convertToVertexId("marko")).out().properties("name").tree().next();
+            final String json = mapper.writeValueAsString(t);
+
+            final HashMap<String, Object> m = (HashMap<String, Object>) mapper.readValue(json, mapTypeReference);
+
+            // Check Structure
+            assertEquals(1, m.size());
+            assertTrue(m.containsKey(convertToVertexId("marko").toString()));
+
+            // Check Structure n+1
+            final HashMap<String, Object> branch = (HashMap<String, Object>) m.get(convertToVertexId("marko").toString());
+            assertEquals(2, branch.size());
+            assertTrue(branch.containsKey(GraphSONTokens.KEY));
+            assertTrue(branch.containsKey(GraphSONTokens.VALUE));
+
+            //Check n+1 key (traversed element)
+            final HashMap<String, Object> branchKey = (HashMap<String, Object>) branch.get(GraphSONTokens.KEY);
+            assertTrue(branchKey.containsKey(GraphSONTokens.ID));
+            assertTrue(branchKey.containsKey(GraphSONTokens.LABEL));
+            assertTrue(branchKey.containsKey(GraphSONTokens.TYPE));
+            assertTrue(branchKey.containsKey(GraphSONTokens.PROPERTIES));
+            assertEquals(convertToVertexId("marko").toString(), branchKey.get(GraphSONTokens.ID).toString());
+            assertEquals("person", branchKey.get(GraphSONTokens.LABEL));
+            assertEquals("vertex", branchKey.get(GraphSONTokens.TYPE));
+            final HashMap<String, List<HashMap<String, Object>>> branchKeyProps = (HashMap<String, List<HashMap<String, Object>>>) branchKey.get(GraphSONTokens.PROPERTIES);
+            assertEquals("marko", branchKeyProps.get("name").get(0).get("value"));
+            assertEquals(29, branchKeyProps.get("age").get(0).get("value"));
+
+            //Check n+1 value (traversed element)
+            final HashMap<String, Object> branchValue = (HashMap<String, Object>) branch.get(GraphSONTokens.VALUE);
+            assertEquals(3, branchValue.size());
+            assertTrue(branchValue.containsKey(convertToVertexId("vadas").toString()));
+            assertTrue(branchValue.containsKey(convertToVertexId("lop").toString()));
+            assertTrue(branchValue.containsKey(convertToVertexId("josh").toString()));
+
+            // Check that vp[] functioned properly
+            final HashMap<String, HashMap<String, Object>> branch2 = (HashMap<String, HashMap<String, Object>>) branchValue.get(convertToVertexId("vadas").toString());
+            assertTrue(branch2.containsKey(GraphSONTokens.KEY));
+            assertTrue(branch2.containsKey(GraphSONTokens.VALUE));
+
+            final Map.Entry entry = branch2.get(GraphSONTokens.VALUE).entrySet().iterator().next();
+            final HashMap<String, HashMap<String, Object>> branch2Prop = (HashMap<String, HashMap<String, Object>>) entry.getValue();
+            assertTrue(branch2Prop.get(GraphSONTokens.KEY).containsKey(GraphSONTokens.ID));
+            assertTrue(branch2Prop.get(GraphSONTokens.KEY).containsKey(GraphSONTokens.VALUE));
+            assertTrue(branch2Prop.get(GraphSONTokens.KEY).containsKey(GraphSONTokens.LABEL));
+            assertEquals("name", branch2Prop.get(GraphSONTokens.KEY).get(GraphSONTokens.LABEL));
+            assertEquals("vadas", branch2Prop.get(GraphSONTokens.KEY).get(GraphSONTokens.VALUE));
+            assertEquals(entry.getKey().toString(), branch2Prop.get(GraphSONTokens.KEY).get(GraphSONTokens.ID).toString());
+        }
+    }
+
+    public static class GraphSONV3d0Test extends AbstractGremlinTest {
+        private final TypeReference<HashMap<String, Object>> mapTypeReference = new TypeReference<HashMap<String, Object>>() {
+        };
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeVertex() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
+            final Vertex v = graph.vertices(convertToVertexId("marko")).next();
+            final String json = mapper.writeValueAsString(v);
+            final Vertex detached = mapper.readValue(json, Vertex.class);
+
+            assertNotNull(detached);
+            assertEquals(v.label(), detached.label());
+            assertEquals(v.id(), detached.id());
+            assertEquals(v.value("name").toString(), detached.value("name"));
+            assertEquals((Integer) v.value("age"), detached.value("age"));
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeEdge() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
+            final Edge e = g.E(convertToEdgeId("marko", "knows", "vadas")).next();
+            final String json = mapper.writeValueAsString(e);
+            final Edge detached = mapper.readValue(json, Edge.class);
+
+            assertNotNull(detached);
+            assertEquals(e.label(), detached.label());
+            assertEquals(e.id(), detached.id());
+            assertEquals((Double) e.value("weight"), detached.value("weight"));
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeProperty() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
+            final Property p = g.E(convertToEdgeId("marko", "knows", "vadas")).next().property("weight");
+            final String json = mapper.writeValueAsString(p);
+            final Property detached = mapper.readValue(json, Property.class);
+
+            assertNotNull(detached);
+            assertEquals(p.key(), detached.key());
+            assertEquals(p.value(), detached.value());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeVertexProperty() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
+            final VertexProperty vp = graph.vertices(convertToVertexId("marko")).next().property("name");
+            final String json = mapper.writeValueAsString(vp);
+            final VertexProperty detached = mapper.readValue(json, VertexProperty.class);
+
+            assertNotNull(detached);
+            assertEquals(vp.label(), detached.label());
+            assertEquals(vp.id(), detached.id());
+            assertEquals(vp.value(), detached.value());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.CREW)
+        public void shouldSerializeVertexPropertyWithProperties() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
+            final VertexProperty vp = IteratorUtils.filter(graph.vertices(convertToVertexId("marko")).next().properties("location"), p -> p.value().equals("brussels")).next();
+            final String json = mapper.writeValueAsString(vp);
+            final VertexProperty<?> detached = mapper.readValue(json, VertexProperty.class);
+
+            assertNotNull(detached);
+            assertEquals(vp.label(), detached.label());
+            assertEquals(vp.id(), detached.id());
+            assertEquals(vp.value(), detached.value());
+            assertEquals(vp.values("startTime").next(), detached.values("startTime").next());
+            assertEquals(((Property) vp.properties("startTime").next()).key(), ((Property) detached.properties("startTime").next()).key());
+            assertEquals(vp.values("endTime").next(), detached.values("endTime").next());
+            assertEquals(((Property) vp.properties("endTime").next()).key(), ((Property) detached.properties("endTime").next()).key());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializePath() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
+            final Path p = g.V(convertToVertexId("marko")).as("a").outE().as("b").inV().as("c").path()
+                    .filter(t -> ((Vertex) t.get().objects().get(2)).value("name").equals("lop")).next();
+            final String json = mapper.writeValueAsString(p);
+            final Path detached = mapper.readValue(json, Path.class);
+
+            assertNotNull(detached);
+            assertEquals(p.labels().size(), detached.labels().size());
+            assertEquals(p.labels().get(0).size(), detached.labels().get(0).size());
+            assertEquals(p.labels().get(1).size(), detached.labels().get(1).size());
+            assertEquals(p.labels().get(2).size(), detached.labels().get(2).size());
+            assertTrue(p.labels().stream().flatMap(Collection::stream).allMatch(detached::hasLabel));
+
+            final Vertex vOut = p.get("a");
+            final Vertex detachedVOut = detached.get("a");
+            assertEquals(vOut.label(), detachedVOut.label());
+            assertEquals(vOut.id(), detachedVOut.id());
+
+            // TODO: dunno GraphSON seems to return properties - will make this more consistent here
+            // this is a SimpleTraverser so no properties are present in detachment
+            //assertFalse(detachedVOut.properties().hasNext());
+
+            final Edge e = p.get("b");
+            final Edge detachedE = detached.get("b");
+            assertEquals(e.label(), detachedE.label());
+            assertEquals(e.id(), detachedE.id());
+
+            // TODO: dunno GraphSON seems to return properties - will make this more consistent here
+            // this is a SimpleTraverser so no properties are present in detachment
+            //assertFalse(detachedE.properties().hasNext());
+
+            final Vertex vIn = p.get("c");
+            final Vertex detachedVIn = detached.get("c");
+            assertEquals(vIn.label(), detachedVIn.label());
+            assertEquals(vIn.id(), detachedVIn.id());
+
+            // TODO: dunno GraphSON seems to return properties - will make this more consistent here
+            // this is a SimpleTraverser so no properties are present in detachment
+            //assertFalse(detachedVIn.properties().hasNext());
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        public void shouldSerializeTraversalMetrics() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
+            final TraversalMetrics before = g.V().both().profile().next();
+            final String json = mapper.writeValueAsString(before);
+            final TraversalMetrics after = mapper.readValue(json, TraversalMetrics.class);
+
+            assertNotNull(after);
+            assertEquals(before.getMetrics().size(), after.getMetrics().size());
+            assertEquals(before.getDuration(TimeUnit.MILLISECONDS), after.getDuration(TimeUnit.MILLISECONDS));
+            assertEquals(before.getMetrics().size(), after.getMetrics().size());
+
+            before.getMetrics().forEach(b -> {
+                final Optional<? extends Metrics> mFromA = after.getMetrics().stream().filter(a -> b.getId().equals(a.getId())).findFirst();
+                if (mFromA.isPresent()) {
+                    final Metrics m = mFromA.get();
+                    assertEquals(b.getAnnotations(), m.getAnnotations());
+                    assertEquals(b.getCounts(), m.getCounts());
+                    assertEquals(b.getName(), m.getName());
+                    assertEquals(b.getDuration(TimeUnit.MILLISECONDS), m.getDuration(TimeUnit.MILLISECONDS));
+                } else {
+                    fail("Metrics were not present after deserialization");
+                }
+            });
+        }
+
+        @Test
+        @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+        @org.junit.Ignore("TINKERPOP-1509")
+        public void shouldSerializeTree() throws Exception {
+            final ObjectMapper mapper = graph.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().version(GraphSONVersion.V3_0).create().createMapper();
             final Tree t = g.V(convertToVertexId("marko")).out().properties("name").tree().next();
             final String json = mapper.writeValueAsString(t);
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoCustomTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoCustomTest.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.TypeInfo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.structure.io.util.CustomId;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -64,20 +65,20 @@ public class IoCustomTest extends AbstractGremlinTest {
 
         return Arrays.asList(new Object[][]{
                 {"graphson-v1-embedded", true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().addCustomModule(moduleV1d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().addCustomModule(moduleV1d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().addCustomModule(moduleV1d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().addCustomModule(moduleV1d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v2-embedded", true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().addCustomModule(moduleV2d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().addCustomModule(moduleV2d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().addCustomModule(moduleV2d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().addCustomModule(moduleV2d0).typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v3", true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().addCustomModule(modulev3d0).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().addCustomModule(modulev3d0).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().addCustomModule(modulev3d0).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().addCustomModule(modulev3d0).create()).create()},
                 {"gryo-v1", true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.gryo()).reader().mapper(g.io(IoCore.gryo()).mapper().version(GryoVersion.V1_0).addCustom(CustomId.class).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.gryo()).writer().mapper(g.io(IoCore.gryo()).mapper().version(GryoVersion.V1_0).addCustom(CustomId.class).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).reader().mapper(g.io(GryoIo.build(GryoVersion.V1_0)).mapper().version(GryoVersion.V1_0).addCustom(CustomId.class).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).writer().mapper(g.io(GryoIo.build(GryoVersion.V1_0)).mapper().version(GryoVersion.V1_0).addCustom(CustomId.class).create()).create()},
                 {"gryo-v3", true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.gryo()).reader().mapper(g.io(IoCore.gryo()).mapper().version(GryoVersion.V3_0).addCustom(CustomId.class).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.gryo()).writer().mapper(g.io(IoCore.gryo()).mapper().version(GryoVersion.V3_0).addCustom(CustomId.class).create()).create()}
+                        (Function<Graph, GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).reader().mapper(g.io(GryoIo.build(GryoVersion.V3_0)).mapper().version(GryoVersion.V3_0).addCustom(CustomId.class).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).writer().mapper(g.io(GryoIo.build(GryoVersion.V3_0)).mapper().version(GryoVersion.V3_0).addCustom(CustomId.class).create()).create()}
         });
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoEdgeTest.java
@@ -27,6 +27,8 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.TypeInfo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
@@ -55,23 +57,26 @@ public class IoEdgeTest extends AbstractGremlinTest {
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {"graphson-v1", false, false,
-                        (Function<Graph,GraphReader>) g -> g.io(IoCore.graphson()).reader().create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().create()},
+                        (Function<Graph,GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().create()},
                 {"graphson-v1-embedded", true, true,
-                        (Function<Graph,GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph,GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v2", false, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create()},
                 {"graphson-v2-embedded", true, true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v3", true, true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create()},
-                {"gryo", true, true,
-                        (Function<Graph,GraphReader>) g -> g.io(IoCore.gryo()).reader().create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.gryo()).writer().create()}
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create()},
+                {"gryo-v1", true, true,
+                        (Function<Graph,GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).writer().create()},
+                {"gryo-v3", true, true,
+                        (Function<Graph,GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).writer().create()}
         });
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoGraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoGraphTest.java
@@ -26,6 +26,8 @@ import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,10 +53,11 @@ public class IoGraphTest extends AbstractGremlinTest {
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {"graphml", IoCore.graphml(), false, true, ".xml"},
-                {"graphsonv1d0", IoCore.graphson(), true, true, ".json"},
+                {"graphsonv1d0", GraphSONIo.build(GraphSONVersion.V1_0), true, true, ".json"},
                 {"graphsonv2d0", GraphSONIo.build(GraphSONVersion.V2_0), true, true, ".json"},
                 {"graphsonv3d0", GraphSONIo.build(GraphSONVersion.V3_0), true, true, ".json"},
-                {"gryo", IoCore.gryo(), false, false, ".kryo"}
+                {"gryo-v3", GryoIo.build(GryoVersion.V1_0), false, false, ".kryo"},
+                {"gryo-v3", GryoIo.build(GryoVersion.V3_0), false, false, ".kryo"}
         });
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoPropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoPropertyTest.java
@@ -28,6 +28,8 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.TypeInfo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,23 +54,26 @@ public class IoPropertyTest extends AbstractGremlinTest {
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {"graphson-v1", false, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().create()},
                 {"graphson-v1-embedded", true, true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).reader().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v2", false, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create()},
                 {"graphson-v2-embedded", true, true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v3", true, true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create()},
-                {"gryo", true, true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.gryo()).reader().create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.gryo()).writer().create()}
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create()},
+                {"gryo-v1", true, true,
+                        (Function<Graph, GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).writer().create()},
+                {"gryo-v3", true, true,
+                        (Function<Graph, GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).writer().create()}
         });
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoVertexTest.java
@@ -32,6 +32,8 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.TypeInfo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.VertexByteArrayInputStream;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -72,23 +74,26 @@ public class IoVertexTest extends AbstractGremlinTest {
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {"graphson-v1", false, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().create()},
                 {"graphson-v1-embedded", true, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(IoCore.graphson()).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V1_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V1_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v2", false, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.NO_TYPES).create()).create()},
                 {"graphson-v2-embedded", true, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V2_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V2_0)).mapper().typeInfo(TypeInfo.PARTIAL_TYPES).create()).create()},
                 {"graphson-v3", true, false,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.graphson()).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.graphson()).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create()},
-                {"gryo", true, true,
-                        (Function<Graph, GraphReader>) g -> g.io(IoCore.gryo()).reader().create(),
-                        (Function<Graph, GraphWriter>) g -> g.io(IoCore.gryo()).writer().create()}
+                        (Function<Graph, GraphReader>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).reader().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GraphSONIo.build(GraphSONVersion.V3_0)).writer().mapper(g.io(GraphSONIo.build(GraphSONVersion.V3_0)).mapper().create()).create()},
+                {"gryo-v1", true, true,
+                        (Function<Graph, GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V1_0)).writer().create()},
+                {"gryo-v3", true, true,
+                        (Function<Graph, GraphReader>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).reader().create(),
+                        (Function<Graph, GraphWriter>) g -> g.io(GryoIo.build(GryoVersion.V3_0)).writer().create()}
         });
     }
 

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -30,6 +30,8 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.io.IoCore;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
@@ -195,7 +197,12 @@ public final class TinkerGraph implements Graph {
 
     @Override
     public <I extends Io> I io(final Io.Builder<I> builder) {
-        return (I) builder.graph(this).onMapper(mapper -> mapper.addRegistry(TinkerIoRegistryV3d0.instance())).create();
+        if (builder.requiresVersion(GryoVersion.V1_0) || builder.requiresVersion(GraphSONVersion.V1_0))
+            return (I) builder.graph(this).onMapper(mapper -> mapper.addRegistry(TinkerIoRegistryV1d0.instance())).create();
+        else if (builder.requiresVersion(GraphSONVersion.V2_0))   // there is no gryo v2
+            return (I) builder.graph(this).onMapper(mapper -> mapper.addRegistry(TinkerIoRegistryV2d0.instance())).create();
+        else
+            return (I) builder.graph(this).onMapper(mapper -> mapper.addRegistry(TinkerIoRegistryV3d0.instance())).create();
     }
 
     @Override

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -697,5 +697,10 @@ public class TinkerGraphTest {
             calledCreate++;
             return mock(Io.class);
         }
+
+        @Override
+        public boolean requiresVersion(final Object version) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1767

Allows the graph provider to determine type and version of the Io being constructed so that they can properly choose the right IoRegistry to assign. Also set the defaults for GraphSON and Gryo to 3.0 when doing `graph.io()` (should have been done for 3.3.0 unfortunately).

All tests pass with `docker/build.sh -t -n -i`

VOTE +1