### PR TITLE
TINKERPOP-1811 Fixed bytecode deserialization error messaging

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Provided a method to configure detachment options with `EventStrategy`.
 * Fixed a race condition in `TinkerIndex`.
+* Improved error messaging for bytecode deserialization errors in Gremlin Server.
 * Fixed an `ArrayOutOfBoundsException` in `hasId()` for the rare situation when the provided collection is empty.
 * Bump to Netty 4.0.52
 * `TraversalVertexProgram` `profile()` now accounts for worker iteration in `GraphComputer` OLAP.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
@@ -173,6 +173,12 @@ public final class JavaTranslator<S extends TraversalSource, T extends Traversal
         for (int i = 0; i < arguments.length; i++) {
             argumentsCopy[i] = translateObject(arguments[i]);
         }
+
+        // without this initial check iterating an invalid methodName will lead to a null pointer and a less than
+        // great error message for the user. 
+        if (!methodCache.containsKey(methodName))
+            throw new IllegalStateException("Could not locate method: " + delegate.getClass().getSimpleName() + "." + methodName + "(" + Arrays.toString(argumentsCopy) + ")");
+
         try {
             for (final Method method : methodCache.get(methodName)) {
                 if (returnType.isAssignableFrom(method.getReturnType())) {
@@ -218,6 +224,9 @@ public final class JavaTranslator<S extends TraversalSource, T extends Traversal
         } catch (final Throwable e) {
             throw new IllegalStateException(e.getMessage() + ":" + methodName + "(" + Arrays.toString(argumentsCopy) + ")", e);
         }
+
+        // if it got down here then the method was in the cache but it was never called as it could not be found
+        // for the supplied arguments
         throw new IllegalStateException("Could not locate method: " + delegate.getClass().getSimpleName() + "." + methodName + "(" + Arrays.toString(argumentsCopy) + ")");
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
@@ -176,8 +176,10 @@ public final class JavaTranslator<S extends TraversalSource, T extends Traversal
 
         // without this initial check iterating an invalid methodName will lead to a null pointer and a less than
         // great error message for the user. 
-        if (!methodCache.containsKey(methodName))
-            throw new IllegalStateException("Could not locate method: " + delegate.getClass().getSimpleName() + "." + methodName + "(" + Arrays.toString(argumentsCopy) + ")");
+        if (!methodCache.containsKey(methodName)) {
+            final String methodArgs = argumentsCopy.length > 0 ? Arrays.toString(argumentsCopy) : "";
+            throw new IllegalStateException("Could not locate method: " + delegate.getClass().getSimpleName() + "." + methodName + "(" + methodArgs + ")");
+        }
 
         try {
             for (final Method method : methodCache.get(methodName)) {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -368,7 +368,7 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
             else
                 traversal = context.getGremlinExecutor().eval(bytecode, EMPTY_BINDINGS, lambdaLanguage.get(), traversalSourceName);
         } catch (Exception ex) {
-            logger.error("Could not deserialize the Traversal instance", context);
+            logger.error("Could not deserialize the Traversal instance", ex);
             throw new OpProcessorException("Could not deserialize the Traversal instance",
                     ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR_SERIALIZATION)
                             .statusMessage(ex.getMessage())


### PR DESCRIPTION
As the original issue description suggests the error message wasn't very helpful. Seems there was a mistype in the log message that prevented a better output and also some error handling that wasn't quite being dealt with properly.

Error now presents as:

```text
gremlin> bytecode = g.V().asAdmin().bytecode
==>[[], [V()]]
gremlin> bytecode.addStep("broken")
gremlin> bytecode
==>[[], [V(), broken()]]
gremlin> conn.submit(bytecode).next()
org.apache.tinkerpop.gremlin.driver.exception.ResponseException: Could not locate method: DefaultGraphTraversal.broken([])
Type ':help' or ':h' for help.
Display stack trace? [yN]n
```

On the server you now get this:

```text
[ERROR] TraversalOpProcessor - Could not deserialize the Traversal instance
java.lang.IllegalStateException: Could not locate method: DefaultGraphTraversal.broken([])
	at org.apache.tinkerpop.gremlin.jsr223.JavaTranslator.invokeMethod(JavaTranslator.java:180)
	at org.apache.tinkerpop.gremlin.jsr223.JavaTranslator.translate(JavaTranslator.java:91)
	at org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor.iterateBytecodeTraversal(TraversalOpProcessor.java:367)
```

builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1