### PR TITLE
TINKERPOP-1830: fix race condition in TinkerIndex

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed a race condition in `TinkerIndex`.
 * Fixed an `ArrayOutOfBoundsException` in `hasId()` for the rare situation when the provided collection is empty.
 * Bump to Netty 4.0.52
 * `TraversalVertexProgram` `profile()` now accounts for worker iteration in `GraphComputer` OLAP.

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIndex.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIndex.java
@@ -48,17 +48,16 @@ final class TinkerIndex<T extends Element> {
 
     protected void put(final String key, final Object value, final T element) {
         Map<Object, Set<T>> keyMap = this.index.get(key);
-        if (keyMap == null) {
-            keyMap = new ConcurrentHashMap<>();
-            this.index.put(key, keyMap);
+        if (null == keyMap) {
+            this.index.putIfAbsent(key, new ConcurrentHashMap<Object, Set<T>>());
+            keyMap = this.index.get(key);
         }
         Set<T> objects = keyMap.get(value);
         if (null == objects) {
-            objects = new HashSet<>();
-            keyMap.put(value, objects);
+            keyMap.putIfAbsent(value, ConcurrentHashMap.newKeySet());
+            objects = keyMap.get(value);
         }
         objects.add(element);
-
     }
 
     public List<T> get(final String key, final Object value) {


### PR DESCRIPTION
My colleage @fabsx00 discovered a race condition in tinkergraph's index creation. He fixed it by simply replacing `parallelStream` with `stream`. Quoting his analysis:

> So, reading the code, you see that this.put is called in parallel, but that method seems to contain a race as get is called on the index, checked for null, and a subsequent write is performed. It still seems like using stream here fixes the problem we've been seeing, and the performance hit is not significant.

Ticket: https://issues.apache.org/jira/browse/TINKERPOP-1830

After initial feedback I can backport this onto tp32. 