### PR TITLE
TINKERPOP-1814: Some process tests require the graph API

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/CoreTraversalTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/CoreTraversalTest.java
@@ -207,47 +207,6 @@ public class CoreTraversalTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void shouldAddStartsProperly() {
-        final Traversal<Object, Vertex> traversal = out().out();
-        assertFalse(traversal.hasNext());
-        traversal.asAdmin().addStarts(traversal.asAdmin().getTraverserGenerator().generateIterator(g.V(), traversal.asAdmin().getSteps().get(0), 1l));
-        assertTrue(traversal.hasNext());
-        assertEquals(2, IteratorUtils.count(traversal));
-
-        traversal.asAdmin().addStarts(traversal.asAdmin().getTraverserGenerator().generateIterator(g.V(), traversal.asAdmin().getSteps().get(0), 1l));
-        traversal.asAdmin().addStarts(traversal.asAdmin().getTraverserGenerator().generateIterator(g.V(), traversal.asAdmin().getSteps().get(0), 1l));
-        assertEquals(4, IteratorUtils.count(traversal));
-        assertFalse(traversal.hasNext());
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
-    public void shouldTraversalResetProperly() {
-        final Traversal<Object, Vertex> traversal = as("a").out().out().has("name", P.within("ripple", "lop")).as("b");
-        if (new Random().nextBoolean()) traversal.asAdmin().reset();
-        assertFalse(traversal.hasNext());
-        traversal.asAdmin().addStarts(traversal.asAdmin().getTraverserGenerator().generateIterator(g.V(), traversal.asAdmin().getSteps().get(0), 1l));
-        assertTrue(traversal.hasNext());
-        assertEquals(2, IteratorUtils.count(traversal));
-
-        if (new Random().nextBoolean()) traversal.asAdmin().reset();
-        traversal.asAdmin().addStarts(traversal.asAdmin().getTraverserGenerator().generateIterator(g.V(), traversal.asAdmin().getSteps().get(0), 1l));
-        assertTrue(traversal.hasNext());
-        traversal.next();
-        assertTrue(traversal.hasNext());
-        traversal.asAdmin().reset();
-        assertFalse(traversal.hasNext());
-
-        traversal.asAdmin().addStarts(traversal.asAdmin().getTraverserGenerator().generateIterator(g.V(), traversal.asAdmin().getSteps().get(0), 1l));
-        assertEquals(2, IteratorUtils.count(traversal));
-
-        assertFalse(traversal.hasNext());
-        if (new Random().nextBoolean()) traversal.asAdmin().reset();
-        assertFalse(traversal.hasNext());
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
     @FeatureRequirement(featureClass = Graph.Features.GraphFeatures.class, feature = FEATURE_TRANSACTIONS)
     public void shouldTraverseIfAutoTxEnabledAndOriginalTxIsClosed() {
         // this should be the default, but manually set in just in case the implementation has other ideas

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeTest.java
@@ -25,7 +25,6 @@ import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
-import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -132,8 +131,8 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("createdBy", edge.label());
-            assertEquals(2.0d, edge.<Number>value("weight").doubleValue(), 0.00001d);
-            assertEquals(1, IteratorUtils.count(edge.properties()));
+            assertEquals(2.0d, g.E(edge).<Double>values("weight").next(), 0.00001d);
+            assertEquals(1, g.E(edge).properties().count().next().intValue());
             count++;
 
 
@@ -153,8 +152,8 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("createdBy", edge.label());
-            assertEquals(2.0d, edge.<Number>value("weight").doubleValue(), 0.00001d);
-            assertEquals(1, IteratorUtils.count(edge.properties()));
+            assertEquals(2.0d, g.E(edge).<Double>values("weight").next(), 0.00001d);
+            assertEquals(1, g.E(edge).properties().count().next().intValue());
             count++;
 
 
@@ -175,15 +174,15 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("existsWith", edge.label());
-            assertEquals("now", edge.value("time"));
-            assertEquals(1, IteratorUtils.count(edge.properties()));
+            assertEquals("now", g.E(edge).values("time").next());
+            assertEquals(1, g.E(edge).properties().count().next().intValue());
             count++;
         }
         assertEquals(36, count);
         assertEquals(42, IteratorUtils.count(g.E()));
         for (final Vertex vertex : IteratorUtils.list(g.V())) {
-            assertEquals(6, IteratorUtils.count(vertex.edges(Direction.OUT, "existsWith")));
-            assertEquals(6, IteratorUtils.count(vertex.edges(Direction.IN, "existsWith")));
+            assertEquals(6, g.V(vertex).out("existsWith").count().next().intValue());
+            assertEquals(6, g.V(vertex).in("existsWith").count().next().intValue());
         }
         assertEquals(6, IteratorUtils.count(g.V()));
     }
@@ -198,15 +197,15 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("existsWith", edge.label());
-            assertEquals("now", edge.value("time"));
-            assertEquals(1, IteratorUtils.count(edge.properties()));
+            assertEquals("now", g.E(edge).values("time").next());
+            assertEquals(1, g.E(edge).properties().count().next().intValue());
             count++;
         }
         assertEquals(36, count);
         assertEquals(42, IteratorUtils.count(g.E()));
         for (final Vertex vertex : IteratorUtils.list(g.V())) {
-            assertEquals(6, IteratorUtils.count(vertex.edges(Direction.OUT, "existsWith")));
-            assertEquals(6, IteratorUtils.count(vertex.edges(Direction.IN, "existsWith")));
+            assertEquals(6, g.V(vertex).out("existsWith").count().next().intValue());
+            assertEquals(6, g.V(vertex).in("existsWith").count().next().intValue());
         }
         assertEquals(6, IteratorUtils.count(g.V()));
     }
@@ -222,13 +221,13 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("codeveloper", edge.label());
-            assertEquals(2009, (int) edge.value("year"));
-            assertEquals(1, IteratorUtils.count(edge.properties()));
-            assertEquals("person", edge.inVertex().label());
-            assertEquals("person", edge.outVertex().label());
-            assertFalse(edge.inVertex().value("name").equals("vadas"));
-            assertFalse(edge.outVertex().value("name").equals("vadas"));
-            assertFalse(edge.inVertex().equals(edge.outVertex()));
+            assertEquals(2009, g.E(edge).values("year").next());
+            assertEquals(1, g.E(edge).properties().count().next().intValue());
+            assertEquals("person", g.E(edge).inV().label().next());
+            assertEquals("person", g.E(edge).outV().label().next());
+            assertFalse(g.E(edge).inV().values("name").next().equals("vadas"));
+            assertFalse(g.E(edge).outV().values("name").next().equals("vadas"));
+            assertFalse(g.E(edge).inV().next().equals(g.E(edge).outV().next()));
             count++;
 
         }
@@ -247,13 +246,13 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("codeveloper", edge.label());
-            assertEquals(2009, (int) edge.value("year"));
-            assertEquals(1, IteratorUtils.count(edge.properties()));
-            assertEquals("person", edge.inVertex().label());
-            assertEquals("person", edge.outVertex().label());
-            assertFalse(edge.inVertex().value("name").equals("vadas"));
-            assertFalse(edge.outVertex().value("name").equals("vadas"));
-            assertFalse(edge.inVertex().equals(edge.outVertex()));
+            assertEquals(2009, g.E(edge).values("year").next());
+            assertEquals(1, g.E(edge).properties().count().next().intValue());
+            assertEquals("person", g.E(edge).inV().label().next());
+            assertEquals("person", g.E(edge).outV().label().next());
+            assertFalse(g.E(edge).inV().values("name").next().equals("vadas"));
+            assertFalse(g.E(edge).outV().values("name").next().equals("vadas"));
+            assertFalse(g.E(edge).inV().next().equals(g.E(edge).outV().next()));
             count++;
 
         }
@@ -275,8 +274,8 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         assertEquals(edge.outVertex(), convertToVertex(graph, "marko"));
         assertEquals(edge.inVertex(), convertToVertex(graph, "peter"));
         assertEquals("knows", edge.label());
-        assertEquals(1, IteratorUtils.count(edge.properties()));
-        assertEquals(0.5d, edge.value("weight"), 0.1d);
+        assertEquals(1, g.E(edge).properties().count().next().intValue());
+        assertEquals(0.5d, g.E(edge).<Double>values("weight").next(), 0.1d);
         assertEquals(6L, g.V().count().next().longValue());
         assertEquals(7L, g.E().count().next().longValue());
     }
@@ -292,13 +291,13 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("createdBy", edge.label());
-            assertEquals(2009, (int) edge.value("year"));
-            assertEquals("public", edge.value("acl"));
-            assertEquals(2, IteratorUtils.count(edge.properties()));
-            assertEquals("person", edge.inVertex().label());
-            assertEquals("software", edge.outVertex().label());
-            if (edge.outVertex().value("name").equals("ripple"))
-                assertEquals("josh", edge.inVertex().value("name"));
+            assertEquals(2009, g.E(edge).values("year").next());
+            assertEquals("public", g.E(edge).values("acl").next());
+            assertEquals(2, g.E(edge).properties().count().next().intValue());
+            assertEquals("person", g.E(edge).inV().label().next());
+            assertEquals("software", g.E(edge).outV().label().next());
+            if (g.E(edge).outV().values("name").next().equals("ripple"))
+                assertEquals("josh", g.E(edge).inV().values("name").next());
             count++;
 
         }
@@ -317,13 +316,13 @@ public abstract class AddEdgeTest extends AbstractGremlinProcessTest {
         while (traversal.hasNext()) {
             final Edge edge = traversal.next();
             assertEquals("createdBy", edge.label());
-            assertEquals(2009, (int) edge.value("year"));
-            assertEquals("public", edge.value("acl"));
-            assertEquals(2, IteratorUtils.count(edge.properties()));
-            assertEquals("person", edge.inVertex().label());
-            assertEquals("software", edge.outVertex().label());
-            if (edge.outVertex().value("name").equals("ripple"))
-                assertEquals("josh", edge.inVertex().value("name"));
+            assertEquals(2009, g.E(edge).values("year").next());
+            assertEquals("public", g.E(edge).values("acl").next());
+            assertEquals(2, g.E(edge).properties().count().next().intValue());
+            assertEquals("person", g.E(edge).inV().label().next());
+            assertEquals("software", g.E(edge).outV().label().next());
+            if (g.E(edge).outV().values("name").next().equals("ripple"))
+                assertEquals("josh", g.E(edge).inV().values("name").next());
             count++;
 
         }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -23,7 +23,6 @@ import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -61,8 +60,8 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final Vertex v = g.withStrategies(partitionStrategy).addV().property("any", "thing").next();
 
         assertNotNull(v);
-        assertEquals("thing", v.property("any").value());
-        assertEquals("A", v.property(partition).value());
+        assertEquals("thing", g.V(v).values("any").next());
+        assertEquals("A", g.V(v).values(partition).next());
     }
 
     @Test
@@ -75,9 +74,8 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final Vertex v = g.withStrategies(partitionStrategy).addV().property("any", "thing").next();
 
         assertNotNull(v);
-        assertEquals("thing", v.property("any").value());
-        assertEquals("A", v.property(partition).value());
-        assertEquals("A", v.property("any").value(partition));
+        assertEquals("thing", g.V(v).values("any").next());
+        assertEquals("A", g.V(v).values(partition).next());
     }
 
     @Test
@@ -92,9 +90,9 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .property(VertexProperty.Cardinality.list, "any", "more").next();
 
         assertNotNull(v);
-        assertThat((List<String>) IteratorUtils.asList(v.properties("any")).stream().map(p -> ((VertexProperty) p).value()).collect(Collectors.toList()), containsInAnyOrder("thing", "more"));
+        assertThat((List<String>) IteratorUtils.asList(g.V(v).properties("any")).stream().map(p -> ((VertexProperty) p).value()).collect(Collectors.toList()), containsInAnyOrder("thing", "more"));
         assertEquals("A", v.property(partition).value());
-        assertThat((List<String>) IteratorUtils.asList(v.properties("any")).stream().map(p -> ((VertexProperty) p).value(partition)).collect(Collectors.toList()), containsInAnyOrder("A", "A"));
+        assertThat((List<String>) IteratorUtils.asList(g.V(v).properties("any")).stream().map(p -> ((VertexProperty) p).value(partition)).collect(Collectors.toList()), containsInAnyOrder("A", "A"));
     }
 
     @Test
@@ -107,9 +105,9 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final Vertex v = g.withStrategies(partitionStrategy).addV().property("any", "thing").next();
 
         assertNotNull(v);
-        assertEquals("thing", v.property("any").value());
-        assertEquals("A", v.property(partition).value());
-        assertThat(v.property("any").properties().hasNext(), is(false));
+        assertEquals("thing", g.V(v).values("any").next());
+        assertEquals("A", g.V(v).values(partition).next());
+        assertThat(g.V(v).properties("any").properties().hasNext(), is(false));
 
     }
 
@@ -132,15 +130,15 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final Vertex v = gOverA.addV().property("any", "thing").property("some", "thing").next();
 
         assertNotNull(v);
-        assertEquals("thing", v.property("any").value());
-        assertEquals("A", v.property(partition).value());
-        assertEquals("A", v.property("any").value(partition));
-        assertEquals("thing", v.property("some").value());
-        assertEquals("A", v.property("some").value(partition));
+        assertEquals("thing", g.V(v).values("any").next());
+        assertEquals("A", g.V(v).values(partition).next());
+        assertEquals("A", g.V(v).properties("any").values(partition).next());
+        assertEquals("thing", g.V(v).values("some").next());
+        assertEquals("A", g.V(v).properties("some").values(partition).next());
 
         gOverAB.V(v).property("that", "thing").iterate();
-        assertEquals("thing", v.property("that").value());
-        assertEquals("B", v.property("that").value(partition));
+        assertEquals("thing", g.V(v).values("that").next());
+        assertEquals("B", g.V(v).properties("that").values(partition).next());
 
         assertThat(gOverAB.V(v).properties("any").hasNext(), is(true));
         assertThat(gOverAB.V(v).properties("that").hasNext(), is(true));
@@ -202,7 +200,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .partitionKey(partition).writePartition("A").readPartitions("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
 
-        assertEquals(1l, (long) gOverA.V(v).values().count().next());
+        assertEquals(1L, (long) gOverA.V(v).values().count().next());
         assertEquals("thing", gOverA.V(v).values().next());
     }
 
@@ -232,7 +230,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .partitionKey(partition).writePartition("A").readPartitions("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
 
-        assertEquals(1l, (long) gOverA.V(v).properties().count().next());
+        assertEquals(1L, (long) gOverA.V(v).properties().count().next());
         assertEquals("thing", gOverA.V(v).properties().value().next());
     }
 
@@ -257,7 +255,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
 
-        assertEquals(1l, (long) gOverA.V(v).propertyMap().count().next());
+        assertEquals(1L, (long) gOverA.V(v).propertyMap().count().next());
         assertEquals("thing", ((List<VertexProperty>) gOverA.V(v).propertyMap().next().get("any")).get(0).value());
     }
 
@@ -287,7 +285,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .partitionKey(partition).writePartition("A").addReadPartition("A").create());
         final Vertex v = gOverA.addV().property("any", "thing").next();
 
-        assertEquals(1l, (long) gOverA.V(v).valueMap().count().next());
+        assertEquals(1L, (long) gOverA.V(v).valueMap().count().next());
         assertEquals("thing", ((List) gOverA.V(v).valueMap().next().get("any")).get(0));
     }
 
@@ -302,17 +300,17 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final Edge e = source.withSideEffect("v2", v2).V(v1.id()).addE("connectsTo").from("v2").property("every", "thing").next();
 
         assertNotNull(v1);
-        assertEquals("thing", v1.property("any").value());
-        assertEquals("A", v2.property(partition).value());
+        assertEquals("thing", g.V(v1).values("any").next());
+        assertEquals("A", g.V(v2).values(partition).next());
 
         assertNotNull(v2);
-        assertEquals("thing", v2.property("some").value());
-        assertEquals("A", v2.property(partition).value());
+        assertEquals("thing", g.V(v2).values("some").next());
+        assertEquals("A", g.V(v2).values(partition).next());
 
         assertNotNull(e);
-        assertEquals("thing", e.property("every").value());
+        assertEquals("thing", g.E(e).values("every").next());
         assertEquals("connectsTo", e.label());
-        assertEquals("A", e.property(partition).value());
+        assertEquals("A", g.E(e).values(partition).next());
     }
 
     @Test
@@ -339,15 +337,15 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final Vertex vB = sourceBA.addV().property("any", "b").next();
 
         assertNotNull(vA);
-        assertEquals("a", vA.property("any").value());
-        assertEquals("A", vA.property(partition).value());
+        assertEquals("a", g.V(vA).values("any").next());
+        assertEquals("A", g.V(vA).values(partition).next());
 
         assertNotNull(vB);
-        assertEquals("b", vB.property("any").value());
-        assertEquals("B", vB.property(partition).value());
+        assertEquals("b", g.V(vB).values("any").next());
+        assertEquals("B", g.V(vB).values(partition).next());
 
-        sourceBA.V().forEachRemaining(v -> assertEquals("a", v.property("any").value()));
-        sourceBB.V().forEachRemaining(v -> assertEquals("b", v.property("any").value()));
+        sourceBA.V().forEachRemaining(v -> assertEquals("a", g.V(v).values("any").next()));
+        sourceBB.V().forEachRemaining(v -> assertEquals("b", g.V(v).values("any").next()));
 
         assertEquals(new Long(2), sourceBAB.V().count().next());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1814

Fixed assertions in the test cases outlined by @BrynCooke that use the structure API when they should stick with the process API. I found more areas than specified in the ticket. I also suspect that other process test cases will have similar problems. As these are exposed, please just make a new ticket accordingly - besides being monotonously boring, these are easy to fix.

VOTE +1.