### PR TITLE
TINKERPOP-1806 Consistent use of Gremlin.Net instead of Gremlin-DotNet

### DIFF
--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -449,9 +449,9 @@ connection = DriverRemoteConnection('ws://localhost:8182/gremlin', 'g',
                                      graphson_writer=graphson_writer)
 ----
 
-===== Supporting Gremlin-DotNet IO
+===== Supporting Gremlin.Net IO
 
-The serialization system of Gremlin-DotNet provides ways to add new types by creating serializers and deserializers in
+The serialization system of Gremlin.Net provides ways to add new types by creating serializers and deserializers in
 any .NET language and registering them with the `GremlinClient`.
 
 [source,csharp]

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -314,27 +314,27 @@ g.V().out().map(lambda: "x: len(x.get().value('name'))").sum().toList()         
 WARNING: Gremlin.Net does not yet have an official release. It is for developers who want to experiment with TinkerPop
 in the .NET ecosystem.
 
-Apache TinkerPop's Gremlin-DotNet implements Gremlin within the C# language. It targets .NET Standard and can
+Apache TinkerPop's Gremlin.Net implements Gremlin within the C# language. It targets .NET Standard and can
 therefore be used on different operating systems and with different .NET frameworks, such as .NET Framework
 and link:https://www.microsoft.com/net/core[.NET Core]. Since the C# syntax is very similar to that of Java, it should be very easy to switch between
-Gremlin-Java and Gremlin-DotNet. The only major syntactical difference is that all method names in Gremlin-DotNet
+Gremlin-Java and Gremlin.Net. The only major syntactical difference is that all method names in Gremlin.Net
 use PascalCase as opposed to camelCase in Gremlin-Java in order to comply with .NET conventions.
 
 [source,powershell]
 nuget install Gremlin.Net
 
-In Gremlin-DotNet there exists `GraphTraversalSource`, `GraphTraversal`, and `__` which mirror the respective classes
+In Gremlin.Net there exists `GraphTraversalSource`, `GraphTraversal`, and `__` which mirror the respective classes
 in Gremlin-Java. The `GraphTraversalSource` requires a driver in order to communicate with <<gremlin-server,GremlinServer>> (or any
 RemoteConnection-enabled server).
 
-The `Gremlin.Net.Driver.Remote.DriverRemoteConnection` is provided as part of Apache TinkerPop’s Gremlin-DotNet.
+The `Gremlin.Net.Driver.Remote.DriverRemoteConnection` is provided as part of Apache TinkerPop’s Gremlin.Net.
 
 IMPORTANT: For developers wishing to provide another driver implementation, be sure to implement `IRemoteConnection` in
-`Gremlin.Net.Process.Remote` so it can then be used by Gremlin-DotNet’s `GraphTraversal`.
+`Gremlin.Net.Process.Remote` so it can then be used by Gremlin.Net’s `GraphTraversal`.
 
-When Gremlin Server is running, Gremlin-DotNet can communicate with Gremlin Server by sending traversals serialized as `Bytecode`.
+When Gremlin Server is running, Gremlin.Net can communicate with Gremlin Server by sending traversals serialized as `Bytecode`.
 
-IMPORTANT: Gremlin-DotNet is not compatible with GraphSON 1.0.
+IMPORTANT: Gremlin.Net is not compatible with GraphSON 1.0.
 
 A traversal source can be spawned with `RemoteStrategy` from an empty `Graph`.
 
@@ -346,10 +346,10 @@ var g = graph.Traversal().WithRemote(new DriverRemoteConnection(new GremlinClien
 
 When a traversal from the `GraphTraversalSource` is iterated, the traversal’s `Bytecode` is sent over the wire via the registered
 `IRemoteConnection`. The bytecode is used to construct the equivalent traversal at the remote traversal source.
-Since Gremlin-DotNet currently doesn't support lambda expressions, all traversals can be translated to Gremlin-Java on the remote
+Since Gremlin.Net currently doesn't support lambda expressions, all traversals can be translated to Gremlin-Java on the remote
 location (e.g. Gremlin Server).
 
-IMPORTANT: Gremlin-DotNet’s `ITraversal` interface supports the standard Gremlin methods such as `Next()`, `NextTraverser()`, `ToSet()`,
+IMPORTANT: Gremlin.Net’s `ITraversal` interface supports the standard Gremlin methods such as `Next()`, `NextTraverser()`, `ToSet()`,
 `ToList()`, etc. Such "terminal" methods trigger the evaluation of the traversal.
 
 === RemoteConnection Submission
@@ -365,7 +365,7 @@ terminal/action methods off of `ITraversal`.
 
 === Static Enums and Methods
 
-Gremlin has various tokens (e.g. `T`, `P`, `Order`, `Operator`, etc.) that are represented in Gremlin-DotNet as Enums.
+Gremlin has various tokens (e.g. `T`, `P`, `Order`, `Operator`, etc.) that are represented in Gremlin.Net as Enums.
 
 These can be used analogously to how they are used in Gremlin-Java.
 
@@ -398,7 +398,7 @@ compiled version should be cached. Many traversals are unique up to some paramet
 `g.V(1).Out("created").Values("name")` is considered different from `g.V(4).Out("created").Values("Name")`
 as they have different script "string" representations. However, `g.V(x).Out("created").Values("name")` with bindings of 
 `{x : 1}` and `{x : 4}` are considered the same. If a traversal is going to be executed repeatedly, but with different 
-parameters, then bindings should be used. In Gremlin-DotNet, bindings are objects that can be created as follows.
+parameters, then bindings should be used. In Gremlin.Net, bindings are objects that can be created as follows.
 
 [source,csharp]
 ----
@@ -409,7 +409,7 @@ g.V(b.Of("id", 4)).Out("created").Values("name").toList()
 
 === Traversal Strategies
 
-In order to add and remove traversal strategies from a traversal source, Gremlin-DotNet has an `AbstractTraversalStrategy`
+In order to add and remove traversal strategies from a traversal source, Gremlin.Net has an `AbstractTraversalStrategy`
 class along with a collection of subclasses that mirror the standard Gremlin-Java strategies.
 
 [source,csharp]
@@ -432,6 +432,6 @@ edgeValueMaps = g.V().OutE().ValueMap(true).ToList();
 // edgeValueMaps: [[label:created, id:9, weight:0.4], [label:knows, id:7, weight:0.5], [label:knows, id:8, weight:1.0]]
 ----
 
-NOTE: Many of the TraversalStrategy classes in Gremlin-DotNet are proxies to the respective strategy on Apache TinkerPop’s
+NOTE: Many of the TraversalStrategy classes in Gremlin.Net are proxies to the respective strategy on Apache TinkerPop’s
 JVM-based Gremlin traversal machine. As such, their `Apply(ITraversal)` method does nothing. However, the strategy is
-encoded in the Gremlin-DotNet bytecode and transmitted to the Gremlin traversal machine for re-construction machine-side.
+encoded in the Gremlin.Net bytecode and transmitted to the Gremlin traversal machine for re-construction machine-side.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1806

This change really just applies to documentation. Directory structures, links and other identifiers have been left as "dotnet". I will do a search for similar changes to master and update accordingly when I merge this.

VOTE +1