### PR TITLE
TINKERPOP-1813: Subgraph step requires the graph API

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
@@ -71,15 +71,15 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         assertVertexEdgeCounts(subgraph, 3, 2);
         subgraph.edges().forEachRemaining(e -> {
             assertEquals("knows", e.label());
-            assertEquals("marko", e.outVertex().values("name").next());
-            assertEquals(new Integer(29), e.outVertex().<Integer>values("age").next());
-            assertEquals("person", e.outVertex().label());
+            assertEquals("marko", g.E(e).outV().values("name").next());
+            assertEquals(new Integer(29), g.E(e).outV().<Integer>values("age").next());
+            assertEquals("person", g.E(e).outV().label().next());
 
-            final String name = e.inVertex().<String>values("name").next();
+            final String name = g.E(e).inV().<String>values("name").next();
             if (name.equals("vadas"))
-                assertEquals(0.5d, e.value("weight"), 0.0001d);
+                assertEquals(0.5d, g.E(e).<Double>values("weight").next(), 0.0001d);
             else if (name.equals("josh"))
-                assertEquals(1.0d, e.value("weight"), 0.0001d);
+                assertEquals(1.0d, g.E(e).<Double>values("weight").next(), 0.0001d);
             else
                 fail("There's a vertex present that should not be in the subgraph");
         });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1813

This ticket wanted `SubgraphStep` to not use the structure API. This is not something we will support in TinkerPop3. The structure API is a fundamental layer to our step API. It was advised to the provider to simply write their own custom `ProviderSubgraphStep` which avoids the structure API as they see fit. However, what was accomplished in this ticket was to change `SubgraphTest` to only use traversals (process API) in its assertions. This theme is good -- our process test suite should never rely on the structure API (beyond `ReferenceXXX` data).

VOTE +1