### PR TITLE
TINKERPOP-1761: Cancel script evaluation timeout

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fixed a bug in `Neo4jGremlinPlugin` that prevented it from loading properly in the `GremlinPythonScriptEngine`.
 * Fixed a bug in `ComputerVerificationStrategy` where child traversals were being analyzed prior to compilation.
 * Fixed a bug that prevented Gremlin from ordering lists and streams made of mixed number types.
+* Cancel script evaluation timeout in `GremlinExecutor` when script evaluation finished.
 
 [[release-3-2-6]]
 TinkerPop 3.2.6 (Release Date: August 21, 2017)

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
@@ -418,6 +418,19 @@ public class GremlinExecutorTest {
     }
 
     @Test
+    public void shouldCancelTimeoutOnSuccessfulEval() throws Exception {
+        final long scriptEvaluationTimeout = 5_000;
+        final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
+                .scriptEvaluationTimeout(scriptEvaluationTimeout)
+                .create();
+
+        final long now = System.currentTimeMillis();
+        assertEquals(2, gremlinExecutor.eval("1+1").get());
+        gremlinExecutor.close();
+        assertTrue(System.currentTimeMillis() - now < scriptEvaluationTimeout);
+    }
+
+    @Test
     public void shouldEvalInMultipleThreads() throws Exception {
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build().create();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1761

I basically added the code again which was wrongly removed in TINKERPOP-1714, plus added a test. All unit tests passed and I confirmed manually that this fixes the issue I experienced.