### PR TITLE
TINKERPOP-2032 bump jython-standalone 2.7.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-10]]
 === TinkerPop 3.2.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Bumped jython-standalone 2.7.1
 * SSL security enhancements
 * Added Gremlin version to Gremlin Server startup logging output.
 * Fixed problem with Gremlin Server sometimes returning an additional message after a failure.

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
         <dependency>
             <groupId>org.python</groupId>
             <artifactId>jython-standalone</artifactId>
-            <version>2.7.1b2</version>
+            <version>2.7.1</version>
         </dependency>
         <!-- TESTING -->
         <dependency>


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JAVA-ORGPYTHON-31451

Overview
org.python:jython-standalone Affected versions of this package are vulnerable to Arbitrary Code Execution by sending a serialized function to the deserializer, which in turn will execute the code.

References
[CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4000)
[Jython Bug Report](http://bugs.jython.org/issue2454)
[Fix Commit](https://hg.python.org/jython/rev/d06e29d100c0)
