### PR TITLE
TINKERPOP-1783: PageRank gives incorrect results for graphs with sinks

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.3.1 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
+* Added support for epsilon-based convergence in `PageRankVertexProgram` (no longer manually capped by iterations).
 * Fixed two major bugs in how PageRank was being calculated in `PageRankVertexProgram`.
 * Added `Io.requiresVersion(Object)` to allow graph providers a way to check the `Io` type and version being constructed.
 * Defaulted `IoCore.gryo()` and `IoCore.graphson()` to both use their 3.0 formats which means that `Graph.io()` will use those by default.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.3.1 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
+* Fixed two major bugs in how PageRank was being calculated in `PageRankVertexProgram`.
 * Added `Io.requiresVersion(Object)` to allow graph providers a way to check the `Io` type and version being constructed.
 * Defaulted `IoCore.gryo()` and `IoCore.graphson()` to both use their 3.0 formats which means that `Graph.io()` will use those by default.
 * Bumped Neo4j 3.2.3

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,7 +28,8 @@ TinkerPop 3.3.1 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
-* Added support for epsilon-based convergence in `PageRankVertexProgram` (no longer manually capped by iterations).
+* `PageRankVertexProgram` supports `maxIterations` but will break out early if epsilon-based convergence occurs.
+* Added support for epsilon-based convergence in `PageRankVertexProgram`.
 * Fixed two major bugs in how PageRank was being calculated in `PageRankVertexProgram`.
 * Added `Io.requiresVersion(Object)` to allow graph providers a way to check the `Io` type and version being constructed.
 * Defaulted `IoCore.gryo()` and `IoCore.graphson()` to both use their 3.0 formats which means that `Graph.io()` will use those by default.

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -186,26 +186,30 @@ methods of a `VertexProgram`, the PageRankVertexProgram code is analyzed below.
 
 [source,java]
 ----
-public class PageRankVertexProgram implements VertexProgram<Double> {  <1>
+public class PageRankVertexProgram implements VertexProgram<Double> { <1>
 
     public static final String PAGE_RANK = "gremlin.pageRankVertexProgram.pageRank";
     private static final String EDGE_COUNT = "gremlin.pageRankVertexProgram.edgeCount";
     private static final String PROPERTY = "gremlin.pageRankVertexProgram.property";
     private static final String VERTEX_COUNT = "gremlin.pageRankVertexProgram.vertexCount";
     private static final String ALPHA = "gremlin.pageRankVertexProgram.alpha";
-    private static final String TOTAL_ITERATIONS = "gremlin.pageRankVertexProgram.totalIterations";
+    private static final String EPSILON = "gremlin.pageRankVertexProgram.epsilon";
+    private static final String MAX_ITERATIONS = "gremlin.pageRankVertexProgram.maxIterations";
     private static final String EDGE_TRAVERSAL = "gremlin.pageRankVertexProgram.edgeTraversal";
     private static final String INITIAL_RANK_TRAVERSAL = "gremlin.pageRankVertexProgram.initialRankTraversal";
+    private static final String TELEPORTATION_ENERGY = "gremlin.pageRankVertexProgram.teleportationEnergy";
+    private static final String CONVERGENCE_ERROR = "gremlin.pageRankVertexProgram.convergenceError";
 
     private MessageScope.Local<Double> incidentMessageScope = MessageScope.Local.of(__::outE); <2>
     private MessageScope.Local<Double> countMessageScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.incidentMessageScope));
     private PureTraversal<Vertex, Edge> edgeTraversal = null;
     private PureTraversal<Vertex, ? extends Number> initialRankTraversal = null;
-    private double vertexCountAsDouble = 1.0d;
     private double alpha = 0.85d;
-    private int totalIterations = 30;
+    private double epsilon = 0.00001d;
+    private int maxIterations = 20;
     private String property = PAGE_RANK; <3>
     private Set<VertexComputeKey> vertexComputeKeys;
+    private Set<MemoryComputeKey> memoryComputeKeys;
 
     private PageRankVertexProgram() {
 
@@ -220,20 +224,26 @@ public class PageRankVertexProgram implements VertexProgram<Double> {  <1>
             this.incidentMessageScope = MessageScope.Local.of(() -> this.edgeTraversal.get().clone());
             this.countMessageScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.incidentMessageScope));
         }
-        this.vertexCountAsDouble = configuration.getDouble(VERTEX_COUNT, 1.0d);
-        this.alpha = configuration.getDouble(ALPHA, 0.85d);
-        this.totalIterations = configuration.getInt(TOTAL_ITERATIONS, 30);
+        this.alpha = configuration.getDouble(ALPHA, this.alpha);
+        this.epsilon = configuration.getDouble(EPSILON, this.epsilon);
+        this.maxIterations = configuration.getInt(MAX_ITERATIONS, 20);
         this.property = configuration.getString(PROPERTY, PAGE_RANK);
-        this.vertexComputeKeys = new HashSet<>(Arrays.asList(VertexComputeKey.of(this.property, false), VertexComputeKey.of(EDGE_COUNT, true))); <5>
+        this.vertexComputeKeys = new HashSet<>(Arrays.asList(
+                VertexComputeKey.of(this.property, false),
+                VertexComputeKey.of(EDGE_COUNT, true))); <5>
+        this.memoryComputeKeys = new HashSet<>(Arrays.asList(
+                MemoryComputeKey.of(TELEPORTATION_ENERGY, Operator.sum, true, true),
+                MemoryComputeKey.of(VERTEX_COUNT, Operator.sum, true, true),
+                MemoryComputeKey.of(CONVERGENCE_ERROR, Operator.sum, false, true)));
     }
 
     @Override
     public void storeState(final Configuration configuration) {
         VertexProgram.super.storeState(configuration);
-        configuration.setProperty(VERTEX_COUNT, this.vertexCountAsDouble);
         configuration.setProperty(ALPHA, this.alpha);
-        configuration.setProperty(TOTAL_ITERATIONS, this.totalIterations);
+        configuration.setProperty(EPSILON, this.epsilon);
         configuration.setProperty(PROPERTY, this.property);
+        configuration.setProperty(MAX_ITERATIONS, this.maxIterations);
         if (null != this.edgeTraversal)
             this.edgeTraversal.storeState(configuration, EDGE_TRAVERSAL);
         if (null != this.initialRankTraversal)
@@ -251,13 +261,18 @@ public class PageRankVertexProgram implements VertexProgram<Double> {  <1>
     }
 
     @Override
-    public Set<VertexComputeKey> getVertexComputeKeys() {   <6>
+    public Set<VertexComputeKey> getVertexComputeKeys() { <6>
         return this.vertexComputeKeys;
     }
 
     @Override
     public Optional<MessageCombiner<Double>> getMessageCombiner() {
         return (Optional) PageRankMessageCombiner.instance();
+    }
+
+    @Override
+    public Set<MemoryComputeKey> getMemoryComputeKeys() {
+        return this.memoryComputeKeys;
     }
 
     @Override
@@ -281,39 +296,59 @@ public class PageRankVertexProgram implements VertexProgram<Double> {  <1>
 
     @Override
     public void setup(final Memory memory) {
-
+        memory.set(TELEPORTATION_ENERGY, null == this.initialRankTraversal ? 1.0d : 0.0d);
+        memory.set(VERTEX_COUNT, 0.0d);
+        memory.set(CONVERGENCE_ERROR, 1.0d);
     }
 
     @Override
     public void execute(final Vertex vertex, Messenger<Double> messenger, final Memory memory) { <7>
         if (memory.isInitialIteration()) {
-            messenger.sendMessage(this.countMessageScope, 1.0d); <8>
-        } else if (1 == memory.getIteration()) {
-            double initialPageRank = (null == this.initialRankTraversal ?
-                    1.0d :
-                    TraversalUtil.apply(vertex, this.initialRankTraversal.get()).doubleValue()) / this.vertexCountAsDouble;  <9>
-            double edgeCount = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
-            vertex.property(VertexProperty.Cardinality.single, this.property, initialPageRank);
-            vertex.property(VertexProperty.Cardinality.single, EDGE_COUNT, edgeCount);
-            if (!this.terminate(memory)) // don't send messages if this is the last iteration
-                messenger.sendMessage(this.incidentMessageScope, initialPageRank / edgeCount);
+            messenger.sendMessage(this.countMessageScope, 1.0d);  <8>
+            memory.add(VERTEX_COUNT, 1.0d);
         } else {
-            double newPageRank = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b); <10>
-            newPageRank = (this.alpha * newPageRank) + ((1.0d - this.alpha) / this.vertexCountAsDouble);
-            vertex.property(VertexProperty.Cardinality.single, this.property, newPageRank);
-            if (!this.terminate(memory)) // don't send messages if this is the last iteration
-                messenger.sendMessage(this.incidentMessageScope, newPageRank / vertex.<Double>value(EDGE_COUNT));
+            final double vertexCount = memory.<Double>get(VERTEX_COUNT);
+            final double edgeCount;
+            double pageRank;
+            if (1 == memory.getIteration()) {
+                edgeCount = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
+                vertex.property(VertexProperty.Cardinality.single, EDGE_COUNT, edgeCount);
+                pageRank = null == this.initialRankTraversal ?
+                        0.0d :
+                        TraversalUtil.apply(vertex, this.initialRankTraversal.get()).doubleValue(); <9>
+            } else {
+                edgeCount = vertex.value(EDGE_COUNT);
+                pageRank = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b); <10>
+            }
+            //////////////////////////
+            final double teleporationEnergy = memory.get(TELEPORTATION_ENERGY);
+            if (teleporationEnergy > 0.0d) {
+                final double localTerminalEnergy = teleporationEnergy / vertexCount;
+                pageRank = pageRank + localTerminalEnergy;
+                memory.add(TELEPORTATION_ENERGY, -localTerminalEnergy);
+            }
+            final double previousPageRank = vertex.<Double>property(this.property).orElse(0.0d);
+            memory.add(CONVERGENCE_ERROR, Math.abs(pageRank - previousPageRank));
+            vertex.property(VertexProperty.Cardinality.single, this.property, pageRank);
+            memory.add(TELEPORTATION_ENERGY, (1.0d - this.alpha) * pageRank);
+            pageRank = this.alpha * pageRank;
+            if (edgeCount > 0.0d)
+                messenger.sendMessage(this.incidentMessageScope, pageRank / edgeCount);
+            else
+                memory.add(TELEPORTATION_ENERGY, pageRank);
         }
     }
 
     @Override
-    public boolean terminate(final Memory memory) {
-        return memory.getIteration() >= this.totalIterations;  <11>
+    public boolean terminate(final Memory memory) { <11>
+        boolean terminate = memory.<Double>get(CONVERGENCE_ERROR) < this.epsilon || memory.getIteration() >= this.maxIterations;
+        memory.set(CONVERGENCE_ERROR, 0.0d);
+        return terminate;
     }
 
     @Override
     public String toString() {
-        return StringFactory.vertexProgramString(this, "alpha=" + this.alpha + ", iterations=" + this.totalIterations);
+        return StringFactory.vertexProgramString(this, "alpha=" + this.alpha + ", epsilon=" + this.epsilon + ", iterations=" + this.maxIterations);
     }
 }
 ----
@@ -328,7 +363,7 @@ public class PageRankVertexProgram implements VertexProgram<Double> {  <1>
 <8> In order to determine how to distribute the energy to neighbors, a "1"-count is used to determine how many incident vertices exist for the `MessageScope`.
 <9> Initially, each vertex is provided an equal amount of energy represented as a double.
 <10> Energy is aggregated, computed on according to the PageRank algorithm, and then disseminated according to the defined `MessageScope.Local`.
-<11> The computation is terminated after a pre-defined number of iterations.
+<11> The computation is terminated after epsilon-convergence is met or a pre-defined number of iterations have taken place.
 
 The above `PageRankVertexProgram` is used as follows.
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -32,6 +32,39 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.1/CHANGELOG.asc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+PageRankVertexProgram
+^^^^^^^^^^^^^^^^^^^^^
+
+There were two major bugs in the way in which PageRank was being calculated in `PageRankVertexProgram`. First, teleportation
+energy was not being distributed correctly amongst the vertices at each round. Second, terminal vertices (i.e. vertices
+with no outgoing edges) did not have their full gathered energy distributed via teleportation. As a secondary benefit,
+`PageRankVertexProgram` also always calculates the vertex count and no longer requires the user to specify the vertex count.
+
+For users upgrading, note that while the relative rank orders will remain "the same," the actual PageRank values will differ
+from prior TinkerPop versions.
+
+```
+VERTEX  iGRAPH    TINKERPOP
+marko   0.1119788 0.11375485828040575
+vadas   0.1370267 0.14598540145985406
+lop     0.2665600 0.30472082661863686
+josh    0.1620746 0.14598540145985406
+ripple  0.2103812 0.1757986539008437
+peter   0.1119788 0.11375485828040575
+```
+
+Normalization preserved through computation:
+
+```
+0.11375485828040575 +
+0.14598540145985406 +
+0.30472082661863686 +
+0.14598540145985406 +
+0.1757986539008437 +
+0.11375485828040575
+==>1.00000000000000018
+```
+
 IO Defaults
 ^^^^^^^^^^^
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -69,6 +69,8 @@ Two other additions to `PageRankVertexProgram` were provided as well.
 1. It now calculates the vertex count and thus, no longer requires the user to specify the vertex count.
 2. It now allows the user to leverage an epsilon-based convergence instead of having to specify the number of iterations to execute.
 
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1783[TINKERPOP-1783]
+
 IO Defaults
 ^^^^^^^^^^^
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -37,8 +37,7 @@ PageRankVertexProgram
 
 There were two major bugs in the way in which PageRank was being calculated in `PageRankVertexProgram`. First, teleportation
 energy was not being distributed correctly amongst the vertices at each round. Second, terminal vertices (i.e. vertices
-with no outgoing edges) did not have their full gathered energy distributed via teleportation. As a secondary benefit,
-`PageRankVertexProgram` also always calculates the vertex count and no longer requires the user to specify the vertex count.
+with no outgoing edges) did not have their full gathered energy distributed via teleportation.
 
 For users upgrading, note that while the relative rank orders will remain "the same," the actual PageRank values will differ
 from prior TinkerPop versions.
@@ -64,6 +63,11 @@ Normalization preserved through computation:
 0.11375485828040575
 ==>1.00000000000000018
 ```
+
+Two other additions to `PageRankVertexProgram` were provided as well.
+
+1. It now calculates the vertex count and thus, no longer requires the user to specify the vertex count.
+2. It now allows the user to leverage an epsilon-based convergence instead of having to specify the number of iterations to execute.
 
 IO Defaults
 ^^^^^^^^^^^

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -206,9 +206,9 @@ public class PageRankVertexProgram implements VertexProgram<Double> {
 
     @Override
     public boolean terminate(final Memory memory) {
-        // System.out.println(memory.<Double>get(CONVERGENCE_ERROR));
+        boolean terminate = memory.<Double>get(CONVERGENCE_ERROR) < this.epsilon || memory.getIteration() >= this.maxIterations;
         memory.set(CONVERGENCE_ERROR, 0.0d);
-        return memory.<Double>get(CONVERGENCE_ERROR) < this.epsilon || memory.getIteration() >= this.maxIterations;
+        return terminate;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -215,7 +215,9 @@ public class PageRankVertexProgram implements VertexProgram<Double> {
 
     @Override
     public String toString() {
-        return StringFactory.vertexProgramString(this, "alpha=" + this.alpha + ", iterations=" + this.totalIterations + ", epsilon=" + this.epsilon);
+        return -1 == this.totalIterations ?
+                StringFactory.vertexProgramString(this, "alpha=" + this.alpha + ", epsilon=" + this.epsilon) :
+                StringFactory.vertexProgramString(this, "alpha=" + this.alpha + ", iterations=" + this.totalIterations);
     }
 
     //////////////////////////////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -47,7 +47,7 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
 
     private PureTraversal<Vertex, Edge> edgeTraversal;
     private String pageRankProperty = PageRankVertexProgram.PAGE_RANK;
-    private int times = -2;
+    private int times = 20;
     private final double alpha;
 
     public PageRankVertexProgramStep(final Traversal.Admin traversal, final double alpha) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -47,7 +47,7 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
 
     private PureTraversal<Vertex, Edge> edgeTraversal;
     private String pageRankProperty = PageRankVertexProgram.PAGE_RANK;
-    private int times = 30;
+    private int times = -2;
     private final double alpha;
 
     public PageRankVertexProgramStep(final Traversal.Admin traversal, final double alpha) {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
@@ -107,7 +107,7 @@ public class PageRankVertexProgramTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void shouldExecutePageRankWithEnergyConservation() throws Exception {
-        final ComputerResult result = graph.compute().program(PageRankVertexProgram.build().create(graph)).submit().get();
+        final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).program(PageRankVertexProgram.build().create(graph)).submit().get();
         final double sum = result.graph().traversal().V().values(PageRankVertexProgram.PAGE_RANK).sum().next().doubleValue();
         assertEquals(1.0d, sum, 0.01d);
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
@@ -36,7 +36,7 @@ public class PageRankVertexProgramTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void shouldExecutePageRank() throws Exception {
+    public void shouldExecutePageRankWithIterationsBreak() throws Exception {
         if (graphProvider.getGraphComputer(graph).features().supportsResultGraphPersistCombination(GraphComputer.ResultGraph.NEW, GraphComputer.Persist.VERTEX_PROPERTIES)) {
             final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).
                     program(PageRankVertexProgram.build().epsilon(0.0d).iterations(30).create(graph)).submit().get(); // by using epsilon 0.0, we guarantee iterations 30
@@ -69,14 +69,46 @@ public class PageRankVertexProgramTest extends AbstractGremlinProcessTest {
         }
     }
 
-    /*@Test
+    @Test
     @LoadGraphWith(MODERN)
-    public void shouldExecutePageRankWithNormalizedValues() throws Exception {
-        final ComputerResult result = graph.compute().program(PageRankVertexProgram.build().vertexCount(6).create()).submit().get();
-        final double sum = result.graph().traversal().V().values(PageRankVertexProgram.PAGE_RANK).sum().next();
-        System.out.println(sum);
-        assertEquals(1.0d,sum,0.01);
-    }*/
+    public void shouldExecutePageRankWithEpsilonBreak() throws Exception {
+        if (graphProvider.getGraphComputer(graph).features().supportsResultGraphPersistCombination(GraphComputer.ResultGraph.NEW, GraphComputer.Persist.VERTEX_PROPERTIES)) {
+            final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).
+                    program(PageRankVertexProgram.build().epsilon(0.00001d).iterations(30).create(graph)).submit().get(); // by using epsilon 0.00001, we should get iterations 11
+            result.graph().traversal().V().forEachRemaining(v -> {
+                assertEquals(3, v.keys().size()); // name, age/lang, pageRank
+                assertTrue(v.keys().contains("name"));
+                assertTrue(v.keys().contains(PageRankVertexProgram.PAGE_RANK));
+                assertEquals(1, IteratorUtils.count(v.values("name")));
+                assertEquals(1, IteratorUtils.count(v.values(PageRankVertexProgram.PAGE_RANK)));
+                final String name = v.value("name");
+                final Double pageRank = v.value(PageRankVertexProgram.PAGE_RANK);
+                //System.out.println(name + "-----" + pageRank);
+                if (name.equals("marko"))
+                    assertTrue(pageRank > 0.10 && pageRank < 0.12);
+                else if (name.equals("vadas"))
+                    assertTrue(pageRank > 0.13 && pageRank < 0.15);
+                else if (name.equals("lop"))
+                    assertTrue(pageRank > 0.29 && pageRank < 0.31);
+                else if (name.equals("josh"))
+                    assertTrue(pageRank > 0.13 && pageRank < 0.15);
+                else if (name.equals("ripple"))
+                    assertTrue(pageRank > 0.16 && pageRank < 0.18);
+                else if (name.equals("peter"))
+                    assertTrue(pageRank > 0.10 && pageRank < 0.12);
+                else
+                    throw new IllegalStateException("The following vertex should not exist in the graph: " + name);
+            });
+            assertEquals(result.memory().getIteration(), 11);
+            assertEquals(result.memory().asMap().size(), 0);
+        }
+    }
 
-
+    @Test
+    @LoadGraphWith(MODERN)
+    public void shouldExecutePageRankWithEnergyConservation() throws Exception {
+        final ComputerResult result = graph.compute().program(PageRankVertexProgram.build().create(graph)).submit().get();
+        final double sum = result.graph().traversal().V().values(PageRankVertexProgram.PAGE_RANK).sum().next().doubleValue();
+        assertEquals(1.0d, sum, 0.01d);
+    }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
@@ -38,7 +38,8 @@ public class PageRankVertexProgramTest extends AbstractGremlinProcessTest {
     @LoadGraphWith(MODERN)
     public void shouldExecutePageRank() throws Exception {
         if (graphProvider.getGraphComputer(graph).features().supportsResultGraphPersistCombination(GraphComputer.ResultGraph.NEW, GraphComputer.Persist.VERTEX_PROPERTIES)) {
-            final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).program(PageRankVertexProgram.build().iterations(30).create(graph)).submit().get();
+            final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).
+                    program(PageRankVertexProgram.build().epsilon(0.0d).iterations(30).create(graph)).submit().get(); // by using epsilon 0.0, we guarantee iterations 30
             result.graph().traversal().V().forEachRemaining(v -> {
                 assertEquals(3, v.keys().size()); // name, age/lang, pageRank
                 assertTrue(v.keys().contains("name"));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
@@ -49,17 +49,17 @@ public class PageRankVertexProgramTest extends AbstractGremlinProcessTest {
                 final Double pageRank = v.value(PageRankVertexProgram.PAGE_RANK);
                 //System.out.println(name + "-----" + pageRank);
                 if (name.equals("marko"))
-                    assertTrue(pageRank > 0.14 && pageRank < 0.16);
+                    assertTrue(pageRank > 0.10 && pageRank < 0.12);
                 else if (name.equals("vadas"))
-                    assertTrue(pageRank > 0.19 && pageRank < 0.20);
+                    assertTrue(pageRank > 0.13 && pageRank < 0.15);
                 else if (name.equals("lop"))
-                    assertTrue(pageRank > 0.40 && pageRank < 0.41);
+                    assertTrue(pageRank > 0.29 && pageRank < 0.31);
                 else if (name.equals("josh"))
-                    assertTrue(pageRank > 0.19 && pageRank < 0.20);
+                    assertTrue(pageRank > 0.13 && pageRank < 0.15);
                 else if (name.equals("ripple"))
-                    assertTrue(pageRank > 0.23 && pageRank < 0.24);
+                    assertTrue(pageRank > 0.16 && pageRank < 0.18);
                 else if (name.equals("peter"))
-                    assertTrue(pageRank > 0.14 && pageRank < 0.16);
+                    assertTrue(pageRank > 0.10 && pageRank < 0.12);
                 else
                     throw new IllegalStateException("The following vertex should not exist in the graph: " + name);
             });

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
@@ -38,7 +38,7 @@ public class PageRankVertexProgramTest extends AbstractGremlinProcessTest {
     @LoadGraphWith(MODERN)
     public void shouldExecutePageRank() throws Exception {
         if (graphProvider.getGraphComputer(graph).features().supportsResultGraphPersistCombination(GraphComputer.ResultGraph.NEW, GraphComputer.Persist.VERTEX_PROPERTIES)) {
-            final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).program(PageRankVertexProgram.build().create(graph)).submit().get();
+            final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).program(PageRankVertexProgram.build().iterations(30).create(graph)).submit().get();
             result.graph().traversal().V().forEachRemaining(v -> {
                 assertEquals(3, v.keys().size()); // name, age/lang, pageRank
                 assertTrue(v.keys().contains("name"));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
@@ -180,7 +180,7 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
             Vertex vertex = (Vertex) map.get("a");
             double pageRank = (Double) map.get("b");
             assertEquals(convertToVertexId("marko"), vertex.id());
-            assertTrue(pageRank > 0.15d);
+            assertTrue(pageRank > 0.10d);
             counter++;
         }
         assertEquals(2, counter);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
@@ -72,10 +72,10 @@ public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
         final Map<Object, Number> map = traversal.next();
         assertFalse(traversal.hasNext());
         assertEquals(4, map.size());
-        assertEquals(1.0d, (double) map.get(convertToVertexId("marko")), 0.001d);
-        assertEquals(0.0d, (double) map.get(convertToVertexId("lop")), 0.001d);
-        assertEquals(0.0d, (double) map.get(convertToVertexId("ripple")), 0.001d);
-        assertEquals(0.0d, (double) map.get(convertToVertexId("peter")), 0.001d);
+        assertEquals(0.583d, (double) map.get(convertToVertexId("marko")), 0.001d);
+        assertEquals(0.138d, (double) map.get(convertToVertexId("lop")), 0.001d);
+        assertEquals(0.138d, (double) map.get(convertToVertexId("ripple")), 0.001d);
+        assertEquals(0.138d, (double) map.get(convertToVertexId("peter")), 0.001d);
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1783

There were a couple of problems with `PageRankVertexProgram`. In order to describe the problems, its necessary to explain PageRank.

***

Initially, every vertex gets `1.0/vertexCount` amount of energy. Thus, the total energy in the system is 1.0.

At every iteration, 0.85 of that energy is distributed amongst adjacent neighbors and 0.15 is distributed amongst all vertices (this is the `alpha` parameter w/ the default being 0.85). If a vertex does not have outgoing edges and it can not distribute its 0.85 energy amongst its neighbors, then all that energy is teleported amongst all vertices.

The algorithm above ensures strong connectivity because the 0.15 energy distribution simulates a strongly connected graph via the concept of "teleportation." According to a Markov chain proof on ergodicity in strongly connected graphs, PageRank yields a positive eigenvector. That eigenvector is your rank vector and that rank vector's sum total is always the initial energy the system at iteration 0.

***

I fixed three things in this PR:

1. Vertex count is now determined in iteration 0 and no longer needs users to provide a vertex count.
2. Teleportation energy (global energy) is defined via a `Memory` variable.
3. Isolated vertices send their energy to the teleportation variable.

Here are the results compared with iGraph's implementation (note that iGraph does a convergence check while TinkerPop does not. It would be extremely expensive to test convergence in a distributed system -- thus, slightly different results).

```
VERTEX  iGRAPH    TINKERPOP
marko   0.1119788 0.11375485828040575
vadas   0.1370267 0.14598540145985406
lop     0.2665600 0.30472082661863686
josh    0.1620746 0.14598540145985406
ripple  0.2103812 0.1757986539008437
peter   0.1119788 0.11375485828040575
```

Finally, a proof of energy conservation:

```
gremlin> 0.11375485828040575 + 0.14598540145985406 + 0.30472082661863686 + 0.14598540145985406 + 0.1757986539008437 + 0.11375485828040575
==>1.00000000000000018
```

VOTE +1
