### PR TITLE
TINKERPOP-2035 Pass custom headers to the websocket connection

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -49,7 +49,7 @@ class DriverRemoteConnection extends RemoteConnection {
    * @param {String} [options.traversalSource] The traversal source. Defaults to: 'g'.
    * @param {GraphSONWriter} [options.writer] The writer to use.
    * @param {Authenticator} [options.authenticator] The authentication handler to use.
-   * @param {String} [options.headers] Add custom headers to the request.
+   * @param {Object} [options.headers] An associative array containing the additional header key/values for the initial request.
    * @constructor
    */
   constructor(url, options) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -49,12 +49,14 @@ class DriverRemoteConnection extends RemoteConnection {
    * @param {String} [options.traversalSource] The traversal source. Defaults to: 'g'.
    * @param {GraphSONWriter} [options.writer] The writer to use.
    * @param {Authenticator} [options.authenticator] The authentication handler to use.
+   * @param {String} [options.headers] Add custom headers to the request.
    * @constructor
    */
   constructor(url, options) {
     super(url);
     options = options || {};
     this._ws = new WebSocket(url, {
+      headers: options.headers,
       ca: options.ca,
       cert: options.cert,
       pfx: options.pfx,


### PR DESCRIPTION
In order to authorize to the gremlin server (in this case AWS Neptune) i need to pass custom headers for authorization to the service. the PR will allow to send any headers (like an API key or signature) and pass them to the Websocket function.
While there can be many use cases for this, in my case i pass the Authorization & x-amz-date required for Signature V4 (IAM) authentication.

VOTE: +1