### PR TITLE
TINKERPOP-1795: Getting Lambda comparator message for .profile() step

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed a bug in `LambdaRestrictionStrategy` where named steps with `@` were being considered lambdas.
 * `ReferenceVertex` was missing its `label()` string. `ReferenceElement` now supports all label handling.
 * Added `GraphHelper.cloneElements(Graph original, Graph clone)` to the `gremlin-test` module to quickly clone a graph.
 * Bump to GMavenPlus 1.6.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
@@ -61,17 +61,17 @@ public final class LambdaRestrictionStrategy extends AbstractTraversalStrategy<T
                 throw new VerificationException("The provided traversal contains a lambda step: " + step, traversal);
             if (step instanceof ComparatorHolder) {
                 for (final Pair<Traversal.Admin<Object, Comparable>, Comparator<Comparable>> comparator : ((ComparatorHolder<Object, Comparable>) step).getComparators()) {
-                    final String comparatorString = comparator.toString();
-                    if (comparatorString.contains("$") || comparatorString.contains("@"))
+                    if (hasLambda(comparator.toString()))
                         throw new VerificationException("The provided step contains a lambda comparator: " + step, traversal);
                 }
             }
-            if (step instanceof SackValueStep) {
-                final String sackString = ((SackValueStep) step).getSackFunction().toString();
-                if (sackString.contains("$") || sackString.contains("@"))
-                    throw new VerificationException("The provided step contains a lambda bi-function: " + step, traversal);
-            }
+            if (step instanceof SackValueStep && hasLambda(((SackValueStep) step).getSackFunction().toString()))
+                throw new VerificationException("The provided step contains a lambda bi-function: " + step, traversal);
         }
+    }
+
+    private final boolean hasLambda(final String objectString) {
+        return objectString.contains("$") || objectString.toLowerCase().contains("lambda");
     }
 
     public static LambdaRestrictionStrategy instance() {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
@@ -24,8 +24,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +36,7 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.Operator.sum;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -63,6 +66,8 @@ public class LambdaRestrictionStrategyTest {
                 //
                 {"sack(sum).by('age')", __.sack(sum).by("age"), true},
                 {"sack{a,b -> a+b}.by('age')", __.sack((a, b) -> (int) a + (int) b).by("age"), false},
+                //
+                {"order().by(outE('rating').values('stars').mean()).profile()", __.order().by(outE("ratings").values("stars").mean()).profile(), true}
         });
     }
 
@@ -78,6 +83,7 @@ public class LambdaRestrictionStrategyTest {
     @Test
     public void shouldBeVerifiedIllegal() {
         final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(ProfileStrategy.instance());
         strategies.addStrategies(LambdaRestrictionStrategy.instance());
         traversal.asAdmin().setStrategies(strategies);
         if (allow) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1795

Some objects are hard to check for "lambdaness" and require a `toString()` analysis. We checked for `@` but that doesn't work for named steps within `order()` (when using `profile()`). That is, its error prone. I came up with a new way to check for lambdas that works for Java, Groovy, and Python/Jython. 

@spmallette -- can you please verify that a "toString()" of a lambda in C# will hold as well for the pattern.

VOTE +1