### PR TITLE
TINKERPOP-1705 Removed rebindings API from java driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,11 +23,12 @@ NEED AND IMAGE
 [[release-3-4-0]]
 === TinkerPop 3.4.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-This release also includes changes from <<release-3-3-2, 3.3.2>>.
+This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
 * Change the `toString()` of `Path` to be standardized as other graph elements are.
 * Fixed a bug in `ReducingBarrierStep`, that returned the provided seed value despite no elements being available.
 * Changed the order of `select()` scopes. The order is now: maps, side-effects, paths.
+* Removed previously deprecated `rebindings` options from the Java driver API.
 * Removed support for Giraph.
 
 == TinkerPop 3.3.0 (Gremlin Symphony #40 in G Minor)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -94,31 +94,9 @@ public abstract class Client {
      * server to a variable called "g" for the context of the requests made through that {@code Client}.
      *
      * @param graphOrTraversalSource rebinds the specified global Gremlin Server variable to "g"
-     * @deprecated As of release 3.1.0, replaced by {@link #alias(String)}
-     */
-    @Deprecated
-    public Client rebind(final String graphOrTraversalSource) {
-        return alias(graphOrTraversalSource);
-    }
-
-    /**
-     * Create a new {@code Client} that aliases the specified {@link Graph} or {@link TraversalSource} name on the
-     * server to a variable called "g" for the context of the requests made through that {@code Client}.
-     *
-     * @param graphOrTraversalSource rebinds the specified global Gremlin Server variable to "g"
      */
     public Client alias(final String graphOrTraversalSource) {
         return alias(makeDefaultAliasMap(graphOrTraversalSource));
-    }
-
-    /**
-     * Creates a {@code Client} that supplies the specified set of aliases, thus allowing the user to re-name
-     * one or more globally defined {@link Graph} or {@link TraversalSource} server bindings for the context of
-     * the created {@code Client}.
-     */
-    @Deprecated
-    public Client rebind(final Map<String,String> rebindings) {
-        return alias(rebindings);
     }
 
     /**
@@ -444,29 +422,10 @@ public abstract class Client {
          * {@inheritDoc}
          */
         @Override
-        @Deprecated
-        public Client rebind(final String graphOrTraversalSource) {
-            return alias(graphOrTraversalSource);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
         public Client alias(final String graphOrTraversalSource) {
             final Map<String,String> aliases = new HashMap<>();
             aliases.put("g", graphOrTraversalSource);
             return alias(aliases);
-        }
-
-        /**
-         * Creates a {@code Client} that supplies the specified set of aliases, thus allowing the user to re-name
-         * one or more globally defined {@link Graph} or {@link TraversalSource} server bindings for the context of
-         * the created {@code Client}.
-         */
-        @Deprecated
-        public Client rebind(final Map<String,String> rebindings) {
-            return alias(rebindings);
         }
 
         /**
@@ -541,30 +500,15 @@ public abstract class Client {
      * Uses a {@link org.apache.tinkerpop.gremlin.driver.Client.ClusteredClient} that rebinds requests to a
      * specified {@link Graph} or {@link TraversalSource} instances on the server-side.
      */
-    public final static class AliasClusteredClient extends ReboundClusteredClient {
-        public AliasClusteredClient(final Client client, final Map<String, String> rebindings,
-                                    final Client.Settings settings) {
-            super(client, rebindings, settings);
-        }
-    }
-
-    /**
-     * Uses a {@link org.apache.tinkerpop.gremlin.driver.Client.ClusteredClient} that rebinds requests to a
-     * specified {@link Graph} or {@link TraversalSource} instances on the server-side.
-     *
-     * @deprecated As of release 3.1.1-incubating, replaced by {@link AliasClusteredClient}.
-     */
-    @Deprecated
-    public static class ReboundClusteredClient extends Client {
+    public static class AliasClusteredClient extends Client {
         private final Client client;
         private final Map<String,String> aliases = new HashMap<>();
         final CompletableFuture<Void> close = new CompletableFuture<>();
 
-        ReboundClusteredClient(final Client client, final Map<String,String> rebindings,
-                               final Client.Settings settings) {
+        AliasClusteredClient(final Client client, final Map<String,String> aliases, final Client.Settings settings) {
             super(client.cluster, settings);
             this.client = client;
-            this.aliases.putAll(rebindings);
+            this.aliases.putAll(aliases);
         }
 
         @Override
@@ -638,15 +582,6 @@ public abstract class Client {
         @Override
         public boolean isClosing() {
             return close.isDone();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        @Deprecated
-        public Client rebind(final String graphOrTraversalSource) {
-            return alias(graphOrTraversalSource);
         }
 
         /**

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
@@ -50,12 +50,6 @@ public final class Tokens {
     public static final String ARGS_AGGREGATE_TO = "aggregateTo";
     public static final String ARGS_SIDE_EFFECT_KEY = "sideEffectKey";
 
-    /**
-     * @deprecated As of release 3.1.0-incubating, replaced by {@link #ARGS_ALIASES}.
-     */
-    @Deprecated
-    public static final String ARGS_REBINDINGS = "rebindings";
-
     public static final String VAL_AGGREGATE_TO_BULKSET = "bulkset";
     public static final String VAL_AGGREGATE_TO_LIST = "list";
     public static final String VAL_AGGREGATE_TO_MAP = "map";

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -290,13 +290,8 @@ public abstract class AbstractOpProcessor implements OpProcessor {
 
     protected static void attemptCommit(final RequestMessage msg, final GraphManager graphManager, final boolean strict) {
         if (strict) {
-            // validations should have already been performed in StandardOpProcessor, but a failure in bindings maker
-            // at the time of the eval might raise through here at which point the validation didn't yet happen. better
-            // to just check again
-            final boolean hasRebindings = msg.getArgs().containsKey(Tokens.ARGS_REBINDINGS);
-            final String rebindingOrAliasParameter = hasRebindings ? Tokens.ARGS_REBINDINGS : Tokens.ARGS_ALIASES;
-            if (msg.getArgs().containsKey(rebindingOrAliasParameter)) {
-                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(rebindingOrAliasParameter);
+            if (msg.getArgs().containsKey(Tokens.ARGS_ALIASES)) {
+                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(Tokens.ARGS_ALIASES);
                 graphManager.commit(new HashSet<>(aliases.values()));
             } else {
                 graphManager.commitAll();
@@ -308,13 +303,8 @@ public abstract class AbstractOpProcessor implements OpProcessor {
 
     protected static void attemptRollback(final RequestMessage msg, final GraphManager graphManager, final boolean strict) {
         if (strict) {
-            // validations should have already been performed in StandardOpProcessor, but a failure in bindings maker
-            // at the time of the eval might raise through here at which point the validation didn't yet happen. better
-            // to just check again
-            final boolean hasRebindings = msg.getArgs().containsKey(Tokens.ARGS_REBINDINGS);
-            final String rebindingOrAliasParameter = hasRebindings ? Tokens.ARGS_REBINDINGS : Tokens.ARGS_ALIASES;
-            if (msg.getArgs().containsKey(rebindingOrAliasParameter)) {
-                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(rebindingOrAliasParameter);
+            if (msg.getArgs().containsKey(Tokens.ARGS_ALIASES)) {
+                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(Tokens.ARGS_ALIASES);
                 graphManager.rollback(new HashSet<>(aliases.values()));
             } else {
                 graphManager.rollbackAll();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -218,22 +218,9 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
             final RequestMessage msg = context.getRequestMessage();
             final Bindings bindings = session.getBindings();
 
-            // don't allow both rebindings and aliases parameters as they are the same thing. aliases were introduced
-            // as of 3.1.0 as a replacement for rebindings. this check can be removed when rebindings are completely
-            // removed from the protocol
-            final boolean hasRebindings = msg.getArgs().containsKey(Tokens.ARGS_REBINDINGS);
-            final boolean hasAliases = msg.getArgs().containsKey(Tokens.ARGS_ALIASES);
-            if (hasRebindings && hasAliases) {
-                final String error = "Prefer use of the 'aliases' parameter over 'rebindings' and do not use both";
-                throw new OpProcessorException(error, ResponseMessage.build(msg)
-                        .code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).statusMessage(error).create());
-            }
-
-            final String rebindingOrAliasParameter = hasRebindings ? Tokens.ARGS_REBINDINGS : Tokens.ARGS_ALIASES;
-
             // alias any global bindings to a different variable
-            if (msg.getArgs().containsKey(rebindingOrAliasParameter)) {
-                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(rebindingOrAliasParameter);
+            if (msg.getArgs().containsKey(Tokens.ARGS_ALIASES)) {
+                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(Tokens.ARGS_ALIASES);
                 for (Map.Entry<String,String> aliasKv : aliases.entrySet()) {
                     boolean found = false;
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/standard/StandardOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/standard/StandardOpProcessor.java
@@ -28,7 +28,6 @@ import org.apache.tinkerpop.gremlin.server.OpProcessor;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.op.AbstractEvalOpProcessor;
 import org.apache.tinkerpop.gremlin.server.op.OpProcessorException;
-import org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.util.function.ThrowingConsumer;
 import org.slf4j.Logger;
@@ -115,22 +114,9 @@ public class StandardOpProcessor extends AbstractEvalOpProcessor {
             final RequestMessage msg = context.getRequestMessage();
             final Bindings bindings = new SimpleBindings();
 
-            // don't allow both rebindings and aliases parameters as they are the same thing. aliases were introduced
-            // as of 3.1.0 as a replacement for rebindings. this check can be removed when rebindings are completely
-            // removed from the protocol
-            final boolean hasRebindings = msg.getArgs().containsKey(Tokens.ARGS_REBINDINGS);
-            final boolean hasAliases = msg.getArgs().containsKey(Tokens.ARGS_ALIASES);
-            if (hasRebindings && hasAliases) {
-                final String error = "Prefer use of the 'aliases' parameter over 'rebindings' and do not use both";
-                throw new OpProcessorException(error, ResponseMessage.build(msg)
-                        .code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).statusMessage(error).create());
-            }
-
-            final String rebindingOrAliasParameter = hasRebindings ? Tokens.ARGS_REBINDINGS : Tokens.ARGS_ALIASES;
-
             // alias any global bindings to a different variable.
-            if (msg.getArgs().containsKey(rebindingOrAliasParameter)) {
-                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(rebindingOrAliasParameter);
+            if (msg.getArgs().containsKey(Tokens.ARGS_ALIASES)) {
+                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(Tokens.ARGS_ALIASES);
                 for (Map.Entry<String,String> aliasKv : aliases.entrySet()) {
                     boolean found = false;
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -1244,11 +1244,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             assertEquals(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS, re.getResponseStatusCode());
         }
 
-        // keep the testing here until "rebind" is completely removed
-        final Client reboundLegacy = cluster.connect().rebind("graph");
-        final Vertex vLegacy = reboundLegacy.submit("g.addVertex('name','stephen')").all().get().get(0).getVertex();
-        assertEquals("stephen", vLegacy.value("name"));
-
         final Client rebound = cluster.connect().alias("graph");
         final Vertex v = rebound.submit("g.addVertex('name','jason')").all().get().get(0).getVertex();
         assertEquals("jason", v.value("name"));
@@ -1270,11 +1265,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             final ResponseException re = (ResponseException) root;
             assertEquals(ResponseStatusCode.SERVER_ERROR_SCRIPT_EVALUATION, re.getResponseStatusCode());
         }
-
-        // keep the testing here until "rebind" is completely removed
-        final Client reboundLegacy = cluster.connect().rebind("graph");
-        final Vertex vLegacy = reboundLegacy.submit("g.addVertex('name','stephen')").all().get().get(0).getVertex();
-        assertEquals("stephen", vLegacy.value("name"));
 
         final Client rebound = cluster.connect().alias("graph");
         final Vertex v = rebound.submit("g.addVertex('name','jason')").all().get().get(0).getVertex();
@@ -1298,11 +1288,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             assertEquals(ResponseStatusCode.SERVER_ERROR_SCRIPT_EVALUATION, re.getResponseStatusCode());
         }
 
-        // keep the testing here until "rebind" is completely removed
-        final Client clientLegacy = client.rebind("g1");
-        final Vertex vLegacy = clientLegacy.submit("g.addV().property('name','stephen')").all().get().get(0).getVertex();
-        assertEquals("stephen", vLegacy.value("name"));
-
         final Client clientAliased = client.alias("g1");
         final Vertex v = clientAliased.submit("g.addV().property('name','jason')").all().get().get(0).getVertex();
         assertEquals("jason", v.value("name"));
@@ -1325,14 +1310,8 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             assertEquals(ResponseStatusCode.SERVER_ERROR_SCRIPT_EVALUATION, re.getResponseStatusCode());
         }
 
-        // keep the testing here until "rebind" is completely removed
-        final Client reboundLegacy = client.rebind("graph");
-        assertEquals("stephen", reboundLegacy.submit("n='stephen'").all().get().get(0).getString());
-        final Vertex vLegacy = reboundLegacy.submit("g.addVertex('name',n)").all().get().get(0).getVertex();
-        assertEquals("stephen", vLegacy.value("name"));
-
         final Client aliased = client.alias("graph");
-        assertEquals("jason", reboundLegacy.submit("n='jason'").all().get().get(0).getString());
+        assertEquals("jason", aliased.submit("n='jason'").all().get().get(0).getString());
         final Vertex v = aliased.submit("g.addVertex('name',n)").all().get().get(0).getVertex();
         assertEquals("jason", v.value("name"));
 
@@ -1353,12 +1332,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             final ResponseException re = (ResponseException) root;
             assertEquals(ResponseStatusCode.SERVER_ERROR_SCRIPT_EVALUATION, re.getResponseStatusCode());
         }
-
-        // keep the testing here until "rebind" is completely removed
-        final Client clientLegacy = client.rebind("g1");
-        assertEquals("stephen", clientLegacy.submit("n='stephen'").all().get().get(0).getString());
-        final Vertex vLegacy = clientLegacy.submit("g.addV().property('name',n)").all().get().get(0).getVertex();
-        assertEquals("stephen", vLegacy.value("name"));
 
         final Client clientAliased = client.alias("g1");
         assertEquals("jason", clientAliased.submit("n='jason'").all().get().get(0).getString());

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
@@ -338,32 +338,6 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     }
 
     @Test
-    public void should200OnGETWithGremlinQueryStringArgumentWithIteratorResultAndAliases() throws Exception {
-        // we can remove this first test when rebindings are completely removed
-        final CloseableHttpClient httpclientLegacy = HttpClients.createDefault();
-        final HttpGet httpgetLegacy = new HttpGet(TestClientFactory.createURLString("?gremlin=g1.V()&rebindings.g1=g"));
-
-        try (final CloseableHttpResponse response = httpclientLegacy.execute(httpgetLegacy)) {
-            assertEquals(200, response.getStatusLine().getStatusCode());
-            assertEquals("application/json", response.getEntity().getContentType().getValue());
-            final String json = EntityUtils.toString(response.getEntity());
-            final JsonNode node = mapper.readTree(json);
-            assertEquals(6, node.get("result").get("data").get(GraphSONTokens.VALUEPROP).size());
-        }
-
-        final CloseableHttpClient httpclient = HttpClients.createDefault();
-        final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=g1.V()&aliases.g1=g"));
-
-        try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
-            assertEquals(200, response.getStatusLine().getStatusCode());
-            assertEquals("application/json", response.getEntity().getContentType().getValue());
-            final String json = EntityUtils.toString(response.getEntity());
-            final JsonNode node = mapper.readTree(json);
-            assertEquals(6, node.get("result").get("data").get(GraphSONTokens.VALUEPROP).size());
-        }
-    }
-
-    @Test
     public void should200OnGETWithGremlinQueryStringArgument() throws Exception {
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final HttpGet httpget = new HttpGet(TestClientFactory.createURLString("?gremlin=1-1"));
@@ -512,20 +486,6 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     public void should200OnPOSTTransactionalGraphInStrictMode() throws Exception {
         assumeNeo4jIsPresent();
 
-        // we can remove this first test when rebindings are completely removed
-        final CloseableHttpClient httpclientLegacy = HttpClients.createDefault();
-        final HttpPost httppostLegacy = new HttpPost(TestClientFactory.createURLString());
-        httppostLegacy.addHeader("Content-Type", "application/json");
-        httppostLegacy.setEntity(new StringEntity("{\"gremlin\":\"g1.addV()\",\"rebindings\":{\"g1\":\"g\"}}", Consts.UTF_8));
-
-        try (final CloseableHttpResponse response = httpclientLegacy.execute(httppostLegacy)) {
-            assertEquals(200, response.getStatusLine().getStatusCode());
-            assertEquals("application/json", response.getEntity().getContentType().getValue());
-            final String json = EntityUtils.toString(response.getEntity());
-            final JsonNode node = mapper.readTree(json);
-            assertEquals(1, node.get("result").get("data").get(GraphSONTokens.VALUEPROP).size());
-        }
-
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");
@@ -578,20 +538,6 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void should200OnPOSTWithGremlinJsonEndcodedBodyWithIteratorResultAndAliases() throws Exception {
-        // we can remove this first test when rebindings are completely removed
-        final CloseableHttpClient httpclientLegacy = HttpClients.createDefault();
-        final HttpPost httppostLegacy = new HttpPost(TestClientFactory.createURLString());
-        httppostLegacy.addHeader("Content-Type", "application/json");
-        httppostLegacy.setEntity(new StringEntity("{\"gremlin\":\"g1.V()\",\"rebindings\":{\"g1\":\"g\"}}", Consts.UTF_8));
-
-        try (final CloseableHttpResponse response = httpclientLegacy.execute(httppostLegacy)) {
-            assertEquals(200, response.getStatusLine().getStatusCode());
-            assertEquals("application/json", response.getEntity().getContentType().getValue());
-            final String json = EntityUtils.toString(response.getEntity());
-            final JsonNode node = mapper.readTree(json);
-            assertEquals(6, node.get("result").get("data").get(GraphSONTokens.VALUEPROP).size());
-        }
-
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -982,24 +982,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void shouldStillSupportDeprecatedRebindingsParameterOnServer() throws Exception {
-        // this test can be removed when the rebindings arg is removed
-        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
-            final Map<String,String> rebindings = new HashMap<>();
-            rebindings.put("xyz", "graph");
-            final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
-                    .addArg(Tokens.ARGS_GREMLIN, "xyz.addVertex('name','jason')")
-                    .addArg(Tokens.ARGS_REBINDINGS, rebindings).create();
-            final List<ResponseMessage> responses = client.submit(request);
-            assertEquals(1, responses.size());
-
-            final DetachedVertex v = ((ArrayList<DetachedVertex>) responses.get(0).getResult().getData()).get(0);
-            assertEquals("jason", v.value("name"));
-        }
-    }
-
-    @Test
     public void shouldSupportLambdasUsingWithRemote() throws Exception {
         final Graph graph = EmptyGraph.instance();
         final GraphTraversalSource g = graph.traversal().withRemote(conf);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1705

The "rebindings" API methods were long ago deprecated in 3.1.0-incubating but were not removed in 3.2.x or 3.3.x for extended support of that feature - especially for third-party drivers. By now, most users should have moved on to use the "aliases" API instead and most of the drivers should be supporting that as well, especially since most of the drivers are now officially TinkerPop maintained.

I didn't add any upgrade docs because I started a "Deprecation Removal" section in #830 and will want to add an entry to that. I'd like to get that one merged first at which point I can rebase and add a "rebindings" entry there.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1