### PR TITLE
TINKERPOP-1518 Cache Graph.Features for tests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * `min()` and `max()` now support all types implementing `Comparable`.
 * Change the `toString()` of `Path` to be standardized as other graph elements are.
 * `hadoop-gremlin` no longer generates a test artifact.
+* Allowed `GraphProvider` to expose a cached `Graph.Feature` object so that the test suite could re-use them to speed test runs.
 * Fixed a bug in `ReducingBarrierStep`, that returned the provided seed value despite no elements being available.
 * Changed the order of `select()` scopes. The order is now: maps, side-effects, paths.
 * Removed previously deprecated Credentials DSL infrastructure.

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -662,6 +662,10 @@ should validate that the ignored tests are appropriately bypassed and that there
 definitions.  Moreover, implementers should consider filling gaps in their own test suites, especially when
 IO-related tests are being ignored.
 
+TIP: If it is expensive to construct a new `Graph` instance, consider implementing `GraphProvider.getStaticFeatures()`
+which can help by caching a static feature set for instances produced by that `GraphProvider` and allow the test suite
+to avoid that construction cost if the test is ignored.
+
 The only test-class that requires any code investment is the `GraphProvider` implementation class. This class is a
 used by the test suite to construct `Graph` configurations and instances and provides information about the
 implementation itself.  In most cases, it is best to simply extend `AbstractGraphProvider` as it provides many

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -241,6 +241,26 @@ See: link:https://issues.apache.org/jira/browse/TINKERPOP-1522[TINKERPOP-1522]
 
 ==== Graph Database Providers
 
+===== Caching Graph Features
+
+For graph implementations that have expensive creation times, it can be time consuming to run the TinkerPop test suite
+as each test run requires a `Graph` instance even if the test is ultimately ignored becaue it doesn't pass the feature
+checks. To possibly help alleviate this problem, the `GraphProvider` interface now includes this method:
+
+[source,java]
+----
+public default Optional<Graph.Features> getStaticFeatures() {
+    return Optional.empty();
+}
+----
+
+This method can be implemented to return a cacheable set of features for a `Graph` generated from that `GraphProvider`.
+Assuming this method is faster than the cost of creating a new `Graph` instance, the test suite should execute
+significantly faster depending on how many tests end up being ignored.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1518[TINKERPOP-1518],
+link:
+
 ===== Configuring Interface
 
 There were some changes to interfaces that were related to `Step`. A new `Configuring` interface was added that was

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -40,7 +40,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
@@ -183,6 +183,11 @@ public class GraphManager {
             if (innerGraphProvider instanceof AutoCloseable)
                 ((AutoCloseable) innerGraphProvider).close();
         }
+
+        @Override
+        public Optional<Graph.Features> getStaticFeatures() {
+            return innerGraphProvider.getStaticFeatures();
+        }
     }
 
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphProvider.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphProvider.java
@@ -294,6 +294,22 @@ public interface GraphProvider {
     }
 
     /**
+     * Gets a {@link Graph.Features} implementation that contains graph feature configuration that will never change
+     * from execution to execution of the tests given this current {@code GraphProvider} implementation. Implementing
+     * this method will allow the test suite to avoid creation of a {@link Graph} instance and thus speed up the
+     * execution of tests if that creation process is expensive. It is important that this static set of features be
+     * representative of what the {@link Graph} instance produced by this {@code GraphProvider} can actually do or
+     * else the cost of {@link Graph} instantiation will be incurred when it doesn't need to be. It is also important
+     * that this method be faster than the cost of {@link Graph} creation in the first place or there really won't be
+     * any difference in execution speed. In cases where some features are static and others are not, simply throw
+     * an {@code UnsupportedOperationException} from those features to let the test suite know that it cannot rely
+     * on them and the test suite will revert to using a constructed {@link Graph} instance.
+     */
+    public default Optional<Graph.Features> getStaticFeatures() {
+        return Optional.empty();
+    }
+
+    /**
      * An annotation to be applied to a {@code GraphProvider} implementation that provides additional information
      * about its intentions. The {@code Descriptor} is required by those {@code GraphProvider} implementations
      * that will be assigned to test suites that use

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
@@ -32,6 +32,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 
@@ -49,6 +50,26 @@ public abstract class AbstractNeo4jGraphProvider extends AbstractGraphProvider {
         add(Neo4jVertexProperty.class);
     }};
 
+    protected Graph.Features features = null;
+
+    @Override
+    public Graph openTestGraph(final Configuration config) {
+        final Graph graph = super.openTestGraph(config);
+
+        // we can just use the initial set of features taken from the first graph generated from the provider because
+        // neo4j feature won't ever change. don't think there is any danger of keeping this instance about even if
+        // the original graph instance goes out of scope.
+        if (null == features) {
+            this.features = graph.features();
+        }
+        return graph;
+    }
+
+    @Override
+    public Optional<Graph.Features> getStaticFeatures() {
+        return Optional.ofNullable(features);
+    }
+
     @Override
     public void clear(final Graph graph, final Configuration configuration) throws Exception {
         if (null != graph) {
@@ -56,7 +77,7 @@ public abstract class AbstractNeo4jGraphProvider extends AbstractGraphProvider {
             graph.close();
         }
 
-        if (configuration.containsKey(Neo4jGraph.CONFIG_DIRECTORY)) {
+        if (configuration != null && configuration.containsKey(Neo4jGraph.CONFIG_DIRECTORY)) {
             // this is a non-in-sideEffects configuration so blow away the directory
             final File graphDirectory = new File(configuration.getString(Neo4jGraph.CONFIG_DIRECTORY));
             deleteDirectory(graphDirectory);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1518

For graphs that have an expensive startup time but a static set of `Graph.Features` the new `GraphProvider.getStaticFeatures()` method should help speed their test times as it will prevent creation of a new `Graph` instance for the test if the graph does not support the requisite features. For testing purposes, this capability was implemented for Neo4j, but it didn't do much to speed the execution time of the test suite - saved a couple minutes or so. It's generally pretty cheap to create Neo4j instances themselves, so I guess that is expected.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1