### PR TITLE
TINKERPOP-1798 Fix signature of MutationListener.vertexPropertyChanged()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added better error message for illegal use of `repeat()`-step.
 * Fixed a bug in `RangeByIsCountStrategy` that led to unexpected behaviors when predicates were used with floating point numbers.
 * Bump to Jackson 2.8.10.
+* Deprecated `MutationListener.vertexPropertyChanged()` method that did not use `VertexProperty` and added a new method that does.
 * Added an `EmbeddedRemoteConnection` so that it's possible to mimic a remote connection within the same JVM.
 * Supported interruption for remote traversals.
 * Allow the `:remote` command to accept a `Cluster` object defined in the console itself.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -102,6 +102,17 @@ In `gremlin-test` there is a new `GraphHelper` class that has a `cloneElements()
 the first graph to the second - `GraphHelper.cloneElements(Graph original, Graph clone)`. This helper method is
 primarily intended for use in tests.
 
+==== MutationListener Changes
+
+The `MutationListener` has a method called `vertexPropertyChanged` which gathered callbacks when a property on a vertex
+was modified. The method had an incorrect signature though using `Property` instead of `VertexProperty`. The old method
+that used `Property` has now been deprecated and a new method added that uses `VertexProperty`. This new method has a
+default implementation that calls the old method, so this change should not cause breaks in compilation on upgrade.
+Internally, TinkerPop no longer calls the old method except by way of that proxy. Users who have `MutationListener`
+implementations can simply add the new method and override its behavior. The old method can thus be ignored completely.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1798[TINKERPOP-1798]
+
 == TinkerPop 3.2.6
 
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -454,9 +454,15 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue,
+        public void vertexPropertyChanged(final Vertex element, final VertexProperty oldValue, final Object setValue,
                                           final Object... vertexPropertyKeyValues) {
             this.counter++;
+        }
+
+        @Override
+        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue,
+                                          final Object... vertexPropertyKeyValues) {
+            // do nothing - deprecated
         }
 
         @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/ConsoleMutationListener.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/ConsoleMutationListener.java
@@ -84,6 +84,11 @@ public class ConsoleMutationListener implements MutationListener {
 
     @Override
     public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        // do nothing - deprecated
+    }
+
+    @Override
+    public void vertexPropertyChanged(final Vertex element, final VertexProperty oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
         System.out.println("Vertex [" + element.toString() + "] property [" + oldValue + "] change to [" + setValue + "] in graph [" + graph.toString() + "]");
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/Event.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/Event.java
@@ -139,7 +139,7 @@ public interface Event {
 
         @Override
         void fire(final MutationListener listener, final Element element, final Property oldValue, final Object newValue, final Object... vertexPropertyKeyValues) {
-            listener.vertexPropertyChanged((Vertex) element, oldValue, newValue, vertexPropertyKeyValues);
+            listener.vertexPropertyChanged((Vertex) element, (VertexProperty) oldValue, newValue, vertexPropertyKeyValues);
         }
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/MutationListener.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/MutationListener.java
@@ -52,10 +52,19 @@ public interface MutationListener {
     /**
      * Raised after the property of a {@link Vertex} changed.
      *
+     * @deprecated As of release 3.2.7, replaced by {@link #vertexPropertyChanged(Vertex, VertexProperty, Object, Object...)}.
+     */
+    public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues);
+
+    /**
+     * Raised after the property of a {@link Vertex} changed.
+     *
      * @param element  the {@link Vertex} that changed
      * @param setValue the new value of the property
      */
-    public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues);
+    public default void vertexPropertyChanged(final Vertex element, final VertexProperty oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        vertexPropertyChanged(element, (Property) oldValue, setValue, vertexPropertyKeyValues);
+    }
 
     /**
      * Raised after a {@link VertexProperty} was removed from the graph.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1798

This method was referencing a Property when it should have been referencing a VertexProperty. Implemented by way of deprecation of the old method so that this ends up being a non-breaking change.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1