### PR TITLE
TINKERPOP-1896 Fixed bug in lambda processing for python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,7 +31,6 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bumped to Jackson 2.9.4.
 * Added `idleConnectionTimeout` and `keepAliveInterval` to Gremlin Server that enables a "ping" and auto-close for seemingly dead clients.
 * Fixed a bug where lambdas in `gremlin-python` would trigger a failure if steps using python-only symbols were present (such as `as_()`).
-* Fixed a bug where lambdas in `gremlin-python` would trigger a failure if `withStrategies()` was evaluated.
 * Fixed a bug in `NumberHelper` that led to wrong min/max results if numbers exceeded the Integer limits.
 * Delayed setting of the request identifier until `RequestMessage` construction by the builder.
 * Improved error messaging for failed serialization and deserialization of request/response messages.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bumped to Jackson 2.9.4.
 * Added `idleConnectionTimeout` and `keepAliveInterval` to Gremlin Server that enables a "ping" and auto-close for seemingly dead clients.
 * Fixed a bug where lambdas in `gremlin-python` would trigger a failure if steps using python-only symbols were present (such as `as_()`).
+* Fixed a bug where lambdas in `gremlin-python` would trigger a failure if `withStrategies()` was evaluated.
 * Fixed a bug in `NumberHelper` that led to wrong min/max results if numbers exceeded the Integer limits.
 * Delayed setting of the request identifier until `RequestMessage` construction by the builder.
 * Improved error messaging for failed serialization and deserialization of request/response messages.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed deserialization of `P.not()` for GraphSON.
 * Bumped to Jackson 2.9.4.
 * Added `idleConnectionTimeout` and `keepAliveInterval` to Gremlin Server that enables a "ping" and auto-close for seemingly dead clients.
+* Fixed a bug where lambdas in `gremlin-python` would trigger a failure if steps using python-only symbols were present (such as `as_()`).
 * Fixed a bug in `NumberHelper` that led to wrong min/max results if numbers exceeded the Integer limits.
 * Delayed setting of the request identifier until `RequestMessage` construction by the builder.
 * Improved error messaging for failed serialization and deserialization of request/response messages.

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/GremlinJythonScriptEngine.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/GremlinJythonScriptEngine.java
@@ -41,11 +41,11 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GremlinJythonScriptEngine implements GremlinScriptEngine {
 
@@ -123,10 +123,7 @@ public class GremlinJythonScriptEngine implements GremlinScriptEngine {
         // extract the named traversalsource prior to that happening so that bytecode bindings can share the same
         // namespace as global bindings (e.g. traversalsources and graphs).
         if (traversalSource.equals(HIDDEN_G))
-            throw new IllegalArgumentException("The traversalSource cannot have the name " + HIDDEN_G+ " - it is reserved");
-
-        if (bindings.containsKey(HIDDEN_G))
-            throw new IllegalArgumentException("Bindings cannot include " + HIDDEN_G + " - it is reserved");
+            throw new IllegalArgumentException("The traversalSource cannot have the name " + HIDDEN_G + " - it is reserved");
 
         if (!bindings.containsKey(traversalSource))
             throw new IllegalArgumentException("The bindings available to the ScriptEngine do not contain a traversalSource named: " + traversalSource);

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslator.java
@@ -19,7 +19,16 @@
 
 package org.apache.tinkerpop.gremlin.python.jsr223;
 
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationConverter;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -62,5 +71,15 @@ public final class JythonTranslator extends PythonTranslator {
         // bound - therefore, unlike the python engine which converts java names to python friendly ones, this
         // jython one can just pass them through.
         return methodName;
+    }
+
+    @Override
+    protected String resolveTraversalStrategyProxy(final TraversalStrategyProxy proxy) {
+        // since this is jython we don't need a traversal proxy here - we need the actual JVM version of the strategy
+        // since this script will be executed in Jython. 
+        if (proxy.getConfiguration().isEmpty())
+            return proxy.getStrategyClass().getCanonicalName() + ".instance()";
+        else
+            return proxy.getStrategyClass().getCanonicalName() + ".create(new org.apache.commons.configuration.MapConfiguration(" + convertToString(ConfigurationConverter.getMap(proxy.getConfiguration())) + "))";
     }
 }

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslator.java
@@ -80,6 +80,6 @@ public final class JythonTranslator extends PythonTranslator {
         if (proxy.getConfiguration().isEmpty())
             return proxy.getStrategyClass().getCanonicalName() + ".instance()";
         else
-            return proxy.getStrategyClass().getCanonicalName() + ".create(new org.apache.commons.configuration.MapConfiguration(" + convertToString(ConfigurationConverter.getMap(proxy.getConfiguration())) + "))";
+            return proxy.getStrategyClass().getCanonicalName() + ".create(org.apache.commons.configuration.MapConfiguration(" + convertToString(ConfigurationConverter.getMap(proxy.getConfiguration())) + "))";
     }
 }

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslator.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.util.function.Lambda;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public final class JythonTranslator extends PythonTranslator {
 
@@ -53,5 +54,13 @@ public final class JythonTranslator extends PythonTranslator {
             return "JythonTwoArgLambda(" + lambdaString + ")";
         else
             return "JythonUnknownArgLambda(" + lambdaString + ")";
+    }
+
+    @Override
+    protected String resolveSymbol(final String methodName) {
+        // since this is Jython we should expect the Gremlin to conform to the java classes to which the engine is
+        // bound - therefore, unlike the python engine which converts java names to python friendly ones, this
+        // jython one can just pass them through.
+        return methodName;
     }
 }

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
@@ -56,6 +56,7 @@ import java.util.stream.Stream;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class PythonTranslator implements Translator.ScriptTranslator {
 
@@ -114,7 +115,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
                     instruction.getArguments()[0].toString().contains("TranslationStrategy"))
                 continue;
             else if (0 == arguments.length)
-                traversalScript.append(".").append(SymbolHelper.toPython(methodName)).append("()");
+                traversalScript.append(".").append(resolveSymbol(methodName)).append("()");
             else if (methodName.equals("range") && 2 == arguments.length)
                 traversalScript.append("[").append(arguments[0]).append(":").append(arguments[1]).append("]");
             else if (methodName.equals("limit") && 1 == arguments.length)
@@ -123,7 +124,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
                 traversalScript.append(".").append(arguments[0]);
             else {
                 traversalScript.append(".");
-                String temp = SymbolHelper.toPython(methodName) + "(";
+                String temp = resolveSymbol(methodName) + "(";
                 for (final Object object : arguments) {
                     temp = temp + convertToString(object) + ",";
                 }
@@ -131,7 +132,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
             }
             // clip off __.
             if (this.importStatics && traversalScript.substring(0, 3).startsWith("__.")
-                    && !NO_STATIC.stream().filter(name -> traversalScript.substring(3).startsWith(SymbolHelper.toPython(name))).findAny().isPresent()) {
+                    && !NO_STATIC.stream().filter(name -> traversalScript.substring(3).startsWith(resolveSymbol(name))).findAny().isPresent()) {
                 traversalScript.delete(0, 3);
             }
         }
@@ -183,13 +184,13 @@ public class PythonTranslator implements Translator.ScriptTranslator {
         else if (object instanceof Class)
             return ((Class) object).getCanonicalName();
         else if (object instanceof VertexProperty.Cardinality)
-            return "Cardinality." + SymbolHelper.toPython(object.toString());
+            return "Cardinality." + resolveSymbol(object.toString());
         else if (object instanceof SackFunctions.Barrier)
-            return "Barrier." + SymbolHelper.toPython(object.toString());
+            return "Barrier." + resolveSymbol(object.toString());
         else if (object instanceof TraversalOptionParent.Pick)
-            return "Pick." + SymbolHelper.toPython(object.toString());
+            return "Pick." + resolveSymbol(object.toString());
         else if (object instanceof Enum)
-            return convertStatic(((Enum) object).getDeclaringClass().getSimpleName() + ".") + SymbolHelper.toPython(object.toString());
+            return convertStatic(((Enum) object).getDeclaringClass().getSimpleName() + ".") + resolveSymbol(object.toString());
         else if (object instanceof P)
             return convertPToString((P) object, new StringBuilder()).toString();
         else if (object instanceof Element) {
@@ -235,6 +236,10 @@ public class PythonTranslator implements Translator.ScriptTranslator {
     protected String convertLambdaToString(final Lambda lambda) {
         final String lambdaString = lambda.getLambdaScript().trim();
         return lambdaString.startsWith("lambda") ? lambdaString : "lambda " + lambdaString;
+    }
+
+    protected String resolveSymbol(final String methodName) {
+        return SymbolHelper.toPython(methodName);
     }
 
 }

--- a/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
+++ b/gremlin-python/src/main/java/org/apache/tinkerpop/gremlin/python/jsr223/PythonTranslator.java
@@ -139,7 +139,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
         return traversalScript.toString();
     }
 
-    private String convertToString(final Object object) {
+    protected String convertToString(final Object object) {
         if (object instanceof Bytecode.Binding)
             return ((Bytecode.Binding) object).variable();
         else if (object instanceof Bytecode)
@@ -172,11 +172,7 @@ public class PythonTranslator implements Translator.ScriptTranslator {
         } else if (object instanceof Long)
             return object + "L";
         else if (object instanceof TraversalStrategyProxy) {
-            final TraversalStrategyProxy proxy = (TraversalStrategyProxy) object;
-            if (proxy.getConfiguration().isEmpty())
-                return "TraversalStrategy(\"" + proxy.getStrategyClass().getSimpleName() + "\")";
-            else
-                return "TraversalStrategy(\"" + proxy.getStrategyClass().getSimpleName() + "\"," + convertToString(ConfigurationConverter.getMap(proxy.getConfiguration())) + ")";
+            return resolveTraversalStrategyProxy((TraversalStrategyProxy) object);
         } else if (object instanceof TraversalStrategy) {
             return convertToString(new TraversalStrategyProxy((TraversalStrategy) object));
         } else if (object instanceof Boolean)
@@ -242,4 +238,10 @@ public class PythonTranslator implements Translator.ScriptTranslator {
         return SymbolHelper.toPython(methodName);
     }
 
+    protected String resolveTraversalStrategyProxy(final TraversalStrategyProxy proxy) {
+        if (proxy.getConfiguration().isEmpty())
+            return "TraversalStrategy(\"" + proxy.getStrategyClass().getSimpleName() + "\")";
+        else
+            return "TraversalStrategy(\"" + proxy.getStrategyClass().getSimpleName() + "\"," + convertToString(ConfigurationConverter.getMap(proxy.getConfiguration())) + ")";
+    }
 }

--- a/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
+++ b/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.Read
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -108,6 +109,7 @@ public class JythonTranslatorTest {
     }
 
     @Test
+    @Ignore("TINKERPOP-1898 - ultimately seems to be a problem with jython and varargs - doesn't act consistently")
     public void shouldTranslateToJythonWhenUsingLambdasAndStrategies() throws Exception {
         // the jython translation kicks in when you add a lambda so ensure that it translates when strategies are
         // present

--- a/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
+++ b/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -33,6 +34,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.hasLabel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -111,9 +113,10 @@ public class JythonTranslatorTest {
         // present
         GraphTraversalSource g = TinkerFactory.createModern().traversal();
         g = g.withStrategies(new TranslationStrategy(g, JythonTranslator.of("g")));
-        final List<Object> o = g.withStrategies(ReadOnlyStrategy.instance()).
-                V().has("name").map(Lambda.function("lambda x: type(x.get())")).toList();
+        final List<Object> o = g.withStrategies(ReadOnlyStrategy.instance(),
+                                                SubgraphStrategy.build().checkAdjacentVertices(false).vertices(hasLabel("person")).create()).
+                                 V().has("name").map(Lambda.function("lambda x: type(x.get())")).toList();
 
-        assertEquals(6, o.size());
+        assertEquals(4, o.size());
     }
 }

--- a/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
+++ b/gremlin-python/src/test/java/org/apache/tinkerpop/gremlin/python/jsr223/JythonTranslatorTest.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
@@ -100,6 +101,18 @@ public class JythonTranslatorTest {
                         __.as("x").id().as("id")).
                 select("lbl", "id").
                                  map(Lambda.function("lambda x: type(x.get())")).toList();
+
+        assertEquals(6, o.size());
+    }
+
+    @Test
+    public void shouldTranslateToJythonWhenUsingLambdasAndStrategies() throws Exception {
+        // the jython translation kicks in when you add a lambda so ensure that it translates when strategies are
+        // present
+        GraphTraversalSource g = TinkerFactory.createModern().traversal();
+        g = g.withStrategies(new TranslationStrategy(g, JythonTranslator.of("g")));
+        final List<Object> o = g.withStrategies(ReadOnlyStrategy.instance()).
+                V().has("name").map(Lambda.function("lambda x: type(x.get())")).toList();
 
         assertEquals(6, o.size());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1896

When a lambda is in a traversal, the bytecode gets pushed to a scriptengine for evaluation. For python that means, using the JythonTranslator. Prior to this change the JythonTranslator largely relied on the PythonTranslator to convert bytecode to Jython-syntaxed Gremlin. The problem there is that in the JythonScriptEngine, the Traversal bindings are Java objects and so if translated to pure Python syntax, traversal steps like as() become as_() and thus not part of the Java API that is expected - and then errors. Not sure why this didn't come up sooner, but it really only ends up being an issue if you are using bytecode, use gremlin server, use jython in gremlin server and then submit a traversal with a lambda - so perhaps that hasn't been a common combination.

Had to roll back declaring completely victor on TINKERPOP-1898/1895 but didn't want to kill the commit work done thus far as it still holds some value. I intend to close 1895 as duplicate of 1898 and leave 1898 open for now - that fix seems somewhat out of our hands. Will document my findings in JIRA.

All tests pass with `docker/build.sh -t -i`

VOTE +1