### PR TITLE
TINKERPOP-1851 Minor fix to allow long forms of -e and -i to work

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Documented the recommended method for constructing DSLs with Gremlin.Net.
 * Provided a method to configure detachment options with `EventStrategy`.
 * Fixed a race condition in `TinkerIndex`.
+* Fixed bug in handling of the long forms of `-e` and `-i` (`--execute` and `--interactive` respectively) for Gremlin Console.
 * Fixed bug in `LambdaRestrictionStrategy` where traversals using `Lambda` scripts weren't causing the strategy to trigger.
 * Improved error messaging for bytecode deserialization errors in Gremlin Server.
 * Fixed an `ArrayOutOfBoundsException` in `hasId()` for the rare situation when the provided collection is empty.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -477,7 +477,7 @@ class Console {
         if (args.length == 1 && !args[0].startsWith("-")) {
             new Console(io, [[args[0]]], true)
         } else {
-            def scriptAndArgs = parseArgs(options.e ? "-e" : "-i", args, cli)
+            def scriptAndArgs = parseArgs(options.e ? ["-e", "--execute"] : ["-i", "--interactive"], args, cli)
             new Console(io, scriptAndArgs, !options.e)
         }
     }
@@ -487,10 +487,10 @@ class Console {
      * argument list to allow for multiple {@code -e} and {@code -i} values and parses such parameters into a list
      * of lists where the inner list is a script file and its arguments.
      */
-    private static List<List<String>> parseArgs(final String option, final String[] args, final CliBuilder cli) {
+    private static List<List<String>> parseArgs(final List<String> options, final String[] args, final CliBuilder cli) {
         def parsed = []
         for (int ix = 0; ix < args.length; ix++) {
-            if (args[ix] == option) {
+            if (args[ix] in options) {
                 // increment the counter to move past the option that was found. should now be positioned on the
                 // first argument to that option
                 ix++

--- a/gremlin-console/src/test/python/tests/test_console.py
+++ b/gremlin-console/src/test/python/tests/test_console.py
@@ -41,8 +41,24 @@ class TestConsole(object):
         TestConsole._expect_prompt(child)
         TestConsole._close(child)
 
+    def test_just_dash_dash_interactive(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--interactive x.script")
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "x")
+        child.expect("==>2\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
     def test_dash_i_with_args(self):
         child = pexpect.spawn(TestConsole.gremlinsh + "-i y.script 1 2 3")
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "y")
+        child.expect("==>6\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
+    def test_dash_dash_interactive_with_args(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--interactive y.script 1 2 3")
         TestConsole._expect_gremlin_header(child)
         TestConsole._send(child, "y")
         child.expect("==>6\r\n")
@@ -63,8 +79,41 @@ class TestConsole(object):
         TestConsole._expect_prompt(child)
         TestConsole._close(child)
 
+    def test_dash_dash_interactive_multiple_scripts(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--interactive y.script 1 2 3 --interactive x.script -i \"z.script x -i --color -D\"")
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "y")
+        child.expect("==>6\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._send(child, "x")
+        child.expect("==>2\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._send(child, "z")
+        child.expect("==>argument=\[x, -i, --color, -D\]\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
+    def test_mixed_interactive_long_short_opts_with_multiple_scripts(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--interactive y.script 1 2 3 --interactive x.script -i \"z.script x -i --color -D\"")
+        TestConsole._expect_gremlin_header(child)
+        TestConsole._send(child, "y")
+        child.expect("==>6\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._send(child, "x")
+        child.expect("==>2\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._send(child, "z")
+        child.expect("==>argument=\[x, -i, --color, -D\]\r\n")
+        TestConsole._expect_prompt(child)
+        TestConsole._close(child)
+
     def test_just_dash_e(self):
         child = pexpect.spawn(TestConsole.gremlinsh + "-e x-printed.script")
+        child.expect("2\r\n")
+        TestConsole._close(child)
+
+    def test_just_dash_dash_execute(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--execute x-printed.script")
         child.expect("2\r\n")
         TestConsole._close(child)
 
@@ -73,8 +122,27 @@ class TestConsole(object):
         child.expect("6\r\n")
         TestConsole._close(child)
 
+    def test_dash_dash_execute_with_args(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--execute y-printed.script 1 2 3")
+        child.expect("6\r\n")
+        TestConsole._close(child)
+
     def test_dash_e_multiple_scripts(self):
         child = pexpect.spawn(TestConsole.gremlinsh + "-e y-printed.script 1 2 3 -e x-printed.script -e \"z-printed.script x -e --color -D\"")
+        child.expect("6\r\n")
+        child.expect("2\r\n")
+        child.expect("argument=\[x, -e, --color, -D\]\r\n")
+        TestConsole._close(child)
+
+    def test_dash_dash_execute_multiple_scripts(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--execute y-printed.script 1 2 3 --execute x-printed.script --execute \"z-printed.script x -e --color -D\"")
+        child.expect("6\r\n")
+        child.expect("2\r\n")
+        child.expect("argument=\[x, -e, --color, -D\]\r\n")
+        TestConsole._close(child)
+
+    def test_mixed_execute_long_short_opts_with_multiple_scripts(self):
+        child = pexpect.spawn(TestConsole.gremlinsh + "--execute y-printed.script 1 2 3 -e x-printed.script --execute \"z-printed.script x -e --color -D\"")
         child.expect("6\r\n")
         child.expect("2\r\n")
         child.expect("argument=\[x, -e, --color, -D\]\r\n")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1851

There was some special handling of the short forms that wasn't accounted for with the long forms. Pretty simple fix. Added lots of tests to ensure the different options were covered.

I could have probably CTR'd this, but since we're in code freeze technically, I thought I'd ask for reviews.

All tests pass with `docker/build.sh -t -i`

VOTE +1