### PR TITLE
TINKERPOP-1768 Bump to Jackson 2.8.10

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Bump to Jackson 2.8.10.
 * The Console's `plugin.txt` file is only updated if there were manually uninstalled plugins.
 * Fixed a bug in `MatchStep` where mid-traversal `where()` variables were not being considered in start-scope.
 * Generalized `MatchStep` to locally compute all clauses with barriers (not just reducing barriers).

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <!-- Update the shade plugin config whenever you change this version -->
-            <version>2.8.7</version>
+            <version>2.8.10</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1768

Adds some key bug fixes.

All tests pass with `docker/build.sh -t -n -i` for both tp32 and master

VOTE +1