### PR TITLE
TINKERPOP-1861 Modify VertexProgram Builder to take varargs Graphs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Delayed setting of the request identifier until `RequestMessage` construction by the builder.
 * Removed hardcoded expectation in metrics serialization test suite as different providers may have different outputs.
+* Fixed a bug in `ComputerAwareStep` that didn't handle `reset()` properly and thus occasionally produced some extra traversers.
 
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: December 17, 2017)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.2.8 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Delayed setting of the request identifier until `RequestMessage` construction by the builder.
+* Removed hardcoded expectation in metrics serialization test suite as different providers may have different outputs.
 
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: December 17, 2017)

--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -79,7 +79,7 @@ file.withWriter { writer ->
   writer.write("~~~~~~~~~~~~~~~\n\n")
   msg = ResponseMessage.build(UUID.fromString("41d2e28a-20a4-4ab0-b379-d810dede3786")).
                         code(org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode.AUTHENTICATE).create()
-  writer.write(toJson(msg, "Authentication Challenge", "When authentication is enabled, an initial request to the server will result in an authentication challenge. The typical response message will appear as follows, but handling it could be different dependending on the SASL implementation (e.g. multiple challenges maybe requested in some cases, but no in the default provided by Gremlin Server)."))
+  writer.write(toJson(msg, "Authentication Challenge", "When authentication is enabled, an initial request to the server will result in an authentication challenge. The typical response message will appear as follows, but handling it could be different dependending on the SASL implementation (e.g. multiple challenges maybe requested in some cases, but not in the default provided by Gremlin Server)."))
   msg = ResponseMessage.build(UUID.fromString("41d2e28a-20a4-4ab0-b379-d810dede3786")).
                         code(org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode.SUCCESS).
                         result(Arrays.asList(graph.vertices().next())).create()

--- a/docs/src/recipes/collections.asciidoc
+++ b/docs/src/recipes/collections.asciidoc
@@ -21,9 +21,237 @@ image:gremlin-collections.png[width=400]
 
 Lists and maps form the basis for much of the processing in Gremlin traversals. They are core to how side-effects
 are typically held and how results are generally produced. Being able to pick them apart and reformat them is sometimes
-required.
+required. This need to shape the date within a traversal may arise both at the
+link:http://tinkerpop.apache.org/docs/current/reference/#terminal-steps[terminal step] of the traversal (technically
+just prior to the terminal step) or in the middle of a traversal. Considering the former, a transformation just prior
+to iteration will get the result into the form required by the application which would remove the need for additional
+application level manipulation. Moreover, a transformation at this stage may reduce the size of the payload being
+returned which could be useful in remote applications. Examining the latter, there may be times where a `List` or `Map`
+requires some mid-traversal transformation so as to continue with the general logic of the traversal itself. For
+example, a traversal at some point might produce a `Map` of `List` objects where the lists contain vertices, where each
+`List` might need to be sorted by some criteria and then the top item for each extracted to become the basis for the
+continued traversal. Executing transformations for either of these types of situations can be made possible with the
+patterns described in this section.
 
-One of the most common ways to end up with a `Map` is with `valueMap()`:
+The appearance of a `List` as a traverser in Gremlin usually arises as a result of a `fold()` operation, but may also
+appear by way of some side-effect steps like `store()`:
+
+[gremlin-groovy,modern]
+----
+g.V().fold()
+g.V().store('a').cap('a')
+----
+
+It is worth noting that while a `Path` is not technically a `List` it does present like one and can be manipulated in
+similar fashion to lists:
+
+[gremlin-groovy,modern]
+----
+g.V().out().out().path()
+----
+
+These examples are obviously trivial and there are other ways that a traverser might end up in a `List` form, but, at
+this moment, the point here is to focus less on how to get a `List` and more on how to manipulate one within the
+Gremlin language. The examples going forward will also be similarly contrived insofar as producing a usable `List` to
+manipulate. Bear in mind that it may be quite possible to get the same end results of these examples using more direct
+means than what is demonstrated.
+
+It may seem simple, but the most obvious choice to modifying what is in a list is to simply `unfold()` the `List`:
+
+[gremlin-groovy,modern]
+----
+g.V().fold().unfold().values('name')
+g.V().store('a').cap('a').unfold().values('name')
+----
+
+The above examples show that `unfold()` works quite well when you want don't want to preserve the `List` structure of
+the traverser as it just flattens `List` traversers to the traversal stream. The above examples only have one `List`
+as a result, but consider what happens when there is more than one:
+
+[gremlin-groovy,modern]
+----
+g.V().union(fold(),fold())
+g.V().union(fold(),fold()).unfold().values('name')
+----
+
+The two separate `List` traversers are flattened to a single traversal stream and all the results are mixed together.
+While this approach may be acceptable, there are many cases where it might not be so. To preserve the individual
+structure of the `List` traversers "locally" `unfold()` the lists to transform them:
+
+[gremlin-groovy,modern]
+----
+g.V().
+  union(fold(),fold()).
+  local(unfold().values('name').fold())
+----
+
+The call to `local()` executes its anonymous sub-traversal over each individual `List` iterator and as the
+sub-traversal ends with a `fold()` step, the results are reduced back into a `List` to preserve the original structure,
+thus maintaining two traverser results.
+
+This pattern for unfolding and folding `List` traversers ends up having other applications:
+
+[gremlin-groovy,modern]
+----
+g.V().union(limit(3).fold(),tail(3).fold())    <1>
+g.V().union(limit(3).fold(),tail(3).fold()).
+  local(unfold().                              <2>
+        order().
+          by(bothE().count(),decr).
+        limit(1).
+        fold())
+g.V().union(limit(3).fold(),tail(3).fold()).   <3>
+  local(unfold().
+        has('age',gte(29)).
+        values('age').
+        mean())
+----
+
+<1> The output consists of two `List` traversers.
+<2> For each `List` of vertices, order them by their number of edges, and choose the first one which will be the one
+with the highest degree (i.e. number of edges). By ending with `fold()` the `List` traverser structure is preserved
+thus returning two `List` objects. Consider this a method for choosing a "max" or a highly ranked vertex. In this case
+the rank was determined by the number of edges, but it could have just as easily been determined by a vertex property,
+edge property, a calculated value, etc. - one simply needs to alter the `by()` step modulator to `order()`.
+<3> For each `List` of vertices, filter that `List` to only include vertices that have an "age" property with a
+value greater than or equal to "29" and then average the results of each list. More generally, consider how this
+approach performs some kind of reducing calculation on each `List` traverser. In this case, an average was calculated,
+but it might also have been a `sum()`, `count()` or similar operation that reduced the list to a single calculated
+value.
+
+So far, this section has focused on what to do with a `List` traverser once there is one present and there have been
+fairly contrived examples for how to produce one in the first place. The use of `fold()` has been used most frequently
+at this point to achieve list creation and that step should be recalled whenever there is a need to reduce some
+traversal stream to an actual `List`. Of course, it may become necessary to more manually construct a `List`,
+especially in cases where the expected output of the traversal is composed of one or more ordered results in the
+form of a `List`. For example, consider the following three traversals:
+
+[gremlin-groovy,modern]
+----
+g.V().has('name','marko').values('age')     <1>
+g.V().has('name','marko').                  <2>
+  repeat(out()).
+    until(has('lang','java')).
+  path().
+    by('name')
+g.V().has('name','marko').                  <3>
+  repeat(outE().inV()).
+    until(has('lang','java')).
+  path().
+  local(unfold().
+        has('weight').
+        values('weight').
+        mean())
+----
+
+<1> Get the age of "marko"
+<2> get the "name" values of the vertices in the collected paths that traverse out from "marko" to any vertex with
+the "lang" of "java".
+<3> Get the average of the "weight" values of edges in the collected paths that traverse out from "marko" to any vertex
+with the "lang" of "java". Note the use of the earlier defined pattern that used `local()` in conjunction with
+`unfold()`. In this case it filters out vertices from the `Path` as they are not relevant as the concern is only with
+the "weight" property on the edges.
+
+For purposes of this example, the three traversals above happen to represent three pieces of data that are required by
+an application. It is plain to note that all of the above traversals hold a similar pattern that starts with
+"getting 'marko'" and, in the case of the latter two, traversing on outgoing edges away from him and collecting data
+from that path. Ideally, all three of these traversals should execute as one to prevent having to submit three separate
+traversals, thus incurring additional query execution costs for what amounts to be largely the same underlying data but
+with different transformations applied. The goal here would be to return the results of this data as a `List` with
+three results (i.e. triple) that could then be submitted once by the application. The following example demonstrates
+the use of `store()` to aid in construction of this `List`:
+
+[gremlin-groovy,modern]
+----
+g.V().has('name','marko').as('v').                             <1>
+  store('a').                                                  <2>
+    by('age').
+  repeat(outE().as('e').inV().as('v')).                        <3>
+    until(has('lang','java')).
+  aggregate('b').                                              <4>
+    by(select(all,'v').unfold().values('name').fold()).
+  aggregate('c').                                              <5>
+    by(select(all,'e').unfold().values('weight').mean()).
+  fold().                                                      <6>
+  store('a').                                                  <7>
+    by(cap('b')).
+  store('a').                                                  <8>
+    by(cap('c')).
+  cap('a')
+----
+
+<1> Get the "marko" vertex and label that step as "v".
+<2> Store the first "age" of "marko" as the first item in the `List` called "a", which will ultimately be the result.
+<3> Execute the traversal away from "marko" and continue to traverse on outgoing edges until the vertex has the value
+of "java" for the "lang" property. Note the labels of "e" and "v". Note that "e" will contain a `List` of all of the
+edges that have been traversed and "v" will contain a `List` of all the vertices that have been traversed.
+<4> The incoming traverser to `aggregate('b')` are vertices that terminate the `repeat()` (i.e. those with the "lang"
+of "java"). Note however that the `by()` modulator overrides that traverser completely by starting a fresh stream of
+the list of vertices in "v". Those vertices are unfolded to retrieve the name property from each and then are reduced
+with `fold()` back into a list to be stored in the side-effected named "b".
+<5> A similar use of `aggregate()` as the previous step, though this one turns "e" into a stream of edges to calculate
+the `mean()` to store in a `List` called "c". Note that `aggregate()` was used here instead of `store()`, as
+the former is an eager collection of the elements in the stream (`store()` is lazy) and will force the traversal to be
+iterated up to that point before moving forward. Without that eager collection, "v" and "e" would not contain the
+complete information required for the production of "b" and "c".
+<6> Adding `fold()` step here is a bit of a trick. To see the trick, copy and paste all lines of Gremlin up to but
+not including this `fold()` step and run them against the "modern" graph. The output is three vertices and if the
+`profile()` step was added one would also see that the traversal contained three traversers. These three traversers
+with a vertex in each one were produced from the `repeat()` step (i.e. those vertices that had the "lang" of "java"
+when traversing away from "marko"). The `aggregate()` steps are side-effects and just allow the traversers to pass
+through them unchanged. The `fold()` obviously converts those three traversers to a single `List` to make one
+traverser with a `List` inside. That means that the remaining steps following the `fold()` will only be executed one
+time each instead of three, which, as will be shown, is critical to the proper result.
+<7> The single traverser with the `List` of three vertices in it passes to `store()`. The `by()` modulator presents an
+override telling Gremlin to ignore the `List` of three vertices and simply grab the "b" side effect created earlier and
+stick that into "a" as part of the result. The `List` with three vertices passes out unchanged as `store()` is a
+side-effect step.
+<8> Again, the single traverser with the `List` of three vertices passes to `store()` and again, the `by()` modulator
+presents an override to include "c" into the result.
+
+All of the above code and explanation show that `store()` can be used to construct `List` objects as side-effects
+which can then be used as a result. Note that `aggregate()` can be used to similar effect, should it make sense that
+lazy `List` creation is not acceptable with respect to the nature of the traversal. An interesting sub-pattern that
+emerges here is that the `by()` step can modulate its step to completely override the current traverser and ignore its
+contents for purpose of that step. This ability to override a traverser acts as a powerful and flexible tool as it
+means that each traverser can effectively become a completely different object as determined by a sub-traversal.
+
+Another interesting method for `List` creation was demonstrated a bit earlier but not examined in detail - the use of
+`union()`. It was shown earlier in the following context where it helped create a `List` of two lists of three
+vertices each:
+
+[gremlin-groovy,modern]
+----
+g.V().union(limit(3).fold(),tail(3).fold())
+----
+
+By folding the results of `union()`, it becomes possible to essentially construct lists with arbitrary traversal
+results.
+
+[gremlin-groovy,modern]
+----
+g.V().
+  local(union(identity(),                   <1>
+              bothE().count()).
+        fold())
+g.V().
+  store('x').
+    by(union(select('x').count(local),      <2>
+             identity(),
+             bothE().count()).
+             fold()).
+  cap('x')
+----
+
+<1> For each vertex, create a "pair" (i.e. a `List` of two objects) of the vertex itself and its edge count.
+<2> For each vertex, create a "triple" (i.e. a `List`of three objects) of the index of the vertex (starting at zero),
+the vertex itself and its edge count.
+
+The pattern here is to use `union()` in conjunction with `fold()`. As explained earlier, the `fold()` operation reduces
+the stream from `union()` to a single `List` that is then fed forward to the next step in the traversal.
+
+Now that `List` patterns have been explained, there can now be some attention on `Map`. One of the most common ways
+to end up with a `Map` is with `valueMap()`:
 
 [gremlin-groovy,modern]
 ----
@@ -65,3 +293,51 @@ Generally speaking, a `Map` constructed as part of `group()` or `project()` will
 the `by()` modulators would be written in such a fashion as to produce that final output. It would be unnecessary to
 deconstruct/reconstruct it. Be certain that there isn't a way to re-write the `group()` or `project()` to get the
 desired output before taking this approach.
+
+In the following case, `project()` is used to create a `Map` that does not meet this requirement as it contains some
+unavoidable extraneous keys in the output `Map`:
+
+[gremlin-groovy,modern]
+----
+g.V().
+  project('name','age','lang').
+    by('name').
+    by(coalesce(values('age'),constant('n/a'))).
+    by(coalesce(values('lang'),constant('n/a')))
+----
+
+The use of `coalesce()` works around the problem where "age" and "lang" are not necessarily property keys present on
+every single vertex in the traversal stream. When the "age" or "lang" are not present, the constant of "n/a" is
+supplied. While this may be an acceptable output, it is possible to shape the `Map` to be "nicer":
+
+[gremlin-groovy,modern]
+----
+g.V().
+  project('name','age','lang').
+    by('name').
+    by(coalesce(values('age'),constant('n/a'))).
+    by(coalesce(values('lang'),constant('n/a'))).
+  local(unfold().
+        filter(select(values).is(P.neq('n/a'))).
+        group().
+          by(keys).
+          by(values))
+----
+
+The addition steps above `unfold()` the `Map` to key-value entries and filter the values for "n/a" and remove them
+prior to reconstructing the `Map` with the method shown earlier. To go a step further, apply the pattern presented
+earlier to flatten `List` values within a `Map`:
+
+[gremlin-groovy,modern]
+----
+g.V().
+  project('name','age','lang').
+    by('name').
+    by(coalesce(values('age'),constant('n/a'))).
+    by(coalesce(values('lang'),constant('n/a'))).
+  local(unfold().
+        filter(select(values).is(P.neq('n/a'))).
+        group().
+          by(keys).
+          by(select(values).unfold()))
+----

--- a/docs/src/recipes/collections.asciidoc
+++ b/docs/src/recipes/collections.asciidoc
@@ -282,7 +282,7 @@ g.V().has('name','marko').
     by(select(values).unfold())
 ----
 
-The code above, basically deconstruct then reconstructs the `Map`. The key to the pattern is to first `unfold()` the
+The code above, basically deconstructs then reconstructs the `Map`. The key to the pattern is to first `unfold()` the
 `Map` into its key and value entries. Then for each key and value produce a new `Map` using `group()` where the key
 for that map is the key of the entry (those are obviously unique as you picked them out of the `valueMap()`) and the
 value is simply the `unfold()` of the list of values in each entry. Recall that the `select(values).unfold()` only
@@ -340,4 +340,49 @@ g.V().
         group().
           by(keys).
           by(select(values).unfold()))
+----
+
+As there may be a desire to remove entries from a `Map`, there may also be the need to add keys to a `Map`. The pattern
+here involves the use of a `union()` that returns the `Map` instances which can be flattened to entries and then
+reconstructed as a new `Map` that has been merged together:
+
+[gremlin-groovy,modern]
+----
+g.V().
+  has('name','marko').
+  union(project('degree').         <1>
+          by(bothE().count()),
+        valueMap(true)).
+  unfold().                        <2>
+  group().
+    by(keys).
+    by(select(values).unfold())
+----
+
+<1> The `valueMap(true)` of a `Vertex` can be extended with the "degree" of the `Vertex` by performing a `union()` of
+the two traversals that produce that output (both produce `Map` objects).
+<2> The `unfold()` step is used to decompose the `Map` objects into key/value entries that are then constructed back
+into a single new `Map` given the patterns shown earlier. The `Map` objects of both traversals in the `union()` are
+essentially merged together.
+
+When using this pattern, it is important to recognize that if there are non-unique keys produced by the traversals
+supplied to `union()`, they will overwrite one another given the final `by()` modulator above. If changed to
+`by(select(values).unfold().fold())` they will merge to produce a `List` of values. Of course, that change will bring
+a `List` back for all the values of the new `Map`. With some added logic the `Map` values can be flattened out of
+`List` instances when necessary:
+
+[gremlin-groovy,modern]
+----
+g.V().
+  has('name','marko').
+  union(valueMap(true),
+        project('age').
+          by(constant(100))).
+  unfold().
+  group().
+    by(keys).
+    by(select(values).
+       unfold().
+       fold().
+       choose(count(local).is(eq(1)), unfold()))
 ----

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
@@ -68,6 +68,19 @@ public interface VertexProgram<M> extends Cloneable {
      * @param graph         the graph that the VertexProgram will run against
      * @param configuration the configuration to load the state of the VertexProgram from.
      */
+    @Deprecated
+    public default void loadState(final Graph graph, final Configuration configuration) {
+        loadState(configuration, graph);
+    }
+
+    /**
+     * When it is necessary to load the state of the VertexProgram, this method is called.
+     * This is typically required when the VertexProgram needs to be serialized to another machine.
+     * Note that what is loaded is simply the instance state, not any processed data.
+     *
+     * @param graphs        the graph that the VertexProgram will run against
+     * @param configuration the configuration to load the state of the VertexProgram from.
+     */
     public default void loadState(final Configuration configuration, final Graph... graphs) {
 
     }
@@ -216,6 +229,21 @@ public interface VertexProgram<M> extends Cloneable {
      *
      * @param graph         The graph that the vertex program will execute against
      * @param configuration A configuration with requisite information to build a vertex program
+     * @param <V>           The vertex program type
+     * @return the newly constructed vertex program
+     */
+    @Deprecated
+    public static <V extends VertexProgram> V createVertexProgram(final Graph graph, final Configuration configuration) {
+        return createVertexProgram(configuration, graph);
+    }
+
+    /**
+     * A helper method to construct a {@link VertexProgram} given the content of the supplied configuration.
+     * The class of the VertexProgram is read from the {@link VertexProgram#VERTEX_PROGRAM} static configuration key.
+     * Once the VertexProgram is constructed, {@link VertexProgram#loadState} method is called with the provided graph and configuration.
+     *
+     * @param configuration A configuration with requisite information to build a vertex program
+     * @param graphs        The graphs that the vertex program will execute against
      * @param <V>           The vertex program type
      * @return the newly constructed vertex program
      */

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
@@ -68,7 +68,7 @@ public interface VertexProgram<M> extends Cloneable {
      * @param graph         the graph that the VertexProgram will run against
      * @param configuration the configuration to load the state of the VertexProgram from.
      */
-    public default void loadState(final Graph graph, final Configuration configuration) {
+    public default void loadState(final Configuration configuration, final Graph... graphs) {
 
     }
 
@@ -219,13 +219,13 @@ public interface VertexProgram<M> extends Cloneable {
      * @param <V>           The vertex program type
      * @return the newly constructed vertex program
      */
-    public static <V extends VertexProgram> V createVertexProgram(final Graph graph, final Configuration configuration) {
+    public static <V extends VertexProgram> V createVertexProgram(final Configuration configuration, final Graph... graphs) {
         try {
             final Class<V> vertexProgramClass = (Class) Class.forName(configuration.getString(VERTEX_PROGRAM));
             final Constructor<V> constructor = vertexProgramClass.getDeclaredConstructor();
             constructor.setAccessible(true);
             final V vertexProgram = constructor.newInstance();
-            vertexProgram.loadState(graph, configuration);
+            vertexProgram.loadState(configuration, graphs);
             return vertexProgram;
         } catch (final Exception e) {
             throw new IllegalStateException(e.getMessage(), e);
@@ -240,7 +240,7 @@ public interface VertexProgram<M> extends Cloneable {
          */
         public Builder configure(final Object... keyValues);
 
-        public <P extends VertexProgram> P create(final Graph graph);
+        public <P extends VertexProgram> P create(final Graph... graphs);
 
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
@@ -233,6 +233,8 @@ public interface VertexProgram<M> extends Cloneable {
      * @param configuration A configuration with requisite information to build a vertex program
      * @param <V>           The vertex program type
      * @return the newly constructed vertex program
+     * @deprecated As of release 3.2.8, replaced by {@link #createVertexProgram(Configuration, Graph...)}
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-1861">TINKERPOP-1861</a>
      */
     @Deprecated
     public static <V extends VertexProgram> V createVertexProgram(final Graph graph, final Configuration configuration) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
@@ -67,6 +67,8 @@ public interface VertexProgram<M> extends Cloneable {
      *
      * @param graph         the graph that the VertexProgram will run against
      * @param configuration the configuration to load the state of the VertexProgram from.
+     * @deprecated As of release 3.2.8, replaced by {@link #loadState(Configuration, Graph...)}
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-1861">TINKERPOP-1861</a>
      */
     @Deprecated
     public default void loadState(final Graph graph, final Configuration configuration) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkdumping/BulkDumperVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkdumping/BulkDumperVertexProgram.java
@@ -91,8 +91,8 @@ public class BulkDumperVertexProgram implements VertexProgram<Tuple> {
 
         @SuppressWarnings("unchecked")
         @Override
-        public BulkDumperVertexProgram create(final Graph graph) {
-            return (BulkDumperVertexProgram) VertexProgram.createVertexProgram(graph, configuration);
+        public BulkDumperVertexProgram create(final Graph... graphs) {
+            return (BulkDumperVertexProgram) VertexProgram.createVertexProgram(configuration, graphs);
         }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -327,7 +327,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
         @Override
         public BulkLoaderVertexProgram create(final Graph... graphs) {
             if (graphs.length == 0) {
-                throw new IllegalStateException("Must provide at least one graph to use");
+                throw new IllegalArgumentException("Must provide at least one graph to use");
             }
             ConfigurationUtils.append(graphs[0].configuration().subset(BULK_LOADER_VERTEX_PROGRAM_CFG_PREFIX), configuration);
             return (BulkLoaderVertexProgram) VertexProgram.createVertexProgram(configuration, graphs);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -326,12 +326,11 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
         @SuppressWarnings("unchecked")
         @Override
         public BulkLoaderVertexProgram create(final Graph... graphs) {
-            if (graphs.length != 1) {
-                throw new IllegalStateException("Must provide one graph to use");
+            if (graphs.length == 0) {
+                throw new IllegalStateException("Must provide at least one graph to use");
             }
-            Graph graph = graphs[0];
-            ConfigurationUtils.append(graph.configuration().subset(BULK_LOADER_VERTEX_PROGRAM_CFG_PREFIX), configuration);
-            return (BulkLoaderVertexProgram) VertexProgram.createVertexProgram(configuration, graph);
+            ConfigurationUtils.append(graphs[0].configuration().subset(BULK_LOADER_VERTEX_PROGRAM_CFG_PREFIX), configuration);
+            return (BulkLoaderVertexProgram) VertexProgram.createVertexProgram(configuration, graphs);
         }
 
         private void setGraphConfigurationProperty(final String key, final Object value) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -147,7 +147,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
     }
 
     @Override
-    public void loadState(final Graph graph, final Configuration config) {
+    public void loadState(final Configuration config, final Graph... graphs) {
         configuration = new BaseConfiguration();
         if (config != null) {
             ConfigurationUtils.copy(config, configuration);
@@ -325,9 +325,13 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
 
         @SuppressWarnings("unchecked")
         @Override
-        public BulkLoaderVertexProgram create(final Graph graph) {
+        public BulkLoaderVertexProgram create(final Graph... graphs) {
+            if (graphs.length != 1) {
+                throw new IllegalStateException("Must provide one graph to use");
+            }
+            Graph graph = graphs[0];
             ConfigurationUtils.append(graph.configuration().subset(BULK_LOADER_VERTEX_PROGRAM_CFG_PREFIX), configuration);
-            return (BulkLoaderVertexProgram) VertexProgram.createVertexProgram(graph, configuration);
+            return (BulkLoaderVertexProgram) VertexProgram.createVertexProgram(configuration, graph);
         }
 
         private void setGraphConfigurationProperty(final String key, final Object value) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -83,9 +83,9 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
     @Override
     public void loadState(final Configuration configuration, final Graph... graphs) {
         if (graphs.length != 1) {
-            throw new IllegalStateException("Must provide one graph to use, received " + graphs.length);
+            throw new IllegalArgumentException("Must provide one graph to use, received " + graphs.length);
         }
-        Graph graph = graphs[0];
+        final Graph graph = graphs[0];
         if (configuration.containsKey(INITIAL_VOTE_STRENGTH_TRAVERSAL))
             this.initialVoteStrengthTraversal = PureTraversal.loadState(configuration, INITIAL_VOTE_STRENGTH_TRAVERSAL, graph);
         if (configuration.containsKey(EDGE_TRAVERSAL)) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -81,7 +81,11 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
     }
 
     @Override
-    public void loadState(final Graph graph, final Configuration configuration) {
+    public void loadState(final Configuration configuration, final Graph... graphs) {
+        if (graphs.length != 1) {
+            throw new IllegalStateException("Must provide one graph to use");
+        }
+        Graph graph = graphs[0];
         if (configuration.containsKey(INITIAL_VOTE_STRENGTH_TRAVERSAL))
             this.initialVoteStrengthTraversal = PureTraversal.loadState(configuration, INITIAL_VOTE_STRENGTH_TRAVERSAL, graph);
         if (configuration.containsKey(EDGE_TRAVERSAL)) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -83,7 +83,7 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
     @Override
     public void loadState(final Configuration configuration, final Graph... graphs) {
         if (graphs.length != 1) {
-            throw new IllegalStateException("Must provide one graph to use");
+            throw new IllegalStateException("Must provide one graph to use, received " + graphs.length);
         }
         Graph graph = graphs[0];
         if (configuration.containsKey(INITIAL_VOTE_STRENGTH_TRAVERSAL))

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -77,7 +77,7 @@ public class PageRankVertexProgram implements VertexProgram<Double> {
     @Override
     public void loadState(final Configuration configuration, final Graph... graphs) {
         if (graphs.length != 1) {
-            throw new IllegalStateException("Must provide one graph to use");
+            throw new IllegalStateException("Must provide one graph to use, received " + graphs.length);
         }
         Graph graph = graphs[0];
         if (configuration.containsKey(INITIAL_RANK_TRAVERSAL))

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -77,9 +77,9 @@ public class PageRankVertexProgram implements VertexProgram<Double> {
     @Override
     public void loadState(final Configuration configuration, final Graph... graphs) {
         if (graphs.length != 1) {
-            throw new IllegalStateException("Must provide one graph to use, received " + graphs.length);
+            throw new IllegalArgumentException("Must provide one graph to use, received " + graphs.length);
         }
-        Graph graph = graphs[0];
+        final Graph graph = graphs[0];
         if (configuration.containsKey(INITIAL_RANK_TRAVERSAL))
             this.initialRankTraversal = PureTraversal.loadState(configuration, INITIAL_RANK_TRAVERSAL, graph);
         if (configuration.containsKey(EDGE_TRAVERSAL)) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -75,7 +75,11 @@ public class PageRankVertexProgram implements VertexProgram<Double> {
     }
 
     @Override
-    public void loadState(final Graph graph, final Configuration configuration) {
+    public void loadState(final Configuration configuration, final Graph... graphs) {
+        if (graphs.length != 1) {
+            throw new IllegalStateException("Must provide one graph to use");
+        }
+        Graph graph = graphs[0];
         if (configuration.containsKey(INITIAL_RANK_TRAVERSAL))
             this.initialRankTraversal = PureTraversal.loadState(configuration, INITIAL_RANK_TRAVERSAL, graph);
         if (configuration.containsKey(EDGE_TRAVERSAL)) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -158,9 +158,13 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
     }
 
     @Override
-    public void loadState(final Graph graph, final Configuration configuration) {
+    public void loadState(final Configuration configuration, final Graph... graphs) {
         if (!configuration.containsKey(TRAVERSAL))
             throw new IllegalArgumentException("The configuration does not have a traversal: " + TRAVERSAL);
+        if (graphs.length != 1) {
+            throw new IllegalStateException("Must provide one graph to use");
+        }
+        Graph graph = graphs[0];
         this.traversal = PureTraversal.loadState(configuration, TRAVERSAL, graph);
         if (!this.traversal.get().isLocked())
             this.traversal.get().applyStrategies();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -162,10 +162,9 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
         if (!configuration.containsKey(TRAVERSAL))
             throw new IllegalArgumentException("The configuration does not have a traversal: " + TRAVERSAL);
         if (graphs.length != 1) {
-            throw new IllegalStateException("Must provide one graph to use");
+            throw new IllegalStateException("Must provide one graph to use, received " + graphs.length);
         }
-        Graph graph = graphs[0];
-        this.traversal = PureTraversal.loadState(configuration, TRAVERSAL, graph);
+        this.traversal = PureTraversal.loadState(configuration, TRAVERSAL, graphs[0]);
         if (!this.traversal.get().isLocked())
             this.traversal.get().applyStrategies();
         /// traversal is compiled and ready to be introspected

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
@@ -52,6 +52,8 @@ public interface VertexComputing {
      * @param graph  the {@link Graph} that the program will be executed over.
      * @param memory the {@link Memory} from the previous OLAP job if it exists, else its an empty memory structure.
      * @return the generated vertex program instance.
+     * @deprecated As of release 3.2.8, replaced by {@link #generateProgram(Memory, Graph...)}
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-1861">TINKERPOP-1861</a>
      */
     @Deprecated
     public default VertexProgram generateProgram(final Graph graph, final Memory memory) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
@@ -53,7 +53,19 @@ public interface VertexComputing {
      * @param memory the {@link Memory} from the previous OLAP job if it exists, else its an empty memory structure.
      * @return the generated vertex program instance.
      */
-    public VertexProgram generateProgram(final Graph graph, final Memory memory);
+    @Deprecated
+    public default VertexProgram generateProgram(final Graph graph, final Memory memory) {
+        return generateProgram(memory, graph);
+    }
+
+    /**
+     * Generate the {@link VertexProgram}.
+     *
+     * @param graph  the {@link Graph} that the program will be executed over.
+     * @param memory the {@link Memory} from the previous OLAP job if it exists, else its an empty memory structure.
+     * @return the generated vertex program instance.
+     */
+    public VertexProgram generateProgram(final Memory memory, final Graph... graphs);
 
     /**
      * @deprecated As of release 3.2.1. Please use {@link VertexComputing#getComputer()}.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/VertexComputing.java
@@ -61,7 +61,7 @@ public interface VertexComputing {
     /**
      * Generate the {@link VertexProgram}.
      *
-     * @param graph  the {@link Graph} that the program will be executed over.
+     * @param graphs the {@link Graph} that the program will be executed over.
      * @param memory the {@link Memory} from the previous OLAP job if it exists, else its an empty memory structure.
      * @return the generated vertex program instance.
      */

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -84,8 +84,12 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
 
     @Override
     public PageRankVertexProgram generateProgram(final Memory memory, final Graph... graphs) {
+        if (graphs.length != 1) {
+            throw new IllegalArgumentException("Must provide one graph to use, received " + graphs.length);
+        }
+        final Graph graph = graphs[0];
         final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
-        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graphs[0].getClass()));
+        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
         final PageRankVertexProgram.Builder builder = PageRankVertexProgram.build()
                 .property(this.pageRankProperty)
                 .iterations(this.times + 1)
@@ -93,7 +97,7 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
                 .edges(detachedTraversal);
         if (this.previousTraversalVertexProgram())
             builder.initialRank(new HaltedTraversersCountTraversal());
-        return builder.create(graphs);
+        return builder.create(graph);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -83,9 +83,9 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
     }
 
     @Override
-    public PageRankVertexProgram generateProgram(final Graph graph, final Memory memory) {
+    public PageRankVertexProgram generateProgram(final Memory memory, final Graph... graphs) {
         final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
-        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graphs[0].getClass()));
         final PageRankVertexProgram.Builder builder = PageRankVertexProgram.build()
                 .property(this.pageRankProperty)
                 .iterations(this.times + 1)
@@ -93,7 +93,7 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
                 .edges(detachedTraversal);
         if (this.previousTraversalVertexProgram())
             builder.initialRank(new HaltedTraversersCountTraversal());
-        return builder.create(graph);
+        return builder.create(graphs);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
@@ -87,15 +87,19 @@ public final class PeerPressureVertexProgramStep extends VertexProgramStep imple
 
     @Override
     public PeerPressureVertexProgram generateProgram(final Memory memory, final Graph... graphs) {
+        if (graphs.length != 1) {
+            throw new IllegalArgumentException("Must provide one graph to use, received " + graphs.length);
+        }
+        final Graph graph = graphs[0];
         final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
-        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graphs[0].getClass()));
+        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
         final PeerPressureVertexProgram.Builder builder = PeerPressureVertexProgram.build()
                 .property(this.clusterProperty)
                 .maxIterations(this.times)
                 .edges(detachedTraversal);
         if (this.previousTraversalVertexProgram())
             builder.initialVoteStrength(new HaltedTraversersCountTraversal());
-        return builder.create(graphs);
+        return builder.create(graph);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
@@ -86,16 +86,16 @@ public final class PeerPressureVertexProgramStep extends VertexProgramStep imple
     }
 
     @Override
-    public PeerPressureVertexProgram generateProgram(final Graph graph, final Memory memory) {
+    public PeerPressureVertexProgram generateProgram(final Memory memory, final Graph... graphs) {
         final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
-        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graphs[0].getClass()));
         final PeerPressureVertexProgram.Builder builder = PeerPressureVertexProgram.build()
                 .property(this.clusterProperty)
                 .maxIterations(this.times)
                 .edges(detachedTraversal);
         if (this.previousTraversalVertexProgram())
             builder.initialVoteStrength(new HaltedTraversersCountTraversal());
-        return builder.create(graph);
+        return builder.create(graphs);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
@@ -55,14 +55,14 @@ public final class ProgramVertexProgramStep extends VertexProgramStep {
     }
 
     @Override
-    public VertexProgram generateProgram(final Graph graph, final Memory memory) {
+    public VertexProgram generateProgram(final Memory memory, final Graph... graphs) {
         final MapConfiguration base = new MapConfiguration(this.configuration);
         base.setDelimiterParsingDisabled(true);
         PureTraversal.storeState(base, ROOT_TRAVERSAL, TraversalHelper.getRootTraversal(this.getTraversal()).clone());
         base.setProperty(STEP_ID, this.getId());
         if (memory.exists(TraversalVertexProgram.HALTED_TRAVERSERS))
             TraversalVertexProgram.storeHaltedTraversers(base, memory.get(TraversalVertexProgram.HALTED_TRAVERSERS));
-        return VertexProgram.createVertexProgram(graph, base);
+        return VertexProgram.createVertexProgram(base, graphs);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -70,10 +70,10 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
     }
 
     @Override
-    public TraversalVertexProgram generateProgram(final Graph graph, final Memory memory) {
+    public TraversalVertexProgram generateProgram(final Memory memory, final Graph... graphs) {
         final Traversal.Admin<?, ?> computerSpecificTraversal = this.computerTraversal.getPure();
         final TraversalStrategies computerSpecificStrategies = this.getTraversal().getStrategies().clone();
-        TraversalStrategies.GlobalCache.getStrategies(graph.getClass())
+        TraversalStrategies.GlobalCache.getStrategies(graphs[0].getClass())
                 .toList()
                 .stream()
                 .filter(s -> s instanceof TraversalStrategy.ProviderOptimizationStrategy)
@@ -84,7 +84,7 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
         final TraversalVertexProgram.Builder builder = TraversalVertexProgram.build().traversal(computerSpecificTraversal);
         if (memory.exists(TraversalVertexProgram.HALTED_TRAVERSERS))
             builder.haltedTraversers(memory.get(TraversalVertexProgram.HALTED_TRAVERSERS));
-        return builder.create(graph);
+        return builder.create(graphs);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
@@ -64,7 +64,7 @@ public abstract class VertexProgramStep extends AbstractStep<ComputerResult, Com
             if (this.first && this.getPreviousStep() instanceof EmptyStep) {
                 this.first = false;
                 final Graph graph = this.getTraversal().getGraph().get();
-                future = this.getComputer().apply(graph).program(this.generateProgram(graph, EmptyMemory.instance())).submit();
+                future = this.getComputer().apply(graph).program(this.generateProgram(EmptyMemory.instance(), graph)).submit();
                 final ComputerResult result = future.get();
                 this.processMemorySideEffects(result.memory());
                 return this.getTraversal().getTraverserGenerator().generate(result, this, 1l);
@@ -72,7 +72,7 @@ public abstract class VertexProgramStep extends AbstractStep<ComputerResult, Com
                 final Traverser.Admin<ComputerResult> traverser = this.starts.next();
                 final Graph graph = traverser.get().graph();
                 final Memory memory = traverser.get().memory();
-                future = this.generateComputer(graph).program(this.generateProgram(graph, memory)).submit();
+                future = this.getComputer().apply(graph).program(this.generateProgram(memory, graph)).submit();
                 final ComputerResult result = future.get();
                 this.processMemorySideEffects(result.memory());
                 return traverser.split(result, this);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
@@ -72,7 +72,7 @@ public abstract class VertexProgramStep extends AbstractStep<ComputerResult, Com
                 final Traverser.Admin<ComputerResult> traverser = this.starts.next();
                 final Graph graph = traverser.get().graph();
                 final Memory memory = traverser.get().memory();
-                future = this.getComputer().apply(graph).program(this.generateProgram(memory, graph)).submit();
+                future = this.generateComputer(graph).program(this.generateProgram(memory, graph)).submit();
                 final ComputerResult result = future.get();
                 this.processMemorySideEffects(result.memory());
                 return traverser.split(result, this);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/optimization/GraphFilterStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/optimization/GraphFilterStrategy.java
@@ -60,7 +60,7 @@ public final class GraphFilterStrategy extends AbstractTraversalStrategy<Travers
             return;
         final Graph graph = traversal.getGraph().orElse(EmptyGraph.instance()); // given that this strategy only works for single OLAP jobs, the graph is the traversal graph
         for (final TraversalVertexProgramStep step : TraversalHelper.getStepsOfClass(TraversalVertexProgramStep.class, traversal)) {   // will be zero or one step
-            final Traversal.Admin<?, ?> computerTraversal = step.generateProgram(graph, EmptyMemory.instance()).getTraversal().get().clone();
+            final Traversal.Admin<?, ?> computerTraversal = step.generateProgram(EmptyMemory.instance(), graph).getTraversal().get().clone();
             if (!computerTraversal.isLocked())
                 computerTraversal.applyStrategies();
             final Computer computer = step.getComputer();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/optimization/MessagePassingReductionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/optimization/MessagePassingReductionStrategy.java
@@ -79,7 +79,7 @@ public final class MessagePassingReductionStrategy extends AbstractTraversalStra
         // only process the first traversal step in an OLAP chain
         TraversalHelper.getFirstStepOfAssignableClass(TraversalVertexProgramStep.class, traversal).ifPresent(step -> {
             final Graph graph = traversal.getGraph().orElse(EmptyGraph.instance()); // best guess at what the graph will be as its dynamically determined
-            final Traversal.Admin<?, ?> compiledComputerTraversal = step.generateProgram(graph, EmptyMemory.instance()).getTraversal().get().clone();
+            final Traversal.Admin<?, ?> compiledComputerTraversal = step.generateProgram(EmptyMemory.instance(), graph).getTraversal().get().clone();
             if (!compiledComputerTraversal.isLocked())
                 compiledComputerTraversal.applyStrategies();
             if (!TraversalHelper.hasStepOfAssignableClassRecursively(Arrays.asList(LocalStep.class, LambdaHolder.class), compiledComputerTraversal) && // don't do anything with lambdas or locals as this leads to unknown adjacencies

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/AbstractVertexProgramBuilder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/AbstractVertexProgramBuilder.java
@@ -57,7 +57,7 @@ public abstract class AbstractVertexProgramBuilder<B extends VertexProgram.Build
     }
 
     @Override
-    public <P extends VertexProgram> P create(final Graph graph) {
-        return (P) VertexProgram.createVertexProgram(graph, this.configuration);
+    public <P extends VertexProgram> P create(final Graph... graphs) {
+        return (P) VertexProgram.createVertexProgram(this.configuration, graphs);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
@@ -59,6 +59,12 @@ public abstract class ComputerAwareStep<S, E> extends AbstractStep<S, E> impleme
         return clone;
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        this.previousIterator = EmptyIterator.instance();
+    }
+
     protected abstract Iterator<Traverser.Admin<E>> standardAlgorithm() throws NoSuchElementException;
 
     protected abstract Iterator<Traverser.Admin<E>> computerAlgorithm() throws NoSuchElementException;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -208,6 +208,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     @Override
     public void reset() {
         this.steps.forEach(Step::reset);
+        this.finalEndStep.reset();
         this.lastTraverser = EmptyTraverser.instance();
     }
 

--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -65,10 +65,10 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the <%= method.methodName %> step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< <%= method.t1 %> , <%= method.t2 %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
+        public GraphTraversal<$method.t1, $method.t2> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
         {
         <%  if (method.parameters.contains("params ")) {
-      %>    var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+      %>    var args = new List<$method.argsListType>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }
@@ -76,7 +76,7 @@ namespace Gremlin.Net.Process.Traversal
       %>    Bytecode.AddStep("<%= method.methodName %>"<% if (method.parameters) out << ', '+ method.paramNames.join(", ") %>);<%
             }
         %>
-            return Wrap< <%= method.t1 %> , <%= method.t2 %> >(this);
+            return Wrap<$method.t1, $method.t2>(this);
         }
 <% } %>
     }

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -127,11 +127,11 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the <%= method.methodName %> step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< <%= method.typeArguments.join(",") %> > <%= toCSharpMethodName.call(method.methodName) %>(<%= method.parameters %>)
+        public GraphTraversal<$method.typeNameString> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(<%= method.parameters %>)
         {
-            var traversal = new GraphTraversal< <%= method.typeArguments.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<$method.typeNameString>(TraversalStrategies, new Bytecode(Bytecode));
             <%  if (method.parameters.contains("params ")) {
-          %>var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+          %>var args = new List<$method.argsListType>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             traversal.Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
 import org.apache.tinkerpop.gremlin.structure.Direction
 import java.lang.reflect.Modifier
 import java.lang.reflect.TypeVariable
+import java.lang.reflect.GenericArrayType
 
 def toCSharpTypeMap = ["Long": "long",
                        "Integer": "int",
@@ -81,6 +82,12 @@ def getCSharpGenericTypeParam = { typeName ->
     else if (typeName.contains("<K, ")) {
         tParam = "<K>"
     }
+    else if (typeName.contains("S")) {
+        tParam = "<S>"
+    }
+    else if (typeName.contains("A")) {
+        tParam = "<A>"
+    }
     return tParam
 }
 
@@ -124,6 +131,9 @@ def toCSharpParamString = { param, genTypeName ->
     else if (csharpParamTypeName == "M") {
         csharpParamTypeName = "object";
     }
+    else if (csharpParamTypeName == "A[]") {
+        csharpParamTypeName = "object[]";
+    }
     else if (csharpParamTypeName == "A" || csharpParamTypeName == "B") {
         csharpParamTypeName = "E2";
     }
@@ -156,6 +166,11 @@ def getCSharpParamString = { method, useGenericParams ->
                     if (genType instanceof TypeVariable<?>) {
                         genTypeName = ((TypeVariable<?>)genType).name
                     }
+                    else if (genType instanceof GenericArrayType) {
+                        if (((GenericArrayType)genType).getGenericComponentType() instanceof TypeVariable<?>) {
+                            genTypeName = ((TypeVariable<?>)((GenericArrayType)genType).getGenericComponentType()).name + "[]"
+                        }                        
+                    }
                 }
                 toCSharpParamString(param, genTypeName)
             }.
@@ -174,6 +189,16 @@ def getParamNames = { parameters ->
         collect { param ->
             param.name
         }
+}
+
+def getArgsListType = { parameterString ->
+    def argsListType = "object"
+    if (parameterString.contains("params ")) {
+        def paramsType = parameterString.substring(parameterString.indexOf("params ") + "params ".length(), parameterString.indexOf("[]"))
+        if (paramsType == "E" || paramsType == "S")
+            argsListType = paramsType
+    }
+    argsListType
 }
 
 def hasMethodNoGenericCounterPartInGraphTraversal = { method ->
@@ -234,15 +259,19 @@ def binding = ["pmethods": P.class.getMethods().
                             return ["methodName": javaMethod.name, "parameters":parameters, "paramNames":paramNames]
                         },
                "sourceSpawnMethods": GraphTraversalSource.getMethods(). // SPAWN STEPS
-                        findAll { GraphTraversal.class.equals(it.returnType) && !it.name.equals('inject')}.          
+                        findAll { GraphTraversal.class.equals(it.returnType) }.          
                 // Select unique combination of C# parameter types and sort by Java parameter type combination                                                                    
                         sort { a, b -> a.name <=> b.name ?: getJavaParamTypeString(a) <=> getJavaParamTypeString(b) }.
                         unique { a,b -> a.name <=> b.name ?: getCSharpParamTypeString(a) <=> getCSharpParamTypeString(b) }.
                         collect { javaMethod ->
-                            def typeArguments = javaMethod.genericReturnType.actualTypeArguments.collect{t -> ((java.lang.Class)t).simpleName}
-                            def parameters = getCSharpParamString(javaMethod, false)
+                            def typeNames = getJavaGenericTypeParameterTypeNames(javaMethod)
+                            def typeNameString = typeNames.join(", ")
+                            def t2 = toCSharpType(typeNames[1])
+                            def tParam = getCSharpGenericTypeParam(t2)
+                            def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
-                            return ["methodName": javaMethod.name, "typeArguments": typeArguments, "parameters":parameters, "paramNames":paramNames]
+                            def argsListType = getArgsListType(parameters)
+                            return ["methodName": javaMethod.name, "typeNameString": typeNameString, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
                         },
                "graphStepMethods": GraphTraversal.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.
@@ -257,7 +286,8 @@ def binding = ["pmethods": P.class.getMethods().
                             def tParam = getCSharpGenericTypeParam(t2)
                             def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
-                            return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames]
+                            def argsListType = getArgsListType(parameters)
+                            return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
                         },
                "anonStepMethods": __.class.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -65,1614 +65,1614 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the V step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > V (params object[] vertexIdsOrElements)
+        public GraphTraversal<S, Vertex> V (params object[] vertexIdsOrElements)
         {
             var args = new List<object>(0 + vertexIdsOrElements.Length) {};
             args.AddRange(vertexIdsOrElements);
             Bytecode.AddStep("V", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the addE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddE (Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
+        public GraphTraversal<S, Edge> AddE (Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
             var args = new List<object>(3 + propertyKeyValues.Length) {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddE (string edgeLabel)
+        public GraphTraversal<S, Edge> AddE (string edgeLabel)
         {
             Bytecode.AddStep("addE", edgeLabel);
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addInE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddInE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
+        public GraphTraversal<S, Edge> AddInE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
             var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addInE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addOutE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddOutE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
+        public GraphTraversal<S, Edge> AddOutE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
             var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addOutE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > AddV ()
+        public GraphTraversal<S, Vertex> AddV ()
         {
             Bytecode.AddStep("addV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > AddV (params object[] propertyKeyValues)
+        public GraphTraversal<S, Vertex> AddV (params object[] propertyKeyValues)
         {
             var args = new List<object>(0 + propertyKeyValues.Length) {};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addV", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > AddV (string vertexLabel)
+        public GraphTraversal<S, Vertex> AddV (string vertexLabel)
         {
             Bytecode.AddStep("addV", vertexLabel);
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the aggregate step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Aggregate (string sideEffectKey)
+        public GraphTraversal<S, E> Aggregate (string sideEffectKey)
         {
             Bytecode.AddStep("aggregate", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the and step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > And (params ITraversal[] andTraversals)
+        public GraphTraversal<S, E> And (params ITraversal[] andTraversals)
         {
             var args = new List<object>(0 + andTraversals.Length) {};
             args.AddRange(andTraversals);
             Bytecode.AddStep("and", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the as step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > As (string stepLabel, params string[] stepLabels)
+        public GraphTraversal<S, E> As (string stepLabel, params string[] stepLabels)
         {
             var args = new List<object>(1 + stepLabels.Length) {stepLabel};
             args.AddRange(stepLabels);
             Bytecode.AddStep("as", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Barrier ()
+        public GraphTraversal<S, E> Barrier ()
         {
             Bytecode.AddStep("barrier");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Barrier (object barrierConsumer)
+        public GraphTraversal<S, E> Barrier (object barrierConsumer)
         {
             Bytecode.AddStep("barrier", barrierConsumer);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Barrier (int maxBarrierSize)
+        public GraphTraversal<S, E> Barrier (int maxBarrierSize)
         {
             Bytecode.AddStep("barrier", maxBarrierSize);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the both step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > Both (params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> Both (params string[] edgeLabels)
         {
             var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("both", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the bothE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > BothE (params string[] edgeLabels)
+        public GraphTraversal<S, Edge> BothE (params string[] edgeLabels)
         {
             var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("bothE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the bothV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > BothV ()
+        public GraphTraversal<S, Vertex> BothV ()
         {
             Bytecode.AddStep("bothV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the branch step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Branch<E2> (object function)
+        public GraphTraversal<S, E2> Branch<E2> (object function)
         {
             Bytecode.AddStep("branch", function);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the branch step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Branch<E2> (ITraversal branchTraversal)
+        public GraphTraversal<S, E2> Branch<E2> (ITraversal branchTraversal)
         {
             Bytecode.AddStep("branch", branchTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By ()
+        public GraphTraversal<S, E> By ()
         {
             Bytecode.AddStep("by");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (object comparator)
+        public GraphTraversal<S, E> By (object comparator)
         {
             Bytecode.AddStep("by", comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (object function, object comparator)
+        public GraphTraversal<S, E> By (object function, object comparator)
         {
             Bytecode.AddStep("by", function, comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (Order order)
+        public GraphTraversal<S, E> By (Order order)
         {
             Bytecode.AddStep("by", order);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (string key)
+        public GraphTraversal<S, E> By (string key)
         {
             Bytecode.AddStep("by", key);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (string key, object comparator)
+        public GraphTraversal<S, E> By (string key, object comparator)
         {
             Bytecode.AddStep("by", key, comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (T token)
+        public GraphTraversal<S, E> By (T token)
         {
             Bytecode.AddStep("by", token);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (ITraversal traversal)
+        public GraphTraversal<S, E> By (ITraversal traversal)
         {
             Bytecode.AddStep("by", traversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (ITraversal traversal, object comparator)
+        public GraphTraversal<S, E> By (ITraversal traversal, object comparator)
         {
             Bytecode.AddStep("by", traversal, comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the cap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Cap<E2> (string sideEffectKey, params string[] sideEffectKeys)
+        public GraphTraversal<S, E2> Cap<E2> (string sideEffectKey, params string[] sideEffectKeys)
         {
             var args = new List<object>(1 + sideEffectKeys.Length) {sideEffectKey};
             args.AddRange(sideEffectKeys);
             Bytecode.AddStep("cap", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (object choiceFunction)
+        public GraphTraversal<S, E2> Choose<E2> (object choiceFunction)
         {
             Bytecode.AddStep("choose", choiceFunction);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice)
+        public GraphTraversal<S, E2> Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice)
         {
             Bytecode.AddStep("choose", choosePredicate, trueChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice, ITraversal falseChoice)
+        public GraphTraversal<S, E2> Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice, ITraversal falseChoice)
         {
             Bytecode.AddStep("choose", choosePredicate, trueChoice, falseChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (ITraversal choiceTraversal)
+        public GraphTraversal<S, E2> Choose<E2> (ITraversal choiceTraversal)
         {
             Bytecode.AddStep("choose", choiceTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice)
+        public GraphTraversal<S, E2> Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice)
         {
             Bytecode.AddStep("choose", traversalPredicate, trueChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice, ITraversal falseChoice)
+        public GraphTraversal<S, E2> Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice, ITraversal falseChoice)
         {
             Bytecode.AddStep("choose", traversalPredicate, trueChoice, falseChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the coalesce step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Coalesce<E2> (params ITraversal[] coalesceTraversals)
+        public GraphTraversal<S, E2> Coalesce<E2> (params ITraversal[] coalesceTraversals)
         {
             var args = new List<object>(0 + coalesceTraversals.Length) {};
             args.AddRange(coalesceTraversals);
             Bytecode.AddStep("coalesce", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the coin step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Coin (double probability)
+        public GraphTraversal<S, E> Coin (double probability)
         {
             Bytecode.AddStep("coin", probability);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the constant step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Constant<E2> (E2 e)
+        public GraphTraversal<S, E2> Constant<E2> (E2 e)
         {
             Bytecode.AddStep("constant", e);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the count step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , long > Count ()
+        public GraphTraversal<S, long> Count ()
         {
             Bytecode.AddStep("count");
-            return Wrap< S , long >(this);
+            return Wrap<S, long>(this);
         }
 
         /// <summary>
         ///     Adds the count step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , long > Count (Scope scope)
+        public GraphTraversal<S, long> Count (Scope scope)
         {
             Bytecode.AddStep("count", scope);
-            return Wrap< S , long >(this);
+            return Wrap<S, long>(this);
         }
 
         /// <summary>
         ///     Adds the cyclicPath step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > CyclicPath ()
+        public GraphTraversal<S, E> CyclicPath ()
         {
             Bytecode.AddStep("cyclicPath");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the dedup step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Dedup (Scope scope, params string[] dedupLabels)
+        public GraphTraversal<S, E> Dedup (Scope scope, params string[] dedupLabels)
         {
             var args = new List<object>(1 + dedupLabels.Length) {scope};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the dedup step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Dedup (params string[] dedupLabels)
+        public GraphTraversal<S, E> Dedup (params string[] dedupLabels)
         {
             var args = new List<object>(0 + dedupLabels.Length) {};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the drop step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Drop ()
+        public GraphTraversal<S, E> Drop ()
         {
             Bytecode.AddStep("drop");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Emit ()
+        public GraphTraversal<S, E> Emit ()
         {
             Bytecode.AddStep("emit");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Emit (TraversalPredicate emitPredicate)
+        public GraphTraversal<S, E> Emit (TraversalPredicate emitPredicate)
         {
             Bytecode.AddStep("emit", emitPredicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Emit (ITraversal emitTraversal)
+        public GraphTraversal<S, E> Emit (ITraversal emitTraversal)
         {
             Bytecode.AddStep("emit", emitTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the filter step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Filter (TraversalPredicate predicate)
+        public GraphTraversal<S, E> Filter (TraversalPredicate predicate)
         {
             Bytecode.AddStep("filter", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the filter step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Filter (ITraversal filterTraversal)
+        public GraphTraversal<S, E> Filter (ITraversal filterTraversal)
         {
             Bytecode.AddStep("filter", filterTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the flatMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > FlatMap<E2> (object function)
+        public GraphTraversal<S, E2> FlatMap<E2> (object function)
         {
             Bytecode.AddStep("flatMap", function);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the flatMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > FlatMap<E2> (ITraversal flatMapTraversal)
+        public GraphTraversal<S, E2> FlatMap<E2> (ITraversal flatMapTraversal)
         {
             Bytecode.AddStep("flatMap", flatMapTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the fold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IList<E> > Fold ()
+        public GraphTraversal<S, IList<E>> Fold ()
         {
             Bytecode.AddStep("fold");
-            return Wrap< S , IList<E> >(this);
+            return Wrap<S, IList<E>>(this);
         }
 
         /// <summary>
         ///     Adds the fold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Fold<E2> (E2 seed, object foldFunction)
+        public GraphTraversal<S, E2> Fold<E2> (E2 seed, object foldFunction)
         {
             Bytecode.AddStep("fold", seed, foldFunction);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the from step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > From (string fromStepLabel)
+        public GraphTraversal<S, E> From (string fromStepLabel)
         {
             Bytecode.AddStep("from", fromStepLabel);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the from step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > From (ITraversal fromVertex)
+        public GraphTraversal<S, E> From (ITraversal fromVertex)
         {
             Bytecode.AddStep("from", fromVertex);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<K, V> > Group<K, V> ()
+        public GraphTraversal<S, IDictionary<K, V>> Group<K, V> ()
         {
             Bytecode.AddStep("group");
-            return Wrap< S , IDictionary<K, V> >(this);
+            return Wrap<S, IDictionary<K, V>>(this);
         }
 
         /// <summary>
         ///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Group (string sideEffectKey)
+        public GraphTraversal<S, E> Group (string sideEffectKey)
         {
             Bytecode.AddStep("group", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the groupCount step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<K, long> > GroupCount<K> ()
+        public GraphTraversal<S, IDictionary<K, long>> GroupCount<K> ()
         {
             Bytecode.AddStep("groupCount");
-            return Wrap< S , IDictionary<K, long> >(this);
+            return Wrap<S, IDictionary<K, long>>(this);
         }
 
         /// <summary>
         ///     Adds the groupCount step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > GroupCount (string sideEffectKey)
+        public GraphTraversal<S, E> GroupCount (string sideEffectKey)
         {
             Bytecode.AddStep("groupCount", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the groupV3d0 step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<K, V> > GroupV3d0<K, V> ()
+        public GraphTraversal<S, IDictionary<K, V>> GroupV3d0<K, V> ()
         {
             Bytecode.AddStep("groupV3d0");
-            return Wrap< S , IDictionary<K, V> >(this);
+            return Wrap<S, IDictionary<K, V>>(this);
         }
 
         /// <summary>
         ///     Adds the groupV3d0 step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > GroupV3d0 (string sideEffectKey)
+        public GraphTraversal<S, E> GroupV3d0 (string sideEffectKey)
         {
             Bytecode.AddStep("groupV3d0", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey)
+        public GraphTraversal<S, E> Has (string propertyKey)
         {
             Bytecode.AddStep("has", propertyKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey, object value)
+        public GraphTraversal<S, E> Has (string propertyKey, object value)
         {
             Bytecode.AddStep("has", propertyKey, value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Has (string propertyKey, TraversalPredicate predicate)
         {
             Bytecode.AddStep("has", propertyKey, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string label, string propertyKey, object value)
+        public GraphTraversal<S, E> Has (string label, string propertyKey, object value)
         {
             Bytecode.AddStep("has", label, propertyKey, value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string label, string propertyKey, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Has (string label, string propertyKey, TraversalPredicate predicate)
         {
             Bytecode.AddStep("has", label, propertyKey, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey, ITraversal propertyTraversal)
+        public GraphTraversal<S, E> Has (string propertyKey, ITraversal propertyTraversal)
         {
             Bytecode.AddStep("has", propertyKey, propertyTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (T accessor, object value)
+        public GraphTraversal<S, E> Has (T accessor, object value)
         {
             Bytecode.AddStep("has", accessor, value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (T accessor, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Has (T accessor, TraversalPredicate predicate)
         {
             Bytecode.AddStep("has", accessor, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (T accessor, ITraversal propertyTraversal)
+        public GraphTraversal<S, E> Has (T accessor, ITraversal propertyTraversal)
         {
             Bytecode.AddStep("has", accessor, propertyTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasId step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasId (object id, params object[] otherIds)
+        public GraphTraversal<S, E> HasId (object id, params object[] otherIds)
         {
             var args = new List<object>(1 + otherIds.Length) {id};
             args.AddRange(otherIds);
             Bytecode.AddStep("hasId", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasId step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasId (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasId (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasId", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasKey step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasKey (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasKey (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasKey", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasKey step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasKey (string label, params string[] otherLabels)
+        public GraphTraversal<S, E> HasKey (string label, params string[] otherLabels)
         {
             var args = new List<object>(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasKey", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasLabel step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasLabel (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasLabel (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasLabel", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasLabel step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasLabel (string label, params string[] otherLabels)
+        public GraphTraversal<S, E> HasLabel (string label, params string[] otherLabels)
         {
             var args = new List<object>(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasLabel", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasNot step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasNot (string propertyKey)
+        public GraphTraversal<S, E> HasNot (string propertyKey)
         {
             Bytecode.AddStep("hasNot", propertyKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasValue step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasValue (object value, params object[] otherValues)
+        public GraphTraversal<S, E> HasValue (object value, params object[] otherValues)
         {
             var args = new List<object>(1 + otherValues.Length) {value};
             args.AddRange(otherValues);
             Bytecode.AddStep("hasValue", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasValue step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasValue (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasValue (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasValue", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the id step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , object > Id ()
+        public GraphTraversal<S, object> Id ()
         {
             Bytecode.AddStep("id");
-            return Wrap< S , object >(this);
+            return Wrap<S, object>(this);
         }
 
         /// <summary>
         ///     Adds the identity step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Identity ()
+        public GraphTraversal<S, E> Identity ()
         {
             Bytecode.AddStep("identity");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the in step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > In (params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> In (params string[] edgeLabels)
         {
             var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("in", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the inE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > InE (params string[] edgeLabels)
+        public GraphTraversal<S, Edge> InE (params string[] edgeLabels)
         {
             var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("inE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the inV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > InV ()
+        public GraphTraversal<S, Vertex> InV ()
         {
             Bytecode.AddStep("inV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the inject step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Inject (params object[] injections)
+        public GraphTraversal<S, E> Inject (params E[] injections)
         {
-            var args = new List<object>(0 + injections.Length) {};
+            var args = new List<E>(0 + injections.Length) {};
             args.AddRange(injections);
             Bytecode.AddStep("inject", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the is step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Is (object value)
+        public GraphTraversal<S, E> Is (object value)
         {
             Bytecode.AddStep("is", value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the is step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Is (TraversalPredicate predicate)
+        public GraphTraversal<S, E> Is (TraversalPredicate predicate)
         {
             Bytecode.AddStep("is", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the key step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , string > Key ()
+        public GraphTraversal<S, string> Key ()
         {
             Bytecode.AddStep("key");
-            return Wrap< S , string >(this);
+            return Wrap<S, string>(this);
         }
 
         /// <summary>
         ///     Adds the label step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , string > Label ()
+        public GraphTraversal<S, string> Label ()
         {
             Bytecode.AddStep("label");
-            return Wrap< S , string >(this);
+            return Wrap<S, string>(this);
         }
 
         /// <summary>
         ///     Adds the limit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Limit<E2> (Scope scope, long limit)
+        public GraphTraversal<S, E2> Limit<E2> (Scope scope, long limit)
         {
             Bytecode.AddStep("limit", scope, limit);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the limit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Limit (long limit)
+        public GraphTraversal<S, E> Limit (long limit)
         {
             Bytecode.AddStep("limit", limit);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the local step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Local<E2> (ITraversal localTraversal)
+        public GraphTraversal<S, E2> Local<E2> (ITraversal localTraversal)
         {
             Bytecode.AddStep("local", localTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the loops step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , int > Loops ()
+        public GraphTraversal<S, int> Loops ()
         {
             Bytecode.AddStep("loops");
-            return Wrap< S , int >(this);
+            return Wrap<S, int>(this);
         }
 
         /// <summary>
         ///     Adds the map step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Map<E2> (object function)
+        public GraphTraversal<S, E2> Map<E2> (object function)
         {
             Bytecode.AddStep("map", function);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the map step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Map<E2> (ITraversal mapTraversal)
+        public GraphTraversal<S, E2> Map<E2> (ITraversal mapTraversal)
         {
             Bytecode.AddStep("map", mapTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mapKeys step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > MapKeys<E2> ()
+        public GraphTraversal<S, E2> MapKeys<E2> ()
         {
             Bytecode.AddStep("mapKeys");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mapValues step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > MapValues<E2> ()
+        public GraphTraversal<S, E2> MapValues<E2> ()
         {
             Bytecode.AddStep("mapValues");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the match step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Match<E2> (params ITraversal[] matchTraversals)
+        public GraphTraversal<S, IDictionary<string, E2>> Match<E2> (params ITraversal[] matchTraversals)
         {
             var args = new List<object>(0 + matchTraversals.Length) {};
             args.AddRange(matchTraversals);
             Bytecode.AddStep("match", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Max<E2> ()
+        public GraphTraversal<S, E2> Max<E2> ()
         {
             Bytecode.AddStep("max");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Max<E2> (Scope scope)
+        public GraphTraversal<S, E2> Max<E2> (Scope scope)
         {
             Bytecode.AddStep("max", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mean step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Mean<E2> ()
+        public GraphTraversal<S, E2> Mean<E2> ()
         {
             Bytecode.AddStep("mean");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mean step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Mean<E2> (Scope scope)
+        public GraphTraversal<S, E2> Mean<E2> (Scope scope)
         {
             Bytecode.AddStep("mean", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the min step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Min<E2> ()
+        public GraphTraversal<S, E2> Min<E2> ()
         {
             Bytecode.AddStep("min");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the min step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Min<E2> (Scope scope)
+        public GraphTraversal<S, E2> Min<E2> (Scope scope)
         {
             Bytecode.AddStep("min", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the not step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Not (ITraversal notTraversal)
+        public GraphTraversal<S, E> Not (ITraversal notTraversal)
         {
             Bytecode.AddStep("not", notTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the option step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Option (object pickToken, ITraversal traversalOption)
+        public GraphTraversal<S, E> Option (object pickToken, ITraversal traversalOption)
         {
             Bytecode.AddStep("option", pickToken, traversalOption);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the option step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Option (ITraversal traversalOption)
+        public GraphTraversal<S, E> Option (ITraversal traversalOption)
         {
             Bytecode.AddStep("option", traversalOption);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the optional step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Optional<E2> (ITraversal optionalTraversal)
+        public GraphTraversal<S, E2> Optional<E2> (ITraversal optionalTraversal)
         {
             Bytecode.AddStep("optional", optionalTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the or step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Or (params ITraversal[] orTraversals)
+        public GraphTraversal<S, E> Or (params ITraversal[] orTraversals)
         {
             var args = new List<object>(0 + orTraversals.Length) {};
             args.AddRange(orTraversals);
             Bytecode.AddStep("or", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the order step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Order ()
+        public GraphTraversal<S, E> Order ()
         {
             Bytecode.AddStep("order");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the order step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Order (Scope scope)
+        public GraphTraversal<S, E> Order (Scope scope)
         {
             Bytecode.AddStep("order", scope);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the otherV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > OtherV ()
+        public GraphTraversal<S, Vertex> OtherV ()
         {
             Bytecode.AddStep("otherV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the out step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > Out (params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> Out (params string[] edgeLabels)
         {
             var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("out", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the outE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > OutE (params string[] edgeLabels)
+        public GraphTraversal<S, Edge> OutE (params string[] edgeLabels)
         {
             var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("outE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the outV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > OutV ()
+        public GraphTraversal<S, Vertex> OutV ()
         {
             Bytecode.AddStep("outV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the pageRank step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PageRank ()
+        public GraphTraversal<S, E> PageRank ()
         {
             Bytecode.AddStep("pageRank");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the pageRank step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PageRank (double alpha)
+        public GraphTraversal<S, E> PageRank (double alpha)
         {
             Bytecode.AddStep("pageRank", alpha);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the path step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Path > Path ()
+        public GraphTraversal<S, Path> Path ()
         {
             Bytecode.AddStep("path");
-            return Wrap< S , Path >(this);
+            return Wrap<S, Path>(this);
         }
 
         /// <summary>
         ///     Adds the peerPressure step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PeerPressure ()
+        public GraphTraversal<S, E> PeerPressure ()
         {
             Bytecode.AddStep("peerPressure");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Profile<E2> ()
+        public GraphTraversal<S, E2> Profile<E2> ()
         {
             Bytecode.AddStep("profile");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Profile (string sideEffectKey)
+        public GraphTraversal<S, E> Profile (string sideEffectKey)
         {
             Bytecode.AddStep("profile", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the program step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Program (object vertexProgram)
+        public GraphTraversal<S, E> Program (object vertexProgram)
         {
             Bytecode.AddStep("program", vertexProgram);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the project step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Project<E2> (string projectKey, params string[] otherProjectKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> Project<E2> (string projectKey, params string[] otherProjectKeys)
         {
             var args = new List<object>(1 + otherProjectKeys.Length) {projectKey};
             args.AddRange(otherProjectKeys);
             Bytecode.AddStep("project", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the properties step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Properties<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, E2> Properties<E2> (params string[] propertyKeys)
         {
             var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("properties", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the property step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Property (Cardinality cardinality, object key, object value, params object[] keyValues)
+        public GraphTraversal<S, E> Property (Cardinality cardinality, object key, object value, params object[] keyValues)
         {
             var args = new List<object>(3 + keyValues.Length) {cardinality, key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the property step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Property (object key, object value, params object[] keyValues)
+        public GraphTraversal<S, E> Property (object key, object value, params object[] keyValues)
         {
             var args = new List<object>(2 + keyValues.Length) {key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the propertyMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > PropertyMap<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> PropertyMap<E2> (params string[] propertyKeys)
         {
             var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("propertyMap", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the range step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Range<E2> (Scope scope, long low, long high)
+        public GraphTraversal<S, E2> Range<E2> (Scope scope, long low, long high)
         {
             Bytecode.AddStep("range", scope, low, high);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the range step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Range (long low, long high)
+        public GraphTraversal<S, E> Range (long low, long high)
         {
             Bytecode.AddStep("range", low, high);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the repeat step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Repeat (ITraversal repeatTraversal)
+        public GraphTraversal<S, E> Repeat (ITraversal repeatTraversal)
         {
             Bytecode.AddStep("repeat", repeatTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Sack<E2> ()
+        public GraphTraversal<S, E2> Sack<E2> ()
         {
             Bytecode.AddStep("sack");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sack (object sackOperator)
+        public GraphTraversal<S, E> Sack (object sackOperator)
         {
             Bytecode.AddStep("sack", sackOperator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sack (object sackOperator, string elementPropertyKey)
+        public GraphTraversal<S, E> Sack (object sackOperator, string elementPropertyKey)
         {
             Bytecode.AddStep("sack", sackOperator, elementPropertyKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sample step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sample (Scope scope, int amountToSample)
+        public GraphTraversal<S, E> Sample (Scope scope, int amountToSample)
         {
             Bytecode.AddStep("sample", scope, amountToSample);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sample step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sample (int amountToSample)
+        public GraphTraversal<S, E> Sample (int amountToSample)
         {
             Bytecode.AddStep("sample", amountToSample);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , ICollection<E2> > Select<E2> (Column column)
+        public GraphTraversal<S, ICollection<E2>> Select<E2> (Column column)
         {
             Bytecode.AddStep("select", column);
-            return Wrap< S , ICollection<E2> >(this);
+            return Wrap<S, ICollection<E2>>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Select<E2> (Pop pop, string selectKey)
+        public GraphTraversal<S, E2> Select<E2> (Pop pop, string selectKey)
         {
             Bytecode.AddStep("select", pop, selectKey);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> Select<E2> (Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
             var args = new List<object>(3 + otherSelectKeys.Length) {pop, selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Select<E2> (string selectKey)
+        public GraphTraversal<S, E2> Select<E2> (string selectKey)
         {
             Bytecode.AddStep("select", selectKey);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> Select<E2> (string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
             var args = new List<object>(2 + otherSelectKeys.Length) {selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the sideEffect step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SideEffect (object consumer)
+        public GraphTraversal<S, E> SideEffect (object consumer)
         {
             Bytecode.AddStep("sideEffect", consumer);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sideEffect step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SideEffect (ITraversal sideEffectTraversal)
+        public GraphTraversal<S, E> SideEffect (ITraversal sideEffectTraversal)
         {
             Bytecode.AddStep("sideEffect", sideEffectTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the simplePath step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SimplePath ()
+        public GraphTraversal<S, E> SimplePath ()
         {
             Bytecode.AddStep("simplePath");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the store step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Store (string sideEffectKey)
+        public GraphTraversal<S, E> Store (string sideEffectKey)
         {
             Bytecode.AddStep("store", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the subgraph step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > Subgraph (string sideEffectKey)
+        public GraphTraversal<S, Edge> Subgraph (string sideEffectKey)
         {
             Bytecode.AddStep("subgraph", sideEffectKey);
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the sum step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Sum<E2> ()
+        public GraphTraversal<S, E2> Sum<E2> ()
         {
             Bytecode.AddStep("sum");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the sum step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Sum<E2> (Scope scope)
+        public GraphTraversal<S, E2> Sum<E2> (Scope scope)
         {
             Bytecode.AddStep("sum", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Tail ()
+        public GraphTraversal<S, E> Tail ()
         {
             Bytecode.AddStep("tail");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Tail<E2> (Scope scope)
+        public GraphTraversal<S, E2> Tail<E2> (Scope scope)
         {
             Bytecode.AddStep("tail", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Tail<E2> (Scope scope, long limit)
+        public GraphTraversal<S, E2> Tail<E2> (Scope scope, long limit)
         {
             Bytecode.AddStep("tail", scope, limit);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Tail (long limit)
+        public GraphTraversal<S, E> Tail (long limit)
         {
             Bytecode.AddStep("tail", limit);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the timeLimit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > TimeLimit (long timeLimit)
+        public GraphTraversal<S, E> TimeLimit (long timeLimit)
         {
             Bytecode.AddStep("timeLimit", timeLimit);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the times step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Times (int maxLoops)
+        public GraphTraversal<S, E> Times (int maxLoops)
         {
             Bytecode.AddStep("times", maxLoops);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > To (Direction direction, params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> To (Direction direction, params string[] edgeLabels)
         {
             var args = new List<object>(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("to", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > To (string toStepLabel)
+        public GraphTraversal<S, E> To (string toStepLabel)
         {
             Bytecode.AddStep("to", toStepLabel);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > To (ITraversal toVertex)
+        public GraphTraversal<S, E> To (ITraversal toVertex)
         {
             Bytecode.AddStep("to", toVertex);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the toE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > ToE (Direction direction, params string[] edgeLabels)
+        public GraphTraversal<S, Edge> ToE (Direction direction, params string[] edgeLabels)
         {
             var args = new List<object>(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("toE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the toV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > ToV (Direction direction)
+        public GraphTraversal<S, Vertex> ToV (Direction direction)
         {
             Bytecode.AddStep("toV", direction);
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the tree step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Tree<E2> ()
+        public GraphTraversal<S, E2> Tree<E2> ()
         {
             Bytecode.AddStep("tree");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tree step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Tree (string sideEffectKey)
+        public GraphTraversal<S, E> Tree (string sideEffectKey)
         {
             Bytecode.AddStep("tree", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the unfold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Unfold<E2> ()
+        public GraphTraversal<S, E2> Unfold<E2> ()
         {
             Bytecode.AddStep("unfold");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the union step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Union<E2> (params ITraversal[] unionTraversals)
+        public GraphTraversal<S, E2> Union<E2> (params ITraversal[] unionTraversals)
         {
             var args = new List<object>(0 + unionTraversals.Length) {};
             args.AddRange(unionTraversals);
             Bytecode.AddStep("union", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the until step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Until (TraversalPredicate untilPredicate)
+        public GraphTraversal<S, E> Until (TraversalPredicate untilPredicate)
         {
             Bytecode.AddStep("until", untilPredicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the until step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Until (ITraversal untilTraversal)
+        public GraphTraversal<S, E> Until (ITraversal untilTraversal)
         {
             Bytecode.AddStep("until", untilTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the value step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Value<E2> ()
+        public GraphTraversal<S, E2> Value<E2> ()
         {
             Bytecode.AddStep("value");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the valueMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> ValueMap<E2> (params string[] propertyKeys)
         {
             var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the valueMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (bool includeTokens, params string[] propertyKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> ValueMap<E2> (bool includeTokens, params string[] propertyKeys)
         {
             var args = new List<object>(1 + propertyKeys.Length) {includeTokens};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the values step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Values<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, E2> Values<E2> (params string[] propertyKeys)
         {
             var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("values", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Where (TraversalPredicate predicate)
+        public GraphTraversal<S, E> Where (TraversalPredicate predicate)
         {
             Bytecode.AddStep("where", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Where (string startKey, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Where (string startKey, TraversalPredicate predicate)
         {
             Bytecode.AddStep("where", startKey, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Where (ITraversal whereTraversal)
+        public GraphTraversal<S, E> Where (ITraversal whereTraversal)
         {
             Bytecode.AddStep("where", whereTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -187,9 +187,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the E step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Edge,Edge > E(params object[] edgesIds)
+        public GraphTraversal<Edge, Edge> E(params object[] edgesIds)
         {
-            var traversal = new GraphTraversal< Edge,Edge >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Edge, Edge>(TraversalStrategies, new Bytecode(Bytecode));
             var args = new List<object>(0 + edgesIds.Length) {};
             args.AddRange(edgesIds);
             traversal.Bytecode.AddStep("E", args.ToArray());
@@ -200,9 +200,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the V step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > V(params object[] vertexIds)
+        public GraphTraversal<Vertex, Vertex> V(params object[] vertexIds)
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
             var args = new List<object>(0 + vertexIds.Length) {};
             args.AddRange(vertexIds);
             traversal.Bytecode.AddStep("V", args.ToArray());
@@ -213,9 +213,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > AddV()
+        public GraphTraversal<Vertex, Vertex> AddV()
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
                 traversal.Bytecode.AddStep("addV");
             return traversal;
         }
@@ -224,9 +224,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > AddV(params object[] keyValues)
+        public GraphTraversal<Vertex, Vertex> AddV(params object[] keyValues)
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
             var args = new List<object>(0 + keyValues.Length) {};
             args.AddRange(keyValues);
             traversal.Bytecode.AddStep("addV", args.ToArray());
@@ -237,10 +237,23 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > AddV(string label)
+        public GraphTraversal<Vertex, Vertex> AddV(string label)
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
                 traversal.Bytecode.AddStep("addV", label);
+            return traversal;
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the inject step to that
+        ///     traversal.
+        /// </summary>
+        public GraphTraversal<S, S> Inject<S>(params S[] starts)
+        {
+            var traversal = new GraphTraversal<S, S>(TraversalStrategies, new Bytecode(Bytecode));
+            var args = new List<S>(0 + starts.Length) {};
+            args.AddRange(starts);
+            traversal.Bytecode.AddStep("inject", args.ToArray());
             return traversal;
         }
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyUnionTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyUnionTest.groovy
@@ -73,5 +73,11 @@ public abstract class GroovyUnionTest {
                 final Object v1Id, final Object v2Id) {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id, v2Id).local(union(outE().count, inE().count, outE().weight.sum))", "v1Id", v1Id, "v2Id", v2Id);
         }
+
+        @Override
+        public Traversal<Vertex, Number> get_g_VX1_2X_localXunionXcountXX(
+                final Object v1Id, final Object v2Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id, v2Id).local(union(count()))", "v1Id", v1Id, "v2Id", v2Id);
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyValueMapTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyValueMapTest.groovy
@@ -34,8 +34,18 @@ public abstract class GroovyValueMapTest {
         }
 
         @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_valueMapXtrueX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.valueMap(true)")
+        }
+
+        @Override
         public Traversal<Vertex, Map<String, List>> get_g_V_valueMapXname_ageX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.valueMap('name', 'age')")
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_valueMapXtrue_name_ageX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.valueMap(true, 'name', 'age')")
         }
 
         @Override

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -315,27 +315,17 @@ limitations under the License.
                                               failonerror="true">
                                             <arg line="--python=python2 env"/>
                                         </exec>
-                                        <!-- temporary manual installation of deps to hardcode colorful version given radish/PyHamcrest troubles -->
                                         <exec dir="${project.build.directory}/python2" executable="env/bin/pip"
                                               failonerror="true">
-                                            <arg line="install wheel aenum pysingleton humanize radish-parse_type docopt 'colorful==0.4.0' 'tag-expressions>=1.0.0'"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python2" executable="env/bin/pip"
-                                              failonerror="true">
-                                            <arg line="install radish-bdd PyHamcrest --no-deps"/>
+                                            <arg line="install wheel radish-bdd PyHamcrest aenum"/>
                                         </exec>
                                         <exec dir="${project.build.directory}/python3" executable="virtualenv"
                                               failonerror="true">
                                             <arg line="--python=python3 env"/>
                                         </exec>
-                                        <!-- temporary manual installation of deps to hardcode colorful version given radish/PyHamcrest troubles -->
                                         <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
                                               failonerror="true">
-                                            <arg line="install wheel aenum pysingleton humanize radish-parse_type docopt 'colorful==0.4.0' 'tag-expressions>=1.0.0'"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
-                                              failonerror="true">
-                                            <arg line="install radish-bdd PyHamcrest --no-deps"/>
+                                            <arg line="install wheel radish-bdd PyHamcrest aenum"/>
                                         </exec>
                                         <exec dir="${project.build.directory}/python-packaged" executable="virtualenv"
                                               failonerror="true">
@@ -433,6 +423,7 @@ limitations under the License.
                                         <exec executable="env/bin/radish" dir="${project.build.directory}/python2"
                                               failonerror="true">
                                             <env key="PYTHONPATH" value=""/>
+                                            <env key="PYTHONIOENCODING" value="utf-8:surrogateescape"/>
                                             <arg line="-e -t -b ${project.build.directory}/python2/radish ${project.basedir}/../gremlin-test/features/"/> <!-- -no-line-jump -->
                                         </exec>
                                     </target>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -315,17 +315,27 @@ limitations under the License.
                                               failonerror="true">
                                             <arg line="--python=python2 env"/>
                                         </exec>
+                                        <!-- temporary manual installation of deps to hardcode colorful version given radish/PyHamcrest troubles -->
                                         <exec dir="${project.build.directory}/python2" executable="env/bin/pip"
                                               failonerror="true">
-                                            <arg line="install wheel radish-bdd PyHamcrest aenum"/>
+                                            <arg line="install wheel aenum pysingleton humanize radish-parse_type docopt 'colorful==0.4.0' 'tag-expressions>=1.0.0'"/>
+                                        </exec>
+                                        <exec dir="${project.build.directory}/python2" executable="env/bin/pip"
+                                              failonerror="true">
+                                            <arg line="install radish-bdd PyHamcrest --no-deps"/>
                                         </exec>
                                         <exec dir="${project.build.directory}/python3" executable="virtualenv"
                                               failonerror="true">
                                             <arg line="--python=python3 env"/>
                                         </exec>
+                                        <!-- temporary manual installation of deps to hardcode colorful version given radish/PyHamcrest troubles -->
                                         <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
                                               failonerror="true">
-                                            <arg line="install wheel radish-bdd PyHamcrest aenum"/>
+                                            <arg line="install wheel aenum pysingleton humanize radish-parse_type docopt 'colorful==0.4.0' 'tag-expressions>=1.0.0'"/>
+                                        </exec>
+                                        <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
+                                              failonerror="true">
+                                            <arg line="install radish-bdd PyHamcrest --no-deps"/>
                                         </exec>
                                         <exec dir="${project.build.directory}/python-packaged" executable="virtualenv"
                                               failonerror="true">

--- a/gremlin-python/src/main/jython/radish/feature_steps.py
+++ b/gremlin-python/src/main/jython/radish/feature_steps.py
@@ -33,6 +33,8 @@ regex_in = re.compile(r"([(.,\s])in\(")
 regex_is = re.compile(r"([(.,\s])is\(")
 regex_not = re.compile(r"([(.,\s])not\(")
 regex_or = re.compile(r"([(.,\s])or\(")
+regex_true = re.compile(r"(true)")
+regex_false = re.compile(r"(false)")
 
 
 ignores = [
@@ -157,6 +159,8 @@ def _convert(val, ctx):
         return Path([set([])], path_objects)
     elif isinstance(val, str) and re.match("^c\[.*\]$", val):         # parse lambda/closure
         return lambda: (val[2:-1], "gremlin-groovy")
+    elif isinstance(val, str) and re.match("^t\[.*\]$", val):         # parse instance of T enum
+        return T[val[2:-1]]
     else:
         return val
 
@@ -209,7 +213,9 @@ def _translate(traversal):
     replaced = regex_is.sub(r"\1is_(", replaced)
     replaced = regex_not.sub(r"\1not_(", replaced)
     replaced = regex_or.sub(r"\1or_(", replaced)
-    return regex_in.sub(r"\1in_(", replaced)
+    replaced = regex_in.sub(r"\1in_(", replaced)
+    replaced = regex_true.sub(r"True", replaced)
+    return regex_false.sub(r"False", replaced)
 
 
 def _make_traversal(g, traversal_string, params):

--- a/gremlin-test/features/map/ValueMap.feature
+++ b/gremlin-test/features/map/ValueMap.feature
@@ -33,6 +33,22 @@ Feature: Step - valueMap()
       | m[{"name": ["lop"], "lang": ["java"]}] |
       | m[{"name": ["ripple"], "lang": ["java"]}] |
 
+  Scenario: g_V_valueMapXtrueX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().valueMap(true)
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"id": "v[marko].id", "label": "person", "name": ["marko"], "age": [29]}] |
+      | m[{"id": "v[josh].id", "label": "person", "name": ["josh"], "age": [32]}] |
+      | m[{"id": "v[peter].id", "label": "person", "name": ["peter"], "age": [35]}] |
+      | m[{"id": "v[vadas].id", "label": "person", "name": ["vadas"], "age": [27]}] |
+      | m[{"id": "v[lop].id", "label": "software", "name": ["lop"], "lang": ["java"]}] |
+      | m[{"id": "v[ripple].id", "label": "software", "name": ["ripple"], "lang": ["java"]}] |
+
   Scenario: g_V_valueMapXname_ageX
     Given the modern graph
     And the traversal of
@@ -48,6 +64,22 @@ Feature: Step - valueMap()
       | m[{"name": ["vadas"], "age": [27]}] |
       | m[{"name": ["lop"]}] |
       | m[{"name": ["ripple"]}] |
+
+  Scenario: g_V_valueMapXtrue_name_ageX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().valueMap(true, "name", "age")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"id": "v[marko].id", "label": "person", "name": ["marko"], "age": [29]}] |
+      | m[{"id": "v[josh].id", "label": "person", "name": ["josh"], "age": [32]}] |
+      | m[{"id": "v[peter].id", "label": "person", "name": ["peter"], "age": [35]}] |
+      | m[{"id": "v[vadas].id", "label": "person", "name": ["vadas"], "age": [27]}] |
+      | m[{"id": "v[lop].id", "label": "software", "name": ["lop"]}] |
+      | m[{"id": "v[ripple].id", "label": "software", "name": ["ripple"]}] |
 
   Scenario: g_VX1X_outXcreatedX_valueMap
     Given the modern graph

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -1865,7 +1865,7 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public void loadState(final Graph graph, final Configuration configuration) {
+        public void loadState(final Configuration configuration, final Graph... graphs) {
             this.state = configuration.getString("state");
         }
 
@@ -2514,7 +2514,7 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
 
 
         @Override
-        public void loadState(final Graph graph, final Configuration config) {
+        public void loadState(final Configuration config, final Graph... graphs) {
             configuration = new BaseConfiguration();
             if (config != null) {
                 ConfigurationUtils.copy(config, configuration);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -2483,15 +2483,11 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
 
             @SuppressWarnings("unchecked")
             @Override
-            public VertexProgramQ create(final Graph graph) {
-                if (graph != null) {
-                    ConfigurationUtils.append(graph.configuration().subset(VERTEX_PROGRAM_Q_CFG_PREFIX), configuration);
+            public VertexProgramQ create(final Graph... graphs) {
+                if (graphs != null && graphs.length > 0) {
+                    ConfigurationUtils.append(graphs[0].configuration().subset(VERTEX_PROGRAM_Q_CFG_PREFIX), configuration);
                 }
-                return (VertexProgramQ) VertexProgram.createVertexProgram(graph, configuration);
-            }
-
-            public VertexProgramQ create() {
-                return create(null);
+                return (VertexProgramQ) VertexProgram.createVertexProgram(configuration, graphs);
             }
 
             public Builder property(final String name) {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/UnionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/UnionTest.java
@@ -31,13 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.inE;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.label;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.repeat;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.union;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -60,6 +54,8 @@ public abstract class UnionTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Number> get_g_VX1_2X_unionXoutE_count__inE_count__outE_weight_sumX(final Object v1Id, final Object v2Id);
 
     public abstract Traversal<Vertex, Number> get_g_VX1_2X_localXunionXoutE_count__inE_count__outE_weight_sumXX(final Object v1Id, final Object v2Id);
+
+    public abstract Traversal<Vertex, Number> get_g_VX1_2X_localXunionXcountXX(final Object v1Id, final Object v2Id);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -144,6 +140,14 @@ public abstract class UnionTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
+    public void g_VX1_2X_localXunionXcountXX() {
+        final Traversal<Vertex, Number> traversal = get_g_VX1_2X_localXunionXcountXX(convertToVertexId("marko"), convertToVertexId("vadas"));
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(1L, 1L), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
     public void g_VX1_2X_unionXoutE_count__inE_count__outE_weight_sumX() {
         final Traversal<Vertex, Number> traversal = get_g_VX1_2X_unionXoutE_count__inE_count__outE_weight_sumX(convertToVertexId("marko"), convertToVertexId("vadas"));
         printTraversalForm(traversal);
@@ -191,6 +195,11 @@ public abstract class UnionTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Number> get_g_VX1_2X_localXunionXoutE_count__inE_count__outE_weight_sumXX(final Object v1Id, final Object v2Id) {
             return g.V(v1Id, v2Id).local(union(outE().count(), inE().count(), (Traversal) outE().values("weight").sum()));
+        }
+
+        @Override
+        public Traversal<Vertex, Number> get_g_VX1_2X_localXunionXcountXX(final Object v1Id, final Object v2Id) {
+            return g.V(v1Id, v2Id).local(union((Traversal) count()));
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProgramTest.java
@@ -168,8 +168,12 @@ public abstract class ProgramTest extends AbstractGremlinProcessTest {
         private final Set<MemoryComputeKey> memoryComputeKeys = new HashSet<>();
 
         @Override
-        public void loadState(final Graph graph, final Configuration configuration) {
-            VertexProgram.super.loadState(graph, configuration);
+        public void loadState(final Configuration configuration, final Graph... graphs) {
+            if (graphs.length != 1) {
+                throw new IllegalArgumentException("Must provide one graph to use, received " + graphs.length);
+            }
+            final Graph graph = graphs[0];
+            VertexProgram.super.loadState(configuration, graphs);
             this.traversal = PureTraversal.loadState(configuration, VertexProgramStep.ROOT_TRAVERSAL, graph);
             this.haltedTraversers = TraversalVertexProgram.loadHaltedTraversers(configuration);
             this.programStep = new TraversalMatrix<>(this.traversal.get()).getStepById(configuration.getString(ProgramVertexProgramStep.STEP_ID));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ValueMapTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ValueMapTest.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 /**
@@ -42,7 +44,11 @@ public abstract class ValueMapTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, List>> get_g_V_valueMap();
 
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_valueMapXtrueX();
+
     public abstract Traversal<Vertex, Map<String, List>> get_g_V_valueMapXname_ageX();
+
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_valueMapXtrue_name_ageX();
 
     public abstract Traversal<Vertex, Map<String, List<String>>> get_g_VX1X_outXcreatedX_valueMap(final Object v1Id);
 
@@ -69,6 +75,43 @@ public abstract class ValueMapTest extends AbstractGremlinProcessTest {
                 assertEquals("java", values.get("lang").get(0));
             } else if (name.equals("ripple")) {
                 assertEquals("java", values.get("lang").get(0));
+            } else {
+                throw new IllegalStateException("It is not possible to reach here: " + values);
+            }
+        }
+        assertEquals(6, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_valueMapXtrueX() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_valueMapXtrueX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            final Map<String, Object> values = traversal.next();
+            final String name = (String) ((List) values.get("name")).get(0);
+            assertEquals(4, values.size());
+            assertThat(values.containsKey(T.id), is(true));
+            if (name.equals("marko")) {
+                assertEquals(29, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("josh")) {
+                assertEquals(32, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("peter")) {
+                assertEquals(35, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("vadas")) {
+                assertEquals(27, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("lop")) {
+                assertEquals("java", ((List) values.get("lang")).get(0));
+                assertEquals("software", values.get(T.label));
+            } else if (name.equals("ripple")) {
+                assertEquals("java", ((List) values.get("lang")).get(0));
+                assertEquals("software", values.get(T.label));
             } else {
                 throw new IllegalStateException("It is not possible to reach here: " + values);
             }
@@ -113,6 +156,48 @@ public abstract class ValueMapTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
+    public void g_V_valueMapXtrue_name_ageX() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_valueMapXtrue_name_ageX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            final Map<String, Object> values = traversal.next();
+            final String name = (String) ((List) values.get("name")).get(0);
+            assertThat(values.containsKey(T.id), is(true));
+            if (name.equals("marko")) {
+                assertEquals(4, values.size());
+                assertEquals(29, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("josh")) {
+                assertEquals(4, values.size());
+                assertEquals(32, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("peter")) {
+                assertEquals(4, values.size());
+                assertEquals(35, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("vadas")) {
+                assertEquals(4, values.size());
+                assertEquals(27, ((List) values.get("age")).get(0));
+                assertEquals("person", values.get(T.label));
+            } else if (name.equals("lop")) {
+                assertEquals(3, values.size());
+                assertNull(values.get("lang"));
+                assertEquals("software", values.get(T.label));
+            } else if (name.equals("ripple")) {
+                assertEquals(3, values.size());
+                assertNull(values.get("lang"));
+                assertEquals("software", values.get(T.label));
+            } else {
+                throw new IllegalStateException("It is not possible to reach here: " + values);
+            }
+        }
+        assertEquals(6, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
     public void g_VX1X_outXcreatedX_valueMap() {
         final Traversal<Vertex, Map<String, List<String>>> traversal = get_g_VX1X_outXcreatedX_valueMap(convertToVertexId("marko"));
         printTraversalForm(traversal);
@@ -132,8 +217,18 @@ public abstract class ValueMapTest extends AbstractGremlinProcessTest {
         }
 
         @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_valueMapXtrueX() {
+            return g.V().valueMap(true);
+        }
+
+        @Override
         public Traversal<Vertex, Map<String, List>> get_g_V_valueMapXname_ageX() {
             return g.V().valueMap("name", "age");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_valueMapXtrue_name_ageX() {
+            return g.V().valueMap(true, "name", "age");
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
@@ -213,7 +213,7 @@ public class SerializationTest {
             final GryoWriter gryoWriter = gryoIo.writer().create();
             final GryoReader gryoReader = gryoIo.reader().create();
 
-            final TraversalMetrics before = (TraversalMetrics) g.V().both().profile().next();
+            final TraversalMetrics before = g.V().both().profile().next();
             final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             gryoWriter.writeObject(outputStream, before);
 
@@ -355,7 +355,7 @@ public class SerializationTest {
         @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
         public void shouldSerializeTraversalMetrics() throws Exception {
             final ObjectMapper mapper = graph.io(GraphSONIo.build()).mapper().create().createMapper();
-            final TraversalMetrics tm = (TraversalMetrics) g.V().both().profile().next();
+            final TraversalMetrics tm = g.V().both().profile().next();
             final String json = mapper.writeValueAsString(tm);
             final Map<String, Object> m = mapper.readValue(json, mapTypeReference);
 
@@ -363,7 +363,7 @@ public class SerializationTest {
             assertTrue(m.containsKey(GraphSONTokens.METRICS));
 
             final List<Map<String, Object>> metrics = (List<Map<String, Object>>) m.get(GraphSONTokens.METRICS);
-            assertEquals(2, metrics.size());
+            assertEquals(tm.getMetrics().size(), metrics.size());
 
             final Map<String, Object> metrics0 = metrics.get(0);
             assertTrue(metrics0.containsKey(GraphSONTokens.ID));

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkInterceptorStrategy.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkInterceptorStrategy.java
@@ -44,7 +44,7 @@ public final class SparkInterceptorStrategy extends AbstractTraversalStrategy<Tr
     public void apply(final Traversal.Admin<?, ?> traversal) {
         final Graph graph = traversal.getGraph().orElse(EmptyGraph.instance()); // best guess at what the graph will be as its dynamically determined
         for (final TraversalVertexProgramStep step : TraversalHelper.getStepsOfClass(TraversalVertexProgramStep.class, traversal)) {
-            final Traversal.Admin<?, ?> computerTraversal = step.generateProgram(graph, EmptyMemory.instance()).getTraversal().get().clone();
+            final Traversal.Admin<?, ?> computerTraversal = step.generateProgram(EmptyMemory.instance(), graph).getTraversal().get().clone();
             if (!computerTraversal.isLocked())
                 computerTraversal.applyStrategies();
             if (SparkStarBarrierInterceptor.isLegal(computerTraversal)) {

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkSingleIterationStrategy.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkSingleIterationStrategy.java
@@ -61,7 +61,7 @@ public final class SparkSingleIterationStrategy extends AbstractTraversalStrateg
     public void apply(final Traversal.Admin<?, ?> traversal) {
         final Graph graph = traversal.getGraph().orElse(EmptyGraph.instance()); // best guess at what the graph will be as its dynamically determined
         for (final TraversalVertexProgramStep step : TraversalHelper.getStepsOfClass(TraversalVertexProgramStep.class, traversal)) {
-            final Traversal.Admin<?, ?> computerTraversal = step.generateProgram(graph, EmptyMemory.instance()).getTraversal().get().clone();
+            final Traversal.Admin<?, ?> computerTraversal = step.generateProgram(EmptyMemory.instance(), graph).getTraversal().get().clone();
             if (!computerTraversal.isLocked())
                 computerTraversal.applyStrategies();
             ///


### PR DESCRIPTION
VertexProgram.Builder.create() now takes varargs Graphs instead of just a single Graph. This change has been propagated through all methods affected. Old API is kept but deprecated for interfaces. Implementations of these interfaces have been updated to use the new API. Possible test problems that I don't understand and build flags due to API change.