### PR TITLE
TINKERPOP-1586 Added checkAdjacentVertices option to SubgraphStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-8]]
 === TinkerPop 3.2.8 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added `checkAdjacentVertices` option to `SubgraphStrategy`.
 * Modified `GremlinDslProcessor` so that it generated the `getAnonymousTraversalClass()` method to return the DSL version of `__`.
 * Added the "Kitchen Sink" test data set.
 * Fixed a bug in `NumberHelper` that led to wrong min/max results if numbers exceeded the Integer limits.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1586

This change allows the user to turn off an aspect of `SubgraphStrategy` that prevents it from working properly in OLAP situations. Added some better javadoc to explain the settings for this strategy. 

All tests pass with `docker/build.sh -t -n -i`

VOTE +1