### PR TITLE
TINKERPOP-1832: TraversalHelper.replaceStep sets previousStep to the wrong step

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -173,8 +173,9 @@ public final class TraversalHelper {
      * @param traversal  the traversal on which the action will occur
      */
     public static <S, E> void replaceStep(final Step<S, E> removeStep, final Step<S, E> insertStep, final Traversal.Admin<?, ?> traversal) {
-        traversal.addStep(stepIndex(removeStep, traversal), insertStep);
-        traversal.removeStep(removeStep);
+        final int i;
+        traversal.removeStep(i = stepIndex(removeStep, traversal));
+        traversal.addStep(i, insertStep);
     }
 
     public static <S, E> Step<?, E> insertTraversal(final Step<?, S> previousStep, final Traversal.Admin<S, E> insertTraversal, final Traversal.Admin<?, ?> traversal) {


### PR DESCRIPTION
`TraversalHelper.replaceStep` needs to first remove the step before adding in the new step. Else it gets its `previousStep` pointer wrong.
    
Added `TraversalHelperTest.shouldSetPreviousStepToEmptyStep` which was the scenario that originally made me aware of the issue.
    
Ran `mvn clean install` and tested Sqlg's tests with the fix.