### PR TITLE
TINKERPOP-1793: addE() should allow dynamic edge labels

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
+* Added missing `GraphTraversalSource.addE()`-method to `GremlinDslProcessor`.
+* Changed `to()` and `from()` traversal-based steps to take a wildcard `?` instead of of `E`.
 * Added `addV(traversal)` and `addE(traversal)` so that created element labels can be determined dynamically.
 * `PageRankVertexProgram` supports `maxIterations` but will break out early if epsilon-based convergence occurs.
 * Added support for epsilon-based convergence in `PageRankVertexProgram`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,7 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
-* Added `addV(traversal)` and `addE(traversal)`, where created element labels can be determined dynamically.
+* Added `addV(traversal)` and `addE(traversal)` so that created element labels can be determined dynamically.
 * `PageRankVertexProgram` supports `maxIterations` but will break out early if epsilon-based convergence occurs.
 * Added support for epsilon-based convergence in `PageRankVertexProgram`.
 * Fixed two major bugs in how PageRank was being calculated in `PageRankVertexProgram`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
+* Added `addV(traversal)` and `addE(traversal)`, where created element labels can be determined dynamically.
 * `PageRankVertexProgram` supports `maxIterations` but will break out early if epsilon-based convergence occurs.
 * Added support for epsilon-based convergence in `PageRankVertexProgram`.
 * Fixed two major bugs in how PageRank was being calculated in `PageRankVertexProgram`.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -29,6 +29,12 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.1/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== addV(traversal) and addE(traversal)
+
+The `GraphTraversal` and `GraphTraversalSource` methods of `addV()` and `addE()` have been extended to support dynamic
+label determination upon element creation. Both these methods can take a `Traversal<?, String>` where the first `String`
+returned by the traversal is used as the label of the respective element.
+
 ==== PageRankVertexProgram
 
 There were two major bugs in the way in which PageRank was being calculated in `PageRankVertexProgram`. First, teleportation

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -29,11 +29,34 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.1/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Changed Typing on `from()` and `to()`
+
+The `from()` and `to()` steps of `GraphTraversal` have a `Traversal<E,Vertex>` overload. The `E` has been changed to `?`
+in order to reduce `< >`-based coersion in strongly type Gremlin language variants.
+
 ==== addV(traversal) and addE(traversal)
 
 The `GraphTraversal` and `GraphTraversalSource` methods of `addV()` and `addE()` have been extended to support dynamic
 label determination upon element creation. Both these methods can take a `Traversal<?, String>` where the first `String`
 returned by the traversal is used as the label of the respective element.
+
+[source,groovy]
+----
+gremlin> g = TinkerFactory.createModern().traversal()
+==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
+gremlin> g.addV(V().has('name','marko').label()).
+           property('name','stephen')
+==>v[13]
+gremlin> g.V().has('name','stephen').valueMap(true)
+==>[name:[stephen],label:person,id:13]
+gremlin> g.V().has('name','stephen').
+           addE(V().hasLabel('software').inE().label()).
+             to(V().has('name','lop'))
+==>e[15][13-created->3]
+gremlin> g.V().has('name','stephen').outE().valueMap(true)
+==>[label:created,id:15]
+gremlin>
+----
 
 ==== PageRankVertexProgram
 

--- a/gremlin-core/api-changes.json
+++ b/gremlin-core/api-changes.json
@@ -9,6 +9,78 @@
           "classSimpleName": "Builder",
           "methodName": "requiresVersion",
           "justification": "Graph providers may run into problems with the test suite if they do not have a way to detect the version and type of IO being requested of them so that they can provide the right version of their IoRegistry instances."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::to(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<E, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "new": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::to(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "oldType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<E extends java.lang.Object, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "newType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "package": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph",
+          "classSimpleName": "DefaultGraphTraversal",
+          "methodName": "to",
+          "parameterIndex": "0",
+          "justification": "Generalized from E to ? to reduce overly complicated typing"
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::from(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<E, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "new": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::from(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "oldType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<E extends java.lang.Object, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "newType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "package": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph",
+          "classSimpleName": "DefaultGraphTraversal",
+          "methodName": "from",
+          "parameterIndex": "0",
+          "justification": "Generalized from E to ? to reduce overly complicated typing"
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::to(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<E, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "new": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::to(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "oldType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<E extends java.lang.Object, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "newType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "package": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph",
+          "classSimpleName": "GraphTraversal",
+          "methodName": "to",
+          "parameterIndex": "0",
+          "justification": "Generalized from E to ? to reduce overly complicated typing"
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::from(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<E, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "new": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::from(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "oldType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<E extends java.lang.Object, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "newType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "package": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph",
+          "classSimpleName": "GraphTraversal",
+          "methodName": "from",
+          "parameterIndex": "0",
+          "justification": "Generalized from E to ? to reduce overly complicated typing"
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::to(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<E, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "new": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::to(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "oldType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<E extends java.lang.Object, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "newType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "package": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph",
+          "classSimpleName": "Admin",
+          "methodName": "to",
+          "parameterIndex": "0",
+          "justification": "Generalized from E to ? to reduce overly complicated typing"
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::from(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<E, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "new": "method parameter org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E> org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<S, E>::from(===org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>===)",
+          "oldType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<E extends java.lang.Object, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "newType": "org.apache.tinkerpop.gremlin.process.traversal.Traversal<?, org.apache.tinkerpop.gremlin.structure.Vertex>",
+          "package": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph",
+          "classSimpleName": "Admin",
+          "methodName": "from",
+          "parameterIndex": "0",
+          "justification": "Generalized from E to ? to reduce overly complicated typing"
         }
       ]
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
@@ -26,10 +26,12 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal;
@@ -245,7 +247,7 @@ public class GremlinDslProcessor extends AbstractProcessor {
                     .addStatement("$N clone = this.clone()", ctx.traversalSourceClazz)
                     .addStatement("clone.getBytecode().addStep($T.addV)", GraphTraversal.Symbols.class)
                     .addStatement("$N traversal = new $N(clone)", ctx.defaultTraversalClazz, ctx.defaultTraversalClazz)
-                    .addStatement("return ($T) traversal.asAdmin().addStep(new $T(traversal, null))", ctx.traversalClassName, AddVertexStartStep.class)
+                    .addStatement("return ($T) traversal.asAdmin().addStep(new $T(traversal, (String) null))", ctx.traversalClassName, AddVertexStartStep.class)
                     .returns(ParameterizedTypeName.get(ctx.traversalClassName, ClassName.get(Vertex.class), ClassName.get(Vertex.class)))
                     .build());
             traversalSourceClass.addMethod(MethodSpec.methodBuilder("addV")
@@ -257,6 +259,36 @@ public class GremlinDslProcessor extends AbstractProcessor {
                     .addStatement("$N traversal = new $N(clone)", ctx.defaultTraversalClazz, ctx.defaultTraversalClazz)
                     .addStatement("return ($T) traversal.asAdmin().addStep(new $T(traversal, label))", ctx.traversalClassName, AddVertexStartStep.class)
                     .returns(ParameterizedTypeName.get(ctx.traversalClassName, ClassName.get(Vertex.class), ClassName.get(Vertex.class)))
+                    .build());
+            traversalSourceClass.addMethod(MethodSpec.methodBuilder("addV")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .addParameter(Traversal.class, "vertexLabelTraversal")
+                    .addStatement("$N clone = this.clone()", ctx.traversalSourceClazz)
+                    .addStatement("clone.getBytecode().addStep($T.addV, vertexLabelTraversal)", GraphTraversal.Symbols.class)
+                    .addStatement("$N traversal = new $N(clone)", ctx.defaultTraversalClazz, ctx.defaultTraversalClazz)
+                    .addStatement("return ($T) traversal.asAdmin().addStep(new $T(traversal, vertexLabelTraversal))", ctx.traversalClassName, AddVertexStartStep.class)
+                    .returns(ParameterizedTypeName.get(ctx.traversalClassName, ClassName.get(Vertex.class), ClassName.get(Vertex.class)))
+                    .build());
+            traversalSourceClass.addMethod(MethodSpec.methodBuilder("addE")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .addParameter(String.class, "label")
+                    .addStatement("$N clone = this.clone()", ctx.traversalSourceClazz)
+                    .addStatement("clone.getBytecode().addStep($T.addV, label)", GraphTraversal.Symbols.class)
+                    .addStatement("$N traversal = new $N(clone)", ctx.defaultTraversalClazz, ctx.defaultTraversalClazz)
+                    .addStatement("return ($T) traversal.asAdmin().addStep(new $T(traversal, label))", ctx.traversalClassName, AddEdgeStartStep.class)
+                    .returns(ParameterizedTypeName.get(ctx.traversalClassName, ClassName.get(Edge.class), ClassName.get(Edge.class)))
+                    .build());
+            traversalSourceClass.addMethod(MethodSpec.methodBuilder("addE")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .addParameter(Traversal.class, "edgeLabelTraversal")
+                    .addStatement("$N clone = this.clone()", ctx.traversalSourceClazz)
+                    .addStatement("clone.getBytecode().addStep($T.addV, edgeLabelTraversal)", GraphTraversal.Symbols.class)
+                    .addStatement("$N traversal = new $N(clone)", ctx.defaultTraversalClazz, ctx.defaultTraversalClazz)
+                    .addStatement("return ($T) traversal.asAdmin().addStep(new $T(traversal, edgeLabelTraversal))", ctx.traversalClassName, AddEdgeStartStep.class)
+                    .returns(ParameterizedTypeName.get(ctx.traversalClassName, ClassName.get(Edge.class), ClassName.get(Edge.class)))
                     .build());
             traversalSourceClass.addMethod(MethodSpec.methodBuilder("V")
                     .addModifiers(Modifier.PUBLIC)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -968,7 +968,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * @since 3.3.1
      */
     public default GraphTraversal<S, Vertex> addV(final Traversal<?, String> vertexLabelTraversal) {
-        this.asAdmin().getBytecode().addStep(Symbols.addV);
+        this.asAdmin().getBytecode().addStep(Symbols.addV, vertexLabelTraversal);
         return this.asAdmin().addStep(new AddVertexStep<>(this.asAdmin(), vertexLabelTraversal.asAdmin()));
     }
 
@@ -1005,7 +1005,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * @since 3.3.1
      */
     public default GraphTraversal<S, Edge> addE(final Traversal<?, String> edgeLabelTraversal) {
-        this.asAdmin().getBytecode().addStep(Symbols.addE);
+        this.asAdmin().getBytecode().addStep(Symbols.addE, edgeLabelTraversal);
         return this.asAdmin().addStep(new AddEdgeStep<>(this.asAdmin(), edgeLabelTraversal.asAdmin()));
     }
 
@@ -1046,7 +1046,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#addedge-step" target="_blank">Reference Documentation - From Step</a>
      * @since 3.1.0-incubating
      */
-    public default GraphTraversal<S, E> to(final Traversal<E, Vertex> toVertex) {
+    public default GraphTraversal<S, E> to(final Traversal<?, Vertex> toVertex) {
         this.asAdmin().getBytecode().addStep(Symbols.to, toVertex);
         ((FromToModulating) this.asAdmin().getEndStep()).addTo(toVertex.asAdmin());
         return this;
@@ -1061,7 +1061,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#addedge-step" target="_blank">Reference Documentation - From Step</a>
      * @since 3.1.0-incubating
      */
-    public default GraphTraversal<S, E> from(final Traversal<E, Vertex> fromVertex) {
+    public default GraphTraversal<S, E> from(final Traversal<?, Vertex> fromVertex) {
         this.asAdmin().getBytecode().addStep(Symbols.from, fromVertex);
         ((FromToModulating) this.asAdmin().getEndStep()).addFrom(fromVertex.asAdmin());
         return this;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -961,6 +961,18 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     /**
+     * Adds a {@link Vertex} with a vertex label determined by a {@link Traversal}.
+     *
+     * @return the traversal with the {@link AddVertexStep} added
+     * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#addvertex-step" target="_blank">Reference Documentation - AddVertex Step</a>
+     * @since 3.3.1
+     */
+    public default GraphTraversal<S, Vertex> addV(final Traversal<?, String> vertexLabelTraversal) {
+        this.asAdmin().getBytecode().addStep(Symbols.addV);
+        return this.asAdmin().addStep(new AddVertexStep<>(this.asAdmin(), vertexLabelTraversal.asAdmin()));
+    }
+
+    /**
      * Adds a {@link Vertex} with a default vertex label.
      *
      * @return the traversal with the {@link AddVertexStep} added
@@ -969,7 +981,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      */
     public default GraphTraversal<S, Vertex> addV() {
         this.asAdmin().getBytecode().addStep(Symbols.addV);
-        return this.asAdmin().addStep(new AddVertexStep<>(this.asAdmin(), null));
+        return this.asAdmin().addStep(new AddVertexStep<>(this.asAdmin(), Vertex.DEFAULT_LABEL));
     }
 
     /**
@@ -983,6 +995,18 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     public default GraphTraversal<S, Edge> addE(final String edgeLabel) {
         this.asAdmin().getBytecode().addStep(Symbols.addE, edgeLabel);
         return this.asAdmin().addStep(new AddEdgeStep<>(this.asAdmin(), edgeLabel));
+    }
+
+    /**
+     * Adds a {@link Edge} with an edge label determined by a {@link Traversal}.
+     *
+     * @return the traversal with the {@link AddEdgeStep} added
+     * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#addedge-step" target="_blank">Reference Documentation - AddEdge Step</a>
+     * @since 3.3.1
+     */
+    public default GraphTraversal<S, Edge> addE(final Traversal<?, String> edgeLabelTraversal) {
+        this.asAdmin().getBytecode().addStep(Symbols.addE);
+        return this.asAdmin().addStep(new AddEdgeStep<>(this.asAdmin(), edgeLabelTraversal.asAdmin()));
     }
 
     /**
@@ -1359,7 +1383,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      */
     public default GraphTraversal<S, E> has(final String propertyKey) {
         this.asAdmin().getBytecode().addStep(Symbols.has, propertyKey);
-        return this.asAdmin().addStep(new TraversalFilterStep(this.asAdmin(),  __.values(propertyKey)));
+        return this.asAdmin().addStep(new TraversalFilterStep(this.asAdmin(), __.values(propertyKey)));
     }
 
     /**
@@ -1708,8 +1732,8 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      *
      * @param skip the number of objects to skip
      * @return the traversal with an appended {@link RangeGlobalStep}
-     * @since 3.3.0
      * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#skip-step" target="_blank">Reference Documentation - Skip Step</a>
+     * @since 3.3.0
      */
     public default GraphTraversal<S, E> skip(final long skip) {
         this.asAdmin().getBytecode().addStep(Symbols.skip, skip);
@@ -1720,10 +1744,10 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * Filters out the first {@code n} objects in the traversal.
      *
      * @param scope the scope of how to apply the {@code tail}
-     * @param skip the number of objects to skip
+     * @param skip  the number of objects to skip
      * @return the traversal with an appended {@link RangeGlobalStep} or {@link RangeLocalStep} depending on {@code scope}
-     * @since 3.3.0
      * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#skip-step" target="_blank">Reference Documentation - Skip Step</a>
+     * @since 3.3.0
      */
     public default <E2> GraphTraversal<S, E2> skip(final Scope scope, final long skip) {
         this.asAdmin().getBytecode().addStep(Symbols.skip, scope, skip);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -981,7 +981,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      */
     public default GraphTraversal<S, Vertex> addV() {
         this.asAdmin().getBytecode().addStep(Symbols.addV);
-        return this.asAdmin().addStep(new AddVertexStep<>(this.asAdmin(), Vertex.DEFAULT_LABEL));
+        return this.asAdmin().addStep(new AddVertexStep<>(this.asAdmin(), (String) null));
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -23,14 +23,11 @@ import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.Bindings;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
-import org.apache.tinkerpop.gremlin.process.traversal.engine.StandardTraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
@@ -39,14 +36,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.Requir
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
@@ -261,11 +254,18 @@ public class GraphTraversalSource implements TraversalSource {
         return traversal.addStep(new AddVertexStartStep(traversal, label));
     }
 
+    public GraphTraversal<Vertex, Vertex> addV(final Traversal<?, String> vertexLabelTraversal) {
+        final GraphTraversalSource clone = this.clone();
+        clone.bytecode.addStep(GraphTraversal.Symbols.addV, vertexLabelTraversal);
+        final GraphTraversal.Admin<Vertex, Vertex> traversal = new DefaultGraphTraversal<>(clone);
+        return traversal.addStep(new AddVertexStartStep(traversal, vertexLabelTraversal));
+    }
+
     public GraphTraversal<Vertex, Vertex> addV() {
         final GraphTraversalSource clone = this.clone();
         clone.bytecode.addStep(GraphTraversal.Symbols.addV);
         final GraphTraversal.Admin<Vertex, Vertex> traversal = new DefaultGraphTraversal<>(clone);
-        return traversal.addStep(new AddVertexStartStep(traversal, null));
+        return traversal.addStep(new AddVertexStartStep(traversal, (String)null));
     }
 
     public GraphTraversal<Edge, Edge> addE(final String label) {
@@ -273,6 +273,13 @@ public class GraphTraversalSource implements TraversalSource {
         clone.bytecode.addStep(GraphTraversal.Symbols.addE, label);
         final GraphTraversal.Admin<Edge, Edge> traversal = new DefaultGraphTraversal<>(clone);
         return traversal.addStep(new AddEdgeStartStep(traversal, label));
+    }
+
+    public GraphTraversal<Edge, Edge> addE(final Traversal<?, String> edgeLabelTraversal) {
+        final GraphTraversalSource clone = this.clone();
+        clone.bytecode.addStep(GraphTraversal.Symbols.addE, edgeLabelTraversal);
+        final GraphTraversal.Admin<Edge, Edge> traversal = new DefaultGraphTraversal<>(clone);
+        return traversal.addStep(new AddEdgeStartStep(traversal, edgeLabelTraversal));
     }
 
     public <S> GraphTraversal<S, S> inject(S... starts) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -471,6 +471,13 @@ public class __ {
     }
 
     /**
+     * @see GraphTraversal#addV(org.apache.tinkerpop.gremlin.process.traversal.Traversal)
+     */
+    public static <A> GraphTraversal<A, Vertex> addV(final Traversal<?, String> vertexLabelTraversal) {
+        return __.<A>start().addV(vertexLabelTraversal);
+    }
+
+    /**
      * @see GraphTraversal#addV()
      */
     public static <A> GraphTraversal<A, Vertex> addV() {
@@ -482,6 +489,13 @@ public class __ {
      */
     public static <A> GraphTraversal<A, Edge> addE(final String edgeLabel) {
         return __.<A>start().addE(edgeLabel);
+    }
+
+    /**
+     * @see GraphTraversal#addE(org.apache.tinkerpop.gremlin.process.traversal.Traversal)
+     */
+    public static <A> GraphTraversal<A, Edge> addE(final Traversal<?, String> edgeLabelTraversal) {
+        return __.<A>start().addE(edgeLabelTraversal);
     }
 
     ///////////////////// FILTER STEPS /////////////////////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
@@ -66,6 +66,11 @@ public final class AddEdgeStartStep extends AbstractStep<Edge, Edge>
         this.parameters.set(this, T.label, edgeLabel);
     }
 
+    public AddEdgeStartStep(final Traversal.Admin traversal, final Traversal<?,String> edgeLabelTraversal) {
+        super(traversal);
+        this.parameters.set(this, T.label, edgeLabelTraversal);
+    }
+
     @Override
     public <S, E> List<Traversal.Admin<S, E>> getLocalChildren() {
         return this.parameters.getTraversals();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
@@ -33,7 +33,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ListCallbackRegistry;
-import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -66,7 +65,7 @@ public final class AddEdgeStartStep extends AbstractStep<Edge, Edge>
         this.parameters.set(this, T.label, edgeLabel);
     }
 
-    public AddEdgeStartStep(final Traversal.Admin traversal, final Traversal<?,String> edgeLabelTraversal) {
+    public AddEdgeStartStep(final Traversal.Admin traversal, final Traversal<?, String> edgeLabelTraversal) {
         super(traversal);
         this.parameters.set(this, T.label, edgeLabelTraversal);
     }
@@ -115,8 +114,7 @@ public final class AddEdgeStartStep extends AbstractStep<Edge, Edge>
             if (fromVertex instanceof Attachable)
                 fromVertex = ((Attachable<Vertex>) fromVertex)
                         .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
-            final String edgeLabel = this.parameters.get(T.label, () -> Edge.DEFAULT_LABEL).get(0);
-
+            final String edgeLabel = (String) this.parameters.get(traverser, T.label, () -> Edge.DEFAULT_LABEL).get(0);
             final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));
             if (callbackRegistry != null) {
                 final Event.EdgeAddedEvent vae = new Event.EdgeAddedEvent(DetachedFactory.detach(edge, true));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -60,6 +60,11 @@ public final class AddEdgeStep<S> extends MapStep<S, Edge>
         this.parameters.set(this, T.label, edgeLabel);
     }
 
+    public AddEdgeStep(final Traversal.Admin traversal, final Traversal.Admin<S,String> edgeLabelTraversal) {
+        super(traversal);
+        this.parameters.set(this, T.label, edgeLabelTraversal);
+    }
+
     @Override
     public <S, E> List<Traversal.Admin<S, E>> getLocalChildren() {
         return this.parameters.getTraversals();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
@@ -57,6 +57,11 @@ public final class AddVertexStartStep extends AbstractStep<Vertex, Vertex>
         this.parameters.set(this, T.label, label);
     }
 
+    public AddVertexStartStep(final Traversal.Admin traversal, final Traversal<?, String> vertexLabelTraversal) {
+        super(traversal);
+        this.parameters.set(this, T.label, vertexLabelTraversal);
+    }
+
     @Override
     public Parameters getParameters() {
         return this.parameters;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
@@ -52,6 +52,11 @@ public final class AddVertexStep<S> extends MapStep<S, Vertex>
         this.parameters.set(this, T.label, label);
     }
 
+    public AddVertexStep(final Traversal.Admin traversal, final Traversal.Admin<S,String> vertexLabelTraversal) {
+        super(traversal);
+        this.parameters.set(this, T.label, vertexLabelTraversal);
+    }
+
     @Override
     public Parameters getParameters() {
         return this.parameters;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
@@ -68,6 +68,8 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Edge, Edge> get_g_addEXknowsX_fromXaX_toXbX_propertyXweight_0_1X(final Vertex a, final Vertex b);
 
+    public abstract Traversal<Vertex,Edge> get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX();
+
     ///////
 
     @Test
@@ -255,6 +257,21 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         assertEquals(7L, g.E().count().next().longValue());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
+    public void g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX() {
+        final Traversal<Vertex,Edge> traversal =  get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX();
+        printTraversalForm(traversal);
+        final Edge edge =traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals("created",edge.label());
+        assertEquals(convertToVertexId("marko"), edge.inVertex().id());
+        assertEquals(convertToVertexId("lop"), edge.outVertex().id());
+        assertEquals(6L, g.V().count().next().longValue());
+        assertEquals(7L, g.E().count().next().longValue());
+    }
+
     public static class Traversals extends AddEdgeTest {
 
         @Override
@@ -300,6 +317,11 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Edge, Edge> get_g_addEXknowsX_fromXaX_toXbX_propertyXweight_0_1X(final Vertex a, final Vertex b) {
             return g.addE("knows").from(a).to(b).property("weight", 0.1d);
+        }
+
+        @Override
+        public Traversal<Vertex,Edge> get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX() {
+            return g.V().has("name","marko").as("a").outE("created").as("b").inV().addE(select("b").label()).to("a");
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
@@ -36,10 +36,15 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.Order.decr;
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.inE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
+import static org.apache.tinkerpop.gremlin.structure.Column.keys;
+import static org.apache.tinkerpop.gremlin.structure.Column.values;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -68,7 +73,9 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Edge, Edge> get_g_addEXknowsX_fromXaX_toXbX_propertyXweight_0_1X(final Vertex a, final Vertex b);
 
-    public abstract Traversal<Vertex,Edge> get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX();
+    public abstract Traversal<Vertex, Edge> get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX();
+
+    public abstract Traversal<Edge, Edge> get_g_addEXV_outE_label_groupCount_orderXlocalX_byXvalues_decrX_selectXkeysX_unfold_limitX1XX_fromXV_hasXname_vadasXX_toXV_hasXname_lopXX();
 
     ///////
 
@@ -261,13 +268,28 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
     @LoadGraphWith(MODERN)
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     public void g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX() {
-        final Traversal<Vertex,Edge> traversal =  get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX();
+        final Traversal<Vertex, Edge> traversal = get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX();
         printTraversalForm(traversal);
-        final Edge edge =traversal.next();
+        final Edge edge = traversal.next();
         assertFalse(traversal.hasNext());
-        assertEquals("created",edge.label());
+        assertEquals("created", edge.label());
         assertEquals(convertToVertexId("marko"), edge.inVertex().id());
         assertEquals(convertToVertexId("lop"), edge.outVertex().id());
+        assertEquals(6L, g.V().count().next().longValue());
+        assertEquals(7L, g.E().count().next().longValue());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
+    public void g_addEXV_outE_label_groupCount_orderXlocalX_byXvalues_decrX_selectXkeysX_unfold_limitX1XX_fromXV_hasXname_vadasXX_toXV_hasXname_lopXX() {
+        final Traversal<Edge, Edge> traversal = get_g_addEXV_outE_label_groupCount_orderXlocalX_byXvalues_decrX_selectXkeysX_unfold_limitX1XX_fromXV_hasXname_vadasXX_toXV_hasXname_lopXX();
+        printTraversalForm(traversal);
+        final Edge edge = traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals("created", edge.label());
+        assertEquals(convertToVertexId("vadas"), edge.outVertex().id());
+        assertEquals(convertToVertexId("lop"), edge.inVertex().id());
         assertEquals(6L, g.V().count().next().longValue());
         assertEquals(7L, g.E().count().next().longValue());
     }
@@ -320,8 +342,13 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex,Edge> get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX() {
-            return g.V().has("name","marko").as("a").outE("created").as("b").inV().addE(select("b").label()).to("a");
+        public Traversal<Vertex, Edge> get_g_V_hasXname_markoX_asXaX_outEXcreatedX_asXbX_inV_addEXselectXbX_labelX_toXaX() {
+            return g.V().has("name", "marko").as("a").outE("created").as("b").inV().addE(select("b").label()).to("a");
+        }
+
+        @Override
+        public Traversal<Edge, Edge> get_g_addEXV_outE_label_groupCount_orderXlocalX_byXvalues_decrX_selectXkeysX_unfold_limitX1XX_fromXV_hasXname_vadasXX_toXV_hasXname_lopXX() {
+            return g.addE(V().outE().label().groupCount().order(local).by(values, decr).select(keys).<String>unfold().limit(1)).from(V().has("name", "vadas")).to(V().has("name", "lop"));
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -71,6 +72,10 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
     public abstract Traversal<Vertex, Map<String, List<String>>> get_g_withSideEffectXa_testX_V_hasLabelXsoftwareX_propertyXtemp_selectXaXX_valueMapXname_tempX();
 
     public abstract Traversal<Vertex, String> get_g_withSideEffectXa_markoX_addV_propertyXname_selectXaXX_name();
+
+    public abstract Traversal<Vertex, String> get_g_addVXV_hasXname_markoX_propertiesXnameX_keyX_label();
+
+    public abstract Traversal<Vertex, Map<Object, Object>> get_g_V_asXaX_hasXname_markoX_outXcreatedX_asXbX_addVXselectXaX_labelX_propertyXtest_selectXbX_labelX_valueMapXtrueX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -273,6 +278,30 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
         assertFalse(traversal.hasNext());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    public void g_addVXV_hasXname_markoX_propertiesXnameX_keyX_label() {
+        final Traversal<Vertex, String> traversal = get_g_addVXV_hasXname_markoX_propertiesXnameX_keyX_label();
+        printTraversalForm(traversal);
+        assertEquals("name", traversal.next());
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY)
+    public void g_V_asXaX_hasXname_markoX_outXcreatedX_asXbX_addVXselectXaX_labelX_propertyXtest_selectXbX_labelX_valueMapXtrueX() {
+        final Traversal<Vertex, Map<Object,Object>> traversal = get_g_V_asXaX_hasXname_markoX_outXcreatedX_asXbX_addVXselectXaX_labelX_propertyXtest_selectXbX_labelX_valueMapXtrueX();
+        printTraversalForm(traversal);
+        final Map<Object,Object> map = traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals("person",map.get(T.label));
+        assertEquals("software",((List)map.get("test")).get(0));
+        assertEquals(1, ((List)map.get("test")).size());
+        assertEquals(3, map.size());
+    }
 
     public static class Traversals extends AddVertexTest {
 
@@ -329,6 +358,16 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
         @Override
         public Traversal<Vertex, String> get_g_withSideEffectXa_markoX_addV_propertyXname_selectXaXX_name() {
             return g.withSideEffect("a", "marko").addV().property("name", select("a")).values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_addVXV_hasXname_markoX_propertiesXnameX_keyX_label() {
+            return g.addV(V().has("name", "marko").properties("name").key()).label();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<Object, Object>> get_g_V_asXaX_hasXname_markoX_outXcreatedX_asXbX_addVXselectXaX_labelX_propertyXtest_selectXbX_labelX_valueMapXtrueX() {
+            return g.V().as("a").has("name", "marko").out("created").as("b").addV(select("a").label()).property("test", select("b").label()).valueMap(true);
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1793

There are a few changes here:

1. `addV(traversal)` and `addE(traversal)` added to both `GraphTraversal` and `GraphTraversalSource`. Thus, the label of the respectively created element can be dynamically determined.

2. Added the above methods as well as `addE(String)` to the traversal source of `GremlinDslProcessor`. The missing `addE(String)` method was a bug.

3. Changed `to()` and `from()` from taking a `Traversal<E,Vertex>` to `Traversal<?,Vertex>`. This reduces type coercion.

Added various test cases to validate proper functioning.

VOTE +1.