### PR TITLE
TINKERPOP-1844 Default GraphSON 3.0 for GLV tests in gremlin-python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,11 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-2]]
 === TinkerPop 3.3.2 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+This release also includes changes from <<release-3-2-8, 3.2.8>>.
+
+* Defaulted GLV tests for gremlin-python to run for GraphSON 3.0.
+* In gremlin-python, the GraphSON 3.0 `g:Set` type is now deserialized to `List`.
+
 [[release-3-3-1]]
 === TinkerPop 3.3.1 (Release Date: December 17, 2017)
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -305,6 +305,13 @@ g.V().out().map(lambda: "x: len(x.get().value('name'))").sum().toList()         
 <7> The default lambda language is changed back to Gremlin-Python.
 <8> If the `lambda`-prefix is not provided, then it is appended automatically in order to give a more natural look to the expression.
 
+=== Limitations
+
+* Traversals that return a `Set` will be coerced to a `List` in Python so that traversals return consistent results
+within a collection across different languages. In the case of Python, number equality is different from JVM languages
+which produces different `Set` results when those types are in use. If a `Set` is needed then convert `List` results
+to `Set` manually.
+
 [[gremlin-DotNet]]
 == Gremlin.Net
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -21,6 +21,38 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *Gremlin Symphony #40 in G Minor*
 
+== TinkerPop 3.3.2
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.3.1/CHANGELOG.asciidoc#release-3-3-2[changelog] for a complete list of all the modifications that are part of this release.
+
+=== Upgrading for Users
+
+==== Gremlin Python Sets
+
+Graph traversals that return a `Set` from Java are now coerced to a `List` in Python. This change ensures that Python
+results match Java results for the same traversal. It is possible to see this problem in prior versions of
+gremlin-python where a `Set` of numbers of different types are returned. In Java, a set of:
+
+[source,text]
+----
+[1,1.0d,2,2.0d]
+----
+
+would be deserialized to the following in Python:
+
+[source,text]
+----
+[1,2]
+----
+
+Now that the Java `Set` is coerced to a `List` in Gremin Python, the Java `Set` can be fully represented. Users who
+require a `Set` will need to manually convert their `List` to a `Set`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1844[TINKERPOP-1844]
+
+
 == TinkerPop 3.3.1
 
 *Release Date: December 17, 2017*

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -428,9 +428,11 @@ class SetIO(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, s, reader):
-        new_set = set()
+        # coerce to list here because Java might return numerics of different types which python won't recognize
+        # see comments of TINKERPOP-1844 for more details
+        new_set = []
         for obj in s:
-            new_set.add(reader.toObject(obj))
+            new_set.append(reader.toObject(obj))
         return new_set
 
 

--- a/gremlin-python/src/main/jython/radish/terrain.py
+++ b/gremlin-python/src/main/jython/radish/terrain.py
@@ -63,7 +63,7 @@ def prepare_static_traversal_source(features, marker):
 @before.each_scenario
 def prepare_traversal_source(scenario):
     # some tests create data - create a fresh remote to the empty graph and clear that graph prior to each test
-    remote = DriverRemoteConnection('ws://localhost:45940/gremlin', "ggraph", message_serializer=serializer.GraphSONSerializersV2d0())
+    remote = DriverRemoteConnection('ws://localhost:45940/gremlin', "ggraph", message_serializer=serializer.GraphSONSerializersV3d0())
     scenario.context.remote_conn["empty"] = remote
     g = Graph().traversal().withRemote(remote)
     g.V().drop().iterate()
@@ -81,7 +81,7 @@ def close_static_traversal_source(features, marker):
 
 
 def __create_remote(server_graph_name):
-    return DriverRemoteConnection('ws://localhost:45940/gremlin', server_graph_name, message_serializer=serializer.GraphSONSerializersV2d0())
+    return DriverRemoteConnection('ws://localhost:45940/gremlin', server_graph_name, message_serializer=serializer.GraphSONSerializersV3d0())
 
 
 def __create_lookup_v(remote):

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -53,9 +53,12 @@ class TestGraphSONReader(object):
         x = self.graphson_reader.readObject(
             json.dumps({"@type": "g:Set", "@value": [{"@type": "g:Int32", "@value": 1},
                                                      {"@type": "g:Int32", "@value": 2},
+                                                     {"@type": "g:Float", "@value": 2.0},
                                                      "3"]}))
-        assert isinstance(x, set)
-        assert x == set([1, 2, "3"])
+        # coerce to list here because Java might return numerics of different types which python won't recognize
+        # see comments of TINKERPOP-1844 for more details
+        assert isinstance(x, list)
+        assert x == list([1, 2, 2.0, "3"])
         ##
         x = self.graphson_reader.readObject(
             json.dumps({"@type": "g:Map",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1844

This is a breaking change because `g:Set` no longer returns a `Set` in python. It is coerced to `List` to account for numeric equality semantics of Java vs Python.

VOTE +1