### PR TITLE
TINKERPOP-1824 Bump netty to 4.0.52

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Bump to Netty 4.0.52
 * `TraversalVertexProgram` ``profile()` now accounts for worker iteration in `GraphComputer` OLAP.
 * Added a test for self-edges and fixed `Neo4jVertex` to provided repeated self-edges on `BOTH`.
 * Better respected permissions on the `plugins.txt` file and prevented writing if marked as read-only.

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -54,7 +54,7 @@ JavaTuples 1.2
 Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
 
 ------------------------------------------------------------------------
-Netty 4.0.50
+Netty 4.0.52
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
 

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -55,6 +55,6 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------
-Netty 4.0.50
+Netty 4.0.52
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ limitations under the License.
         <javadoc-plugin.version>2.10.4</javadoc-plugin.version>
         <jcabi.version>1.1</jcabi.version>
         <metrics.version>3.0.2</metrics.version>
-        <netty.version>4.0.50.Final</netty.version>
+        <netty.version>4.0.52.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <spark.version>1.6.1</spark.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1824

Latest bug-fix release.

VOTE +1
