### PR TITLE
TINKERPOP-1846 Fixed bug in LambdaRestrictionStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Documented the recommended method for constructing DSLs with Gremlin.Net.
 * Provided a method to configure detachment options with `EventStrategy`.
 * Fixed a race condition in `TinkerIndex`.
+* Fixed bug in `LambdaRestrictionStrategy` where traversals using `Lambda` scripts weren't causing the strategy to trigger.
 * Improved error messaging for bytecode deserialization errors in Gremlin Server.
 * Fixed an `ArrayOutOfBoundsException` in `hasId()` for the rare situation when the provided collection is empty.
 * Bump to Netty 4.0.53

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/Lambda.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/Lambda.java
@@ -66,7 +66,7 @@ public interface Lambda extends Serializable {
 
         @Override
         public String toString() {
-            return this.lambdaSource;
+            return "lambda[" + this.lambdaSource + "]";
         }
 
         @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrat
 import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -50,6 +51,8 @@ public class LambdaRestrictionStrategyTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
+                {"map(Lambda.function('true')}", __.map(Lambda.function("true")), false},
+                {"filter(Lambda.predicate('true')}", __.filter(Lambda.predicate("true")), false},
                 {"filter(x->true)", __.filter(x -> true), false},
                 {"map(Traverser::get)", __.map(Traverser::get), false},
                 {"sideEffect(x -> {int i = 1+1;})", __.sideEffect(x -> {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1846

Traversals using Lambda scripts were not triggering this strategy. The strategy expected the word "lambda" in the toString() of the step that held it. Lambda objects weren't including that word. This is ready for review/feedback. I'll withhold my vote while tests are running and others have a chance to chime in as there are other ways this could be resolved.