### PR TITLE
TINKERPOP-1934 Bumped httpclient to 4.5.5

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,11 @@ limitations under the License.
 
 image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/nine-inch-gremlins.png[width=185]
 
+[[release-3-2-9]]
+=== TinkerPop 3.2.9 (Release Date: NOT OFFICIALLY RELEASED YET)
+
+* Bumped to httpclient 4.5.5.
+
 [[release-3-2-8]]
 === TinkerPop 3.2.8 (Release Date: April 2, 2018)
 

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -39,7 +39,6 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -29,12 +29,6 @@ Licensed under the Creative Commons Attribution Licence v2.5
 http://creativecommons.org/licenses/by/2.5/
 
 ------------------------------------------------------------------------
-Apache Http Components Core 4.4.3 (AL ASF)
-------------------------------------------------------------------------
-This project contains annotations derived from JCIP-ANNOTATIONS
-Copyright (c) 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
-
-------------------------------------------------------------------------
 Apache Ivy 2.3.0 (AL ASF)
 ------------------------------------------------------------------------
 Portions of Ivy were originally developed by

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -96,7 +96,6 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,11 @@ limitations under the License.
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.5</version>
+            </dependency>
+            <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>1.2.17</version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1934

Removed httpcore NOTICE entry as this more recent version does not contain that designation in its NOTICE.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1