### PR TITLE
TINKERPOP-1758 Apply RemoteStrategy before all DecorationStrategy instances

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Modified `GremlinDslProcessor` so that it generated the `getAnonymousTraversalClass()` method to return the DSL version of `__`.
 * Added the "Kitchen Sink" test data set.
 * Fixed deserialization of `P.not()` for GraphSON.
+* Ensure that `RemoteStrategy` is applied before all other `DecorationStrategy` instances.
 * Added `idleConnectionTimeout` and `keepAliveInterval` to Gremlin Server that enables a "ping" and auto-close for seemingly dead clients.
 * Fixed a bug in `NumberHelper` that led to wrong min/max results if numbers exceeded the Integer limits.
 * Delayed setting of the request identifier until `RequestMessage` construction by the builder.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/strategy/decoration/RemoteStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/traversal/strategy/decoration/RemoteStrategy.java
@@ -27,11 +27,22 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileSideEffectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.RequirementsStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SackStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SideEffectStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.VerificationException;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -49,7 +60,21 @@ public final class RemoteStrategy extends AbstractTraversalStrategy<TraversalStr
     private static final RemoteStrategy INSTANCE = new RemoteStrategy();
     private final Optional<RemoteConnection> remoteConnection;
 
-    private static final Set<Class<? extends DecorationStrategy>> POSTS = Collections.singleton(VertexProgramStrategy.class);
+    /**
+     * Should be applied before all {@link DecorationStrategy} instances.
+     */
+    private static final Set<Class<? extends DecorationStrategy>> POSTS = new HashSet<Class<? extends DecorationStrategy>>() {{
+        add(VertexProgramStrategy.class);
+        add(ConnectiveStrategy.class);
+        add(ElementIdStrategy.class);
+        add(EventStrategy.class);
+        add(HaltedTraverserStrategy.class);
+        add(PartitionStrategy.class);
+        add(RequirementsStrategy.class);
+        add(SackStrategy.class);
+        add(SideEffectStrategy.class);
+        add(SubgraphStrategy.class);
+    }};
 
     private RemoteStrategy() {
         remoteConnection = Optional.empty();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -141,9 +141,9 @@ public interface TraversalStrategies extends Serializable, Cloneable {
         });
 
         //Add dependencies by category
-        List<Class<? extends TraversalStrategy>> strategiesInPreviousCategories = new ArrayList<>();
+        final List<Class<? extends TraversalStrategy>> strategiesInPreviousCategories = new ArrayList<>();
         for (Class<? extends TraversalStrategy> category : STRATEGY_CATEGORIES) {
-            Set<Class<? extends TraversalStrategy>> strategiesInThisCategory = MultiMap.get(strategiesByCategory, category);
+            final Set<Class<? extends TraversalStrategy>> strategiesInThisCategory = MultiMap.get(strategiesByCategory, category);
             for (Class<? extends TraversalStrategy> strategy : strategiesInThisCategory) {
                 for (Class<? extends TraversalStrategy> previousStrategy : strategiesInPreviousCategories) {
                     MultiMap.put(dependencyMap, strategy, previousStrategy);
@@ -153,16 +153,16 @@ public interface TraversalStrategies extends Serializable, Cloneable {
         }
 
         //Finally sort via t-sort
-        List<Class<? extends TraversalStrategy>> unprocessedStrategyClasses = new ArrayList<>(strategies.stream().map(s -> s.getClass()).collect(Collectors.toSet()));
-        List<Class<? extends TraversalStrategy>> sortedStrategyClasses = new ArrayList<>();
-        Set<Class<? extends TraversalStrategy>> seenStrategyClasses = new HashSet<>();
+        final List<Class<? extends TraversalStrategy>> unprocessedStrategyClasses = new ArrayList<>(strategies.stream().map(s -> s.getClass()).collect(Collectors.toSet()));
+        final List<Class<? extends TraversalStrategy>> sortedStrategyClasses = new ArrayList<>();
+        final Set<Class<? extends TraversalStrategy>> seenStrategyClasses = new HashSet<>();
 
         while (!unprocessedStrategyClasses.isEmpty()) {
-            Class<? extends TraversalStrategy> strategy = unprocessedStrategyClasses.get(0);
+            final Class<? extends TraversalStrategy> strategy = unprocessedStrategyClasses.get(0);
             visit(dependencyMap, sortedStrategyClasses, seenStrategyClasses, unprocessedStrategyClasses, strategy);
         }
 
-        List<TraversalStrategy<?>> sortedStrategies = new ArrayList<>();
+        final List<TraversalStrategy<?>> sortedStrategies = new ArrayList<>();
         //We now have a list of sorted strategy classes
         for (Class<? extends TraversalStrategy> strategyClass : sortedStrategyClasses) {
             for (TraversalStrategy strategy : strategies) {
@@ -172,12 +172,13 @@ public interface TraversalStrategies extends Serializable, Cloneable {
             }
         }
 
-
         return sortedStrategies;
     }
 
-
-    static void visit(Map<Class<? extends TraversalStrategy>, Set<Class<? extends TraversalStrategy>>> dependencyMap, List<Class<? extends TraversalStrategy>> sortedStrategyClasses, Set<Class<? extends TraversalStrategy>> seenStrategyClases, List<Class<? extends TraversalStrategy>> unprocessedStrategyClasses, Class<? extends TraversalStrategy> strategyClass) {
+    static void visit(final Map<Class<? extends TraversalStrategy>, Set<Class<? extends TraversalStrategy>>> dependencyMap,
+                      final List<Class<? extends TraversalStrategy>> sortedStrategyClasses,
+                      final Set<Class<? extends TraversalStrategy>> seenStrategyClases,
+                      final List<Class<? extends TraversalStrategy>> unprocessedStrategyClasses, Class<? extends TraversalStrategy> strategyClass) {
         if (seenStrategyClases.contains(strategyClass)) {
             throw new IllegalStateException("Cyclic dependency between traversal strategies: ["
                     + seenStrategyClases + ']');
@@ -194,7 +195,6 @@ public interface TraversalStrategies extends Serializable, Cloneable {
             sortedStrategyClasses.add(strategyClass);
         }
     }
-
 
     public static final class GlobalCache {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1758

Played around with a few ways to test this, but none seemed especially good. Everything I try to do seems fairly contrived or redundant. In the end, I ended up feeling like it was safe to just rely on the TraversalStrategies sorting system with posts/priors. That's pretty solidly tested so perhaps that is enough...

Here's the result of a quick manual test:

```text
gremlin> g = TinkerGraph.open().traversal().withRemote('conf/remote-graph.properties').withStrategies(SubgraphStrategy.build().vertices(identity()).create())
==>graphtraversalsource[tinkergraph[vertices:0 edges:0], standard]
gremlin> g.V().out().out().values('name').explain()
==>Traversal Explanation
=======================================================================================================================================
Original Traversal                 [GraphStep(vertex,[]), VertexStep(OUT,vertex), VertexStep(OUT,vertex), PropertiesStep([name],value)]

RemoteStrategy               [D]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
SubgraphStrategy             [D]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
ConnectiveStrategy           [D]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
RangeByIsCountStrategy       [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
RepeatUnrollStrategy         [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
MatchPredicateStrategy       [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
FilterRankingStrategy        [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
InlineFilterStrategy         [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
IncidentToAdjacentStrategy   [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
AdjacentToIncidentStrategy   [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
PathRetractionStrategy       [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
LazyBarrierStrategy          [O]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
TinkerGraphCountStrategy     [P]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
TinkerGraphStepStrategy      [P]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
ProfileStrategy              [F]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
StandardVerificationStrategy [V]   [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]

Final Traversal                    [RemoteStep(DriverServerConnection-localhost/127.0.0.1:8182 [graph=g])]
```

All tests pass with `docker/build.sh -t -n -i`

VOTE +1