### PR TITLE
TINKERPOP-1927 Coerced BulkSet to g:List in GraphSON 3.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,13 @@ limitations under the License.
 
 image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-mozart.png[width=185]
 
+[[release-3-3-3]]
+=== TinkerPop 3.3.3 (Release Date: NOT OFFICIALLY RELEASED YET)
+
+This release also includes changes from <<release-3-2-9, 3.2.9>>.
+
+* Coerced `BulkSet` to `g:List` in GraphSON 3.0.
+
 [[release-3-3-2]]
 === TinkerPop 3.3.2 (Release Date: April 2, 2018)
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeSerializerV3d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeSerializerV3d0.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.SackFunctions;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
 import org.apache.tinkerpop.gremlin.process.traversal.util.Metrics;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
@@ -124,7 +125,7 @@ public class GraphSONTypeSerializerV3d0 extends AbstractGraphSONTypeSerializer {
                 mapped = Tree.class;
             else
                 mapped = Map.class;
-        } else if (List.class.isAssignableFrom(c))
+        } else if (List.class.isAssignableFrom(c) || BulkSet.class.isAssignableFrom(c))  // coerce BulkSet to List as their behavior on iteration is identical
             mapped = List.class;
         else if (Set.class.isAssignableFrom(c))
             mapped = Set.class;

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -38,10 +38,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
     public class GherkinTestRunner
     {
         private static readonly IDictionary<string, IgnoreReason> IgnoredScenarios =
-            new Dictionary<string, IgnoreReason>
-            {
-                {"g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX", IgnoreReason.ReceivedDataDoesntMatchExpected}
-            };
+            new Dictionary<string, IgnoreReason>();
         
         private static class Keywords
         {

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
@@ -40,14 +40,8 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             string reasonSuffix = null;
             switch (reason)
             {
-                case IgnoreReason.TraversalTDeserializationNotSupported:
-                    reasonSuffix = " as deserialization of g:T on GraphSON3 is not supported";
-                    break;
                 case IgnoreReason.NoReason:
                     reasonSuffix = "";
-                    break;
-                case IgnoreReason.ReceivedDataDoesntMatchExpected:
-                    reasonSuffix = " because received data from server doesn't match expected data.";
                     break;
             }
             return $"Scenario ignored" + reasonSuffix;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1927

Since GLVs don't have `BulkSet` infrastructure and the need to include it doesn't seem high the most direct fix here is to coerce to `g:List` as the behavior for `BulkSet` iteration is basically that same as a List.

All tests pass with `docker/build.sh -t -i`

VOTE +1