### PR TITLE
TINKERPOP-1987 Bump to Spark 2.3.1 and Netty 4.1.25.Final

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
+* Bumped to Netty 4.1.25.
+* Bumped to Spark 2.3.1.
 * Moved `Parameterizing` interface to the `org.apache.tinkerpop.gremlin.process.traversal.step` package with other marker interfaces of its type.
 * Replaced `Parameterizing.addPropertyMutations()` with `Configuring.configure()`.
 * Changed interface hierarchy for `Parameterizing` and `Mutating` interfaces as they are tightly related.

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -48,7 +48,7 @@ JavaTuples 1.2
 Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
 
 ------------------------------------------------------------------------
-Netty 4.0.56
+Netty 4.1.25
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -1685,5 +1685,14 @@ namespace Gremlin.Net.Process.Traversal
             return Wrap<S, E>(this);
         }
 
+        /// <summary>
+        ///     Adds the with step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal<S, E> With (string key, object value)
+        {
+            Bytecode.AddStep("with", key, value);
+            return Wrap<S, E>(this);
+        }
+
     }
 }

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -55,6 +55,6 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------
-Netty 4.0.56
+Netty 4.1.25
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project

--- a/pom.xml
+++ b/pom.xml
@@ -146,10 +146,10 @@ limitations under the License.
         <jcabi.version>1.1</jcabi.version>
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
-        <netty.version>4.0.56.Final</netty.version>
+        <netty.version>4.1.25.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
-        <spark.version>2.2.0</spark.version>
+        <spark.version>2.3.1</spark.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -261,7 +261,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.5</version>
+            <version>2.6.7</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -281,7 +281,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.43.Final</version>
+            <version>4.1.25.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/LocalPropertyTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/LocalPropertyTest.java
@@ -84,7 +84,12 @@ public class LocalPropertyTest extends AbstractSparkTest {
         configuration.setProperty(Constants.GREMLIN_HADOOP_INPUT_LOCATION, rddName);
         configuration.setProperty(Constants.GREMLIN_HADOOP_GRAPH_WRITER, null);
         configuration.setProperty(Constants.GREMLIN_HADOOP_OUTPUT_LOCATION, null);
-        configuration.setProperty(Constants.GREMLIN_SPARK_PERSIST_CONTEXT, false);
+
+        // just a note that this value should have always been set to true, but from the initial commit was false.
+        // interestingly the last assertion had always passed up to spark 2.3.x when it started to fail. apparently
+        // that assertion should likely have never passed, so it stands to reason that there was a bug in spark in
+        // 2.2.x that was resolved for 2.3.x....that's my story and i'm sticking to it.
+        configuration.setProperty(Constants.GREMLIN_SPARK_PERSIST_CONTEXT, true);
         configuration.setProperty("spark.jobGroup.id", "44");
         graph = GraphFactory.open(configuration);
         graph.compute(SparkGraphComputer.class)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1987
https://issues.apache.org/jira/browse/TINKERPOP-1993

These really needed to be bumped together because going to netty 4.1.x doesn't work nicely with Spark 2.2.x - Spark only upgraded to that version on 2.3.x. 

That odd change to `gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs` is incidental - that modification is already on master and rebase doesn't seem to to want to get rid of it. Hopefully no one is too turned off by that little stain in change history - doesn't seem like a huge problem.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1