### PR TITLE
TINKERPOP-1912 Remove MD5 checksums (tp33)

### DIFF
--- a/bin/validate-distribution.sh
+++ b/bin/validate-distribution.sh
@@ -83,10 +83,11 @@ fi
 
 echo -n "* downloading ${COMPONENT} (${ZIP_FILENAME})... "
 curl -Lsf ${URL} -o ${ZIP_FILENAME} || { echo "Failed to download ${COMPONENT}" ; exit 1; }
-for ext in "asc" "md5" "sha1"
+for ext in "asc" "sha1"
 do
   curl -Lsf ${URL}.${ext} -o ${ZIP_FILENAME}.${ext} || { echo "Failed to download ${COMPONENT} (${ext})" ; exit 1 ; }
 done
+curl -Lsf ${URL}.md5 -o ${ZIP_FILENAME}.md5 && { echo "MD5 checksums should not be released (${ZIP_FILENAME}.md5)" ; exit 1 ; }
 echo "OK"
 
 # validate zip file

--- a/docs/site/home/downloads.html
+++ b/docs/site/home/downloads.html
@@ -491,7 +491,7 @@ limitations under the License.
     </table>
     <p><strong>Note</strong> that upgrade documentation was only introduced at 3.1.1-incubating which is why there are no links "upgrade" links in versions prior to that one.
     <h4>Verifying Downloads</h4>
-    <p>All downloads have associated PGP and MD5 signatures to help verify a distribution provided by a mirror. To verify a distribution via PGP or GPG first download the
+    <p>All downloads have associated PGP and SHA1 signatures to help verify a distribution provided by a mirror. To verify a distribution via PGP or GPG first download the
        <a href="https://www.apache.org/dist/tinkerpop/KEYS">KEYS</a> file (it is important to use the linked file which is from the main distribution directory and not a
        mirror. Next download the appropriate "asc" signature file for the relevant distribution (again, this file should come from the <a href="https://www.apache.org/dist/tinkerpop/">main
        distribution directory</a> - note that older releases will have such files in the <a href="https://archive.apache.org/dist/tinkerpop/">archives</a> or if released under Apache
@@ -517,7 +517,7 @@ limitations under the License.
       gpg --verify apache-gremlin-console-x.y.z-bin.zip.asc apache-gremlin-console-x.y.z-bin.zip
       </code></pre>
     </p>
-    <p>Alternatively, consider verifying the MD5 signature on the files. An MD5 signature consists of 32 hex characters, and a SHA1 signature consists of 40 hex characters.
+    <p>Alternatively, consider verifying the SHA1 signature on the files. An SHA1 signature consists of 40 hex characters.
        Ensure that the generated signature string matches the signature string published in the files above.</p>
  </div>
 </div>

--- a/docs/src/dev/developer/release.asciidoc
+++ b/docs/src/dev/developer/release.asciidoc
@@ -224,6 +224,7 @@ for generating javadoc and without that the binary distributions won't contain t
 .. `cp ~/.m2/repository/org/apache/tinkerpop/gremlin-console/xx.yy.zz/gremlin-console-xx.yy.zz-distribution.zip* dev/xx.yy.zz`
 .. `cp ~/.m2/repository/org/apache/tinkerpop/gremlin-server/xx.yy.zz/gremlin-server-xx.yy.zz-distribution.zip* dev/xx.yy.zz`
 .. `cp ~/.m2/repository/org/apache/tinkerpop/tinkerpop/xx.yy.zz/tinkerpop-xx.yy.zz-source-release.zip* dev/xx.yy.zz`
+.. `rm -f dev/*.md5
 .. `cd dev/xx.yy.zz`
 .. pass:[<code>ls * | xargs -n1 -I {} echo "mv apache-tinkerpop-{} {}" | sed -e 's/distribution/bin/' -e 's/source-release/src/' -e 's/tinkerpop-tinkerpop/tinkerpop/' -e s'/^\(.*\) \(.*\) \(.*\)$/\1 \3 \2/' | /bin/bash</code>]
 .. `cd ..; svn add xx.yy.zz/; svn ci -m "TinkerPop xx.yy.zz release"`


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1912

This PR adds another step to the release process, that removes the auto-generated MD5 checksums, and updates the instructions about release artifact verifications.

See: http://www.apache.org/dev/release-publishing.html#distribution_maven

VOTE: +1