### PR TITLE
TINKERPOP-1802: hasId() fails for empty collections

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed an `ArrayOutOfBoundsException` in `hasId()` for the rare situation when the provided collection is empty.
 * Bump to Netty 4.0.52
 * `TraversalVertexProgram` ``profile()` now accounts for worker iteration in `GraphComputer` OLAP.
 * Added a test for self-edges and fixed `Neo4jVertex` to provided repeated self-edges on `BOTH`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,7 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Fixed an `ArrayOutOfBoundsException` in `hasId()` for the rare situation when the provided collection is empty.
 * Bump to Netty 4.0.52
-* `TraversalVertexProgram` ``profile()` now accounts for worker iteration in `GraphComputer` OLAP.
+* `TraversalVertexProgram` `profile()` now accounts for worker iteration in `GraphComputer` OLAP.
 * Added a test for self-edges and fixed `Neo4jVertex` to provided repeated self-edges on `BOTH`.
 * Better respected permissions on the `plugins.txt` file and prevented writing if marked as read-only.
 * Added getters for the lambdas held by `LambdaCollectingBarrierStep`, `LambdaFlatMapStep` and `LambdaSideEffectStep`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -36,8 +36,6 @@ import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -102,10 +100,15 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
     }
 
     public void addIds(final Object... newIds) {
-        this.ids = ArrayUtils.addAll(this.ids,
-                (newIds.length == 1 && newIds[0] instanceof Collection) ?
-                        ((Collection) newIds[0]).toArray(new Object[((Collection) newIds[0]).size()]) :
-                        newIds);
+        if (this.ids.length == 0 &&
+                newIds.length == 1 &&
+                newIds[0] instanceof Collection && ((Collection) newIds[0]).isEmpty())
+            this.ids = null;
+        else
+            this.ids = ArrayUtils.addAll(this.ids,
+                    (newIds.length == 1 && newIds[0] instanceof Collection) ?
+                            ((Collection) newIds[0]).toArray(new Object[((Collection) newIds[0]).size()]) :
+                            newIds);
     }
 
     public void clearIds() {

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
@@ -18,7 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
+import org.apache.tinkerpop.gremlin.process.traversal.P
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
 import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
@@ -168,6 +170,26 @@ public abstract class GroovyHasTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_hasLabelXsoftwareX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').hasLabel('software')")
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_hasIdXemptyX_count() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId([]).count")
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_hasIdXwithinXemptyXX_count() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(within([])).count")
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_hasIdXwithoutXemptyXX_count() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(without([])).count")
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_notXhasIdXwithinXemptyXXX_count() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.not(hasId(within([]))).count")
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
@@ -107,6 +108,14 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Vertex> get_g_V_hasIdX1X_hasIdX2X(final Object v1Id, final Object v2Id);
 
     public abstract Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_hasLabelXsoftwareX();
+
+    public abstract Traversal<Vertex, Long> get_g_V_hasIdXemptyX_count();
+
+    public abstract Traversal<Vertex, Long> get_g_V_hasIdXwithinXemptyXX_count();
+
+    public abstract Traversal<Vertex, Long> get_g_V_hasIdXwithoutXemptyXX_count();
+
+    public abstract Traversal<Vertex, Long> get_g_V_notXhasIdXwithinXemptyXXX_count();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -449,6 +458,38 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         assertFalse(traversal.hasNext());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasIdXemptyX_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_hasIdXemptyX_count();
+        printTraversalForm(traversal);
+        assertEquals(0L, traversal.next().longValue());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasIdXwithinXemptyXX_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_hasIdXwithinXemptyXX_count();
+        printTraversalForm(traversal);
+        assertEquals(0L, traversal.next().longValue());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasIdXwithoutXemptyXX_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_hasIdXwithoutXemptyXX_count();
+        printTraversalForm(traversal);
+        assertEquals(6L, traversal.next().longValue());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_notXhasIdXwithinXemptyXXX_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_notXhasIdXwithinXemptyXXX_count();
+        printTraversalForm(traversal);
+        assertEquals(6L, traversal.next().longValue());
+    }
+
     public static class Traversals extends HasTest {
         @Override
         public Traversal<Edge, Edge> get_g_EX11X_outV_outE_hasXid_10X(final Object e11Id, final Object e8Id) {
@@ -588,6 +629,26 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_hasLabelXsoftwareX() {
             return g.V().hasLabel("person").hasLabel("software");
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_hasIdXemptyX_count() {
+            return g.V().hasId(Collections.emptyList()).count();
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_hasIdXwithinXemptyXX_count() {
+            return g.V().hasId(P.within(Collections.emptyList())).count();
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_hasIdXwithoutXemptyXX_count() {
+            return g.V().hasId(P.without(Collections.emptyList())).count();
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_notXhasIdXwithinXemptyXXX_count() {
+            return g.V().not(__.hasId(P.within(Collections.emptyList()))).count();
         }
     }
 }

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/Neo4jGraphStep.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/Neo4jGraphStep.java
@@ -52,10 +52,14 @@ public final class Neo4jGraphStep<S, E extends Element> extends GraphStep<S, E> 
     }
 
     private Iterator<? extends Edge> edges() {
+        if (null == this.ids)
+            return Collections.emptyIterator();
         return IteratorUtils.filter(this.getTraversal().getGraph().get().edges(this.ids), edge -> HasContainer.testAll(edge, this.hasContainers));
     }
 
     private Iterator<? extends Vertex> vertices() {
+        if (null == this.ids)
+            return Collections.emptyIterator();
         final Neo4jGraph graph = (Neo4jGraph) this.getTraversal().getGraph().get();
         return graph.getTrait().lookupVertices(graph, this.hasContainers, this.ids);
     }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -63,7 +63,9 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
         final TinkerGraph graph = (TinkerGraph) this.getTraversal().getGraph().get();
         final HasContainer indexedContainer = getIndexKey(Edge.class);
         // ids are present, filter on them first
-        if (this.ids != null && this.ids.length > 0)
+        if (null == this.ids)
+            return Collections.emptyIterator();
+        else if (this.ids.length > 0)
             return this.iteratorList(graph.edges(this.ids));
         else
             return null == indexedContainer ?
@@ -77,7 +79,9 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
         final TinkerGraph graph = (TinkerGraph) this.getTraversal().getGraph().get();
         final HasContainer indexedContainer = getIndexKey(Vertex.class);
         // ids are present, filter on them first
-        if (this.ids != null && this.ids.length > 0)
+        if (null == this.ids)
+            return Collections.emptyIterator();
+        else if (this.ids.length > 0)
             return this.iteratorList(graph.vertices(this.ids));
         else
             return null == indexedContainer ?


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1802

If `hasId([])` is specified, then an `ArrayOutOfBoundsException` occurs. This has been fixed by simply filtering out (`filter(true)` in essence) all vertices once a `hasId([])` is reached. cc/ @rjbriody 

VOTE +1.