### PR TITLE
TINKERPOP-1821: Consistent behavior of self-referencing edges

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added a test for self-edges and fixed `Neo4jVertex` to provided repeated self-edges on `BOTH`.
 * Better respected permissions on the `plugins.txt` file and prevented writing if marked as read-only.
 * Added getters for the lambdas held by `LambdaCollectingBarrierStep`, `LambdaFlatMapStep` and `LambdaSideEffectStep`.
 * Fixed an old hack in `GroovyTranslator` and `PythonTranslator` where `Elements` were being mapped to their id only.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -167,6 +167,16 @@ implementations can simply add the new method and override its behavior. The old
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1798[TINKERPOP-1798]
 
+=== Upgrading for Providers
+
+==== Direction.BOTH Requires Duplication of Self-Edges
+
+Prior to this release, there was no semantic check to determine whether a self-edge (e.g. `e[1][2-self->2]`) would be returned
+twice on a `BOTH`. The semantics have been specified now in the test suite where the edge should be returned twice as it
+is both an incoming edge and an outgoing edge.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1821[TINKERPOP-1821]
+
 == TinkerPop 3.2.6
 
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyVertexTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyVertexTest.groovy
@@ -183,5 +183,15 @@ public abstract class GroovyVertexTest {
         public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_V_hasLabelXsoftwareX_name() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').V.hasLabel('software').name")
         }
+
+        @Override
+        public Traversal<Vertex, Edge> get_g_V_bothEXselfX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().bothE('self')")
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_bothXselfX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().both('self')")
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexTest.java
@@ -113,6 +113,10 @@ public abstract class VertexTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, String> get_g_V_hasLabelXpersonX_V_hasLabelXsoftwareX_name();
 
+    public abstract Traversal<Vertex, Edge> get_g_V_bothEXselfX();
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_bothXselfX();
+
     // GRAPH VERTEX/EDGE
 
     @Test
@@ -570,6 +574,28 @@ public abstract class VertexTest extends AbstractGremlinProcessTest {
         checkResults(Arrays.asList("lop", "lop", "lop", "lop", "ripple", "ripple", "ripple", "ripple"), traversal);
     }
 
+    @Test
+    public void g_V_bothEXselfX() {
+        g.addV().as("a").addE("self").to("a").iterate();
+        final Traversal<Vertex, Edge> traversal = get_g_V_bothEXselfX();
+        printTraversalForm(traversal);
+
+        List<Edge> edges = traversal.toList();
+        assertEquals(2, edges.size());
+        assertEquals(edges.get(0), edges.get(1));
+    }
+
+    @Test
+    public void g_V_bothXselfX() {
+        g.addV().as("a").addE("self").to("a").iterate();
+        final Traversal<Vertex, Vertex> traversal = get_g_V_bothXselfX();
+        printTraversalForm(traversal);
+
+        List<Vertex> vertices = traversal.toList();
+        assertEquals(2, vertices.size());
+        assertEquals(vertices.get(0), vertices.get(1));
+    }
+
     public static class Traversals extends VertexTest {
 
         @Override
@@ -720,6 +746,16 @@ public abstract class VertexTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_V_hasLabelXsoftwareX_name() {
             return g.V().hasLabel("person").V().hasLabel("software").values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Edge> get_g_V_bothEXselfX() {
+            return g.V().bothE("self");
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_bothXselfX() {
+            return g.V().both("self");
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexTest.java
@@ -575,6 +575,7 @@ public abstract class VertexTest extends AbstractGremlinProcessTest {
     }
 
     @Test
+    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     public void g_V_bothEXselfX() {
         g.addV().as("a").addE("self").to("a").iterate();
         final Traversal<Vertex, Edge> traversal = get_g_V_bothEXselfX();
@@ -586,6 +587,7 @@ public abstract class VertexTest extends AbstractGremlinProcessTest {
     }
 
     @Test
+    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     public void g_V_bothXselfX() {
         g.addV().as("a").addE("self").to("a").iterate();
         final Traversal<Vertex, Vertex> traversal = get_g_V_bothXselfX();

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertex.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertex.java
@@ -20,7 +20,6 @@ package org.apache.tinkerpop.gremlin.neo4j.structure;
 
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
@@ -35,6 +34,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
+
+import static org.apache.tinkerpop.gremlin.structure.Direction.BOTH;
+import static org.apache.tinkerpop.gremlin.structure.Direction.IN;
+import static org.apache.tinkerpop.gremlin.structure.Direction.OUT;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -110,8 +113,14 @@ public final class Neo4jVertex extends Neo4jElement implements Vertex, WrappedVe
         this.graph.tx().readWrite();
         return new Iterator<Vertex>() {
             final Iterator<Neo4jRelationship> relationshipIterator = IteratorUtils.filter(0 == edgeLabels.length ?
-                    getBaseVertex().relationships(Neo4jHelper.mapDirection(direction)).iterator() :
-                    getBaseVertex().relationships(Neo4jHelper.mapDirection(direction), (edgeLabels)).iterator(), graph.trait.getRelationshipPredicate());
+                    BOTH == direction ?
+                            IteratorUtils.concat(getBaseVertex().relationships(Neo4jHelper.mapDirection(OUT)).iterator(),
+                                    getBaseVertex().relationships(Neo4jHelper.mapDirection(IN)).iterator()) :
+                            getBaseVertex().relationships(Neo4jHelper.mapDirection(direction)).iterator() :
+                    BOTH == direction ?
+                            IteratorUtils.concat(getBaseVertex().relationships(Neo4jHelper.mapDirection(OUT), (edgeLabels)).iterator(),
+                                    getBaseVertex().relationships(Neo4jHelper.mapDirection(IN), (edgeLabels)).iterator()) :
+                            getBaseVertex().relationships(Neo4jHelper.mapDirection(direction), (edgeLabels)).iterator(), graph.trait.getRelationshipPredicate());
 
             @Override
             public boolean hasNext() {
@@ -130,8 +139,14 @@ public final class Neo4jVertex extends Neo4jElement implements Vertex, WrappedVe
         this.graph.tx().readWrite();
         return new Iterator<Edge>() {
             final Iterator<Neo4jRelationship> relationshipIterator = IteratorUtils.filter(0 == edgeLabels.length ?
-                    getBaseVertex().relationships(Neo4jHelper.mapDirection(direction)).iterator() :
-                    getBaseVertex().relationships(Neo4jHelper.mapDirection(direction), (edgeLabels)).iterator(), graph.trait.getRelationshipPredicate());
+                    BOTH == direction ?
+                            IteratorUtils.concat(getBaseVertex().relationships(Neo4jHelper.mapDirection(OUT)).iterator(),
+                                    getBaseVertex().relationships(Neo4jHelper.mapDirection(IN)).iterator()) :
+                            getBaseVertex().relationships(Neo4jHelper.mapDirection(direction)).iterator() :
+                    BOTH == direction ?
+                            IteratorUtils.concat(getBaseVertex().relationships(Neo4jHelper.mapDirection(OUT), (edgeLabels)).iterator(),
+                                    getBaseVertex().relationships(Neo4jHelper.mapDirection(IN), (edgeLabels)).iterator()) :
+                            getBaseVertex().relationships(Neo4jHelper.mapDirection(direction), (edgeLabels)).iterator(), graph.trait.getRelationshipPredicate());
 
             @Override
             public boolean hasNext() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1821

Added test for self-edges and fixed a semantic issue in `Neo4jGraph` regarding self edges not being repeated on `BOTH`.

VOTE +1.