### PR TITLE
TINKERPOP-1976 GLV testing for computer tests

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
@@ -48,10 +48,6 @@ import java.util.Iterator;
 @Graph.OptIn(Graph.OptIn.SUITE_PROCESS_STANDARD)
 @Graph.OptIn(Graph.OptIn.SUITE_PROCESS_COMPUTER)
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupCountTest",
-        method = "g_V_hasXnoX_groupCountXaX_capXaX",
-        reason = "This test asserts an empty side-effect which reflects as a null rather than an \"empty\" and thus doesn't assert")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.CoreTraversalTest",
         method = "*",
         reason = "The test suite does not support profiling or lambdas and for groovy tests: 'Could not locate method: GraphTraversalSource.withStrategies([{traversalCategory=interface org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy$DecorationStrategy}])'")

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
@@ -24,7 +24,6 @@ import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
@@ -52,18 +51,6 @@ import java.util.Iterator;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupCountTest",
         method = "g_V_hasXnoX_groupCountXaX_capXaX",
         reason = "This test asserts an empty side-effect which reflects as a null rather than an \"empty\" and thus doesn't assert")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest",
-        method = "*",
-        reason = "https://issues.apache.org/jira/browse/TINKERPOP-1976")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest",
-        method = "*",
-        reason = "https://issues.apache.org/jira/browse/TINKERPOP-1976")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategyProcessTest",
-        method = "*",
-        reason = "hmmmm")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.CoreTraversalTest",
         method = "*",

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/TraversalSerializersV2d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/TraversalSerializersV2d0.java
@@ -37,18 +37,14 @@ import org.apache.tinkerpop.shaded.jackson.core.JsonParser;
 import org.apache.tinkerpop.shaded.jackson.core.JsonProcessingException;
 import org.apache.tinkerpop.shaded.jackson.core.JsonToken;
 import org.apache.tinkerpop.shaded.jackson.databind.DeserializationContext;
-import org.apache.tinkerpop.shaded.jackson.databind.JavaType;
-import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
 import org.apache.tinkerpop.shaded.jackson.databind.SerializerProvider;
 import org.apache.tinkerpop.shaded.jackson.databind.deser.std.StdDeserializer;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeSerializer;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdScalarSerializer;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdSerializer;
-import org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/ModernGraphTypeInformation.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/ModernGraphTypeInformation.cs
@@ -38,6 +38,9 @@ namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
             {"name", typeof(string)},
             {"lang", typeof(string)},
             {"weight", typeof(float)},
+            {"gremlin.pageRankVertexProgram.pageRank", typeof(double)},
+            {"friendRank", typeof(double)},
+            {"pageRank", typeof(double)},
             {"foo", typeof(object)}, // used when for invalid property key lookups
             {"friendWeight", typeof(float)},  // used in an AddVertex.feature test
             {"performances", typeof(int)} // grateful dead graph

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/ModernGraphTypeInformation.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/ModernGraphTypeInformation.cs
@@ -39,6 +39,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
             {"lang", typeof(string)},
             {"weight", typeof(float)},
             {"gremlin.pageRankVertexProgram.pageRank", typeof(double)},
+            {"gremlin.peerPressureVertexProgram.cluster", typeof(int)},
             {"friendRank", typeof(double)},
             {"pageRank", typeof(double)},
             {"foo", typeof(object)}, // used when for invalid property key lookups

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalSideEffects;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -88,7 +89,7 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
                 final Result result = client.submitAsync(msg).get().all().get().get(0);
                 sideEffects.put(key, null == result ? null : result.getObject());
             } catch (Exception ex) {
-                // we use to try to catch  "no found" situations returned from the server here and then null the
+                // we use to try to catch "no found" situations returned from the server here and then null the
                 // side-effect for the requested key. doesn't seem like there is a need for that now because calls
                 // to get() now initially trigger a call the keys() so you would know all of the keys available on
                 // the server and would validate them up front throwing sideEffectKeyDoesNotExist(key) which thus

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -31,8 +31,8 @@ public abstract class GroovyPageRankTest {
     public static class Traversals extends PageRankTest {
 
         @Override
-        public Traversal<Vertex, Vertex> get_g_V_pageRank() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank")
+        public Traversal<Vertex, Vertex> get_g_V_pageRank_hasXpageRankX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.has(PageRankVertexProgram.PAGE_RANK)")
         }
 
         @Override

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -42,7 +42,7 @@ public abstract class GroovyPageRankTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_byXnameX_name() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).name")
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).by('name').name")
         }
 
         @Override

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -41,7 +41,7 @@ public abstract class GroovyPageRankTest {
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name() {
+        public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_byXnameX_name() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).name")
         }
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPeerPressureTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPeerPressureTest.groovy
@@ -31,8 +31,8 @@ public abstract class GroovyPeerPressureTest {
     public static class Traversals extends PeerPressureTest {
 
         @Override
-        public Traversal<Vertex, Vertex> get_g_V_peerPressure() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.peerPressure")
+        public Traversal<Vertex, Vertex> get_g_V_peerPressure_hasXclusterX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.peerPressure.has(PeerPressureVertexProgram.CLUSTER)")
         }
 
         @Override

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -70,6 +70,9 @@ const ignoredScenarios = {
   'g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_outXcreatedX_groupXmX_byXlabelX_pageRankX1X_byXpageRankX_byXinEX_timesX1X_inXcreatedX_groupXmX_byXpageRankX_capXmX': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_peerPressure': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_hasXname_rippleX_inXcreatedX_peerPressure_byXoutEX_byXclusterX_repeatXunionXidentity__bothX_timesX2X_dedup_valueMapXname_clusterX': new IgnoreError(ignoreReason.computerNotSupported),
 };
 
 defineSupportCode(function(methods) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -63,7 +63,7 @@ const ignoredScenarios = {
   // An associative array containing the scenario name as key, for example:
   'g_V_pageRank': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_outXcreatedX_pageRank_byXbothEX_byXprojectRankX_timesX0X_valueMapXname_projectRankX': new IgnoreError(ignoreReason.computerNotSupported),
-  'g_V_pageRank_order_byXpageRank_decrX_name': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_pageRank_order_byXpageRank_decrX_byXnameX_name': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_pageRank_order_byXpageRank_decrX_name_limitX2X': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_hasLabelXpersonX_pageRank_byXpageRankX_order_byXpageRankX_valueMapXname_pageRankX': new IgnoreError(ignoreReason.computerNotSupported),

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -55,12 +55,21 @@ const parsers = [
 
 const ignoreReason = {
   lambdaNotSupported: 'Lambdas are not supported on gremlin-javascript',
+  computerNotSupported: "withComputer() is not supported on gremlin-javascript",
   needsFurtherInvestigation: '',
 };
 
 const ignoredScenarios = {
   // An associative array containing the scenario name as key, for example:
-  // 'g_V_asXa_bX_out_asXcX_path_selectXkeysX': new IgnoreError(ignoreReason.embeddedListAssertion),
+  'g_V_pageRank': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_outXcreatedX_pageRank_byXbothEX_byXprojectRankX_timesX0X_valueMapXname_projectRankX': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_pageRank_order_byXpageRank_decrX_name': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_pageRank_order_byXpageRank_decrX_name_limitX2X': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_hasLabelXpersonX_pageRank_byXpageRankX_order_byXpageRankX_valueMapXname_pageRankX': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_outXcreatedX_groupXmX_byXlabelX_pageRankX1X_byXpageRankX_byXinEX_timesX1X_inXcreatedX_groupXmX_byXpageRankX_capXmX': new IgnoreError(ignoreReason.computerNotSupported),
 };
 
 defineSupportCode(function(methods) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -61,7 +61,7 @@ const ignoreReason = {
 
 const ignoredScenarios = {
   // An associative array containing the scenario name as key, for example:
-  'g_V_pageRank': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_pageRank_hasXpageRankX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_outXcreatedX_pageRank_byXbothEX_byXprojectRankX_timesX0X_valueMapXname_projectRankX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_pageRank_order_byXpageRank_decrX_byXnameX_name': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_pageRank_order_byXpageRank_decrX_name_limitX2X': new IgnoreError(ignoreReason.computerNotSupported),
@@ -70,7 +70,7 @@ const ignoredScenarios = {
   'g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_outXcreatedX_groupXmX_byXlabelX_pageRankX1X_byXpageRankX_byXinEX_timesX1X_inXcreatedX_groupXmX_byXpageRankX_capXmX': new IgnoreError(ignoreReason.computerNotSupported),
-  'g_V_peerPressure': new IgnoreError(ignoreReason.computerNotSupported),
+  'g_V_peerPressure_hasXclusterX': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X': new IgnoreError(ignoreReason.computerNotSupported),
   'g_V_hasXname_rippleX_inXcreatedX_peerPressure_byXoutEX_byXclusterX_repeatXunionXidentity__bothX_timesX2X_dedup_valueMapXname_clusterX': new IgnoreError(ignoreReason.computerNotSupported),
 };

--- a/gremlin-python/glv/GraphTraversalSource.template
+++ b/gremlin-python/glv/GraphTraversalSource.template
@@ -52,9 +52,9 @@ class GraphTraversalSource(object):
         source = self.get_graph_traversal_source()
         source.traversal_strategies.add_strategies([RemoteStrategy(remote_connection)])
         return source
+
     def withComputer(self,graph_computer=None, workers=None, result=None, persist=None, vertices=None, edges=None, configuration=None):
         return self.withStrategies(VertexProgramStrategy(graph_computer,workers,result,persist,vertices,edges,configuration))
-
 <% sourceSpawnMethods.each { method -> %>
     def <%= method %>(self, *args):
         traversal = self.get_graph_traversal()

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -77,9 +77,9 @@ class GraphTraversalSource(object):
         source = self.get_graph_traversal_source()
         source.traversal_strategies.add_strategies([RemoteStrategy(remote_connection)])
         return source
+
     def withComputer(self,graph_computer=None, workers=None, result=None, persist=None, vertices=None, edges=None, configuration=None):
         return self.withStrategies(VertexProgramStrategy(graph_computer,workers,result,persist,vertices,edges,configuration))
-
 
     def E(self, *args):
         traversal = self.get_graph_traversal()

--- a/gremlin-test/features/map/PageRank.feature
+++ b/gremlin-test/features/map/PageRank.feature
@@ -48,6 +48,8 @@ Feature: Step - pageRank()
       | m[{"name": ["lop"], "projectRank": [3.0]}] |
       | m[{"name": ["ripple"], "projectRank": [1.0]}] |
 
+  # can't fully assert order here because some ranks are equivalent. the java test does an "or" type assert to deal
+  # with this, which we can't express here in these tests. should probably change the test or
   Scenario: g_V_pageRank_order_byXpageRank_decrX_name
     Given the modern graph
     And the traversal of
@@ -55,7 +57,7 @@ Feature: Step - pageRank()
       g.withComputer().V().pageRank().order().by("gremlin.pageRankVertexProgram.pageRank", Order.decr).values("name")
       """
     When iterated to list
-    Then the result should be ordered
+    Then the result should be unordered
       | result |
       | lop    |
       | ripple |

--- a/gremlin-test/features/map/PageRank.feature
+++ b/gremlin-test/features/map/PageRank.feature
@@ -48,21 +48,19 @@ Feature: Step - pageRank()
       | m[{"name": ["lop"], "projectRank": [3.0]}] |
       | m[{"name": ["ripple"], "projectRank": [1.0]}] |
 
-  # can't fully assert order here because some ranks are equivalent. the java test does an "or" type assert to deal
-  # with this, which we can't express here in these tests. should probably change the test or
-  Scenario: g_V_pageRank_order_byXpageRank_decrX_name
+  Scenario: g_V_pageRank_order_byXpageRank_decrX_byXnameX_name
     Given the modern graph
     And the traversal of
       """
-      g.withComputer().V().pageRank().order().by("gremlin.pageRankVertexProgram.pageRank", Order.decr).values("name")
+      g.withComputer().V().pageRank().order().by("gremlin.pageRankVertexProgram.pageRank", Order.decr).by("name").values("name")
       """
     When iterated to list
-    Then the result should be unordered
+    Then the result should be ordered
       | result |
       | lop    |
       | ripple |
-      | vadas  |
       | josh   |
+      | vadas  |
       | marko  |
       | peter  |
 

--- a/gremlin-test/features/map/PageRank.feature
+++ b/gremlin-test/features/map/PageRank.feature
@@ -17,11 +17,11 @@
 
 Feature: Step - pageRank()
                 
-  Scenario: g_V_pageRank
+  Scenario: g_V_pageRank_hasXpageRankX
     Given the modern graph
     And the traversal of
       """
-      g.withComputer().V().pageRank()
+      g.withComputer().V().pageRank().has("gremlin.pageRankVertexProgram.pageRank")
       """
     When iterated to list
     Then the result should be unordered

--- a/gremlin-test/features/map/PageRank.feature
+++ b/gremlin-test/features/map/PageRank.feature
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Feature: Step - pageRank()
+                
+  Scenario: g_V_pageRank
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().pageRank()
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | v[marko] |
+      | v[vadas] |
+      | v[lop] |
+      | v[josh] |
+      | v[ripple] |
+      | v[peter] |
+    And the graph should return 6 for count of "g.withComputer().V().pageRank().has(\"gremlin.pageRankVertexProgram.pageRank\")"
+
+  Scenario: g_V_outXcreatedX_pageRank_byXbothEX_byXprojectRankX_timesX0X_valueMapXname_projectRankX
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().out("created").pageRank().by(__.bothE()).by("projectRank").times(0).valueMap("name", "projectRank")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"name": ["lop"], "projectRank": [3.0]}] |
+      | m[{"name": ["lop"], "projectRank": [3.0]}] |
+      | m[{"name": ["lop"], "projectRank": [3.0]}] |
+      | m[{"name": ["ripple"], "projectRank": [1.0]}] |
+
+  Scenario: g_V_pageRank_order_byXpageRank_decrX_name
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().pageRank().order().by("gremlin.pageRankVertexProgram.pageRank", Order.decr).values("name")
+      """
+    When iterated to list
+    Then the result should be ordered
+      | result |
+      | lop    |
+      | ripple |
+      | vadas  |
+      | josh   |
+      | marko  |
+      | peter  |
+
+  Scenario: g_V_pageRank_order_byXpageRank_decrX_name_limitX2X
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().pageRank().order().by("gremlin.pageRankVertexProgram.pageRank", Order.decr).values("name").limit(2)
+      """
+    When iterated to list
+    Then the result should be ordered
+      | result |
+      | lop    |
+      | ripple |
+
+  Scenario: g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().pageRank().by(__.outE("knows")).by("friendRank").valueMap("name", "friendRank")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"name": ["marko"], "friendRank": [0.15000000000000002]}] |
+      | m[{"name": ["vadas"], "friendRank": [0.21375000000000002]}] |
+      | m[{"name": ["lop"], "friendRank": [0.15000000000000002]}] |
+      | m[{"name": ["josh"], "friendRank": [0.21375000000000002]}] |
+      | m[{"name": ["ripple"], "friendRank": [0.15000000000000002]}] |
+      | m[{"name": ["peter"], "friendRank": [0.15000000000000002]}] |
+
+  Scenario: g_V_hasLabelXpersonX_pageRank_byXpageRankX_order_byXpageRankX_valueMapXname_pageRankX
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().hasLabel("person").pageRank().by("pageRank").order().by("pageRank").valueMap("name", "pageRank")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"name": ["marko"], "pageRank": [0.15000000000000002]}] |
+      | m[{"name": ["vadas"], "pageRank": [0.19250000000000003]}] |
+      | m[{"name": ["josh"], "pageRank": [0.19250000000000003]}] |
+      | m[{"name": ["peter"], "pageRank": [0.15000000000000002]}] |
+
+  Scenario: g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().pageRank().by("pageRank").as("a").out("knows").values("pageRank").as("b").select("a", "b")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"a": "v[marko]", "b": 0.19250000000000003}] |
+      | m[{"a": "v[marko]", "b": 0.19250000000000003}] |
+
+  Scenario: g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().hasLabel("software").has("name", "ripple").pageRank(1.0).by(__.inE("created")).times(1).by("priors").in("created").union(__.both(), __.identity()).valueMap("name", "priors")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"name": ["josh"], "priors": [1.0]}] |
+      | m[{"name": ["marko"], "priors": [0.0]}] |
+      | m[{"name": ["lop"], "priors": [0.0]}] |
+      | m[{"name": ["ripple"], "priors": [0.0]}] |
+
+  Scenario: g_V_outXcreatedX_groupXmX_byXlabelX_pageRankX1X_byXpageRankX_byXinEX_timesX1X_inXcreatedX_groupXmX_byXpageRankX_capXmX()
+    Given an unsupported test
+    Then nothing should happen because
+      """
+      The result returned is not supported under GraphSON 2.x and therefore cannot be properly asserted. More
+      specifically it has long keys which basically get toString()'d under GraphSON 2.x. This test can be supported
+      with GraphSON 3.x.
+      """

--- a/gremlin-test/features/map/PeerPressure.feature
+++ b/gremlin-test/features/map/PeerPressure.feature
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Feature: Step - peerPressure()
+                
+  Scenario: g_V_peerPressure
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().peerPressure()
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | v[marko] |
+      | v[vadas] |
+      | v[lop] |
+      | v[josh] |
+      | v[ripple] |
+      | v[peter] |
+    And the graph should return 6 for count of "g.withComputer().V().peerPressure().has(\"gremlin.peerPressureVertexProgram.cluster\")"
+
+  Scenario: g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X
+    Given an unsupported test
+    Then nothing should happen because
+      """
+      The result returned is not supported under GraphSON 2.x and therefore cannot be properly asserted. More
+      specifically it has long keys which basically get toString()'d under GraphSON 2.x. This test can be supported
+      with GraphSON 3.x.
+      """
+
+  Scenario: g_V_hasXname_rippleX_inXcreatedX_peerPressure_byXoutEX_byXclusterX_repeatXunionXidentity__bothX_timesX2X_dedup_valueMapXname_clusterX
+    Given the modern graph
+    And the traversal of
+      """
+      g.withComputer().V().has("name", "ripple").in("created").peerPressure().by(__.outE()).by("cluster").repeat(__.union(__.identity(), __.both())).times(2).dedup().valueMap("name", "cluster")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"name": ["marko"], "cluster": [1]}] |
+      | m[{"name": ["vadas"], "cluster": [2]}] |
+      | m[{"name": ["lop"], "cluster": [4]}] |
+      | m[{"name": ["josh"], "cluster": [4]}] |
+      | m[{"name": ["ripple"], "cluster": [4]}] |
+      | m[{"name": ["peter"], "cluster": [6]}] |

--- a/gremlin-test/features/map/PeerPressure.feature
+++ b/gremlin-test/features/map/PeerPressure.feature
@@ -17,11 +17,11 @@
 
 Feature: Step - peerPressure()
                 
-  Scenario: g_V_peerPressure
+  Scenario: g_V_peerPressure_hasXclusterX
     Given the modern graph
     And the traversal of
       """
-      g.withComputer().V().peerPressure()
+      g.withComputer().V().peerPressure().has("gremlin.peerPressureVertexProgram.cluster")
       """
     When iterated to list
     Then the result should be unordered

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process;
 
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.GraphManager;
+import org.apache.tinkerpop.gremlin.process.remote.traversal.RemoteTraversalSideEffects;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSideEffects;
@@ -96,8 +97,15 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
             final Class clazz = (Class) keysClasses[i + 1];
             assertThat(sideEffects.keys().contains(key), is(true));
             assertThat(sideEffects.exists(key), is(true));
-            assertEquals(clazz, sideEffects.get((String) keysClasses[i]).getClass());
             assertThat(sideEffects.exists(UUID.randomUUID().toString()), is(false));
+
+            // there is slightly different behavior for remote side-effects so carving out a few asserts with that
+            // in mind. the client really doesnt' really have a way of knowing what type of object to create when it
+            // gets an empty iterator so it makes the result null and therefore we end up with a NPE if we try to
+            // access it. the rest of the behavior is solid so better to do this than OptOut I think
+            if (!(sideEffects instanceof RemoteTraversalSideEffects)) {
+                assertEquals(clazz, sideEffects.get((String) keysClasses[i]).getClass());
+            }
         }
         assertEquals(sideEffects.keys().size(), counter);
         assertThat(sideEffects.keys().contains(UUID.randomUUID().toString()), is(false));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -81,7 +81,7 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
             final String methodName = testName.contains("[") ? testName.substring(0, testName.indexOf('[')) : testName;
             final IgnoreEngine ignoreEngine = this.getClass().getMethod(methodName).getAnnotation(IgnoreEngine.class);
             if (ignoreEngine != null)
-                assumeTrue(String.format("This test is ignored for %s", ignoreEngine.value()), !ignoreEngine.value().equals(GraphManager.getTraversalEngineType()));
+                assumeTrue(String.format("%s.%s is ignored for %s", this.getClass().getName(), testName, ignoreEngine.value()), !ignoreEngine.value().equals(GraphManager.getTraversalEngineType()));
         } catch (NoSuchMethodException nsme) {
             // some tests are parameterized
             throw new RuntimeException(String.format("Could not find test method %s in test case %s", name.getMethodName(), this.getClass().getName()));
@@ -128,7 +128,7 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
 
         for (T t : results) {
             if (t instanceof Map) {
-                assertThat("Checking map result existence: " + t, expectedResults.stream().filter(e -> e instanceof Map).filter(e -> internalCheckMap((Map) e, (Map) t)).findAny().isPresent(), is(true));
+                assertThat("Checking map result existence: " + t, expectedResults.stream().filter(e -> e instanceof Map).anyMatch(e -> internalCheckMap((Map) e, (Map) t)), is(true));
             } else {
                 assertThat("Checking result existence: " + t, expectedResults.contains(t), is(true));
             }
@@ -153,8 +153,8 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
     }
 
     public static <A, B> void checkMap(final Map<A, B> expectedMap, final Map<A, B> actualMap) {
-        final List<Map.Entry<A, B>> actualList = actualMap.entrySet().stream().sorted((a, b) -> a.getKey().toString().compareTo(b.getKey().toString())).collect(Collectors.toList());
-        final List<Map.Entry<A, B>> expectedList = expectedMap.entrySet().stream().sorted((a, b) -> a.getKey().toString().compareTo(b.getKey().toString())).collect(Collectors.toList());
+        final List<Map.Entry<A, B>> actualList = actualMap.entrySet().stream().sorted(Comparator.comparing(a -> a.getKey().toString())).collect(Collectors.toList());
+        final List<Map.Entry<A, B>> expectedList = expectedMap.entrySet().stream().sorted(Comparator.comparing(a -> a.getKey().toString())).collect(Collectors.toList());
         assertEquals(expectedList.size(), actualList.size());
         for (int i = 0; i < actualList.size(); i++) {
             assertEquals(expectedList.get(i).getKey(), actualList.get(i).getKey());
@@ -163,8 +163,8 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
     }
 
     private static <A, B> boolean internalCheckMap(final Map<A, B> expectedMap, final Map<A, B> actualMap) {
-        final List<Map.Entry<A, B>> actualList = actualMap.entrySet().stream().sorted((a, b) -> a.getKey().toString().compareTo(b.getKey().toString())).collect(Collectors.toList());
-        final List<Map.Entry<A, B>> expectedList = expectedMap.entrySet().stream().sorted((a, b) -> a.getKey().toString().compareTo(b.getKey().toString())).collect(Collectors.toList());
+        final List<Map.Entry<A, B>> actualList = actualMap.entrySet().stream().sorted(Comparator.comparing(a -> a.getKey().toString())).collect(Collectors.toList());
+        final List<Map.Entry<A, B>> expectedList = expectedMap.entrySet().stream().sorted(Comparator.comparing(a -> a.getKey().toString())).collect(Collectors.toList());
 
         if (expectedList.size() != actualList.size()) {
             return false;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,7 +48,7 @@ import static org.junit.Assert.fail;
 @RunWith(GremlinProcessRunner.class)
 public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
-    public abstract Traversal<Vertex, Vertex> get_g_V_pageRank();
+    public abstract Traversal<Vertex, Vertex> get_g_V_pageRank_hasXpageRankX();
 
     public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_outXcreatedX_pageRank_byXbothEX_byXprojectRankX_timesX0X_valueMapXname_projectRankX();
 
@@ -67,16 +68,10 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_pageRank() {
-        final Traversal<Vertex, Vertex> traversal = get_g_V_pageRank();
+    public void g_V_pageRank_hasXpageRankX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_pageRank_hasXpageRankX();
         printTraversalForm(traversal);
-        int counter = 0;
-        while (traversal.hasNext()) {
-            final Vertex vertex = traversal.next();
-            counter++;
-            assertTrue(vertex.property(PageRankVertexProgram.PAGE_RANK).isPresent());
-        }
-        assertEquals(6, counter);
+        assertEquals(6, IteratorUtils.count(traversal));
     }
 
     @Test
@@ -241,8 +236,8 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
     public static class Traversals extends PageRankTest {
 
         @Override
-        public Traversal<Vertex, Vertex> get_g_V_pageRank() {
-            return g.V().pageRank();
+        public Traversal<Vertex, Vertex> get_g_V_pageRank_hasXpageRankX() {
+            return g.V().pageRank().has(PageRankVertexProgram.PAGE_RANK);
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
@@ -51,7 +51,7 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_outXcreatedX_pageRank_byXbothEX_byXprojectRankX_timesX0X_valueMapXname_projectRankX();
 
-    public abstract Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name();
+    public abstract Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_byXnameX_name();
 
     public abstract Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name_limitX2X();
 
@@ -99,17 +99,17 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_pageRank_order_byXpageRank_decrX_name() {
-        final Traversal<Vertex, String> traversal = get_g_V_pageRank_order_byXpageRank_decrX_name();
+    public void g_V_pageRank_order_byXpageRank_decrX_byXnameX_name() {
+        final Traversal<Vertex, String> traversal = get_g_V_pageRank_order_byXpageRank_decrX_byXnameX_name();
         printTraversalForm(traversal);
         final List<String> names = traversal.toList();
         assertEquals(6, names.size());
         assertEquals("lop", names.get(0));
         assertEquals("ripple", names.get(1));
-        assertTrue(names.get(2).equals("josh") || names.get(2).equals("vadas"));
-        assertTrue(names.get(3).equals("josh") || names.get(3).equals("vadas"));
-        assertTrue(names.get(4).equals("marko") || names.get(4).equals("peter"));
-        assertTrue(names.get(5).equals("marko") || names.get(5).equals("peter"));
+        assertEquals("josh", names.get(2));
+        assertEquals("vadas", names.get(3));
+        assertEquals("marko", names.get(4));
+        assertEquals("peter", names.get(5));
     }
 
     @Test
@@ -256,8 +256,8 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
         }
 
         @Override
-        public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name() {
-            return g.V().pageRank().order().by(PageRankVertexProgram.PAGE_RANK, Order.decr).values("name");
+        public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_byXnameX_name() {
+            return g.V().pageRank().order().by(PageRankVertexProgram.PAGE_RANK, Order.decr).by("name").values("name");
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
@@ -22,11 +22,13 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.computer.clustering.peerpressure.PeerPressureVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +44,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
+@RunWith(GremlinProcessRunner.class)
 public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_peerPressure();
@@ -99,8 +102,7 @@ public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
         assertTrue(ids.contains(convertToVertexId("josh")));
         assertTrue(ids.contains(convertToVertexId("peter")));
     }
-
-
+    
     public static class Traversals extends PeerPressureTest {
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.computer.clustering.peerpressure.Pee
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(GremlinProcessRunner.class)
 public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
 
-    public abstract Traversal<Vertex, Vertex> get_g_V_peerPressure();
+    public abstract Traversal<Vertex, Vertex> get_g_V_peerPressure_hasXclusterX();
 
     public abstract Traversal<Vertex, Map<Object, Number>> get_g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X();
 
@@ -55,16 +56,10 @@ public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_peerPressure() {
-        final Traversal<Vertex, Vertex> traversal = get_g_V_peerPressure();
+    public void g_V_peerPressure_hasXclusterX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_peerPressure_hasXclusterX();
         printTraversalForm(traversal);
-        int counter = 0;
-        while (traversal.hasNext()) {
-            final Vertex vertex = traversal.next();
-            counter++;
-            assertTrue(vertex.property(PeerPressureVertexProgram.CLUSTER).isPresent());
-        }
-        assertEquals(6, counter);
+        assertEquals(6, IteratorUtils.count(traversal));
     }
 
     @Test
@@ -106,8 +101,8 @@ public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
     public static class Traversals extends PeerPressureTest {
 
         @Override
-        public Traversal<Vertex, Vertex> get_g_V_peerPressure() {
-            return g.V().peerPressure();
+        public Traversal<Vertex, Vertex> get_g_V_peerPressure_hasXclusterX() {
+            return g.V().peerPressure().has(PeerPressureVertexProgram.CLUSTER);
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/TranslationStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/TranslationStrategyProcessTest.java
@@ -21,9 +21,11 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
+@RunWith(GremlinProcessRunner.class)
 public class TranslationStrategyProcessTest extends AbstractGremlinProcessTest {
     private static final Logger logger = LoggerFactory.getLogger(TranslationStrategyProcessTest.class);
 

--- a/gremlin-test/src/test/java/org/apache/tinkerpop/gremlin/process/FeatureCoverageTest.java
+++ b/gremlin-test/src/test/java/org/apache/tinkerpop/gremlin/process/FeatureCoverageTest.java
@@ -55,6 +55,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest;
@@ -143,7 +144,7 @@ public class FeatureCoverageTest {
                 OrderTest.class,
                 PageRankTest.class,
                 PathTest.class,
-                // PeerPressureTest.class,
+                PeerPressureTest.class,
                 // ProfileTest.class,
                 // ProgramTest.class,
                 ProjectTest.class,

--- a/gremlin-test/src/test/java/org/apache/tinkerpop/gremlin/process/FeatureCoverageTest.java
+++ b/gremlin-test/src/test/java/org/apache/tinkerpop/gremlin/process/FeatureCoverageTest.java
@@ -53,6 +53,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MaxTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MeanTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest;
@@ -140,7 +141,7 @@ public class FeatureCoverageTest {
                 MeanTest.class,
                 MinTest.class,
                 OrderTest.class,
-                //PageRankTest.class,
+                PageRankTest.class,
                 PathTest.class,
                 // PeerPressureTest.class,
                 // ProfileTest.class,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1976

Added GLV tests for `pageRank()` and `peerPressure()` (i.e. "computer" tests). Apparently we had good support for this already in the GLVs (except gremlin-javascript - which will need that support added). Got rid of some remote test `OptOut` declarations too.

All tests pass with `docker/build.sh -t -i`

VOTE +1