### PR TITLE
TINKERPOP-1979 Fix math() on OLAP/Spark

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-2-10, 3.2.10>>.
 
 * Deprecated `Order` for `incr` and `decr` in favor of `asc` and `desc`.
+* Fixed bug in `math()` for OLAP where `ComputerVerificationStrategy` was incorrectly detecting path label access and preventing execution.
 
 [[release-3-3-3]]
 === TinkerPop 3.3.3 (Release Date: May 8, 2018)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
@@ -86,6 +86,19 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
     }
 
     @Override
+    public ElementRequirement getMaxRequirement() {
+        // this is a trick i saw in DedupGlobalStep that allows ComputerVerificationStrategy to be happy for OLAP.
+        // it's a bit more of a hack here. in DedupGlobalStep, the dedup operation really only just needs the ID, but
+        // here the true max requirement is PROPERTIES, but because of how map() works in this implementation in
+        // relation to CURRENT, if we don't access the path labels, then we really only just operate on the stargraph
+        // and are thus OLAP safe. In tracing around the code a bit, I don't see a problem with taking this approach,
+        // but I suppose a better way might be make it more clear when this step is dealing with an actual path and
+        // when it is not and/or adjust ComputerVerificationStrategy to cope with the situation where math() is only
+        // dealing with the local stargraph.
+        return (variables.contains(CURRENT) && variables.size() == 1) ? ElementRequirement.ID : PathProcessor.super.getMaxRequirement();
+    }
+
+    @Override
     public String toString() {
         return StringFactory.stepString(this, this.equation, this.traversalRing);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -47,19 +48,14 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
 
     private static final String CURRENT = "_";
     private final String equation;
-    private final Set<String> variables;
-    private final Expression expression;
+    private final TinkerExpression expression;
     private TraversalRing<S, Number> traversalRing = new TraversalRing<>();
     private Set<String> keepLabels;
 
     public MathStep(final Traversal.Admin traversal, final String equation) {
         super(traversal);
         this.equation = equation;
-        this.variables = MathStep.getVariables(this.equation);
-        this.expression = new ExpressionBuilder(this.equation)
-                .variables(this.variables)
-                .implicitMultiplication(false)
-                .build();
+        this.expression = new TinkerExpression(equation, MathStep.getVariables(this.equation));
     }
 
     @Override
@@ -69,8 +65,8 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
 
     @Override
     protected Double map(final Traverser.Admin<S> traverser) {
-        final Expression localExpression = new Expression(this.expression);
-        for (final String var : this.variables) {
+        final Expression localExpression = new Expression(this.expression.getExpression());
+        for (final String var : this.expression.getVariables()) {
             localExpression.setVariable(var,
                     var.equals(CURRENT) ?
                             TraversalUtil.applyNullable(traverser, this.traversalRing.next()).doubleValue() :
@@ -95,7 +91,8 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
         // but I suppose a better way might be make it more clear when this step is dealing with an actual path and
         // when it is not and/or adjust ComputerVerificationStrategy to cope with the situation where math() is only
         // dealing with the local stargraph.
-        return (variables.contains(CURRENT) && variables.size() == 1) ? ElementRequirement.ID : PathProcessor.super.getMaxRequirement();
+        return (this.expression.getVariables().contains(CURRENT) && this.expression.getVariables().size() == 1) ?
+                ElementRequirement.ID : PathProcessor.super.getMaxRequirement();
     }
 
     @Override
@@ -139,12 +136,12 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
 
     @Override
     public Set<String> getScopeKeys() {
-        if (this.variables.contains(CURRENT)) {
-            final Set<String> temp = new HashSet<>(this.variables);
+        if (this.expression.getVariables().contains(CURRENT)) {
+            final Set<String> temp = new HashSet<>(this.expression.getVariables());
             temp.remove(CURRENT);
             return temp;
         } else
-            return this.variables;
+            return this.expression.getVariables();
     }
 
     @Override
@@ -179,6 +176,36 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
             variables.add(matcher.group());
         }
         return variables;
+    }
+
+    /**
+     * A wrapper for the {@code Expression} class. That class is not marked {@code Serializable} and therefore gives
+     * problems in OLAP specifically with Spark. This wrapper allows the {@code Expression} to be serialized in that
+     * context with Java serialization.
+     */
+    public static class TinkerExpression implements Serializable {
+        private transient Expression expression;
+        private final String equation;
+        private final Set<String> variables;
+
+        public TinkerExpression(final String equation, final Set<String> variables) {
+            this.variables = variables;
+            this.equation = equation;
+        }
+
+        public Expression getExpression() {
+            if (null == expression) {
+                this.expression = new ExpressionBuilder(this.equation)
+                        .variables(this.variables)
+                        .implicitMultiplication(false)
+                        .build();
+            }
+            return expression;
+        }
+
+        public Set<String> getVariables() {
+            return variables;
+        }
     }
 
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathTest.java
@@ -38,6 +38,7 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.math;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.sack;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -45,6 +46,10 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(GremlinProcessRunner.class)
 public abstract class MathTest extends AbstractGremlinProcessTest {
+
+    public abstract Traversal<Vertex, Double> get_g_V_outE_mathX0_minus_itX_byXweightX();
+
+    public abstract Traversal<Vertex, Double> get_g_V_hasXageX_valueMap_mathXit_plus_itXbyXselectXageX_unfoldXX();
 
     public abstract Traversal<Vertex, Double> get_g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX();
 
@@ -55,6 +60,22 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Integer, Double> get_g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX();
 
     public abstract Traversal<Vertex, String> get_g_V_projectXa_b_cX_byXbothE_weight_sumX_byXbothE_countX_byXnameX_order_byXmathXa_div_bX_descX_selectXcX();
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_outE_mathX0_minus_itX_byXweightX() {
+        final Traversal<Vertex, Double> traversal = get_g_V_outE_mathX0_minus_itX_byXweightX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(-0.4, -0.4, -0.5, -1.0, -1.0, -0.2), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasXageX_valueMap_mathXit_plus_itXbyXselectXageX_unfoldXX() {
+        final Traversal<Vertex, Double> traversal = get_g_V_hasXageX_valueMap_mathXit_plus_itXbyXselectXageX_unfoldXX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(64.0, 58.0, 54.0, 70.0), traversal);
+    }
 
     @Test
     @LoadGraphWith(MODERN)
@@ -101,6 +122,17 @@ public abstract class MathTest extends AbstractGremlinProcessTest {
     }
 
     public static class Traversals extends MathTest {
+        @Override
+        public Traversal<Vertex, Double> get_g_V_outE_mathX0_minus_itX_byXweightX() {
+            // https://issues.apache.org/jira/browse/TINKERPOP-1979 - should work in OLAP
+            return g.V().outE().math("0-_").by("weight");
+        }
+
+        @Override
+        public Traversal<Vertex, Double> get_g_V_hasXageX_valueMap_mathXit_plus_itXbyXselectXageX_unfoldXX() {
+            // https://issues.apache.org/jira/browse/TINKERPOP-1979 - should work in OLAP
+            return g.V().has("age").valueMap().math("_+_").by(select("age").unfold());
+        }
 
         @Override
         public Traversal<Vertex, Double> get_g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1979

Should be working now - just a serialization problem and fix to dealing with requirements for `PathProcessor` on `MathStep`. Note that you still can't access path labels with `math()` in OLAP after this fix or you will run afoul of standard behavior of `ComputerVerificationStrategy`. I think that's just a limitation of the overall design with OLAP and path.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1