### PR TITLE
TINKERPOP-1865 Run Gremlin.Net tests with GraphSON 3.0

### DIFF
--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
@@ -252,8 +252,9 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
         {
             if (value.Type == JTokenType.Object)
             {
-                IDictionary<string, JToken> jsonMap = (JObject)value; 
-                return jsonMap.ToDictionary(kv => kv.Key, kv => ParseMapValue(kv.Value, graphName));
+                IDictionary<string, JToken> jsonMap = (JObject)value;
+                return jsonMap.ToDictionary(kv => ParseMapValue(kv.Key, graphName),
+                    kv => ParseMapValue(kv.Value, graphName));
             }
             if (value.Type == JTokenType.Array)
             {

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -44,10 +44,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
                 { "g_V_valueMapXtrue_name_ageX", IgnoreReason.TraversalTDeserializationNotSupported }, // TINKERPOP-1866
                 { "g_V_hasLabelXpersonX_filterXoutEXcreatedXX_valueMapXtrueX", IgnoreReason.TraversalTDeserializationNotSupported }, // TINKERPOP-1866
                 {"g_V_asXaX_hasXname_markoX_outXcreatedX_asXbX_addVXselectXaX_labelX_propertyXtest_selectXbX_labelX_valueMapXtrueX", IgnoreReason.TraversalTDeserializationNotSupported},
-                {"g_V_hasIdXwithinXemptyXX_count", IgnoreReason.PWithinWrapsArgumentsInArray},
-                {"g_VX1X_out_aggregateXxX_out_whereXnotXwithinXaXXX", IgnoreReason.PWithinWrapsArgumentsInArray},
-                {"g_VX1X_hasXlabel_personX_mapXmapXint_ageXX_orderXlocalX_byXvalues_decrX_byXkeys_incrX", IgnoreReason.ReceivedDataDoesntMatchExpected},
-                {"g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX", IgnoreReason.PWithinWrapsArgumentsInArray}
+                {"g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX", IgnoreReason.ReceivedDataDoesntMatchExpected}
             };
         
         private static class Keywords

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -42,7 +42,12 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             {
                 { "g_V_valueMapXtrueX", IgnoreReason.TraversalTDeserializationNotSupported },   // TINKERPOP-1866
                 { "g_V_valueMapXtrue_name_ageX", IgnoreReason.TraversalTDeserializationNotSupported }, // TINKERPOP-1866
-                { "g_V_hasLabelXpersonX_filterXoutEXcreatedXX_valueMapXtrueX", IgnoreReason.TraversalTDeserializationNotSupported } // TINKERPOP-1866
+                { "g_V_hasLabelXpersonX_filterXoutEXcreatedXX_valueMapXtrueX", IgnoreReason.TraversalTDeserializationNotSupported }, // TINKERPOP-1866
+                {"g_V_asXaX_hasXname_markoX_outXcreatedX_asXbX_addVXselectXaX_labelX_propertyXtest_selectXbX_labelX_valueMapXtrueX", IgnoreReason.TraversalTDeserializationNotSupported},
+                {"g_V_hasIdXwithinXemptyXX_count", IgnoreReason.PWithinWrapsArgumentsInArray},
+                {"g_VX1X_out_aggregateXxX_out_whereXnotXwithinXaXXX", IgnoreReason.PWithinWrapsArgumentsInArray},
+                {"g_VX1X_hasXlabel_personX_mapXmapXint_ageXX_orderXlocalX_byXvalues_decrX_byXkeys_incrX", IgnoreReason.ReceivedDataDoesntMatchExpected},
+                {"g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX", IgnoreReason.PWithinWrapsArgumentsInArray}
             };
         
         private static class Keywords

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
@@ -60,8 +60,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
         /// Deserialization of g:T on GraphSON3 is not supported.
         /// </summary>
         TraversalTDeserializationNotSupported,
-        PWithinWrapsArgumentsInArray,
-        ReceivedDataDoesntMatchExpected
+        ReceivedDataDoesntMatchExpected,
         NoReason
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
@@ -46,6 +46,9 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
                 case IgnoreReason.NoReason:
                     reasonSuffix = "";
                     break;
+                case IgnoreReason.ReceivedDataDoesntMatchExpected:
+                    reasonSuffix = " because received data from server doesn't match expected data.";
+                    break;
             }
             return $"Scenario ignored" + reasonSuffix;
         }
@@ -57,6 +60,8 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
         /// Deserialization of g:T on GraphSON3 is not supported.
         /// </summary>
         TraversalTDeserializationNotSupported,
+        PWithinWrapsArgumentsInArray,
+        ReceivedDataDoesntMatchExpected
         NoReason
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Generic;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Process.Remote;
-using Gremlin.Net.Structure.IO.GraphSON;
 using DriverRemoteConnectionImpl = Gremlin.Net.Driver.Remote.DriverRemoteConnection;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
@@ -45,9 +44,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
         public IRemoteConnection CreateRemoteConnection(string traversalSource)
         {
-            var c = new DriverRemoteConnectionImpl(
-                new GremlinClient(new GremlinServer(TestHost, TestPort), new GraphSON2Reader(), new GraphSON2Writer(),
-                    GremlinClient.GraphSON2MimeType), traversalSource);
+            var c = new DriverRemoteConnectionImpl(new GremlinClient(new GremlinServer(TestHost, TestPort)),
+                traversalSource);
             _connections.Add(c);
             return c;
         }

--- a/gremlin-test/features/map/Order.feature
+++ b/gremlin-test/features/map/Order.feature
@@ -313,7 +313,7 @@ Feature: Step - order()
   Scenario: g_VX1X_hasXlabel_personX_mapXmapXint_ageXX_orderXlocalX_byXvalues_decrX_byXkeys_incrX
     Given the modern graph
     And using the parameter v1 defined as "v[marko]"
-    And using the parameter l1 defined as "c[[1:it.get().value('age'),2:it.get().value('age')*2,3:it.get().value('age')*3,4:it.get().value('age')]]"
+    And using the parameter l1 defined as "c[['1':it.get().value('age'),'2':it.get().value('age')*2,'3':it.get().value('age')*3,'4':it.get().value('age')]]"
     And the traversal of
       """
       g.V(v1).hasLabel("person").map(l1).order(Scope.local).by(Column.values, Order.decr).by(Column.keys, Order.incr)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1865

The tests simply failed because of the traversal used in `ScenarioData.GetEdges()`. I didn't dig deep into why it failed, but it had something to do with the deserialization of the keys of the received dictionary. I also couldn't get the traversal used there to work with gremlin-python, so I simply replaced it by two simpler traversals. This increases the runtime a bit as the second traversal now has to be executed for every edge, but I think that it improves the readability a lot.

Unfortunately, I had to add 3 more tests to the list of ignored ones. One failed due to the missing `T` deserializer (TINKERPOP-1866) and two failed because the data received from the server didn't match the expected data:

- `g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX`: We receive a `g:Set` of 8 values here, including 4 duplicates. This is deserialized to a `HashSet` by Gremlin.Net which means that the 8 values are reduced to 4 unique values, but the scenario expects a collection of 8 values.
- `g_VX1X_hasXlabel_personX_mapXmapXint_ageXX_orderXlocalX_byXvalues_decrX_byXkeys_incrX`: Here we receive a map with `g:Int32` keys (at least when my understanding of the `g:Map` type is correct), but the scenario expects `string` keys.

To me, this looks like mistakes in the scenarios, but it would be good if someone could verify that. I tried to modify the scenarios accordingly, but then both gremlin-python and gremlin-javascript failed for the scenario with the `g:Set` containing duplicates. So either the deserialization of `g:Set` is flawed in those two GLVs or my understanding of sets is wrong.