### PR TITLE
TINKERPOP-1864 Run python glv tests on GraphSON 2.0 and 3.0

### DIFF
--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -420,11 +420,19 @@ limitations under the License.
                                             <env key="PYTHONPATH" value=""/>
                                             <arg line="setup.py install"/>
                                         </exec>
+                                        <!-- run for graphson 3.0 -->
                                         <exec executable="env/bin/radish" dir="${project.build.directory}/python2"
                                               failonerror="true">
                                             <env key="PYTHONPATH" value=""/>
                                             <env key="PYTHONIOENCODING" value="utf-8:surrogateescape"/>
-                                            <arg line="-e -t -b ${project.build.directory}/python2/radish ${project.basedir}/../gremlin-test/features/"/> <!-- -no-line-jump -->
+                                            <arg line="-e -t -b ${project.build.directory}/python2/radish ${project.basedir}/../gremlin-test/features/ --user-data=&quot;graphson=v2&quot;"/> <!-- -no-line-jump -->
+                                        </exec>
+                                        <!-- run for graphson 3.0 -->
+                                        <exec executable="env/bin/radish" dir="${project.build.directory}/python2"
+                                              failonerror="true">
+                                            <env key="PYTHONPATH" value=""/>
+                                            <env key="PYTHONIOENCODING" value="utf-8:surrogateescape"/>
+                                            <arg line="-e -t -b ${project.build.directory}/python2/radish ${project.basedir}/../gremlin-test/features/ --user-data=&quot;graphson=v3&quot;"/> <!-- -no-line-jump -->
                                         </exec>
                                     </target>
                                 </configuration>

--- a/gremlin-python/src/main/jython/radish/terrain.py
+++ b/gremlin-python/src/main/jython/radish/terrain.py
@@ -66,7 +66,17 @@ def prepare_static_traversal_source(features, marker):
 @before.each_scenario
 def prepare_traversal_source(scenario):
     # some tests create data - create a fresh remote to the empty graph and clear that graph prior to each test
-    remote = DriverRemoteConnection('ws://localhost:45940/gremlin', "ggraph", message_serializer=serializer.GraphSONSerializersV3d0())
+    if not("graphson" in world.config.user_data):
+        raise ValueError('test configuration requires setting of --user-data="graphson=*" to one of [v2,v3]')
+
+    if world.config.user_data["graphson"] == "v3":
+        s = serializer.GraphSONSerializersV3d0()
+    elif world.config.user_data["graphson"] == "v2":
+        s = serializer.GraphSONSerializersV2d0()
+    else:
+        raise ValueError('serializer set with --user-data="graphson=v2" must be one of [v2,v3]')
+
+    remote = DriverRemoteConnection('ws://localhost:45940/gremlin', "ggraph", message_serializer=s)
     scenario.context.remote_conn["empty"] = remote
     g = Graph().traversal().withRemote(remote)
     g.V().drop().iterate()

--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -71,7 +71,7 @@ setup(
     tests_require=[
         'pytest',
         'mock',
-        'radish-bdd==0.8.0',
+        'radish-bdd==0.8.6',
         'PyHamcrest'
     ],
     install_requires=install_requires,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1864

There was about a 10 second time increase for adding the additional test execution option. Seems worthwhile.

Builds with `mvn clean install -pl gremlin-python`

VOTE +1