### PR TITLE
Add support for rate-limited request retries when utilizing cosmosDb

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/AttributeKeys.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/AttributeKeys.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Gremlin.Net.Driver
+{
+    internal static class AttributeKeys
+    {
+        public const string CosmosDbRetryAfterMs = "x-ms-retry-after-ms";
+        public const string CosmosDbStatusCode = "x-ms-status-code";
+        public const string CosmosDbRequestRateException = "RequestRateTooLargeException";
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/RequestRateTooLargeException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/RequestRateTooLargeException.cs
@@ -1,0 +1,45 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+
+namespace Gremlin.Net.Driver.Exceptions
+{
+    /// <summary>
+    ///     The exception that is thrown when a request is rate-limited.
+    /// </summary>
+    internal class RequestRateTooLargeException : Exception
+    {
+        /// <summary>
+        /// Indicates the amount of time, in milliseconds, that must be waited before retrying the request
+        /// </summary>
+        public double RetryAfterMs { get; internal set; }
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RequestRateTooLargeException" /> class.
+        /// </summary>
+        /// <param name="message">The error message string.</param>
+        public RequestRateTooLargeException(string message) : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
In order to support better application stability in high stability scenarios, it is necessary to implement rate-limited retries as defined by the cosmosDb documentation. 
(https://docs.microsoft.com/en-us/azure/cosmos-db/request-units#RequestRateTooLarge)
It would be a nice enhancement in the future if additional performance related telemetry could be exposed on a per-traversal basis, but those changes would have a larger impact on the framework.

