### PR TITLE
TINKERPOP-1650: PathRetractionStrategy makes Match steps unsolvable

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed a bug in `Neo4jGremlinPlugin` that prevented it from loading properly in the `GremlinPythonScriptEngine`.
 * Fixed a bug in `ComputerVerificationStrategy` where child traversals were being analyzed prior to compilation.
 * Fixed a bug that prevented Gremlin from ordering lists and streams made of mixed number types.
+* Fixed a bug where `keepLabels` were being corrupted because a defensive copy was not being made when they were being set by `PathRetractionStrategy`. 
 
 [[release-3-2-6]]
 === TinkerPop 3.2.6 (Release Date: August 21, 2017)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/PathProcessor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/PathProcessor.java
@@ -60,7 +60,7 @@ public interface PathProcessor {
         return max;
     }
 
-    public void setKeepLabels(final Set<String> labels);
+    public void setKeepLabels(final Set<String> keepLabels);
 
     public Set<String> getKeepLabels();
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
@@ -223,8 +223,8 @@ public final class DedupGlobalStep<S> extends FilterStep<S> implements Traversal
     }
 
     @Override
-    public void setKeepLabels(Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -123,8 +124,8 @@ public final class PathFilterStep<S> extends FilterStep<S> implements FromToModu
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
@@ -151,8 +151,8 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTraversalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTraversalStep.java
@@ -139,7 +139,7 @@ public final class WhereTraversalStep<S> extends FilterStep<S> implements Traver
 
     @Override
     public void setKeepLabels(final Set<String> keepLabels) {
-        this.keepLabels = keepLabels;
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStep.java
@@ -183,8 +183,8 @@ public final class MatchStep<S, E> extends ComputerAwareStep<S, Map<String, E>> 
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = new HashSet<>(labels);
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
         if (null != this.dedupLabels)
             this.keepLabels.addAll(this.dedupLabels);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -108,8 +109,8 @@ public final class PathStep<S> extends MapStep<S, Path> implements TraversalPare
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -116,8 +117,8 @@ public final class SelectOneStep<S, E> extends MapStep<S, E> implements Traversa
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -142,8 +142,8 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.function.TreeSupplier;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BinaryOperator;
@@ -113,8 +114,8 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements T
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.function.TreeSupplier;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -123,8 +124,8 @@ public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements Si
     }
 
     @Override
-    public void setKeepLabels(final Set<String> labels) {
-        this.keepLabels = labels;
+    public void setKeepLabels(final Set<String> keepLabels) {
+        this.keepLabels = new HashSet<>(keepLabels);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategy.java
@@ -120,7 +120,7 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
                     pathProcessor.getKeepLabels().addAll(((MatchStep) currentStep).getMatchEndLabels());
                 } else {
                     if (pathProcessor.getKeepLabels() == null)
-                        pathProcessor.setKeepLabels(new HashSet<>(keepLabels));
+                        pathProcessor.setKeepLabels(keepLabels);
                     else
                         pathProcessor.getKeepLabels().addAll(new HashSet<>(keepLabels));
                 }
@@ -242,10 +242,11 @@ public final class PathRetractionStrategy extends AbstractTraversalStrategy<Trav
     }
 
     private void addLabels(final PathProcessor s, final Set<String> keepLabels) {
+        final Set<String> labelsCopy = new HashSet<>(keepLabels);
         if (null == s.getKeepLabels())
-            s.setKeepLabels(new HashSet<>(keepLabels));
+            s.setKeepLabels(labelsCopy);
         else
-            s.getKeepLabels().addAll(new HashSet<>(keepLabels));
+            s.getKeepLabels().addAll(labelsCopy);
     }
 
     @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/PathRetractionStrategyTest.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
 
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -210,7 +211,10 @@ public class PathRetractionStrategyTest {
                         "[[[a, b]], [[a, b]], [[a, b]], [[[a, b]]], [[a, b]]]", null},
                 {__.V().as("a").out().where(neq("a")).program(labeledPathVertexProgram), PATH_RETRACTION_STRATEGY_DISABLED, null},
                 {__.V().as("a").out().where(neq("a")).program(pathVertexProgram).select("a"), PATH_RETRACTION_STRATEGY_DISABLED, null},
-                {__.V().as("a").out().program(emptyRequirementsVertexProgram).select("a"), "[[]]", null}
+                {__.V().as("a").out().program(emptyRequirementsVertexProgram).select("a"), "[[]]", null},
+                {__.V().as("a").out().as("b").where(__.as("b").in().count().is(eq(3)).or().where(
+                        __.as("b").out("created").and().as("b").has(T.label, "person"))).select("a", "b"),
+                        "[[a, b], [[[a, b]]], []]", null}
         });
     }
 }


### PR DESCRIPTION
This bug was a result of an unintentionally shared set between a MatchStep and WhereStep's. This caused the `p` label to be incorrectly pulled into the `matchStartLabels` for the following query:

` g.V().hasLabel("person").as("p").match(__.as("a").out("created").as("sw"), __.as("sw").has("lang", "java").as("java")).where("sw", neq("a")).select("p")`

As a result, when the match step was attempting to pick a `startLabelsBundle`, it failed to grab one because the incoming traverser already had the `p` label in its path. This fix added defensive copying to all of the `setKeepLabels` calls to prevent the possibility of this unintentional sharing of a mutable collection.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Apache TinkerPop ................................... SUCCESS [  3.238 s]
[INFO] Apache TinkerPop :: Gremlin Shaded ................. SUCCESS [  1.972 s]
[INFO] Apache TinkerPop :: Gremlin Core ................... SUCCESS [01:04 min]
[INFO] Apache TinkerPop :: Gremlin Test ................... SUCCESS [  9.145 s]
[INFO] Apache TinkerPop :: Gremlin Groovy ................. SUCCESS [04:00 min]
[INFO] Apache TinkerPop :: Gremlin Groovy Test ............ SUCCESS [  5.057 s]
[INFO] Apache TinkerPop :: TinkerGraph Gremlin ............ SUCCESS [02:58 min]
[INFO] Apache TinkerPop :: Gremlin Benchmark .............. SUCCESS [  3.874 s]
[INFO] Apache TinkerPop :: Gremlin Driver ................. SUCCESS [  9.796 s]
[INFO] Apache TinkerPop :: Neo4j Gremlin .................. SUCCESS [  2.134 s]
[INFO] Apache TinkerPop :: Gremlin Server ................. SUCCESS [ 42.125 s]
[INFO] Apache TinkerPop :: Gremlin Python ................. SUCCESS [  6.630 s]
[INFO] Apache TinkerPop :: Gremlin.Net .................... SUCCESS [  2.892 s]
[INFO] Apache TinkerPop :: Gremlin.Net - Source ........... SUCCESS [  0.118 s]
[INFO] Apache TinkerPop :: Gremlin.Net - Tests ............ SUCCESS [  0.067 s]
[INFO] Apache TinkerPop :: Hadoop Gremlin ................. SUCCESS [03:12 min]
[INFO] Apache TinkerPop :: Spark Gremlin .................. SUCCESS [01:14 min]
[INFO] Apache TinkerPop :: Giraph Gremlin ................. SUCCESS [  7.819 s]
[INFO] Apache TinkerPop :: Gremlin Console ................ SUCCESS [ 21.415 s]
[INFO] Apache TinkerPop :: Gremlin Archetype .............. SUCCESS [  0.045 s]
[INFO] Apache TinkerPop :: Archetype - TinkerGraph ........ SUCCESS [  4.934 s]
[INFO] Apache TinkerPop :: Archetype - Server ............. SUCCESS [ 11.442 s]
[INFO] Apache TinkerPop :: Archetype - DSL ................ SUCCESS [  5.675 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 14:49 min
[INFO] Finished at: 2017-10-10T15:35:23-05:00
[INFO] Final Memory: 278M/6262M
[INFO] ------------------------------------------------------------------------
```
VOTE: +1