### PR TITLE
TINKERPOP-1797: LambdaRestrictionStrategy and LambdaMapStep in by()-modulation.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,7 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Truncate the script in error logs and error return messages for "Method code too large" errors in Gremlin Server.
-* Fixed a bug in `LambdaRestrictionStrategy` where named steps with `@` were being considered lambdas.
+* Fixed a bug in `LambdaRestrictionStrategy` where it was too eager to consider a step as being a lambda step.
 * `ReferenceVertex` was missing its `label()` string. `ReferenceElement` now supports all label handling.
 * Fixed a bug where bytecode containing lambdas would randomly select a traversal source from bindings.
 * Deprecated `GremlinScriptEngine.eval()` methods and replaced them with new overloads that include the specific `TraversalSource` to bind to.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
@@ -34,7 +35,7 @@ import java.util.function.BiFunction;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements TraversalParent, ByModulating {
+public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements TraversalParent, ByModulating, LambdaHolder {
 
     private Traversal.Admin<S, B> sackTraversal = null;
 
@@ -70,7 +71,7 @@ public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements T
         return super.hashCode() ^ this.sackFunction.hashCode() ^ ((null == this.sackTraversal) ? "null".hashCode() : this.sackTraversal.hashCode());
     }
 
-    public BiFunction<A,B,A> getSackFunction() {
+    public BiFunction<A, B, A> getSackFunction() {
         return this.sackFunction;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
@@ -224,7 +224,7 @@ public final class StringFactory {
                 })
                 .map(o -> {
                     final String string = o.toString();
-                    return string.contains("$") ? "lambda" : string;
+                    return hasLambda(string) ? "lambda" : string;
                 }).collect(Collectors.toList());
         if (!strings.isEmpty()) {
             builder.append('(');
@@ -234,6 +234,12 @@ public final class StringFactory {
         if (!step.getLabels().isEmpty()) builder.append('@').append(step.getLabels());
         //builder.append("^").append(step.getId());
         return builder.toString();
+    }
+
+    private static boolean hasLambda(final String objectString) {
+        return objectString.contains("$Lambda$") || // JAVA (org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraphPlayTest$$Lambda$1/1711574013@61a52fb)
+                objectString.contains("$_run_closure") || // GROOVY (groovysh_evaluate$_run_closure1@db44aa2)
+                objectString.contains("<lambda>");  // PYTHON (<function <lambda> at 0x10dfaec80>)
     }
 
     public static String traversalString(final Traversal.Admin<?, ?> traversal) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.Operator.sum;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
+import static org.apache.tinkerpop.gremlin.structure.Column.values;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -54,14 +55,16 @@ public class LambdaRestrictionStrategyTest {
                 {"sideEffect(x -> {int i = 1+1;})", __.sideEffect(x -> {
                     int i = 1 + 1;
                 }), false},
+                {"select('a').by(values)", __.select("a").by(values), true},
                 {"select('a','b').by(Object::toString)", __.select("a", "b").by(Object::toString), false},
                 {"order().by((a,b)->a.compareTo(b))", __.order().by((a, b) -> ((Integer) a).compareTo((Integer) b)), false},
                 {"order(local).by((a,b)->a.compareTo(b))", __.order(Scope.local).by((a, b) -> ((Integer) a).compareTo((Integer) b)), false},
                 {"__.choose(v->v.toString().equals(\"marko\"),__.out(),__.in())", __.choose(v -> v.toString().equals("marko"), __.out(), __.in()), false},
-                {"order(local).by(values,decr)", __.order(Scope.local).by(Column.values, (a, b) -> ((Double) a).compareTo((Double) b)), false},
-                //
-                {"order(local).by(values,decr)", __.order(Scope.local).by(Column.values, Order.decr), true},
                 {"order().by(label,decr)", __.order().by(T.label, Order.decr), true},
+                {"order(local).by(values)", __.order(Scope.local).by(values), true},
+                {"order(local).by(values,decr)", __.order(Scope.local).by(values,Order.decr), true},
+                {"order(local).by(values,(a,b) -> a.compareTo(b))", __.order(Scope.local).by(values, (a, b) -> ((Double) a).compareTo((Double) b)), false},
+                //
                 {"groupCount().by(label)", __.groupCount().by(T.label), true},
                 //
                 {"sack(sum).by('age')", __.sack(sum).by("age"), true},


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1797

We have had too many problems with `LambdaRestrictionStrategy` because it is difficult to know what is a true lambda. I have now simply hardcoded the lambda determination as a `String` analysis of the lambda object for Java, Groovy, and Python. As we add more GLVs, we can add more string mappers. Every other solution thus far has either been too lenient or too restrictive.

VOTE +1