### PR TITLE
TINKERPOP-1848 use generated datetime to ignore timezone, DST differences in test

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -328,8 +328,7 @@ class DateIO(_GraphSONTypeIO):
             pts = obj.timestamp()
         else:
             # Hack for legacy Python
-            # Taken from:
-            # https://github.com/jaraco/backports.datetime_timestamp/blob/master/backports/datetime_timestamp/__init__.py
+            # timestamp() in Python 3.3
             pts = time.mktime((obj.year, obj.month, obj.day,
 			                   obj.hour, obj.minute, obj.second,
 			                   -1, -1, -1)) + obj.microsecond / 1e6

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
@@ -19,6 +19,7 @@ under the License.
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 import datetime
+import time
 import json
 import uuid
 
@@ -126,10 +127,15 @@ class TestGraphSONReader(object):
         assert o is serdes.objectify()
 
     def test_datetime(self):
-        dt = self.graphson_reader.readObject(json.dumps({"@type": "g:Date", "@value": 1481750076295}))
+        expected = datetime.datetime(2016, 12, 14, 16, 14, 36, 295000)
+        pts = time.mktime((expected.year, expected.month, expected.day,
+                                           expected.hour, expected.minute, expected.second,
+                                           -1, -1, -1)) + expected.microsecond / 1e6
+        timestamp = int(round(pts * 1000))
+        dt = self.graphson_reader.readObject(json.dumps({"@type": "g:Date", "@value": timestamp}))
         assert isinstance(dt, datetime.datetime)
         # TINKERPOP-1848
-        # assert dt == datetime.datetime(2016, 12, 14, 16, 14, 36, 295000, tzinfo=None)
+        assert dt == expected
 
     def test_timestamp(self):
         dt = self.graphson_reader.readObject(json.dumps({"@type": "g:Timestamp", "@value": 1481750076295}))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1848

