### PR TITLE
TINKERPOP-2015 Expose WebSocket configuration in Gremlin.Net driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Removed conflicting non-indy groovy core dependency
 * Bumped jython-standalone 2.7.1
+* Added a delegate to the Gremlin.Net driver that can be used to configure the WebSocket connection.
 * SSL security enhancements
 * Added Gremlin version to Gremlin Server startup logging output.
 * Fixed problem with Gremlin Server sometimes returning an additional message after a failure.

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.WebSockets;
 using System.Text;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
@@ -38,18 +39,19 @@ namespace Gremlin.Net.Driver
         private readonly GraphSONWriter _graphSONWriter;
         private readonly JsonMessageSerializer _messageSerializer = new JsonMessageSerializer();
         private readonly Uri _uri;
-        private readonly WebSocketConnection _webSocketConnection = new WebSocketConnection();
+        private readonly WebSocketConnection _webSocketConnection;
         private readonly string _username;
         private readonly string _password;
 
         public Connection(Uri uri, string username, string password, GraphSONReader graphSONReader,
-            GraphSONWriter graphSONWriter)
+            GraphSONWriter graphSONWriter, Action<ClientWebSocketOptions> webSocketConfiguration)
         {
             _uri = uri;
             _username = username;
             _password = password;
             _graphSONReader = graphSONReader;
             _graphSONWriter = graphSONWriter;
+            _webSocketConnection = new WebSocketConnection(webSocketConfiguration);
         }
 
         public async Task<IReadOnlyCollection<T>> SubmitAsync<T>(RequestMessage requestMessage)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
@@ -21,6 +21,8 @@
 
 #endregion
 
+using System;
+using System.Net.WebSockets;
 using Gremlin.Net.Structure.IO.GraphSON;
 
 namespace Gremlin.Net.Driver
@@ -29,20 +31,22 @@ namespace Gremlin.Net.Driver
     {
         private readonly GraphSONReader _graphSONReader;
         private readonly GraphSONWriter _graphSONWriter;
+        private readonly Action<ClientWebSocketOptions> _webSocketConfiguration;
         private readonly GremlinServer _gremlinServer;
 
         public ConnectionFactory(GremlinServer gremlinServer, GraphSONReader graphSONReader,
-            GraphSONWriter graphSONWriter)
+            GraphSONWriter graphSONWriter, Action<ClientWebSocketOptions> webSocketConfiguration)
         {
             _gremlinServer = gremlinServer;
             _graphSONReader = graphSONReader;
             _graphSONWriter = graphSONWriter;
+            _webSocketConfiguration = webSocketConfiguration;
         }
 
         public Connection CreateConnection()
         {
             return new Connection(_gremlinServer.Uri, _gremlinServer.Username, _gremlinServer.Password, _graphSONReader,
-                _graphSONWriter);
+                _graphSONWriter, _webSocketConfiguration);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Structure.IO.GraphSON;
@@ -42,12 +43,16 @@ namespace Gremlin.Net.Driver
         /// <param name="gremlinServer">The <see cref="GremlinServer" /> the requests should be sent to.</param>
         /// <param name="graphSONReader">A <see cref="GraphSONReader" /> instance to read received GraphSON data.</param>
         /// <param name="graphSONWriter">a <see cref="GraphSONWriter" /> instance to write GraphSON data.</param>
+        /// <param name="webSocketConfiguration">
+        ///     A delegate that will be invoked with the <see cref="ClientWebSocketOptions" />
+        ///     object used to configure WebSocket connections.
+        /// </param>
         public GremlinClient(GremlinServer gremlinServer, GraphSONReader graphSONReader = null,
-            GraphSONWriter graphSONWriter = null)
+            GraphSONWriter graphSONWriter = null, Action<ClientWebSocketOptions> webSocketConfiguration = null)
         {
             var reader = graphSONReader ?? new GraphSONReader();
             var writer = graphSONWriter ?? new GraphSONWriter();
-            var connectionFactory = new ConnectionFactory(gremlinServer, reader, writer);
+            var connectionFactory = new ConnectionFactory(gremlinServer, reader, writer, webSocketConfiguration);
             _connectionPool = new ConnectionPool(connectionFactory);
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -33,11 +33,16 @@ namespace Gremlin.Net.Driver
     {
         private const int ReceiveBufferSize = 1024;
         private const WebSocketMessageType MessageType = WebSocketMessageType.Binary;
-        private ClientWebSocket _client;
+        private readonly ClientWebSocket _client;
+
+        public WebSocketConnection(Action<ClientWebSocketOptions> webSocketConfiguration)
+        {
+            _client = new ClientWebSocket();
+            webSocketConfiguration?.Invoke(_client.Options);
+        }
 
         public async Task ConnectAsync(Uri uri)
         {
-            _client = new ClientWebSocket();
             await _client.ConnectAsync(uri, CancellationToken.None).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2015

Users can now provide a delegate to the Gremlin.Net driver that will be used to configure WebSocket connections. Using a delegate for this has the advantage that it's extensible as the options available via [`ClientWebSocketOptions`](https://docs.microsoft.com/dotnet/api/system.net.websockets.clientwebsocketoptions) change between different .NET implementations, e.g., as mentioned in the ticket, a `RemoteCertificateValidationCallback` was added with .NET Core 2.1.

When #903 is merged first, then we need to add this new option also to the docs when merging this into `master` as #903 adds descriptions for the config options to the docs.

VOTE +1