### PR TITLE
TINKERPOP-1953 Bump to Groovy 2.4.15

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.2.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Bumped to httpclient 4.5.5.
+* Bumped to Groovy 2.4.15 - fixes bug with `Lambda` construction.
 * Improved performance of GraphSON deserialization of `Bytecode`.
 
 [[release-3-2-8]]

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -21,6 +21,30 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *Nine Inch Gremlins*
 
+== TinkerPop 3.2.9
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.2.8/CHANGELOG.asciidoc#release-3-2-9[changelog] for a complete list of all the modifications that are part of this release.
+
+=== Upgrading for Users
+
+==== Lambda Construction
+
+It was realized quite shortly after release of 3.2.8 that there was a bug in construction of `Lambda` instances:
+
+[source,text]
+----
+gremlin> org.apache.tinkerpop.gremlin.util.function.Lambda.function("{ it.get() }")
+(class: org/apache/tinkerpop/gremlin/util/function/Lambda$function, method: callStatic signature: (Ljava/lang/Class;[Ljava/lang/Object;)Ljava/lang/Object;) Illegal type in constant pool
+Type ':help' or ':h' for help.
+Display stack trace? [yN]n
+----
+
+The problem was related to a bug in Groovy 2.4.14 and was fixed in 2.4.15.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1953[TINKERPOP-1953]
+
 == TinkerPop 3.2.8
 
 *Release Date: April 2, 2018*

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.groovy.CompilerCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.NoImportCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.InterpreterModeCustomizerProvider;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.javatuples.Pair;
 import org.junit.Test;
@@ -602,5 +603,13 @@ public class GremlinGroovyScriptEngineTest {
         assertEquals(101, engine.getClassCacheLoadCount());
         assertEquals(1, engine.getClassCacheLoadFailureCount());
         assertEquals(100, engine.getClassCacheLoadSuccessCount());
+    }
+
+    @Test
+    public void shouldEvalForLambda() throws Exception {
+        // https://issues.apache.org/jira/browse/TINKERPOP-1953
+        final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine();
+        final Lambda l = (Lambda) engine.eval(" org.apache.tinkerpop.gremlin.util.function.Lambda.function(\"{ it.get() }\")");
+        assertEquals("{ it.get() }", l.getLambdaScript());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@ limitations under the License.
         <commons.configuration.version>1.10</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.lang3.version>3.3.1</commons.lang3.version>
-        <groovy.version>2.4.14</groovy.version>
+        <groovy.version>2.4.15</groovy.version>
         <hadoop.version>2.7.2</hadoop.version>
         <java.tuples.version>1.2</java.tuples.version>
         <javadoc-plugin.version>2.10.4</javadoc-plugin.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1953

Fixes a bug in Lambda construction for remote traversals

All tests pass with `docker/build.sh -t -i`

VOTE +1