### PR TITLE
Update comments in GraphProvider clear() and openTestGraph() [tp33]

### DIFF
--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/util/TinkerGraphProvider.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/util/TinkerGraphProvider.java
@@ -85,7 +85,7 @@ public class TinkerGraphProvider extends AbstractGraphProvider {
             graph.close();
 
         // in the even the graph is persisted we need to clean up
-        final String graphLocation = configuration.getString(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, null);
+        final String graphLocation = null != configuration ? configuration.getString(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, null) : null;
         if (graphLocation != null) {
             final File f = new File(graphLocation);
             f.delete();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -31,7 +31,6 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
@@ -133,6 +132,8 @@ public abstract class AbstractGremlinTest {
     public void tearDown() throws Exception {
         if (null != graphProvider) {
             graphProvider.getTestListener().ifPresent(l -> l.onTestEnd(this.getClass(), name.getMethodName()));
+
+            // GraphProvider that has implemented the clear method must check null for graph and config.
             graphProvider.clear(graph, config);
 
             // All GraphProvider objects should be an instance of ManagedGraphProvider, as this is handled by GraphManager
@@ -144,6 +145,7 @@ public abstract class AbstractGremlinTest {
                 logger.warn("The {} is not of type ManagedGraphProvider and therefore graph instances may leak between test cases.", graphProvider.getClass());
 
             g = null;
+            graph = null;
             config = null;
             graphProvider = null;
         }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphProvider.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphProvider.java
@@ -125,8 +125,8 @@ public interface GraphProvider {
     }
 
     /**
-     * Creates a new {@link Graph} instance from the Configuration object using {@link GraphFactory}. The assumption
-     * here is that the {@code Configuration} has been created by one of the
+     * Creates a new {@link Graph} instance from the {@link org.apache.commons.configuration.Configuration} object using {@link GraphFactory}.
+     * The assumption here is that the {@code Configuration} has been created by one of the
      * {@link #newGraphConfiguration(String, Class, String, LoadGraphWith.GraphData)} methods and has therefore
      * already been modified by the implementation as necessary for {@link Graph} creation.
      */
@@ -149,6 +149,9 @@ public interface GraphProvider {
      * to construct the graph.  The default implementation simply calls
      * {@link #clear(Graph, org.apache.commons.configuration.Configuration)} with
      * a null graph argument.
+     * <p/>
+     * Implementations should be able to accept an argument of null for the {@code org.apache.commons.configuration.Configuration}
+     * as well, and a proper handling is needed. Otherwise, a NullPointerException may be thrown.
      */
     public default void clear(final Configuration configuration) throws Exception {
         clear(null, configuration);
@@ -160,9 +163,12 @@ public interface GraphProvider {
      * For a brute force approach, implementers can simply delete data directories provided in the configuration.
      * Implementers may choose a more elegant approach if it exists.
      * <p/>
-     * Implementations should be able to accept an argument of null for the Graph, in which case the only action
+     * Implementations should be able to accept an argument of null for the {@code Graph}, in which case the only action
      * that can be performed is a clear given the configuration.  The method will typically be called this way
      * as clean up task on setup to ensure that a persisted graph has a clear space to create a test graph.
+     * <p/>
+     * Implementations should be able to accept an argument of null for the {@code org.apache.commons.configuration.Configuration}
+     * as well, and a proper handling is needed. Otherwise, a NullPointerException may be thrown.
      * <p/>
      * Calls to this method may occur multiple times for a specific test. Develop this method to be idempotent.
      */

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
@@ -57,7 +57,7 @@ public abstract class AbstractNeo4jGraphProvider extends AbstractGraphProvider {
             graph.close();
         }
 
-        if (configuration.containsKey(Neo4jGraph.CONFIG_DIRECTORY)) {
+        if (null != configuration && configuration.containsKey(Neo4jGraph.CONFIG_DIRECTORY)) {
             // this is a non-in-sideEffects configuration so blow away the directory
             final File graphDirectory = new File(configuration.getString(Neo4jGraph.CONFIG_DIRECTORY));
             deleteDirectory(graphDirectory);

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
@@ -85,7 +85,7 @@ public class TinkerGraphProvider extends AbstractGraphProvider {
             graph.close();
 
         // in the even the graph is persisted we need to clean up
-        final String graphLocation = configuration.getString(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, null);
+        final String graphLocation = null != configuration ? configuration.getString(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, null) : null;
         if (graphLocation != null) {
             final File f = new File(graphLocation);
             f.delete();


### PR DESCRIPTION
What's changed [tp33]:

Classes that have implemented `GraphProvider#clear` must note that the parameter `graph` and `config` are nullable, so that a proper `null` checking and handling is needed. Otherwise, test cases that have extended `org.apache.tinkerpop.gremlin.AbstractGremlinTest.java` may throw exception when it comes to `tearDown()`

* Update comments in `GraphProvider#clear`, `GraphProvider#openTestGraph`.
* Add `null` checking in the `clear` method of the three implemented `GraphProvider`:
  - `org.apache.tinkerpop.gremlin.neo4j.AbstractNeo4jGraphProvider.java`
  - `org.apache.tinkerpop.gremlin.tinkergraph.TinkerGraphProvider.java`
  - `org.apache.tinkerpop.gremlin.util.TinkerGraphProvider.java`
* `org.apache.tinkerpop.gremlin.AbstractGremlinTest`
  - Set `graph` to `null` when `tearDown()`
  - Add comment at `tearDown()`
  - Remove unused imports
