### PR TITLE
TINKERPOP-1880 Sign assembly on Linux and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,12 @@ install:
   - mvn -version
 
 before_install:
-  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
+  - curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+  - sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+  - sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+  - sudo apt-get install apt-transport-https
   - sudo apt-get update
-  - sudo apt-get install dotnet-dev-1.0.4
+  - sudo apt-get install dotnet-sdk-2.1.101
 
 jobs:
   include:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,11 +23,12 @@ RUN apt-get update \
     && apt-get -y install software-properties-common python-software-properties apt-transport-https \
     && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
     && add-apt-repository -y ppa:webupd8team/java \
-    && sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' \
+    && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list' \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893 \
     && apt-get update \
-    && apt-get install -y oracle-java8-installer curl gawk git maven openssh-server dotnet-dev-1.0.4 subversion zip \
-    && apt-get install -y python python-dev python-pip build-essential \
+    && apt-get install -y oracle-java8-installer curl gawk git maven openssh-server subversion zip \
+    && sh -c 'curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg' \
+    && apt-get install -y --force-yes dotnet-sdk-2.1.101 python python-dev python-pip build-essential \
     && pip install virtualenv virtualenvwrapper \
     && pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* /var/cache/oracle-jdk8-installer

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -100,7 +100,7 @@ mvn clean install -pl gremlin-console -DskipIntegrationTests=false
 [[dotnet-environment]]
 === DotNet Environment
 
-The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=1.1.0) to work with the
+The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=2.1.101) to work with the
 `gremlin-dotnet` module. If .NET Core SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
 

--- a/gremlin-dotnet/glv/Gremlin.Net.csproj.template
+++ b/gremlin-dotnet/glv/Gremlin.Net.csproj.template
@@ -41,7 +41,6 @@ Please see the reference documentation at Apache TinkerPop for more information 
 NOTE: Gremlin.Net is an extension of the Gremlin.Net driver by Florian Hockmann (versions: 0.y.z) and is now included as part of the Apache TinkerPop project.</Description>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition="'\$(OS)' != 'Windows_NT'">true</PublicSign>
     <PackageId>Gremlin.Net</PackageId>
     <PackageTags>gremlin;tinkerpop;apache</PackageTags>
     <PackageProjectUrl>http://tinkerpop.apache.org</PackageProjectUrl>

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -41,7 +41,6 @@ Please see the reference documentation at Apache TinkerPop for more information 
 NOTE: Gremlin.Net is an extension of the Gremlin.Net driver by Florian Hockmann (versions: 0.y.z) and is now included as part of the Apache TinkerPop project.</Description>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <PackageId>Gremlin.Net</PackageId>
     <PackageTags>gremlin;tinkerpop;apache</PackageTags>
     <PackageProjectUrl>http://tinkerpop.apache.org</PackageProjectUrl>

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Gremlin.Net.IntegrationTest</AssemblyName>
     <PackageId>Gremlin.Net.IntegrationTest</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Gremlin.Net.UnitTest</AssemblyName>
     <PackageId>Gremlin.Net.UnitTest</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>


### PR DESCRIPTION
With the latest .NET Core SDK (2.1.101), its now possible to sign assemblies from Linux and macOS.

We should update our own local installation to use 2.1.101+ to run the .NET test locally.
The Gremlin.NET package still targets .NET Standard 1.3, there isn't any change for our users.

VOTE +1