### PR TITLE
TINKERPOP-1446 Added standard string representation for Path objects

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ NEED AND IMAGE
 
 This release also includes changes from <<release-3-3-2, 3.3.2>>.
 
+* Change the `toString()` of `Path` to be standardized as other graph elements are.
 
 == TinkerPop 3.3.0 (Gremlin Symphony #40 in G Minor)
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/EmptyPath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/EmptyPath.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -102,5 +103,10 @@ public final class EmptyPath implements Path, Serializable {
     @Override
     public boolean equals(final Object object) {
         return object instanceof EmptyPath;
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.pathString(this);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePath.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -217,7 +218,7 @@ public class ImmutablePath implements Path, Serializable, Cloneable {
 
     @Override
     public String toString() {
-        return this.objects().toString();
+        return StringFactory.pathString(this);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -168,7 +169,7 @@ public class MutablePath implements Path, Serializable {
 
     @Override
     public String toString() {
-        return this.objects.toString();
+        return StringFactory.pathString(this);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Translator;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -40,6 +41,7 @@ import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.util.function.FunctionUtils;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.javatuples.Pair;
 
 import java.lang.reflect.Method;
@@ -53,7 +55,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-
 /**
  * A collection of helpful methods for creating standard {@link Object#toString()} representations of graph-related
  * objects.
@@ -66,6 +67,7 @@ public final class StringFactory {
     private static final String E = "e";
     private static final String P = "p";
     private static final String VP = "vp";
+    private static final String PATH = "path";
     private static final String L_BRACKET = "[";
     private static final String R_BRACKET = "]";
     private static final String COMMA_SPACE = ", ";
@@ -176,7 +178,7 @@ public final class StringFactory {
     }
 
     public static String translatorString(final Translator translator) {
-        return "translator[" + translator.getTraversalSource() + ":" + translator.getTargetLanguage() + "]";
+        return "translator" + L_BRACKET + translator.getTraversalSource() + ":" + translator.getTargetLanguage() + R_BRACKET;
     }
 
     public static String vertexProgramString(final VertexProgram vertexProgram, final String internalString) {
@@ -252,4 +254,7 @@ public final class StringFactory {
         return string.substring(1, string.length() - 1);
     }
 
+    public static String pathString(final Path path) {
+        return PATH + L_BRACKET + String.join(", ", IteratorUtils.map(path, Object::toString)) + R_BRACKET;
+    }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Path.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Path.cs
@@ -111,7 +111,7 @@ namespace Gremlin.Net.Structure
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"[{string.Join(", ", Objects)}]";
+            return $"path[{string.Join(", ", Objects)}]";
         }
 
         /// <summary>

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONReaderTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONReaderTests.cs
@@ -229,7 +229,7 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
 
             Path readPath = reader.ToObject(JObject.Parse(graphSon));
 
-            Assert.Equal("[v[1], v[3], lop]", readPath.ToString());
+            Assert.Equal("path[v[1], v[3], lop]", readPath.ToString());
             Assert.Equal(new Vertex(1), readPath[0]);
             Assert.Equal(new Vertex(1), readPath["a"]);
             Assert.Equal("lop", readPath[2]);
@@ -246,7 +246,7 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
 
             Path readPath = reader.ToObject(JObject.Parse(graphSon));
 
-            Assert.Equal("[v[5]]", readPath.ToString());
+            Assert.Equal("path[v[5]]", readPath.ToString());
             Assert.Equal(new Vertex(5L), readPath[0]);
             Assert.Equal(new Vertex(5L), readPath["z"]);
             Assert.Equal(1, readPath.Count);

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/PathTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/PathTests.cs
@@ -364,7 +364,7 @@ namespace Gremlin.Net.UnitTest.Structure
 
             var pathStr = path.ToString();
 
-            Assert.Equal("[1, v[1], hello]", pathStr);
+            Assert.Equal("path[1, v[1], hello]", pathStr);
         }
 
         [Fact]

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
@@ -126,6 +126,10 @@ class Path {
     this.objects = objects;
   }
 
+  toString() {
+    return 'path[' + objects.join(", ") +  ']';
+  }
+
   equals(other) {
     if (!(other instanceof Path)) {
       return false;

--- a/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
@@ -103,7 +103,7 @@ class Path(object):
         self.objects = objects
 
     def __repr__(self):
-        return str(self.objects)
+        return "path[" + ", ".join(map(str, self.objects)) + "]"
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.objects == other.objects and self.labels == other.labels

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -124,10 +124,7 @@ class TestGraphSONReader(object):
             """{"@type":"g:Path","@value":{"labels":[["a"],["b","c"],[]],"objects":[{"@type":"g:Vertex","@value":{"id":{"@type":"g:Int32","@value":1},"label":"person","properties":{"name":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":0},"value":"marko","label":"name"}}],"age":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":1},"value":{"@type":"g:Int32","@value":29},"label":"age"}}]}}},{"@type":"g:Vertex","@value":{"id":{"@type":"g:Int32","@value":3},"label":"software","properties":{"name":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":4},"value":"lop","label":"name"}}],"lang":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":5},"value":"java","label":"lang"}}]}}},"lop"]}}"""
         )
         assert isinstance(path, Path)
-        if six.PY3:
-            assert "[v[1], v[3], 'lop']" == str(path)
-        else:
-            assert "[v[1], v[3], u'lop']" == str(path)
+        assert "path[v[1], v[3], lop]" == str(path)
         assert Vertex(1) == path[0]
         assert Vertex(1) == path["a"]
         assert "lop" == path[2]

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -152,10 +152,7 @@ class TestGraphSONReader(object):
             """{"@type":"g:Path","@value":{"labels":{"@type":"g:List","@value":[{"@type":"g:Set","@value":["a"]},{"@type":"g:Set","@value":["b","c"]},{"@type":"g:Set","@value":[]}]},"objects":{"@type":"g:List","@value":[{"@type":"g:Vertex","@value":{"id":{"@type":"g:Int32","@value":1},"label":"person","properties":{"name":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":0},"value":"marko","label":"name"}}],"age":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":1},"value":{"@type":"g:Int32","@value":29},"label":"age"}}]}}},{"@type":"g:Vertex","@value":{"id":{"@type":"g:Int32","@value":3},"label":"software","properties":{"name":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":4},"value":"lop","label":"name"}}],"lang":[{"@type":"g:VertexProperty","@value":{"id":{"@type":"g:Int64","@value":5},"value":"java","label":"lang"}}]}}},"lop"]}}}"""
         )
         assert isinstance(path, Path)
-        if six.PY3:
-            assert "[v[1], v[3], 'lop']" == str(path)
-        else:
-            assert "[v[1], v[3], u'lop']" == str(path)
+        assert "path[v[1], v[3], lop]" == str(path)
         assert Vertex(1) == path[0]
         assert Vertex(1) == path["a"]
         assert "lop" == path[2]

--- a/gremlin-python/src/main/jython/tests/structure/test_graph.py
+++ b/gremlin-python/src/main/jython/tests/structure/test_graph.py
@@ -75,7 +75,7 @@ class TestGraph(object):
 
     def test_path(self):
         path = Path([set(["a", "b"]), set(["c", "b"]), set([])], [1, Vertex(1), "hello"])
-        assert "[1, v[1], 'hello']" == str(path)
+        assert "path[1, v[1], hello]" == str(path)
         assert 1 == path["a"]
         assert Vertex(1) == path["c"]
         assert [1, Vertex(1)] == path["b"]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1446

Only applying this to 3.4.x as people might be relying on the old string representations of `Path` objects for some reason. 

All tests pass with `docker/build.sh -t -n -i`

VOTE +1