### PR TITLE
TINKERPOP-2026 Make closing of connections more robust in Gremlin.Net.Driver 

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -43,10 +43,23 @@ namespace Gremlin.Net.Driver
 
         public async Task CloseAsync()
         {
-            await
-                _client.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None)
-                    .ConfigureAwait(false);
+            if (CloseAlreadyInitiated) return;
+
+            try
+            {
+                await
+                    _client.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None)
+                        .ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Swallow exceptions silently as there is nothing to do when closing fails
+            }
         }
+
+        private bool CloseAlreadyInitiated => _client.State == WebSocketState.Closed ||
+                                            _client.State == WebSocketState.Aborted ||
+                                            _client.State == WebSocketState.CloseSent;
 
         public async Task SendMessageAsync(byte[] message)
         {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2026

This should solve the problem described in the ticket where apparently the server already initiated closing of the connection when the driver tries to close it which led to an exception.

VOTE +1