### PR TITLE
TINKERPOP-1595 Optimize TraversalVertexProgram

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug where path history was not being preserved for keys in mutations.
 * Bumped to httpclient 4.5.5.
 * Bumped to Groovy 2.4.15 - fixes bug with `Lambda` construction.
+* Improved performance of `TraversalVertexProgram` and related infrastructure.
 * Improved performance of GraphSON deserialization of `Bytecode`.
 * Improved performance of traversal construction.
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.2.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Removed recursive handling of streaming results from Gremlin-Python driver to avoid max recursion depth errors.
+* Improved performance of `TraversalVertexProgram` and related infrastructure.
 * Fixed bug in `GroovyTranslator` that didn't properly handle empty `Map` objects.
 
 [[release-3-2-9]]
@@ -32,7 +33,6 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug where path history was not being preserved for keys in mutations.
 * Bumped to httpclient 4.5.5.
 * Bumped to Groovy 2.4.15 - fixes bug with `Lambda` construction.
-* Improved performance of `TraversalVertexProgram` and related infrastructure.
 * Improved performance of GraphSON deserialization of `Bytecode`.
 * Improved performance of traversal construction.
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/MemoryComputeKey.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/MemoryComputeKey.java
@@ -79,14 +79,17 @@ public final class MemoryComputeKey<A> implements Serializable, Cloneable {
     public MemoryComputeKey<A> clone() {
         try {
             final MemoryComputeKey<A> clone = (MemoryComputeKey<A>) super.clone();
-            for (final Method method : this.reducer.getClass().getMethods()) {
-                if (method.getName().equals("clone") && 0 == method.getParameterCount()) {
-                    clone.reducer = (BinaryOperator<A>) method.invoke(this.reducer);
-                    break;
-                }
+
+            try {
+                final Method cloneMethod = this.reducer.getClass().getMethod("clone");
+                if (cloneMethod != null)
+                    clone.reducer = (BinaryOperator<A>) cloneMethod.invoke(this.reducer);
+            } catch(Exception ignored) {
+
             }
+
             return clone;
-        } catch (final IllegalAccessException | InvocationTargetException | CloneNotSupportedException e) {
+        } catch (final CloneNotSupportedException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -176,12 +176,11 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
                         this.traversal.get().getParent().asStep().getNextStep() instanceof EmptyStep ||  // same as above, but if using TraversalVertexProgramStep directly
                         (this.traversal.get().getParent().asStep().getNextStep() instanceof ProfileStep && // same as above, but needed for profiling
                                 this.traversal.get().getParent().asStep().getNextStep().getNextStep() instanceof ComputerResultStep));
+
         // determine how to store halted traversers
-        this.haltedTraverserStrategy = ((HaltedTraverserStrategy) this.traversal.get().getStrategies().toList()
-                .stream()
-                .filter(strategy -> strategy instanceof HaltedTraverserStrategy)
-                .findAny()
-                .orElse(HaltedTraverserStrategy.reference()));
+        final Iterator<?> itty = IteratorUtils.filter(this.traversal.get().getStrategies().toList(), strategy -> strategy instanceof HaltedTraverserStrategy).iterator();
+        this.haltedTraverserStrategy = itty.hasNext() ? (HaltedTraverserStrategy) itty.next() : HaltedTraverserStrategy.reference();
+
         // register traversal side-effects in memory
         this.memoryComputeKeys.addAll(MemoryTraversalSideEffects.getMemoryComputeKeys(this.traversal.get()));
         // register MapReducer memory compute keys

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -32,6 +32,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequire
 import org.apache.tinkerpop.gremlin.process.traversal.util.PureTraversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -73,11 +74,10 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
     public TraversalVertexProgram generateProgram(final Graph graph, final Memory memory) {
         final Traversal.Admin<?, ?> computerSpecificTraversal = this.computerTraversal.getPure();
         final TraversalStrategies computerSpecificStrategies = this.getTraversal().getStrategies().clone();
-        TraversalStrategies.GlobalCache.getStrategies(graph.getClass())
-                .toList()
-                .stream()
-                .filter(s -> s instanceof TraversalStrategy.ProviderOptimizationStrategy)
-                .forEach(computerSpecificStrategies::addStrategies);
+
+        IteratorUtils.filter(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()).toList(),
+                s -> s instanceof TraversalStrategy.ProviderOptimizationStrategy).forEach(computerSpecificStrategies::addStrategies);
+
         computerSpecificTraversal.setStrategies(computerSpecificStrategies);
         computerSpecificTraversal.setSideEffects(new MemoryTraversalSideEffects(this.getTraversal().getSideEffects()));
         computerSpecificTraversal.setParent(this);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
@@ -72,7 +72,7 @@ public abstract class VertexProgramStep extends AbstractStep<ComputerResult, Com
                 final Traverser.Admin<ComputerResult> traverser = this.starts.next();
                 final Graph graph = traverser.get().graph();
                 final Memory memory = traverser.get().memory();
-                future = this.generateComputer(graph).program(this.generateProgram(graph, memory)).submit();
+                future = this.getComputer().apply(graph).program(this.generateProgram(graph, memory)).submit();
                 final ComputerResult result = future.get();
                 this.processMemorySideEffects(result.memory());
                 return traverser.split(result, this);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/VertexProgramHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/VertexProgramHelper.java
@@ -28,7 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.util.Serializer;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -64,8 +64,7 @@ public final class VertexProgramHelper {
         if (configuration instanceof AbstractConfiguration)
             ((AbstractConfiguration) configuration).setDelimiterParsingDisabled(true);
         try {
-            final String byteString = Arrays.toString(Serializer.serializeObject(object));
-            configuration.setProperty(key, byteString.substring(1, byteString.length() - 1));
+            configuration.setProperty(key, Base64.getEncoder().encodeToString(Serializer.serializeObject(object)));
         } catch (final IOException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
@@ -73,12 +72,8 @@ public final class VertexProgramHelper {
 
     public static <T> T deserialize(final Configuration configuration, final String key) {
         try {
-            final String[] stringBytes = configuration.getString(key).split(",");
-            byte[] bytes = new byte[stringBytes.length];
-            for (int i = 0; i < stringBytes.length; i++) {
-                bytes[i] = Byte.valueOf(stringBytes[i].trim());
-            }
-            return (T) Serializer.deserializeObject(bytes);
+
+            return (T) Serializer.deserializeObject(Base64.getDecoder().decode(configuration.getString(key).getBytes()));
         } catch (final IOException | ClassNotFoundException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1595

I did as the issue requested and optimized `TraversalVertexProgram`. Definitely some hotspots in there that have been removed. I'd say that the main fixes involved the direct lookup of `clone()` in `MemoryComputeKey` rather than cycling all methods and the use of Base64 encoding instead of CSV style string/regex derser for traversals in OLAP.

Feel free to VOTE but this change will not be merged until we open development for 3.2.10.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1