### PR TITLE
TINKERPOP-1963 Fixed branch() problems with reducing steps as options

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-10]]
 === TinkerPop 3.2.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed bug in `branch()` where reducing steps as options would produce incorrect results.
 * Removed recursive handling of streaming results from Gremlin-Python driver to avoid max recursion depth errors.
 * Fixed bug in `GroovyTranslator` that didn't properly handle empty `Map` objects.
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
@@ -32,7 +32,6 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-
 public abstract class ReducingBarrierStep<S, E> extends AbstractStep<S, E> implements Barrier<E>, Generating<E, E> {
 
     protected Supplier<E> seedSupplier;

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -38,7 +38,11 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
     public class GherkinTestRunner
     {
         private static readonly IDictionary<string, IgnoreReason> IgnoredScenarios =
-            new Dictionary<string, IgnoreReason>();
+            new Dictionary<string, IgnoreReason>()
+            {
+                { "g_injectX1X_chooseXisX1X__constantX10Xfold__foldX", IgnoreReason.NoReason },
+                { "g_injectX2X_chooseXisX1X__constantX10Xfold__foldX", IgnoreReason.NoReason }
+            };
         
         private static class Keywords
         {

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyChooseTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyChooseTest.groovy
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex
 public abstract class GroovyChooseTest {
 
     public static class Traversals extends ChooseTest {
+
         @Override
         public Traversal<Vertex, Object> get_g_V_chooseXout_countX_optionX2L__nameX_optionX3L__valueMapX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose(__.out.count).option(2L, __.values('name')).option(3L, __.valueMap())")
@@ -62,6 +63,16 @@ public abstract class GroovyChooseTest {
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_hasLabelXpersonX_asXp1X_chooseXoutEXknowsX__outXknowsXX_asXp2X_selectXp1_p2X_byXnameX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').as('p1').choose(outE('knows'), out('knows')).as('p2').select('p1', 'p2').by('name')");
+        }
+
+        @Override
+        public Traversal<Integer, List<Integer>> get_g_injectX1X_chooseXisX1X__constantX10Xfold__foldX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.inject(1).choose(__.is(1), __.constant(10).fold(), __.fold())")
+        }
+
+        @Override
+        public Traversal<Integer, List<Integer>> get_g_injectX2X_chooseXisX1X__constantX10Xfold__foldX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.inject(2).choose(__.is(1), __.constant(10).fold(), __.fold())")
         }
     }
 }

--- a/gremlin-test/features/branch/Choose.feature
+++ b/gremlin-test/features/branch/Choose.feature
@@ -122,3 +122,30 @@ Feature: Step - choose()
       | m[{"p1":"vadas", "p2":"vadas"}] |
       | m[{"p1":"josh", "p2":"josh"}] |
       | m[{"p1":"peter", "p2":"peter"}] |
+
+  Scenario: g_injectX1X_chooseXisX1X__constantX10Xfold__foldX
+    Given the empty graph
+    And using the parameter d10 defined as "d[10].i"
+    And using the parameter d1 defined as "d[1].i"
+    And the traversal of
+      """
+      g.inject(d1).choose(__.is(d1), __.constant(d10).fold(), __.fold())
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | l[d[10].i] |
+
+  Scenario: g_injectX2X_chooseXisX1X__constantX10Xfold__foldX
+    Given the empty graph
+    And using the parameter d10 defined as "d[10].i"
+    And using the parameter d1 defined as "d[1].i"
+    And using the parameter d2 defined as "d[2].i"
+    And the traversal of
+      """
+      g.inject(d2).choose(__.is(d1), __.constant(d10).fold(), __.fold())
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | l[d[2].i] |

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/ChooseTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/ChooseTest.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.MapHelper;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -30,7 +31,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
@@ -42,6 +45,8 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.valueMap;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.values;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -63,6 +68,10 @@ public abstract class ChooseTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, String> get_g_V_chooseXoutXknowsX_count_isXgtX0XX__outXknowsXX_name();
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_hasLabelXpersonX_asXp1X_chooseXoutEXknowsX__outXknowsXX_asXp2X_selectXp1_p2X_byXnameX();
+
+    public abstract Traversal<Integer, List<Integer>> get_g_injectX1X_chooseXisX1X__constantX10Xfold__foldX();
+
+    public abstract Traversal<Integer, List<Integer>> get_g_injectX2X_chooseXisX1X__constantX10Xfold__foldX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -128,6 +137,22 @@ public abstract class ChooseTest extends AbstractGremlinProcessTest {
         ), traversal);
     }
 
+    @Test
+    public void g_injectX1X_chooseXisX1X__constantX10Xfold__foldX() {
+        final Traversal<Integer, List<Integer>> traversal = get_g_injectX1X_chooseXisX1X__constantX10Xfold__foldX();
+        printTraversalForm(traversal);
+        assertEquals(Collections.singletonList(10), traversal.next());
+        assertThat(traversal.hasNext(), is(false));
+    }
+
+    @Test
+    public void g_injectX2X_chooseXisX1X__constantX10Xfold__foldX() {
+        final Traversal<Integer, List<Integer>> traversal = get_g_injectX2X_chooseXisX1X__constantX10Xfold__foldX();
+        printTraversalForm(traversal);
+        assertEquals(Collections.singletonList(2), traversal.next());
+        assertThat(traversal.hasNext(), is(false));
+    }
+
     public static class Traversals extends ChooseTest {
 
         @Override
@@ -163,6 +188,16 @@ public abstract class ChooseTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_hasLabelXpersonX_asXp1X_chooseXoutEXknowsX__outXknowsXX_asXp2X_selectXp1_p2X_byXnameX() {
             return g.V().hasLabel("person").as("p1").choose(outE("knows"), out("knows")).as("p2").<String>select("p1", "p2").by("name");
+        }
+
+        @Override
+        public Traversal<Integer, List<Integer>> get_g_injectX1X_chooseXisX1X__constantX10Xfold__foldX() {
+            return g.inject(1).choose(__.is(1), __.constant(10).fold(), __.fold());
+        }
+
+        @Override
+        public Traversal<Integer, List<Integer>> get_g_injectX2X_chooseXisX1X__constantX10Xfold__foldX() {
+            return g.inject(2).choose(__.is(1), __.constant(10).fold(), __.fold());
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1963

Not sure I fixed this in the best way possible, but I added an `IdentityStep` to the front of each option:

https://github.com/apache/tinkerpop/compare/tp32...TINKERPOP-1963?expand=1#diff-546a91c51e7b731ccea30f0e4aff5d83R68

and then later checked that step to see if anything had been injected into it to determine if the choice had evaluated to `true` or not (since that was the existing way in which that was done).  I'm open to better approaches to resolving this problem if they can be suggested. Also ready to hear that "this way won't work because..." In the mean time.....

All tests pass with `docker/build.sh -t -n -i`

VOTE +1