### PR TITLE
Add Joshua Shinavier to committers

### DIFF
--- a/docs/site/home/index.html
+++ b/docs/site/home/index.html
@@ -294,6 +294,7 @@ limitations under the License.
          <p/>
          <ul>
             <li><a href="http://markorodriguez.com">Marko A. Rodriguez</a> (2009 - PMC): Gremlin language, Gremlin machine, documentation.</li>
+            <li><a href="https://github.com/joshsh">Joshua Shinavier</a> (2009 - Committer): Graph data models, language design, interoperability.</li>
             <li><a href="http://ketrinadrawsalot.tumblr.com">Ketrina Yim</a> (2009 - Committer): Illustrator, creator of Gremlin and his merry band of robots.</li>
             <li><a href="http://stephen.genoprime.com/">Stephen Mallette</a> (2011 - PMC Chair): Gremlin Console/Server/Driver, Graph I/O, testing, documentation, mailing list support.</li>
             <li><a href="http://jamesthornton.com/">James Thornton</a> (2013 - PMC): Promotions, evangelism.</li>


### PR DESCRIPTION
Original TinkerPopper, still on the [first page](https://github.com/apache/tinkerpop/graphs/contributors) of TP3 contributors. Likely future contributions around schema and schema-aware queries.