### PR TITLE
TINKERPOP-1803: inject() doesn't re-attach with remote traversals

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed an "attachement"-bug in `InjectStep` with a solution generalized to `StartStep`.
 * Truncate the script in error logs and error return messages for "Method code too large" errors in Gremlin Server.
 * Fixed a bug in `LambdaRestrictionStrategy` where it was too eager to consider a step as being a lambda step.
 * `ReferenceVertex` was missing its `label()` string. `ReferenceElement` now supports all label handling.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed an old hack in `GroovyTranslator` and `PythonTranslator` where `Elements` were being mapped to their id only.
 * Fixed an "attachement"-bug in `InjectStep` with a solution generalized to `StartStep`.
 * Truncate the script in error logs and error return messages for "Method code too large" errors in Gremlin Server.
 * Fixed a bug in `LambdaRestrictionStrategy` where it was too eager to consider a step as being a lambda step.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StartStep.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.structure.util.Attachable;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.ArrayList;
@@ -65,7 +66,11 @@ public class StartStep<S> extends AbstractStep<S, S> {
             }
             this.first = false;
         }
-        return this.starts.next();
+        ///
+        final Traverser.Admin<S> start = this.starts.next();
+        if (start.get() instanceof Attachable && this.getTraversal().getGraph().isPresent())
+            start.set(((Attachable<S>) start.get()).attach(Attachable.Method.get(this.getTraversal().getGraph().get())));
+        return start;
     }
 
     @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/InjectStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/InjectStepTest.java
@@ -33,7 +33,10 @@ public class InjectStepTest extends StepTest {
     @Override
     protected List<Traversal> getTraversals() {
         return Arrays.asList(
-                __.identity()
+                __.identity(),
+                __.inject("a", "b"),
+                __.inject("a"),
+                __.inject("b")
         );
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyInjectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyInjectTest.groovy
@@ -38,5 +38,10 @@ public abstract class GroovyInjectTest {
         public Traversal<Vertex, Path> get_g_VX1X_out_name_injectXdanielX_asXaX_mapXlengthX_path(final Object v1Id) {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out().name.inject('daniel').as('a').map { it.length() }.path", "v1Id", v1Id);
         }
+
+        @Override
+        public Traversal<Vertex, String> get_g_VX1X_injectXg_VX4XX_out_name(final Object v1Id, final Object v4Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).inject(g.V(v4Id).next()).out.name", "v1Id", v1Id, "v4Id", v4Id)
+        }
     }
 }

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
@@ -33,8 +33,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
@@ -190,9 +192,23 @@ public class PythonTranslator implements Translator.ScriptTranslator {
             return convertStatic(((Enum) object).getDeclaringClass().getSimpleName() + ".") + SymbolHelper.toPython(object.toString());
         else if (object instanceof P)
             return convertPToString((P) object, new StringBuilder()).toString();
-        else if (object instanceof Element)
-            return convertToString(((Element) object).id()); // hack
-        else if (object instanceof Lambda)
+        else if (object instanceof Element) {
+            if (object instanceof Vertex) {
+                final Vertex vertex = (Vertex) object;
+                return "Vertex(" + convertToString(vertex.id()) + "," + convertToString(vertex.label()) + ")";
+            } else if (object instanceof Edge) {
+                final Edge edge = (Edge) object;
+                return "Edge(" + convertToString(edge.id()) + ", " +
+                        "Vertex(" + convertToString(edge.outVertex().id()) + ")," +
+                        convertToString(edge.label()) +
+                        ",Vertex(" + convertToString(edge.inVertex().id()) + "))";
+            } else { // VertexProperty
+                final VertexProperty vertexProperty = (VertexProperty) object;
+                return "VertexProperty(" + convertToString(vertexProperty.id()) + "," +
+                        convertToString(vertexProperty.label()) + "," +
+                        convertToString(vertexProperty.value()) + ")";
+            }
+        } else if (object instanceof Lambda)
             return convertLambdaToString((Lambda) object);
         else
             return null == object ? "None" : object.toString();

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -67,7 +67,8 @@ class TestDriverRemoteConnection(object):
         # # todo: need a traversal metrics deserializer
         g.V().out().profile().next()
         # #
-        results = g.V().has('name','peter').as_('a').out('created').as_('b').select('a','b').by(__.valueMap()).toList()
+        results = g.V().has('name', 'peter').as_('a').out('created').as_('b').select('a', 'b').by(
+            __.valueMap()).toList()
         assert 1 == len(results)
         assert 'peter' == results[0]['a']['name'][0]
         assert 35 == results[0]['a']['age'][0]
@@ -75,6 +76,11 @@ class TestDriverRemoteConnection(object):
         assert 'java' == results[0]['b']['lang'][0]
         assert 2 == len(results[0]['a'])
         assert 2 == len(results[0]['b'])
+        # #
+        results = g.V(1).inject(g.V(2).next()).values('name').toList()
+        assert 2 == len(results)
+        assert 'marko' in results
+        assert 'vadas' in results
 
     def test_strategies(self, remote_connection):
         statics.load_statics(globals())
@@ -169,13 +175,13 @@ class TestDriverRemoteConnection(object):
         assert "knows" == edge.label
         assert a == edge.outV
         assert b == edge.inV
-        g.V().has("name","marko").outE("knows").where(__.inV().has("name","peter")).drop().iterate()
+        g.V().has("name", "marko").outE("knows").where(__.inV().has("name", "peter")).drop().iterate()
         ##
         edge = g.withSideEffect("a", a).withSideEffect("b", b).V().limit(1).addE("knows").from_("a").to("b").next()
         assert "knows" == edge.label
         assert a == edge.outV
         assert b == edge.inV
-        g.V().has("name","marko").outE("knows").where(__.inV().has("name","peter")).drop().iterate()
+        g.V().has("name", "marko").outE("knows").where(__.inV().has("name", "peter")).drop().iterate()
 
     def test_side_effect_close(self, remote_connection):
         g = Graph().traversal().withRemote(remote_connection)

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/InjectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/InjectTest.java
@@ -23,7 +23,6 @@ import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.MapHelper;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
@@ -46,6 +45,8 @@ public abstract class InjectTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, String> get_g_VX1X_out_injectXv2X_name(final Object v1Id, final Object v2Id);
 
     public abstract Traversal<Vertex, Path> get_g_VX1X_out_name_injectXdanielX_asXaX_mapXlengthX_path(final Object v1Id);
+
+    public abstract Traversal<Vertex, String> get_g_VX1X_injectXg_VX4XX_out_name(final Object v1Id, final Object v4Id);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -83,6 +84,14 @@ public abstract class InjectTest extends AbstractGremlinProcessTest {
         assertEquals(4, counter);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX1X_injectXg_VX4XX_out_name() {
+        final Traversal<Vertex, String> traversal = get_g_VX1X_injectXg_VX4XX_out_name(convertToVertexId("marko"), convertToVertexId("josh"));
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList("ripple", "lop", "lop", "vadas", "josh"), traversal);
+    }
+
     public static class Traversals extends InjectTest {
 
         @Override
@@ -93,6 +102,11 @@ public abstract class InjectTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Path> get_g_VX1X_out_name_injectXdanielX_asXaX_mapXlengthX_path(final Object v1Id) {
             return g.V(v1Id).out().<String>values("name").inject("daniel").as("a").map(t -> t.get().length()).path();
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_VX1X_injectXg_VX4XX_out_name(final Object v1Id, final Object v4Id) {
+            return g.V(v1Id).inject(g.V(v4Id).next()).out().values("name");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1803

Fixed an "attachement"-bug in `InjectStep` with a solution generalized to `StartStep`.

VOTE +1