### PR TITLE
optmizes collection copy with Collections addAll

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -149,6 +149,7 @@ import org.apache.tinkerpop.gremlin.util.function.ConstantSupplier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -1484,16 +1485,12 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         else {
             final List<Object> ids = new ArrayList<>();
             if (id instanceof Object[]) {
-                for (final Object i : (Object[]) id) {
-                    ids.add(i);
-                }
+                Collections.addAll(ids, (Object[]) id);
             } else
                 ids.add(id);
             for (final Object i : otherIds) {
                 if (i.getClass().isArray()) {
-                    for (final Object ii : (Object[]) i) {
-                        ids.add(ii);
-                    }
+                    Collections.addAll(ids, (Object[]) i);
                 } else
                     ids.add(i);
             }
@@ -1559,16 +1556,12 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         else {
             final List<Object> values = new ArrayList<>();
             if (value instanceof Object[]) {
-                for (final Object v : (Object[]) value) {
-                    values.add(v);
-                }
+                Collections.addAll(values, (Object[]) value);
             } else
                 values.add(value);
             for (final Object v : otherValues) {
                 if (v instanceof Object[]) {
-                    for (final Object vv : (Object[]) v) {
-                        values.add(vv);
-                    }
+                    Collections.addAll(values, (Object[]) v);
                 } else
                     values.add(v);
             }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SideEffectCapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SideEffectCapStep.java
@@ -46,9 +46,7 @@ public final class SideEffectCapStep<S, E> extends SupplyingBarrierStep<S, E> {
         super(traversal);
         this.sideEffectKeys = new ArrayList<>(1 + sideEffectKeys.length);
         this.sideEffectKeys.add(sideEffectKey);
-        for (final String key : sideEffectKeys) {
-            this.sideEffectKeys.add(key);
-        }
+        Collections.addAll(this.sideEffectKeys, sideEffectKeys);
     }
 
     @Override


### PR DESCRIPTION
Copying of array contents to a collection where each element is added individually using a for a loop. We can be replaced by a call to Collections.addAll().
As the documentation says:

> Adds all of the specified elements to the specified collection. Elements to be added may be specified individually or as an array. The behavior of this convenience method is identical to that of c.addAll(Arrays.asList(elements)), but this method is likely to run significantly faster under most implementations.
When elements are specified individually, this method provides a convenient way to add a few elements to an existing collection:

https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#addAll-java.util.Collection-T...-

In my experience using either Collections.addll or Collections.addAll used to be 30% faster then add from loop.
