### PR TITLE
TINKERPOP-1867 union() can produce extra traversers 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Delayed setting of the request identifier until `RequestMessage` construction by the builder.
 * Removed hardcoded expectation in metrics serialization test suite as different providers may have different outputs.
+* Fixed a bug in `ComputerAwareStep` that didn't handle `reset()` properly and thus occasionally produced some extra traversers.
 
 [[release-3-2-7]]
 === TinkerPop 3.2.7 (Release Date: December 17, 2017)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
@@ -59,6 +59,12 @@ public abstract class ComputerAwareStep<S, E> extends AbstractStep<S, E> impleme
         return clone;
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        this.previousIterator = EmptyIterator.instance();
+    }
+
     protected abstract Iterator<Traverser.Admin<E>> standardAlgorithm() throws NoSuchElementException;
 
     protected abstract Iterator<Traverser.Admin<E>> computerAlgorithm() throws NoSuchElementException;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -208,6 +208,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     @Override
     public void reset() {
         this.steps.forEach(Step::reset);
+        this.finalEndStep.reset();
         this.lastTraverser = EmptyTraverser.instance();
     }
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyUnionTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyUnionTest.groovy
@@ -73,5 +73,11 @@ public abstract class GroovyUnionTest {
                 final Object v1Id, final Object v2Id) {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id, v2Id).local(union(outE().count, inE().count, outE().weight.sum))", "v1Id", v1Id, "v2Id", v2Id);
         }
+
+        @Override
+        public Traversal<Vertex, Number> get_g_VX1_2X_localXunionXcountXX(
+                final Object v1Id, final Object v2Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id, v2Id).local(union(count()))", "v1Id", v1Id, "v2Id", v2Id);
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/UnionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/UnionTest.java
@@ -31,13 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.inE;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.label;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.repeat;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.union;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -60,6 +54,8 @@ public abstract class UnionTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Number> get_g_VX1_2X_unionXoutE_count__inE_count__outE_weight_sumX(final Object v1Id, final Object v2Id);
 
     public abstract Traversal<Vertex, Number> get_g_VX1_2X_localXunionXoutE_count__inE_count__outE_weight_sumXX(final Object v1Id, final Object v2Id);
+
+    public abstract Traversal<Vertex, Number> get_g_VX1_2X_localXunionXcountXX(final Object v1Id, final Object v2Id);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -144,6 +140,14 @@ public abstract class UnionTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
+    public void g_VX1_2X_localXunionXcountXX() {
+        final Traversal<Vertex, Number> traversal = get_g_VX1_2X_localXunionXcountXX(convertToVertexId("marko"), convertToVertexId("vadas"));
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(1L, 1L), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
     public void g_VX1_2X_unionXoutE_count__inE_count__outE_weight_sumX() {
         final Traversal<Vertex, Number> traversal = get_g_VX1_2X_unionXoutE_count__inE_count__outE_weight_sumX(convertToVertexId("marko"), convertToVertexId("vadas"));
         printTraversalForm(traversal);
@@ -191,6 +195,11 @@ public abstract class UnionTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Number> get_g_VX1_2X_localXunionXoutE_count__inE_count__outE_weight_sumXX(final Object v1Id, final Object v2Id) {
             return g.V(v1Id, v2Id).local(union(outE().count(), inE().count(), (Traversal) outE().values("weight").sum()));
+        }
+
+        @Override
+        public Traversal<Vertex, Number> get_g_VX1_2X_localXunionXcountXX(final Object v1Id, final Object v2Id) {
+            return g.V(v1Id, v2Id).local(union((Traversal) count()));
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1867

Implemented `reset()` in `ComputerAwareStep` to reset the `previousIterator`, and reset the `finalStep` in `DefaultTraversal`.

This fixes the false behavior, mainly seen in reducing barrier steps.

```
$ docker/build.sh -t -i
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Apache TinkerPop .................................. SUCCESS [1:45.623s]
[INFO] Apache TinkerPop :: Gremlin Shaded ................ SUCCESS [21.575s]
[INFO] Apache TinkerPop :: Gremlin Core .................. SUCCESS [57.690s]
[INFO] Apache TinkerPop :: Gremlin Test .................. SUCCESS [6.146s]
[INFO] Apache TinkerPop :: Gremlin Groovy ................ SUCCESS [3:03.207s]
[INFO] Apache TinkerPop :: Gremlin Groovy Test ........... SUCCESS [4.203s]
[INFO] Apache TinkerPop :: TinkerGraph Gremlin ........... SUCCESS [2:59.389s]
[INFO] Apache TinkerPop :: Gremlin Benchmark ............. SUCCESS [7.549s]
[INFO] Apache TinkerPop :: Gremlin Driver ................ SUCCESS [1:31.627s]
[INFO] Apache TinkerPop :: Neo4j Gremlin ................. SUCCESS [0.936s]
[INFO] Apache TinkerPop :: Gremlin Server ................ SUCCESS [15:29.995s]
[INFO] Apache TinkerPop :: Gremlin Python ................ SUCCESS [2:40.883s]
[INFO] Apache TinkerPop :: Gremlin.Net ................... SUCCESS [2.247s]
[INFO] Apache TinkerPop :: Gremlin.Net - Source .......... SUCCESS [44.422s]
[INFO] Apache TinkerPop :: Gremlin.Net - Tests ........... SUCCESS [44.304s]
[INFO] Apache TinkerPop :: Hadoop Gremlin ................ SUCCESS [6:30.134s]
[INFO] Apache TinkerPop :: Spark Gremlin ................. SUCCESS [15:04.061s]
[INFO] Apache TinkerPop :: Giraph Gremlin ................ SUCCESS [2:23:46.498s]
[INFO] Apache TinkerPop :: Gremlin Console ............... SUCCESS [4:00.598s]
[INFO] Apache TinkerPop :: Gremlin Archetype ............. SUCCESS [0.080s]
[INFO] Apache TinkerPop :: Archetype - TinkerGraph ....... SUCCESS [33.522s]
[INFO] Apache TinkerPop :: Archetype - Server ............ SUCCESS [15.100s]
[INFO] Apache TinkerPop :: Archetype - DSL ............... SUCCESS [3.588s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3:21:02.647s
[INFO] Finished at: Wed Jan 10 01:21:22 UTC 2018
[INFO] Final Memory: 173M/631M
[INFO] ------------------------------------------------------------------------
```

VOTE: +1