### PR TITLE
TINKERPOP-1869 Allowed iterate() after profile()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ This release also includes changes from <<release-3-2-9, 3.2.9>>.
 
 * Coerced `BulkSet` to `g:List` in GraphSON 3.0.
 * Deprecated `CredentialsGraph` DSL in favor of `CredentialsTraversalDsl` which uses the recommended method for Gremlin DSL development.
+* Allowed `iterate()` to be called after `profile()`.
 
 [[release-3-3-2]]
 === TinkerPop 3.3.2 (Release Date: April 2, 2018)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1869

The `iterate()` method adds a `NoneStep` that was preventing traversals like `g.V().profile().iterate()`. Not the typical type of traversal you would do, but it seems like it should be allowed for consistency sake.

All tests pass with `docker/build.sh -t -i`

VOTE +1