### PR TITLE
TINKERPOP-1522 Order of select() scopes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,7 @@ NEED AND IMAGE
 This release also includes changes from <<release-3-3-2, 3.3.2>>.
 
 * Fixed a bug in `ReducingBarrierStep`, that returned the provided seed value despite no elements being available.
-
+* Changed the order of `select()` scopes. The order is now: maps, side-effects, paths.
 
 == TinkerPop 3.3.0 (Gremlin Symphony #40 in G Minor)
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -64,7 +64,6 @@ gremlin> g.V().group().
 ......1>   by(label).
 ......2>   by(outE().values("weight").sum())
 ==>[person:3.5]
-gremlin> 
 gremlin> g.V().group().
 ......1>   by(label).
 ......2>   by(coalesce(outE().values("weight"), constant(0)).sum())
@@ -73,3 +72,45 @@ gremlin> g.V().group().
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1777[TINKERPOP-1777]
 
+==== Change in order of select() scopes
+
+The order of select scopes has been changed to: maps, side-effects, paths
+Previously the order was: side-effects, maps, paths - which made it almost impossible to select a specific map entry if a side-effect with the same name existed.
+
+The following snippets illustrate the changed behavior:
+
+[source,groovy]
+----
+gremlin> g.V(1).
+......1>   group("a").
+......2>     by(__.constant("a")).
+......3>     by(__.values("name")).
+......4>   select("a")
+==>[a:marko]
+gremlin> g.V(1).
+......1>   group("a").
+......2>     by(__.constant("a")).
+......3>     by(__.values("name")).
+......4>   select("a").select("a")
+==>[a:marko]
+----
+
+Above is the old behavior; the second `select("a")` has no effect, it selects the side-effect `a` again, although one would expect to get the map entry `a`. What follows is the new behavior:
+
+[source,groovy]
+----
+gremlin> g.V(1).
+......1>   group("a").
+......2>     by(__.constant("a")).
+......3>     by(__.values("name")).
+......4>   select("a")
+==>[a:marko]
+gremlin> g.V(1).
+......1>   group("a").
+......2>     by(__.constant("a")).
+......3>     by(__.values("name")).
+......4>   select("a").select("a")
+==>marko
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1522[TINKERPOP-1522]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/Scoping.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/Scoping.java
@@ -110,12 +110,12 @@ public interface Scoping {
     public enum Variable {START, END}
 
     public default <S> S getScopeValue(final Pop pop, final String key, final Traverser.Admin<?> traverser) throws IllegalArgumentException {
-        if (traverser.getSideEffects().exists(key))
-            return traverser.getSideEffects().get(key);
-        ///
         final Object object = traverser.get();
         if (object instanceof Map && ((Map<String, S>) object).containsKey(key))
             return ((Map<String, S>) object).get(key);
+        ///
+        if (traverser.getSideEffects().exists(key))
+            return traverser.getSideEffects().get(key);
         ///
         final Path path = traverser.path();
         if (path.hasLabel(key))
@@ -125,12 +125,12 @@ public interface Scoping {
     }
 
     public default <S> S getNullableScopeValue(final Pop pop, final String key, final Traverser.Admin<?> traverser) {
-        if (traverser.getSideEffects().exists(key))
-            return traverser.getSideEffects().get(key);
-        ///
         final Object object = traverser.get();
         if (object instanceof Map && ((Map<String, S>) object).containsKey(key))
             return ((Map<String, S>) object).get(key);
+        ///
+        if (traverser.getSideEffects().exists(key))
+            return traverser.getSideEffects().get(key);
         ///
         final Path path = traverser.path();
         if (path.hasLabel(key))

--- a/gremlin-test/features/map/Select.feature
+++ b/gremlin-test/features/map/Select.feature
@@ -204,6 +204,22 @@ Feature: Step - select()
       | v[ripple] |
       | v[peter] |
 
+  Scenario: g_VX1X_groupXaX_byXconstantXaXX_byXnameX_selectXaX_selectXaX
+    Given the modern graph
+    And using the parameter v1Id defined as "v[marko].id"
+    And the traversal of
+      """
+      g.V(v1Id).group("a").
+                  by(__.constant("a")).
+                  by(__.values("name")).
+        barrier().
+        select("a").select("a")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | marko |
+
   Scenario: g_VX1X_asXhereX_out_selectXhereX
     Given the modern graph
     And using the parameter v1Id defined as "v[marko].id"

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
@@ -83,6 +83,8 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_chooseXoutE_count_isX0X__asXaX__asXbXX_chooseXselectXaX__selectXaX__selectXbXX();
 
+    public abstract Traversal<Integer, String> get_g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX();
+
     // below are original back()-tests
 
     public abstract Traversal<Vertex, Vertex> get_g_VX1X_asXhereX_out_selectXhereX(final Object v1Id);
@@ -339,6 +341,16 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         assertEquals(6, counter);
         assertEquals(3, yCounter);
         assertEquals(3, xCounter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX() {
+        final Traversal<Integer, String> traversal = get_g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX();
+        printTraversalForm(traversal);
+        assertTrue(traversal.hasNext());
+        assertEquals("marko", traversal.next());
+        assertFalse(traversal.hasNext());
     }
 
     // below are original back()-tests
@@ -720,6 +732,12 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_chooseXoutE_count_isX0X__asXaX__asXbXX_chooseXselectXaX__selectXaX__selectXbXX() {
             return g.V().choose(__.outE().count().is(0L), __.as("a"), __.as("b")).choose(__.select("a"), __.select("a"), __.select("b"));
+        }
+
+        public Traversal<Integer, String> get_g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX() {
+            final Map<String, String> m = new HashMap<>(1);
+            m.put("a", "marko");
+            return g.withSideEffect("a", m).inject(1).select("a").select("a");
         }
 
         // below are original back()-tests

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
@@ -83,7 +83,7 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_chooseXoutE_count_isX0X__asXaX__asXbXX_chooseXselectXaX__selectXaX__selectXbXX();
 
-    public abstract Traversal<Integer, String> get_g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX();
+    public abstract Traversal<Vertex, String> get_g_VX1X_groupXaX_byXconstantXaXX_byXnameX_selectXaX_selectXaX(final Object v1Id);
 
     // below are original back()-tests
 
@@ -345,8 +345,8 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX() {
-        final Traversal<Integer, String> traversal = get_g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX();
+    public void g_VX1X_groupXaX_byXconstantXaXX_byXnameX_selectXaX_selectXaX() {
+        final Traversal<Vertex, String> traversal = get_g_VX1X_groupXaX_byXconstantXaXX_byXnameX_selectXaX_selectXaX(convertToVertexId("marko"));
         printTraversalForm(traversal);
         assertTrue(traversal.hasNext());
         assertEquals("marko", traversal.next());
@@ -658,7 +658,6 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         }
         assertFalse(traversal.hasNext());
     }
-
     @Test
     @LoadGraphWith(MODERN)
     public void g_VX1X_asXaX_repeatXout_asXaXX_timesX2X_selectXfirst_aX() {
@@ -734,10 +733,10 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
             return g.V().choose(__.outE().count().is(0L), __.as("a"), __.as("b")).choose(__.select("a"), __.select("a"), __.select("b"));
         }
 
-        public Traversal<Integer, String> get_g_withSideEffectXa_a_markoX_injectX1X_selectXaX_select_XaX() {
-            final Map<String, String> m = new HashMap<>(1);
-            m.put("a", "marko");
-            return g.withSideEffect("a", m).inject(1).select("a").select("a");
+        public Traversal<Vertex, String> get_g_VX1X_groupXaX_byXconstantXaXX_byXnameX_selectXaX_selectXaX(final Object v1Id) {
+            return g.V(v1Id).group("a").by(__.constant("a")).by(__.values("name"))
+                    .barrier() // TODO: this barrier() should not be necessary
+                    .select("a").select("a");
         }
 
         // below are original back()-tests


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1522

This PR changes the order of `select()` scope from 

* side-effects, maps, paths

to

* maps, side-effects, paths

`docker/build.sh -t -i` passed.

Note that I discovered a bug in OLAP while writing the test case, that's why there is an extra `barrier()` step. I'll create another ticket to address this issue.