### PR TITLE
TINKERPOP-1836 Add Gremlin.Net.Template project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ tools/
 .vs/
 *nupkg
 NuGet.Config
-nuget.exe
+nuget*.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,13 @@ install:
 before_install:
   - wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
   - sudo dpkg -i packages-microsoft-prod.deb
+  - sudo sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list'  
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
   - sudo apt-get install apt-transport-https
   - sudo apt-get update
   - sudo apt-get install dotnet-sdk-2.1
+  - sudo apt install mono-devel
+
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,9 @@ install:
 before_install:
   - wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
   - sudo dpkg -i packages-microsoft-prod.deb
-  - sudo sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list'  
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
   - sudo apt-get install apt-transport-https
   - sudo apt-get update
   - sudo apt-get install dotnet-sdk-2.1
-  - sudo apt install mono-devel
-
 
 jobs:
   include:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-10]]
 === TinkerPop 3.2.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added a dotnet template project that should make it easier to get started with Gremlin.Net.
 * Removed `ThreadInterruptCustomizerProvider` from documentation as a way to timeout.
 * Added Docker images for Gremlin Console and Gremlin Server.
 * Fixed bug in `branch()` where reducing steps as options would produce incorrect results.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,10 +25,12 @@ RUN apt-get update \
     && add-apt-repository -y ppa:webupd8team/java \
     && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list' \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893 \
+    && sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list' \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
     && apt-get update \
     && apt-get install -y oracle-java8-installer curl gawk git maven openssh-server subversion zip \
     && sh -c 'curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg' \
-    && apt-get install -y --force-yes dotnet-sdk-2.1.101 python python-dev python-pip build-essential \
+    && apt-get install -y --force-yes dotnet-sdk-2.1.101 python python-dev python-pip build-essential mono-devel \
     && pip install virtualenv virtualenvwrapper \
     && pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* /var/cache/oracle-jdk8-installer

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -181,9 +181,9 @@ For .NET releases, install link:http://www.mono-project.com/[Mono]. The release 
 so it is best to probably install that version. Release managers should probably also do an install of
 link:https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe[nuget 3.4.4] as it will help with environmental setup.
 To get an environment ready to deploy to NuGet, it is necessary to have a NuGet API key. First, create an account with
-link:https://www.nuget.org[nuget] and request that a PMC member add your account to the Gremlin.Net package in nuget
-so that you can deploy. Next, generate an API key for your account on the nuget website. The API key should be added
-to `NuGet.Config` with the following:
+link:https://www.nuget.org[nuget] and request that a PMC member add your account to the Gremlin.Net and
+the Gremlin.Net.Template package in nuget so that you can deploy. Next, generate an API key for your account on the
+nuget website. The API key should be added to `NuGet.Config` with the following:
 
 [source,text]
 ----

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -105,8 +105,6 @@ See the <<release-environment,Release Environment>> section for more information
 The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=2.1.101) to work with the
 `gremlin-dotnet` module. If .NET Core SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
-In order to pack the Gremlin.Net Template project, it is also necessary to install link:http://www.mono-project.com/[Mono].
-The template will still be built and tested when Mono is not present but packing will be skipped.
 
 `gremlin-dotnet` can be built and tested from the command line with:
 
@@ -117,6 +115,14 @@ which enables the "gremlin-dotnet" Maven profile or in a more automated fashion 
 and `test` directories of the `gremlin-dotnet` module  which will signify to Maven that the environment is .NET-ready.
 The `.glv` file need not have any contents and is ignored by Git. A standard `mvn clean install` will then build
 `gremlin-dotnet` in full.
+
+In order to pack the Gremlin.Net.Template project, it is also necessary to install link:http://www.mono-project.com/[Mono].
+The template can still be built and tested without Mono but packing will be skipped.
+To pack the template (which will also download the link:https://docs.microsoft.com/en-us/nuget/tools/nuget-exe-cli-reference[NuGet CLI tool])
+the `nuget` property has to be set:
+
+[source,text]
+mvn clean install -Dnuget
 
 See the <<release-environment,Release Environment>> section for more information on release manager configurations.
 

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -105,6 +105,8 @@ See the <<release-environment,Release Environment>> section for more information
 The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=2.1.101) to work with the
 `gremlin-dotnet` module. If .NET Core SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
+In order to pack the Gremlin.Net Template project, it is also necessary to install link:http://www.mono-project.com/[Mono].
+The template will still be built and tested when Mono is not present but packing will be skipped.
 
 `gremlin-dotnet` can be built and tested from the command line with:
 

--- a/docs/src/dev/developer/release.asciidoc
+++ b/docs/src/dev/developer/release.asciidoc
@@ -112,6 +112,7 @@ during this period.
 . At some point during the week:
 .. Run the full integration test suite: `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`
 .. Build and test the Docker images: `mvn clean install -pl gremlin-server,gremlin-console -DdockerImages`
+.. Ensure that the Gremlin.Net.Template gets packaged successfully: `mvn clean install -Dnuget`
 .. Deploy a final SNAPSHOT to the snapshot repository as well as GLV and Docker image pre-releases.
 .. Review LICENSE and NOTICE files to make sure that no <<dependencies,changes are needed>>.
 .. Review javadoc filters on the "Core API" docs to be sure nothing needs to change.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -2238,11 +2238,15 @@ The following shows the output for `HadoopGraph`:
 describeGraph(HadoopGraph)
 ----
 
-[[gremlin-archetypes]]
-== Gremlin Archetypes
+[[application-templates]]
+== Application Templates
 
-TinkerPop has a number of link:https://maven.apache.org/guides/introduction/introduction-to-archetypes.html[Maven archetypes],
-which provide example project templates to quickly get started with TinkerPop. The available archetypes are as follows:
+TinkerPop has a number of application templates, which provide example project templates to quickly get started with TinkerPop.
+
+[[gremlin-archetypes]]
+=== Maven Archetypes
+
+The available link:https://maven.apache.org/guides/introduction/introduction-to-archetypes.html[Maven archetypes] are as follows:
 
 * `gremlin-archetype-dsl` - An example project that demonstrates how to build Domain Specific Languages with Gremlin in Java.
 * `gremlin-archetype-server` - An example project that demonstrates the basic structure of a
@@ -2259,3 +2263,24 @@ $ mvn archetype:generate -DarchetypeGroupId=org.apache.tinkerpop -DarchetypeArti
 This command will generate a new Maven project in a directory called "app" with a `pom.xml` specifying a `groupId` of
 `com.my`. Please see the `README.asciidoc` in the root of each generated project for information on how to build and
 execute it.
+
+[[gremlin-dotnet-template]]
+=== Gremlin.Net Template
+
+This link:https://docs.microsoft.com/dotnet/core/tools/custom-templates[dotnet template] helps getting started with
+<<gremlin-DotNet,Gremlin.Net>>. It creates a new C# console project that shows how to connect to a
+<<gremlin-server,Gremlin Server>> with Gremlin.Net.
+
+You can install the template with the dotnet CLI tool:
+[source,shell]
+dotnet new -i Gremlin.Net.Template
+
+After the template is installed, a new project based on this template can be installed:
+
+[source,shell]
+dotnet new gremlin
+
+You can specify the output directory for the new project which will then also be used as the name of the created project:
+
+[source,shell]
+dotnet new gremlin -o MyFirstGremlinProject

--- a/gremlin-dotnet/Gremlin.Net.sln
+++ b/gremlin-dotnet/Gremlin.Net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.12
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{584F838B-DAE2-44F5-868C-1F532949C827}"
 EndProject
@@ -14,6 +14,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gremlin.Net.UnitTest", "test\Gremlin.Net.UnitTest\Gremlin.Net.UnitTest.csproj", "{1FAB781B-B857-4AD2-BEC8-E20C214D9E21}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gremlin.Net.IntegrationTest", "test\Gremlin.Net.IntegrationTest\Gremlin.Net.IntegrationTest.csproj", "{CC54ABE3-13D2-491C-81E2-4D0355ABFA93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gremlin.Net.Template", "src\Gremlin.Net.Template\Gremlin.Net.Template.csproj", "{A9D2567A-6FD0-452B-A2F9-4256FE513ADD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gremlin.Net.Template.IntegrationTest", "test\Gremlin.Net.Template.IntegrationTest\Gremlin.Net.Template.IntegrationTest.csproj", "{3BFC3559-E317-4327-AFB7-CFBB31E1C868}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +37,14 @@ Global
 		{CC54ABE3-13D2-491C-81E2-4D0355ABFA93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC54ABE3-13D2-491C-81E2-4D0355ABFA93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC54ABE3-13D2-491C-81E2-4D0355ABFA93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9D2567A-6FD0-452B-A2F9-4256FE513ADD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9D2567A-6FD0-452B-A2F9-4256FE513ADD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9D2567A-6FD0-452B-A2F9-4256FE513ADD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9D2567A-6FD0-452B-A2F9-4256FE513ADD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BFC3559-E317-4327-AFB7-CFBB31E1C868}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BFC3559-E317-4327-AFB7-CFBB31E1C868}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BFC3559-E317-4327-AFB7-CFBB31E1C868}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BFC3559-E317-4327-AFB7-CFBB31E1C868}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -41,5 +53,10 @@ Global
 		{6C1DD34D-E30F-4E37-AACC-BEB8AD2320D8} = {584F838B-DAE2-44F5-868C-1F532949C827}
 		{1FAB781B-B857-4AD2-BEC8-E20C214D9E21} = {1B54FAC2-5411-4BB6-B450-FE2FFD8C4782}
 		{CC54ABE3-13D2-491C-81E2-4D0355ABFA93} = {1B54FAC2-5411-4BB6-B450-FE2FFD8C4782}
+		{A9D2567A-6FD0-452B-A2F9-4256FE513ADD} = {584F838B-DAE2-44F5-868C-1F532949C827}
+		{3BFC3559-E317-4327-AFB7-CFBB31E1C868} = {1B54FAC2-5411-4BB6-B450-FE2FFD8C4782}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F0AF408C-2147-434A-80FB-73A1626FC30C}
 	EndGlobalSection
 EndGlobal

--- a/gremlin-dotnet/glv/Gremlin.Net.Template.csproj.template
+++ b/gremlin-dotnet/glv/Gremlin.Net.Template.csproj.template
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--  THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- We need both reference elements until this is resolved: https://github.com/dotnet/sdk/issues/1151 -->
+    <ProjectReference Include="../Gremlin.Net/Gremlin.Net.csproj" />
+    <PackageReference Include="Gremlin.Net" Version="$projectVersion" />
+  </ItemGroup>
+
+</Project>

--- a/gremlin-dotnet/glv/Gremlin.Net.Template.nuspec.template
+++ b/gremlin-dotnet/glv/Gremlin.Net.Template.nuspec.template
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Gremlin.Net.Template</id>
+        <title>Gremlin.Net Template</title>
+        <version>$projectVersion</version>
+        <description>Gremlin.Net template to create a console application with dotnet new.</description>
+        <authors>Apache TinkerPop</authors>
+        <licenseUrl>https://github.com/apache/tinkerpop/blob/master/LICENSE</licenseUrl>
+        <projectUrl>http://tinkerpop.apache.org</projectUrl>
+        <tags>TinkerPop Gremlin Gremlin.Net</tags>
+        <packageTypes>
+            <packageType name="Template" />
+        </packageTypes>
+    </metadata>
+    <files>
+        <file src=".template.config/template.json" target="content/.template.config" />
+        <file src="Gremlin.Net.Template.csproj" target="content" />
+        <file src="*.cs" target="content" />
+</files>
+</package>

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -379,3 +379,9 @@ def versionToUse = determineVersion()
 def csprojTemplate = engine.createTemplate(new File("${projectBaseDir}/glv/Gremlin.Net.csproj.template")).make(["projectVersion":versionToUse])
 def csprojFile = new File("${projectBaseDir}/src/Gremlin.Net/Gremlin.Net.csproj")
 csprojFile.newWriter().withWriter{ it << csprojTemplate }
+def templateCsprojTemplate = engine.createTemplate(new File("${projectBaseDir}/glv/Gremlin.Net.Template.csproj.template")).make(["projectVersion":versionToUse])
+def templateCsprojFile = new File("${projectBaseDir}/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+templateCsprojFile.newWriter().withWriter{ it << templateCsprojTemplate }
+def nuspecTemplate = engine.createTemplate(new File("${projectBaseDir}/glv/Gremlin.Net.Template.nuspec.template")).make(["projectVersion":versionToUse])
+def nuspecFile = new File("${projectBaseDir}/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+nuspecFile.newWriter().withWriter{ it << nuspecTemplate }

--- a/gremlin-dotnet/src/Gremlin.Net.Template/.template.config/template.json
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/.template.config/template.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "Apache TinkerPop",
+    "classifications": [ "TinkerPop", "Gremlin", "Gremlin.Net" ],
+    "identity": "Gremlin.Net.Template",
+    "name": "Gremlin.Net Template",
+    "shortName": "gremlin",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "Gremlin.Net.Template",
+    "preferNameDirectory": true
+  }

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--  THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- We need both reference elements until this is resolved: https://github.com/dotnet/sdk/issues/1151 -->
+    <ProjectReference Include="../Gremlin.Net/Gremlin.Net.csproj" />
+    <PackageReference Include="Gremlin.Net" Version="3.2.10-SNAPSHOT" />
+  </ItemGroup>
+
+</Project>

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Gremlin.Net.Template</id>
+        <title>Gremlin.Net Template</title>
+        <version>3.2.10-SNAPSHOT</version>
+        <description>Gremlin.Net template to create a console application with dotnet new.</description>
+        <authors>Apache TinkerPop</authors>
+        <licenseUrl>https://github.com/apache/tinkerpop/blob/master/LICENSE</licenseUrl>
+        <projectUrl>http://tinkerpop.apache.org</projectUrl>
+        <tags>TinkerPop Gremlin Gremlin.Net</tags>
+        <packageTypes>
+            <packageType name="Template" />
+        </packageTypes>
+    </metadata>
+    <files>
+        <file src=".template.config/template.json" target="content/.template.config" />
+        <file src="Gremlin.Net.Template.csproj" target="content" />
+        <file src="*.cs" target="content" />
+</files>
+</package>

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
@@ -1,0 +1,50 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+using Gremlin.Net.Structure;
+
+namespace Gremlin.Net.Template
+{
+    internal class Program
+    {
+        private const string GremlinServerHostname = "localhost";
+        private const int GremlinServerPort = 45940;
+
+        private static void Main()
+        {
+            using (var client = new GremlinClient(new GremlinServer(GremlinServerHostname, GremlinServerPort)))
+            {
+                var g = new Graph().Traversal().WithRemote(new DriverRemoteConnection(client));
+                var service = new Service(g);
+                var creators = service.FindCreatorsOfSoftware("lop");
+                foreach (var c in creators)
+                {
+                    Console.WriteLine(c);
+                }
+            }
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net.Template/README.md
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/README.md
@@ -1,0 +1,46 @@
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+# Gremlin.Net Template
+
+This dotnet template helps getting started with [Gremlin.Net](http://tinkerpop.apache.org/docs/current/reference/#gremlin-DotNet) - the .NET Gremlin Language Variant (GLV) of Apache TinkerPop™. It creates a new C# console project that shows how to connect to a [Gremlin Server](http://tinkerpop.apache.org/docs/current/reference/#gremlin-server) with Gremlin.Net.
+
+## Installation
+
+You can install the template with the dotnet CLI tool:
+
+```bash
+dotnet new -i Gremlin.Net.Template
+```
+
+## Creating a project using the template
+
+After the template is installed, a new project based on this template can be installed:
+
+```bash
+dotnet new gremlin
+```
+
+You can specify the output directory for the new project which will then also be used as the name of the created project:
+
+```bash
+dotnet new gremlin -o MyFirstGremlinProject
+```

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Service.cs
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Service.cs
@@ -1,0 +1,43 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Collections.Generic;
+using Gremlin.Net.Process.Traversal;
+
+namespace Gremlin.Net.Template
+{
+    public class Service
+    {
+        private readonly GraphTraversalSource _g;
+
+        public Service(GraphTraversalSource g)
+        {
+            _g = g;
+        }
+
+        public IList<string> FindCreatorsOfSoftware(string softwareName)
+        {
+            return _g.V().HasLabel("software").Has("name", softwareName).In("created").Values<string>("name").ToList();
+        }
+    }
+}

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -26,6 +26,10 @@ limitations under the License.
     <artifactId>gremlin-dotnet-source</artifactId>
     <name>Apache TinkerPop :: Gremlin.Net - Source</name>
     <packaging>${packaging.type}</packaging>
+    <properties>
+        <nugetVersion>4.4.1</nugetVersion>
+        <nugetExe>nuget-${nugetVersion}.exe</nugetExe>
+    </properties>
 
     <build>
         <plugins>
@@ -106,19 +110,19 @@ limitations under the License.
                                             <available file="mono" filepath="${env.PATH}"/>
                                             <then>
                                                 <if>
-                                                    <available file="Gremlin.Net/bin/nuget.exe"/>
+                                                    <available file="${nugetExe}"/>
                                                     <then>
-                                                        <echo>nuget.exe already downloaded and at Gremlin.Net/bin/nuget.exe.</echo>
+                                                        <echo>nuget.exe already downloaded.</echo>
                                                     </then>
 
                                                     <else>
-                                                        <exec dir="Gremlin.Net/bin" executable="wget" failonerror="true">
-                                                            <arg line="https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe"/>
+                                                        <exec executable="wget" failonerror="true">
+                                                            <arg line="https://dist.nuget.org/win-x86-commandline/v${nugetVersion}/nuget.exe -O ${nugetExe}"/>
                                                         </exec>
                                                     </else>
                                                 </if>
-                                                <exec dir="Gremlin.Net/bin" executable="mono" failonerror="true">
-                                                    <arg line="nuget.exe pack ../../Gremlin.Net.Template/Gremlin.Net.Template.nuspec"/>
+                                                <exec executable="mono" failonerror="true">
+                                                    <arg line="${nugetExe} pack Gremlin.Net.Template/Gremlin.Net.Template.nuspec"/>
                                                 </exec>
                                             </then>
                                             <else>
@@ -178,14 +182,14 @@ limitations under the License.
                                     <tasks>
                                         <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
                                         <if>
-                                            <available file="Gremlin.Net/bin/nuget.exe"/>
+                                            <available file="${nugetExe}"/>
                                             <then>
-                                                <echo>nuget.exe already downloaded and at Gremlin.Net/bin/nuget.exe.</echo>
+                                                <echo>nuget.exe already downloaded.</echo>
                                             </then>
 
                                             <else>
-                                                <exec dir="Gremlin.Net/bin" executable="wget" failonerror="true">
-                                                    <arg line="https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe"/>
+                                                <exec executable="wget" failonerror="true">
+                                                    <arg line="https://dist.nuget.org/win-x86-commandline/v${nugetVersion}/nuget.exe -O ${nugetExe}"/>
                                                 </exec>
                                             </else>
                                         </if>
@@ -194,8 +198,8 @@ limitations under the License.
                                         until https://github.com/NuGet/Home/issues/4095 we have to have to specify
                                         the "ConfigFile" option to nuget.
                                         -->
-                                        <exec dir="Gremlin.Net/bin" executable="mono" failonerror="true">
-                                            <arg line="nuget.exe push Gremlin.Net.*.nupkg -Source https://www.nuget.org/api/v2/package -ConfigFile ${user.home}/.config/NuGet/NuGet.Config"/>
+                                        <exec executable="mono" failonerror="true">
+                                            <arg line="${nugetExe} push Gremlin.Net/bin/Gremlin.Net.*.nupkg -Source https://www.nuget.org/api/v2/package -ConfigFile ${user.home}/.config/NuGet/NuGet.Config"/>
                                         </exec>
                                     </tasks>
                                 </configuration>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -93,6 +93,33 @@ limitations under the License.
                             <nugetAddEnabled>false</nugetAddEnabled>
                         </configuration>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
+        Provides a way to deploy the Gremlin.Net GLV to nuget. This cannot be part of the standard maven execution
+        because nuget does not have a staging environment like sonatype for releases. As soon as the release is
+        published it is public. In our release workflow, deploy occurs prior to vote on the release and we can't
+        make this stuff public until the vote is over.
+        -->
+        <profile>
+            <id>glv-dotnet-deploy</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>nuget</name>
+                </property>
+            </activation>
+            <properties>
+                <packaging.type>dotnet-library</packaging.type>
+            </properties>
+            <build>
+                <plugins>
+                    <!--
+                      not seeing much point to making this OS agnostic really. as far as it is known, no one who does
+                      deployments will do so from a windows machine. this part of the build requires mono. note that
+                      the "correct" version of nuget is downloaded as part of the process.
+                     -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
@@ -132,46 +159,6 @@ limitations under the License.
                                     </tasks>
                                 </configuration>
                             </execution>
-                        </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ant-contrib</groupId>
-                                <artifactId>ant-contrib</artifactId>
-                                <version>20020829</version>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <!--
-        Provides a way to deploy the Gremlin.Net GLV to nuget. This cannot be part of the standard maven execution
-        because nuget does not have a staging environment like sonatype for releases. As soon as the release is
-        published it is public. In our release workflow, deploy occurs prior to vote on the release and we can't
-        make this stuff public until the vote is over.
-        -->
-        <profile>
-            <id>glv-dotnet-deploy</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>nuget</name>
-                </property>
-            </activation>
-            <properties>
-                <packaging.type>dotnet-library</packaging.type>
-            </properties>
-            <build>
-                <plugins>
-                    <!--
-                      not seeing much point to making this OS agnostic really. as far as it is known, no one who does
-                      deployments will do so from a windows machine. this part of the build requires mono. note that
-                      the "correct" version of nuget is downloaded as part of the process.
-                     -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
                             <execution>
                                 <id>deploy-nuget</id>
                                 <phase>deploy</phase>
@@ -200,6 +187,9 @@ limitations under the License.
                                         -->
                                         <exec executable="mono" failonerror="true">
                                             <arg line="${nugetExe} push Gremlin.Net/bin/Gremlin.Net.*.nupkg -Source https://www.nuget.org/api/v2/package -ConfigFile ${user.home}/.config/NuGet/NuGet.Config"/>
+                                        </exec>
+                                        <exec executable="mono" failonerror="true">
+                                            <arg line="${nugetExe} push Gremlin.Net.Template.*.nupkg -Source https://www.nuget.org/api/v2/package -ConfigFile ${user.home}/.config/NuGet/NuGet.Config"/>
                                         </exec>
                                     </tasks>
                                 </configuration>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -89,6 +89,54 @@ limitations under the License.
                             <nugetAddEnabled>false</nugetAddEnabled>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>pack-dotnet-template</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
+                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" />                                       
+                                        <if>
+                                            <available file="mono" filepath="${env.PATH}"/>
+                                            <then>
+                                                <if>
+                                                    <available file="Gremlin.Net/bin/nuget.exe"/>
+                                                    <then>
+                                                        <echo>nuget.exe already downloaded and at Gremlin.Net/bin/nuget.exe.</echo>
+                                                    </then>
+
+                                                    <else>
+                                                        <exec dir="Gremlin.Net/bin" executable="wget" failonerror="true">
+                                                            <arg line="https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe"/>
+                                                        </exec>
+                                                    </else>
+                                                </if>
+                                                <exec dir="Gremlin.Net/bin" executable="mono" failonerror="true">
+                                                    <arg line="nuget.exe pack ../../Gremlin.Net.Template/Gremlin.Net.Template.nuspec"/>
+                                                </exec>
+                                            </then>
+                                            <else>
+                                                <echo>Skipping packaging of Gremlin.Net.Template as mono is not available</echo>
+                                            </else>
+                                        </if>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>ant-contrib</groupId>
+                                <artifactId>ant-contrib</artifactId>
+                                <version>20020829</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -200,6 +248,12 @@ def engine = new groovy.text.GStringTemplateEngine()
 def csprojTemplate = engine.createTemplate(new File('${project.parent.basedir}/glv/Gremlin.Net.csproj.template')).make(["projectVersion":versionToUse])
 def csprojFile = new File('${project.basedir}/Gremlin.Net/Gremlin.Net.csproj')
 csprojFile.newWriter().withWriter{ it << csprojTemplate }
+def templateCsprojTemplate = engine.createTemplate(new File('${project.parent.basedir}/glv/Gremlin.Net.Template.csproj.template')).make(["projectVersion":versionToUse])
+def templateCsprojFile = new File('${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.csproj')
+templateCsprojFile.newWriter().withWriter{ it << templateCsprojTemplate }
+def nuspecTemplate = engine.createTemplate(new File('${project.parent.basedir}/glv/Gremlin.Net.Template.nuspec.template')).make(["projectVersion":versionToUse])
+def nuspecFile = new File('${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec')
+nuspecFile.newWriter().withWriter{ it << nuspecTemplate }
 ]]>
                                         </script>
                                     </scripts>

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Gremlin.Net.Template\Gremlin.Net.Template.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
@@ -1,0 +1,56 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Collections.Generic;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+using Gremlin.Net.Structure;
+using Xunit;
+
+namespace Gremlin.Net.Template.IntegrationTest
+{
+    public class ServiceTests
+    {
+        private const string TestHost = "localhost";
+        private const int TestPort = 45940;
+
+        [Fact]
+        public void ShouldReturnExpectedCreators()
+        {
+            using (var client = CreateClient())
+            {
+                var g = new Graph().Traversal().WithRemote(new DriverRemoteConnection(client));
+                var service = new Service(g);
+            
+                var creators = service.FindCreatorsOfSoftware("lop");
+
+                Assert.Equal(new List<string> {"marko", "josh", "peter"}, creators);
+            }
+        }
+
+        private static IGremlinClient CreateClient()
+        {
+            return new GremlinClient(new GremlinServer(TestHost, TestPort));
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
@@ -33,13 +33,14 @@ namespace Gremlin.Net.Template.IntegrationTest
     {
         private const string TestHost = "localhost";
         private const int TestPort = 45940;
+        private const string TestTraversalSource = "gmodern";
 
         [Fact]
         public void ShouldReturnExpectedCreators()
         {
             using (var client = CreateClient())
             {
-                var g = new Graph().Traversal().WithRemote(new DriverRemoteConnection(client));
+                var g = new Graph().Traversal().WithRemote(new DriverRemoteConnection(client, TestTraversalSource));
                 var service = new Service(g);
             
                 var creators = service.FindCreatorsOfSoftware("lop");

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,8 @@ limitations under the License.
                         <exclude>**/*.csproj</exclude>
                         <exclude>**/.vs/**</exclude>
                         <exclude>**/NuGet.Config</exclude>
+                        <exclude>**/*.nuspec</exclude>
+                        <exclude>**/*.nuspec.template</exclude>
                         <exclude>**/gremlin-javascript/node_modules/**</exclude>
                         <exclude>**/node/node_modules/**</exclude>
                         <exclude>**/node/node</exclude>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1836

This adds a dotnet template that can be installed and then used to create a simple dotnet console application ready to be used together with a Gremlin Server.

We need to release the template just like Gremlin.Net itself as a NuGet package to nuget.org.

**IMPORTANT**: The Maven `package` now **requires Mono** when .NET should be built as it's not possible to pack dotnet templates without Nuget (`dotnet pack` doesn't work for this unfortunately).

`./docker/build.sh -t -i` ran successfully until it failed due to some Giraph tests and the .NET projects were already built successfully. Since the Giraph tests are known to be flaky and we already deprecated Giraph, I didn't look further into that.

VOTE +1