### PR TITLE
TINKERPOP-1807 Gremlin-Python doesn't support GraphSON types g:Date, g:Timestamp and g:UUID

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added core GraphSON classes for Gremlin-Python: `UUID`, `Date`, and `Timestamp`.
 * `TraversalVertexProgram` ``profile()` now accounts for worker iteration in `GraphComputer` OLAP.
 * Added a test for self-edges and fixed `Neo4jVertex` to provided repeated self-edges on `BOTH`.
 * Better respected permissions on the `plugins.txt` file and prevented writing if marked as read-only.

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -29,6 +29,15 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.2.7/CHANGELOG.asciidoc#release-3-2-7[changelog] for a complete list of all the modifications that are part of this release.
 
+==== Gremlin-Python Core Types
+With the addition of `UUID`, `Date`, and `Timestamp`, Gremlin-Python now implements serializers for all core GraphSON types. Users
+that were using other types to represent this data can now use the Python classes `datetime.datetime` and`uuid.UUID` in GLV traversals.
+Since Python does not support a native `Timestamp` object, Gremlin-Python now offers a dummy class `Timestamp`, which allows
+users to wrap a float and submit it to the Gremlin Server as a `Timestamp` GraphSON type. `Timestamp` can be found in
+`gremlin_python.statics`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1807[TINKERPOP-1807]
+
 ==== Embedded Remote Connection
 
 As Gremlin Language Variants (GLVs) expand their usage and use of `withRemote()` becomes more common, the need to mock

--- a/gremlin-python/src/main/jython/gremlin_python/statics.py
+++ b/gremlin-python/src/main/jython/gremlin_python/statics.py
@@ -36,6 +36,15 @@ else:
     from types import LongType
     from types import TypeType
 
+
+class timestamp(float):
+    """
+    In Python a timestamp is simply a float. This dummy class (similar to long), allows users to wrap a float
+    in a GLV script to make sure the value is serialized as a GraphSON timestamp.
+    """
+    pass
+
+
 staticMethods = {}
 staticEnums = {}
 default_lambda_language = "gremlin-python"

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
@@ -128,15 +128,18 @@ class TestGraphSONReader(object):
     def test_datetime(self):
         dt = self.graphson_reader.readObject(json.dumps({"@type": "g:Date", "@value": 1481750076295}))
         assert isinstance(dt, datetime.datetime)
+        assert dt == datetime.datetime(2016, 12, 14, 13, 14, 36, 295000)
 
     def test_timestamp(self):
         dt = self.graphson_reader.readObject(json.dumps({"@type": "g:Timestamp", "@value": 1481750076295}))
         assert isinstance(dt, timestamp)
+        assert float(dt) == 1481750076.295
 
     def test_uuid(self):
         prop = self.graphson_reader.readObject(
             json.dumps({'@type': 'g:UUID', '@value': "41d2e28a-20a4-4ab0-b379-d810dede3786"}))
         assert isinstance(prop, uuid.UUID)
+        assert str(prop) == '41d2e28a-20a4-4ab0-b379-d810dede3786'
 
 
 class TestGraphSONWriter(object):
@@ -259,6 +262,7 @@ class TestGraphSONWriter(object):
         prop = uuid.UUID("41d2e28a-20a4-4ab0-b379-d810dede3786")
         output = self.graphson_writer.writeObject(prop)
         assert expected == output
+
 
 class TestFunctionalGraphSONIO(object):
     """Functional IO tests"""


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1807

This PR add support for GraphSON types `UUID`, `Date`, and `Timestamp` as well as associated tests. `UUID` and `Date` are straightforward, as the Python standard library includes `Date` (`datetime.datetime`) and `UUID` (`uuid.UUID`) objects. However, in Python, a timestamp is just a float, so in order to support serialization to a GraphSON type Timestamp, I added a dummy class `timestamp` to the `statics` module, similar to the `long` class for Python 3.

Note, another PR will be required for master with implementations for both GraphSON2 and 3. I will open upon approval of this one.