### PR TITLE
TINKERPOP-1365 Refactored use of Random in tests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `createGratefulDead()`to `TinkerFactory` to help make it easier to try to instantiate that toy graph.
 * Added identifiers to edges in the Kitchen Sink toy graph.
 * Refactored the Gremlin Server integration testing framework and streamlined that infrastructure.
+* Logged the seed used in initializing `Random` for tests.
 * Fixed bug in `GroovyTranslator` that didn't properly handle empty `Map` objects.
 * Added concrete configuration methods to `SparkGraphComputer` to make a more clear API for configuring it.
 * Fixed a bug in `TinkerGraphCountStrategy`, which didn't consider that certain map steps may not emit an element.

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -238,6 +238,7 @@ mvn -Dmaven.javadoc.skip=true --projects tinkergraph-gremlin test
 ** Process a single AsciiDoc file: +pass:[docs/preprocessor/preprocess-file.sh `pwd`/gremlin-console/target/apache-tinkerpop-gremlin-console-*-standalone "" "*" `pwd`/docs/src/xyz.asciidoc]+
 * Build JavaDocs: `mvn process-resources -Djavadoc`
 * Check for Apache License headers: `mvn apache-rat:check`
+* Specify the seed used for `Random` in tests `mvn clean install -DtestSeed` - useful when a test fails, the seed will be printed in the build output so that the test can run with the same version of random (look for "TestHelper" logger in output)
 * Check for newer dependencies: `mvn versions:display-dependency-updates` or `mvn versions:display-plugin-updates`
 * Check the effective `pom.xml`: `mvn -pl gremlin-python -Pglv-python help:effective-pom -Doutput=withProfilePom.xml`
 * Deploy JavaDocs/AsciiDocs: `bin/publish-docs.sh svn-username`

--- a/giraph-gremlin/src/test/resources/log4j-silent.properties
+++ b/giraph-gremlin/src/test/resources/log4j-silent.properties
@@ -21,3 +21,6 @@ log4j.rootLogger=OFF, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/giraph-gremlin/src/test/resources/log4j-test.properties
+++ b/giraph-gremlin/src/test/resources/log4j-test.properties
@@ -21,3 +21,6 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
 
 log4j.logger.org.apache.hadoop=ERROR
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/gremlin-core/src/test/resources/log4j-silent.properties
+++ b/gremlin-core/src/test/resources/log4j-silent.properties
@@ -20,4 +20,7 @@
 log4j.rootLogger=OFF, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n 
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/gremlin-core/src/test/resources/log4j-test.properties
+++ b/gremlin-core/src/test/resources/log4j-test.properties
@@ -18,4 +18,7 @@
 log4j.rootLogger=WARN, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n 
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/TestHelper.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/TestHelper.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin;
 
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -28,6 +27,8 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.Comparators;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -51,10 +52,18 @@ import static org.junit.Assume.assumeThat;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public final class TestHelper {
+    private static final Logger logger = LoggerFactory.getLogger(TestHelper.class);
 
+    public static final Random RANDOM;
     private static final String SEP = File.separator;
     private static final char URL_SEP = '/';
     public static final String TEST_DATA_RELATIVE_DIR = "test-case-data";
+
+    static {
+        final long seed = Long.parseLong(System.getProperty("testSeed", String.valueOf(System.currentTimeMillis())));
+        logger.info("*** THE RANDOM TEST SEED IS {} ***", seed);
+        RANDOM = new Random(seed);
+    }
 
     private TestHelper() {
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoIntegrateTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoIntegrateTest.java
@@ -56,7 +56,7 @@ public class IoIntegrateTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY)
     public void shouldHaveSizeOfStarGraphLessThanDetached() throws Exception {
-        final Random random = new Random(95746498l);
+        final Random random = TestHelper.RANDOM;
         final Vertex vertex = graph.addVertex("person");
         for (int i = 0; i < 100; i++) { // vertex properties and meta properties
             vertex.property(VertexProperty.Cardinality.list, UUID.randomUUID().toString(), random.nextDouble(),

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedGraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedGraphTest.java
@@ -69,7 +69,7 @@ public class DetachedGraphTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY)
     public void testAttachableCreateMethod() {
-        final Random random = new Random(234335l);
+        final Random random = TestHelper.RANDOM;
         StarGraph starGraph = StarGraph.open();
         Vertex starVertex = starGraph.addVertex(T.label, "person", "name", "stephen", "name", "spmallete");
         starVertex.property("acl", true, "timestamp", random.nextLong(), "creator", "marko");

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphTest.java
@@ -152,7 +152,7 @@ public class StarGraphTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY)
     public void shouldAttachWithCreateMethod() {
-        final Random random = new Random(234335l);
+        final Random random = TestHelper.RANDOM;
         StarGraph starGraph = StarGraph.open();
         Vertex starVertex = starGraph.addVertex(T.label, "person", "name", "stephen", "name", "spmallete");
         starVertex.property("acl", true, "timestamp", random.nextLong(), "creator", "marko");

--- a/gremlin-test/src/test/resources/log4j-silent.properties
+++ b/gremlin-test/src/test/resources/log4j-silent.properties
@@ -24,3 +24,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
 
 # need to turn this on as this test actually tests "logging" - needs INFO at minimum for tests to pass
 log4j.logger.org.apache.tinkerpop.gremlin.util.Log4jRecordingAppenderTest=INFO
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/gremlin-test/src/test/resources/log4j-test.properties
+++ b/gremlin-test/src/test/resources/log4j-test.properties
@@ -21,4 +21,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
 
 # need to turn this on as this test actually tests "logging" - needs INFO at minimum for tests to pass
-log4j.logger.org.apache.tinkerpop.gremlin.util.Log4jRecordingAppenderTest=INFO
+log4j.logger.org.apache.tinkerpop.gremlin.util.Log4jRecordingAppenderTest=INFO   
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/HadoopGraphProvider.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/HadoopGraphProvider.java
@@ -54,7 +54,7 @@ import static org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.KryoShimSe
  */
 public class HadoopGraphProvider extends AbstractGraphProvider {
 
-    protected static final Random RANDOM = new Random();
+    protected static final Random RANDOM = TestHelper.RANDOM;
     private boolean graphSONInput = false;
 
     public static Map<String, String> PATHS = new HashMap<>();

--- a/hadoop-gremlin/src/test/resources/log4j-silent.properties
+++ b/hadoop-gremlin/src/test/resources/log4j-silent.properties
@@ -20,4 +20,7 @@
 log4j.rootLogger=OFF, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n  
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/hadoop-gremlin/src/test/resources/log4j-test.properties
+++ b/hadoop-gremlin/src/test/resources/log4j-test.properties
@@ -18,4 +18,7 @@
 log4j.rootLogger=WARN, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n   
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.neo4j;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.AbstractGraphProvider;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jEdge;
 import org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jElement;
 import org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph;
@@ -98,7 +99,7 @@ public abstract class AbstractNeo4jGraphProvider extends AbstractGraphProvider {
     }
 
     private void createIndices(final Neo4jGraph graph, final LoadGraphWith.GraphData graphData) {
-        final Random random = new Random();
+        final Random random = TestHelper.RANDOM;
         final boolean pick = random.nextBoolean();
         if (graphData.equals(LoadGraphWith.GraphData.GRATEFUL)) {
             if (pick) {

--- a/neo4j-gremlin/src/test/resources/log4j-silent.properties
+++ b/neo4j-gremlin/src/test/resources/log4j-silent.properties
@@ -21,3 +21,6 @@ log4j.rootLogger=OFF, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/neo4j-gremlin/src/test/resources/log4j-test.properties
+++ b/neo4j-gremlin/src/test/resources/log4j-test.properties
@@ -19,3 +19,6 @@ log4j.rootLogger=WARN, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/spark-gremlin/src/test/resources/log4j-silent.properties
+++ b/spark-gremlin/src/test/resources/log4j-silent.properties
@@ -21,3 +21,6 @@ log4j.rootLogger=OFF, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/spark-gremlin/src/test/resources/log4j-test.properties
+++ b/spark-gremlin/src/test/resources/log4j-test.properties
@@ -23,3 +23,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
 log4j.logger.org.apache.spark=ERROR
 log4j.logger.org.spark-project=ERROR
 log4j.logger.org.apache.hadoop=ERROR
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphComputerProvider.java
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.tinkergraph.process;
 
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.GraphProvider;
-import org.apache.tinkerpop.gremlin.process.computer.Computer;
+import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -37,7 +37,7 @@ import java.util.Random;
 @GraphProvider.Descriptor(computer = TinkerGraphComputer.class)
 public class TinkerGraphComputerProvider extends TinkerGraphProvider {
 
-    private static final Random RANDOM = new Random();
+    private static final Random RANDOM = TestHelper.RANDOM;
 
     @Override
     public GraphTraversalSource traversal(final Graph graph) {

--- a/tinkergraph-gremlin/src/test/resources/log4j-silent.properties
+++ b/tinkergraph-gremlin/src/test/resources/log4j-silent.properties
@@ -21,3 +21,6 @@ log4j.rootLogger=OFF, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO

--- a/tinkergraph-gremlin/src/test/resources/log4j-test.properties
+++ b/tinkergraph-gremlin/src/test/resources/log4j-test.properties
@@ -19,3 +19,6 @@ log4j.rootLogger=WARN, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %C - %m%n
+
+# need to turn this on so that we know the test seed
+log4j.logger.org.apache.tinkerpop.gremlin.TestHelper=INFO


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1365

Each test suite now uses the same instance of Random which prints the seed given to it so that if there is a failure, we can easily try to recreate it by taking the seed and passing it in as a system property with -DtestSeed. The output logs as:

```text
[INFO] org.apache.tinkerpop.gremlin.TestHelper - *** THE RANDOM TEST SEED IS 1529585621517 ***
```

I didn't replace all of the old use of `Random` - there were a couple places where I felt like a true `Random` was still necessary and just left it alone despite the horror it might cause. Going forward we'll want to use the `TestHelper.RANDOM` whenever possible (or, better, just not use a `Random` at all).

All tests pass with `docker/build.sh -t -n -i`

VOTE +1