### PR TITLE
TINKERPOP-1796: Driver connection pool SSL properties missing

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -169,6 +169,15 @@ final class Settings {
             if (connectionPoolConf.containsKey("enableSsl"))
                 cpSettings.enableSsl = connectionPoolConf.getBoolean("enableSsl");
 
+            if (connectionPoolConf.containsKey("keyCertChainFile"))
+                cpSettings.keyCertChainFile = connectionPoolConf.getString("keyCertChainFile");
+
+            if (connectionPoolConf.containsKey("keyFile"))
+                cpSettings.keyFile = connectionPoolConf.getString("keyFile");
+
+            if (connectionPoolConf.containsKey("keyPassword"))
+                cpSettings.keyPassword = connectionPoolConf.getString("keyPassword");
+
             if (connectionPoolConf.containsKey("trustCertChainFile"))
                 cpSettings.trustCertChainFile = connectionPoolConf.getString("trustCertChainFile");
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.junit.Test;
 
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -45,6 +45,9 @@ public class SettingsTest {
         conf.setProperty("serializer.className", "my.serializers.MySerializer");
         conf.setProperty("serializer.config.any", "thing");
         conf.setProperty("connectionPool.enableSsl", true);
+        conf.setProperty("connectionPool.keyCertChainFile", "X.509");
+        conf.setProperty("connectionPool.keyFile", "PKCS#8");
+        conf.setProperty("connectionPool.keyPassword", "password1");
         conf.setProperty("connectionPool.trustCertChainFile", "pem");
         conf.setProperty("connectionPool.minSize", 100);
         conf.setProperty("connectionPool.maxSize", 200);
@@ -71,6 +74,9 @@ public class SettingsTest {
         assertEquals("my.serializers.MySerializer", settings.serializer.className);
         assertEquals("thing", settings.serializer.config.get("any"));
         assertEquals(true, settings.connectionPool.enableSsl);
+        assertEquals("X.509", settings.connectionPool.keyCertChainFile);
+        assertEquals("PKCS#8", settings.connectionPool.keyFile);
+        assertEquals("password1", settings.connectionPool.keyPassword);
         assertEquals("pem", settings.connectionPool.trustCertChainFile);
         assertEquals(100, settings.connectionPool.minSize);
         assertEquals(200, settings.connectionPool.maxSize);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1796

The missing configs is:
1. keyCertChainFile
2. keyFile
3. keyPassword