### PR TITLE
String loop to String builder [tp32]

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
@@ -107,7 +107,7 @@ public abstract class AbstractGremlinScriptEngineFactory implements GremlinScrip
      */
     @Override
     public String getProgram(final String... statements) {
-        StringBuilder program = new StringBuilder();
+        final StringBuilder program = new StringBuilder();
 
         for (String statement : statements) {
             program.append(statement).append(System.lineSeparator());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
@@ -107,12 +107,12 @@ public abstract class AbstractGremlinScriptEngineFactory implements GremlinScrip
      */
     @Override
     public String getProgram(final String... statements) {
-        String program = "";
+        StringBuilder program = new StringBuilder();
 
         for (String statement : statements) {
-            program = program + statement + System.lineSeparator();
+            program.append(statement).append(System.lineSeparator());
         }
 
-        return program;
+        return program.toString();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
@@ -429,7 +429,7 @@ public class GremlinDslProcessor extends AbstractProcessor {
     private void addMethodBody(final MethodSpec.Builder methodToAdd, final ExecutableElement templateMethod,
                                final String startBody, final String endBody, final Object... statementArgs) {
         final List<? extends VariableElement> parameters = templateMethod.getParameters();
-        StringBuilder body = new StringBuilder(startBody);
+        final StringBuilder body = new StringBuilder(startBody);
 
         final int numberOfParams = parameters.size();
         for (int ix = 0; ix < numberOfParams; ix++) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
@@ -429,23 +429,25 @@ public class GremlinDslProcessor extends AbstractProcessor {
     private void addMethodBody(final MethodSpec.Builder methodToAdd, final ExecutableElement templateMethod,
                                final String startBody, final String endBody, final Object... statementArgs) {
         final List<? extends VariableElement> parameters = templateMethod.getParameters();
-        String body = startBody;
+        StringBuilder body = new StringBuilder(startBody);
 
         final int numberOfParams = parameters.size();
         for (int ix = 0; ix < numberOfParams; ix++) {
             final VariableElement param = parameters.get(ix);
             methodToAdd.addParameter(ParameterSpec.get(param));
-            body = body + param.getSimpleName();
-            if (ix < numberOfParams - 1) body = body + ",";
+            body.append(param.getSimpleName());
+            if (ix < numberOfParams - 1) {
+                body.append(",");
+            }
         }
 
-        body = body + endBody;
+        body.append(endBody);
 
         // treat a final array as a varargs param
         if (!parameters.isEmpty() && parameters.get(parameters.size() - 1).asType().getKind() == TypeKind.ARRAY)
             methodToAdd.varargs(true);
 
-        methodToAdd.addStatement(body, statementArgs);
+        methodToAdd.addStatement(body.toString(), statementArgs);
     }
 
     private TypeName getOverridenReturnTypeDefinition(final ClassName returnClazz, final String[] typeValues) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalMetrics.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalMetrics.java
@@ -109,14 +109,14 @@ public final class DefaultTraversalMetrics implements TraversalMetrics, Serializ
     private void appendMetrics(final Collection<? extends Metrics> metrics, final StringBuilder sb, final int indent) {
         // Append each StepMetric's row. indexToLabelMap values are ordered by index.
         for (Metrics m : metrics) {
-            String rowName = m.getName();
+            StringBuilder rowName = new StringBuilder(m.getName());
 
             // Handle indentation
             for (int ii = 0; ii < indent; ii++) {
-                rowName = "  " + rowName;
+                rowName.insert(0, "  ");
             }
             // Abbreviate if necessary
-            rowName = StringUtils.abbreviate(rowName, 50);
+            rowName = new StringBuilder(StringUtils.abbreviate(rowName.toString(), 50));
 
             // Grab the values
             final Long itemCount = m.getCount(ELEMENT_COUNT_ID);
@@ -125,7 +125,7 @@ public final class DefaultTraversalMetrics implements TraversalMetrics, Serializ
 
             // Build the row string
 
-            sb.append(String.format("%n%-50s", rowName));
+            sb.append(String.format("%n%-50s", rowName.toString()));
 
             if (itemCount != null) {
                 sb.append(String.format(" %21d", itemCount));
@@ -187,11 +187,11 @@ public final class DefaultTraversalMetrics implements TraversalMetrics, Serializ
     private static String padLeft(final String text, final int amountToPad) {
         // not sure why this method needed to exist. stupid string format stuff and commons utilities wouldn't
         // work for some reason in the context this method was used above.
-        String newText = text;
+        StringBuilder newText = new StringBuilder(text);
         for (int ix = 0; ix < amountToPad; ix++) {
-            newText = " " + newText;
+            newText.insert(0, " ");
         }
-        return newText;
+        return newText.toString();
     }
 
     private void computeTotals() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalMetrics.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalMetrics.java
@@ -109,12 +109,13 @@ public final class DefaultTraversalMetrics implements TraversalMetrics, Serializ
     private void appendMetrics(final Collection<? extends Metrics> metrics, final StringBuilder sb, final int indent) {
         // Append each StepMetric's row. indexToLabelMap values are ordered by index.
         for (Metrics m : metrics) {
-            final StringBuilder metricName = new StringBuilder(m.getName());
+            final StringBuilder metricName = new StringBuilder();
 
             // Handle indentation
             for (int ii = 0; ii < indent; ii++) {
-                metricName.insert(0, "  ");
+                metricName.append("  ");
             }
+            metricName.append(m.getName());
             // Abbreviate if necessary
             final StringBuilder rowName = new StringBuilder(StringUtils.abbreviate(metricName.toString(), 50));
 
@@ -187,10 +188,11 @@ public final class DefaultTraversalMetrics implements TraversalMetrics, Serializ
     private static String padLeft(final String text, final int amountToPad) {
         // not sure why this method needed to exist. stupid string format stuff and commons utilities wouldn't
         // work for some reason in the context this method was used above.
-        final StringBuilder newText = new StringBuilder(text);
+        final StringBuilder newText = new StringBuilder();
         for (int ix = 0; ix < amountToPad; ix++) {
-            newText.insert(0, " ");
+            newText.append(" ");
         }
+        newText.append(text);
         return newText.toString();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalMetrics.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalMetrics.java
@@ -109,14 +109,14 @@ public final class DefaultTraversalMetrics implements TraversalMetrics, Serializ
     private void appendMetrics(final Collection<? extends Metrics> metrics, final StringBuilder sb, final int indent) {
         // Append each StepMetric's row. indexToLabelMap values are ordered by index.
         for (Metrics m : metrics) {
-            StringBuilder rowName = new StringBuilder(m.getName());
+            final StringBuilder metricName = new StringBuilder(m.getName());
 
             // Handle indentation
             for (int ii = 0; ii < indent; ii++) {
-                rowName.insert(0, "  ");
+                metricName.insert(0, "  ");
             }
             // Abbreviate if necessary
-            rowName = new StringBuilder(StringUtils.abbreviate(rowName.toString(), 50));
+            final StringBuilder rowName = new StringBuilder(StringUtils.abbreviate(metricName.toString(), 50));
 
             // Grab the values
             final Long itemCount = m.getCount(ELEMENT_COUNT_ID);
@@ -187,7 +187,7 @@ public final class DefaultTraversalMetrics implements TraversalMetrics, Serializ
     private static String padLeft(final String text, final int amountToPad) {
         // not sure why this method needed to exist. stupid string format stuff and commons utilities wouldn't
         // work for some reason in the context this method was used above.
-        StringBuilder newText = new StringBuilder(text);
+        final StringBuilder newText = new StringBuilder(text);
         for (int ix = 0; ix < amountToPad; ix++) {
             newText.insert(0, " ");
         }


### PR DESCRIPTION
String concatenation in loops. As every String concatenation copies the whole String, usually it is preferable to replace it with explicit calls to StringBuilder.append() or StringBuffer.append().