### PR TITLE
TINKERPOP-1961 Removed duplication of images in binaries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -811,9 +811,14 @@ limitations under the License.
                                     <goal>process-asciidoc</goal>
                                 </goals>
                                 <configuration>
-                                    <sourceDirectory>${asciidoc.input.dir}/</sourceDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${asciidoc.input.dir}/</directory>
+                                            <targetPath>${htmlsingle.output.dir}/</targetPath>
+                                            <excludes>${asciidoc.input.dir}/static/*.*</excludes>
+                                        </resource>
+                                    </resources>
                                     <sourceDocumentName>index.asciidoc</sourceDocumentName>
-                                    <outputDirectory>${htmlsingle.output.dir}/</outputDirectory>
                                     <backend>html5</backend>
                                     <doctype>article</doctype>
                                     <attributes>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1961

The asciidoc plugin copies all files in the source directories of its execution. The asciidoc plugin was upgraded between 3.2.5 and 3.2.6 which introduced this new behavior.

VOTE +1