### PR TITLE
Gremlin.Net: Add ConnectionPool min and max sizes TINKERPOP-1774

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,7 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
-* Added min and max connection pool sizes for Gremlin.Net which are configurable through optional ConnectionPoolSettings.
+* Added min and max connection pool sizes for Gremlin.Net which are configurable through optional `ConnectionPoolSettings`.
 * Implemented `ShortestPathVertexProgram` and the `shortestPath()` step.
 * `AbstractGraphProvider` uses `g.io()` for loading test data.
 * Added the `io()` start step and `read()` and `write()` termination steps to the Gremlin language.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
+* Added min and max connection pool sizes for Gremlin.Net which are configurable through optional ConnectionPoolSettings.
 * Implemented `ShortestPathVertexProgram` and the `shortestPath()` step.
 * `AbstractGraphProvider` uses `g.io()` for loading test data.
 * Added the `io()` start step and `read()` and `write()` termination steps to the Gremlin language.

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -572,9 +572,9 @@ internal class MyTypeReader : IGraphSONDeserializer
     }
 }
 
-var graphsonReader = new GraphSONReader(
+var graphsonReader = new GraphSON3Reader(
     new Dictionary<string, IGraphSONDeserializer> {{MyType.GraphsonType, new MyTypeReader()}});
-var graphsonWriter = new GraphSONWriter(
+var graphsonWriter = new GraphSON3Writer(
     new Dictionary<Type, IGraphSONSerializer> {{typeof(MyType), new MyClassWriter()}});
 
 var gremlinClient = new GremlinClient(new GremlinServer("localhost", 8182), graphsonReader, graphsonWriter);

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1308,6 +1308,7 @@ Gremlin-Console |PLAIN SASL (username/password) |3.0.0-incubating
 |Pluggable SASL |3.0.0-incubating
 |GSSAPI SASL (Kerberos) |3.3.0
 |Gremlin-Python |PLAIN SASL |3.2.2
+|Gremlin.Net |PLAIN SASL |3.2.7
 |Gremlin-Javascript |PLAIN SASL |3.3.0
 |=========================================================
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -342,7 +342,8 @@ A traversal source can be spawned with `RemoteStrategy` from an empty `Graph`.
 [source,csharp]
 ----
 var graph = new Graph();
-var g = graph.Traversal().WithRemote(new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182))));
+var remoteConnection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)));
+var g = graph.Traversal().WithRemote(remoteConnection);
 ----
 
 When a traversal from the `GraphTraversalSource` is iterated, the traversal’s `Bytecode` is sent over the wire via the registered
@@ -365,6 +366,48 @@ terminal/action methods off of `ITraversal`.
 * `ITraversal.ToList()`
 * `ITraversal.ToSet()`
 * `ITraversal.Iterate()`
+
+=== Configuration
+
+The following sections describe how the Gremlin.Net driver can be configured.
+
+==== Gremlin Server
+
+The connection properties for the Gremlin.Net driver can be passed to the `GremlinServer` instance as keyword arguments:
+
+[width="100%",cols="3,10,^2",options="header"]
+|=========================================================
+|Key |Description |Default
+|hostname |The hostname that the driver will connect to. |localhost
+|port |The port on which Gremlin Server can be reached. |8182
+|enableSsl |Determines if SSL should be enabled or not. If enabled on the server then it must be enabled on the client. |false
+|username |The username to submit on requests that require authentication. |_none_
+|password |The password to submit on requests that require authentication. |_none_
+|=========================================================
+
+==== Connection Pool
+
+It is also possible to configure the `ConnectionPool` of the Gremlin.Net driver. These configuration options can be set as properties
+on the `ConnectionPoolSettings` instance that can be passed to the `GremlinClient`:
+
+[width="100%",cols="3,10,^2",options="header"]
+|=========================================================
+|Key |Description |Default
+|MinSize |The minimum size of the connection pool. This determines how many connections are initially created. |8
+|MaxSize |The maximum size of the connection pool. |128
+|WaitForConnectionTimeout |The timespan to wait for a connection when the maximum size is reached before timing out. A `TimeoutException` is thrown when no connection becomes available until this timeout is reached. |3 seconds.
+|=========================================================
+
+==== GraphSON Serialization
+
+The Gremlin.Net driver uses by default GraphSON 3.0 but it is also possible to use GraphSON 2.0 which can be necessary
+when the server does not support GraphSON 3.0 yet:
+
+[source,csharp]
+----
+var client = new GremlinClient(new GremlinServer("localhost", 8182), new GraphSON2Reader(),
+    new GraphSON2Writer(), GremlinClient.GraphSON2MimeType);
+----
 
 === Static Enums and Methods
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -242,9 +242,9 @@ when dealing with that event. To make this easier, the event now raises with a `
 
 link:https://issues.apache.org/jira/browse/TINKERPOP-1831[TINKERPOP-1831]
 
-==== Gremlin.Net: Configurable Max and Min ConnectionPool Sizes
+==== Gremlin.Net Connection Pool
 
-Gremlin.Net's `ConnectionPool` now has a minimum and a maximum size. These sizes are configurable through added
+Gremlin.Net's `ConnectionPool` now has a minimum and a maximum size. These sizes are configurable through the newly added
 `ConnectionPoolSettings`. The minimum size determines how many connections are initially created. The maximum size
 is an upper limit of connections that can be created. When this limit is reached and another connection is needed,
 then the connection pool waits for a connection to become available again. The time to be waited is limited by the

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -242,6 +242,17 @@ when dealing with that event. To make this easier, the event now raises with a `
 
 link:https://issues.apache.org/jira/browse/TINKERPOP-1831[TINKERPOP-1831]
 
+==== Gremlin.Net: Configurable Max and Min ConnectionPool Sizes
+
+Gremlin.Net's `ConnectionPool` now has a minimum and a maximum size. These sizes are configurable through added
+`ConnectionPoolSettings`. The minimum size determines how many connections are initially created. The maximum size
+is an upper limit of connections that can be created. When this limit is reached and another connection is needed,
+then the connection pool waits for a connection to become available again. The time to be waited is limited by the
+newly introduced option `ConnectionPoolSettings.WaitForConnectionTimeout`. A `TimeoutException` is thrown when
+no connection becomes available until this timeout is reached.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1774[TINKERPOP-1774]
+
 ==== Deprecation Removal
 
 The following deprecated classes, methods or fields have been removed in this version:

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/AsyncAutoResetEvent.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/AsyncAutoResetEvent.cs
@@ -1,0 +1,103 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+// The implementation is based on this blog post by Stephen Toub:
+// https://blogs.msdn.microsoft.com/pfxteam/2012/02/11/building-async-coordination-primitives-part-2-asyncautoresetevent/
+
+namespace Gremlin.Net.Driver
+{
+    /// <summary>
+    ///     An async version of the AutoResetEvent.
+    /// </summary>
+    public class AsyncAutoResetEvent
+    {
+        private static readonly Task<bool> CompletedTask = Task.FromResult(true);
+        private readonly List<TaskCompletionSource<bool>> _waitingTasks = new List<TaskCompletionSource<bool>>();
+        private bool _isSignaled;
+        
+        /// <summary>
+        ///     Asynchronously waits for this event to be set or until a timeout occurs.
+        /// </summary>
+        /// <param name="timeout">A <see cref="TimeSpan"/> that that represents the number of milliseconds to wait.</param>
+        /// <returns>true if the current instance received a signal before timing out; otherwise, false.</returns>
+        public async Task<bool> WaitOneAsync(TimeSpan timeout)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var waitTask = WaitForSignalAsync(tcs);
+            if (waitTask.IsCompleted) return true;
+            
+            await Task.WhenAny(waitTask, Task.Delay(timeout)).ConfigureAwait(false);
+            lock (_waitingTasks)
+            {
+                if (!waitTask.IsCompleted)
+                {
+                    // The wait timed out, so we need to remove the waiting task.
+                    _waitingTasks.Remove(tcs);
+                    tcs.SetResult(false);
+                }
+            }
+            
+            return waitTask.Result;
+        }
+
+        private Task<bool> WaitForSignalAsync(TaskCompletionSource<bool> tcs)
+        {
+            lock (_waitingTasks)
+            {
+                if (_isSignaled)
+                {
+                    _isSignaled = false;
+                    return CompletedTask;
+                }
+                _waitingTasks.Add(tcs);
+            }
+            return tcs.Task;
+        }
+        
+        /// <summary>
+        ///     Sets the event.
+        /// </summary>
+        public void Set()
+        {
+            TaskCompletionSource<bool> toRelease = null;
+            lock (_waitingTasks)
+            {
+                if (_waitingTasks.Count == 0)
+                {
+                    _isSignaled = true;
+                }
+                else
+                {
+                    toRelease = _waitingTasks[0];
+                    _waitingTasks.RemoveAt(0);
+                }
+            }
+
+            toRelease?.SetResult(true);
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -59,23 +59,23 @@ namespace Gremlin.Net.Driver
             return await ReceiveAsync<T>().ConfigureAwait(false);
         }
 
-        public async Task ConnectAsync()
+        public Task ConnectAsync()
         {
-            await _webSocketConnection.ConnectAsync(_uri).ConfigureAwait(false);
+            return _webSocketConnection.ConnectAsync(_uri);
         }
 
-        public async Task CloseAsync()
+        public Task CloseAsync()
         {
-            await _webSocketConnection.CloseAsync().ConfigureAwait(false);
+            return _webSocketConnection.CloseAsync();
         }
 
         public bool IsOpen => _webSocketConnection.IsOpen;
 
-        private async Task SendAsync(RequestMessage message)
+        private Task SendAsync(RequestMessage message)
         {
             var graphsonMsg = _graphSONWriter.WriteObject(message);
             var serializedMsg = _messageSerializer.SerializeMessage(graphsonMsg);
-            await _webSocketConnection.SendMessageAsync(serializedMsg).ConfigureAwait(false);
+            return _webSocketConnection.SendMessageAsync(serializedMsg);
         }
 
         private async Task<IReadOnlyCollection<T>> ReceiveAsync<T>()
@@ -121,7 +121,7 @@ namespace Gremlin.Net.Driver
             return result;
         }
 
-        private async Task AuthenticateAsync()
+        private Task AuthenticateAsync()
         {
             if (string.IsNullOrEmpty(_username) || string.IsNullOrEmpty(_password))
                 throw new InvalidOperationException(
@@ -130,7 +130,7 @@ namespace Gremlin.Net.Driver
             var message = RequestMessage.Build(Tokens.OpsAuthentication).Processor(Tokens.ProcessorTraversal)
                 .AddArgument(Tokens.ArgsSasl, SaslArgument()).Create();
 
-            await SendAsync(message).ConfigureAwait(false);
+            return SendAsync(message);
         }
 
         private string SaslArgument()

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
@@ -1,0 +1,55 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+
+namespace Gremlin.Net.Driver
+{
+    /// <summary>
+    ///     Holds settings for the <see cref="ConnectionPool"/>.
+    /// </summary>
+    public class ConnectionPoolSettings
+    {
+        private const int DefaultMinPoolSize = 8;
+        private const int DefaultMaxPoolSize = 128;
+        private static readonly TimeSpan DefaultWaitForConnectionTimeout = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        ///     Gets or sets the minimum size of a connection pool.
+        /// </summary>
+        /// <remarks>The default value is 8.</remarks>
+        public int MinSize { get; set; } = DefaultMinPoolSize;
+
+        /// <summary>
+        ///     Gets or sets the maximum size of a connection pool.
+        /// </summary>
+        /// <remarks>The default value is 128.</remarks>
+        public int MaxSize { get; set; } = DefaultMaxPoolSize;
+
+        /// <summary>
+        ///     Gets or sets the timespan to wait for a new connection before timing out.
+        /// </summary>
+        /// <remarks>The default value is 3 seconds.</remarks>
+        public TimeSpan WaitForConnectionTimeout { get; set; } = DefaultWaitForConnectionTimeout;
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
@@ -47,7 +47,7 @@ namespace Gremlin.Net.Driver
         public int MaxSize { get; set; } = DefaultMaxPoolSize;
 
         /// <summary>
-        ///     Gets or sets the timespan to wait for a new connection before timing out.
+        ///     Gets or sets the timespan to wait for a connection to become available before timing out.
         /// </summary>
         /// <remarks>The default value is 3 seconds.</remarks>
         public TimeSpan WaitForConnectionTimeout { get; set; } = DefaultWaitForConnectionTimeout;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -53,13 +53,16 @@ namespace Gremlin.Net.Driver
         /// <param name="graphSONReader">A <see cref="GraphSONReader" /> instance to read received GraphSON data.</param>
         /// <param name="graphSONWriter">a <see cref="GraphSONWriter" /> instance to write GraphSON data.</param>
         /// <param name="mimeType">The GraphSON version mime type, defaults to latest supported by the server.</param>
+        /// <param name="connectionPoolSettings">The <see cref="ConnectionPoolSettings"/> for the connection pool.</param>
         public GremlinClient(GremlinServer gremlinServer, GraphSONReader graphSONReader = null,
-                             GraphSONWriter graphSONWriter = null, string mimeType = null)
+            GraphSONWriter graphSONWriter = null, string mimeType = null,
+            ConnectionPoolSettings connectionPoolSettings = null)
         {
             var reader = graphSONReader ?? new GraphSON3Reader();
             var writer = graphSONWriter ?? new GraphSON3Writer();
             var connectionFactory = new ConnectionFactory(gremlinServer, reader, writer, mimeType ?? DefaultMimeType);
-            _connectionPool = new ConnectionPool(connectionFactory);
+            _connectionPool =
+                new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());
         }
 
         /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClientExtensions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClientExtensions.cs
@@ -92,10 +92,10 @@ namespace Gremlin.Net.Driver
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
-        public static async Task SubmitAsync(this IGremlinClient gremlinClient, string requestScript,
+        public static Task SubmitAsync(this IGremlinClient gremlinClient, string requestScript,
             Dictionary<string, object> bindings = null)
         {
-            await gremlinClient.SubmitAsync<object>(requestScript, bindings).ConfigureAwait(false);
+            return gremlinClient.SubmitAsync<object>(requestScript, bindings);
         }
 
         /// <summary>
@@ -109,9 +109,9 @@ namespace Gremlin.Net.Driver
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
-        public static async Task SubmitAsync(this IGremlinClient gremlinClient, RequestMessage requestMessage)
+        public static Task SubmitAsync(this IGremlinClient gremlinClient, RequestMessage requestMessage)
         {
-            await gremlinClient.SubmitAsync<object>(requestMessage).ConfigureAwait(false);
+            return gremlinClient.SubmitAsync<object>(requestMessage);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Gremlin.Net.Driver
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
-        public static async Task<IReadOnlyCollection<T>> SubmitAsync<T>(this IGremlinClient gremlinClient,
+        public static Task<IReadOnlyCollection<T>> SubmitAsync<T>(this IGremlinClient gremlinClient,
             string requestScript,
             Dictionary<string, object> bindings = null)
         {
@@ -134,7 +134,7 @@ namespace Gremlin.Net.Driver
             if (bindings != null)
                 msgBuilder.AddArgument(Tokens.ArgsBindings, bindings);
             var msg = msgBuilder.Create();
-            return await gremlinClient.SubmitAsync<T>(msg).ConfigureAwait(false);
+            return gremlinClient.SubmitAsync<T>(msg);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
@@ -38,7 +38,8 @@ namespace Gremlin.Net.Driver
         /// <param name="enableSsl">Specifies whether SSL should be enabled.</param>
         /// <param name="username">The username to submit on requests that require authentication.</param>
         /// <param name="password">The password to submit on requests that require authentication.</param>
-        public GremlinServer(string hostname, int port = 8182, bool enableSsl = false, string username = null, string password = null)
+        public GremlinServer(string hostname = "localhost", int port = 8182, bool enableSsl = false,
+            string username = null, string password = null)
         {
             Uri = CreateUri(hostname, port, enableSsl);
             Username = username;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
@@ -71,7 +71,7 @@ namespace Gremlin.Net.Driver.Remote
             return new DriverRemoteTraversal<S, E>(_client, requestId, resultSet);
         }
 
-        private async Task<IEnumerable<Traverser>> SubmitBytecodeAsync(Guid requestid, Bytecode bytecode)
+        private Task<IReadOnlyCollection<Traverser>> SubmitBytecodeAsync(Guid requestid, Bytecode bytecode)
         {
             var requestMsg =
                 RequestMessage.Build(Tokens.OpsBytecode)
@@ -80,7 +80,7 @@ namespace Gremlin.Net.Driver.Remote
                     .AddArgument(Tokens.ArgsGremlin, bytecode)
                     .AddArgument(Tokens.ArgsAliases, new Dictionary<string, string> {{"g", _traversalSource}})
                     .Create();
-            return await _client.SubmitAsync<Traverser>(requestMsg).ConfigureAwait(false);
+            return _client.SubmitAsync<Traverser>(requestMsg);
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -35,24 +35,20 @@ namespace Gremlin.Net.Driver
         private const WebSocketMessageType MessageType = WebSocketMessageType.Binary;
         private ClientWebSocket _client;
 
-        public async Task ConnectAsync(Uri uri)
+        public Task ConnectAsync(Uri uri)
         {
             _client = new ClientWebSocket();
-            await _client.ConnectAsync(uri, CancellationToken.None).ConfigureAwait(false);
+            return _client.ConnectAsync(uri, CancellationToken.None);
         }
 
-        public async Task CloseAsync()
+        public Task CloseAsync()
         {
-            await
-                _client.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None)
-                    .ConfigureAwait(false);
+            return _client.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
         }
 
-        public async Task SendMessageAsync(byte[] message)
+        public Task SendMessageAsync(byte[] message)
         {
-            await
-                _client.SendAsync(new ArraySegment<byte>(message), MessageType, true, CancellationToken.None)
-                    .ConfigureAwait(false);
+            return _client.SendAsync(new ArraySegment<byte>(message), MessageType, true, CancellationToken.None);
         }
 
         public async Task<byte[]> ReceiveMessageAsync()

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
@@ -44,7 +44,9 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
         public IRemoteConnection CreateRemoteConnection(string traversalSource)
         {
-            var c = new DriverRemoteConnectionImpl(new GremlinClient(new GremlinServer(TestHost, TestPort)),
+            var c = new DriverRemoteConnectionImpl(
+                new GremlinClient(new GremlinServer(TestHost, TestPort),
+                    connectionPoolSettings: new ConnectionPoolSettings {MinSize = 1}),
                 traversalSource);
             _connections.Add(c);
             return c;

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/AsyncAutoResetEventTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/AsyncAutoResetEventTests.cs
@@ -1,0 +1,169 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Xunit;
+
+namespace Gremlin.Net.UnitTest.Driver
+{
+    public class AsyncAutoResetEventTests
+    {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMilliseconds(100);
+        
+        [Fact]
+        public async Task WaitOneAsync_AfterSet_CompletesSynchronously()
+        {
+            var are = new AsyncAutoResetEvent();
+
+            are.Set();
+            var task = are.WaitOneAsync(DefaultTimeout);
+            
+            Assert.True(task.IsCompleted);
+            Assert.True(await task);
+        }
+        
+        [Fact]
+        public async Task MultipleWaitOneAsync_AfterSet_OnlyFirstWaitIsSuccessful()
+        {
+            var are = new AsyncAutoResetEvent();
+
+            are.Set();
+            var task1 = are.WaitOneAsync(DefaultTimeout);
+            var task2 = are.WaitOneAsync(DefaultTimeout);
+
+            Assert.True(task1.IsCompleted);
+            Assert.True(await task1);
+            Assert.False(await task2);
+        }
+
+        [Fact]
+        public async Task MultipleWaitOneAsync_AfterMultipleSet_OnlyFirstWaitIsSuccessful()
+        {
+            var are = new AsyncAutoResetEvent();
+
+            are.Set();
+            are.Set();
+            var task1 = are.WaitOneAsync(DefaultTimeout);
+            var task2 = are.WaitOneAsync(DefaultTimeout);
+
+            Assert.True(task1.IsCompleted);
+            Assert.True(await task1);
+            Assert.False(await task2);
+        }
+        
+        [Fact]
+        public async Task WaitOneAsync_SetBeforeTimeout_WaitSuccessful()
+        {
+            var are = new AsyncAutoResetEvent();
+            
+            var task = are.WaitOneAsync(DefaultTimeout);
+            are.Set();
+            
+            Assert.True(await task);
+        }
+
+        [Fact]
+        public async Task Set_AfterMultipleWaitOneAsync_OnlyFirstWaitIsSuccessful()
+        {
+            var are = new AsyncAutoResetEvent();
+            
+            var task1 = are.WaitOneAsync(DefaultTimeout);
+            var task2 = are.WaitOneAsync(DefaultTimeout);
+            are.Set();
+
+            await AssertCompletesBeforeTimeoutAsync(task1, DefaultTimeout.Milliseconds + 50);
+            Assert.False(await task2);
+        }
+        
+        [Fact]
+        public async Task WaitOneAsync_NotSet_OnlyWaitUntilTimeout()
+        {
+            var are = new AsyncAutoResetEvent();
+
+            var task = are.WaitOneAsync(DefaultTimeout);
+
+            await AssertCompletesBeforeTimeoutAsync(task, DefaultTimeout.Milliseconds + 50);
+        }
+        
+        [Fact]
+        public async Task WaitOneAsync_NotSet_WaitNotSuccessful()
+        {
+            var are = new AsyncAutoResetEvent();
+
+            var task = are.WaitOneAsync(DefaultTimeout);
+
+            Assert.False(await task);
+        }
+
+        [Fact]
+        public async Task WaitOneAsync_SetAfterPreviousWaitTimedOut_OnlySecondWaitSuccessful()
+        {
+            var are = new AsyncAutoResetEvent();
+
+            var task1 = are.WaitOneAsync(DefaultTimeout);
+            await Task.Delay(DefaultTimeout + TimeSpan.FromMilliseconds(50));
+            var task2 = are.WaitOneAsync(DefaultTimeout);
+            are.Set();
+            
+            Assert.False(await task1);
+            Assert.True(await task2);
+        }
+        
+        [Fact]
+        public async Task WaitOneAsync_SetAfterMultipleWaitsTimedOut_OnlyLastWaitSuccessful()
+        {
+            var are = new AsyncAutoResetEvent();
+
+            var timedOutTasks = new List<Task<bool>>();
+            for (var i = 0; i < 1000; i++)
+            {
+                timedOutTasks.Add(are.WaitOneAsync(DefaultTimeout));
+            }
+            
+            await Task.Delay(DefaultTimeout + TimeSpan.FromMilliseconds(50));
+            var task2 = are.WaitOneAsync(DefaultTimeout);
+            are.Set();
+
+            foreach (var t in timedOutTasks)
+            {
+                Assert.False(await t);
+            }
+            Assert.True(await task2);
+        }
+
+        private static async Task AssertCompletesBeforeTimeoutAsync(Task task, int timeoutInMs)
+        {
+            var completedTask = await WaitForTaskOrTimeoutAsync(task, TimeSpan.FromMilliseconds(timeoutInMs));
+            if (completedTask != task)
+                throw new Exception("Task did not complete.");
+        }
+
+        private static Task<Task> WaitForTaskOrTimeoutAsync(Task task, TimeSpan timeout)
+        {
+            return Task.WhenAny(task, Task.Delay(timeout));
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,7 @@ limitations under the License.
                         <exclude>**/node/node_modules/**</exclude>
                         <exclude>**/node/node</exclude>
                         <exclude>**/npm-debug.log</exclude>
+                        <exclude>**/.idea/**</exclude>
                     </excludes>
                     <licenses>
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1774

The Gremlin.Net `ConnectionPool` now has min and max sizes. The pool will be initialized with the configured minimum number of connections on creation. It will also no longer create an unlimited number of connections. Instead, a `TimeoutException` will be thrown when the max limit is reached and no connection became available within a configurable time.

The implementation is very similar to that of the `ConnectionPool` in the Java driver. This also means that it doesn't contain a lock any more which was already suggested in the ticket by @jorgebay.

I also optimized a bit of async code in the driver by removing `await`s that weren't necessary because they were immediately returned. In those cases, the `Task` can also be just returned without being awaited which avoids the need for the compiler to generate a state machine just for the `await`.

Tests passed with `./docker/build.sh -t -i` a few days ago but I made some minor changes afterwards and also rebased on `master` and now I can't build any more due to the current problem with gremlin-python mentioned by @spmallette on the mailing list. 

VOTE +1