### PR TITLE
TINKERPOP-1787 Add syntax for :remote to accept a Cluster object

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Bump to Jackson 2.8.10.
 * Added an `EmbeddedRemoteConnection` so that it's possible to mimic a remote connection within the same JVM.
 * Supported interruption for remote traversals.
+* Allow the `:remote` command to accept a `Cluster` object defined in the console itself.
 * The Console's `plugin.txt` file is only updated if there were manually uninstalled plugins.
 * Fixed a bug in `MatchStep` where mid-traversal `where()` variables were not being considered in start-scope.
 * Generalized `MatchStep` to locally compute all clauses with barriers (not just reducing barriers).

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -538,6 +538,15 @@ submitting `:> graph` will return a `Graph` instance and in most cases those are
 and will return a serialization error.  It should be noted that `TinkerGraph`, as a convenience for shipping around
 small sub-graphs, is serializable from Gremlin Server.
 
+The alternative syntax to connecting allows for the `Cluster` to be user constructed directly in the console as
+opposed to simply providing a static YAML file.
+
+[gremlin-groovy]
+----
+cluster = Cluster.open()
+:remote connect tinkerpop.server cluster
+----
+
 The Gremlin Server `:remote config` command for the driver has the following configuration options:
 
 [width="100%",cols="3,10a",options="header"]

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -41,6 +41,21 @@ simple way to provide a "remote" that is actually local to the same JVM.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1756[TINKERPOP-1756]
 
+Specify a Cluster Object
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `:remote connect` command can now take a pre-defined `Cluster` object as its argument as opposed to a YAML
+configuration file.
+
+[source,text]
+----
+gremlin> cluster = Cluster.open()
+==>localhost/127.0.0.1:8182
+gremlin> :remote connect tinkerpop.server cluster
+==>Configured localhost/127.0.0.1:8182
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1787[TINKERPOP-1787]
 
 Remote Traversal Timeout
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.jsr223.console.RemoteException;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 
 import javax.security.sasl.SaslException;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
@@ -84,10 +85,21 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
 
     @Override
     public Object connect(final List<String> args) throws RemoteException {
-        if (args.size() < 1) throw new RemoteException("Expects the location of a configuration file as an argument");
+        if (args.size() < 1) throw new RemoteException("Expects the location of a configuration file or variable name for a Cluster object as an argument");
 
         try {
-            this.currentCluster = Cluster.open(args.get(0));
+            final String fileOrVar = args.get(0);
+            if (new File(fileOrVar).isFile())
+                this.currentCluster = Cluster.open(fileOrVar);
+            else if (shellEnvironment.getVariable(fileOrVar) != null) {
+                final Object o = shellEnvironment.getVariable(fileOrVar);
+                if (o instanceof Cluster) {
+                    this.currentCluster = (Cluster) o;
+                }
+            }
+
+            if (null == currentCluster)
+                throw new RemoteException("Expects the location of a configuration file or variable name for a Cluster object as an argument");
             final boolean useSession = args.size() >= 2 && (args.get(1).equals(TOKEN_SESSION) || args.get(1).equals(TOKEN_SESSION_MANAGED));
             if (useSession) {
                 final String sessionName = args.size() == 3 ? args.get(2) : UUID.randomUUID().toString();

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.console.groovy.plugin;
 
 import org.apache.tinkerpop.gremlin.TestHelper;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -80,8 +81,14 @@ public class DriverRemoteAcceptorIntegrateTest extends AbstractGremlinServerInte
     }
 
     @Test
-    public void shouldConnect() throws Exception {
+    public void shouldConnectWithRemoteYaml() throws Exception {
         assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Configured "));
+    }
+
+    @Test
+    public void shouldConnectWithRemoteVariable() throws Exception {
+        groovysh.getInterp().evaluate(Collections.singletonList("cluster = " + Cluster.class.getName() + ".open(\"" + TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath() + "\")"));
+        assertThat(acceptor.connect(Collections.singletonList("cluster")).toString(), startsWith("Configured "));
     }
 
     @Test

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorIntegrateTest.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.console.jsr223;
 
 import org.apache.tinkerpop.gremlin.TestHelper;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.jsr223.console.GremlinShellEnvironment;
 import org.apache.tinkerpop.gremlin.server.Settings;
@@ -82,8 +83,14 @@ public class DriverRemoteAcceptorIntegrateTest extends AbstractGremlinServerInte
     }
 
     @Test
-    public void shouldConnect() throws Exception {
+    public void shouldConnectWithRemoteYaml() throws Exception {
         assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Configured "));
+    }
+
+    @Test
+    public void shouldConnectWithRemoteVariable() throws Exception {
+        groovysh.getInterp().evaluate(Collections.singletonList("cluster = " + Cluster.class.getName() + ".open(\"" + TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath() + "\")"));
+        assertThat(acceptor.connect(Collections.singletonList("cluster")).toString(), startsWith("Configured "));
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1787

Allows for this syntax:

```text
gremlin> cluster = Cluster.open()
==>localhost/127.0.0.1:8182
gremlin> :remote connect tinkerpop.server cluster
==>Configured localhost/127.0.0.1:8182
```

All tests pass and docs generate with `docker/build.sh -t -n -i -d`

VOTE +1