### PR TITLE
TINKERPOP-2016 Bumped to Jackson 2.9.6

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added concrete configuration methods to `SparkGraphComputer` to make a more clear API for configuring it.
 * Fixed a bug in `TinkerGraphCountStrategy`, which didn't consider that certain map steps may not emit an element.
 * Fixed a bug in JavaScript GLV where DriverRemoteConnection close() method didn't returned a Promise instance.
+* Bumped to Jackson 2.9.6.
 
 [[release-3-2-9]]
 === TinkerPop 3.2.9 (Release Date: May 8, 2018)

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -49,8 +49,8 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <!-- Update the shade plugin config whenever you change this version -->
-            <version>2.9.4</version>
+            <!-- Update the shade plugin config whenever you change this version; update what exactly? -->
+            <version>2.9.6</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2016

Bumped to Jackson 2.9.6 for CVE.

All tests pass with `docker/build.sh -i -t -n`

The CI build errors are Grapes related. I built several times locally and through docker with no issues.

VOTE +1