### PR TITLE
TINKERPOP-1746: Better error message on wrong ordering of emit()/until()/has()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added better error message for illegal use of `repeat()`-step.
 * Bump to Jackson 2.8.10.
 * Added an `EmbeddedRemoteConnection` so that it's possible to mimic a remote connection within the same JVM.
 * The Console's `plugin.txt` file is only updated if there were manually uninstalled plugins.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
@@ -91,8 +91,6 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
     }
 
     public Traversal.Admin<S, S> getRepeatTraversal() {
-        if(null == this.repeatTraversal)
-            throw new IllegalStateException("The repeat()-traversal was not defined: " + this);
         return this.repeatTraversal;
     }
 
@@ -183,7 +181,7 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
 
     @Override
     protected Iterator<Traverser.Admin<S>> standardAlgorithm() throws NoSuchElementException {
-        if(null == this.repeatTraversal)
+        if (null == this.repeatTraversal)
             throw new IllegalStateException("The repeat()-traversal was not defined: " + this);
 
         while (true) {
@@ -207,7 +205,7 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
 
     @Override
     protected Iterator<Traverser.Admin<S>> computerAlgorithm() throws NoSuchElementException {
-        if(null == this.repeatTraversal)
+        if (null == this.repeatTraversal)
             throw new IllegalStateException("The repeat()-traversal was not defined: " + this);
 
         final Traverser.Admin<S> start = this.starts.next();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
@@ -91,6 +91,8 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
     }
 
     public Traversal.Admin<S, S> getRepeatTraversal() {
+        if(null == this.repeatTraversal)
+            throw new IllegalStateException("The repeat()-traversal was not defined: " + this);
         return this.repeatTraversal;
     }
 
@@ -181,6 +183,9 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
 
     @Override
     protected Iterator<Traverser.Admin<S>> standardAlgorithm() throws NoSuchElementException {
+        if(null == this.repeatTraversal)
+            throw new IllegalStateException("The repeat()-traversal was not defined: " + this);
+
         while (true) {
             if (this.repeatTraversal.getEndStep().hasNext()) {
                 return this.repeatTraversal.getEndStep();
@@ -202,6 +207,9 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
 
     @Override
     protected Iterator<Traverser.Admin<S>> computerAlgorithm() throws NoSuchElementException {
+        if(null == this.repeatTraversal)
+            throw new IllegalStateException("The repeat()-traversal was not defined: " + this);
+
         final Traverser.Admin<S> start = this.starts.next();
         if (doUntil(start, true)) {
             start.resetLoops();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RepeatUnrollStrategy.java
@@ -56,7 +56,7 @@ public final class RepeatUnrollStrategy extends AbstractTraversalStrategy<Traver
         for (int i = 0; i < traversal.getSteps().size(); i++) {
             if (traversal.getSteps().get(i) instanceof RepeatStep) {
                 final RepeatStep<?> repeatStep = (RepeatStep) traversal.getSteps().get(i);
-                if (null == repeatStep.getEmitTraversal() &&
+                if (null == repeatStep.getEmitTraversal() && null != repeatStep.getRepeatTraversal() &&
                         repeatStep.getUntilTraversal() instanceof LoopTraversal && ((LoopTraversal) repeatStep.getUntilTraversal()).getMaxLoops() > 0 &&
                         !TraversalHelper.hasStepOfAssignableClassRecursively(Scope.global, DedupGlobalStep.class, repeatStep.getRepeatTraversal()) &&
                         !TraversalHelper.hasStepOfAssignableClassRecursively(INVALIDATING_STEPS, repeatStep.getRepeatTraversal())) {


### PR DESCRIPTION
Simply added a proper error message when `repeatTraversal` is null. This provides a better user experience than `NullPointerException`.

VOTE +1