### PR TITLE
Fix JavaScript Gremlin documentation

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -458,16 +458,31 @@ their Java counterparts which makes it possible to use lambdas with Gremlin.Net 
 == Gremlin-JavaScript
 
 image:gremlin-js.png[width=130,float=right] Apache TinkerPop's Gremlin-JavaScript implements Gremlin within the
-JavaScript language. It targets Node.js runtime and can be used on different operating systems on any Node.js 4 or
+JavaScript language. It targets Node.js runtime and can be used on different operating systems on any Node.js 6 or
 above. Since the JavaScript naming conventions are very similar to that of Java, it should be very easy to switch
 between Gremlin-Java and Gremlin-JavaScript.
 
 [source,bash]
-npm install gremlin-javascript
+npm install gremlin
 
 The Gremlin-JavaScript provides `GraphTraversalSource`, `GraphTraversal`, and `__` which mirror the respective classes
 in Gremlin-Java. The `GraphTraversalSource` requires a RemoteConnection implementation in order to communicate with
 <<gremlin-server,GremlinServer>>.
+
+[source,javascript]
+----
+const gremlin = require('gremlin');
+const Graph = gremlin.structure.Graph;
+----
+
+The `DriverRemoteConnection` class is not exported due to a bug in the implementation as detailed in
+link:https://issues.apache.org/jira/browse/TINKERPOP-1944[the ticket TINKERPOP-1944], that is going to be fixed in
+the upcoming version of the GLV. In the meantime, you can import the `DriverRemoteConnection` class by using:
+
+[source,javascript]
+----
+const DriverRemoteConnection = require('./node_modules/gremlin/lib/driver/driver-remote-connection');
+----
 
 A traversal source can be spawned with `RemoteStrategy` from an empty `Graph`.
 
@@ -489,27 +504,41 @@ IMPORTANT: Gremlin-JavaScript’s `Traversal` base class supports the standard G
 
 === RemoteConnection Submission
 
-Very similar to Gremlin-Python and Gremlin-Java, there are various ways to submit a traversal to a
+In a similar way as in other GLVs, there are various ways to submit a traversal to a
 `RemoteConnection` using terminal/action methods off of `Traversal`.
 
 * `Traversal.next()`
 * `Traversal.toList()`
+
+Given that I/O operations in Node.js are asynchronous by default, this terminal methods return a Promise. For example:
+
+[source,javascript]
+----
+g.V().hasLabel('person').values('name').toList()
+  .then(names => console.log(names));
+----
+
+You can `await` the promises if you are using `async` functions.
+
+[source,javascript]
+----
+const names = await g.V().hasLabel('person').values('name').toList();
+console.log(names);
+----
 
 === Static Enums and Methods
 
 Gremlin has various tokens (e.g. `t`, `P`, `order`, `direction`, etc.) that are represented in Gremlin-JavaScript as
 objects.
 
-These can be used analogously to how they are used in Gremlin-Java.
-
 [source,javascript]
-g.V().hasLabel("person").has("age",P.gt(30)).Order().By("age", order.decr).toList()
+g.V().hasLabel('person').has('age', P.gt(30)).order().by('age', order.decr).toList()
 
 These objects must be required manually from the `process` namespace:
 
 [source,javascript]
 ----
-const gremlin = require('gremlin-javascript');
+const gremlin = require('gremlin');
 const P = gremlin.process.P;
 ----
 
@@ -517,7 +546,7 @@ Finally, using static `__` anonymous traversals like `__.out()` can be expressed
 
 [source,javascript]
 ----
-const gremlin = require('gremlin-javascript');
+const gremlin = require('gremlin');
 const __ = gremlin.process.statics;
 
 g.V().repeat(__.out()).times(2).values("name").fold().toList();


### PR DESCRIPTION
Several fixes to the JavaScript GLV documentation:
- Use 'gremlin' package name
- Include information regarding Promises
- Reference DriverRemoteConnection not exported
- Fix method names

No need to vote, we can CTR, just giving the opportunity for quick review before committing.

I'll create a different patch targeting `tp33` to document the lack of support for GraphSON3 in the JavaScript GLV.