### PR TITLE
TINKERPOP-1752: Gremlin.Net: Generate completely type-safe methods

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -470,7 +470,7 @@ g = g.WithStrategies(new SubgraphStrategy(vertexCriterion: HasLabel("person"),
     edgeCriterion: Has("weight", Gt(0.5))));
 var names = g.V().Values("name").ToList();  // names: [marko, vadas, josh, peter]
 
-g = g.WithoutStrategies(new SubgraphStrategy());
+g = g.WithoutStrategies(typeof(SubgraphStrategy));
 names = g.V().Values("name").ToList(); // names: [marko, vadas, lop, josh, ripple, peter]
 
 var edgeValueMaps = g.V().OutE().ValueMap(true).ToList();

--- a/gremlin-dotnet/glv/AnonymousTraversal.template
+++ b/gremlin-dotnet/glv/AnonymousTraversal.template
@@ -43,9 +43,16 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the <%= method.methodName %> step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, <%= method.t2 %>> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(params object[] args)
+        public static GraphTraversal<object, <%= method.t2 %>> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(<%= method.parameters %>)
         {
-            return new GraphTraversal<object, object>().<%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(args);
+        <%  if (method.parameters.contains("params ")) {
+      %>    return <%= method.paramNames.last() %>.Length == 0
+                ? new GraphTraversal<object, <%= method.graphTraversalT2 %>>().<%= toCSharpMethodName.call(method.methodName) %><%= method.callGenericTypeArg %>(<%= method.paramNames.init().join(", ") %>)
+                : new GraphTraversal<object, <%= method.graphTraversalT2 %>>().<%= toCSharpMethodName.call(method.methodName) %><%= method.callGenericTypeArg %>(<%= method.paramNames.join(", ") %>);<%
+            }
+            else {
+      %>    return new GraphTraversal<object, <%= method.graphTraversalT2 %>>().<%= toCSharpMethodName.call(method.methodName) %><%= method.callGenericTypeArg %>(<%= method.paramNames.join(", ") %>);<%
+            } %>            
         }
 <% } %>
     }

--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -65,9 +65,17 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the <%= method.methodName %> step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< <%= method.t1 %> , <%= method.t2 %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (params object[] args)
+        public GraphTraversal< <%= method.t1 %> , <%= method.t2 %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
         {
-            Bytecode.AddStep("<%= method.methodName %>", args);
+        <%  if (method.parameters.contains("params ")) {
+      %>    var args = new List<object> {<%= method.paramNames.init().join(", ") %>};
+            args.AddRange(<%= method.paramNames.last() %>);
+            Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
+            }
+            else {
+      %>    Bytecode.AddStep("<%= method.methodName %>"<% if (method.parameters) out << ', '+ method.paramNames.join(", ") %>);<%
+            }
+        %>
             return Wrap< <%= method.t1 %> , <%= method.t2 %> >(this);
         }
 <% } %>

--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -68,7 +68,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< <%= method.t1 %> , <%= method.t2 %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
         {
         <%  if (method.parameters.contains("params ")) {
-      %>    var args = new List<object> {<%= method.paramNames.init().join(", ") %>};
+      %>    var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -72,11 +72,19 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 <% sourceStepMethods.each{ method -> %>
-        public GraphTraversalSource <%= toCSharpMethodName.call(method) %>(params object[] args)
+        public GraphTraversalSource <%= toCSharpMethodName.call(method.methodName) %>(<%= method.parameters %>)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            source.Bytecode.AddSource("<%= method %>", args);
+            <%  if (method.parameters.contains("params ")) {
+          %>var args = new List<object> {<%= method.paramNames.init().join(", ") %>};
+            args.AddRange(<%= method.paramNames.last() %>);
+            source.Bytecode.AddSource("<%= method.methodName %>", args.ToArray());<%
+            }
+            else {
+          %>source.Bytecode.AddSource("<%= method.methodName %>"<% if (method.parameters) out << ', '+ method.paramNames.join(", ") %>);<%
+            }
+        %>
             return source;
         }
 <% } %>
@@ -119,10 +127,18 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the <%= method.methodName %> step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< <%= method.typeArguments.join(",") %> > <%= toCSharpMethodName.call(method.methodName) %>(params object[] args)
+        public GraphTraversal< <%= method.typeArguments.join(",") %> > <%= toCSharpMethodName.call(method.methodName) %>(<%= method.parameters %>)
         {
             var traversal = new GraphTraversal< <%= method.typeArguments.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));
-            traversal.Bytecode.AddStep("<%= method.methodName %>", args);
+            <%  if (method.parameters.contains("params ")) {
+          %>var args = new List<object> {<%= method.paramNames.init().join(", ") %>};
+            args.AddRange(<%= method.paramNames.last() %>);
+            traversal.Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
+            }
+            else {
+      %>    traversal.Bytecode.AddStep("<%= method.methodName %>"<% if (method.parameters) out << ', '+ method.paramNames.join(", ") %>);<%
+            }
+        %>
             return traversal;
         }
 <% } %>

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -77,7 +77,7 @@ namespace Gremlin.Net.Process.Traversal
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
             <%  if (method.parameters.contains("params ")) {
-          %>var args = new List<object> {<%= method.paramNames.init().join(", ") %>};
+          %>var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             source.Bytecode.AddSource("<%= method.methodName %>", args.ToArray());<%
             }
@@ -131,7 +131,7 @@ namespace Gremlin.Net.Process.Traversal
         {
             var traversal = new GraphTraversal< <%= method.typeArguments.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));
             <%  if (method.parameters.contains("params ")) {
-          %>var args = new List<object> {<%= method.paramNames.init().join(", ") %>};
+          %>var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             traversal.Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -29,15 +29,35 @@ import java.lang.reflect.Modifier
 def toCSharpTypeMap = ["Long": "long",
                        "Integer": "int",
                        "String": "string",
+                       "boolean": "bool",
                        "Object": "object",
+                       "String[]": "string[]",
+                       "Object[]": "object[]",
+                       "Class": "Type",
+                       "Class[]": "Type[]",
                        "java.util.Map<java.lang.String, E2>": "IDictionary<string, E2>",
                        "java.util.Map<java.lang.String, B>": "IDictionary<string, E2>",
                        "java.util.List<E>": "IList<E>",
+                       "java.util.List<A>": "IList<E2>",
                        "java.util.Map<K, V>": "IDictionary<K, V>",
                        "java.util.Collection<E2>": "ICollection<E2>",
                        "java.util.Collection<B>": "ICollection<E2>",
                        "java.util.Map<K, java.lang.Long>": "IDictionary<K, long>",
-                       "TraversalMetrics": "E2"]
+                       "TraversalMetrics": "E2",
+                       "Traversal": "ITraversal",
+                       "Traversal[]": "ITraversal[]",
+                       "Predicate": "TraversalPredicate",
+                       "P": "TraversalPredicate",
+                       "TraversalStrategy": "ITraversalStrategy",
+                       "TraversalStrategy[]": "ITraversalStrategy[]",
+                       "Function": "object",
+                       "BiFunction": "object",
+                       "UnaryOperator": "object",
+                       "BinaryOperator": "object",
+                       "Consumer": "object",
+                       "Supplier": "object",
+                       "Comparator": "object",
+                       "VertexProgram": "object"]
 
 def useE2 = ["E2", "E2"];
 def methodsWithSpecificTypes = ["constant": useE2,
@@ -45,11 +65,9 @@ def methodsWithSpecificTypes = ["constant": useE2,
                                 "mean": useE2,
                                 "optional": useE2,
                                 "range": useE2,
-                                "select": ["IDictionary<string, E2>", "E2"],
                                 "sum": useE2,
                                 "tail": useE2,
-                                "tree": ["object"],
-                                "unfold": useE2]
+                                "unfold": useE2]                                                        
 
 def getCSharpGenericTypeParam = { typeName ->
     def tParam = ""
@@ -75,7 +93,7 @@ def toCSharpType = { name ->
 
 def toCSharpMethodName = { symbol -> (String) Character.toUpperCase(symbol.charAt(0)) + symbol.substring(1) }
 
-def getJavaParameterTypeNames = { method ->
+def getJavaGenericTypeParameterTypeNames = { method ->
     def typeArguments = method.genericReturnType.actualTypeArguments;
     return typeArguments.
             collect { (it instanceof Class) ? ((Class)it).simpleName : it.typeName }.
@@ -90,6 +108,89 @@ def getJavaParameterTypeNames = { method ->
             }
 }
 
+def getJavaParameterTypeNames = { method ->
+    return method.parameters.
+            collect { param ->
+                param.type.simpleName
+            } 
+}
+
+def toCSharpParamString = { param ->
+    csharpParamTypeName = toCSharpType(param.type.simpleName)
+    "${csharpParamTypeName} ${param.name}"
+    }
+
+def getJavaParamTypeString = { method ->
+    getJavaParameterTypeNames(method).join(",")
+}
+
+def getCSharpParamTypeString = { method ->
+    return method.parameters.
+            collect { param ->
+                toCSharpType(param.type.simpleName)
+            }.join(",")
+}
+
+def getCSharpParamString = { method ->
+    def parameters = method.parameters;
+    if (parameters.length == 0)
+        return ""        
+    def csharpParameters = parameters.
+            init().
+            collect { param ->
+                toCSharpParamString(param)
+            };
+    def lastCSharpParam = "";
+    if (method.isVarArgs())
+        lastCSharpParam += "params ";
+    lastCSharpParam += toCSharpParamString(parameters.last())
+    csharpParameters += lastCSharpParam
+    csharpParamString = csharpParameters.join(", ")
+    csharpParamString
+}
+
+def getParamNames = { parameters ->
+    return parameters.
+        collect { param ->
+            param.name
+        }
+}
+
+def hasMethodNoGenericCounterPartInGraphTraversal = { method ->
+    def parameterTypeNames = getJavaParameterTypeNames(method)
+    if (method.name.equals("fold")) {
+        return parameterTypeNames.size() == 0
+    }
+    if (method.name.equals("limit")) {
+        if (parameterTypeNames.size() == 1) {
+            return parameterTypeNames[0].equals("long")
+        }
+    }
+    if (method.name.equals("range")) {
+        if (parameterTypeNames.size() == 2) {
+            return parameterTypeNames[0].equals("long") && parameterTypeNames[1].equals("long")
+        }
+    }
+    if (method.name.equals("tail")) {
+        if (parameterTypeNames.size() == 0) {
+            return true
+        }
+        if (parameterTypeNames.size() == 1) {
+            return parameterTypeNames[0].equals("long")
+        }
+    }
+    return false
+}
+
+def t2withSpecialGraphTraversalt2 = ["IList<E2>": "E2"]
+
+def getGraphTraversalT2ForT2 = { t2 ->
+    if (t2withSpecialGraphTraversalt2.containsKey(t2)) {
+        return t2withSpecialGraphTraversalt2.get(t2)
+    }
+    return t2
+}
+
 def binding = ["pmethods": P.class.getMethods().
         findAll { Modifier.isStatic(it.getModifiers()) }.
         findAll { P.class.isAssignableFrom(it.returnType) }.
@@ -97,54 +198,69 @@ def binding = ["pmethods": P.class.getMethods().
         unique().
         sort { a, b -> a <=> b },
                "sourceStepMethods": GraphTraversalSource.getMethods(). // SOURCE STEPS
-                       findAll { GraphTraversalSource.class.equals(it.returnType) }.
-                       findAll {
-                           !it.name.equals("clone") &&
-                                   !it.name.equals(TraversalSource.Symbols.withBindings) &&
-                                   !it.name.equals(TraversalSource.Symbols.withRemote) &&
-                                   !it.name.equals(TraversalSource.Symbols.withComputer)
-                       }.
-                       collect { it.name }.
-                       unique().
-                       sort { a, b -> a <=> b },
+                        findAll { GraphTraversalSource.class.equals(it.returnType) }.
+                        findAll {
+                            !it.name.equals("clone") &&
+                                    !it.name.equals(TraversalSource.Symbols.withBindings) &&
+                                    !it.name.equals(TraversalSource.Symbols.withRemote) &&
+                                    !it.name.equals(TraversalSource.Symbols.withComputer)
+                        }.
+                // Select unique combination of C# parameter types and sort by Java parameter type combination
+                        sort { a, b -> a.name <=> b.name ?: getJavaParamTypeString(a) <=> getJavaParamTypeString(b) }.
+                        unique { a,b -> a.name <=> b.name ?: getCSharpParamTypeString(a) <=> getCSharpParamTypeString(b) }.
+                        collect { javaMethod ->
+                            def parameters = getCSharpParamString(javaMethod)
+                            def paramNames = getParamNames(javaMethod.parameters)
+                            return ["methodName": javaMethod.name, "parameters":parameters, "paramNames":paramNames]
+                        },
                "sourceSpawnMethods": GraphTraversalSource.getMethods(). // SPAWN STEPS
-                       findAll { GraphTraversal.class.equals(it.returnType) && !it.name.equals('inject')}.
-                       collect { [methodName: it.name, typeArguments: it.genericReturnType.actualTypeArguments.collect{t -> ((java.lang.Class)t).simpleName}] }.
-                       unique().
-                       sort { a, b -> a.methodName <=> b.methodName },
+                        findAll { GraphTraversal.class.equals(it.returnType) && !it.name.equals('inject')}.          
+                // Select unique combination of C# parameter types and sort by Java parameter type combination                                                                    
+                        sort { a, b -> a.name <=> b.name ?: getJavaParamTypeString(a) <=> getJavaParamTypeString(b) }.
+                        unique { a,b -> a.name <=> b.name ?: getCSharpParamTypeString(a) <=> getCSharpParamTypeString(b) }.
+                        collect { javaMethod ->
+                            def typeArguments = javaMethod.genericReturnType.actualTypeArguments.collect{t -> ((java.lang.Class)t).simpleName}
+                            def parameters = getCSharpParamString(javaMethod)
+                            def paramNames = getParamNames(javaMethod.parameters)
+                            return ["methodName": javaMethod.name, "typeArguments": typeArguments, "parameters":parameters, "paramNames":paramNames]
+                        },
                "graphStepMethods": GraphTraversal.getMethods().
-                       findAll { GraphTraversal.class.equals(it.returnType) }.
-                       findAll { !it.name.equals("clone") && !it.name.equals("iterate") }.
-                       groupBy { it.name }.
-               // Select unique by name, with the most amount of parameters
-                       collect { it.value.sort { a, b -> b.parameterCount <=> a.parameterCount }.first() }.
-                       sort { a, b -> a.name <=> b.name }.
-                       collect { javaMethod ->
-                           def typeNames = getJavaParameterTypeNames(javaMethod)
-                           def t1 = toCSharpType(typeNames[0])
-                           def t2 = toCSharpType(typeNames[1])
-                           def tParam = getCSharpGenericTypeParam(t2)
-                           return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam]
-                       },
+                        findAll { GraphTraversal.class.equals(it.returnType) }.
+                        findAll { !it.name.equals("clone") && !it.name.equals("iterate") }.
+                // Select unique combination of C# parameter types and sort by Java parameter type combination
+                        sort { a, b -> a.name <=> b.name ?: getJavaParamTypeString(a) <=> getJavaParamTypeString(b) }.
+                        unique { a,b -> a.name <=> b.name ?: getCSharpParamTypeString(a) <=> getCSharpParamTypeString(b) }.
+                        collect { javaMethod ->
+                            def typeNames = getJavaGenericTypeParameterTypeNames(javaMethod)
+                            def t1 = toCSharpType(typeNames[0])
+                            def t2 = toCSharpType(typeNames[1])
+                            def tParam = getCSharpGenericTypeParam(t2)
+                            def parameters = getCSharpParamString(javaMethod)
+                            def paramNames = getParamNames(javaMethod.parameters)
+                            return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames]
+                        },
                "anonStepMethods": __.class.getMethods().
-                       findAll { GraphTraversal.class.equals(it.returnType) }.
-                       findAll { Modifier.isStatic(it.getModifiers()) }.
-                       findAll { !it.name.equals("__") && !it.name.equals("start") }.
-                       groupBy { it.name }.
-               // Select unique by name, with the most amount of parameters
-                       collect { it.value.sort { a, b -> b.parameterCount <=> a.parameterCount }.first() }.
-                       sort { it.name }.
-                       collect { javaMethod ->
-                           def typeNames = getJavaParameterTypeNames(javaMethod)
-                           def t2 = toCSharpType(typeNames[1])
-                           def tParam = getCSharpGenericTypeParam(t2)
-                           def specificTypes = methodsWithSpecificTypes.get(javaMethod.name)
-                           if (specificTypes) {
-                               t2 = specificTypes[0]
-                               tParam = specificTypes.size() > 1 ? "<" + specificTypes[1] + ">" : ""
-                           }
-                           return ["methodName": javaMethod.name, "t2":t2, "tParam":tParam]
-                       },
+                        findAll { GraphTraversal.class.equals(it.returnType) }.
+                        findAll { Modifier.isStatic(it.getModifiers()) }.
+                        findAll { !it.name.equals("__") && !it.name.equals("start") }.
+                // Select unique combination of C# parameter types and sort by Java parameter type combination
+                        sort { a, b -> a.name <=> b.name ?: getJavaParamTypeString(a) <=> getJavaParamTypeString(b) }.
+                        unique { a,b -> a.name <=> b.name ?: getCSharpParamTypeString(a) <=> getCSharpParamTypeString(b) }.
+                        collect { javaMethod ->
+                            def typeNames = getJavaGenericTypeParameterTypeNames(javaMethod)
+                            def t2 = toCSharpType(typeNames[1])
+                            def tParam = getCSharpGenericTypeParam(t2)
+                            def specificTypes = methodsWithSpecificTypes.get(javaMethod.name)
+                            if (specificTypes) {
+                                t2 = specificTypes[0]
+                                tParam = specificTypes.size() > 1 ? "<" + specificTypes[1] + ">" : ""
+                            }
+                            def parameters = getCSharpParamString(javaMethod)
+                            def paramNames = getParamNames(javaMethod.parameters)
+                            def callGenericTypeArg = hasMethodNoGenericCounterPartInGraphTraversal(javaMethod) ? "" : tParam
+                            def graphTraversalT2 = getGraphTraversalT2ForT2(t2)
+                            return ["methodName": javaMethod.name, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "callGenericTypeArg":callGenericTypeArg, "graphTraversalT2":graphTraversalT2]
+                        },
                "toCSharpMethodName": toCSharpMethodName]
 
 def engine = new groovy.text.GStringTemplateEngine()
@@ -176,12 +292,12 @@ def toCSharpName = { enumClass, itemName ->
 def createEnum = { enumClass, csharpToJava ->
     def b = ["enumClass": enumClass,
              "constants": enumClass.getEnumConstants().
-                     sort { a, b -> a.name() <=> b.name() }.
-                     collect { value ->
-                         def csharpName = toCSharpName(enumClass, value.name())
-                         csharpToJava.put(enumClass.simpleName + "." + csharpName, value.name())
-                         return csharpName
-                     }.join(",\n\t\t")]
+                    sort { a, b -> a.name() <=> b.name() }.
+                    collect { value ->
+                        def csharpName = toCSharpName(enumClass, value.name())
+                        csharpToJava.put(enumClass.simpleName + "." + csharpName, value.name())
+                        return csharpName
+                    }.join(",\n\t\t")]
 
     def enumTemplate = engine.createTemplate(new File("${projectBaseDir}/glv/Enum.template")).make(b)
     def enumFile = new File("${projectBaseDir}/src/Gremlin.Net/Process/Traversal/" + enumClass.getSimpleName() + ".cs")

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Bindings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Bindings.cs
@@ -62,7 +62,8 @@ namespace Gremlin.Net.Process.Traversal
             var dict = BoundVariableByValue.Value;
             if (dict == null)
                 return null;
-            return !dict.ContainsKey(value) ? null : dict[value];
+            dict.TryGetValue(value, out var variable);
+            return variable;
         }
 
         internal static void Clear()

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -65,882 +65,1613 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the V step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > V (params object[] args)
+        public GraphTraversal< S , Vertex > V (params object[] vertexIdsOrElements)
         {
-            Bytecode.AddStep("V", args);
+            var args = new List<object> {};
+            args.AddRange(vertexIdsOrElements);
+            Bytecode.AddStep("V", args.ToArray());
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the addE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddE (params object[] args)
+        public GraphTraversal< S , Edge > AddE (Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            Bytecode.AddStep("addE", args);
+            var args = new List<object> {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            args.AddRange(propertyKeyValues);
+            Bytecode.AddStep("addE", args.ToArray());
+            return Wrap< S , Edge >(this);
+        }
+
+        /// <summary>
+        ///     Adds the addE step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , Edge > AddE (string edgeLabel)
+        {
+            Bytecode.AddStep("addE", edgeLabel);
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the addInE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddInE (params object[] args)
+        public GraphTraversal< S , Edge > AddInE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            Bytecode.AddStep("addInE", args);
+            var args = new List<object> {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            args.AddRange(propertyKeyValues);
+            Bytecode.AddStep("addInE", args.ToArray());
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the addOutE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddOutE (params object[] args)
+        public GraphTraversal< S , Edge > AddOutE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            Bytecode.AddStep("addOutE", args);
+            var args = new List<object> {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            args.AddRange(propertyKeyValues);
+            Bytecode.AddStep("addOutE", args.ToArray());
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > AddV (params object[] args)
+        public GraphTraversal< S , Vertex > AddV ()
         {
-            Bytecode.AddStep("addV", args);
+            Bytecode.AddStep("addV");
+            return Wrap< S , Vertex >(this);
+        }
+
+        /// <summary>
+        ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , Vertex > AddV (params object[] propertyKeyValues)
+        {
+            var args = new List<object> {};
+            args.AddRange(propertyKeyValues);
+            Bytecode.AddStep("addV", args.ToArray());
+            return Wrap< S , Vertex >(this);
+        }
+
+        /// <summary>
+        ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , Vertex > AddV (string vertexLabel)
+        {
+            Bytecode.AddStep("addV", vertexLabel);
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the aggregate step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Aggregate (params object[] args)
+        public GraphTraversal< S , E > Aggregate (string sideEffectKey)
         {
-            Bytecode.AddStep("aggregate", args);
+            Bytecode.AddStep("aggregate", sideEffectKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the and step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > And (params object[] args)
+        public GraphTraversal< S , E > And (params ITraversal[] andTraversals)
         {
-            Bytecode.AddStep("and", args);
+            var args = new List<object> {};
+            args.AddRange(andTraversals);
+            Bytecode.AddStep("and", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the as step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > As (params object[] args)
+        public GraphTraversal< S , E > As (string stepLabel, params string[] stepLabels)
         {
-            Bytecode.AddStep("as", args);
+            var args = new List<object> {stepLabel};
+            args.AddRange(stepLabels);
+            Bytecode.AddStep("as", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Barrier (params object[] args)
+        public GraphTraversal< S , E > Barrier ()
         {
-            Bytecode.AddStep("barrier", args);
+            Bytecode.AddStep("barrier");
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Barrier (object barrierConsumer)
+        {
+            Bytecode.AddStep("barrier", barrierConsumer);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Barrier (int maxBarrierSize)
+        {
+            Bytecode.AddStep("barrier", maxBarrierSize);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the both step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > Both (params object[] args)
+        public GraphTraversal< S , Vertex > Both (params string[] edgeLabels)
         {
-            Bytecode.AddStep("both", args);
+            var args = new List<object> {};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("both", args.ToArray());
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the bothE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > BothE (params object[] args)
+        public GraphTraversal< S , Edge > BothE (params string[] edgeLabels)
         {
-            Bytecode.AddStep("bothE", args);
+            var args = new List<object> {};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("bothE", args.ToArray());
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the bothV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > BothV (params object[] args)
+        public GraphTraversal< S , Vertex > BothV ()
         {
-            Bytecode.AddStep("bothV", args);
+            Bytecode.AddStep("bothV");
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the branch step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Branch<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Branch<E2> (object function)
         {
-            Bytecode.AddStep("branch", args);
+            Bytecode.AddStep("branch", function);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the branch step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Branch<E2> (ITraversal branchTraversal)
+        {
+            Bytecode.AddStep("branch", branchTraversal);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (params object[] args)
+        public GraphTraversal< S , E > By ()
         {
-            Bytecode.AddStep("by", args);
+            Bytecode.AddStep("by");
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (object comparator)
+        {
+            Bytecode.AddStep("by", comparator);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (object function, object comparator)
+        {
+            Bytecode.AddStep("by", function, comparator);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (Order order)
+        {
+            Bytecode.AddStep("by", order);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (string key)
+        {
+            Bytecode.AddStep("by", key);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (string key, object comparator)
+        {
+            Bytecode.AddStep("by", key, comparator);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (T token)
+        {
+            Bytecode.AddStep("by", token);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (ITraversal traversal)
+        {
+            Bytecode.AddStep("by", traversal);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > By (ITraversal traversal, object comparator)
+        {
+            Bytecode.AddStep("by", traversal, comparator);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the cap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Cap<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Cap<E2> (string sideEffectKey, params string[] sideEffectKeys)
         {
-            Bytecode.AddStep("cap", args);
+            var args = new List<object> {sideEffectKey};
+            args.AddRange(sideEffectKeys);
+            Bytecode.AddStep("cap", args.ToArray());
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Choose<E2> (object choiceFunction)
         {
-            Bytecode.AddStep("choose", args);
+            Bytecode.AddStep("choose", choiceFunction);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice)
+        {
+            Bytecode.AddStep("choose", choosePredicate, trueChoice);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice, ITraversal falseChoice)
+        {
+            Bytecode.AddStep("choose", choosePredicate, trueChoice, falseChoice);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Choose<E2> (ITraversal choiceTraversal)
+        {
+            Bytecode.AddStep("choose", choiceTraversal);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice)
+        {
+            Bytecode.AddStep("choose", traversalPredicate, trueChoice);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice, ITraversal falseChoice)
+        {
+            Bytecode.AddStep("choose", traversalPredicate, trueChoice, falseChoice);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the coalesce step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Coalesce<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Coalesce<E2> (params ITraversal[] coalesceTraversals)
         {
-            Bytecode.AddStep("coalesce", args);
+            var args = new List<object> {};
+            args.AddRange(coalesceTraversals);
+            Bytecode.AddStep("coalesce", args.ToArray());
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the coin step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Coin (params object[] args)
+        public GraphTraversal< S , E > Coin (double probability)
         {
-            Bytecode.AddStep("coin", args);
+            Bytecode.AddStep("coin", probability);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the constant step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Constant<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Constant<E2> (object e)
         {
-            Bytecode.AddStep("constant", args);
+            Bytecode.AddStep("constant", e);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the count step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , long > Count (params object[] args)
+        public GraphTraversal< S , long > Count ()
         {
-            Bytecode.AddStep("count", args);
+            Bytecode.AddStep("count");
+            return Wrap< S , long >(this);
+        }
+
+        /// <summary>
+        ///     Adds the count step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , long > Count (Scope scope)
+        {
+            Bytecode.AddStep("count", scope);
             return Wrap< S , long >(this);
         }
 
         /// <summary>
         ///     Adds the cyclicPath step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > CyclicPath (params object[] args)
+        public GraphTraversal< S , E > CyclicPath ()
         {
-            Bytecode.AddStep("cyclicPath", args);
+            Bytecode.AddStep("cyclicPath");
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the dedup step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Dedup (params object[] args)
+        public GraphTraversal< S , E > Dedup (Scope scope, params string[] dedupLabels)
         {
-            Bytecode.AddStep("dedup", args);
+            var args = new List<object> {scope};
+            args.AddRange(dedupLabels);
+            Bytecode.AddStep("dedup", args.ToArray());
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the dedup step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Dedup (params string[] dedupLabels)
+        {
+            var args = new List<object> {};
+            args.AddRange(dedupLabels);
+            Bytecode.AddStep("dedup", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the drop step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Drop (params object[] args)
+        public GraphTraversal< S , E > Drop ()
         {
-            Bytecode.AddStep("drop", args);
+            Bytecode.AddStep("drop");
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Emit (params object[] args)
+        public GraphTraversal< S , E > Emit ()
         {
-            Bytecode.AddStep("emit", args);
+            Bytecode.AddStep("emit");
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Emit (TraversalPredicate emitPredicate)
+        {
+            Bytecode.AddStep("emit", emitPredicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Emit (ITraversal emitTraversal)
+        {
+            Bytecode.AddStep("emit", emitTraversal);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the filter step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Filter (params object[] args)
+        public GraphTraversal< S , E > Filter (TraversalPredicate predicate)
         {
-            Bytecode.AddStep("filter", args);
+            Bytecode.AddStep("filter", predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the filter step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Filter (ITraversal filterTraversal)
+        {
+            Bytecode.AddStep("filter", filterTraversal);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the flatMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > FlatMap<E2> (params object[] args)
+        public GraphTraversal< S , E2 > FlatMap<E2> (object function)
         {
-            Bytecode.AddStep("flatMap", args);
+            Bytecode.AddStep("flatMap", function);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the flatMap step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > FlatMap<E2> (ITraversal flatMapTraversal)
+        {
+            Bytecode.AddStep("flatMap", flatMapTraversal);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the fold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Fold<E2> (params object[] args)
+        public GraphTraversal< S , IList<E> > Fold ()
         {
-            Bytecode.AddStep("fold", args);
+            Bytecode.AddStep("fold");
+            return Wrap< S , IList<E> >(this);
+        }
+
+        /// <summary>
+        ///     Adds the fold step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Fold<E2> (object seed, object foldFunction)
+        {
+            Bytecode.AddStep("fold", seed, foldFunction);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the from step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > From (params object[] args)
+        public GraphTraversal< S , E > From (string fromStepLabel)
         {
-            Bytecode.AddStep("from", args);
+            Bytecode.AddStep("from", fromStepLabel);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the from step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > From (ITraversal fromVertex)
+        {
+            Bytecode.AddStep("from", fromVertex);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Group (params object[] args)
+        public GraphTraversal< S , IDictionary<K, V> > Group<K, V> ()
         {
-            Bytecode.AddStep("group", args);
+            Bytecode.AddStep("group");
+            return Wrap< S , IDictionary<K, V> >(this);
+        }
+
+        /// <summary>
+        ///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Group (string sideEffectKey)
+        {
+            Bytecode.AddStep("group", sideEffectKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the groupCount step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > GroupCount (params object[] args)
+        public GraphTraversal< S , IDictionary<K, long> > GroupCount<K> ()
         {
-            Bytecode.AddStep("groupCount", args);
+            Bytecode.AddStep("groupCount");
+            return Wrap< S , IDictionary<K, long> >(this);
+        }
+
+        /// <summary>
+        ///     Adds the groupCount step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > GroupCount (string sideEffectKey)
+        {
+            Bytecode.AddStep("groupCount", sideEffectKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the groupV3d0 step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > GroupV3d0 (params object[] args)
+        public GraphTraversal< S , IDictionary<K, V> > GroupV3d0<K, V> ()
         {
-            Bytecode.AddStep("groupV3d0", args);
+            Bytecode.AddStep("groupV3d0");
+            return Wrap< S , IDictionary<K, V> >(this);
+        }
+
+        /// <summary>
+        ///     Adds the groupV3d0 step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > GroupV3d0 (string sideEffectKey)
+        {
+            Bytecode.AddStep("groupV3d0", sideEffectKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (params object[] args)
+        public GraphTraversal< S , E > Has (string propertyKey)
         {
-            Bytecode.AddStep("has", args);
+            Bytecode.AddStep("has", propertyKey);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (string propertyKey, object value)
+        {
+            Bytecode.AddStep("has", propertyKey, value);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (string propertyKey, TraversalPredicate predicate)
+        {
+            Bytecode.AddStep("has", propertyKey, predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (string label, string propertyKey, object value)
+        {
+            Bytecode.AddStep("has", label, propertyKey, value);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (string label, string propertyKey, TraversalPredicate predicate)
+        {
+            Bytecode.AddStep("has", label, propertyKey, predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (string propertyKey, ITraversal propertyTraversal)
+        {
+            Bytecode.AddStep("has", propertyKey, propertyTraversal);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (T accessor, object value)
+        {
+            Bytecode.AddStep("has", accessor, value);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (T accessor, TraversalPredicate predicate)
+        {
+            Bytecode.AddStep("has", accessor, predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Has (T accessor, ITraversal propertyTraversal)
+        {
+            Bytecode.AddStep("has", accessor, propertyTraversal);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the hasId step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasId (params object[] args)
+        public GraphTraversal< S , E > HasId (object id, params object[] otherIds)
         {
-            Bytecode.AddStep("hasId", args);
+            var args = new List<object> {id};
+            args.AddRange(otherIds);
+            Bytecode.AddStep("hasId", args.ToArray());
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the hasId step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > HasId (TraversalPredicate predicate)
+        {
+            Bytecode.AddStep("hasId", predicate);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the hasKey step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasKey (params object[] args)
+        public GraphTraversal< S , E > HasKey (TraversalPredicate predicate)
         {
-            Bytecode.AddStep("hasKey", args);
+            Bytecode.AddStep("hasKey", predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the hasKey step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > HasKey (string label, params string[] otherLabels)
+        {
+            var args = new List<object> {label};
+            args.AddRange(otherLabels);
+            Bytecode.AddStep("hasKey", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the hasLabel step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasLabel (params object[] args)
+        public GraphTraversal< S , E > HasLabel (TraversalPredicate predicate)
         {
-            Bytecode.AddStep("hasLabel", args);
+            Bytecode.AddStep("hasLabel", predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the hasLabel step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > HasLabel (string label, params string[] otherLabels)
+        {
+            var args = new List<object> {label};
+            args.AddRange(otherLabels);
+            Bytecode.AddStep("hasLabel", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the hasNot step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasNot (params object[] args)
+        public GraphTraversal< S , E > HasNot (string propertyKey)
         {
-            Bytecode.AddStep("hasNot", args);
+            Bytecode.AddStep("hasNot", propertyKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the hasValue step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasValue (params object[] args)
+        public GraphTraversal< S , E > HasValue (object value, params object[] otherValues)
         {
-            Bytecode.AddStep("hasValue", args);
+            var args = new List<object> {value};
+            args.AddRange(otherValues);
+            Bytecode.AddStep("hasValue", args.ToArray());
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the hasValue step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > HasValue (TraversalPredicate predicate)
+        {
+            Bytecode.AddStep("hasValue", predicate);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the id step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , object > Id (params object[] args)
+        public GraphTraversal< S , object > Id ()
         {
-            Bytecode.AddStep("id", args);
+            Bytecode.AddStep("id");
             return Wrap< S , object >(this);
         }
 
         /// <summary>
         ///     Adds the identity step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Identity (params object[] args)
+        public GraphTraversal< S , E > Identity ()
         {
-            Bytecode.AddStep("identity", args);
+            Bytecode.AddStep("identity");
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the in step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > In (params object[] args)
+        public GraphTraversal< S , Vertex > In (params string[] edgeLabels)
         {
-            Bytecode.AddStep("in", args);
+            var args = new List<object> {};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("in", args.ToArray());
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the inE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > InE (params object[] args)
+        public GraphTraversal< S , Edge > InE (params string[] edgeLabels)
         {
-            Bytecode.AddStep("inE", args);
+            var args = new List<object> {};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("inE", args.ToArray());
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the inV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > InV (params object[] args)
+        public GraphTraversal< S , Vertex > InV ()
         {
-            Bytecode.AddStep("inV", args);
+            Bytecode.AddStep("inV");
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the inject step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Inject (params object[] args)
+        public GraphTraversal< S , E > Inject (params object[] injections)
         {
-            Bytecode.AddStep("inject", args);
+            var args = new List<object> {};
+            args.AddRange(injections);
+            Bytecode.AddStep("inject", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the is step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Is (params object[] args)
+        public GraphTraversal< S , E > Is (object value)
         {
-            Bytecode.AddStep("is", args);
+            Bytecode.AddStep("is", value);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the is step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Is (TraversalPredicate predicate)
+        {
+            Bytecode.AddStep("is", predicate);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the key step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , string > Key (params object[] args)
+        public GraphTraversal< S , string > Key ()
         {
-            Bytecode.AddStep("key", args);
+            Bytecode.AddStep("key");
             return Wrap< S , string >(this);
         }
 
         /// <summary>
         ///     Adds the label step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , string > Label (params object[] args)
+        public GraphTraversal< S , string > Label ()
         {
-            Bytecode.AddStep("label", args);
+            Bytecode.AddStep("label");
             return Wrap< S , string >(this);
         }
 
         /// <summary>
         ///     Adds the limit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Limit<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Limit<E2> (Scope scope, long limit)
         {
-            Bytecode.AddStep("limit", args);
+            Bytecode.AddStep("limit", scope, limit);
             return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the limit step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Limit (long limit)
+        {
+            Bytecode.AddStep("limit", limit);
+            return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the local step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Local<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Local<E2> (ITraversal localTraversal)
         {
-            Bytecode.AddStep("local", args);
+            Bytecode.AddStep("local", localTraversal);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the loops step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , int > Loops (params object[] args)
+        public GraphTraversal< S , int > Loops ()
         {
-            Bytecode.AddStep("loops", args);
+            Bytecode.AddStep("loops");
             return Wrap< S , int >(this);
         }
 
         /// <summary>
         ///     Adds the map step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Map<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Map<E2> (object function)
         {
-            Bytecode.AddStep("map", args);
+            Bytecode.AddStep("map", function);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the map step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Map<E2> (ITraversal mapTraversal)
+        {
+            Bytecode.AddStep("map", mapTraversal);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the mapKeys step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > MapKeys<E2> (params object[] args)
+        public GraphTraversal< S , E2 > MapKeys<E2> ()
         {
-            Bytecode.AddStep("mapKeys", args);
+            Bytecode.AddStep("mapKeys");
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the mapValues step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > MapValues<E2> (params object[] args)
+        public GraphTraversal< S , E2 > MapValues<E2> ()
         {
-            Bytecode.AddStep("mapValues", args);
+            Bytecode.AddStep("mapValues");
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the match step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Match<E2> (params object[] args)
+        public GraphTraversal< S , IDictionary<string, E2> > Match<E2> (params ITraversal[] matchTraversals)
         {
-            Bytecode.AddStep("match", args);
+            var args = new List<object> {};
+            args.AddRange(matchTraversals);
+            Bytecode.AddStep("match", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
         /// <summary>
         ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Max<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Max<E2> ()
         {
-            Bytecode.AddStep("max", args);
+            Bytecode.AddStep("max");
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Max<E2> (Scope scope)
+        {
+            Bytecode.AddStep("max", scope);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the mean step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Mean<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Mean<E2> ()
         {
-            Bytecode.AddStep("mean", args);
+            Bytecode.AddStep("mean");
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the mean step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Mean<E2> (Scope scope)
+        {
+            Bytecode.AddStep("mean", scope);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the min step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Min<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Min<E2> ()
         {
-            Bytecode.AddStep("min", args);
+            Bytecode.AddStep("min");
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the min step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Min<E2> (Scope scope)
+        {
+            Bytecode.AddStep("min", scope);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the not step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Not (params object[] args)
+        public GraphTraversal< S , E > Not (ITraversal notTraversal)
         {
-            Bytecode.AddStep("not", args);
+            Bytecode.AddStep("not", notTraversal);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the option step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Option (params object[] args)
+        public GraphTraversal< S , E > Option (object pickToken, ITraversal traversalOption)
         {
-            Bytecode.AddStep("option", args);
+            Bytecode.AddStep("option", pickToken, traversalOption);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the option step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Option (ITraversal traversalOption)
+        {
+            Bytecode.AddStep("option", traversalOption);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the optional step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Optional<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Optional<E2> (ITraversal optionalTraversal)
         {
-            Bytecode.AddStep("optional", args);
+            Bytecode.AddStep("optional", optionalTraversal);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the or step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Or (params object[] args)
+        public GraphTraversal< S , E > Or (params ITraversal[] orTraversals)
         {
-            Bytecode.AddStep("or", args);
+            var args = new List<object> {};
+            args.AddRange(orTraversals);
+            Bytecode.AddStep("or", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the order step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Order (params object[] args)
+        public GraphTraversal< S , E > Order ()
         {
-            Bytecode.AddStep("order", args);
+            Bytecode.AddStep("order");
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the order step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Order (Scope scope)
+        {
+            Bytecode.AddStep("order", scope);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the otherV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > OtherV (params object[] args)
+        public GraphTraversal< S , Vertex > OtherV ()
         {
-            Bytecode.AddStep("otherV", args);
+            Bytecode.AddStep("otherV");
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the out step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > Out (params object[] args)
+        public GraphTraversal< S , Vertex > Out (params string[] edgeLabels)
         {
-            Bytecode.AddStep("out", args);
+            var args = new List<object> {};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("out", args.ToArray());
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the outE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > OutE (params object[] args)
+        public GraphTraversal< S , Edge > OutE (params string[] edgeLabels)
         {
-            Bytecode.AddStep("outE", args);
+            var args = new List<object> {};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("outE", args.ToArray());
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the outV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > OutV (params object[] args)
+        public GraphTraversal< S , Vertex > OutV ()
         {
-            Bytecode.AddStep("outV", args);
+            Bytecode.AddStep("outV");
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the pageRank step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PageRank (params object[] args)
+        public GraphTraversal< S , E > PageRank ()
         {
-            Bytecode.AddStep("pageRank", args);
+            Bytecode.AddStep("pageRank");
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the pageRank step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > PageRank (double alpha)
+        {
+            Bytecode.AddStep("pageRank", alpha);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the path step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Path > Path (params object[] args)
+        public GraphTraversal< S , Path > Path ()
         {
-            Bytecode.AddStep("path", args);
+            Bytecode.AddStep("path");
             return Wrap< S , Path >(this);
         }
 
         /// <summary>
         ///     Adds the peerPressure step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PeerPressure (params object[] args)
+        public GraphTraversal< S , E > PeerPressure ()
         {
-            Bytecode.AddStep("peerPressure", args);
+            Bytecode.AddStep("peerPressure");
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Profile (params object[] args)
+        public GraphTraversal< S , E2 > Profile<E2> ()
         {
-            Bytecode.AddStep("profile", args);
+            Bytecode.AddStep("profile");
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Profile (string sideEffectKey)
+        {
+            Bytecode.AddStep("profile", sideEffectKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the program step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Program (params object[] args)
+        public GraphTraversal< S , E > Program (object vertexProgram)
         {
-            Bytecode.AddStep("program", args);
+            Bytecode.AddStep("program", vertexProgram);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the project step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Project<E2> (params object[] args)
+        public GraphTraversal< S , IDictionary<string, E2> > Project<E2> (string projectKey, params string[] otherProjectKeys)
         {
-            Bytecode.AddStep("project", args);
+            var args = new List<object> {projectKey};
+            args.AddRange(otherProjectKeys);
+            Bytecode.AddStep("project", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
         /// <summary>
         ///     Adds the properties step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Properties<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Properties<E2> (params string[] propertyKeys)
         {
-            Bytecode.AddStep("properties", args);
+            var args = new List<object> {};
+            args.AddRange(propertyKeys);
+            Bytecode.AddStep("properties", args.ToArray());
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the property step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Property (params object[] args)
+        public GraphTraversal< S , E > Property (Cardinality cardinality, object key, object value, params object[] keyValues)
         {
-            Bytecode.AddStep("property", args);
+            var args = new List<object> {cardinality, key, value};
+            args.AddRange(keyValues);
+            Bytecode.AddStep("property", args.ToArray());
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the property step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Property (object key, object value, params object[] keyValues)
+        {
+            var args = new List<object> {key, value};
+            args.AddRange(keyValues);
+            Bytecode.AddStep("property", args.ToArray());
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the propertyMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > PropertyMap<E2> (params object[] args)
+        public GraphTraversal< S , IDictionary<string, E2> > PropertyMap<E2> (params string[] propertyKeys)
         {
-            Bytecode.AddStep("propertyMap", args);
+            var args = new List<object> {};
+            args.AddRange(propertyKeys);
+            Bytecode.AddStep("propertyMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
         /// <summary>
         ///     Adds the range step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Range<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Range<E2> (Scope scope, long low, long high)
         {
-            Bytecode.AddStep("range", args);
+            Bytecode.AddStep("range", scope, low, high);
             return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the range step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Range (long low, long high)
+        {
+            Bytecode.AddStep("range", low, high);
+            return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the repeat step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Repeat (params object[] args)
+        public GraphTraversal< S , E > Repeat (ITraversal repeatTraversal)
         {
-            Bytecode.AddStep("repeat", args);
+            Bytecode.AddStep("repeat", repeatTraversal);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sack (params object[] args)
+        public GraphTraversal< S , E2 > Sack<E2> ()
         {
-            Bytecode.AddStep("sack", args);
+            Bytecode.AddStep("sack");
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Sack (object sackOperator)
+        {
+            Bytecode.AddStep("sack", sackOperator);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Sack (object sackOperator, string elementPropertyKey)
+        {
+            Bytecode.AddStep("sack", sackOperator, elementPropertyKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the sample step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sample (params object[] args)
+        public GraphTraversal< S , E > Sample (Scope scope, int amountToSample)
         {
-            Bytecode.AddStep("sample", args);
+            Bytecode.AddStep("sample", scope, amountToSample);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the sample step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Sample (int amountToSample)
+        {
+            Bytecode.AddStep("sample", amountToSample);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (params object[] args)
+        public GraphTraversal< S , ICollection<E2> > Select<E2> (Column column)
         {
-            Bytecode.AddStep("select", args);
+            Bytecode.AddStep("select", column);
+            return Wrap< S , ICollection<E2> >(this);
+        }
+
+        /// <summary>
+        ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Select<E2> (Pop pop, string selectKey)
+        {
+            Bytecode.AddStep("select", pop, selectKey);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        {
+            var args = new List<object> {pop, selectKey1, selectKey2};
+            args.AddRange(otherSelectKeys);
+            Bytecode.AddStep("select", args.ToArray());
+            return Wrap< S , IDictionary<string, E2> >(this);
+        }
+
+        /// <summary>
+        ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Select<E2> (string selectKey)
+        {
+            Bytecode.AddStep("select", selectKey);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        {
+            var args = new List<object> {selectKey1, selectKey2};
+            args.AddRange(otherSelectKeys);
+            Bytecode.AddStep("select", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
         /// <summary>
         ///     Adds the sideEffect step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SideEffect (params object[] args)
+        public GraphTraversal< S , E > SideEffect (object consumer)
         {
-            Bytecode.AddStep("sideEffect", args);
+            Bytecode.AddStep("sideEffect", consumer);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the sideEffect step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > SideEffect (ITraversal sideEffectTraversal)
+        {
+            Bytecode.AddStep("sideEffect", sideEffectTraversal);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the simplePath step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SimplePath (params object[] args)
+        public GraphTraversal< S , E > SimplePath ()
         {
-            Bytecode.AddStep("simplePath", args);
+            Bytecode.AddStep("simplePath");
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the store step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Store (params object[] args)
+        public GraphTraversal< S , E > Store (string sideEffectKey)
         {
-            Bytecode.AddStep("store", args);
+            Bytecode.AddStep("store", sideEffectKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the subgraph step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > Subgraph (params object[] args)
+        public GraphTraversal< S , Edge > Subgraph (string sideEffectKey)
         {
-            Bytecode.AddStep("subgraph", args);
+            Bytecode.AddStep("subgraph", sideEffectKey);
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the sum step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Sum<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Sum<E2> ()
         {
-            Bytecode.AddStep("sum", args);
+            Bytecode.AddStep("sum");
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the sum step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Sum<E2> (Scope scope)
+        {
+            Bytecode.AddStep("sum", scope);
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Tail<E2> (params object[] args)
+        public GraphTraversal< S , E > Tail ()
         {
-            Bytecode.AddStep("tail", args);
+            Bytecode.AddStep("tail");
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Tail<E2> (Scope scope)
+        {
+            Bytecode.AddStep("tail", scope);
             return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E2 > Tail<E2> (Scope scope, long limit)
+        {
+            Bytecode.AddStep("tail", scope, limit);
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Tail (long limit)
+        {
+            Bytecode.AddStep("tail", limit);
+            return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the timeLimit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > TimeLimit (params object[] args)
+        public GraphTraversal< S , E > TimeLimit (long timeLimit)
         {
-            Bytecode.AddStep("timeLimit", args);
+            Bytecode.AddStep("timeLimit", timeLimit);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the times step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Times (params object[] args)
+        public GraphTraversal< S , E > Times (int maxLoops)
         {
-            Bytecode.AddStep("times", args);
+            Bytecode.AddStep("times", maxLoops);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > To (params object[] args)
+        public GraphTraversal< S , Vertex > To (Direction direction, params string[] edgeLabels)
         {
-            Bytecode.AddStep("to", args);
+            var args = new List<object> {direction};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("to", args.ToArray());
             return Wrap< S , Vertex >(this);
+        }
+
+        /// <summary>
+        ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > To (string toStepLabel)
+        {
+            Bytecode.AddStep("to", toStepLabel);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > To (ITraversal toVertex)
+        {
+            Bytecode.AddStep("to", toVertex);
+            return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the toE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > ToE (params object[] args)
+        public GraphTraversal< S , Edge > ToE (Direction direction, params string[] edgeLabels)
         {
-            Bytecode.AddStep("toE", args);
+            var args = new List<object> {direction};
+            args.AddRange(edgeLabels);
+            Bytecode.AddStep("toE", args.ToArray());
             return Wrap< S , Edge >(this);
         }
 
         /// <summary>
         ///     Adds the toV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > ToV (params object[] args)
+        public GraphTraversal< S , Vertex > ToV (Direction direction)
         {
-            Bytecode.AddStep("toV", args);
+            Bytecode.AddStep("toV", direction);
             return Wrap< S , Vertex >(this);
         }
 
         /// <summary>
         ///     Adds the tree step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Tree (params object[] args)
+        public GraphTraversal< S , E2 > Tree<E2> ()
         {
-            Bytecode.AddStep("tree", args);
+            Bytecode.AddStep("tree");
+            return Wrap< S , E2 >(this);
+        }
+
+        /// <summary>
+        ///     Adds the tree step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Tree (string sideEffectKey)
+        {
+            Bytecode.AddStep("tree", sideEffectKey);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the unfold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Unfold<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Unfold<E2> ()
         {
-            Bytecode.AddStep("unfold", args);
+            Bytecode.AddStep("unfold");
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the union step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Union<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Union<E2> (params ITraversal[] unionTraversals)
         {
-            Bytecode.AddStep("union", args);
+            var args = new List<object> {};
+            args.AddRange(unionTraversals);
+            Bytecode.AddStep("union", args.ToArray());
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the until step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Until (params object[] args)
+        public GraphTraversal< S , E > Until (TraversalPredicate untilPredicate)
         {
-            Bytecode.AddStep("until", args);
+            Bytecode.AddStep("until", untilPredicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the until step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Until (ITraversal untilTraversal)
+        {
+            Bytecode.AddStep("until", untilTraversal);
             return Wrap< S , E >(this);
         }
 
         /// <summary>
         ///     Adds the value step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Value<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Value<E2> ()
         {
-            Bytecode.AddStep("value", args);
+            Bytecode.AddStep("value");
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the valueMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (params object[] args)
+        public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (params string[] propertyKeys)
         {
-            Bytecode.AddStep("valueMap", args);
+            var args = new List<object> {};
+            args.AddRange(propertyKeys);
+            Bytecode.AddStep("valueMap", args.ToArray());
+            return Wrap< S , IDictionary<string, E2> >(this);
+        }
+
+        /// <summary>
+        ///     Adds the valueMap step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (bool includeTokens, params string[] propertyKeys)
+        {
+            var args = new List<object> {includeTokens};
+            args.AddRange(propertyKeys);
+            Bytecode.AddStep("valueMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
         }
 
         /// <summary>
         ///     Adds the values step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Values<E2> (params object[] args)
+        public GraphTraversal< S , E2 > Values<E2> (params string[] propertyKeys)
         {
-            Bytecode.AddStep("values", args);
+            var args = new List<object> {};
+            args.AddRange(propertyKeys);
+            Bytecode.AddStep("values", args.ToArray());
             return Wrap< S , E2 >(this);
         }
 
         /// <summary>
         ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Where (params object[] args)
+        public GraphTraversal< S , E > Where (TraversalPredicate predicate)
         {
-            Bytecode.AddStep("where", args);
+            Bytecode.AddStep("where", predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Where (string startKey, TraversalPredicate predicate)
+        {
+            Bytecode.AddStep("where", startKey, predicate);
+            return Wrap< S , E >(this);
+        }
+
+        /// <summary>
+        ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , E > Where (ITraversal whereTraversal)
+        {
+            Bytecode.AddStep("where", whereTraversal);
             return Wrap< S , E >(this);
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -67,7 +67,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > V (params object[] vertexIdsOrElements)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + vertexIdsOrElements.Length) {};
             args.AddRange(vertexIdsOrElements);
             Bytecode.AddStep("V", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -78,7 +78,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > AddE (Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List<object> {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List<object>(3 + propertyKeyValues.Length) {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -98,7 +98,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > AddInE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List<object> {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addInE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -109,7 +109,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > AddOutE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List<object> {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addOutE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -129,7 +129,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > AddV (params object[] propertyKeyValues)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + propertyKeyValues.Length) {};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addV", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -158,7 +158,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > And (params ITraversal[] andTraversals)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + andTraversals.Length) {};
             args.AddRange(andTraversals);
             Bytecode.AddStep("and", args.ToArray());
             return Wrap< S , E >(this);
@@ -169,7 +169,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > As (string stepLabel, params string[] stepLabels)
         {
-            var args = new List<object> {stepLabel};
+            var args = new List<object>(1 + stepLabels.Length) {stepLabel};
             args.AddRange(stepLabels);
             Bytecode.AddStep("as", args.ToArray());
             return Wrap< S , E >(this);
@@ -207,7 +207,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > Both (params string[] edgeLabels)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("both", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -218,7 +218,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > BothE (params string[] edgeLabels)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("bothE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -337,7 +337,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Cap<E2> (string sideEffectKey, params string[] sideEffectKeys)
         {
-            var args = new List<object> {sideEffectKey};
+            var args = new List<object>(1 + sideEffectKeys.Length) {sideEffectKey};
             args.AddRange(sideEffectKeys);
             Bytecode.AddStep("cap", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -402,7 +402,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Coalesce<E2> (params ITraversal[] coalesceTraversals)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + coalesceTraversals.Length) {};
             args.AddRange(coalesceTraversals);
             Bytecode.AddStep("coalesce", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -458,7 +458,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Dedup (Scope scope, params string[] dedupLabels)
         {
-            var args = new List<object> {scope};
+            var args = new List<object>(1 + dedupLabels.Length) {scope};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
             return Wrap< S , E >(this);
@@ -469,7 +469,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Dedup (params string[] dedupLabels)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + dedupLabels.Length) {};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
             return Wrap< S , E >(this);
@@ -723,7 +723,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasId (object id, params object[] otherIds)
         {
-            var args = new List<object> {id};
+            var args = new List<object>(1 + otherIds.Length) {id};
             args.AddRange(otherIds);
             Bytecode.AddStep("hasId", args.ToArray());
             return Wrap< S , E >(this);
@@ -752,7 +752,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasKey (string label, params string[] otherLabels)
         {
-            var args = new List<object> {label};
+            var args = new List<object>(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasKey", args.ToArray());
             return Wrap< S , E >(this);
@@ -772,7 +772,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasLabel (string label, params string[] otherLabels)
         {
-            var args = new List<object> {label};
+            var args = new List<object>(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasLabel", args.ToArray());
             return Wrap< S , E >(this);
@@ -792,7 +792,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasValue (object value, params object[] otherValues)
         {
-            var args = new List<object> {value};
+            var args = new List<object>(1 + otherValues.Length) {value};
             args.AddRange(otherValues);
             Bytecode.AddStep("hasValue", args.ToArray());
             return Wrap< S , E >(this);
@@ -830,7 +830,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > In (params string[] edgeLabels)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("in", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -841,7 +841,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > InE (params string[] edgeLabels)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("inE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -861,7 +861,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Inject (params object[] injections)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + injections.Length) {};
             args.AddRange(injections);
             Bytecode.AddStep("inject", args.ToArray());
             return Wrap< S , E >(this);
@@ -980,7 +980,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Match<E2> (params ITraversal[] matchTraversals)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + matchTraversals.Length) {};
             args.AddRange(matchTraversals);
             Bytecode.AddStep("match", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1081,7 +1081,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Or (params ITraversal[] orTraversals)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + orTraversals.Length) {};
             args.AddRange(orTraversals);
             Bytecode.AddStep("or", args.ToArray());
             return Wrap< S , E >(this);
@@ -1119,7 +1119,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > Out (params string[] edgeLabels)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("out", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -1130,7 +1130,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > OutE (params string[] edgeLabels)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("outE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -1213,7 +1213,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Project<E2> (string projectKey, params string[] otherProjectKeys)
         {
-            var args = new List<object> {projectKey};
+            var args = new List<object>(1 + otherProjectKeys.Length) {projectKey};
             args.AddRange(otherProjectKeys);
             Bytecode.AddStep("project", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1224,7 +1224,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Properties<E2> (params string[] propertyKeys)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("properties", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -1235,7 +1235,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Property (Cardinality cardinality, object key, object value, params object[] keyValues)
         {
-            var args = new List<object> {cardinality, key, value};
+            var args = new List<object>(3 + keyValues.Length) {cardinality, key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
             return Wrap< S , E >(this);
@@ -1246,7 +1246,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Property (object key, object value, params object[] keyValues)
         {
-            var args = new List<object> {key, value};
+            var args = new List<object>(2 + keyValues.Length) {key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
             return Wrap< S , E >(this);
@@ -1257,7 +1257,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > PropertyMap<E2> (params string[] propertyKeys)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("propertyMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1358,7 +1358,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
-            var args = new List<object> {pop, selectKey1, selectKey2};
+            var args = new List<object>(3 + otherSelectKeys.Length) {pop, selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1378,7 +1378,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
-            var args = new List<object> {selectKey1, selectKey2};
+            var args = new List<object>(2 + otherSelectKeys.Length) {selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1506,7 +1506,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > To (Direction direction, params string[] edgeLabels)
         {
-            var args = new List<object> {direction};
+            var args = new List<object>(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("to", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -1535,7 +1535,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > ToE (Direction direction, params string[] edgeLabels)
         {
-            var args = new List<object> {direction};
+            var args = new List<object>(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("toE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -1582,7 +1582,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Union<E2> (params ITraversal[] unionTraversals)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + unionTraversals.Length) {};
             args.AddRange(unionTraversals);
             Bytecode.AddStep("union", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -1620,7 +1620,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (params string[] propertyKeys)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1631,7 +1631,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (bool includeTokens, params string[] propertyKeys)
         {
-            var args = new List<object> {includeTokens};
+            var args = new List<object>(1 + propertyKeys.Length) {includeTokens};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1642,7 +1642,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Values<E2> (params string[] propertyKeys)
         {
-            var args = new List<object> {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("values", args.ToArray());
             return Wrap< S , E2 >(this);

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -72,51 +72,79 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 
-        public GraphTraversalSource WithBulk(params object[] args)
+        public GraphTraversalSource WithBulk(bool useBulk)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            source.Bytecode.AddSource("withBulk", args);
+            source.Bytecode.AddSource("withBulk", useBulk);
             return source;
         }
 
-        public GraphTraversalSource WithPath(params object[] args)
+        public GraphTraversalSource WithPath()
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            source.Bytecode.AddSource("withPath", args);
+            source.Bytecode.AddSource("withPath");
             return source;
         }
 
-        public GraphTraversalSource WithSack(params object[] args)
+        public GraphTraversalSource WithSack(object initialValue)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            source.Bytecode.AddSource("withSack", args);
+            source.Bytecode.AddSource("withSack", initialValue);
             return source;
         }
 
-        public GraphTraversalSource WithSideEffect(params object[] args)
+        public GraphTraversalSource WithSack(object initialValue, object mergeOperator)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            source.Bytecode.AddSource("withSideEffect", args);
+            source.Bytecode.AddSource("withSack", initialValue, mergeOperator);
             return source;
         }
 
-        public GraphTraversalSource WithStrategies(params object[] args)
+        public GraphTraversalSource WithSack(object initialValue, object splitOperator, object mergeOperator)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            source.Bytecode.AddSource("withStrategies", args);
+            source.Bytecode.AddSource("withSack", initialValue, splitOperator, mergeOperator);
             return source;
         }
 
-        public GraphTraversalSource WithoutStrategies(params object[] args)
+        public GraphTraversalSource WithSideEffect(string key, object initialValue)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            source.Bytecode.AddSource("withoutStrategies", args);
+            source.Bytecode.AddSource("withSideEffect", key, initialValue);
+            return source;
+        }
+
+        public GraphTraversalSource WithSideEffect(string key, object initialValue, object reducer)
+        {
+            var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
+                                                  new Bytecode(Bytecode));
+            source.Bytecode.AddSource("withSideEffect", key, initialValue, reducer);
+            return source;
+        }
+
+        public GraphTraversalSource WithStrategies(params ITraversalStrategy[] traversalStrategies)
+        {
+            var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
+                                                  new Bytecode(Bytecode));
+            var args = new List<object> {};
+            args.AddRange(traversalStrategies);
+            source.Bytecode.AddSource("withStrategies", args.ToArray());
+            return source;
+        }
+
+        public GraphTraversalSource WithoutStrategies(params Type[] traversalStrategyClasses)
+        {
+            var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
+                                                  new Bytecode(Bytecode));
+            var args = new List<object> {};
+            args.AddRange(traversalStrategyClasses);
+            source.Bytecode.AddSource("withoutStrategies", args.ToArray());
             return source;
         }
 
@@ -159,10 +187,12 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the E step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Edge,Edge > E(params object[] args)
+        public GraphTraversal< Edge,Edge > E(params object[] edgesIds)
         {
             var traversal = new GraphTraversal< Edge,Edge >(TraversalStrategies, new Bytecode(Bytecode));
-            traversal.Bytecode.AddStep("E", args);
+            var args = new List<object> {};
+            args.AddRange(edgesIds);
+            traversal.Bytecode.AddStep("E", args.ToArray());
             return traversal;
         }
 
@@ -170,10 +200,12 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the V step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > V(params object[] args)
+        public GraphTraversal< Vertex,Vertex > V(params object[] vertexIds)
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            traversal.Bytecode.AddStep("V", args);
+            var args = new List<object> {};
+            args.AddRange(vertexIds);
+            traversal.Bytecode.AddStep("V", args.ToArray());
             return traversal;
         }
 
@@ -181,10 +213,34 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > AddV(params object[] args)
+        public GraphTraversal< Vertex,Vertex > AddV()
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            traversal.Bytecode.AddStep("addV", args);
+                traversal.Bytecode.AddStep("addV");
+            return traversal;
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
+        ///     traversal.
+        /// </summary>
+        public GraphTraversal< Vertex,Vertex > AddV(params object[] keyValues)
+        {
+            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+            var args = new List<object> {};
+            args.AddRange(keyValues);
+            traversal.Bytecode.AddStep("addV", args.ToArray());
+            return traversal;
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
+        ///     traversal.
+        /// </summary>
+        public GraphTraversal< Vertex,Vertex > AddV(string label)
+        {
+            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+                traversal.Bytecode.AddStep("addV", label);
             return traversal;
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -132,7 +132,7 @@ namespace Gremlin.Net.Process.Traversal
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            var args = new List<object> {};
+            var args = new List<object>(0 + traversalStrategies.Length) {};
             args.AddRange(traversalStrategies);
             source.Bytecode.AddSource("withStrategies", args.ToArray());
             return source;
@@ -142,7 +142,7 @@ namespace Gremlin.Net.Process.Traversal
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                                                   new Bytecode(Bytecode));
-            var args = new List<object> {};
+            var args = new List<object>(0 + traversalStrategyClasses.Length) {};
             args.AddRange(traversalStrategyClasses);
             source.Bytecode.AddSource("withoutStrategies", args.ToArray());
             return source;
@@ -190,7 +190,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< Edge,Edge > E(params object[] edgesIds)
         {
             var traversal = new GraphTraversal< Edge,Edge >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<object> {};
+            var args = new List<object>(0 + edgesIds.Length) {};
             args.AddRange(edgesIds);
             traversal.Bytecode.AddStep("E", args.ToArray());
             return traversal;
@@ -203,7 +203,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< Vertex,Vertex > V(params object[] vertexIds)
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<object> {};
+            var args = new List<object>(0 + vertexIds.Length) {};
             args.AddRange(vertexIds);
             traversal.Bytecode.AddStep("V", args.ToArray());
             return traversal;
@@ -227,7 +227,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< Vertex,Vertex > AddV(params object[] keyValues)
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<object> {};
+            var args = new List<object>(0 + keyValues.Length) {};
             args.AddRange(keyValues);
             traversal.Bytecode.AddStep("addV", args.ToArray());
             return traversal;

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/HaltedTraverserStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/HaltedTraverserStrategy.cs
@@ -26,6 +26,10 @@ namespace Gremlin.Net.Process.Traversal.Strategy.Decoration
 #pragma warning disable 1591
     public class HaltedTraverserStrategy : AbstractTraversalStrategy
     {
+        public HaltedTraverserStrategy()
+        {
+        }
+
         public HaltedTraverserStrategy(string haltedTraverserFactoryName = null)
         {
             if (haltedTraverserFactoryName != null)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/PartitionStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/PartitionStrategy.cs
@@ -33,6 +33,13 @@ namespace Gremlin.Net.Process.Traversal.Strategy.Decoration
         /// <summary>
         ///     Initializes a new instance of the <see cref="PartitionStrategy" /> class.
         /// </summary>
+        public PartitionStrategy()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PartitionStrategy" /> class.
+        /// </summary>
         /// <param name="partitionKey">Specifies the partition key name.</param>
         /// <param name="writePartition">
         ///     Specifies the name of the partition to write when adding vertices, edges and vertex

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/SubgraphStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/SubgraphStrategy.cs
@@ -31,6 +31,13 @@ namespace Gremlin.Net.Process.Traversal.Strategy.Decoration
         /// <summary>
         ///     Initializes a new instance of the <see cref="SubgraphStrategy" /> class.
         /// </summary>
+        public SubgraphStrategy()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="SubgraphStrategy" /> class.
+        /// </summary>
         /// <param name="vertexCriterion">Constrains vertices for the <see cref="ITraversal" />.</param>
         /// <param name="edgeCriterion">Constrains edges for the <see cref="ITraversal" />.</param>
         /// <param name="vertexPropertyCriterion">Constrains vertex properties for the <see cref="ITraversal" />.</param>

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/VertexProgramStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/VertexProgramStrategy.cs
@@ -29,6 +29,10 @@ namespace Gremlin.Net.Process.Traversal.Strategy.Decoration
 #pragma warning disable 1591
     public class VertexProgramStrategy : AbstractTraversalStrategy
     {
+        public VertexProgramStrategy()
+        {
+        }
+
         public VertexProgramStrategy(string graphComputer = null, int? workers = null, string persist = null,
             string result = null, ITraversal vertices = null, ITraversal edges = null,
             Dictionary<string, dynamic> configuration = null)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
@@ -43,729 +43,1275 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the V step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> V(params object[] args)
+        public static GraphTraversal<object, Vertex> V(params object[] vertexIdsOrElements)
         {
-            return new GraphTraversal<object, object>().V(args);
+            return vertexIdsOrElements.Length == 0
+                ? new GraphTraversal<object, Vertex>().V()
+                : new GraphTraversal<object, Vertex>().V(vertexIdsOrElements);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addE step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> AddE(params object[] args)
+        public static GraphTraversal<object, Edge> AddE(Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            return new GraphTraversal<object, object>().AddE(args);
+            return propertyKeyValues.Length == 0
+                ? new GraphTraversal<object, Edge>().AddE(direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey)
+                : new GraphTraversal<object, Edge>().AddE(direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addE step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, Edge> AddE(string edgeLabel)
+        {
+            return new GraphTraversal<object, Edge>().AddE(edgeLabel);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addInE step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> AddInE(params object[] args)
+        public static GraphTraversal<object, Edge> AddInE(string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            return new GraphTraversal<object, object>().AddInE(args);
+            return propertyKeyValues.Length == 0
+                ? new GraphTraversal<object, Edge>().AddInE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey)
+                : new GraphTraversal<object, Edge>().AddInE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addOutE step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> AddOutE(params object[] args)
+        public static GraphTraversal<object, Edge> AddOutE(string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            return new GraphTraversal<object, object>().AddOutE(args);
+            return propertyKeyValues.Length == 0
+                ? new GraphTraversal<object, Edge>().AddOutE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey)
+                : new GraphTraversal<object, Edge>().AddOutE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addV step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> AddV(params object[] args)
+        public static GraphTraversal<object, Vertex> AddV()
         {
-            return new GraphTraversal<object, object>().AddV(args);
+            return new GraphTraversal<object, Vertex>().AddV();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addV step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, Vertex> AddV(params object[] propertyKeyValues)
+        {
+            return propertyKeyValues.Length == 0
+                ? new GraphTraversal<object, Vertex>().AddV()
+                : new GraphTraversal<object, Vertex>().AddV(propertyKeyValues);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the addV step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, Vertex> AddV(string vertexLabel)
+        {
+            return new GraphTraversal<object, Vertex>().AddV(vertexLabel);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the aggregate step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Aggregate(params object[] args)
+        public static GraphTraversal<object, object> Aggregate(string sideEffectKey)
         {
-            return new GraphTraversal<object, object>().Aggregate(args);
+            return new GraphTraversal<object, object>().Aggregate(sideEffectKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the and step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> And(params object[] args)
+        public static GraphTraversal<object, object> And(params ITraversal[] andTraversals)
         {
-            return new GraphTraversal<object, object>().And(args);
+            return andTraversals.Length == 0
+                ? new GraphTraversal<object, object>().And()
+                : new GraphTraversal<object, object>().And(andTraversals);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the as step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> As(params object[] args)
+        public static GraphTraversal<object, object> As(string label, params string[] labels)
         {
-            return new GraphTraversal<object, object>().As(args);
+            return labels.Length == 0
+                ? new GraphTraversal<object, object>().As(label)
+                : new GraphTraversal<object, object>().As(label, labels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the barrier step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Barrier(params object[] args)
+        public static GraphTraversal<object, object> Barrier()
         {
-            return new GraphTraversal<object, object>().Barrier(args);
+            return new GraphTraversal<object, object>().Barrier();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the barrier step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Barrier(object barrierConsumer)
+        {
+            return new GraphTraversal<object, object>().Barrier(barrierConsumer);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the barrier step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Barrier(int maxBarrierSize)
+        {
+            return new GraphTraversal<object, object>().Barrier(maxBarrierSize);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the both step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> Both(params object[] args)
+        public static GraphTraversal<object, Vertex> Both(params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().Both(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Vertex>().Both()
+                : new GraphTraversal<object, Vertex>().Both(edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the bothE step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> BothE(params object[] args)
+        public static GraphTraversal<object, Edge> BothE(params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().BothE(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Edge>().BothE()
+                : new GraphTraversal<object, Edge>().BothE(edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the bothV step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> BothV(params object[] args)
+        public static GraphTraversal<object, Vertex> BothV()
         {
-            return new GraphTraversal<object, object>().BothV(args);
+            return new GraphTraversal<object, Vertex>().BothV();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the branch step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Branch<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Branch<E2>(object function)
         {
-            return new GraphTraversal<object, object>().Branch<E2>(args);
+            return new GraphTraversal<object, E2>().Branch<E2>(function);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the branch step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Branch<E2>(ITraversal traversalFunction)
+        {
+            return new GraphTraversal<object, E2>().Branch<E2>(traversalFunction);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the cap step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Cap<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Cap<E2>(string sideEffectKey, params string[] sideEffectKeys)
         {
-            return new GraphTraversal<object, object>().Cap<E2>(args);
+            return sideEffectKeys.Length == 0
+                ? new GraphTraversal<object, E2>().Cap<E2>(sideEffectKey)
+                : new GraphTraversal<object, E2>().Cap<E2>(sideEffectKey, sideEffectKeys);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the choose step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Choose<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Choose<E2>(object choiceFunction)
         {
-            return new GraphTraversal<object, object>().Choose<E2>(args);
+            return new GraphTraversal<object, E2>().Choose<E2>(choiceFunction);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the choose step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Choose<E2>(TraversalPredicate choosePredicate, ITraversal trueChoice)
+        {
+            return new GraphTraversal<object, E2>().Choose<E2>(choosePredicate, trueChoice);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the choose step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Choose<E2>(TraversalPredicate choosePredicate, ITraversal trueChoice, ITraversal falseChoice)
+        {
+            return new GraphTraversal<object, E2>().Choose<E2>(choosePredicate, trueChoice, falseChoice);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the choose step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Choose<E2>(ITraversal traversalFunction)
+        {
+            return new GraphTraversal<object, E2>().Choose<E2>(traversalFunction);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the choose step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Choose<E2>(ITraversal traversalPredicate, ITraversal trueChoice)
+        {
+            return new GraphTraversal<object, E2>().Choose<E2>(traversalPredicate, trueChoice);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the choose step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Choose<E2>(ITraversal traversalPredicate, ITraversal trueChoice, ITraversal falseChoice)
+        {
+            return new GraphTraversal<object, E2>().Choose<E2>(traversalPredicate, trueChoice, falseChoice);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the coalesce step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Coalesce<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Coalesce<E2>(params ITraversal[] traversals)
         {
-            return new GraphTraversal<object, object>().Coalesce<E2>(args);
+            return traversals.Length == 0
+                ? new GraphTraversal<object, E2>().Coalesce<E2>()
+                : new GraphTraversal<object, E2>().Coalesce<E2>(traversals);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the coin step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Coin(params object[] args)
+        public static GraphTraversal<object, object> Coin(double probability)
         {
-            return new GraphTraversal<object, object>().Coin(args);
+            return new GraphTraversal<object, object>().Coin(probability);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the constant step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Constant<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Constant<E2>(object a)
         {
-            return new GraphTraversal<object, object>().Constant<E2>(args);
+            return new GraphTraversal<object, E2>().Constant<E2>(a);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the count step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, long> Count(params object[] args)
+        public static GraphTraversal<object, long> Count()
         {
-            return new GraphTraversal<object, object>().Count(args);
+            return new GraphTraversal<object, long>().Count();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the count step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, long> Count(Scope scope)
+        {
+            return new GraphTraversal<object, long>().Count(scope);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the cyclicPath step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> CyclicPath(params object[] args)
+        public static GraphTraversal<object, object> CyclicPath()
         {
-            return new GraphTraversal<object, object>().CyclicPath(args);
+            return new GraphTraversal<object, object>().CyclicPath();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the dedup step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Dedup(params object[] args)
+        public static GraphTraversal<object, object> Dedup(Scope scope, params string[] dedupLabels)
         {
-            return new GraphTraversal<object, object>().Dedup(args);
+            return dedupLabels.Length == 0
+                ? new GraphTraversal<object, object>().Dedup(scope)
+                : new GraphTraversal<object, object>().Dedup(scope, dedupLabels);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the dedup step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Dedup(params string[] dedupLabels)
+        {
+            return dedupLabels.Length == 0
+                ? new GraphTraversal<object, object>().Dedup()
+                : new GraphTraversal<object, object>().Dedup(dedupLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the drop step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Drop(params object[] args)
+        public static GraphTraversal<object, object> Drop()
         {
-            return new GraphTraversal<object, object>().Drop(args);
+            return new GraphTraversal<object, object>().Drop();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the emit step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Emit(params object[] args)
+        public static GraphTraversal<object, object> Emit()
         {
-            return new GraphTraversal<object, object>().Emit(args);
+            return new GraphTraversal<object, object>().Emit();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the emit step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Emit(TraversalPredicate emitPredicate)
+        {
+            return new GraphTraversal<object, object>().Emit(emitPredicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the emit step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Emit(ITraversal emitTraversal)
+        {
+            return new GraphTraversal<object, object>().Emit(emitTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the filter step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Filter(params object[] args)
+        public static GraphTraversal<object, object> Filter(TraversalPredicate predicate)
         {
-            return new GraphTraversal<object, object>().Filter(args);
+            return new GraphTraversal<object, object>().Filter(predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the filter step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Filter(ITraversal filterTraversal)
+        {
+            return new GraphTraversal<object, object>().Filter(filterTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the flatMap step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> FlatMap<E2>(params object[] args)
+        public static GraphTraversal<object, E2> FlatMap<E2>(object function)
         {
-            return new GraphTraversal<object, object>().FlatMap<E2>(args);
+            return new GraphTraversal<object, E2>().FlatMap<E2>(function);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the flatMap step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> FlatMap<E2>(ITraversal flatMapTraversal)
+        {
+            return new GraphTraversal<object, E2>().FlatMap<E2>(flatMapTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the fold step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Fold<E2>(params object[] args)
+        public static GraphTraversal<object, IList<E2>> Fold<E2>()
         {
-            return new GraphTraversal<object, object>().Fold<E2>(args);
+            return new GraphTraversal<object, E2>().Fold();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the fold step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Fold<E2>(object seed, object foldFunction)
+        {
+            return new GraphTraversal<object, E2>().Fold<E2>(seed, foldFunction);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the group step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Group(params object[] args)
+        public static GraphTraversal<object, IDictionary<K, V>> Group<K, V>()
         {
-            return new GraphTraversal<object, object>().Group(args);
+            return new GraphTraversal<object, IDictionary<K, V>>().Group<K, V>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the group step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Group(string sideEffectKey)
+        {
+            return new GraphTraversal<object, object>().Group(sideEffectKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the groupCount step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> GroupCount(params object[] args)
+        public static GraphTraversal<object, IDictionary<K, long>> GroupCount<K>()
         {
-            return new GraphTraversal<object, object>().GroupCount(args);
+            return new GraphTraversal<object, IDictionary<K, long>>().GroupCount<K>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the groupCount step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> GroupCount(string sideEffectKey)
+        {
+            return new GraphTraversal<object, object>().GroupCount(sideEffectKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the groupV3d0 step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> GroupV3d0(params object[] args)
+        public static GraphTraversal<object, IDictionary<K, V>> GroupV3d0<K, V>()
         {
-            return new GraphTraversal<object, object>().GroupV3d0(args);
+            return new GraphTraversal<object, IDictionary<K, V>>().GroupV3d0<K, V>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the groupV3d0 step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> GroupV3d0(string sideEffectKey)
+        {
+            return new GraphTraversal<object, object>().GroupV3d0(sideEffectKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Has(params object[] args)
+        public static GraphTraversal<object, object> Has(string propertyKey)
         {
-            return new GraphTraversal<object, object>().Has(args);
+            return new GraphTraversal<object, object>().Has(propertyKey);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(string propertyKey, object value)
+        {
+            return new GraphTraversal<object, object>().Has(propertyKey, value);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(string propertyKey, TraversalPredicate predicate)
+        {
+            return new GraphTraversal<object, object>().Has(propertyKey, predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(string label, string propertyKey, object value)
+        {
+            return new GraphTraversal<object, object>().Has(label, propertyKey, value);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(string label, string propertyKey, TraversalPredicate predicate)
+        {
+            return new GraphTraversal<object, object>().Has(label, propertyKey, predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(string propertyKey, ITraversal propertyTraversal)
+        {
+            return new GraphTraversal<object, object>().Has(propertyKey, propertyTraversal);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(T accessor, object value)
+        {
+            return new GraphTraversal<object, object>().Has(accessor, value);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(T accessor, TraversalPredicate predicate)
+        {
+            return new GraphTraversal<object, object>().Has(accessor, predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the has step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Has(T accessor, ITraversal propertyTraversal)
+        {
+            return new GraphTraversal<object, object>().Has(accessor, propertyTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasId step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> HasId(params object[] args)
+        public static GraphTraversal<object, object> HasId(object id, params object[] otherIds)
         {
-            return new GraphTraversal<object, object>().HasId(args);
+            return otherIds.Length == 0
+                ? new GraphTraversal<object, object>().HasId(id)
+                : new GraphTraversal<object, object>().HasId(id, otherIds);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasId step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> HasId(TraversalPredicate predicate)
+        {
+            return new GraphTraversal<object, object>().HasId(predicate);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasKey step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> HasKey(params object[] args)
+        public static GraphTraversal<object, object> HasKey(TraversalPredicate predicate)
         {
-            return new GraphTraversal<object, object>().HasKey(args);
+            return new GraphTraversal<object, object>().HasKey(predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasKey step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> HasKey(string label, params string[] otherLabels)
+        {
+            return otherLabels.Length == 0
+                ? new GraphTraversal<object, object>().HasKey(label)
+                : new GraphTraversal<object, object>().HasKey(label, otherLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasLabel step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> HasLabel(params object[] args)
+        public static GraphTraversal<object, object> HasLabel(TraversalPredicate predicate)
         {
-            return new GraphTraversal<object, object>().HasLabel(args);
+            return new GraphTraversal<object, object>().HasLabel(predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasLabel step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> HasLabel(string label, params string[] otherLabels)
+        {
+            return otherLabels.Length == 0
+                ? new GraphTraversal<object, object>().HasLabel(label)
+                : new GraphTraversal<object, object>().HasLabel(label, otherLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasNot step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> HasNot(params object[] args)
+        public static GraphTraversal<object, object> HasNot(string propertyKey)
         {
-            return new GraphTraversal<object, object>().HasNot(args);
+            return new GraphTraversal<object, object>().HasNot(propertyKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasValue step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> HasValue(params object[] args)
+        public static GraphTraversal<object, object> HasValue(object value, params object[] values)
         {
-            return new GraphTraversal<object, object>().HasValue(args);
+            return values.Length == 0
+                ? new GraphTraversal<object, object>().HasValue(value)
+                : new GraphTraversal<object, object>().HasValue(value, values);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the hasValue step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> HasValue(TraversalPredicate predicate)
+        {
+            return new GraphTraversal<object, object>().HasValue(predicate);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the id step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Id(params object[] args)
+        public static GraphTraversal<object, object> Id()
         {
-            return new GraphTraversal<object, object>().Id(args);
+            return new GraphTraversal<object, object>().Id();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the identity step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Identity(params object[] args)
+        public static GraphTraversal<object, object> Identity()
         {
-            return new GraphTraversal<object, object>().Identity(args);
+            return new GraphTraversal<object, object>().Identity();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the in step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> In(params object[] args)
+        public static GraphTraversal<object, Vertex> In(params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().In(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Vertex>().In()
+                : new GraphTraversal<object, Vertex>().In(edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the inE step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> InE(params object[] args)
+        public static GraphTraversal<object, Edge> InE(params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().InE(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Edge>().InE()
+                : new GraphTraversal<object, Edge>().InE(edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the inV step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> InV(params object[] args)
+        public static GraphTraversal<object, Vertex> InV()
         {
-            return new GraphTraversal<object, object>().InV(args);
+            return new GraphTraversal<object, Vertex>().InV();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the inject step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Inject(params object[] args)
+        public static GraphTraversal<object, object> Inject(params object[] injections)
         {
-            return new GraphTraversal<object, object>().Inject(args);
+            return injections.Length == 0
+                ? new GraphTraversal<object, object>().Inject()
+                : new GraphTraversal<object, object>().Inject(injections);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the is step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Is(params object[] args)
+        public static GraphTraversal<object, object> Is(object value)
         {
-            return new GraphTraversal<object, object>().Is(args);
+            return new GraphTraversal<object, object>().Is(value);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the is step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Is(TraversalPredicate predicate)
+        {
+            return new GraphTraversal<object, object>().Is(predicate);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the key step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, string> Key(params object[] args)
+        public static GraphTraversal<object, string> Key()
         {
-            return new GraphTraversal<object, object>().Key(args);
+            return new GraphTraversal<object, string>().Key();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the label step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, string> Label(params object[] args)
+        public static GraphTraversal<object, string> Label()
         {
-            return new GraphTraversal<object, object>().Label(args);
+            return new GraphTraversal<object, string>().Label();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the limit step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Limit<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Limit<E2>(Scope scope, long limit)
         {
-            return new GraphTraversal<object, object>().Limit<E2>(args);
+            return new GraphTraversal<object, E2>().Limit<E2>(scope, limit);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the limit step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Limit<E2>(long limit)
+        {
+            return new GraphTraversal<object, E2>().Limit(limit);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the local step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Local<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Local<E2>(ITraversal localTraversal)
         {
-            return new GraphTraversal<object, object>().Local<E2>(args);
+            return new GraphTraversal<object, E2>().Local<E2>(localTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the loops step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, int> Loops(params object[] args)
+        public static GraphTraversal<object, int> Loops()
         {
-            return new GraphTraversal<object, object>().Loops(args);
+            return new GraphTraversal<object, int>().Loops();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the map step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Map<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Map<E2>(object function)
         {
-            return new GraphTraversal<object, object>().Map<E2>(args);
+            return new GraphTraversal<object, E2>().Map<E2>(function);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the map step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Map<E2>(ITraversal mapTraversal)
+        {
+            return new GraphTraversal<object, E2>().Map<E2>(mapTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the mapKeys step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> MapKeys<E2>(params object[] args)
+        public static GraphTraversal<object, E2> MapKeys<E2>()
         {
-            return new GraphTraversal<object, object>().MapKeys<E2>(args);
+            return new GraphTraversal<object, E2>().MapKeys<E2>();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the mapValues step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> MapValues<E2>(params object[] args)
+        public static GraphTraversal<object, E2> MapValues<E2>()
         {
-            return new GraphTraversal<object, object>().MapValues<E2>(args);
+            return new GraphTraversal<object, E2>().MapValues<E2>();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the match step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, IDictionary<string, E2>> Match<E2>(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> Match<E2>(params ITraversal[] matchTraversals)
         {
-            return new GraphTraversal<object, object>().Match<E2>(args);
+            return matchTraversals.Length == 0
+                ? new GraphTraversal<object, IDictionary<string, E2>>().Match<E2>()
+                : new GraphTraversal<object, IDictionary<string, E2>>().Match<E2>(matchTraversals);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the max step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Max<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Max<E2>()
         {
-            return new GraphTraversal<object, object>().Max<E2>(args);
+            return new GraphTraversal<object, E2>().Max<E2>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the max step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Max<E2>(Scope scope)
+        {
+            return new GraphTraversal<object, E2>().Max<E2>(scope);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the mean step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Mean<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Mean<E2>()
         {
-            return new GraphTraversal<object, object>().Mean<E2>(args);
+            return new GraphTraversal<object, E2>().Mean<E2>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the mean step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Mean<E2>(Scope scope)
+        {
+            return new GraphTraversal<object, E2>().Mean<E2>(scope);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the min step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Min<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Min<E2>()
         {
-            return new GraphTraversal<object, object>().Min<E2>(args);
+            return new GraphTraversal<object, E2>().Min<E2>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the min step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Min<E2>(Scope scope)
+        {
+            return new GraphTraversal<object, E2>().Min<E2>(scope);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the not step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Not(params object[] args)
+        public static GraphTraversal<object, object> Not(ITraversal notTraversal)
         {
-            return new GraphTraversal<object, object>().Not(args);
+            return new GraphTraversal<object, object>().Not(notTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the optional step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Optional<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Optional<E2>(ITraversal optionalTraversal)
         {
-            return new GraphTraversal<object, object>().Optional<E2>(args);
+            return new GraphTraversal<object, E2>().Optional<E2>(optionalTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the or step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Or(params object[] args)
+        public static GraphTraversal<object, object> Or(params ITraversal[] orTraversals)
         {
-            return new GraphTraversal<object, object>().Or(args);
+            return orTraversals.Length == 0
+                ? new GraphTraversal<object, object>().Or()
+                : new GraphTraversal<object, object>().Or(orTraversals);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the order step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Order(params object[] args)
+        public static GraphTraversal<object, object> Order()
         {
-            return new GraphTraversal<object, object>().Order(args);
+            return new GraphTraversal<object, object>().Order();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the order step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Order(Scope scope)
+        {
+            return new GraphTraversal<object, object>().Order(scope);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the otherV step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> OtherV(params object[] args)
+        public static GraphTraversal<object, Vertex> OtherV()
         {
-            return new GraphTraversal<object, object>().OtherV(args);
+            return new GraphTraversal<object, Vertex>().OtherV();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the out step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> Out(params object[] args)
+        public static GraphTraversal<object, Vertex> Out(params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().Out(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Vertex>().Out()
+                : new GraphTraversal<object, Vertex>().Out(edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the outE step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> OutE(params object[] args)
+        public static GraphTraversal<object, Edge> OutE(params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().OutE(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Edge>().OutE()
+                : new GraphTraversal<object, Edge>().OutE(edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the outV step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> OutV(params object[] args)
+        public static GraphTraversal<object, Vertex> OutV()
         {
-            return new GraphTraversal<object, object>().OutV(args);
+            return new GraphTraversal<object, Vertex>().OutV();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the path step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Path> Path(params object[] args)
+        public static GraphTraversal<object, Path> Path()
         {
-            return new GraphTraversal<object, object>().Path(args);
+            return new GraphTraversal<object, Path>().Path();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the project step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, IDictionary<string, E2>> Project<E2>(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> Project<E2>(string projectKey, params string[] projectKeys)
         {
-            return new GraphTraversal<object, object>().Project<E2>(args);
+            return projectKeys.Length == 0
+                ? new GraphTraversal<object, IDictionary<string, E2>>().Project<E2>(projectKey)
+                : new GraphTraversal<object, IDictionary<string, E2>>().Project<E2>(projectKey, projectKeys);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the properties step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Properties<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Properties<E2>(params string[] propertyKeys)
         {
-            return new GraphTraversal<object, object>().Properties<E2>(args);
+            return propertyKeys.Length == 0
+                ? new GraphTraversal<object, E2>().Properties<E2>()
+                : new GraphTraversal<object, E2>().Properties<E2>(propertyKeys);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the property step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Property(params object[] args)
+        public static GraphTraversal<object, object> Property(Cardinality cardinality, object key, object value, params object[] keyValues)
         {
-            return new GraphTraversal<object, object>().Property(args);
+            return keyValues.Length == 0
+                ? new GraphTraversal<object, object>().Property(cardinality, key, value)
+                : new GraphTraversal<object, object>().Property(cardinality, key, value, keyValues);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the property step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Property(object key, object value, params object[] keyValues)
+        {
+            return keyValues.Length == 0
+                ? new GraphTraversal<object, object>().Property(key, value)
+                : new GraphTraversal<object, object>().Property(key, value, keyValues);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the propertyMap step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, IDictionary<string, E2>> PropertyMap<E2>(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> PropertyMap<E2>(params string[] propertyKeys)
         {
-            return new GraphTraversal<object, object>().PropertyMap<E2>(args);
+            return propertyKeys.Length == 0
+                ? new GraphTraversal<object, IDictionary<string, E2>>().PropertyMap<E2>()
+                : new GraphTraversal<object, IDictionary<string, E2>>().PropertyMap<E2>(propertyKeys);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the range step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Range<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Range<E2>(Scope scope, long low, long high)
         {
-            return new GraphTraversal<object, object>().Range<E2>(args);
+            return new GraphTraversal<object, E2>().Range<E2>(scope, low, high);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the range step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Range<E2>(long low, long high)
+        {
+            return new GraphTraversal<object, E2>().Range(low, high);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the repeat step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Repeat(params object[] args)
+        public static GraphTraversal<object, object> Repeat(ITraversal traversal)
         {
-            return new GraphTraversal<object, object>().Repeat(args);
+            return new GraphTraversal<object, object>().Repeat(traversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sack step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Sack(params object[] args)
+        public static GraphTraversal<object, E2> Sack<E2>()
         {
-            return new GraphTraversal<object, object>().Sack(args);
+            return new GraphTraversal<object, E2>().Sack<E2>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sack step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Sack(object sackOperator)
+        {
+            return new GraphTraversal<object, object>().Sack(sackOperator);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sack step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Sack(object sackOperator, string elementPropertyKey)
+        {
+            return new GraphTraversal<object, object>().Sack(sackOperator, elementPropertyKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sample step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Sample(params object[] args)
+        public static GraphTraversal<object, object> Sample(Scope scope, int amountToSample)
         {
-            return new GraphTraversal<object, object>().Sample(args);
+            return new GraphTraversal<object, object>().Sample(scope, amountToSample);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sample step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Sample(int amountToSample)
+        {
+            return new GraphTraversal<object, object>().Sample(amountToSample);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the select step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, IDictionary<string, E2>> Select<E2>(params object[] args)
+        public static GraphTraversal<object, ICollection<E2>> Select<E2>(Column column)
         {
-            return new GraphTraversal<object, object>().Select<E2>(args);
+            return new GraphTraversal<object, ICollection<E2>>().Select<E2>(column);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the select step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Select<E2>(Pop pop, string selectKey)
+        {
+            return new GraphTraversal<object, E2>().Select<E2>(pop, selectKey);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the select step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, IDictionary<string, E2>> Select<E2>(Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        {
+            return otherSelectKeys.Length == 0
+                ? new GraphTraversal<object, IDictionary<string, E2>>().Select<E2>(pop, selectKey1, selectKey2)
+                : new GraphTraversal<object, IDictionary<string, E2>>().Select<E2>(pop, selectKey1, selectKey2, otherSelectKeys);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the select step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Select<E2>(string selectKey)
+        {
+            return new GraphTraversal<object, E2>().Select<E2>(selectKey);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the select step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, IDictionary<string, E2>> Select<E2>(string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        {
+            return otherSelectKeys.Length == 0
+                ? new GraphTraversal<object, IDictionary<string, E2>>().Select<E2>(selectKey1, selectKey2)
+                : new GraphTraversal<object, IDictionary<string, E2>>().Select<E2>(selectKey1, selectKey2, otherSelectKeys);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sideEffect step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> SideEffect(params object[] args)
+        public static GraphTraversal<object, object> SideEffect(object consumer)
         {
-            return new GraphTraversal<object, object>().SideEffect(args);
+            return new GraphTraversal<object, object>().SideEffect(consumer);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sideEffect step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> SideEffect(ITraversal sideEffectTraversal)
+        {
+            return new GraphTraversal<object, object>().SideEffect(sideEffectTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the simplePath step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> SimplePath(params object[] args)
+        public static GraphTraversal<object, object> SimplePath()
         {
-            return new GraphTraversal<object, object>().SimplePath(args);
+            return new GraphTraversal<object, object>().SimplePath();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the store step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Store(params object[] args)
+        public static GraphTraversal<object, object> Store(string sideEffectKey)
         {
-            return new GraphTraversal<object, object>().Store(args);
+            return new GraphTraversal<object, object>().Store(sideEffectKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the subgraph step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> Subgraph(params object[] args)
+        public static GraphTraversal<object, Edge> Subgraph(string sideEffectKey)
         {
-            return new GraphTraversal<object, object>().Subgraph(args);
+            return new GraphTraversal<object, Edge>().Subgraph(sideEffectKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sum step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Sum<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Sum<E2>()
         {
-            return new GraphTraversal<object, object>().Sum<E2>(args);
+            return new GraphTraversal<object, E2>().Sum<E2>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the sum step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Sum<E2>(Scope scope)
+        {
+            return new GraphTraversal<object, E2>().Sum<E2>(scope);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tail step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Tail<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Tail<E2>()
         {
-            return new GraphTraversal<object, object>().Tail<E2>(args);
+            return new GraphTraversal<object, E2>().Tail();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tail step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Tail<E2>(Scope scope)
+        {
+            return new GraphTraversal<object, E2>().Tail<E2>(scope);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tail step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Tail<E2>(Scope scope, long limit)
+        {
+            return new GraphTraversal<object, E2>().Tail<E2>(scope, limit);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tail step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, E2> Tail<E2>(long limit)
+        {
+            return new GraphTraversal<object, E2>().Tail(limit);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the timeLimit step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> TimeLimit(params object[] args)
+        public static GraphTraversal<object, object> TimeLimit(long timeLimit)
         {
-            return new GraphTraversal<object, object>().TimeLimit(args);
+            return new GraphTraversal<object, object>().TimeLimit(timeLimit);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the times step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Times(params object[] args)
+        public static GraphTraversal<object, object> Times(int maxLoops)
         {
-            return new GraphTraversal<object, object>().Times(args);
+            return new GraphTraversal<object, object>().Times(maxLoops);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the to step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> To(params object[] args)
+        public static GraphTraversal<object, Vertex> To(Direction direction, params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().To(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Vertex>().To(direction)
+                : new GraphTraversal<object, Vertex>().To(direction, edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the toE step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Edge> ToE(params object[] args)
+        public static GraphTraversal<object, Edge> ToE(Direction direction, params string[] edgeLabels)
         {
-            return new GraphTraversal<object, object>().ToE(args);
+            return edgeLabels.Length == 0
+                ? new GraphTraversal<object, Edge>().ToE(direction)
+                : new GraphTraversal<object, Edge>().ToE(direction, edgeLabels);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the toV step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Vertex> ToV(params object[] args)
+        public static GraphTraversal<object, Vertex> ToV(Direction direction)
         {
-            return new GraphTraversal<object, object>().ToV(args);
+            return new GraphTraversal<object, Vertex>().ToV(direction);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tree step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Tree(params object[] args)
+        public static GraphTraversal<object, E2> Tree<E2>()
         {
-            return new GraphTraversal<object, object>().Tree(args);
+            return new GraphTraversal<object, E2>().Tree<E2>();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the tree step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Tree(string sideEffectKey)
+        {
+            return new GraphTraversal<object, object>().Tree(sideEffectKey);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the unfold step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Unfold<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Unfold<E2>()
         {
-            return new GraphTraversal<object, object>().Unfold<E2>(args);
+            return new GraphTraversal<object, E2>().Unfold<E2>();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the union step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Union<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Union<E2>(params ITraversal[] traversals)
         {
-            return new GraphTraversal<object, object>().Union<E2>(args);
+            return traversals.Length == 0
+                ? new GraphTraversal<object, E2>().Union<E2>()
+                : new GraphTraversal<object, E2>().Union<E2>(traversals);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the until step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Until(params object[] args)
+        public static GraphTraversal<object, object> Until(TraversalPredicate untilPredicate)
         {
-            return new GraphTraversal<object, object>().Until(args);
+            return new GraphTraversal<object, object>().Until(untilPredicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the until step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Until(ITraversal untilTraversal)
+        {
+            return new GraphTraversal<object, object>().Until(untilTraversal);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the value step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Value<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Value<E2>()
         {
-            return new GraphTraversal<object, object>().Value<E2>(args);
+            return new GraphTraversal<object, E2>().Value<E2>();            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the valueMap step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, IDictionary<string, E2>> ValueMap<E2>(params object[] args)
+        public static GraphTraversal<object, IDictionary<string, E2>> ValueMap<E2>(params string[] propertyKeys)
         {
-            return new GraphTraversal<object, object>().ValueMap<E2>(args);
+            return propertyKeys.Length == 0
+                ? new GraphTraversal<object, IDictionary<string, E2>>().ValueMap<E2>()
+                : new GraphTraversal<object, IDictionary<string, E2>>().ValueMap<E2>(propertyKeys);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the valueMap step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, IDictionary<string, E2>> ValueMap<E2>(bool includeTokens, params string[] propertyKeys)
+        {
+            return propertyKeys.Length == 0
+                ? new GraphTraversal<object, IDictionary<string, E2>>().ValueMap<E2>(includeTokens)
+                : new GraphTraversal<object, IDictionary<string, E2>>().ValueMap<E2>(includeTokens, propertyKeys);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the values step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> Values<E2>(params object[] args)
+        public static GraphTraversal<object, E2> Values<E2>(params string[] propertyKeys)
         {
-            return new GraphTraversal<object, object>().Values<E2>(args);
+            return propertyKeys.Length == 0
+                ? new GraphTraversal<object, E2>().Values<E2>()
+                : new GraphTraversal<object, E2>().Values<E2>(propertyKeys);            
         }
 
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the where step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Where(params object[] args)
+        public static GraphTraversal<object, object> Where(TraversalPredicate predicate)
         {
-            return new GraphTraversal<object, object>().Where(args);
+            return new GraphTraversal<object, object>().Where(predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the where step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Where(string startKey, TraversalPredicate predicate)
+        {
+            return new GraphTraversal<object, object>().Where(startKey, predicate);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the where step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Where(ITraversal whereTraversal)
+        {
+            return new GraphTraversal<object, object>().Where(whereTraversal);            
         }
 
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/ClassSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/ClassSerializer.cs
@@ -21,20 +21,17 @@
 
 #endregion
 
-namespace Gremlin.Net.Process.Traversal.Strategy.Finalization
-{
-#pragma warning disable 1591
-    public class MatchAlgorithmStrategy : AbstractTraversalStrategy
-    {
-        public MatchAlgorithmStrategy()
-        {
-        }
+using System;
+using System.Collections.Generic;
 
-        public MatchAlgorithmStrategy(string matchAlgorithm = null)
+namespace Gremlin.Net.Structure.IO.GraphSON
+{
+    internal class ClassSerializer : IGraphSONSerializer
+    {
+        public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)
         {
-            if (matchAlgorithm != null)
-                Configuration["matchAlgorithm"] = matchAlgorithm;
+            var type = (Type) objectData;
+            return writer.ToDict(Activator.CreateInstance(type));
         }
     }
-#pragma warning restore 1591
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
@@ -51,6 +51,7 @@ namespace Gremlin.Net.Structure.IO.GraphSON
                 {typeof(double), new DoubleConverter()},
                 {typeof(Guid), new UuidSerializer()},
                 {typeof(DateTime), new DateSerializer()},
+                {typeof(Type), new ClassSerializer()},
                 {typeof(Enum), new EnumSerializer()},
                 {typeof(TraversalPredicate), new TraversalPredicateSerializer()},
                 {typeof(Vertex), new VertexSerializer()},

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
@@ -30,6 +30,18 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
     public class BytecodeGenerationTests
     {
         [Fact]
+        public void GraphTraversalStepsShouldUnrollParamsParameters()
+        {
+            var g = new Graph().Traversal();
+
+            var bytecode = g.V().HasLabel("firstLabel", "secondLabel", "thirdLabel").Bytecode;
+
+            Assert.Equal(0, bytecode.SourceInstructions.Count);
+            Assert.Equal(2, bytecode.StepInstructions.Count);
+            Assert.Equal(3, bytecode.StepInstructions[1].Arguments.Length);
+        }
+
+        [Fact]
         public void g_V_OutXcreatedX()
         {
             var g = new Graph().Traversal();
@@ -49,7 +61,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         {
             var g = new Graph().Traversal();
 
-            var bytecode = g.WithSack(1).E().GroupCount().By("weight").Bytecode;
+            var bytecode = g.WithSack(1).E().GroupCount<double>().By("weight").Bytecode;
 
             Assert.Equal(1, bytecode.SourceInstructions.Count);
             Assert.Equal("withSack", bytecode.SourceInstructions[0].OperatorName);

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
@@ -40,7 +40,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
             var graph = new Graph();
             var g = graph.Traversal().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
 
-            var bytecode = g.WithoutStrategies(new ReadOnlyStrategy()).Bytecode;
+            var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
             Assert.Equal(2, bytecode.SourceInstructions.Count);
             Assert.Equal("withStrategies", bytecode.SourceInstructions[0].OperatorName);
@@ -50,7 +50,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
 
             Assert.Equal("withoutStrategies", bytecode.SourceInstructions[1].OperatorName);
             Assert.Equal(1, bytecode.SourceInstructions[1].Arguments.Length);
-            Assert.Equal(new ReadOnlyStrategy(), bytecode.SourceInstructions[1].Arguments[0]);
+            Assert.Equal(typeof(ReadOnlyStrategy), bytecode.SourceInstructions[1].Arguments[0]);
         }
 
         [Fact]
@@ -59,13 +59,13 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
             var graph = new Graph();
             var g = graph.Traversal();
 
-            var bytecode = g.WithoutStrategies(new ReadOnlyStrategy(), new LazyBarrierStrategy()).Bytecode;
+            var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy), typeof(LazyBarrierStrategy)).Bytecode;
 
             Assert.Equal(1, bytecode.SourceInstructions.Count);
             Assert.Equal(2, bytecode.SourceInstructions[0].Arguments.Length);
             Assert.Equal("withoutStrategies", bytecode.SourceInstructions[0].OperatorName);
-            Assert.Equal(new ReadOnlyStrategy(), bytecode.SourceInstructions[0].Arguments[0]);
-            Assert.Equal(new LazyBarrierStrategy(), bytecode.SourceInstructions[0].Arguments[1]);
+            Assert.Equal(typeof(ReadOnlyStrategy), bytecode.SourceInstructions[0].Arguments[0]);
+            Assert.Equal(typeof(LazyBarrierStrategy), bytecode.SourceInstructions[0].Arguments[1]);
         }
 
         [Fact]
@@ -74,12 +74,12 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
             var graph = new Graph();
             var g = graph.Traversal();
 
-            var bytecode = g.WithoutStrategies(new ReadOnlyStrategy()).Bytecode;
+            var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
             Assert.Equal(1, bytecode.SourceInstructions.Count);
             Assert.Equal(1, bytecode.SourceInstructions[0].Arguments.Length);
             Assert.Equal("withoutStrategies", bytecode.SourceInstructions[0].OperatorName);
-            Assert.Equal(new ReadOnlyStrategy(), bytecode.SourceInstructions[0].Arguments[0]);
+            Assert.Equal(typeof(ReadOnlyStrategy), bytecode.SourceInstructions[0].Arguments[0]);
         }
 
         [Fact]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -135,24 +135,24 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var g = graph.Traversal().WithRemote(connection);
 
             var shortestPath =
-                g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit<object>(1).Path().Next();
+                g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit(1).Path().Next();
 
             Assert.Equal(4, shortestPath.Count);
             Assert.Equal(new Vertex((long) 6), shortestPath[3]);
         }
 
-        [Fact]
-        public void ShouldUseBindingsInTraversal()
-        {
-            var graph = new Graph();
-            var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+        //[Fact]
+        //public void ShouldUseBindingsInTraversal()
+        //{
+        //    var graph = new Graph();
+        //    var connection = _connectionFactory.CreateRemoteConnection();
+        //    var g = graph.Traversal().WithRemote(connection);
 
-            var b = new Bindings();
-            var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
+        //    var b = new Bindings();
+        //    var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
 
-            Assert.Equal(3, count);
-        }
+        //    Assert.Equal(3, count);
+        //}
 
         [Fact]
         public async Task ShouldExecuteAsynchronouslyWhenPromiseIsCalled()

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -141,18 +141,18 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             Assert.Equal(new Vertex((long) 6), shortestPath[3]);
         }
 
-        //[Fact]
-        //public void ShouldUseBindingsInTraversal()
-        //{
-        //    var graph = new Graph();
-        //    var connection = _connectionFactory.CreateRemoteConnection();
-        //    var g = graph.Traversal().WithRemote(connection);
+        [Fact]
+        public void ShouldUseBindingsInTraversal()
+        {
+            var graph = new Graph();
+            var connection = _connectionFactory.CreateRemoteConnection();
+            var g = graph.Traversal().WithRemote(connection);
 
-        //    var b = new Bindings();
-        //    var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
+            var b = new Bindings();
+            var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
 
-        //    Assert.Equal(3, count);
-        //}
+            Assert.Equal(3, count);
+        }
 
         [Fact]
         public async Task ShouldExecuteAsynchronouslyWhenPromiseIsCalled()

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
@@ -189,5 +189,19 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
             await Assert.ThrowsAsync<ResponseException>(async () => await g.AddV("person").Promise(t => t.Next()));
         }
+
+        [Fact]
+        public void WithoutStrategiesShouldNeutralizeWithStrategy()
+        {
+            var graph = new Graph();
+            var connection = _connectionFactory.CreateRemoteConnection();
+            var g = graph.Traversal().WithRemote(connection)
+                .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")))
+                .WithoutStrategies(typeof(SubgraphStrategy));
+
+            var count = g.V().Count().Next();
+
+            Assert.Equal(6, count);
+        }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/BytecodeTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/BytecodeTests.cs
@@ -21,6 +21,9 @@
 
 #endregion
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Gremlin.Net.Process.Traversal;
 using Xunit;
 
@@ -29,16 +32,145 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
     public class BytecodeTests
     {
         [Fact]
-        public void ShouldUseBingings()
+        public void ShouldUseBingingsForSimpleValueInStepArgument()
         {
             var bytecode = new Bytecode();
-            var bindings = new Bindings();
+            var bindings = Bindings.Instance;
 
-            bytecode.AddStep("hasLabel", bindings.Of("label", "testLabel"));
+            bytecode.AddStep("hasLabel", bindings.Of("label", "testvalue"));
+
+            Assert.Equal(new Binding("label", "testvalue"), bytecode.StepInstructions[0].Arguments[0]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideArrayInStepArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddStep("someStep", "test", new[] {b.Of("arrayVariable", "arrayValue")});
+
+            Assert.Equal(new Binding("arrayVariable", "arrayValue"), bytecode.StepInstructions[0].Arguments[1]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideDictionaryValuesInStepArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddStep("someStep", new Dictionary<string, object> {{"someKey", b.Of("valVariable", "valValue")}});
+
+            var arg = bytecode.StepInstructions[0].Arguments[0] as IDictionary;
+            Assert.Equal(new Binding("valVariable", "valValue"), arg["someKey"]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideDictionaryKeysInStepArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddStep("someStep", new Dictionary<string, object> {{b.Of("keyVariable", "keyValue"), 1234}});
 
             var arg = bytecode.StepInstructions[0].Arguments[0];
-            var binding = arg as Binding;
-            Assert.Equal(new Binding("label", "testLabel"), binding);
+            var binding = ((Dictionary<object, object>) arg).Keys.First() as Binding;
+            Assert.Equal(new Binding("keyVariable", "keyValue"), binding);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideListInStepArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddStep("someStep", new List<string> {"test", b.Of("listVariable", "listValue")});
+
+            var arg = bytecode.StepInstructions[0].Arguments[0] as IList;
+            Assert.Equal(new Binding("listVariable", "listValue"), arg[1]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideHashSetInStepArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddStep("someStep", new HashSet<string> { "test", b.Of("setVariable", "setValue") });
+
+            var arg = bytecode.StepInstructions[0].Arguments[0] as ISet<object>;
+            Assert.Equal(new Binding("setVariable", "setValue"), arg.ToList()[1]);
+        }
+
+        [Fact]
+        public void ShouldUseBingingsForSimpleValueInSourceArgument()
+        {
+            var bytecode = new Bytecode();
+            var bindings = Bindings.Instance;
+
+            bytecode.AddSource("hasLabel", bindings.Of("label", "testvalue"));
+
+            Assert.Equal(new Binding("label", "testvalue"), bytecode.SourceInstructions[0].Arguments[0]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideArrayInSourceArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddSource("someSource", "test", new[] { b.Of("arrayVariable", "arrayValue") });
+
+            Assert.Equal(new Binding("arrayVariable", "arrayValue"), bytecode.SourceInstructions[0].Arguments[1]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideDictionaryValuesInSourceArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddSource("someSource", new Dictionary<string, object> { { "someKey", b.Of("valVariable", "valValue") } });
+
+            var arg = bytecode.SourceInstructions[0].Arguments[0] as IDictionary;
+            Assert.Equal(new Binding("valVariable", "valValue"), arg["someKey"]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideDictionaryKeysInSourceArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddSource("someSource", new Dictionary<string, object> { { b.Of("keyVariable", "keyValue"), 1234 } });
+
+            var arg = bytecode.SourceInstructions[0].Arguments[0];
+            var binding = ((Dictionary<object, object>)arg).Keys.First() as Binding;
+            Assert.Equal(new Binding("keyVariable", "keyValue"), binding);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideListInSourceArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddSource("someSource", new List<string> { "test", b.Of("listVariable", "listValue") });
+
+            var arg = bytecode.SourceInstructions[0].Arguments[0] as IList;
+            Assert.Equal(new Binding("listVariable", "listValue"), arg[1]);
+        }
+
+        [Fact]
+        public void ShouldUseBindingsInsideHashSetInSourceArgument()
+        {
+            var bytecode = new Bytecode();
+            var b = Bindings.Instance;
+
+            bytecode.AddSource("someSource", new HashSet<string> { "test", b.Of("setVariable", "setValue") });
+
+            var arg = bytecode.SourceInstructions[0].Arguments[0] as ISet<object>;
+            Assert.Equal(new Binding("setVariable", "setValue"), arg.ToList()[1]);
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/Strategy/StrategyTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/Strategy/StrategyTests.cs
@@ -21,6 +21,10 @@
 
 #endregion
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Gremlin.Net.Process.Traversal.Strategy;
 using Gremlin.Net.Process.Traversal.Strategy.Optimization;
 using Gremlin.Net.Process.Traversal.Strategy.Verification;
@@ -92,6 +96,33 @@ namespace Gremlin.Net.UnitTest.Process.Traversal.Strategy
             var strategyStr = testStrategy.ToString();
 
             Assert.Equal("TestStrategy", strategyStr);
+        }
+
+        [Fact]
+        public void AllStrategiesShouldHaveADefaultConstructor()
+        {
+            // We need a default constructor as the ClassWriter needs that for serialization
+            foreach (var type in _allStrategyTypes)
+            {
+                Assert.True(HasParameterlessConstructor(type), $"{type} has no parameterless constructor");
+            }
+        }
+
+        private readonly IEnumerable<Type> _allStrategyTypes = typeof(AbstractTraversalStrategy).GetTypeInfo().Assembly
+            .GetTypes().Where(t => typeof(AbstractTraversalStrategy).IsAssignableFrom(t))
+            .Where(t => t != typeof(AbstractTraversalStrategy));
+
+        private bool HasParameterlessConstructor(Type type)
+        {
+            try
+            {
+                Activator.CreateInstance(type);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
     }
 

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONWriterTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONWriterTests.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
+using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure;
 using Gremlin.Net.Structure.IO.GraphSON;
 using Moq;
@@ -309,6 +310,18 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
             const string expected =
                 "{\"@type\":\"g:Vertex\",\"@value\":{\"id\":{\"@type\":\"g:Int64\",\"@value\":123},\"label\":\"project\"}}";
             Assert.Equal(expected, graphSON);
+        }
+
+        [Fact]
+        public void ShouldSerializeTypeToItsObject()
+        {
+            var writer = CreateStandardGraphSONWriter();
+            var type = typeof(SubgraphStrategy);
+
+            var graphSon = writer.WriteObject(type);
+
+            const string expected = "{\"@type\":\"g:SubgraphStrategy\",\"@value\":{}}";
+            Assert.Equal(expected, graphSon);
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1752

All steps are now (basically) type-safe and the original argument names from Gremlin-Java are used. However, we currently don't support some Java types like `Comparator`. Those were simply replaced by `object` until we find a better solution. A problem with this workaround is that some overloads from Gremlin-Java are not supported in Gremlin.Net as they would result in the same method signature.

The implementation of `Bindings` is now basically the same as in Gremlin-Java. This change was necessary as `Bindings.Of()` can no longer return a `Binding` object

These changes also revealed a bug in the tests where the `WithoutStrategies` source step was called with objects of strategies instead of just with their types. However, `WithoutStrategies` still can't work right now as a GraphSON serializer is missing for `Type`.

The `Group` step for example looks now like this:
```cs
/// <summary>
///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
/// </summary>
public GraphTraversal< S , IDictionary<K, V> > Group<K, V> ()
{
    Bytecode.AddStep("group");
    return Wrap< S , IDictionary<K, V> >(this);
}

/// <summary>
///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
/// </summary>
public GraphTraversal< S , E > Group (string sideEffectKey)
{
    Bytecode.AddStep("group", sideEffectKey);
    return Wrap< S , E >(this);
}
```
So this should also solve [TINKERPOP-1751](https://issues.apache.org/jira/browse/TINKERPOP-1751) that mentioned the missing overload for `Group` that returns `IDictionary<K, V>`.