### PR TITLE
TINKERPOP-1875 Gremlin-Python only aggregates to list when using GraphSON3

### DIFF
--- a/gremlin-python/src/main/jython/tests/conftest.py
+++ b/gremlin-python/src/main/jython/tests/conftest.py
@@ -1,4 +1,4 @@
-'''
+"""
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
@@ -15,7 +15,7 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-'''
+"""
 import concurrent.futures
 import pytest
 
@@ -65,10 +65,14 @@ def client(request):
         request.addfinalizer(fin)
         return client
 
-@pytest.fixture
+@pytest.fixture(params=['v2', 'v3'])
 def remote_connection(request):
     try:
-        remote_conn = DriverRemoteConnection('ws://localhost:45940/gremlin', 'g')
+        if request.param == 'v2':
+            remote_conn = DriverRemoteConnection('ws://localhost:45940/gremlin', 'g',
+                                                 message_serializer=serializer.GraphSONSerializersV2d0())
+        else:
+            remote_conn = DriverRemoteConnection('ws://localhost:45940/gremlin', 'g')
     except OSError:
         pytest.skip('Gremlin Server is not running')
     else:

--- a/gremlin-python/src/main/jython/tests/driver/test_client.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_client.py
@@ -79,12 +79,13 @@ def test_client_async(client):
 
 def test_connection_share(client):
     # Overwrite fixture with pool_size=1 client
-    client = Client('ws://localhost:45940/gremlin', 'g', pool_size=1, message_serializer=serializer.GraphSONSerializersV2d0())
+    client = Client('ws://localhost:45940/gremlin', 'g', pool_size=1)
     g = Graph().traversal()
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode})
+    message2 = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode})
     future = client.submitAsync(message)
-    future2 = client.submitAsync(message)
+    future2 = client.submitAsync(message2)
 
     result_set2 = future2.result()
     assert len(result_set2.all().result()) == 6
@@ -99,10 +100,10 @@ def test_multi_conn_pool(client):
     g = Graph().traversal()
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode})
-
-    client = Client('ws://localhost:45940/gremlin', 'g', pool_size=1, message_serializer=serializer.GraphSONSerializersV2d0())
+    message2 = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode})
+    client = Client('ws://localhost:45940/gremlin', 'g', pool_size=1)
     future = client.submitAsync(message)
-    future2 = client.submitAsync(message)
+    future2 = client.submitAsync(message2)
 
     result_set2 = future2.result()
     assert len(result_set2.all().result()) == 6

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -119,10 +119,10 @@ class TestDriverRemoteConnection(object):
         assert 6 == g.V().count().next()
         assert 6 == g.E().count().next()
 
-    def test_side_effects(self, remote_connection_v2):
+    def test_side_effects(self, remote_connection):
         statics.load_statics(globals())
         #
-        g = Graph().traversal().withRemote(remote_connection_v2)
+        g = Graph().traversal().withRemote(remote_connection)
         ###
         t = g.V().hasLabel("project").name.iterate()
         assert 0 == len(t.side_effects.keys())


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1875

This PR fixes server response message deserialization in Gremlin-Python. Improper deserialization was leading to `aggregate_to` always resulting in a list as well as API comparability issues between GraphSON2 and GraphSON3 message serializers.

This PR also improves testing--all Gremlin-Python tests using a remote connection are now run with both GraphSON 2 and 3 serializers. 