### PR TITLE
Expose Pick in module.exports

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
@@ -54,6 +54,7 @@ module.exports = {
     direction: t.direction,
     operator: t.operator,
     order: t.order,
+    pick: t.pick,
     pop: t.pop,
     scope: t.scope,
     t: t.t,


### PR DESCRIPTION
#460 so `Pick.any` and `Pick.none` can be used in gremlin-javascript.