### PR TITLE
TINKERPOP-1941 Removed deprecated structure api exception

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Fixed a bug in `ReducingBarrierStep`, that returned the provided seed value despite no elements being available.
 * Changed the order of `select()` scopes. The order is now: maps, side-effects, paths.
 * Moved `TraversalEngine` to `gremlin-test` as it has long been only used in testing infrastructure.
+* Removed previously deprecated Structure API exceptions related to "element not found" situations.
 * Removed previously deprecated `rebindings` options from the Java driver API.
 * Removed support for Giraph.
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -84,6 +84,9 @@ The following deprecated classes, methods or fields have been removed in this ve
 * `gremlin-core`
 ** `org.apache.tinkerpop.gremlin.process.traversal.engine.*`
 ** `org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine`
+** `org.apache.tinkerpop.gremlin.structure.Element.Exceptions.elementAlreadyRemoved(Class, Object)`
+** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions.elementNotFound(Class, Object)`
+** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions.elementNotFound(Class, Object, Exception)`
 * `gremlin-driver`
 ** `org.apache.tinkerpop.gremlin.driver.Client#rebind(String)`
 ** `org.apache.tinkerpop.gremlin.driver.Client.ReboundClusterdClient`

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Element.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Element.java
@@ -144,14 +144,5 @@ public abstract interface Element {
         public static IllegalArgumentException labelCanNotBeAHiddenKey(final String label) {
             return new IllegalArgumentException("Label can not be a hidden key: " + label);
         }
-
-        /**
-         * @deprecated As of release 3.1.0, not replaced - this exception is no longer enforced by the test suite.
-         * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-297">TINKERPOP-297</a>
-         */
-        @Deprecated
-        public static IllegalStateException elementAlreadyRemoved(final Class<? extends Element> clazz, final Object id) {
-            return new IllegalStateException(String.format("%s with id %s was removed.", clazz.getSimpleName(), id));
-        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -1141,34 +1141,6 @@ public interface Graph extends AutoCloseable, Host {
         public static IllegalArgumentException argumentCanNotBeNull(final String argument) {
             return new IllegalArgumentException(String.format("The provided argument can not be null: %s", argument));
         }
-
-        /**
-         * Deprecated as of 3.2.3, not replaced.
-         *
-         * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-944">TINKERPOP-944</a>
-         */
-        @Deprecated
-        public static NoSuchElementException elementNotFound(final Class<? extends Element> elementClass, final Object id) {
-            return (null == id) ?
-                    new NoSuchElementException("The " + elementClass.getSimpleName().toLowerCase() + " with id null does not exist in the graph") :
-                    new NoSuchElementException("The " + elementClass.getSimpleName().toLowerCase() + " with id " + id + " of type " + id.getClass().getSimpleName() + " does not exist in the graph");
-        }
-
-        /**
-         * Deprecated as of 3.2.3, not replaced.
-         *
-         * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-944">TINKERPOP-944</a>
-         */
-        @Deprecated
-        public static NoSuchElementException elementNotFound(final Class<? extends Element> elementClass, final Object id, final Exception rootCause) {
-            NoSuchElementException elementNotFoundException;
-            if (null == id)
-                elementNotFoundException = new NoSuchElementException("The " + elementClass.getSimpleName().toLowerCase() + " with id null does not exist in the graph");
-            else
-                elementNotFoundException = new NoSuchElementException("The " + elementClass.getSimpleName().toLowerCase() + " with id " + id + " of type " + id.getClass().getSimpleName() + " does not exist in the graph");
-            elementNotFoundException.initCause(rootCause);
-            return elementNotFoundException;
-        }
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1941

These were related to elements not being found and were deprecated a long long time ago. Pretty easy one, but since it's a breaking change I figured it should go through review.

Builds with `mvn clean install`.

VOTE +1