### PR TITLE
TINKERPOP-1789: Reference elements should be represented by id and label

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* `ReferenceVertex` was missing its `label()` string. `ReferenceElement` now supports all label handling.
 * Added `GraphHelper.cloneElements(Graph original, Graph clone)` to the `gremlin-test` module to quickly clone a graph.
 * Bump to GMavenPlus 1.6.
 * Added better error message for illegal use of `repeat()`-step.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -101,7 +101,7 @@ Upgrading for Providers
 ReferenceVertex Label
 ^^^^^^^^^^^^^^^^^^^^^
 
-`ReferenceVertex.label()` was hard coded to return `EMPTY_STRING`. At some point, `ReferenceElements` were support to
+`ReferenceVertex.label()` was hard coded to return `EMPTY_STRING`. At some point, `ReferenceElements` were suppose to
 return labels and `ReferenceVertex` was never updated as such. Note that `ReferenceEdge` and `ReferenceVertexProperty`
 work as expected. However, given a general change at `ReferenceElement`, the Gryo serialization of `ReferenceXXX` is
 different. If the vertex does not have a label `Vertex.DEFAULT_LABEL` is assumed.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -104,7 +104,7 @@ ReferenceVertex Label
 `ReferenceVertex.label()` was hard coded to return `EMPTY_STRING`. At some point, `ReferenceElements` were support to
 return labels and `ReferenceVertex` was never updated as such. Note that `ReferenceEdge` and `ReferenceVertexProperty`
 work as expected. However, given a general change at `ReferenceElement`, the Gryo serialization of `ReferenceXXX` is
-different.
+different. If the vertex does not have a label `Vertex.DEFAULT_LABEL` is assumed.
 
 See: https://issues.apache.org/jira/browse/TINKERPOP-1789[TINKERPOP-1789]
 

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -95,6 +95,19 @@ In `gremlin-test` there is a new `GraphHelper` class that has a `cloneElements()
 the first graph to the second - `GraphHelper.cloneElements(Graph original, Graph clone)`. This helper method is
 primarily intended for use in tests.
 
+Upgrading for Providers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+ReferenceVertex Label
+^^^^^^^^^^^^^^^^^^^^^
+
+`ReferenceVertex.label()` was hard coded to return `EMPTY_STRING`. At some point, `ReferenceElements` were support to
+return labels and `ReferenceVertex` was never updated as such. Note that `ReferenceEdge` and `ReferenceVertexProperty`
+work as expected. However, given a general change at `ReferenceElement`, the Gryo serialization of `ReferenceXXX` is
+different.
+
+See: https://issues.apache.org/jira/browse/TINKERPOP-1789[TINKERPOP-1789]
+
 TinkerPop 3.2.6
 ---------------
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceEdge.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceEdge.java
@@ -36,7 +36,6 @@ public class ReferenceEdge extends ReferenceElement<Edge> implements Edge {
 
     private ReferenceVertex inVertex;
     private ReferenceVertex outVertex;
-    private String label;
 
     private ReferenceEdge() {
 
@@ -46,7 +45,6 @@ public class ReferenceEdge extends ReferenceElement<Edge> implements Edge {
         super(edge);
         this.inVertex = new ReferenceVertex(edge.inVertex());
         this.outVertex = new ReferenceVertex(edge.outVertex());
-        this.label = edge.label();
     }
 
     @Override
@@ -87,10 +85,5 @@ public class ReferenceEdge extends ReferenceElement<Edge> implements Edge {
     @Override
     public String toString() {
         return StringFactory.edgeString(this);
-    }
-
-    @Override
-    public String label() {
-        return this.label;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceElement.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceElement.java
@@ -31,9 +31,8 @@ import java.io.Serializable;
  */
 public abstract class ReferenceElement<E extends Element> implements Element, Serializable, Attachable<E> {
 
-    protected static final String EMPTY_STRING = "";
-
     protected Object id;
+    protected String label;
 
     protected ReferenceElement() {
 
@@ -41,6 +40,7 @@ public abstract class ReferenceElement<E extends Element> implements Element, Se
 
     public ReferenceElement(final Element element) {
         this.id = element.id();
+        this.label = element.label();
     }
 
     @Override
@@ -50,7 +50,7 @@ public abstract class ReferenceElement<E extends Element> implements Element, Se
 
     @Override
     public String label() {
-        return EMPTY_STRING;
+        return this.label;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceElement.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceElement.java
@@ -18,10 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.structure.util.reference;
 
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
+import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.io.Serializable;
@@ -30,6 +33,8 @@ import java.io.Serializable;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public abstract class ReferenceElement<E extends Element> implements Element, Serializable, Attachable<E> {
+
+    private final static String EMPTY_STRING = "";
 
     protected Object id;
     protected String label;
@@ -40,7 +45,16 @@ public abstract class ReferenceElement<E extends Element> implements Element, Se
 
     public ReferenceElement(final Element element) {
         this.id = element.id();
-        this.label = element.label();
+        try {
+            this.label = element.label();
+        } catch (final UnsupportedOperationException e) {
+            if (element instanceof Vertex)
+                this.label = Vertex.DEFAULT_LABEL;
+            else if (element instanceof Edge)
+                this.label = Edge.DEFAULT_LABEL;
+            else
+                this.label = VertexProperty.DEFAULT_LABEL;
+        }
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceElement.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceElement.java
@@ -34,8 +34,6 @@ import java.io.Serializable;
  */
 public abstract class ReferenceElement<E extends Element> implements Element, Serializable, Attachable<E> {
 
-    private final static String EMPTY_STRING = "";
-
     protected Object id;
     protected String label;
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexProperty.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexProperty.java
@@ -34,7 +34,6 @@ import java.util.NoSuchElementException;
 public class ReferenceVertexProperty<V> extends ReferenceElement<VertexProperty<V>> implements VertexProperty<V> {
 
     private ReferenceVertex vertex;
-    private String key;
     private V value;
 
     private ReferenceVertexProperty() {
@@ -44,7 +43,6 @@ public class ReferenceVertexProperty<V> extends ReferenceElement<VertexProperty<
     public ReferenceVertexProperty(final VertexProperty<V> vertexProperty) {
         super(vertexProperty);
         this.vertex = ReferenceFactory.detach(vertexProperty.element());
-        this.key = vertexProperty.key();
         this.value = vertexProperty.value();
     }
 
@@ -55,12 +53,7 @@ public class ReferenceVertexProperty<V> extends ReferenceElement<VertexProperty<
 
     @Override
     public String key() {
-        return this.key;
-    }
-
-    @Override
-    public String label() {
-        return this.key;
+        return this.label();
     }
 
     @Override

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GryoLiteMessageSerializerV1d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GryoLiteMessageSerializerV1d0Test.java
@@ -82,9 +82,9 @@ public class GryoLiteMessageSerializerV1d0Test {
 
         assertEquals(0, IteratorUtils.count(deserializedEdge.properties()));
         assertEquals(v1.id(), deserializedEdge.outVertex().id());
-        assertEquals("", deserializedEdge.outVertex().label());
+        assertEquals(Vertex.DEFAULT_LABEL, deserializedEdge.outVertex().label());
         assertEquals(v2.id(), deserializedEdge.inVertex().id());
-        assertEquals("", deserializedEdge.inVertex().label());
+        assertEquals(Vertex.DEFAULT_LABEL, deserializedEdge.inVertex().label());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class GryoLiteMessageSerializerV1d0Test {
 
         final ReferenceVertex deserializedVertex = vertexList.get(0);
         assertEquals(0L, deserializedVertex.id());
-        assertEquals("", deserializedVertex.label());
+        assertEquals(Vertex.DEFAULT_LABEL, deserializedVertex.label());
 
         assertEquals(0, IteratorUtils.count(deserializedVertex.properties()));
     }
@@ -133,7 +133,7 @@ public class GryoLiteMessageSerializerV1d0Test {
         final Vertex deserializedMarko = deserializedMap.keySet().iterator().next();
         assertEquals(0, IteratorUtils.count(deserializedMarko.properties()));
         assertEquals(1, deserializedMarko.id());
-        assertEquals("", deserializedMarko.label());
+        assertEquals(Vertex.DEFAULT_LABEL, deserializedMarko.label());
 
         assertEquals(new Integer(1000), deserializedMap.values().iterator().next());
     }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -148,7 +148,7 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
         assertThat(v, instanceOf(ReferenceVertex.class));
 
         assertEquals(1L, v.id());
-        assertEquals("", v.label());
+        assertEquals("person", v.label());
         assertEquals(0, IteratorUtils.count(v.properties()));
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceEdgeTest.java
@@ -63,7 +63,7 @@ public class ReferenceEdgeTest extends AbstractGremlinTest {
         final Vertex v = graph.addVertex();
         final Edge e = v.addEdge("test", v);
         final ReferenceEdge re = ReferenceFactory.detach(e);
-        assertEquals("test", e.label());
+        assertEquals("test", re.label());
         assertSame(re, ReferenceFactory.detach(re));
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceEdgeTest.java
@@ -34,7 +34,10 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -60,6 +63,7 @@ public class ReferenceEdgeTest extends AbstractGremlinTest {
         final Vertex v = graph.addVertex();
         final Edge e = v.addEdge("test", v);
         final ReferenceEdge re = ReferenceFactory.detach(e);
+        assertEquals("test", e.label());
         assertSame(re, ReferenceFactory.detach(re));
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexPropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexPropertyTest.java
@@ -25,7 +25,10 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -38,6 +41,9 @@ public class ReferenceVertexPropertyTest extends AbstractGremlinTest {
         final Vertex v = graph.addVertex();
         final VertexProperty vp = v.property(VertexProperty.Cardinality.single, "test", "this");
         final ReferenceVertexProperty dvp = ReferenceFactory.detach(vp);
+        assertEquals("test", vp.label());
+        assertEquals("test", vp.key());
+        assertEquals("this", vp.value());
         assertSame(dvp, ReferenceFactory.detach(dvp));
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexPropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexPropertyTest.java
@@ -41,9 +41,9 @@ public class ReferenceVertexPropertyTest extends AbstractGremlinTest {
         final Vertex v = graph.addVertex();
         final VertexProperty vp = v.property(VertexProperty.Cardinality.single, "test", "this");
         final ReferenceVertexProperty dvp = ReferenceFactory.detach(vp);
-        assertEquals("test", vp.label());
-        assertEquals("test", vp.key());
-        assertEquals("this", vp.value());
+        assertEquals("test", dvp.label());
+        assertEquals("test", dvp.key());
+        assertEquals("this", dvp.value());
         assertSame(dvp, ReferenceFactory.detach(dvp));
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
@@ -70,11 +71,12 @@ public class ReferenceVertexTest extends AbstractGremlinTest {
     @Test
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
     public void shouldConstructReferenceVertex() {
-        final Vertex v = graph.addVertex("test", "123");
+        final Vertex v = graph.addVertex(T.label, "blah", "test", "123");
         final ReferenceVertex referenceVertex = ReferenceFactory.detach(v);
 
         assertEquals(v.id(), referenceVertex.id());
-        assertEquals("test", v.label());
+        assertEquals("blah", referenceVertex.label());
+        assertEquals(v.label(), referenceVertex.label());
         assertEquals(0, IteratorUtils.count(referenceVertex.properties()));
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceVertexTest.java
@@ -74,6 +74,7 @@ public class ReferenceVertexTest extends AbstractGremlinTest {
         final ReferenceVertex referenceVertex = ReferenceFactory.detach(v);
 
         assertEquals(v.id(), referenceVertex.id());
+        assertEquals("test", v.label());
         assertEquals(0, IteratorUtils.count(referenceVertex.properties()));
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1789

Fixed a bug where `ReferenceVertex` was always returning an `EMPTY_STRING` `label()`. `ReferenceEdge` and `ReferenceVertexProperty` were behaving correctly, but I needed to make a change at `ReferenceElement` for general handling of all element labels. Thus, those other two classes changed. And thus, the Gryo. I updated all the `ReferenceXXXTest` classes to check for `label()` accordingly. Updated CHANGELOG and upgrade docs.

VOTE +1