### PR TITLE
TINKERPOP-1958 Fixed a bug in TinkerGraphCountStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-10]]
 === TinkerPop 3.2.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed a bug in `TinkerGraphCountStrategy`, which didn't consider that certain map steps may not emit an element.
 
 [[release-3-2-9]]
 === TinkerPop 3.2.9 (Release Date: May 8, 2018)

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectTest.groovy
@@ -104,6 +104,11 @@ public abstract class GroovySelectTest {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose(__.outE().count().is(0L), __.as('a'), __.as('b')).choose(select('a'),select('a'),select('b'))")
         }
 
+        @Override
+        public Traversal<Vertex, Long> get_g_V_selectXaX_count() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.select('a').count")
+        }
+
         // below are original back()-tests
 
         @Override

--- a/gremlin-test/features/map/Select.feature
+++ b/gremlin-test/features/map/Select.feature
@@ -515,3 +515,23 @@ Feature: Step - select()
       | result |
       | d[2].l |
       | d[2].l |
+
+  Scenario: g_V_selectXaX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().select("a")
+      """
+    When iterated to list
+    Then the result should be empty
+
+  Scenario: g_V_selectXaX_count
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().select("a").count()
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[0].l |

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
@@ -83,6 +83,8 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_chooseXoutE_count_isX0X__asXaX__asXbXX_chooseXselectXaX__selectXaX__selectXbXX();
 
+    public abstract Traversal<Vertex, Long> get_g_V_selectXaX_count();
+
     // below are original back()-tests
 
     public abstract Traversal<Vertex, Vertex> get_g_VX1X_asXhereX_out_selectXhereX(final Object v1Id);
@@ -342,6 +344,14 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         assertEquals(6, counter);
         assertEquals(3, yCounter);
         assertEquals(3, xCounter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_selectXaX_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_selectXaX_count();
+        printTraversalForm(traversal);
+        assertEquals(0L, traversal.next().longValue());
     }
 
     // below are original back()-tests
@@ -723,6 +733,11 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_chooseXoutE_count_isX0X__asXaX__asXbXX_chooseXselectXaX__selectXaX__selectXbXX() {
             return g.V().choose(__.outE().count().is(0L), __.as("a"), __.as("b")).choose(__.select("a"), __.select("a"), __.select("b"));
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_selectXaX_count() {
+            return g.V().select("a").count();
         }
 
         // below are original back()-tests

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphCountStrategy.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphCountStrategy.java
@@ -71,7 +71,7 @@ public final class TinkerGraphCountStrategy extends AbstractTraversalStrategy<Tr
             return;
         for (int i = 1; i < steps.size() - 1; i++) {
             final Step current = steps.get(i);
-            if (!(current instanceof MapStep ||
+            if (!(//current instanceof MapStep ||  // MapSteps will not necessarily emit an element as demonstrated in https://issues.apache.org/jira/browse/TINKERPOP-1958
                     current instanceof IdentityStep ||
                     current instanceof NoOpBarrierStep ||
                     current instanceof CollectingBarrierStep) ||

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphCountStrategyTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphCountStrategyTest.java
@@ -64,6 +64,11 @@ public class TinkerGraphCountStrategyTest {
         for (final TraversalStrategy strategy : this.otherStrategies) {
             strategies.addStrategies(strategy);
         }
+        if (this.optimized == null) {
+            this.optimized = this.original.asAdmin().clone();
+            this.optimized.asAdmin().setStrategies(strategies);
+            this.optimized.asAdmin().applyStrategies();
+        }
         this.original.asAdmin().setStrategies(strategies);
         this.original.asAdmin().applyStrategies();
         assertEquals(this.optimized, this.original);
@@ -81,17 +86,17 @@ public class TinkerGraphCountStrategyTest {
                 {__.V().count(), countStep(Vertex.class), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
                 {__.V().as("a").count(), countStep(Vertex.class), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
                 {__.V().count().as("a"), countStep(Vertex.class), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
-                {__.V().map(out()).count().as("a"), countStep(Vertex.class), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
-                {__.V().map(out()).identity().count().as("a"), countStep(Vertex.class), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
-                {__.V().map(out().groupCount()).identity().count().as("a"), countStep(Vertex.class), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
-                {__.V().label().map(s -> s.get().length()).count(), countStep(Vertex.class), TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
-                {__.V().as("a").map(select("a")).count(), countStep(Vertex.class),TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
+                {__.V().map(out()).count().as("a"), null, TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
+                {__.V().map(out()).identity().count().as("a"), null, TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
+                {__.V().map(out().groupCount()).identity().count().as("a"), null, TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
+                {__.V().label().map(s -> s.get().length()).count(), null, TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
+                {__.V().as("a").map(select("a")).count(), null, TraversalStrategies.GlobalCache.getStrategies(TinkerGraph.class).toList()},
                 //
-                {__.V(), __.V(), Collections.emptyList()},
-                {__.V().out().count(), __.V().out().count(), Collections.emptyList()},
-                {__.V(1).count(), __.V(1).count(), Collections.emptyList()},
-                {__.count(), __.count(), Collections.emptyList()},
-                {__.V().map(out().groupCount("m")).identity().count().as("a"), __.V().map(out().groupCount("m")).identity().count().as("a"), Collections.emptyList()},
+                {__.V(), null, Collections.emptyList()},
+                {__.V().out().count(), null, Collections.emptyList()},
+                {__.V(1).count(), null, Collections.emptyList()},
+                {__.count(), null, Collections.emptyList()},
+                {__.V().map(out().groupCount("m")).identity().count().as("a"), null, Collections.emptyList()},
         });
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1958

The strategy did not consider, that certain map steps may not emit an element.

`docker/build.sh -t -i` passed.

VOTE: +1