### PR TITLE
TINKERPOP-1296 Remove previously deprecated Gremlin Server infrastructure

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Changed the order of `select()` scopes. The order is now: maps, side-effects, paths.
 * Removed previously deprecated Credentials DSL infrastructure.
 * Moved `TraversalEngine` to `gremlin-test` as it has long been only used in testing infrastructure.
+* Removed previously deprecated Gremlin Server setting for `serializedResponseTimeout`.
 * Removed previously deprecated Structure API exceptions related to "element not found" situations.
 * Removed previously deprecated `rebindings` options from the Java driver API.
 * Removed previously deprecated `AuthenticationSettings.className` configuration option in Gremlin Server.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Moved `TraversalEngine` to `gremlin-test` as it has long been only used in testing infrastructure.
 * Removed previously deprecated Structure API exceptions related to "element not found" situations.
 * Removed previously deprecated `rebindings` options from the Java driver API.
+* Removed previously deprecated `AuthenticationSettings.className` configuration option in Gremlin Server.
 * Removed support for Giraph.
 
 == TinkerPop 3.3.0 (Gremlin Symphony #40 in G Minor)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,10 +32,13 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Changed the order of `select()` scopes. The order is now: maps, side-effects, paths.
 * Removed previously deprecated Credentials DSL infrastructure.
 * Moved `TraversalEngine` to `gremlin-test` as it has long been only used in testing infrastructure.
+* Removed previously deprecated `OpSelectorHandler` constructor.
+* Removed previously deprecated `AbstractOpProcessor#makeFrame()` method.
+* Removed previously deprecated `AuthenticationSettings.className` configuration option in Gremlin Server.
+* Removed previously deprecated `GraphManager` methods `getGraphs()` and `getTraversalSources()`.
 * Removed previously deprecated Gremlin Server setting for `serializedResponseTimeout`.
 * Removed previously deprecated Structure API exceptions related to "element not found" situations.
 * Removed previously deprecated `rebindings` options from the Java driver API.
-* Removed previously deprecated `AuthenticationSettings.className` configuration option in Gremlin Server.
 * Removed support for Giraph.
 
 == TinkerPop 3.3.0 (Gremlin Symphony #40 in G Minor)

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -84,16 +84,20 @@ The following deprecated classes, methods or fields have been removed in this ve
 * `gremlin-core`
 ** `org.apache.tinkerpop.gremlin.process.traversal.engine.*`
 ** `org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine`
-** `org.apache.tinkerpop.gremlin.structure.Element.Exceptions.elementAlreadyRemoved(Class, Object)`
-** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions.elementNotFound(Class, Object)`
-** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions.elementNotFound(Class, Object, Exception)`
+** `org.apache.tinkerpop.gremlin.structure.Element.Exceptions#elementAlreadyRemoved(Class, Object)`
+** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions#elementNotFound(Class, Object)`
+** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions#elementNotFound(Class, Object, Exception)`
 * `gremlin-driver`
 ** `org.apache.tinkerpop.gremlin.driver.Client#rebind(String)`
 ** `org.apache.tinkerpop.gremlin.driver.Client.ReboundClusterdClient`
 ** `org.apache.tinkerpop.gremlin.driver.Tokens#ARGS_REBINDINGS`
 * `gremlin-server`
-** `org.apache.tinkerpop.gremlin.server.Settings.serializedResponseTimeout`
-** `org.apache.tinkerpop.gremlin.server.Settings.AuthenticationSettings.className`
+** `org.apache.tinkerpop.gremlin.server.GraphManager#getGraphs()`
+** `org.apache.tinkerpop.gremlin.server.GraphManager#getTraversalSources()`
+** `org.apache.tinkerpop.gremlin.server.Settings#serializedResponseTimeout`
+** `org.apache.tinkerpop.gremlin.server.Settings.AuthenticationSettings#className`
+** `org.apache.tinkerpop.gremlin.server.handler.OpSelectorHandler(Settings, GraphManager, GremlinExecutor, ScheduledExecutorService)`
+** `org.apache.tinkerpop.gremlin.server.op.AbstractOpProcessor#makeFrame(ChannelHandlerContext, RequestMessage, MessageSerializer serializer, boolean, List, ResponseStatusCode code)`
 
 Please see the javadoc deprecation notes or upgrade documentation specific to when the deprecation took place to
 understand how to resolve this breaking change.
@@ -101,7 +105,8 @@ understand how to resolve this breaking change.
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1143[TINKERPOP-1143],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1296[TINKERPOP-1296],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1705[TINKERPOP-1705],
-link:https://issues.apache.org/jira/browse/TINKERPOP-1707[TINKERPOP-1707]
+link:https://issues.apache.org/jira/browse/TINKERPOP-1707[TINKERPOP-1707],
+link:https://issues.apache.org/jira/browse/TINKERPOP-1954[TINKERPOP-1954]
 
 ==== Modifications to reducing barrier steps
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -91,12 +91,15 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.driver.Client#rebind(String)`
 ** `org.apache.tinkerpop.gremlin.driver.Client.ReboundClusterdClient`
 ** `org.apache.tinkerpop.gremlin.driver.Tokens#ARGS_REBINDINGS`
+* `gremlin-server`
+** `org.apache.tinkerpop.gremlin.server.Settings.AuthenticationSettings.className`
 
 Please see the javadoc deprecation notes or upgrade documentation specific to when the deprecation took place to
 understand how to resolve this breaking change.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1143[TINKERPOP-1143],
-link:https://issues.apache.org/jira/browse/TINKERPOP-1705[TINKERPOP-1705]
+link:https://issues.apache.org/jira/browse/TINKERPOP-1705[TINKERPOP-1705],
+link:https://issues.apache.org/jira/browse/TINKERPOP-1707[TINKERPOP-1707]
 
 ==== Modifications to reducing barrier steps
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -92,12 +92,14 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.driver.Client.ReboundClusterdClient`
 ** `org.apache.tinkerpop.gremlin.driver.Tokens#ARGS_REBINDINGS`
 * `gremlin-server`
+** `org.apache.tinkerpop.gremlin.server.Settings.serializedResponseTimeout`
 ** `org.apache.tinkerpop.gremlin.server.Settings.AuthenticationSettings.className`
 
 Please see the javadoc deprecation notes or upgrade documentation specific to when the deprecation took place to
 understand how to resolve this breaking change.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1143[TINKERPOP-1143],
+link:https://issues.apache.org/jira/browse/TINKERPOP-1296[TINKERPOP-1296],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1705[TINKERPOP-1705],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1707[TINKERPOP-1707]
 

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/resources/gremlin-server.yaml
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/resources/gremlin-server.yaml
@@ -20,7 +20,6 @@ port: 45940
 threadPoolWorker: 1
 gremlinPool: 8
 scriptEvaluationTimeout: 30000
-serializedResponseTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 scriptEngines: {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -179,12 +179,7 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
     }
 
     private Authenticator createAuthenticator(final Settings.AuthenticationSettings config) {
-        String authenticatorClass = null;
-        if (config.authenticator == null) {
-            authenticatorClass = config.className;
-        } else {
-            authenticatorClass = config.authenticator;
-        }
+        final String authenticatorClass = config.authenticator;
         try {
             final Class<?> clazz = Class.forName(authenticatorClass);
             final Authenticator authenticator = (Authenticator) clazz.newInstance();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
@@ -35,16 +35,6 @@ import java.util.function.Function;
  * the interface also defines similar features for {@link TraversalSource} objects.
  */
 public interface GraphManager {
-    /**
-     * Get a list of the {@link Graph} instances and their binding names.
-     *
-     * @return a {@code Map} where the key is the name of the {@link Graph} and the value is the {@link Graph} itself
-     * @deprecated  As of release 3.2.5, replaced by a combination of {@link #getGraphNames()} and
-     * {@link #getGraph(String)} - note that the expectation is this method return an immutable {@code Map} which was
-     * not the expectation prior to 3.2.5.
-     */
-    @Deprecated
-    public Map<String, Graph> getGraphs();
 
     /**
      * Get a {@link Set} of {@link String} graphNames corresponding to names stored in the graph's
@@ -63,18 +53,6 @@ public interface GraphManager {
      * Add or update the specified {@link Graph} with the specified name to {@code Map<String, Graph>} .
      */
     public void putGraph(final String graphName, final Graph g);
-
-    /**
-     * Get a list of the {@link TraversalSource} instances and their binding names
-     *
-     * @return a {@link Map} where the key is the name of the {@link TraversalSource} and the value is the
-     *         {@link TraversalSource} itself
-     * @deprecated  As of release 3.2.5, replaced by a combination of {@link #getTraversalSourceNames()} and
-     * {@link #getTraversalSource(String)} - note that the expectation is this method return an immutable
-     * {@code Map} which was not the expectation prior to 3.2.5.
-     */
-    @Deprecated
-    public Map<String, TraversalSource> getTraversalSources();
 
     /**
      * Get a {@code Set} of the names of the the stored {@link TraversalSource} instances.

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -104,15 +104,6 @@ public class Settings {
     public long scriptEvaluationTimeout = 30000L;
 
     /**
-     * Time in milliseconds to wait while an evaluated script serializes its results. This value represents the
-     * total serialization time allowed for the request.  Defaults to 0 which disables this setting.
-     *
-     * @deprecated As of release 3.2.1, replaced wholly by {@link #scriptEvaluationTimeout}.
-     */
-    @Deprecated
-    public long serializedResponseTimeout = 0L;
-
-    /**
      * Number of items in a particular resultset to iterate and serialize prior to pushing the data down the wire
      * to the client.
      */

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -30,7 +30,6 @@ import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
 import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
 import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.util.DefaultGraphManager;
-import info.ganglia.gmetric4j.gmetric.GMetric;
 import org.apache.tinkerpop.gremlin.server.util.LifeCycleHook;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.yaml.snakeyaml.TypeDescription;
@@ -411,16 +410,7 @@ public class Settings {
          * used to load the implementation from the classpath. Defaults to {@link AllowAllAuthenticator} when
          * not specified.
          */
-        public String authenticator = null;
-
-        /**
-         * The fully qualified class name of the {@link Authenticator} implementation. This class name will be
-         * used to load the implementation from the classpath. Defaults to {@link AllowAllAuthenticator} when
-         * not specified.
-         * @deprecated As of release 3.2.5, replaced by {@link #authenticator}.
-         */
-        @Deprecated
-        public String className = AllowAllAuthenticator.class.getName();
+        public String authenticator = AllowAllAuthenticator.class.getName();
 
         /**
          * The fully qualified class name of the {@link AbstractAuthenticationHandler} implementation.

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/OpSelectorHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/OpSelectorHandler.java
@@ -56,15 +56,6 @@ public class OpSelectorHandler extends MessageToMessageDecoder<RequestMessage> {
     private final ScheduledExecutorService scheduledExecutorService;
     private final Channelizer channelizer;
 
-    /**
-     * @deprecated As of release 3.2.8, replaced by {@link #OpSelectorHandler(Settings, GraphManager, GremlinExecutor, ScheduledExecutorService, Channelizer)}
-     */
-    @Deprecated
-    public OpSelectorHandler(final Settings settings, final GraphManager graphManager, final GremlinExecutor gremlinExecutor,
-                             final ScheduledExecutorService scheduledExecutorService) {
-        this(settings, graphManager, gremlinExecutor, scheduledExecutorService, null);
-    }
-
     public OpSelectorHandler(final Settings settings, final GraphManager graphManager, final GremlinExecutor gremlinExecutor,
                              final ScheduledExecutorService scheduledExecutorService, final Channelizer channelizer) {
         this.settings = settings;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -228,18 +228,9 @@ public abstract class AbstractOpProcessor implements OpProcessor {
         return Collections.emptyMap();
     }
 
-    /**
-     * @deprecated As of release 3.2.2, replaced by {@link #makeFrame(ChannelHandlerContext, RequestMessage, MessageSerializer, boolean, List, ResponseStatusCode, Map)}.
-     */
     protected static Frame makeFrame(final ChannelHandlerContext ctx, final RequestMessage msg,
                                      final MessageSerializer serializer, final boolean useBinary, final List<Object> aggregate,
-                                     final ResponseStatusCode code) throws Exception {
-        return makeFrame(ctx, msg, serializer, useBinary, aggregate, code, Collections.emptyMap());
-    }
-
-    protected static Frame makeFrame(final ChannelHandlerContext ctx, final RequestMessage msg,
-                                   final MessageSerializer serializer, final boolean useBinary, final List<Object> aggregate,
-                                   final ResponseStatusCode code, final Map<String,Object> responseMetaData) throws Exception {
+                                     final ResponseStatusCode code, final Map<String,Object> responseMetaData) throws Exception {
         try {
             if (useBinary) {
                 return new Frame(serializer.serializeResponseAsBinary(ResponseMessage.build(msg)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.server.op;
 
 import io.netty.channel.ChannelHandlerContext;
-import org.apache.commons.lang.time.StopWatch;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
@@ -43,7 +42,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * A base {@link OpProcessor} implementation that processes an {@code Iterator} of results in a generalized way while
@@ -64,16 +62,12 @@ public abstract class AbstractOpProcessor implements OpProcessor {
     }
 
     /**
-     * Provides a generic way of iterating a result set back to the client. Implementers should respect the
-     * {@link Settings#serializedResponseTimeout} configuration and break the serialization process if
-     * it begins to take too long to do so, throwing a {@link java.util.concurrent.TimeoutException} in such
-     * cases.
+     * Provides a generic way of iterating a result set back to the client.
      *
      * @param context The Gremlin Server {@link Context} object containing settings, request message, etc.
      * @param itty The result to iterator
-     * @throws TimeoutException if the time taken to serialize the entire result set exceeds the allowable time.
      */
-    protected void handleIterator(final Context context, final Iterator itty) throws TimeoutException, InterruptedException {
+    protected void handleIterator(final Context context, final Iterator itty) throws InterruptedException {
         final ChannelHandlerContext ctx = context.getChannelHandlerContext();
         final RequestMessage msg = context.getRequestMessage();
         final Settings settings = context.getSettings();
@@ -95,10 +89,6 @@ public abstract class AbstractOpProcessor implements OpProcessor {
                     .create());
             return;
         }
-
-        // timer for the total serialization time
-        final StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
 
         // the batch size can be overridden by the request
         final int resultIterationBatchSize = (Integer) msg.optionalArgs(Tokens.ARGS_BATCH_SIZE)
@@ -204,18 +194,7 @@ public abstract class AbstractOpProcessor implements OpProcessor {
                 // this isn't blocking the IO thread - just a worker.
                 TimeUnit.MILLISECONDS.sleep(10);
             }
-
-            stopWatch.split();
-            if (settings.serializedResponseTimeout > 0 && stopWatch.getSplitTime() > settings.serializedResponseTimeout) {
-                final String timeoutMsg = String.format("Serialization of the entire response exceeded the 'serializeResponseTimeout' setting %s",
-                        warnOnce ? "[Gremlin Server paused writes to client as messages were not being consumed quickly enough]" : "");
-                throw new TimeoutException(timeoutMsg.trim());
-            }
-
-            stopWatch.unsplit();
         }
-
-        stopWatch.stop();
     }
 
     /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -68,7 +68,6 @@ import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -301,14 +300,6 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                         }
 
                         handleIterator(context, new SideEffectIterator(sideEffects.get(sideEffectKey.get()), sideEffectKey.get()));
-                    } catch (TimeoutException ex) {
-                        final String errorMessage = String.format("Response iteration exceeded the configured threshold for request [%s] - %s", msg.getRequestId(), ex.getMessage());
-                        logger.warn(errorMessage);
-                        ctx.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR_TIMEOUT)
-                                .statusMessage(errorMessage)
-                                .statusAttributeException(ex).create());
-                        onError(graph, context);
-                        return;
                     } catch (Exception ex) {
                         logger.warn(String.format("Exception processing a side-effect on iteration for request [%s].", msg.getRequestId()), ex);
                         ctx.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/DefaultGraphManager.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/DefaultGraphManager.java
@@ -65,19 +65,6 @@ public final class DefaultGraphManager implements GraphManager {
         });
     }
 
-    /**
-     * Get a list of the {@link Graph} instances and their binding names as defined in the Gremlin Server
-     * configuration file.
-     *
-     * @return a {@code Map} where the key is the name of the {@link Graph} and the value is the {@link Graph} itself
-     * @deprecated As of release 3.2.5, replaced by a combination of {@link #getGraphNames()} and
-     * {@link #getGraph(String)}
-     */
-    @Deprecated
-    public final Map<String, Graph> getGraphs() {
-        return graphs;
-    }
-
     public final Set<String> getGraphNames() {
         return graphs.keySet();
     }
@@ -88,20 +75,6 @@ public final class DefaultGraphManager implements GraphManager {
 
     public final void putGraph(final String graphName, final Graph g) {
         graphs.put(graphName, g);
-    }
-
-    /**
-     * Get a list of the {@link TraversalSource} instances and their binding names as defined by Gremlin Server
-     * initialization scripts.
-     *
-     * @return a {@code Map} where the key is the name of the {@link TraversalSource} and the value is the
-     * {@link TraversalSource} itself
-     * @deprecated As of release 3.2.5, replaced by a combination of {@link #getTraversalSourceNames()} and
-     * {@link #getTraversalSource(String)}
-     */
-    @Deprecated
-    public final Map<String, TraversalSource> getTraversalSources() {
-        return traversalSources;
     }
 
     public final Set<String> getTraversalSourceNames() {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuditLogIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuditLogIntegrateTest.java
@@ -115,7 +115,7 @@ public class GremlinServerAuditLogIntegrateTest extends AbstractGremlinServerInt
         final Settings.AuthenticationSettings authSettings = new Settings.AuthenticationSettings();
         settings.authentication = authSettings;
         authSettings.enableAuditLog = AUDIT_LOG_ENABLED;
-        authSettings.className = Krb5Authenticator.class.getName();
+        authSettings.authenticator = Krb5Authenticator.class.getName();
         final Map<String,Object> authConfig = new HashMap<>();
         authSettings.config = authConfig;
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -54,7 +54,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
     @Override
     public Settings overrideSettings(final Settings settings) {
         final Settings.AuthenticationSettings authSettings = new Settings.AuthenticationSettings();
-        authSettings.className = SimpleAuthenticator.class.getName();
+        authSettings.authenticator = SimpleAuthenticator.class.getName();
 
         // use a credentials graph with one user in it: stephen/password
         final Map<String,Object> authConfig = new HashMap<>();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthKrb5IntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthKrb5IntegrateTest.java
@@ -97,7 +97,7 @@ public class GremlinServerAuthKrb5IntegrateTest extends AbstractGremlinServerInt
         settings.ssl = sslConfig;
         final Settings.AuthenticationSettings authSettings = new Settings.AuthenticationSettings();
         settings.authentication = authSettings;
-        authSettings.className = Krb5Authenticator.class.getName();
+        authSettings.authenticator = Krb5Authenticator.class.getName();
         final Map<String,Object> authConfig = new HashMap<>();
         authConfig.put("principal", kdcServer.serverPrincipal);
         authConfig.put("keytab", kdcServer.serviceKeytabFile.getAbsolutePath());

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -59,7 +59,6 @@ import org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
@@ -70,7 +69,6 @@ import org.junit.Test;
 
 import java.lang.reflect.Field;
 import java.nio.channels.ClosedChannelException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +90,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -176,9 +173,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 break;
             case "shouldReceiveFailureTimeOutOnScriptEval":
                 settings.scriptEvaluationTimeout = 1000;
-                break;
-            case "shouldReceiveFailureTimeOutOnTotalSerialization":
-                settings.serializedResponseTimeout = 1;
                 break;
             case "shouldBlockRequestWhenTooBig":
                 settings.maxContentLength = 1024;
@@ -805,24 +799,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             // scriptEvaluationTimeout which is at 30 seconds by default
             final List<ResponseMessage> responses = client.submit("while(true){}");
             assertThat(responses.get(0).getStatus().getMessage(), startsWith("Timeout during script evaluation triggered by TimedInterruptCustomizerProvider"));
-
-            // validate that we can still send messages to the server
-            assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());
-        }
-    }
-
-    /**
-     * @deprecated As of release 3.2.1, replaced by tests covering {@link Settings#scriptEvaluationTimeout}.
-     */
-    @Test
-    @SuppressWarnings("unchecked")
-    @Deprecated
-    public void shouldReceiveFailureTimeOutOnTotalSerialization() throws Exception {
-        try (SimpleClient client = TestClientFactory.createWebSocketClient()){
-            final List<ResponseMessage> responses = client.submit("(0..<100000)");
-
-            // the last message should contain the error
-            assertThat(responses.get(responses.size() - 1).getStatus().getMessage(), endsWith("Serialization of the entire response exceeded the 'serializeResponseTimeout' setting"));
 
             // validate that we can still send messages to the server
             assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());


### PR DESCRIPTION
This PR actually covers these three related issues which all involve deprecation removal related to Gremlin Server:

https://issues.apache.org/jira/browse/TINKERPOP-1296
https://issues.apache.org/jira/browse/TINKERPOP-1707
https://issues.apache.org/jira/browse/TINKERPOP-1954

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false'

VOTE +1