### PR TITLE
TINKERPOP-1933 gremlin-python maximum recursion depth exceeded on large responses

### DIFF
--- a/gremlin-python/src/main/jython/gremlin_python/driver/connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/connection.py
@@ -73,6 +73,9 @@ class Connection:
         return future
 
     def _receive(self):
-        data = self._transport.read()
-        self._protocol.data_received(data, self._results)
+        while True:
+            data = self._transport.read()
+            status_code = self._protocol.data_received(data, self._results)
+            if status_code != 206:
+                break
         self._pool.put_nowait(self)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1933

Recursive calls to the `data_received` were causing max recursion depth error with large streaming responses. This PR remove the recursion in favor of a simple loop. I didn't add any new tests. Locally, I tested like this:

```python
from gremlin_python.driver import client


groovy = """
def num_nodes = 1..100000
for (n in num_nodes) {
    g.addV().next()
}
"""
c = client.Client('ws://localhost:8182/gremlin', 'g')
results = c.submit(groovy)
results.all().result()

results = c.submit("g.V().count()")
print("Added %d nodes to graph" % results.all().result()[0])

# This was always ok
print("Ok up to len: %d" % len(c.submit("g.V().limit(61888)").all().result()))

try:
    # This used to throw error
    print("Retrieved %d nodes, no more recursion issue" % len(c.submit("g.V().limit(100000)").all().result()))
except:
    pass
```