### PR TITLE
TINKERPOP-1920 Fixed P.within/without() handling for collections

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `IndexedTraverserSet` which indexes on the value of a `Traverser` thus improving performance when used.
 * Utilized `IndexedTraverserSet` in `TraversalVertexProgram` to avoid extra iteration when doing `Vertex` lookups.
 * Bumped to Netty 4.0.56.Final.
+* Fixed .NET GraphSON serialization of `P.Within()` and `P.without()` when passing a `Collection` as an argument.
 * Fixed a bug in Gremlin Console which prevented handling of `gremlin.sh` flags that had an "=" between the flag and its arguments.
 * Fixed bug where `SparkMessenger` was not applying the `edgeFunction` from `MessageScope`.
 * Fixed a bug in `ComputerAwareStep` that didn't handle `reset()` properly and thus occasionally produced some extra traversers.

--- a/gremlin-dotnet/glv/P.template
+++ b/gremlin-dotnet/glv/P.template
@@ -22,6 +22,12 @@
 #endregion
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
 namespace Gremlin.Net.Process.Traversal
 {
 #pragma warning disable 1591
@@ -88,9 +94,18 @@ namespace Gremlin.Net.Process.Traversal
 <% } %><% pmethods.findAll{ it in ["within", "without"] }.each { method -> %>
         public static P <%= toCSharpMethodName.call(method) %>(params object[] args)
         {
-            return new P("<%= method %>", args);
+            if (args.Length == 1 && args[0] is ICollection<object> collection)
+                return new P("<%= method %>", ToGenericArray(collection));
+            else
+                return new P("<%= method %>", args);
         }
 <% } %>
+
+        private static T[] ToGenericArray<T>(ICollection<T> collection)
+        {
+            return collection?.ToArray() ?? new T[0];;
+        }
+
         /// <inheritdoc />
         public override string ToString()
         {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
@@ -22,6 +22,12 @@
 #endregion
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
 namespace Gremlin.Net.Process.Traversal
 {
 #pragma warning disable 1591
@@ -148,12 +154,24 @@ namespace Gremlin.Net.Process.Traversal
 
         public static P Within(params object[] args)
         {
-            return new P("within", args);
+            if (args.Length == 1 && args[0] is ICollection<object> collection)
+                return new P("within", ToGenericArray(collection));
+            else
+                return new P("within", args);
         }
 
         public static P Without(params object[] args)
         {
-            return new P("without", args);
+            if (args.Length == 1 && args[0] is ICollection<object> collection)
+                return new P("without", ToGenericArray(collection));
+            else
+                return new P("without", args);
+        }
+
+
+        private static T[] ToGenericArray<T>(ICollection<T> collection)
+        {
+            return collection?.ToArray() ?? new T[0];;
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -38,11 +38,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
     public class GherkinTestRunner
     {
         private static readonly IDictionary<string, IgnoreReason> IgnoredScenarios =
-            new Dictionary<string, IgnoreReason>
-            {
-                {"g_V_hasIdXwithinXemptyXX_count", IgnoreReason.PWithinWrapsArgumentsInArray},
-                {"g_VX1X_out_aggregateXxX_out_whereXnotXwithinXaXXX", IgnoreReason.PWithinWrapsArgumentsInArray}
-            };
+            new Dictionary<string, IgnoreReason>();
         
         private static class Keywords
         {

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
@@ -40,11 +40,8 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             string reasonSuffix = null;
             switch (reason)
             {
-                case IgnoreReason.PWithinWrapsArgumentsInArray:
-                    reasonSuffix = " because P.Within() arguments are incorrectly wrapped in an array (TINKERPOP-1920)";
-                    break;
-                case IgnoreReason.PNotDeserializationProblem:
-                    reasonSuffix = " because P.Not() cannot be deserialized by Gremlin Server (TINKERPOP-1922)";
+                case IgnoreReason.NoReason:
+                    reasonSuffix = "";
                     break;
             }
             return $"Scenario ignored" + reasonSuffix;
@@ -53,7 +50,6 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
     
     public enum IgnoreReason
     {
-        PWithinWrapsArgumentsInArray,
-        PNotDeserializationProblem
+        NoReason
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1920

Made the logic the same as what we have in Java currently for `P.within()` and `P.without()` for handling single collection values. I pretty much just made this work so open to input from C# experts for a nicer handling of `P`, but for now in terms of fixing the problem:

Builds with `mvn clean install -pl :gremlin-dotnet,:gremlin-dotnet-source,:gremlin-dotnet-tests -DskipIntegrationTests=false`

VOTE+1