### PR TITLE
TINKERPOP-1868 Gremlin.Net: Add Inject step to GraphTraversalSource

### DIFF
--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -65,10 +65,10 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the <%= method.methodName %> step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< <%= method.t1 %> , <%= method.t2 %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
+        public GraphTraversal<$method.t1, $method.t2> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
         {
         <%  if (method.parameters.contains("params ")) {
-      %>    var args = new List< <%= method.argsListType %> >(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+      %>    var args = new List<$method.argsListType>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }
@@ -76,7 +76,7 @@ namespace Gremlin.Net.Process.Traversal
       %>    Bytecode.AddStep("<%= method.methodName %>"<% if (method.parameters) out << ', '+ method.paramNames.join(", ") %>);<%
             }
         %>
-            return Wrap< <%= method.t1 %> , <%= method.t2 %> >(this);
+            return Wrap<$method.t1, $method.t2>(this);
         }
 <% } %>
     }

--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -68,7 +68,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< <%= method.t1 %> , <%= method.t2 %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
         {
         <%  if (method.parameters.contains("params ")) {
-      %>    var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+      %>    var args = new List< <%= method.argsListType %> >(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -127,11 +127,11 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the <%= method.methodName %> step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< <%= method.typeNames.join(",") %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(<%= method.parameters %>)
+        public GraphTraversal<$method.typeNameString> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(<%= method.parameters %>)
         {
-            var traversal = new GraphTraversal< <%= method.typeNames.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<$method.typeNameString>(TraversalStrategies, new Bytecode(Bytecode));
             <%  if (method.parameters.contains("params ")) {
-          %>var args = new List< <%= method.argsListType %> >(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+          %>var args = new List<$method.argsListType>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             traversal.Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -127,9 +127,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the <%= method.methodName %> step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< <%= method.typeArguments.join(",") %> > <%= toCSharpMethodName.call(method.methodName) %>(<%= method.parameters %>)
+        public GraphTraversal< <%= method.typeNames.join(",") %> > <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %>(<%= method.parameters %>)
         {
-            var traversal = new GraphTraversal< <%= method.typeArguments.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal< <%= method.typeNames.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));
             <%  if (method.parameters.contains("params ")) {
           %>var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -131,7 +131,7 @@ namespace Gremlin.Net.Process.Traversal
         {
             var traversal = new GraphTraversal< <%= method.typeNames.join(",") %> >(TraversalStrategies, new Bytecode(Bytecode));
             <%  if (method.parameters.contains("params ")) {
-          %>var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+          %>var args = new List< <%= method.argsListType %> >(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
             args.AddRange(<%= method.paramNames.last() %>);
             traversal.Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -81,6 +81,9 @@ def getCSharpGenericTypeParam = { typeName ->
     else if (typeName.contains("<K, ")) {
         tParam = "<K>"
     }
+    else if (typeName.contains("S")) {
+        tParam = "<S>"
+    }
     return tParam
 }
 
@@ -234,15 +237,17 @@ def binding = ["pmethods": P.class.getMethods().
                             return ["methodName": javaMethod.name, "parameters":parameters, "paramNames":paramNames]
                         },
                "sourceSpawnMethods": GraphTraversalSource.getMethods(). // SPAWN STEPS
-                        findAll { GraphTraversal.class.equals(it.returnType) && !it.name.equals('inject')}.          
+                        findAll { GraphTraversal.class.equals(it.returnType) }.          
                 // Select unique combination of C# parameter types and sort by Java parameter type combination                                                                    
                         sort { a, b -> a.name <=> b.name ?: getJavaParamTypeString(a) <=> getJavaParamTypeString(b) }.
                         unique { a,b -> a.name <=> b.name ?: getCSharpParamTypeString(a) <=> getCSharpParamTypeString(b) }.
                         collect { javaMethod ->
-                            def typeArguments = javaMethod.genericReturnType.actualTypeArguments.collect{t -> ((java.lang.Class)t).simpleName}
-                            def parameters = getCSharpParamString(javaMethod, false)
+                            def typeNames = getJavaGenericTypeParameterTypeNames(javaMethod)
+                            def t2 = toCSharpType(typeNames[1])
+                            def tParam = getCSharpGenericTypeParam(t2)
+                            def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
-                            return ["methodName": javaMethod.name, "typeArguments": typeArguments, "parameters":parameters, "paramNames":paramNames]
+                            return ["methodName": javaMethod.name, "typeNames": typeNames, "tParam":tParam, "parameters":parameters, "paramNames":paramNames]
                         },
                "graphStepMethods": GraphTraversal.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -265,12 +265,13 @@ def binding = ["pmethods": P.class.getMethods().
                         unique { a,b -> a.name <=> b.name ?: getCSharpParamTypeString(a) <=> getCSharpParamTypeString(b) }.
                         collect { javaMethod ->
                             def typeNames = getJavaGenericTypeParameterTypeNames(javaMethod)
+                            def typeNameString = typeNames.join(", ")
                             def t2 = toCSharpType(typeNames[1])
                             def tParam = getCSharpGenericTypeParam(t2)
                             def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
                             def argsListType = getArgsListType(parameters)
-                            return ["methodName": javaMethod.name, "typeNames": typeNames, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
+                            return ["methodName": javaMethod.name, "typeNameString": typeNameString, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
                         },
                "graphStepMethods": GraphTraversal.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
 import org.apache.tinkerpop.gremlin.structure.Direction
 import java.lang.reflect.Modifier
 import java.lang.reflect.TypeVariable
+import java.lang.reflect.GenericArrayType
 
 def toCSharpTypeMap = ["Long": "long",
                        "Integer": "int",
@@ -84,6 +85,9 @@ def getCSharpGenericTypeParam = { typeName ->
     else if (typeName.contains("S")) {
         tParam = "<S>"
     }
+    else if (typeName.contains("A")) {
+        tParam = "<A>"
+    }
     return tParam
 }
 
@@ -127,6 +131,9 @@ def toCSharpParamString = { param, genTypeName ->
     else if (csharpParamTypeName == "M") {
         csharpParamTypeName = "object";
     }
+    else if (csharpParamTypeName == "A[]") {
+        csharpParamTypeName = "object[]";
+    }
     else if (csharpParamTypeName == "A" || csharpParamTypeName == "B") {
         csharpParamTypeName = "E2";
     }
@@ -159,6 +166,11 @@ def getCSharpParamString = { method, useGenericParams ->
                     if (genType instanceof TypeVariable<?>) {
                         genTypeName = ((TypeVariable<?>)genType).name
                     }
+                    else if (genType instanceof GenericArrayType) {
+                        if (((GenericArrayType)genType).getGenericComponentType() instanceof TypeVariable<?>) {
+                            genTypeName = ((TypeVariable<?>)((GenericArrayType)genType).getGenericComponentType()).name + "[]"
+                        }                        
+                    }
                 }
                 toCSharpParamString(param, genTypeName)
             }.
@@ -177,6 +189,16 @@ def getParamNames = { parameters ->
         collect { param ->
             param.name
         }
+}
+
+def getArgsListType = { parameterString ->
+    def argsListType = "object"
+    if (parameterString.contains("params ")) {
+        def paramsType = parameterString.substring(parameterString.indexOf("params ") + "params ".length(), parameterString.indexOf("[]"))
+        if (paramsType == "E" || paramsType == "S")
+            argsListType = paramsType
+    }
+    argsListType
 }
 
 def hasMethodNoGenericCounterPartInGraphTraversal = { method ->
@@ -247,7 +269,8 @@ def binding = ["pmethods": P.class.getMethods().
                             def tParam = getCSharpGenericTypeParam(t2)
                             def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
-                            return ["methodName": javaMethod.name, "typeNames": typeNames, "tParam":tParam, "parameters":parameters, "paramNames":paramNames]
+                            def argsListType = getArgsListType(parameters)
+                            return ["methodName": javaMethod.name, "typeNames": typeNames, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
                         },
                "graphStepMethods": GraphTraversal.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.
@@ -262,7 +285,8 @@ def binding = ["pmethods": P.class.getMethods().
                             def tParam = getCSharpGenericTypeParam(t2)
                             def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
-                            return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames]
+                            def argsListType = getArgsListType(parameters)
+                            return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
                         },
                "anonStepMethods": __.class.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -65,1614 +65,1614 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the V step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > V (params object[] vertexIdsOrElements)
+        public GraphTraversal<S, Vertex> V (params object[] vertexIdsOrElements)
         {
-            var args = new List< object >(0 + vertexIdsOrElements.Length) {};
+            var args = new List<object>(0 + vertexIdsOrElements.Length) {};
             args.AddRange(vertexIdsOrElements);
             Bytecode.AddStep("V", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the addE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddE (Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
+        public GraphTraversal<S, Edge> AddE (Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List< object >(3 + propertyKeyValues.Length) {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List<object>(3 + propertyKeyValues.Length) {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddE (string edgeLabel)
+        public GraphTraversal<S, Edge> AddE (string edgeLabel)
         {
             Bytecode.AddStep("addE", edgeLabel);
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addInE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddInE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
+        public GraphTraversal<S, Edge> AddInE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List< object >(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addInE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addOutE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > AddOutE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
+        public GraphTraversal<S, Edge> AddOutE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List< object >(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addOutE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > AddV ()
+        public GraphTraversal<S, Vertex> AddV ()
         {
             Bytecode.AddStep("addV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > AddV (params object[] propertyKeyValues)
+        public GraphTraversal<S, Vertex> AddV (params object[] propertyKeyValues)
         {
-            var args = new List< object >(0 + propertyKeyValues.Length) {};
+            var args = new List<object>(0 + propertyKeyValues.Length) {};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addV", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the addV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > AddV (string vertexLabel)
+        public GraphTraversal<S, Vertex> AddV (string vertexLabel)
         {
             Bytecode.AddStep("addV", vertexLabel);
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the aggregate step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Aggregate (string sideEffectKey)
+        public GraphTraversal<S, E> Aggregate (string sideEffectKey)
         {
             Bytecode.AddStep("aggregate", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the and step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > And (params ITraversal[] andTraversals)
+        public GraphTraversal<S, E> And (params ITraversal[] andTraversals)
         {
-            var args = new List< object >(0 + andTraversals.Length) {};
+            var args = new List<object>(0 + andTraversals.Length) {};
             args.AddRange(andTraversals);
             Bytecode.AddStep("and", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the as step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > As (string stepLabel, params string[] stepLabels)
+        public GraphTraversal<S, E> As (string stepLabel, params string[] stepLabels)
         {
-            var args = new List< object >(1 + stepLabels.Length) {stepLabel};
+            var args = new List<object>(1 + stepLabels.Length) {stepLabel};
             args.AddRange(stepLabels);
             Bytecode.AddStep("as", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Barrier ()
+        public GraphTraversal<S, E> Barrier ()
         {
             Bytecode.AddStep("barrier");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Barrier (object barrierConsumer)
+        public GraphTraversal<S, E> Barrier (object barrierConsumer)
         {
             Bytecode.AddStep("barrier", barrierConsumer);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the barrier step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Barrier (int maxBarrierSize)
+        public GraphTraversal<S, E> Barrier (int maxBarrierSize)
         {
             Bytecode.AddStep("barrier", maxBarrierSize);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the both step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > Both (params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> Both (params string[] edgeLabels)
         {
-            var args = new List< object >(0 + edgeLabels.Length) {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("both", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the bothE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > BothE (params string[] edgeLabels)
+        public GraphTraversal<S, Edge> BothE (params string[] edgeLabels)
         {
-            var args = new List< object >(0 + edgeLabels.Length) {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("bothE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the bothV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > BothV ()
+        public GraphTraversal<S, Vertex> BothV ()
         {
             Bytecode.AddStep("bothV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the branch step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Branch<E2> (object function)
+        public GraphTraversal<S, E2> Branch<E2> (object function)
         {
             Bytecode.AddStep("branch", function);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the branch step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Branch<E2> (ITraversal branchTraversal)
+        public GraphTraversal<S, E2> Branch<E2> (ITraversal branchTraversal)
         {
             Bytecode.AddStep("branch", branchTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By ()
+        public GraphTraversal<S, E> By ()
         {
             Bytecode.AddStep("by");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (object comparator)
+        public GraphTraversal<S, E> By (object comparator)
         {
             Bytecode.AddStep("by", comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (object function, object comparator)
+        public GraphTraversal<S, E> By (object function, object comparator)
         {
             Bytecode.AddStep("by", function, comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (Order order)
+        public GraphTraversal<S, E> By (Order order)
         {
             Bytecode.AddStep("by", order);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (string key)
+        public GraphTraversal<S, E> By (string key)
         {
             Bytecode.AddStep("by", key);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (string key, object comparator)
+        public GraphTraversal<S, E> By (string key, object comparator)
         {
             Bytecode.AddStep("by", key, comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (T token)
+        public GraphTraversal<S, E> By (T token)
         {
             Bytecode.AddStep("by", token);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (ITraversal traversal)
+        public GraphTraversal<S, E> By (ITraversal traversal)
         {
             Bytecode.AddStep("by", traversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the by step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > By (ITraversal traversal, object comparator)
+        public GraphTraversal<S, E> By (ITraversal traversal, object comparator)
         {
             Bytecode.AddStep("by", traversal, comparator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the cap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Cap<E2> (string sideEffectKey, params string[] sideEffectKeys)
+        public GraphTraversal<S, E2> Cap<E2> (string sideEffectKey, params string[] sideEffectKeys)
         {
-            var args = new List< object >(1 + sideEffectKeys.Length) {sideEffectKey};
+            var args = new List<object>(1 + sideEffectKeys.Length) {sideEffectKey};
             args.AddRange(sideEffectKeys);
             Bytecode.AddStep("cap", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (object choiceFunction)
+        public GraphTraversal<S, E2> Choose<E2> (object choiceFunction)
         {
             Bytecode.AddStep("choose", choiceFunction);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice)
+        public GraphTraversal<S, E2> Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice)
         {
             Bytecode.AddStep("choose", choosePredicate, trueChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice, ITraversal falseChoice)
+        public GraphTraversal<S, E2> Choose<E2> (TraversalPredicate choosePredicate, ITraversal trueChoice, ITraversal falseChoice)
         {
             Bytecode.AddStep("choose", choosePredicate, trueChoice, falseChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (ITraversal choiceTraversal)
+        public GraphTraversal<S, E2> Choose<E2> (ITraversal choiceTraversal)
         {
             Bytecode.AddStep("choose", choiceTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice)
+        public GraphTraversal<S, E2> Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice)
         {
             Bytecode.AddStep("choose", traversalPredicate, trueChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the choose step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice, ITraversal falseChoice)
+        public GraphTraversal<S, E2> Choose<E2> (ITraversal traversalPredicate, ITraversal trueChoice, ITraversal falseChoice)
         {
             Bytecode.AddStep("choose", traversalPredicate, trueChoice, falseChoice);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the coalesce step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Coalesce<E2> (params ITraversal[] coalesceTraversals)
+        public GraphTraversal<S, E2> Coalesce<E2> (params ITraversal[] coalesceTraversals)
         {
-            var args = new List< object >(0 + coalesceTraversals.Length) {};
+            var args = new List<object>(0 + coalesceTraversals.Length) {};
             args.AddRange(coalesceTraversals);
             Bytecode.AddStep("coalesce", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the coin step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Coin (double probability)
+        public GraphTraversal<S, E> Coin (double probability)
         {
             Bytecode.AddStep("coin", probability);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the constant step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Constant<E2> (E2 e)
+        public GraphTraversal<S, E2> Constant<E2> (E2 e)
         {
             Bytecode.AddStep("constant", e);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the count step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , long > Count ()
+        public GraphTraversal<S, long> Count ()
         {
             Bytecode.AddStep("count");
-            return Wrap< S , long >(this);
+            return Wrap<S, long>(this);
         }
 
         /// <summary>
         ///     Adds the count step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , long > Count (Scope scope)
+        public GraphTraversal<S, long> Count (Scope scope)
         {
             Bytecode.AddStep("count", scope);
-            return Wrap< S , long >(this);
+            return Wrap<S, long>(this);
         }
 
         /// <summary>
         ///     Adds the cyclicPath step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > CyclicPath ()
+        public GraphTraversal<S, E> CyclicPath ()
         {
             Bytecode.AddStep("cyclicPath");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the dedup step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Dedup (Scope scope, params string[] dedupLabels)
+        public GraphTraversal<S, E> Dedup (Scope scope, params string[] dedupLabels)
         {
-            var args = new List< object >(1 + dedupLabels.Length) {scope};
+            var args = new List<object>(1 + dedupLabels.Length) {scope};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the dedup step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Dedup (params string[] dedupLabels)
+        public GraphTraversal<S, E> Dedup (params string[] dedupLabels)
         {
-            var args = new List< object >(0 + dedupLabels.Length) {};
+            var args = new List<object>(0 + dedupLabels.Length) {};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the drop step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Drop ()
+        public GraphTraversal<S, E> Drop ()
         {
             Bytecode.AddStep("drop");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Emit ()
+        public GraphTraversal<S, E> Emit ()
         {
             Bytecode.AddStep("emit");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Emit (TraversalPredicate emitPredicate)
+        public GraphTraversal<S, E> Emit (TraversalPredicate emitPredicate)
         {
             Bytecode.AddStep("emit", emitPredicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the emit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Emit (ITraversal emitTraversal)
+        public GraphTraversal<S, E> Emit (ITraversal emitTraversal)
         {
             Bytecode.AddStep("emit", emitTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the filter step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Filter (TraversalPredicate predicate)
+        public GraphTraversal<S, E> Filter (TraversalPredicate predicate)
         {
             Bytecode.AddStep("filter", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the filter step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Filter (ITraversal filterTraversal)
+        public GraphTraversal<S, E> Filter (ITraversal filterTraversal)
         {
             Bytecode.AddStep("filter", filterTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the flatMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > FlatMap<E2> (object function)
+        public GraphTraversal<S, E2> FlatMap<E2> (object function)
         {
             Bytecode.AddStep("flatMap", function);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the flatMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > FlatMap<E2> (ITraversal flatMapTraversal)
+        public GraphTraversal<S, E2> FlatMap<E2> (ITraversal flatMapTraversal)
         {
             Bytecode.AddStep("flatMap", flatMapTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the fold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IList<E> > Fold ()
+        public GraphTraversal<S, IList<E>> Fold ()
         {
             Bytecode.AddStep("fold");
-            return Wrap< S , IList<E> >(this);
+            return Wrap<S, IList<E>>(this);
         }
 
         /// <summary>
         ///     Adds the fold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Fold<E2> (E2 seed, object foldFunction)
+        public GraphTraversal<S, E2> Fold<E2> (E2 seed, object foldFunction)
         {
             Bytecode.AddStep("fold", seed, foldFunction);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the from step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > From (string fromStepLabel)
+        public GraphTraversal<S, E> From (string fromStepLabel)
         {
             Bytecode.AddStep("from", fromStepLabel);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the from step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > From (ITraversal fromVertex)
+        public GraphTraversal<S, E> From (ITraversal fromVertex)
         {
             Bytecode.AddStep("from", fromVertex);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<K, V> > Group<K, V> ()
+        public GraphTraversal<S, IDictionary<K, V>> Group<K, V> ()
         {
             Bytecode.AddStep("group");
-            return Wrap< S , IDictionary<K, V> >(this);
+            return Wrap<S, IDictionary<K, V>>(this);
         }
 
         /// <summary>
         ///     Adds the group step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Group (string sideEffectKey)
+        public GraphTraversal<S, E> Group (string sideEffectKey)
         {
             Bytecode.AddStep("group", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the groupCount step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<K, long> > GroupCount<K> ()
+        public GraphTraversal<S, IDictionary<K, long>> GroupCount<K> ()
         {
             Bytecode.AddStep("groupCount");
-            return Wrap< S , IDictionary<K, long> >(this);
+            return Wrap<S, IDictionary<K, long>>(this);
         }
 
         /// <summary>
         ///     Adds the groupCount step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > GroupCount (string sideEffectKey)
+        public GraphTraversal<S, E> GroupCount (string sideEffectKey)
         {
             Bytecode.AddStep("groupCount", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the groupV3d0 step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<K, V> > GroupV3d0<K, V> ()
+        public GraphTraversal<S, IDictionary<K, V>> GroupV3d0<K, V> ()
         {
             Bytecode.AddStep("groupV3d0");
-            return Wrap< S , IDictionary<K, V> >(this);
+            return Wrap<S, IDictionary<K, V>>(this);
         }
 
         /// <summary>
         ///     Adds the groupV3d0 step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > GroupV3d0 (string sideEffectKey)
+        public GraphTraversal<S, E> GroupV3d0 (string sideEffectKey)
         {
             Bytecode.AddStep("groupV3d0", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey)
+        public GraphTraversal<S, E> Has (string propertyKey)
         {
             Bytecode.AddStep("has", propertyKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey, object value)
+        public GraphTraversal<S, E> Has (string propertyKey, object value)
         {
             Bytecode.AddStep("has", propertyKey, value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Has (string propertyKey, TraversalPredicate predicate)
         {
             Bytecode.AddStep("has", propertyKey, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string label, string propertyKey, object value)
+        public GraphTraversal<S, E> Has (string label, string propertyKey, object value)
         {
             Bytecode.AddStep("has", label, propertyKey, value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string label, string propertyKey, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Has (string label, string propertyKey, TraversalPredicate predicate)
         {
             Bytecode.AddStep("has", label, propertyKey, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (string propertyKey, ITraversal propertyTraversal)
+        public GraphTraversal<S, E> Has (string propertyKey, ITraversal propertyTraversal)
         {
             Bytecode.AddStep("has", propertyKey, propertyTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (T accessor, object value)
+        public GraphTraversal<S, E> Has (T accessor, object value)
         {
             Bytecode.AddStep("has", accessor, value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (T accessor, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Has (T accessor, TraversalPredicate predicate)
         {
             Bytecode.AddStep("has", accessor, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the has step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Has (T accessor, ITraversal propertyTraversal)
+        public GraphTraversal<S, E> Has (T accessor, ITraversal propertyTraversal)
         {
             Bytecode.AddStep("has", accessor, propertyTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasId step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasId (object id, params object[] otherIds)
+        public GraphTraversal<S, E> HasId (object id, params object[] otherIds)
         {
-            var args = new List< object >(1 + otherIds.Length) {id};
+            var args = new List<object>(1 + otherIds.Length) {id};
             args.AddRange(otherIds);
             Bytecode.AddStep("hasId", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasId step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasId (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasId (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasId", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasKey step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasKey (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasKey (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasKey", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasKey step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasKey (string label, params string[] otherLabels)
+        public GraphTraversal<S, E> HasKey (string label, params string[] otherLabels)
         {
-            var args = new List< object >(1 + otherLabels.Length) {label};
+            var args = new List<object>(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasKey", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasLabel step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasLabel (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasLabel (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasLabel", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasLabel step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasLabel (string label, params string[] otherLabels)
+        public GraphTraversal<S, E> HasLabel (string label, params string[] otherLabels)
         {
-            var args = new List< object >(1 + otherLabels.Length) {label};
+            var args = new List<object>(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasLabel", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasNot step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasNot (string propertyKey)
+        public GraphTraversal<S, E> HasNot (string propertyKey)
         {
             Bytecode.AddStep("hasNot", propertyKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasValue step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasValue (object value, params object[] otherValues)
+        public GraphTraversal<S, E> HasValue (object value, params object[] otherValues)
         {
-            var args = new List< object >(1 + otherValues.Length) {value};
+            var args = new List<object>(1 + otherValues.Length) {value};
             args.AddRange(otherValues);
             Bytecode.AddStep("hasValue", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the hasValue step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > HasValue (TraversalPredicate predicate)
+        public GraphTraversal<S, E> HasValue (TraversalPredicate predicate)
         {
             Bytecode.AddStep("hasValue", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the id step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , object > Id ()
+        public GraphTraversal<S, object> Id ()
         {
             Bytecode.AddStep("id");
-            return Wrap< S , object >(this);
+            return Wrap<S, object>(this);
         }
 
         /// <summary>
         ///     Adds the identity step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Identity ()
+        public GraphTraversal<S, E> Identity ()
         {
             Bytecode.AddStep("identity");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the in step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > In (params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> In (params string[] edgeLabels)
         {
-            var args = new List< object >(0 + edgeLabels.Length) {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("in", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the inE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > InE (params string[] edgeLabels)
+        public GraphTraversal<S, Edge> InE (params string[] edgeLabels)
         {
-            var args = new List< object >(0 + edgeLabels.Length) {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("inE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the inV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > InV ()
+        public GraphTraversal<S, Vertex> InV ()
         {
             Bytecode.AddStep("inV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the inject step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Inject (params E[] injections)
+        public GraphTraversal<S, E> Inject (params E[] injections)
         {
-            var args = new List< E >(0 + injections.Length) {};
+            var args = new List<E>(0 + injections.Length) {};
             args.AddRange(injections);
             Bytecode.AddStep("inject", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the is step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Is (object value)
+        public GraphTraversal<S, E> Is (object value)
         {
             Bytecode.AddStep("is", value);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the is step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Is (TraversalPredicate predicate)
+        public GraphTraversal<S, E> Is (TraversalPredicate predicate)
         {
             Bytecode.AddStep("is", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the key step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , string > Key ()
+        public GraphTraversal<S, string> Key ()
         {
             Bytecode.AddStep("key");
-            return Wrap< S , string >(this);
+            return Wrap<S, string>(this);
         }
 
         /// <summary>
         ///     Adds the label step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , string > Label ()
+        public GraphTraversal<S, string> Label ()
         {
             Bytecode.AddStep("label");
-            return Wrap< S , string >(this);
+            return Wrap<S, string>(this);
         }
 
         /// <summary>
         ///     Adds the limit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Limit<E2> (Scope scope, long limit)
+        public GraphTraversal<S, E2> Limit<E2> (Scope scope, long limit)
         {
             Bytecode.AddStep("limit", scope, limit);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the limit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Limit (long limit)
+        public GraphTraversal<S, E> Limit (long limit)
         {
             Bytecode.AddStep("limit", limit);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the local step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Local<E2> (ITraversal localTraversal)
+        public GraphTraversal<S, E2> Local<E2> (ITraversal localTraversal)
         {
             Bytecode.AddStep("local", localTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the loops step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , int > Loops ()
+        public GraphTraversal<S, int> Loops ()
         {
             Bytecode.AddStep("loops");
-            return Wrap< S , int >(this);
+            return Wrap<S, int>(this);
         }
 
         /// <summary>
         ///     Adds the map step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Map<E2> (object function)
+        public GraphTraversal<S, E2> Map<E2> (object function)
         {
             Bytecode.AddStep("map", function);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the map step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Map<E2> (ITraversal mapTraversal)
+        public GraphTraversal<S, E2> Map<E2> (ITraversal mapTraversal)
         {
             Bytecode.AddStep("map", mapTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mapKeys step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > MapKeys<E2> ()
+        public GraphTraversal<S, E2> MapKeys<E2> ()
         {
             Bytecode.AddStep("mapKeys");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mapValues step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > MapValues<E2> ()
+        public GraphTraversal<S, E2> MapValues<E2> ()
         {
             Bytecode.AddStep("mapValues");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the match step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Match<E2> (params ITraversal[] matchTraversals)
+        public GraphTraversal<S, IDictionary<string, E2>> Match<E2> (params ITraversal[] matchTraversals)
         {
-            var args = new List< object >(0 + matchTraversals.Length) {};
+            var args = new List<object>(0 + matchTraversals.Length) {};
             args.AddRange(matchTraversals);
             Bytecode.AddStep("match", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Max<E2> ()
+        public GraphTraversal<S, E2> Max<E2> ()
         {
             Bytecode.AddStep("max");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the max step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Max<E2> (Scope scope)
+        public GraphTraversal<S, E2> Max<E2> (Scope scope)
         {
             Bytecode.AddStep("max", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mean step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Mean<E2> ()
+        public GraphTraversal<S, E2> Mean<E2> ()
         {
             Bytecode.AddStep("mean");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the mean step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Mean<E2> (Scope scope)
+        public GraphTraversal<S, E2> Mean<E2> (Scope scope)
         {
             Bytecode.AddStep("mean", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the min step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Min<E2> ()
+        public GraphTraversal<S, E2> Min<E2> ()
         {
             Bytecode.AddStep("min");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the min step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Min<E2> (Scope scope)
+        public GraphTraversal<S, E2> Min<E2> (Scope scope)
         {
             Bytecode.AddStep("min", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the not step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Not (ITraversal notTraversal)
+        public GraphTraversal<S, E> Not (ITraversal notTraversal)
         {
             Bytecode.AddStep("not", notTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the option step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Option (object pickToken, ITraversal traversalOption)
+        public GraphTraversal<S, E> Option (object pickToken, ITraversal traversalOption)
         {
             Bytecode.AddStep("option", pickToken, traversalOption);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the option step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Option (ITraversal traversalOption)
+        public GraphTraversal<S, E> Option (ITraversal traversalOption)
         {
             Bytecode.AddStep("option", traversalOption);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the optional step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Optional<E2> (ITraversal optionalTraversal)
+        public GraphTraversal<S, E2> Optional<E2> (ITraversal optionalTraversal)
         {
             Bytecode.AddStep("optional", optionalTraversal);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the or step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Or (params ITraversal[] orTraversals)
+        public GraphTraversal<S, E> Or (params ITraversal[] orTraversals)
         {
-            var args = new List< object >(0 + orTraversals.Length) {};
+            var args = new List<object>(0 + orTraversals.Length) {};
             args.AddRange(orTraversals);
             Bytecode.AddStep("or", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the order step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Order ()
+        public GraphTraversal<S, E> Order ()
         {
             Bytecode.AddStep("order");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the order step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Order (Scope scope)
+        public GraphTraversal<S, E> Order (Scope scope)
         {
             Bytecode.AddStep("order", scope);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the otherV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > OtherV ()
+        public GraphTraversal<S, Vertex> OtherV ()
         {
             Bytecode.AddStep("otherV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the out step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > Out (params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> Out (params string[] edgeLabels)
         {
-            var args = new List< object >(0 + edgeLabels.Length) {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("out", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the outE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > OutE (params string[] edgeLabels)
+        public GraphTraversal<S, Edge> OutE (params string[] edgeLabels)
         {
-            var args = new List< object >(0 + edgeLabels.Length) {};
+            var args = new List<object>(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("outE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the outV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > OutV ()
+        public GraphTraversal<S, Vertex> OutV ()
         {
             Bytecode.AddStep("outV");
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the pageRank step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PageRank ()
+        public GraphTraversal<S, E> PageRank ()
         {
             Bytecode.AddStep("pageRank");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the pageRank step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PageRank (double alpha)
+        public GraphTraversal<S, E> PageRank (double alpha)
         {
             Bytecode.AddStep("pageRank", alpha);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the path step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Path > Path ()
+        public GraphTraversal<S, Path> Path ()
         {
             Bytecode.AddStep("path");
-            return Wrap< S , Path >(this);
+            return Wrap<S, Path>(this);
         }
 
         /// <summary>
         ///     Adds the peerPressure step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > PeerPressure ()
+        public GraphTraversal<S, E> PeerPressure ()
         {
             Bytecode.AddStep("peerPressure");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Profile<E2> ()
+        public GraphTraversal<S, E2> Profile<E2> ()
         {
             Bytecode.AddStep("profile");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Profile (string sideEffectKey)
+        public GraphTraversal<S, E> Profile (string sideEffectKey)
         {
             Bytecode.AddStep("profile", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the program step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Program (object vertexProgram)
+        public GraphTraversal<S, E> Program (object vertexProgram)
         {
             Bytecode.AddStep("program", vertexProgram);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the project step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Project<E2> (string projectKey, params string[] otherProjectKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> Project<E2> (string projectKey, params string[] otherProjectKeys)
         {
-            var args = new List< object >(1 + otherProjectKeys.Length) {projectKey};
+            var args = new List<object>(1 + otherProjectKeys.Length) {projectKey};
             args.AddRange(otherProjectKeys);
             Bytecode.AddStep("project", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the properties step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Properties<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, E2> Properties<E2> (params string[] propertyKeys)
         {
-            var args = new List< object >(0 + propertyKeys.Length) {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("properties", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the property step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Property (Cardinality cardinality, object key, object value, params object[] keyValues)
+        public GraphTraversal<S, E> Property (Cardinality cardinality, object key, object value, params object[] keyValues)
         {
-            var args = new List< object >(3 + keyValues.Length) {cardinality, key, value};
+            var args = new List<object>(3 + keyValues.Length) {cardinality, key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the property step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Property (object key, object value, params object[] keyValues)
+        public GraphTraversal<S, E> Property (object key, object value, params object[] keyValues)
         {
-            var args = new List< object >(2 + keyValues.Length) {key, value};
+            var args = new List<object>(2 + keyValues.Length) {key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the propertyMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > PropertyMap<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> PropertyMap<E2> (params string[] propertyKeys)
         {
-            var args = new List< object >(0 + propertyKeys.Length) {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("propertyMap", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the range step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Range<E2> (Scope scope, long low, long high)
+        public GraphTraversal<S, E2> Range<E2> (Scope scope, long low, long high)
         {
             Bytecode.AddStep("range", scope, low, high);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the range step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Range (long low, long high)
+        public GraphTraversal<S, E> Range (long low, long high)
         {
             Bytecode.AddStep("range", low, high);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the repeat step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Repeat (ITraversal repeatTraversal)
+        public GraphTraversal<S, E> Repeat (ITraversal repeatTraversal)
         {
             Bytecode.AddStep("repeat", repeatTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Sack<E2> ()
+        public GraphTraversal<S, E2> Sack<E2> ()
         {
             Bytecode.AddStep("sack");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sack (object sackOperator)
+        public GraphTraversal<S, E> Sack (object sackOperator)
         {
             Bytecode.AddStep("sack", sackOperator);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sack step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sack (object sackOperator, string elementPropertyKey)
+        public GraphTraversal<S, E> Sack (object sackOperator, string elementPropertyKey)
         {
             Bytecode.AddStep("sack", sackOperator, elementPropertyKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sample step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sample (Scope scope, int amountToSample)
+        public GraphTraversal<S, E> Sample (Scope scope, int amountToSample)
         {
             Bytecode.AddStep("sample", scope, amountToSample);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sample step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Sample (int amountToSample)
+        public GraphTraversal<S, E> Sample (int amountToSample)
         {
             Bytecode.AddStep("sample", amountToSample);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , ICollection<E2> > Select<E2> (Column column)
+        public GraphTraversal<S, ICollection<E2>> Select<E2> (Column column)
         {
             Bytecode.AddStep("select", column);
-            return Wrap< S , ICollection<E2> >(this);
+            return Wrap<S, ICollection<E2>>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Select<E2> (Pop pop, string selectKey)
+        public GraphTraversal<S, E2> Select<E2> (Pop pop, string selectKey)
         {
             Bytecode.AddStep("select", pop, selectKey);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> Select<E2> (Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
-            var args = new List< object >(3 + otherSelectKeys.Length) {pop, selectKey1, selectKey2};
+            var args = new List<object>(3 + otherSelectKeys.Length) {pop, selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Select<E2> (string selectKey)
+        public GraphTraversal<S, E2> Select<E2> (string selectKey)
         {
             Bytecode.AddStep("select", selectKey);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the select step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (string selectKey1, string selectKey2, params string[] otherSelectKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> Select<E2> (string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
-            var args = new List< object >(2 + otherSelectKeys.Length) {selectKey1, selectKey2};
+            var args = new List<object>(2 + otherSelectKeys.Length) {selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the sideEffect step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SideEffect (object consumer)
+        public GraphTraversal<S, E> SideEffect (object consumer)
         {
             Bytecode.AddStep("sideEffect", consumer);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the sideEffect step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SideEffect (ITraversal sideEffectTraversal)
+        public GraphTraversal<S, E> SideEffect (ITraversal sideEffectTraversal)
         {
             Bytecode.AddStep("sideEffect", sideEffectTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the simplePath step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > SimplePath ()
+        public GraphTraversal<S, E> SimplePath ()
         {
             Bytecode.AddStep("simplePath");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the store step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Store (string sideEffectKey)
+        public GraphTraversal<S, E> Store (string sideEffectKey)
         {
             Bytecode.AddStep("store", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the subgraph step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > Subgraph (string sideEffectKey)
+        public GraphTraversal<S, Edge> Subgraph (string sideEffectKey)
         {
             Bytecode.AddStep("subgraph", sideEffectKey);
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the sum step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Sum<E2> ()
+        public GraphTraversal<S, E2> Sum<E2> ()
         {
             Bytecode.AddStep("sum");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the sum step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Sum<E2> (Scope scope)
+        public GraphTraversal<S, E2> Sum<E2> (Scope scope)
         {
             Bytecode.AddStep("sum", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Tail ()
+        public GraphTraversal<S, E> Tail ()
         {
             Bytecode.AddStep("tail");
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Tail<E2> (Scope scope)
+        public GraphTraversal<S, E2> Tail<E2> (Scope scope)
         {
             Bytecode.AddStep("tail", scope);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Tail<E2> (Scope scope, long limit)
+        public GraphTraversal<S, E2> Tail<E2> (Scope scope, long limit)
         {
             Bytecode.AddStep("tail", scope, limit);
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tail step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Tail (long limit)
+        public GraphTraversal<S, E> Tail (long limit)
         {
             Bytecode.AddStep("tail", limit);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the timeLimit step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > TimeLimit (long timeLimit)
+        public GraphTraversal<S, E> TimeLimit (long timeLimit)
         {
             Bytecode.AddStep("timeLimit", timeLimit);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the times step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Times (int maxLoops)
+        public GraphTraversal<S, E> Times (int maxLoops)
         {
             Bytecode.AddStep("times", maxLoops);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > To (Direction direction, params string[] edgeLabels)
+        public GraphTraversal<S, Vertex> To (Direction direction, params string[] edgeLabels)
         {
-            var args = new List< object >(1 + edgeLabels.Length) {direction};
+            var args = new List<object>(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("to", args.ToArray());
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > To (string toStepLabel)
+        public GraphTraversal<S, E> To (string toStepLabel)
         {
             Bytecode.AddStep("to", toStepLabel);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the to step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > To (ITraversal toVertex)
+        public GraphTraversal<S, E> To (ITraversal toVertex)
         {
             Bytecode.AddStep("to", toVertex);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the toE step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Edge > ToE (Direction direction, params string[] edgeLabels)
+        public GraphTraversal<S, Edge> ToE (Direction direction, params string[] edgeLabels)
         {
-            var args = new List< object >(1 + edgeLabels.Length) {direction};
+            var args = new List<object>(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("toE", args.ToArray());
-            return Wrap< S , Edge >(this);
+            return Wrap<S, Edge>(this);
         }
 
         /// <summary>
         ///     Adds the toV step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , Vertex > ToV (Direction direction)
+        public GraphTraversal<S, Vertex> ToV (Direction direction)
         {
             Bytecode.AddStep("toV", direction);
-            return Wrap< S , Vertex >(this);
+            return Wrap<S, Vertex>(this);
         }
 
         /// <summary>
         ///     Adds the tree step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Tree<E2> ()
+        public GraphTraversal<S, E2> Tree<E2> ()
         {
             Bytecode.AddStep("tree");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the tree step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Tree (string sideEffectKey)
+        public GraphTraversal<S, E> Tree (string sideEffectKey)
         {
             Bytecode.AddStep("tree", sideEffectKey);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the unfold step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Unfold<E2> ()
+        public GraphTraversal<S, E2> Unfold<E2> ()
         {
             Bytecode.AddStep("unfold");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the union step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Union<E2> (params ITraversal[] unionTraversals)
+        public GraphTraversal<S, E2> Union<E2> (params ITraversal[] unionTraversals)
         {
-            var args = new List< object >(0 + unionTraversals.Length) {};
+            var args = new List<object>(0 + unionTraversals.Length) {};
             args.AddRange(unionTraversals);
             Bytecode.AddStep("union", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the until step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Until (TraversalPredicate untilPredicate)
+        public GraphTraversal<S, E> Until (TraversalPredicate untilPredicate)
         {
             Bytecode.AddStep("until", untilPredicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the until step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Until (ITraversal untilTraversal)
+        public GraphTraversal<S, E> Until (ITraversal untilTraversal)
         {
             Bytecode.AddStep("until", untilTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the value step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Value<E2> ()
+        public GraphTraversal<S, E2> Value<E2> ()
         {
             Bytecode.AddStep("value");
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the valueMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> ValueMap<E2> (params string[] propertyKeys)
         {
-            var args = new List< object >(0 + propertyKeys.Length) {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the valueMap step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (bool includeTokens, params string[] propertyKeys)
+        public GraphTraversal<S, IDictionary<string, E2>> ValueMap<E2> (bool includeTokens, params string[] propertyKeys)
         {
-            var args = new List< object >(1 + propertyKeys.Length) {includeTokens};
+            var args = new List<object>(1 + propertyKeys.Length) {includeTokens};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
-            return Wrap< S , IDictionary<string, E2> >(this);
+            return Wrap<S, IDictionary<string, E2>>(this);
         }
 
         /// <summary>
         ///     Adds the values step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E2 > Values<E2> (params string[] propertyKeys)
+        public GraphTraversal<S, E2> Values<E2> (params string[] propertyKeys)
         {
-            var args = new List< object >(0 + propertyKeys.Length) {};
+            var args = new List<object>(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("values", args.ToArray());
-            return Wrap< S , E2 >(this);
+            return Wrap<S, E2>(this);
         }
 
         /// <summary>
         ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Where (TraversalPredicate predicate)
+        public GraphTraversal<S, E> Where (TraversalPredicate predicate)
         {
             Bytecode.AddStep("where", predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Where (string startKey, TraversalPredicate predicate)
+        public GraphTraversal<S, E> Where (string startKey, TraversalPredicate predicate)
         {
             Bytecode.AddStep("where", startKey, predicate);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
         /// <summary>
         ///     Adds the where step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Where (ITraversal whereTraversal)
+        public GraphTraversal<S, E> Where (ITraversal whereTraversal)
         {
             Bytecode.AddStep("where", whereTraversal);
-            return Wrap< S , E >(this);
+            return Wrap<S, E>(this);
         }
 
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -67,7 +67,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > V (params object[] vertexIdsOrElements)
         {
-            var args = new List<object>(0 + vertexIdsOrElements.Length) {};
+            var args = new List< object >(0 + vertexIdsOrElements.Length) {};
             args.AddRange(vertexIdsOrElements);
             Bytecode.AddStep("V", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -78,7 +78,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > AddE (Direction direction, string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List<object>(3 + propertyKeyValues.Length) {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List< object >(3 + propertyKeyValues.Length) {direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -98,7 +98,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > AddInE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List< object >(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addInE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -109,7 +109,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > AddOutE (string firstVertexKeyOrEdgeLabel, string edgeLabelOrSecondVertexKey, params object[] propertyKeyValues)
         {
-            var args = new List<object>(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
+            var args = new List< object >(2 + propertyKeyValues.Length) {firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addOutE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -129,7 +129,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > AddV (params object[] propertyKeyValues)
         {
-            var args = new List<object>(0 + propertyKeyValues.Length) {};
+            var args = new List< object >(0 + propertyKeyValues.Length) {};
             args.AddRange(propertyKeyValues);
             Bytecode.AddStep("addV", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -158,7 +158,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > And (params ITraversal[] andTraversals)
         {
-            var args = new List<object>(0 + andTraversals.Length) {};
+            var args = new List< object >(0 + andTraversals.Length) {};
             args.AddRange(andTraversals);
             Bytecode.AddStep("and", args.ToArray());
             return Wrap< S , E >(this);
@@ -169,7 +169,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > As (string stepLabel, params string[] stepLabels)
         {
-            var args = new List<object>(1 + stepLabels.Length) {stepLabel};
+            var args = new List< object >(1 + stepLabels.Length) {stepLabel};
             args.AddRange(stepLabels);
             Bytecode.AddStep("as", args.ToArray());
             return Wrap< S , E >(this);
@@ -207,7 +207,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > Both (params string[] edgeLabels)
         {
-            var args = new List<object>(0 + edgeLabels.Length) {};
+            var args = new List< object >(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("both", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -218,7 +218,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > BothE (params string[] edgeLabels)
         {
-            var args = new List<object>(0 + edgeLabels.Length) {};
+            var args = new List< object >(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("bothE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -337,7 +337,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Cap<E2> (string sideEffectKey, params string[] sideEffectKeys)
         {
-            var args = new List<object>(1 + sideEffectKeys.Length) {sideEffectKey};
+            var args = new List< object >(1 + sideEffectKeys.Length) {sideEffectKey};
             args.AddRange(sideEffectKeys);
             Bytecode.AddStep("cap", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -402,7 +402,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Coalesce<E2> (params ITraversal[] coalesceTraversals)
         {
-            var args = new List<object>(0 + coalesceTraversals.Length) {};
+            var args = new List< object >(0 + coalesceTraversals.Length) {};
             args.AddRange(coalesceTraversals);
             Bytecode.AddStep("coalesce", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -458,7 +458,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Dedup (Scope scope, params string[] dedupLabels)
         {
-            var args = new List<object>(1 + dedupLabels.Length) {scope};
+            var args = new List< object >(1 + dedupLabels.Length) {scope};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
             return Wrap< S , E >(this);
@@ -469,7 +469,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Dedup (params string[] dedupLabels)
         {
-            var args = new List<object>(0 + dedupLabels.Length) {};
+            var args = new List< object >(0 + dedupLabels.Length) {};
             args.AddRange(dedupLabels);
             Bytecode.AddStep("dedup", args.ToArray());
             return Wrap< S , E >(this);
@@ -723,7 +723,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasId (object id, params object[] otherIds)
         {
-            var args = new List<object>(1 + otherIds.Length) {id};
+            var args = new List< object >(1 + otherIds.Length) {id};
             args.AddRange(otherIds);
             Bytecode.AddStep("hasId", args.ToArray());
             return Wrap< S , E >(this);
@@ -752,7 +752,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasKey (string label, params string[] otherLabels)
         {
-            var args = new List<object>(1 + otherLabels.Length) {label};
+            var args = new List< object >(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasKey", args.ToArray());
             return Wrap< S , E >(this);
@@ -772,7 +772,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasLabel (string label, params string[] otherLabels)
         {
-            var args = new List<object>(1 + otherLabels.Length) {label};
+            var args = new List< object >(1 + otherLabels.Length) {label};
             args.AddRange(otherLabels);
             Bytecode.AddStep("hasLabel", args.ToArray());
             return Wrap< S , E >(this);
@@ -792,7 +792,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > HasValue (object value, params object[] otherValues)
         {
-            var args = new List<object>(1 + otherValues.Length) {value};
+            var args = new List< object >(1 + otherValues.Length) {value};
             args.AddRange(otherValues);
             Bytecode.AddStep("hasValue", args.ToArray());
             return Wrap< S , E >(this);
@@ -830,7 +830,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > In (params string[] edgeLabels)
         {
-            var args = new List<object>(0 + edgeLabels.Length) {};
+            var args = new List< object >(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("in", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -841,7 +841,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > InE (params string[] edgeLabels)
         {
-            var args = new List<object>(0 + edgeLabels.Length) {};
+            var args = new List< object >(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("inE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -859,9 +859,9 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the inject step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal< S , E > Inject (params object[] injections)
+        public GraphTraversal< S , E > Inject (params E[] injections)
         {
-            var args = new List<object>(0 + injections.Length) {};
+            var args = new List< E >(0 + injections.Length) {};
             args.AddRange(injections);
             Bytecode.AddStep("inject", args.ToArray());
             return Wrap< S , E >(this);
@@ -980,7 +980,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Match<E2> (params ITraversal[] matchTraversals)
         {
-            var args = new List<object>(0 + matchTraversals.Length) {};
+            var args = new List< object >(0 + matchTraversals.Length) {};
             args.AddRange(matchTraversals);
             Bytecode.AddStep("match", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1081,7 +1081,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Or (params ITraversal[] orTraversals)
         {
-            var args = new List<object>(0 + orTraversals.Length) {};
+            var args = new List< object >(0 + orTraversals.Length) {};
             args.AddRange(orTraversals);
             Bytecode.AddStep("or", args.ToArray());
             return Wrap< S , E >(this);
@@ -1119,7 +1119,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > Out (params string[] edgeLabels)
         {
-            var args = new List<object>(0 + edgeLabels.Length) {};
+            var args = new List< object >(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("out", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -1130,7 +1130,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > OutE (params string[] edgeLabels)
         {
-            var args = new List<object>(0 + edgeLabels.Length) {};
+            var args = new List< object >(0 + edgeLabels.Length) {};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("outE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -1213,7 +1213,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Project<E2> (string projectKey, params string[] otherProjectKeys)
         {
-            var args = new List<object>(1 + otherProjectKeys.Length) {projectKey};
+            var args = new List< object >(1 + otherProjectKeys.Length) {projectKey};
             args.AddRange(otherProjectKeys);
             Bytecode.AddStep("project", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1224,7 +1224,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Properties<E2> (params string[] propertyKeys)
         {
-            var args = new List<object>(0 + propertyKeys.Length) {};
+            var args = new List< object >(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("properties", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -1235,7 +1235,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Property (Cardinality cardinality, object key, object value, params object[] keyValues)
         {
-            var args = new List<object>(3 + keyValues.Length) {cardinality, key, value};
+            var args = new List< object >(3 + keyValues.Length) {cardinality, key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
             return Wrap< S , E >(this);
@@ -1246,7 +1246,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E > Property (object key, object value, params object[] keyValues)
         {
-            var args = new List<object>(2 + keyValues.Length) {key, value};
+            var args = new List< object >(2 + keyValues.Length) {key, value};
             args.AddRange(keyValues);
             Bytecode.AddStep("property", args.ToArray());
             return Wrap< S , E >(this);
@@ -1257,7 +1257,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > PropertyMap<E2> (params string[] propertyKeys)
         {
-            var args = new List<object>(0 + propertyKeys.Length) {};
+            var args = new List< object >(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("propertyMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1358,7 +1358,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (Pop pop, string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
-            var args = new List<object>(3 + otherSelectKeys.Length) {pop, selectKey1, selectKey2};
+            var args = new List< object >(3 + otherSelectKeys.Length) {pop, selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1378,7 +1378,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > Select<E2> (string selectKey1, string selectKey2, params string[] otherSelectKeys)
         {
-            var args = new List<object>(2 + otherSelectKeys.Length) {selectKey1, selectKey2};
+            var args = new List< object >(2 + otherSelectKeys.Length) {selectKey1, selectKey2};
             args.AddRange(otherSelectKeys);
             Bytecode.AddStep("select", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1506,7 +1506,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Vertex > To (Direction direction, params string[] edgeLabels)
         {
-            var args = new List<object>(1 + edgeLabels.Length) {direction};
+            var args = new List< object >(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("to", args.ToArray());
             return Wrap< S , Vertex >(this);
@@ -1535,7 +1535,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , Edge > ToE (Direction direction, params string[] edgeLabels)
         {
-            var args = new List<object>(1 + edgeLabels.Length) {direction};
+            var args = new List< object >(1 + edgeLabels.Length) {direction};
             args.AddRange(edgeLabels);
             Bytecode.AddStep("toE", args.ToArray());
             return Wrap< S , Edge >(this);
@@ -1582,7 +1582,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Union<E2> (params ITraversal[] unionTraversals)
         {
-            var args = new List<object>(0 + unionTraversals.Length) {};
+            var args = new List< object >(0 + unionTraversals.Length) {};
             args.AddRange(unionTraversals);
             Bytecode.AddStep("union", args.ToArray());
             return Wrap< S , E2 >(this);
@@ -1620,7 +1620,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (params string[] propertyKeys)
         {
-            var args = new List<object>(0 + propertyKeys.Length) {};
+            var args = new List< object >(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1631,7 +1631,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , IDictionary<string, E2> > ValueMap<E2> (bool includeTokens, params string[] propertyKeys)
         {
-            var args = new List<object>(1 + propertyKeys.Length) {includeTokens};
+            var args = new List< object >(1 + propertyKeys.Length) {includeTokens};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("valueMap", args.ToArray());
             return Wrap< S , IDictionary<string, E2> >(this);
@@ -1642,7 +1642,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal< S , E2 > Values<E2> (params string[] propertyKeys)
         {
-            var args = new List<object>(0 + propertyKeys.Length) {};
+            var args = new List< object >(0 + propertyKeys.Length) {};
             args.AddRange(propertyKeys);
             Bytecode.AddStep("values", args.ToArray());
             return Wrap< S , E2 >(this);

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -190,7 +190,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< Edge,Edge > E(params object[] edgesIds)
         {
             var traversal = new GraphTraversal< Edge,Edge >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<object>(0 + edgesIds.Length) {};
+            var args = new List< object >(0 + edgesIds.Length) {};
             args.AddRange(edgesIds);
             traversal.Bytecode.AddStep("E", args.ToArray());
             return traversal;
@@ -203,7 +203,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< Vertex,Vertex > V(params object[] vertexIds)
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<object>(0 + vertexIds.Length) {};
+            var args = new List< object >(0 + vertexIds.Length) {};
             args.AddRange(vertexIds);
             traversal.Bytecode.AddStep("V", args.ToArray());
             return traversal;
@@ -227,7 +227,7 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal< Vertex,Vertex > AddV(params object[] keyValues)
         {
             var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<object>(0 + keyValues.Length) {};
+            var args = new List< object >(0 + keyValues.Length) {};
             args.AddRange(keyValues);
             traversal.Bytecode.AddStep("addV", args.ToArray());
             return traversal;
@@ -248,10 +248,10 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the inject step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< S,S > Inject<S>(params object[] starts)
+        public GraphTraversal< S,S > Inject<S>(params S[] starts)
         {
             var traversal = new GraphTraversal< S,S >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<object>(0 + starts.Length) {};
+            var args = new List< S >(0 + starts.Length) {};
             args.AddRange(starts);
             traversal.Bytecode.AddStep("inject", args.ToArray());
             return traversal;

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -187,10 +187,10 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the E step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Edge,Edge > E(params object[] edgesIds)
+        public GraphTraversal<Edge, Edge> E(params object[] edgesIds)
         {
-            var traversal = new GraphTraversal< Edge,Edge >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List< object >(0 + edgesIds.Length) {};
+            var traversal = new GraphTraversal<Edge, Edge>(TraversalStrategies, new Bytecode(Bytecode));
+            var args = new List<object>(0 + edgesIds.Length) {};
             args.AddRange(edgesIds);
             traversal.Bytecode.AddStep("E", args.ToArray());
             return traversal;
@@ -200,10 +200,10 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the V step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > V(params object[] vertexIds)
+        public GraphTraversal<Vertex, Vertex> V(params object[] vertexIds)
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List< object >(0 + vertexIds.Length) {};
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
+            var args = new List<object>(0 + vertexIds.Length) {};
             args.AddRange(vertexIds);
             traversal.Bytecode.AddStep("V", args.ToArray());
             return traversal;
@@ -213,9 +213,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > AddV()
+        public GraphTraversal<Vertex, Vertex> AddV()
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
                 traversal.Bytecode.AddStep("addV");
             return traversal;
         }
@@ -224,10 +224,10 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > AddV(params object[] keyValues)
+        public GraphTraversal<Vertex, Vertex> AddV(params object[] keyValues)
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List< object >(0 + keyValues.Length) {};
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
+            var args = new List<object>(0 + keyValues.Length) {};
             args.AddRange(keyValues);
             traversal.Bytecode.AddStep("addV", args.ToArray());
             return traversal;
@@ -237,9 +237,9 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the addV step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< Vertex,Vertex > AddV(string label)
+        public GraphTraversal<Vertex, Vertex> AddV(string label)
         {
-            var traversal = new GraphTraversal< Vertex,Vertex >(TraversalStrategies, new Bytecode(Bytecode));
+            var traversal = new GraphTraversal<Vertex, Vertex>(TraversalStrategies, new Bytecode(Bytecode));
                 traversal.Bytecode.AddStep("addV", label);
             return traversal;
         }
@@ -248,10 +248,10 @@ namespace Gremlin.Net.Process.Traversal
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the inject step to that
         ///     traversal.
         /// </summary>
-        public GraphTraversal< S,S > Inject<S>(params S[] starts)
+        public GraphTraversal<S, S> Inject<S>(params S[] starts)
         {
-            var traversal = new GraphTraversal< S,S >(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List< S >(0 + starts.Length) {};
+            var traversal = new GraphTraversal<S, S>(TraversalStrategies, new Bytecode(Bytecode));
+            var args = new List<S>(0 + starts.Length) {};
             args.AddRange(starts);
             traversal.Bytecode.AddStep("inject", args.ToArray());
             return traversal;

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -244,6 +244,19 @@ namespace Gremlin.Net.Process.Traversal
             return traversal;
         }
 
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> off this graph traversal source and adds the inject step to that
+        ///     traversal.
+        /// </summary>
+        public GraphTraversal< S,S > Inject<S>(params object[] starts)
+        {
+            var traversal = new GraphTraversal< S,S >(TraversalStrategies, new Bytecode(Bytecode));
+            var args = new List<object>(0 + starts.Length) {};
+            args.AddRange(starts);
+            traversal.Bytecode.AddStep("inject", args.ToArray());
+            return traversal;
+        }
+
     }
     
 #pragma warning restore 1591


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1868

This adds the `Inject` step to `GraphTraversalSource` for Gremlin.Net. While working on this I also noticed that the interface wasn't optimal for the existing `GraphTraversal` `Inject` step as it accepted a `params object[] injections` although it should only except `injections` of the generic type `E`. So I also fixed that.

Method signature before:
```
public GraphTraversal< S , E > Inject (params object[] injections)
```
and after:
```
public GraphTraversal< S , E > Inject (params E[] injections)
```

Now, a traversal like the following isn't possible any more in Gremlin.Net:
```
g.V().Values<string>("name").Inject(1).ToList();
```
as `Inject` now only accepts strings here (just like Gremlin-Java does).