### PR TITLE
TINKERPOP-1947 Fixed path history problem with mutations

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-9]]
 === TinkerPop 3.2.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed bug where path history was not being preserved for keys in mutations.
 * Bumped to httpclient 4.5.5.
 
 [[release-3-2-8]]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/Parameters.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/Parameters.java
@@ -174,26 +174,30 @@ public final class Parameters implements Cloneable, Serializable {
         if (keyValues.length % 2 != 0)
             throw Element.Exceptions.providedKeyValuesMustBeAMultipleOfTwo();
 
-        for (int i = 0; i < keyValues.length; i = i + 2) {
-            if (!(keyValues[i] instanceof String) && !(keyValues[i] instanceof T) && !(keyValues[i] instanceof Traversal))
+        for (int ix = 0; ix < keyValues.length; ix = ix + 2) {
+            if (!(keyValues[ix] instanceof String) && !(keyValues[ix] instanceof T) && !(keyValues[ix] instanceof Traversal))
                 throw new IllegalArgumentException("The provided key/value array must have a String, T, or Traversal on even array indices");
 
-            if (keyValues[i + 1] != null) {
-                // track the list of traversals that are present so that elsewhere in Parameters there is no need
-                // to iterate all values to not find any. also grab available labels in traversal values
-                if (keyValues[i + 1] instanceof Traversal.Admin) {
-                    final Traversal.Admin t = (Traversal.Admin) keyValues[i + 1];
-                    addTraversal(t);
-                    if (parent != null) parent.integrateChild(t);
+            if (keyValues[ix + 1] != null) {
+
+                // check both key and value for traversal instances. track the list of traversals that are present so
+                // that elsewhere in Parameters there is no need to iterate all values to not find any. also grab
+                // available labels in traversal values
+                for (int iy = 0; iy < 2; iy++) {
+                    if (keyValues[ix + iy] instanceof Traversal.Admin) {
+                        final Traversal.Admin t = (Traversal.Admin) keyValues[ix + iy];
+                        addTraversal(t);
+                        if (parent != null) parent.integrateChild(t);
+                    }
                 }
 
-                List<Object> values = this.parameters.get(keyValues[i]);
+                List<Object> values = this.parameters.get(keyValues[ix]);
                 if (null == values) {
                     values = new ArrayList<>();
-                    values.add(keyValues[i + 1]);
-                    this.parameters.put(keyValues[i], values);
+                    values.add(keyValues[ix + 1]);
+                    this.parameters.put(keyValues[ix], values);
                 } else {
-                    values.add(keyValues[i + 1]);
+                    values.add(keyValues[ix + 1]);
                 }
             }
         }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddVertexTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddVertexTest.groovy
@@ -81,6 +81,11 @@ public abstract class GroovyAddVertexTest {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('a', 'marko').addV().property('name', select('a')).name")
         }
 
+        @Override
+        public Traversal<Vertex, String> get_g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('a', 'name').addV().property(select('a'), 'marko').name")
+        }
+
         ///////// DEPRECATED BELOW
 
         @Override

--- a/gremlin-test/features/map/AddVertex.feature
+++ b/gremlin-test/features/map/AddVertex.feature
@@ -308,3 +308,30 @@ Feature: Step - addV()
       | result |
       | m[{"temp": ["test"], "name": ["lop"]}] |
       | m[{"temp": ["test"], "name": ["ripple"]}] |
+
+  Scenario: g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name
+    Given the empty graph
+    And the graph initializer of
+      """
+      g.addV("person").property(T.id, 1).property("name", "marko").property("age", 29).as("marko").
+        addV("person").property(T.id, 2).property("name", "vadas").property("age", 27).as("vadas").
+        addV("software").property(T.id, 3).property("name", "lop").property("lang", "java").as("lop").
+        addV("person").property(T.id, 4).property("name","josh").property("age", 32).as("josh").
+        addV("software").property(T.id, 5).property("name", "ripple").property("lang", "java").as("ripple").
+        addV("person").property(T.id, 6).property("name", "peter").property("age", 35).as('peter').
+        addE("knows").from("marko").to("vadas").property(T.id, 7).property("weight", 0.5).
+        addE("knows").from("marko").to("josh").property(T.id, 8).property("weight", 1.0).
+        addE("created").from("marko").to("lop").property(T.id, 9).property("weight", 0.4).
+        addE("created").from("josh").to("ripple").property(T.id, 10).property("weight", 1.0).
+        addE("created").from("josh").to("lop").property(T.id, 11).property("weight", 0.4).
+        addE("created").from("peter").to("lop").property(T.id, 12).property("weight", 0.2)
+      """
+    And the traversal of
+      """
+      g.withSideEffect("a", "name").addV().property(__.select("a"), "marko").values("name")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | marko |
+    And the graph should return 2 for count of "g.V().has(\"name\",\"marko\")"

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexTest.java
@@ -38,10 +38,8 @@ import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -69,6 +67,8 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
     public abstract Traversal<Vertex, Map<String, List<String>>> get_g_withSideEffectXa_testX_V_hasLabelXsoftwareX_propertyXtemp_selectXaXX_valueMapXname_tempX();
 
     public abstract Traversal<Vertex, String> get_g_withSideEffectXa_markoX_addV_propertyXname_selectXaXX_name();
+
+    public abstract Traversal<Vertex, String> get_g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name();
 
     // 3.0.0 DEPRECATIONS
     @Deprecated
@@ -296,6 +296,17 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
         assertFalse(traversal.hasNext());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY)
+    public void g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name() {
+        final Traversal<Vertex, String> traversal = get_g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name();
+        printTraversalForm(traversal);
+        assertEquals("marko", traversal.next());
+        assertFalse(traversal.hasNext());
+    }
+
 
     public static class Traversals extends AddVertexTest {
 
@@ -357,6 +368,11 @@ public abstract class AddVertexTest extends AbstractGremlinTest {
         @Override
         public Traversal<Vertex, String> get_g_withSideEffectXa_markoX_addV_propertyXname_selectXaXX_name() {
             return g.withSideEffect("a", "marko").addV().property("name", select("a")).values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name() {
+            return g.withSideEffect("a", "name").addV().property(select("a"),"marko").values("name");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1947

When a key of a mutation was a traversal it was not being integrated to the parent traversal and tracked in the Parameters. Works now with:

```text
gremlin> g.withSideEffect('k','name').addV('person').property(select('k'),'stephen')
==>v[3]
```

All tests pass with `docker/build.sh -t -n -i`

VOTE +1