### PR TITLE
TINKERPOP-1832: TraversalHelper.replaceStep sets previousStep to the wrong step

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -62,6 +62,7 @@ import java.util.function.Predicate;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @author Pieter Martin (https://github.com/pietermartin)
  */
 public final class TraversalHelper {
 
@@ -172,8 +173,9 @@ public final class TraversalHelper {
      * @param traversal  the traversal on which the action will occur
      */
     public static <S, E> void replaceStep(final Step<S, E> removeStep, final Step<S, E> insertStep, final Traversal.Admin<?, ?> traversal) {
-        traversal.addStep(stepIndex(removeStep, traversal), insertStep);
-        traversal.removeStep(removeStep);
+        final int i;
+        traversal.removeStep(i = stepIndex(removeStep, traversal));
+        traversal.addStep(i, insertStep);
     }
 
     public static <S, E> Step<?, E> insertTraversal(final Step<?, S> previousStep, final Traversal.Admin<S, E> insertTraversal, final Traversal.Admin<?, ?> traversal) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/util/TraversalHelperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/util/TraversalHelperTest.java
@@ -32,6 +32,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.LambdaFilterSt
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.PathFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.FlatMapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.TraversalFlatMapStep;
@@ -47,6 +48,8 @@ import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -62,8 +65,25 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @author Pieter Martin (https://github.com/pietermartin)
  */
 public class TraversalHelperTest {
+
+    @Test
+    public void shouldSetPreviousStepToEmptyStep() {
+        final Traversal.Admin<?, ?> traversal = __.V().out().asAdmin();
+        //transform the traversal to __.V().not(out())
+        //the VertexStep's previousStep should be the EmptyStep
+        Optional<VertexStep> vertexStepOpt = TraversalHelper.getFirstStepOfAssignableClass(VertexStep.class, traversal);
+        assertTrue(vertexStepOpt.isPresent());
+        Traversal.Admin<?,?> inner = __.start().asAdmin();
+        inner.addStep(0, vertexStepOpt.get());
+        TraversalHelper.replaceStep(vertexStepOpt.get(), new NotStep<>(__.identity().asAdmin(), inner), traversal);
+        List<VertexStep> vertexSteps = TraversalHelper.getStepsOfAssignableClassRecursively(VertexStep.class, traversal);
+        assertEquals(1, vertexSteps.size());
+        VertexStep vertexStep = vertexSteps.get(0);
+        assertTrue("Expected the previousStep to be an EmptyStep, found instead " + vertexStep.getPreviousStep().toString(),vertexStep.getPreviousStep() == EmptyStep.instance());
+    }
 
     @Test
     public void shouldIdentifyLocalChildren() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1832

`TraversalHelper.replaceStep` needs to first remove the step before adding in the new step. Else it gets its `previousStep` pointer wrong.

Added `TraversalHelperTest.shouldSetPreviousStepToEmptyStep` which was the scenario that originally made me aware of the issue.

Ran `mvn clean install` and tested Sqlg's tests with the fix.