### PR TITLE
TINKERPOP-1632: Create a set of default functions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-2-7, 3.2.7>>.
 
+* Added `math()`-step which supports scientific calculator capabilities for numbers within a traversal.
 * Added missing `GraphTraversalSource.addE()`-method to `GremlinDslProcessor`.
 * Changed `to()` and `from()` traversal-based steps to take a wildcard `?` instead of of `E`.
 * Added `addV(traversal)` and `addE(traversal)` so that created element labels can be determined dynamically.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1207,6 +1207,50 @@ system to leverage the filter for index lookups.
 IMPORTANT: A `where()`-step is a filter and thus, variables within a `where()` clause are not globally bound to the
 path of the traverser in `match()`. As such, `where()`-steps in `match()` are used for filtering, not binding.
 
+[[math-step]]
+=== Math Step
+
+The `math()`-step (*math*) enables scientific calculator functionality within Gremlin. This step deviates from the common
+function composition and nesting formalisms to provide an easy to read string-based math processor. Variables within the
+equation map to scopes in Gremlin -- e.g. path labels, side-effects, or incoming map keys. This step supports
+`by()`-modulation where the `by()`-modulators are applied in the order in which the variables are first referenced
+within the equation. Note that the reserved variable `_` refers to the current numeric traverser object incoming to the
+`math()`-step.
+
+[gremlin-groovy,modern]
+----
+g.V().as('a').out('knows').as('b').math('a + b').by('age')
+g.V().as('a').out('created').as('b').
+  math('b + a').
+    by(both().count().math('_ + 100')).
+    by('age')
+g.withSideEffect('x',10).V().values('age').math('_ / x')
+g.withSack(1).V(1).repeat(sack(sum).by(constant(1))).times(10).emit().sack().math('sin _')
+----
+
+The operators supported by the calculator include: `*`, `+`, `\`, `^`, and `%`.
+Furthermore, the following built in functions are provided:
+
+* `abs`: absolute value
+* `acos`: arc cosine
+* `asin`: arc sine
+* `atan`: arc tangent
+* `cbrt`: cubic root
+* `ceil`: nearest upper integer
+* `cos`: cosine
+* `cosh`: hyperbolic cosine
+* `exp`: euler's number raised to the power (`e^x`)
+* `floor`: nearest lower integer
+* `log`: logarithmus naturalis (base e)
+* `log10`: logarithm (base 10)
+* `log2`: logarithm (base 2)
+* `sin`: sine
+* `sinh`: hyperbolic sine
+* `sqrt`: square root
+* `tan`: tangent
+* `tanh`: hyperbolic tangent
+* `signum`: signum function
+
 [[max-step]]
 === Max Step
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -29,10 +29,44 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.1/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Added `math()`-step for Scientific Traversal Computing
+
+`GraphTraversal.math(String)` was added. This step provides scientific calculator capabilities to a Gremlin traversal.
+
+[source,groovy]
+----
+gremlin> g.V().as('a').out('knows').as('b').math('a + b').by('age')
+==>56.0
+==>61.0
+gremlin> g.V().as('a').out('created').as('b').
+......1>   math('b + a').
+......2>     by(both().count().math('_ + 100')).
+......3>     by('age')
+==>132.0
+==>133.0
+==>135.0
+==>138.0
+gremlin> g.withSack(1).V(1).repeat(sack(sum).by(constant(1))).times(10).emit().sack().math('sin _')
+==>0.9092974268256817
+==>0.1411200080598672
+==>-0.7568024953079282
+==>-0.9589242746631385
+==>-0.27941549819892586
+==>0.6569865987187891
+==>0.9893582466233818
+==>0.4121184852417566
+==>-0.5440211108893698
+==>-0.9999902065507035
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1632[TINKERPOP-1632]
+
 ==== Changed Typing on `from()` and `to()`
 
 The `from()` and `to()` steps of `GraphTraversal` have a `Traversal<E,Vertex>` overload. The `E` has been changed to `?`
 in order to reduce `< >`-based coersion in strongly type Gremlin language variants.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1793[TINKERPOP-1793]
 
 ==== addV(traversal) and addE(traversal)
 
@@ -57,6 +91,8 @@ gremlin> g.V().has('name','stephen').outE().valueMap(true)
 ==>[label:created,id:15]
 gremlin>
 ----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1793[TINKERPOP-1793]
 
 ==== PageRankVertexProgram
 

--- a/gremlin-core/pom.xml
+++ b/gremlin-core/pom.xml
@@ -68,6 +68,11 @@ limitations under the License.
             <artifactId>javapoet</artifactId>
             <version>1.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>net.objecthunter</groupId>
+            <artifactId>exp4j</artifactId>
+            <version>0.4.8</version>
+        </dependency>
         <!-- LOGGING -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -86,6 +86,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.LambdaFlatMapStep
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LambdaMapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.MathStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MaxGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MaxLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MeanGlobalStep;
@@ -1095,6 +1096,18 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         this.asAdmin().getBytecode().addStep(Symbols.from, fromVertex);
         ((FromToModulating) this.asAdmin().getEndStep()).addFrom(__.constant(fromVertex).asAdmin());
         return this;
+    }
+
+    /**
+     * Map the {@link Traverser} to a {@link Double} according to the mathematical expression provided in the argument.
+     *
+     * @param expression the mathematical expression with variables refering to scope variables.
+     * @return the traversal with the {@link MathStep} added.
+     * @since 3.3.1
+     */
+    public default GraphTraversal<S, Double> math(final String expression) {
+        this.asAdmin().getBytecode().addStep(Symbols.math, expression);
+        return this.asAdmin().addStep(new MathStep<>(this.asAdmin(), expression));
     }
 
     ///////////////////// FILTER STEPS /////////////////////
@@ -2691,6 +2704,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         public static final String value = "value";
         public static final String path = "path";
         public static final String match = "match";
+        public static final String math = "math";
         public static final String sack = "sack";
         public static final String loops = "loops";
         public static final String project = "project";

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -498,6 +498,13 @@ public class __ {
         return __.<A>start().addE(edgeLabelTraversal);
     }
 
+    /**
+     * @see GraphTraversal#math(String)
+     */
+    public static <A> GraphTraversal<A, Double> math(final String expression) {
+        return __.<A>start().math(expression);
+    }
+
     ///////////////////// FILTER STEPS /////////////////////
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
@@ -21,7 +21,6 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
@@ -38,6 +37,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -133,32 +134,6 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
             return this.variables;
     }
 
-    protected static final Set<String> getVariables(final String equation) {
-        final StringBuilder builder = new StringBuilder();
-        final char[] chars = equation.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            if ('+' == chars[i] || '-' == chars[i] || '*' == chars[i] ||
-                    '/' == chars[i] || '^' == chars[i] || '%' == chars[i] ||
-                    '(' == chars[i] || ')' == chars[i])
-                builder.append(" ");
-            else
-                builder.append(chars[i]);
-        }
-        final Set<String> variables = new LinkedHashSet<>();
-        for (final String slot : builder.toString().split(" ")) {
-            if (!slot.trim().isEmpty() && !StringUtils.isNumeric(slot) &&
-                    !slot.equals("abs") && !slot.equals("acos") &&
-                    !slot.equals("asin") && !slot.equals("atan") && !slot.equals("cbrt") &&
-                    !slot.equals("ceil") && !slot.equals("cos") && !slot.equals("cosh") &&
-                    !slot.equals("exp") && !slot.equals("floor") && !slot.equals("log") &&
-                    !slot.equals("log10") && !slot.equals("log2") && !slot.equals("sin") &&
-                    !slot.equals("sinh") && !slot.equals("sqrt") && !slot.equals("tan") &&
-                    !slot.equals("tanh") && !slot.equals("signum"))
-                variables.add(slot);
-        }
-        return variables;
-    }
-
     @Override
     public void setKeepLabels(final Set<String> labels) {
         this.keepLabels = labels;
@@ -168,4 +143,29 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
     public Set<String> getKeepLabels() {
         return this.keepLabels;
     }
+
+    ///
+
+    private static final String[] FUNCTIONS = new String[]{
+            "abs", "acos", "asin", "atan",
+            "cbrt", "ceil", "cos", "cosh",
+            "exp",
+            "floor",
+            "log", "log10", "log2",
+            "signum", "sin", "sinh", "sqrt",
+            "tan", "tanh"
+    };
+
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\b(?!" +
+            String.join("|", FUNCTIONS) + "|([0-9]+))([a-zA-Z_][a-zA-Z0-9_]*)\\b");
+
+    protected static final Set<String> getVariables(final String equation) {
+        final Matcher matcher = VARIABLE_PATTERN.matcher(equation);
+        final Set<String> variables = new LinkedHashSet<>();
+        while (matcher.find()) {
+            variables.add(matcher.group());
+        }
+        return variables;
+    }
+
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
@@ -48,7 +48,7 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
     private static final String CURRENT = "_";
     private final String equation;
     private final Set<String> variables;
-    private TraversalRing<Object, Number> traversalRing = new TraversalRing<>();
+    private TraversalRing<S, Number> traversalRing = new TraversalRing<>();
     private Set<String> keepLabels;
 
     public MathStep(final Traversal.Admin traversal, final String equation) {
@@ -70,11 +70,10 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
                 .implicitMultiplication(false)
                 .build();
         for (final String var : this.variables) {
-            expression.setVariable(var, TraversalUtil.applyNullable(
+            expression.setVariable(var,
                     var.equals(CURRENT) ?
-                            traverser.get() :
-                            this.getNullableScopeValue(Pop.last, var, traverser),
-                    this.traversalRing.next()).doubleValue());
+                            TraversalUtil.applyNullable(traverser, this.traversalRing.next()).doubleValue() :
+                            TraversalUtil.applyNullable((S) this.getNullableScopeValue(Pop.last, var, traverser), this.traversalRing.next()).doubleValue());
         }
         this.traversalRing.reset();
         return expression.evaluate();
@@ -96,7 +95,7 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
     }
 
     @Override
-    public List<Traversal.Admin<Object, Number>> getLocalChildren() {
+    public List<Traversal.Admin<S, Number>> getLocalChildren() {
         return this.traversalRing.getTraversals();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
@@ -1,0 +1,128 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import net.objecthunter.exp4j.Expression;
+import net.objecthunter.exp4j.ExpressionBuilder;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class MathStep<S> extends MapStep<S, Double> implements ByModulating, TraversalParent, Scoping {
+
+    private static final String CURRENT = "_";
+    private final String equation;
+    private final Set<String> variables;
+    private final Expression expression;
+    private TraversalRing<Object, Number> traversalRing = new TraversalRing<>();
+
+    public MathStep(final Traversal.Admin traversal, final String equation) {
+        super(traversal);
+        this.equation = equation;
+        final Set<String> labels = TraversalHelper.getLabels(TraversalHelper.getRootTraversal(this.getTraversal()));
+        this.variables = new LinkedHashSet<>();
+        for (final String label : labels) {
+            if (this.equation.contains(label))
+                this.variables.add(label);
+        }
+        if (this.equation.contains(CURRENT))
+            this.variables.add(CURRENT);
+        this.expression = new ExpressionBuilder(this.equation)
+                .variables(this.variables)
+                .build();
+    }
+
+    @Override
+    protected Double map(final Traverser.Admin<S> traverser) {
+        for (final String var : this.variables) {
+            this.expression.setVariable(var, TraversalUtil.applyNullable(
+                    var.equals(CURRENT) ?
+                            traverser.get() :
+                            this.getNullableScopeValue(Pop.last, var, traverser),
+                    this.traversalRing.next()).doubleValue());
+        }
+        this.traversalRing.reset();
+        return this.expression.evaluate();
+    }
+
+    @Override
+    public void modulateBy(final Traversal.Admin<?, ?> selectTraversal) {
+        this.traversalRing.addTraversal(this.integrateChild(selectTraversal));
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.stepString(this, this.equation, this.traversalRing);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.equation.hashCode() ^ this.traversalRing.hashCode();
+    }
+
+    @Override
+    public List<Traversal.Admin<Object, Number>> getLocalChildren() {
+        return this.traversalRing.getTraversals();
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.traversalRing.reset();
+    }
+
+    @Override
+    public MathStep<S> clone() {
+        final MathStep<S> clone = (MathStep<S>) super.clone();
+        clone.traversalRing = this.traversalRing.clone();
+        return clone;
+    }
+
+    @Override
+    public void setTraversal(final Traversal.Admin<?, ?> parentTraversal) {
+        super.setTraversal(parentTraversal);
+        this.traversalRing.getTraversals().forEach(this::integrateChild);
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return this.getSelfAndChildRequirements(TraverserRequirement.OBJECT, TraverserRequirement.SIDE_EFFECTS);
+    }
+
+    @Override
+    public Set<String> getScopeKeys() {
+        return this.variables;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
@@ -53,6 +53,7 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
         this.variables = MathStep.getVariables(this.equation);
         this.expression = new ExpressionBuilder(this.equation)
                 .variables(this.variables)
+                .implicitMultiplication(false)
                 .build();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -560,7 +560,7 @@ public final class TraversalHelper {
     }
 
     public static Set<String> getLabels(final Traversal.Admin<?, ?> traversal) {
-        return TraversalHelper.getLabels(new HashSet<>(), traversal);
+        return TraversalHelper.getLabels(new LinkedHashSet<>(), traversal);
     }
 
     private static Set<String> getLabels(final Set<String> labels, final Traversal.Admin<?, ?> traversal) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -52,7 +52,6 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -560,7 +559,7 @@ public final class TraversalHelper {
     }
 
     public static Set<String> getLabels(final Traversal.Admin<?, ?> traversal) {
-        return TraversalHelper.getLabels(new LinkedHashSet<>(), traversal);
+        return TraversalHelper.getLabels(new HashSet<>(), traversal);
     }
 
     private static Set<String> getLabels(final Set<String> labels, final Traversal.Admin<?, ?> traversal) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
@@ -112,6 +112,8 @@ public class GraphTraversalTest {
                         list.add(arguments[0] = (long) (Math.abs(random.nextInt(10))));
                         list.add(arguments[1] = (long) (Math.abs(random.nextInt(10) + 100)));
                     }
+                } else if (stepMethod.getName().equals("math")) {
+                    list.add(arguments[0] = random.nextInt(100) + " + " + random.nextInt(100));
                 } else {
                     for (int i = 0; i < stepMethod.getParameterTypes().length; i++) {
                         final Class<?> type = stepMethod.getParameterTypes()[i];

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class MathStepTest extends StepTest {
+
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Arrays.asList(
+                __.math("a+b"),
+                __.math("a+b").by("age"),
+                __.math("a/b").by("age"),
+                __.math("a+b").by("age").by(both().count()),
+                __.math("sin a + b")
+        );
+    }
+
+    @Test
+    public void shouldParseVariablesCorrectly() {
+        assertEquals(Arrays.asList("a", "b"), new ArrayList<>(MathStep.getVariables("a + b / 2")));
+        assertEquals(Arrays.asList("a", "b"), new ArrayList<>(MathStep.getVariables("a + b / sin 2")));
+        assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z")));
+        assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z + b + a")));
+    }
+
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
@@ -54,7 +54,7 @@ public class MathStepTest extends StepTest {
         assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z")));
         assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z + b + a")));
         assertEquals(Arrays.asList("a_ASDF", "b", "_", "x", "z", "a"), new ArrayList<>(MathStep.getVariables("(a_ASDF + b / _) + log2 (x^3)^z + b + a")));
-        assertEquals(Arrays.asList("a_ASDF", "b", "_", "x", "z", "a"), new ArrayList<>(MathStep.getVariables("(a_ASDF + b / _) + log2 (x^3)^z + b + a")));
+        assertEquals(Arrays.asList("a_ASDF", "bzz_", "_", "x", "z", "a_var", "d"), new ArrayList<>(MathStep.getVariables("((a_ASDF + bzz_ / _) + log2 (x^3)^z + bzz_ + (sinh (a_var + 10))) / (2.0265 * d)")));
         assertEquals(Arrays.asList("ac", "b", "_", "x", "z2"), new ArrayList<>(MathStep.getVariables("(ac + b / _) + log2 (x^3)^z2 + b + (tan (log10 ac / sqrt b))")));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
@@ -53,6 +53,9 @@ public class MathStepTest extends StepTest {
         assertEquals(Arrays.asList("a", "b"), new ArrayList<>(MathStep.getVariables("a + b / sin 2")));
         assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z")));
         assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z + b + a")));
+        assertEquals(Arrays.asList("a_ASDF", "b", "_", "x", "z", "a"), new ArrayList<>(MathStep.getVariables("(a_ASDF + b / _) + log2 (x^3)^z + b + a")));
+        assertEquals(Arrays.asList("a_ASDF", "b", "_", "x", "z", "a"), new ArrayList<>(MathStep.getVariables("(a_ASDF + b / _) + log2 (x^3)^z + b + a")));
+        assertEquals(Arrays.asList("ac", "b", "_", "x", "z2"), new ArrayList<>(MathStep.getVariables("(ac + b / _) + log2 (x^3)^z2 + b + (tan (log10 ac / sqrt b))")));
     }
 
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStepTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
@@ -49,8 +50,10 @@ public class MathStepTest extends StepTest {
 
     @Test
     public void shouldParseVariablesCorrectly() {
+        assertEquals(Collections.emptyList(), new ArrayList<>(MathStep.getVariables("1 + 2")));
         assertEquals(Arrays.asList("a", "b"), new ArrayList<>(MathStep.getVariables("a + b / 2")));
         assertEquals(Arrays.asList("a", "b"), new ArrayList<>(MathStep.getVariables("a + b / sin 2")));
+        assertEquals(Arrays.asList("a", "b"), new ArrayList<>(MathStep.getVariables("a + b / sin (2 + 6.67e−11)")));
         assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z")));
         assertEquals(Arrays.asList("a", "b", "_", "x", "z"), new ArrayList<>(MathStep.getVariables("(a + b / _) + log2 (x^3)^z + b + a")));
         assertEquals(Arrays.asList("a_ASDF", "b", "_", "x", "z", "a"), new ArrayList<>(MathStep.getVariables("(a_ASDF + b / _) + log2 (x^3)^z + b + a")));

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 import java.lang.reflect.Modifier
 
 def toCSharpTypeMap = ["Long": "long",
+                       "Double": "double",
                        "Integer": "int",
                        "String": "string",
                        "Object": "object",

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -497,10 +497,10 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the math step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Double > Math (params object[] args)
+        public GraphTraversal< S , double > Math (params object[] args)
         {
             Bytecode.AddStep("math", args);
-            return Wrap< S , Double >(this);
+            return Wrap< S , double >(this);
         }
 
         /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -495,6 +495,15 @@ namespace Gremlin.Net.Process.Traversal
         }
 
         /// <summary>
+        ///     Adds the math step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal< S , Double > Math (params object[] args)
+        {
+            Bytecode.AddStep("math", args);
+            return Wrap< S , Double >(this);
+        }
+
+        /// <summary>
         ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
         public GraphTraversal< S , E2 > Max<E2> (params object[] args)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
@@ -411,7 +411,7 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the math step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, Double> Math(params object[] args)
+        public static GraphTraversal<object, double> Math(params object[] args)
         {
             return new GraphTraversal<object, object>().Math(args);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
@@ -409,6 +409,14 @@ namespace Gremlin.Net.Process.Traversal
         }
 
         /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the math step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, Double> Math(params object[] args)
+        {
+            return new GraphTraversal<object, object>().Math(args);
+        }
+
+        /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the max step to that traversal.
         /// </summary>
         public static GraphTraversal<object, E2> Max<E2>(params object[] args)

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -317,6 +317,10 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("match", *args)
         return self
 
+    def math(self, *args):
+        self.bytecode.add_step("math", *args)
+        return self
+
     def max(self, *args):
         self.bytecode.add_step("max", *args)
         return self
@@ -697,6 +701,10 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).match(*args)
 
     @classmethod
+    def math(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).math(*args)
+
+    @classmethod
     def max(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).max(*args)
 
@@ -1045,6 +1053,10 @@ statics.add_static('map', map)
 def match(*args):
     return __.match(*args)
 statics.add_static('match', match)
+
+def math(*args):
+    return __.math(*args)
+statics.add_static('math', math)
 
 def max(*args):
     return __.max(*args)

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
@@ -57,6 +57,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MapTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MaxTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MeanTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinTest;
@@ -147,6 +148,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             MapTest.Traversals.class,
             MatchTest.CountMatchTraversals.class,
             MatchTest.GreedyMatchTraversals.class,
+            MathTest.Traversals.class,
             MaxTest.Traversals.class,
             MeanTest.Traversals.class,
             MinTest.Traversals.class,
@@ -230,6 +232,8 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             CountTest.class,
             FlatMapTest.class,
             FoldTest.class,
+            MatchTest.class,
+            MathTest.class,
             MapTest.class,
             MaxTest.class,
             MeanTest.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
@@ -54,6 +54,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MapTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MaxTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MeanTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinTest;
@@ -141,6 +142,7 @@ public class ProcessStandardSuite extends AbstractGremlinSuite {
             MapTest.Traversals.class,
             MatchTest.CountMatchTraversals.class,
             MatchTest.GreedyMatchTraversals.class,
+            MathTest.Traversals.class,
             MaxTest.Traversals.class,
             MeanTest.Traversals.class,
             MinTest.Traversals.class,
@@ -223,6 +225,7 @@ public class ProcessStandardSuite extends AbstractGremlinSuite {
             LoopsTest.class,
             MapTest.class,
             MatchTest.class,
+            MathTest.class,
             MaxTest.class,
             MeanTest.class,
             MinTest.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+@RunWith(GremlinProcessRunner.class)
+public abstract class MathTest extends AbstractGremlinProcessTest {
+
+    public abstract Traversal<Vertex, Double> get_g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX();
+
+    public abstract Traversal<Vertex, Double> get_g_withSideEffectXx_100X_V_age_mathX__plus_xX();
+
+    public abstract Traversal<Vertex, Double> get_g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX();
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX() {
+        final Traversal<Vertex, Double> traversal = get_g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(56.0d, 61.0d), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_withSideEffectXx_100X_V_age_mathX__plus_xX() {
+        final Traversal<Vertex, Double> traversal = get_g_withSideEffectXx_100X_V_age_mathX__plus_xX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(129.0d, 127.0d, 132.0d, 135.0d), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX() {
+        final Traversal<Vertex, Double> traversal = get_g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(32.0d, 33.0d, 35.0d, 38.0d), traversal);
+    }
+
+    public static class Traversals extends MathTest {
+
+        @Override
+        public Traversal<Vertex, Double> get_g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX() {
+            return g.V().as("a").out("knows").as("b").math("a + b").by("age");
+        }
+
+        @Override
+        public Traversal<Vertex, Double> get_g_withSideEffectXx_100X_V_age_mathX__plus_xX() {
+            return g.withSideEffect("x", 100).V().values("age").math("_ + x");
+        }
+
+        @Override
+        public Traversal<Vertex, Double> get_g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX() {
+            return g.V().as("a").out("created").as("b").math("b + a").by(in("created").count()).by("age");
+        }
+    }
+}

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
@@ -23,14 +23,19 @@ import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.function.BiFunction;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.Operator.sum;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.sack;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -43,6 +48,8 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Double> get_g_withSideEffectXx_100X_V_age_mathX__plus_xX();
 
     public abstract Traversal<Vertex, Double> get_g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX();
+
+    public abstract Traversal<Integer, Double> get_g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -68,6 +75,18 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
         checkResults(Arrays.asList(32.0d, 33.0d, 35.0d, 38.0d), traversal);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX() {
+        final Traversal<Integer, Double> traversal = get_g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX();
+        printTraversalForm(traversal);
+        assertEquals(0.9092974268256817d, traversal.next(), 0.01d);
+        assertEquals(0.1411200080598672d, traversal.next(), 0.01d);
+        assertEquals(-0.7568024953079282d, traversal.next(), 0.01d);
+        assertEquals(-0.9589242746631385d, traversal.next(), 0.01d);
+        assertEquals(-0.27941549819892586d, traversal.next(), 0.01d);
+    }
+
     public static class Traversals extends MathTest {
 
         @Override
@@ -83,6 +102,11 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Double> get_g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX() {
             return g.V().as("a").out("created").as("b").math("b + a").by(in("created").count()).by("age");
+        }
+
+        @Override
+        public Traversal<Integer, Double> get_g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX() {
+            return g.withSack(1).inject(1).repeat(__.sack((BiFunction) sum).by(__.constant(1))).times(10).emit().math("sin _").by(sack());
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
@@ -33,7 +33,10 @@ import java.util.function.BiFunction;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.traversal.Operator.sum;
+import static org.apache.tinkerpop.gremlin.process.traversal.Order.decr;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.math;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.sack;
 import static org.junit.Assert.assertEquals;
 
@@ -50,6 +53,8 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Double> get_g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX();
 
     public abstract Traversal<Integer, Double> get_g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX();
+
+    public abstract Traversal<Vertex, String> get_g_V_projectXa_b_cX_byXbothE_weight_sumX_byXbothE_countX_byXnameX_order_byXmathXa_div_bX_decrX_selectXcX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -87,6 +92,14 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
         assertEquals(-0.27941549819892586d, traversal.next(), 0.01d);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_projectXa_b_cX_byXbothE_weight_sumX_byXbothE_countX_byXnameX_order_byXmathXa_div_bX_decrX_selectXcX() {
+        final Traversal<Vertex, String> traversal = get_g_V_projectXa_b_cX_byXbothE_weight_sumX_byXbothE_countX_byXnameX_order_byXmathXa_div_bX_decrX_selectXcX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList("ripple", "josh", "marko", "vadas", "lop", "peter"), traversal);
+    }
+
     public static class Traversals extends MathTest {
 
         @Override
@@ -107,6 +120,11 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Integer, Double> get_g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX() {
             return g.withSack(1).inject(1).repeat(__.sack((BiFunction) sum).by(__.constant(1))).times(10).emit().math("sin _").by(sack());
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_projectXa_b_cX_byXbothE_weight_sumX_byXbothE_countX_byXnameX_order_byXmathXa_div_bX_decrX_selectXcX() {
+            return g.V().project("a", "b", "c").by(bothE().values("weight").sum()).by(bothE().count()).by("name").order().by(math("a / b"), decr).select("c");
         }
     }
 }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -71,7 +71,7 @@ public class TinkerGraphPlayTest {
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
         GraphTraversalSource g = graph.traversal();
-        System.out.println(g.withSideEffect("x",10.1d).V().as("a").out("knows").math("((a ^ _) / a) + x").by("age").by(bothE().count()).by().toList());
+        System.out.println(g.V().values("age").toList());
     }
 
     @Test

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -71,7 +71,7 @@ public class TinkerGraphPlayTest {
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
         GraphTraversalSource g = graph.traversal();
-        System.out.println(g.V().as("a").out("knows").math("((a ^ _) / a)").by("age").by(bothE().count()).toList());
+        System.out.println(g.withSideEffect("x",10.1d).V().as("a").out("knows").math("((a ^ _) / a) + x").by("age").by(bothE().count()).by().toList());
     }
 
     @Test

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -50,6 +50,7 @@ import static org.apache.tinkerpop.gremlin.process.traversal.P.lt;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.choose;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
@@ -70,47 +71,8 @@ public class TinkerGraphPlayTest {
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
         GraphTraversalSource g = graph.traversal();
-
-        final Traversal<?, ?> traversal = g.V().repeat(out()).times(2).groupCount().by("name").select(Column.keys).order().by(Order.decr);
-        final Bytecode bytecode = traversal.asAdmin().getBytecode();
-        //final JavaTranslator translator = JavaTranslator.of(g);
-        final Map<Bytecode, Traversal.Admin<?, ?>> cache = new HashMap<>();
-        cache.put(bytecode, traversal.asAdmin());
-        final HashSet<?> result = new LinkedHashSet<>(Arrays.asList("ripple", "lop"));
-
-        System.out.println("BYTECODE: " + bytecode + "\n");
-        System.out.println("Bytecode->Traversal.clone() cache: " + TimeUtil.clock(1000, () -> {
-            final Traversal.Admin<?, ?> t = cache.get(bytecode).clone();
-            //assertEquals(result, t.next());
-        }));
-
-        System.out.println("Bytecode->JavaTranslator call    : " + TimeUtil.clock(1000, () -> {
-            final Traversal t = JavaTranslator.of(g).translate(bytecode);
-            //assertEquals(result, t.next());
-        }));
-
-        System.out.println("\n==Second test with reversed execution==\n");
-
-        System.out.println("BYTECODE: " + bytecode + "\n");
-        System.out.println("Bytecode->JavaTranslator call    : " + TimeUtil.clock(1000, () -> {
-            final Traversal t = JavaTranslator.of(g).translate(bytecode);
-            //assertEquals(result, t.next());
-        }));
-
-        System.out.println("Bytecode->Traversal.clone() cache: " + TimeUtil.clock(1000, () -> {
-            final Traversal.Admin<?, ?> t = cache.get(bytecode).clone();
-            //assertEquals(result, t.next());
-        }));
+        System.out.println(g.V().as("a").out("knows").math("((a ^ _) / a)").by("age").by(bothE().count()).toList());
     }
-
-   /* @Test
-    public void testTraversalDSL() throws Exception {
-        Graph g = TinkerFactory.createClassic();
-        assertEquals(2, g.of(TinkerFactory.SocialTraversal.class).people("marko").knows().name().toList().size());
-        g.of(TinkerFactory.SocialTraversal.class).people("marko").knows().name().forEachRemaining(name -> assertTrue(name.equals("josh") || name.equals("vadas")));
-        assertEquals(1, g.of(TinkerFactory.SocialTraversal.class).people("marko").created().name().toList().size());
-        g.of(TinkerFactory.SocialTraversal.class).people("marko").created().name().forEachRemaining(name -> assertEquals("lop", name));
-    }*/
 
     @Test
     @Ignore

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -71,7 +71,7 @@ public class TinkerGraphPlayTest {
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
         GraphTraversalSource g = graph.traversal();
-        System.out.println(g.V().values("age").toList());
+        System.out.println(g.V().values("age").math("sin _").toList());
     }
 
     @Test

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -18,16 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
-import org.apache.tinkerpop.gremlin.jsr223.JavaTranslator;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
-import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathRetractionStrategy;
-import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -39,23 +36,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.Operator.sum;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.lt;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.neq;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.choose;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.sack;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.union;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.valueMap;
@@ -71,7 +66,7 @@ public class TinkerGraphPlayTest {
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
         GraphTraversalSource g = graph.traversal();
-        System.out.println(g.V().values("age").math("sin _").toList());
+        System.out.println(g.withSack(1).inject(1).repeat(__.sack((BiFunction)sum).by(__.constant(1))).times(10).emit().math("sin _").by(sack()).toList());
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1632

This is an implementation of lambda-less math capabilities in Gremlin leveraging the String-based calculator model proposed by @twilmes. This model deviates from Gremlin's standard function composition and nesting model to provide a easy to read "math processor" that leverages Gremlin scopes for data access (e.g. path data, map keys, and side-effects). The feature is encapsulated in `MathStep` which implements `PathProcessor` and `Scoping`. Furthermore, `by()`-modulation is supported. `by()`-modulators are applied in the order in which the variable is first used in the equation. Thus:

```
g.V().as("a").out("knows").by("b").
  math("b + a").
    by(out().count()).
    by("age")
```

In the above: `a` -> `age` and `b` -> `out().count()`. More complex examples are provided below:

```
gremlin> g = TinkerFactory.createModern().traversal()
==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
gremlin> g.V().as('a').out('knows').as('b').math('a + b').by('age')
==>56.0
==>61.0
gremlin> g.V().as('a').out('created').as('b').
......1>   math('b + a').
......2>     by(both().count().math('_ + 100')).
......3>     by('age')
==>132.0
==>133.0
==>135.0
==>138.0
gremlin> g.withSideEffect('x',10).V().values('age').math('_ / x')
==>2.9
==>2.7
==>3.2
==>3.5
gremlin> g.withSack(1).V(1).repeat(sack(sum).by(constant(1))).times(10).emit().sack().math('sin _')
==>0.9092974268256817
==>0.1411200080598672
==>-0.7568024953079282
==>-0.9589242746631385
==>-0.27941549819892586
==>0.6569865987187891
==>0.9893582466233818
==>0.4121184852417566
==>-0.5440211108893698
==>-0.9999902065507035
```