### PR TITLE
Do not strong-freeze dependencies

### DIFF
--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -45,13 +45,13 @@ from gremlin_python import __version__
 version = __version__.version
 
 install_requires = [
-    'aenum==1.4.5',
-    'tornado==4.4.1',
-    'six==1.10.0'
+    'aenum>=1.4.5',
+    'tornado>=4.4.1',
+    'six>=1.10.0'
 ]
 
 if sys.version_info < (3,2):
-    install_requires += ['futures==3.0.5']
+    install_requires += ['futures>=3.0.5']
 
 setup(
     name='gremlinpython',


### PR DESCRIPTION
In setup.py, strongly freezing deps is not recommended since it can easily create a conflict with other packages in a user environment. 

Also, If you know that gremlinpython works well with a lower package version (e.g six 1.6), I recommend to just change it to the minimum required to be more flexible.