### PR TITLE
TINKERPOP-1831 Refactored EventStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,9 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Changed the order of `select()` scopes. The order is now: maps, side-effects, paths.
 * Removed previously deprecated Credentials DSL infrastructure.
 * Moved `TraversalEngine` to `gremlin-test` as it has long been only used in testing infrastructure.
+* Events from `EventStrategy`raised from "new" mutations will now return a true "empty" property from `VertexProperty.empty()` or `Property.empty()` as is appropriate.
+* `MutationListener#vertexPropertyChanged(Vertex, VertexProperty, Object, Object...)` no longer has a default implementation.
+* Removed previously deprecated `MutationListener#vertexPropertyChanged(Vertex, Property, Object, Object...)`.
 * Removed previously deprecated `OpSelectorHandler` constructor.
 * Removed previously deprecated `close()` from `GremlinGroovyScriptEngine` which no longer implements `AutoCloseable`.
 * Removed previously deprecated `getGraphInputFormat()` and `getGraphOutputFormat()` from `HadoopConfiguration`.

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -113,6 +113,27 @@ gremlin> g.V().values('name').max()
 ==>vadas
 ----
 
+==== EventStrategy API
+
+There were some minor modifications to how `EventStrategy` is constructed and what can be expected from events raised
+from the addition of new properties.
+
+With respect to the change in terms of `EventStrategy` construction, the `detach()` builder method formerly took a
+`Class` as an argument and that `Class` was meant to be one of the various "detachment factories" or `null`. That
+approach was a bit confusing, so that signature has changed to `detach(EventStrategy.Detachment)` where the argument
+is a more handy enum of detachment options.
+
+As for the changes related to events themselves, it is first worth noting that the previously deprecated
+`vertexPropertyChanged(Vertex, Property, Object, Object...)` on `MutationListener` has been removed for what should
+have originally been the correct signature of `vertexPropertyChanged(Vertex, VertexProperty, Object, Object...)`. In
+prior versions when this method and its related `edgePropertyChanged()` and `vertexPropertyPropertyChanged()` were
+triggered by way of the addition of a new property a "fake" property was included with a `null` value for the
+"oldValue" argument to these methods (as it did not exist prior to this event). That was a bit awkward to reason about
+when dealing with that event. To make this easier, the event now raises with a `VertexProperty.empty()` or
+`Property.empty()` instance, which can be evaluated with `equals()` easily to determine if the property is new or not.
+
+link:https://issues.apache.org/jira/browse/TINKERPOP-1831[TINKERPOP-1831]
+
 ==== Deprecation Removal
 
 The following deprecated classes, methods or fields have been removed in this version:
@@ -122,6 +143,7 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.process.traversal.engine.*`
 ** `org.apache.tinkerpop.gremlin.process.traversal.step.map.LambdaCollectingBarrierStep.Consumers`
 ** `org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer#makeHasContainers(String, P)`
+** `org.apache.tinkerpop.gremlin.process.traversal.step.util.event.MutationListener#vertexPropertyChanged(Vertex, Property, Object, Object...)`
 ** `org.apache.tinkerpop.gremlin.structure.Element.Exceptions#elementAlreadyRemoved(Class, Object)`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions#elementNotFound(Class, Object)`
 ** `org.apache.tinkerpop.gremlin.structure.Graph.Exceptions#elementNotFound(Class, Object, Exception)`

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -460,12 +460,6 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue,
-                                          final Object... vertexPropertyKeyValues) {
-            // do nothing - deprecated
-        }
-
-        @Override
         public void vertexPropertyRemoved(final VertexProperty vertexProperty) {
             this.counter++;
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
@@ -97,17 +97,17 @@ public final class AddPropertyStep<S extends Element> extends SideEffectStep<S>
             if (element instanceof Vertex)
                 evt = new Event.VertexPropertyChangedEvent(eventStrategy.detach((Vertex) element),
                         newProperty ?
-                                eventStrategy.empty(element, key) :
+                                VertexProperty.empty() :
                                 eventStrategy.detach((VertexProperty) currentProperty), value, vertexPropertyKeyValues);
             else if (element instanceof Edge)
                 evt = new Event.EdgePropertyChangedEvent(eventStrategy.detach((Edge) element),
                         newProperty ?
-                                eventStrategy.empty(element, key) :
+                                Property.empty() :
                                 eventStrategy.detach(currentProperty), value);
             else if (element instanceof VertexProperty)
                 evt = new Event.VertexPropertyPropertyChangedEvent(eventStrategy.detach((VertexProperty) element),
                         newProperty ?
-                                eventStrategy.empty(element, key) :
+                                Property.empty() :
                                 eventStrategy.detach(currentProperty), value);
             else
                 throw new IllegalStateException(String.format("The incoming object cannot be processed by change eventing in %s:  %s", AddPropertyStep.class.getName(), element));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/ConsoleMutationListener.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/ConsoleMutationListener.java
@@ -83,11 +83,6 @@ public class ConsoleMutationListener implements MutationListener {
     }
 
     @Override
-    public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
-        // do nothing - deprecated
-    }
-
-    @Override
     public void vertexPropertyChanged(final Vertex element, final VertexProperty oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
         System.out.println("Vertex [" + element.toString() + "] property [" + oldValue + "] change to [" + setValue + "] in graph [" + graph.toString() + "]");
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/MutationListener.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/MutationListener.java
@@ -52,19 +52,10 @@ public interface MutationListener {
     /**
      * Raised after the property of a {@link Vertex} changed.
      *
-     * @deprecated As of release 3.2.7, replaced by {@link #vertexPropertyChanged(Vertex, VertexProperty, Object, Object...)}.
-     */
-    public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues);
-
-    /**
-     * Raised after the property of a {@link Vertex} changed.
-     *
      * @param element  the {@link Vertex} that changed
      * @param setValue the new value of the property
      */
-    public default void vertexPropertyChanged(final Vertex element, final VertexProperty oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
-        vertexPropertyChanged(element, (Property) oldValue, setValue, vertexPropertyKeyValues);
-    }
+    public void vertexPropertyChanged(final Vertex element, final VertexProperty oldValue, final Object setValue, final Object... vertexPropertyKeyValues);
 
     /**
      * Raised after a {@link VertexProperty} was removed from the graph.

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyTest.java
@@ -23,7 +23,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTrav
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ConsoleMutationListener;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.MutationListener;
-import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyProcessTest.java
@@ -32,7 +32,6 @@ import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceEdge;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -634,8 +633,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertThat(element, instanceOf(DetachedVertexProperty.class));
                 assertEquals(label, element.label());
                 assertEquals(value, element.value());
-                assertEquals(null, oldValue.value());
-                assertEquals("new", oldValue.key());
+                assertEquals(Property.empty(), oldValue);
                 assertEquals("yay!", setValue);
                 triggered.set(true);
             }
@@ -752,8 +750,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertEquals(label, element.label());
                 assertEquals(inId, element.inVertex().id());
                 assertEquals(outId, element.outVertex().id());
-                assertEquals(null, oldValue.value());
-                assertEquals("new", oldValue.key());
+                assertEquals(Property.empty(), oldValue);
                 assertEquals("yay!", setValue);
                 triggered.set(true);
             }
@@ -928,44 +925,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertThat(element, instanceOf(DetachedVertex.class));
                 assertEquals(label, element.label());
                 assertEquals(id, element.id());
-                assertEquals("new", oldValue.key());
-                assertEquals(null, oldValue.value());
-                assertEquals("dah", setValue);
-                triggered.set(true);
-            }
-        };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener);
-
-        if (graph.features().graph().supportsTransactions())
-            builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
-
-        final EventStrategy eventStrategy = builder.create();
-        final GraphTraversalSource gts = create(eventStrategy);
-
-        gts.V(v).property(VertexProperty.Cardinality.single, "new", "dah").iterate();
-        tryCommit(graph);
-
-        assertEquals(2, IteratorUtils.count(g.V(v).properties()));
-        assertThat(triggered.get(), is(true));
-    }
-
-    @Test
-    @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
-    public void shouldDetachVertexPropertyWhenNewDeprecated() {
-        final AtomicBoolean triggered = new AtomicBoolean(false);
-        final Vertex v = graph.addVertex();
-        final String label = v.label();
-        final Object id = v.id();
-        v.property("old","blah");
-
-        final MutationListener listener = new AbstractMutationListener() {
-            @Override
-            public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
-                assertThat(element, instanceOf(DetachedVertex.class));
-                assertEquals(label, element.label());
-                assertEquals(id, element.id());
-                assertEquals("new", oldValue.key());
-                assertEquals(null, oldValue.value());
+                assertEquals(VertexProperty.empty(), oldValue);
                 assertEquals("dah", setValue);
                 triggered.set(true);
             }
@@ -1069,7 +1029,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1109,7 +1069,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1142,13 +1102,12 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertThat(element, instanceOf(ReferenceVertexProperty.class));
                 assertEquals(label, element.label());
                 assertEquals(value, element.value());
-                assertEquals(null, oldValue.value());
-                assertEquals("new", oldValue.key());
+                assertEquals(Property.empty(), oldValue);
                 assertEquals("yay!", setValue);
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1187,7 +1146,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1227,7 +1186,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1260,13 +1219,12 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertEquals(label, element.label());
                 assertEquals(inId, element.inVertex().id());
                 assertEquals(outId, element.outVertex().id());
-                assertEquals(null, oldValue.value());
-                assertEquals("new", oldValue.key());
+                assertEquals(Property.empty(), oldValue);
                 assertEquals("yay!", setValue);
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1302,7 +1260,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1335,7 +1293,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1369,7 +1327,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1408,7 +1366,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1425,7 +1383,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
 
     @Test
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
-    public void shouldRefereceVertexPropertyWhenNew() {
+    public void shouldReferenceVertexPropertyWhenNew() {
         final AtomicBoolean triggered = new AtomicBoolean(false);
         final Vertex v = graph.addVertex();
         final String label = v.label();
@@ -1438,49 +1396,12 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertThat(element, instanceOf(ReferenceVertex.class));
                 assertEquals(label, element.label());
                 assertEquals(id, element.id());
-                assertEquals("new", oldValue.key());
-                assertEquals(null, oldValue.value());
+                assertEquals(VertexProperty.empty(), oldValue);
                 assertEquals("dah", setValue);
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
-
-        if (graph.features().graph().supportsTransactions())
-            builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
-
-        final EventStrategy eventStrategy = builder.create();
-        final GraphTraversalSource gts = create(eventStrategy);
-
-        gts.V(v).property(VertexProperty.Cardinality.single, "new", "dah").iterate();
-        tryCommit(graph);
-
-        assertEquals(2, IteratorUtils.count(g.V(v).properties()));
-        assertThat(triggered.get(), is(true));
-    }
-
-    @Test
-    @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
-    public void shouldReferenceVertexPropertyWhenNewDeprecated() {
-        final AtomicBoolean triggered = new AtomicBoolean(false);
-        final Vertex v = graph.addVertex();
-        final String label = v.label();
-        final Object id = v.id();
-        v.property("old","blah");
-
-        final MutationListener listener = new AbstractMutationListener() {
-            @Override
-            public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
-                assertThat(element, instanceOf(ReferenceVertex.class));
-                assertEquals(label, element.label());
-                assertEquals(id, element.id());
-                assertEquals("new", oldValue.key());
-                assertEquals(null, oldValue.value());
-                assertEquals("dah", setValue);
-                triggered.set(true);
-            }
-        };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1512,7 +1433,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1541,7 +1462,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1578,7 +1499,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1618,7 +1539,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1651,13 +1572,12 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertEquals(vp, element);
                 assertEquals(label, element.label());
                 assertEquals(value, element.value());
-                assertEquals(null, oldValue.value());
-                assertEquals("new", oldValue.key());
+                assertEquals(Property.empty(), oldValue);
                 assertEquals("yay!", setValue);
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1696,7 +1616,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1736,7 +1656,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1769,13 +1689,12 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertEquals(label, element.label());
                 assertEquals(inId, element.inVertex().id());
                 assertEquals(outId, element.outVertex().id());
-                assertEquals(null, oldValue.value());
-                assertEquals("new", oldValue.key());
+                assertEquals(Property.empty(), oldValue);
                 assertEquals("yay!", setValue);
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1811,7 +1730,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1845,7 +1764,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1880,7 +1799,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1917,7 +1836,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -1947,49 +1866,12 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 assertEquals(v, element);
                 assertEquals(label, element.label());
                 assertEquals(id, element.id());
-                assertEquals("new", oldValue.key());
-                assertEquals(null, oldValue.value());
+                assertEquals(VertexProperty.empty(), oldValue);
                 assertEquals("dah", setValue);
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
-
-        if (graph.features().graph().supportsTransactions())
-            builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
-
-        final EventStrategy eventStrategy = builder.create();
-        final GraphTraversalSource gts = create(eventStrategy);
-
-        gts.V(v).property(VertexProperty.Cardinality.single, "new", "dah").iterate();
-        tryCommit(graph);
-
-        assertEquals(2, IteratorUtils.count(g.V(v).properties()));
-        assertThat(triggered.get(), is(true));
-    }
-
-    @Test
-    @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
-    public void shouldUseActualVertexPropertyWhenNewDeprecated() {
-        final AtomicBoolean triggered = new AtomicBoolean(false);
-        final Vertex v = graph.addVertex();
-        final String label = v.label();
-        final Object id = v.id();
-        v.property("old","blah");
-
-        final MutationListener listener = new AbstractMutationListener() {
-            @Override
-            public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
-                assertEquals(v, element);
-                assertEquals(label, element.label());
-                assertEquals(id, element.id());
-                assertEquals("new", oldValue.key());
-                assertEquals(null, oldValue.value());
-                assertEquals("dah", setValue);
-                triggered.set(true);
-            }
-        };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -2021,7 +1903,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -2051,7 +1933,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(EventStrategy.Detachment.REFERENCE);
 
         if (graph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(graph));
@@ -2083,7 +1965,7 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        public void vertexPropertyChanged(final Vertex element, final VertexProperty oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
 
         }
 
@@ -2208,11 +2090,6 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
         public void vertexPropertyPropertyChanged(final VertexProperty element, final Property oldValue, final Object setValue) {
             vertexPropertyPropertyChangedEvent.incrementAndGet();
             order.add("vp-property-changed-" + element.id());
-        }
-
-        @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
-            // do nothing - deprecated
         }
 
         @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1831

Removed deprecated method. Used `VertexProperty.empty()` and `Property.empty()` to represent the "old" value for new property events. Created an enum for configuring detachment on the `EventStrategy` builder. Upgrade docs describe this change in more detail.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1