### PR TITLE
TINKERPOP-2024 Make server archetype use remote traversal

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Fixed problem with Gremlin Server sometimes returning an additional message after a failure.
 * Allowed spaces in classpath for `gremlin-server.bat`.
+* Modified Maven archetype for Gremlin Server to use remote traversals rather than scripts.
 * Added an system error code for failed plugin installs for Gremlin Server `-i` option.
 * Match numbers in `choose()` options using `NumberHelper` (match values, ignore data type).
 * Added support for GraphSON serialization of `Date` in Javascript.

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/README.asciidoc
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/README.asciidoc
@@ -18,8 +18,8 @@ limitations under the License.
 
 This is a starter project that demonstrates how a basic
 link:http://tinkerpop.apache.org/docs/${project.version}/reference/#gremlin-server[Gremlin Server] project is structured
-with Maven. This project demonstrates how to connect to Gremlin Server through Java using the
-link:http://tinkerpop.apache.org/docs/${project.version}/reference/#connecting-via-java[Gremlin Driver] that is
+with Maven. This project demonstrates how to connect to Gremlin Server with Java using remote traversals with the
+link:http://tinkerpop.apache.org/docs/${project.version}/reference/#connecting-via-remotegraph[Gremlin Driver] that is
 distributed by TinkerPop.
 
 == Prerequisites

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/README.asciidoc
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/README.asciidoc
@@ -65,4 +65,4 @@ $ bin/gremlin-server.sh  conf/gremlin-server-modern.yaml
 Run this project as follows:
 
 [source,text]
-mvn exec:java -Dexec.mainClass="${package}.App" -Dlog4j.configuration=file:conf/log4j.properties
+mvn exec:java -Dexec.mainClass="${package}.App" -Dlog4j.configuration=file:conf/log4j.properties -Dport=8182

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/App.java
@@ -37,6 +37,7 @@ public class App {
         } finally {
             service.close();
             logger.info("Service closed and resources released");
+            System.exit(0);
         }
     }
 }

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
@@ -27,10 +27,12 @@ import java.util.List;
 
 public class Service implements AutoCloseable {
 
+    private final int port = Integer.parseInt(System.getProperty("port", "45940"));
+
     /**
      * There typically needs to be only one Cluster instance in an application.
      */
-    private final Cluster cluster = Cluster.build().port(45940).create();
+    private final Cluster cluster = Cluster.build().port(port).create();
 
     /**
      * Construct a remote GraphTraversalSource using the above created Cluster instance that will connect to Gremlin

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/java/ServiceTest.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/java/ServiceTest.java
@@ -78,7 +78,7 @@ public class ServiceTest {
 
     @Test
     public void shouldCreateGraph() throws Exception {
-        final List<String> result = service.findCreatorsOfSoftware("lop");
+        final List<Object> result = service.findCreatorsOfSoftware("lop");
         assertThat(result, is(Arrays.asList("marko", "josh", "peter")));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2024

Since we're promoting remote traversals over scripts it would be better for the archetype to use them.

Builds with `mvn clean install` 

VOTE +1