### PR TITLE
Pinned netty to 4.0.x for spark/console

### DIFF
--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -50,6 +50,20 @@ limitations under the License.
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
             <version>${project.version}</version>
+            <!-- force the console to use netty 4.0.56.Final to comply with spark 2.2.0 which is incompatible with
+                 netty 4.1.x line used by Gremlin driver/server -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- We can avoid pinning the console to this version once spark is upgraded to support netty 4.1.x -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.0.56.Final</version>
         </dependency>
         <dependency>
             <groupId>org.gperfutils</groupId>

--- a/gremlin-tools/gremlin-coverage/pom.xml
+++ b/gremlin-tools/gremlin-coverage/pom.xml
@@ -15,6 +15,14 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-console</artifactId>
             <version>${project.version}</version>
+            <!-- console is temporarily pinned to netty 4.0.x until spark upgrades to 4.1.x - see the gremlin-console
+                 and spark-gremlin pom.xml for more information -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -233,10 +233,6 @@
                 </exclusion>
                 <exclusion>
                     <groupId>io.netty</groupId>
-                    <artifactId>netty</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
             </exclusions>
@@ -278,15 +274,14 @@
             <artifactId>snappy-java</artifactId>
             <version>1.1.1.7</version>
         </dependency>
+        <!-- this is the last version of netty on the 4.0.x line. spark 2.2.0 is bound to 4.0.43.Final actually.
+             4.1.x is not compatible which is what gremlin-server/console are on. allowed netty to specify the version
+             of io.netty/netty which is 3.9.9.Final. when this gets sorted, fix-up gremlin-coverage and gremlin-console
+             pom.xml files as well -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.43.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-            <version>3.9.9.Final</version>
+            <version>4.0.56.Final</version>
         </dependency>
         <!-- TEST -->
         <dependency>


### PR DESCRIPTION
Spark and Gremlin Console use netty 4.0.x. They have to be the same version because spark is incompatible with 4.1.x so if the console has that version present then spark jobs won't submit and docs won't generate. Luckily, the driver is fine with 4.0.x in terms of connecting to 4.1.x from the testing i've tried.

All tests pass with `docker/build.sh -t -n -i`

seems really hacky - especially with gremlin server/spark deployment problems.......second thoughts.....