### PR TITLE
TINKERPOP-2029 ConcurrentModificationException for InlineFilterStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
+* Rewrote `ConnectiveStrategy` to support an arbitrary number of infix notations in a single traversal.
 * GraphSON `MessageSerializer`s will automatically register the GremlinServerModule to a provided GraphSONMapper.
 * Implemented `ShortestPathVertexProgram` and the `shortestPath()` step.
 * `AbstractGraphProvider` uses `g.io()` for loading test data.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -339,8 +339,7 @@ g.V().and(
 The `and()`-step can take an arbitrary number of traversals. All traversals must produce at least one output for the
 original traverser to pass to the next step.
 
-An link:http://en.wikipedia.org/wiki/Infix_notation[infix notation] can be used as well. Though, with infix notation,
-only two traversals can be and'd together.
+An link:http://en.wikipedia.org/wiki/Infix_notation[infix notation] can be used as well.
 
 [gremlin-groovy,modern]
 ----
@@ -1864,8 +1863,7 @@ g.V().or(
 The `or()`-step can take an arbitrary number of traversals. At least one of the traversals must produce at least one
 output for the original traverser to pass to the next step.
 
-An link:http://en.wikipedia.org/wiki/Infix_notation[infix notation] can be used as well. Though, with infix notation,
-only two traversals can be or'd together.
+An link:http://en.wikipedia.org/wiki/Infix_notation[infix notation] can be used as well.
 
 [gremlin-groovy,modern]
 ----

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -31,8 +31,19 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.4.0/CHANGELOG.asc
 
 ==== Changed infix behavior
 
-The infix notation of `and()` and `or()` now supports an arbitrary number of traversals and `ConnectiveStrategy` produces a traversal with the correct AND and OR semantics. Furthermore,
-previous versions failed to apply 3 or more `and()` steps in an infix notation, this is now fixed.
+The infix notation of `and()` and `or()` now supports an arbitrary number of traversals and `ConnectiveStrategy` produces a traversal with proper AND and OR semantics.
+
+```
+Input: a.or.b.and.c.or.d.and.e.or.f.and.g.and.h.or.i
+
+## BEFORE
+Output: or(a, or(and(b, c), or(and(d, e), or(and(and(f, g), h), i))))
+
+## NOW
+Output: or(a, and(b, c), and(d, e), and(f, g, h), i)
+```
+
+Furthermore, previous versions failed to apply 3 or more `and()` steps using the infix notation, this is now fixed.
 
 [source,groovy]
 ----
@@ -41,16 +52,7 @@ gremlin> g.V().has("name","marko").and().has("age", lt(30)).or().has("name","jos
 ==>v[4]
 ----
 
-In previous versions the above traversal 
-[source,groovy]
-----
-gremlin> g.V().repeat(__.in('traverses').repeat(__.in('develops')).emit()).emit().values('name')
-==>stephen
-==>matthias
-==>marko
-----
-
-See: link:https://issues.apache.org/jira/browse/TINKERPOP-967[TINKERPOP-967]
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2029[TINKERPOP-2029]
 
 ==== sparql-gremlin
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -29,6 +29,29 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.4.0/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Changed infix behavior
+
+The infix notation of `and()` and `or()` now supports an arbitrary number of traversals and `ConnectiveStrategy` produces a traversal with the correct AND and OR semantics. Furthermore,
+previous versions failed to apply 3 or more `and()` steps in an infix notation, this is now fixed.
+
+[source,groovy]
+----
+gremlin> g.V().has("name","marko").and().has("age", lt(30)).or().has("name","josh").and().has("age", gt(30)).and().out("created")
+==>v[1]
+==>v[4]
+----
+
+In previous versions the above traversal 
+[source,groovy]
+----
+gremlin> g.V().repeat(__.in('traverses').repeat(__.in('develops')).emit()).emit().values('name')
+==>stephen
+==>matthias
+==>marko
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-967[TINKERPOP-967]
+
 ==== sparql-gremlin
 
 The `sparql-gremlin` module is a link:https://en.wikipedia.org/wiki/SPARQL[SPARQL] to Gremlin compiler, which allows

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategyTest.java
@@ -28,6 +28,9 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.filter;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -58,6 +61,7 @@ public class ConnectiveStrategyTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> generateTestParameters() {
         return Arrays.asList(new Traversal[][]{
+                {__.has("name", "marko").and().has("name", "marko").and().has("name", "marko"), __.and(has("name", "marko"), __.has("name", "marko"), __.has("name", "marko"))},
                 {__.has("name", "stephen").or().where(__.out("knows").has("name", "stephen")), __.or(__.has("name", "stephen"), __.where(__.out("knows").has("name", "stephen")))},
                 {__.out("a").out("b").and().out("c").or().out("d"), __.or(__.and(__.out("a").out("b"), __.out("c")), __.out("d"))},
                 {__.as("1").out("a").out("b").as("2").and().as("3").out("c").as("4").or().as("5").out("d").as("6"), __.or(__.and(__.as("1").out("a").out("b").as("2"), __.as("3").out("c").as("4")), __.as("5").out("d").as("6"))},
@@ -83,43 +87,24 @@ public class ConnectiveStrategyTest {
                         // EXPECT:
                         __.or(
                                 __.as("a1").out("a").as("a2"),
-                                __.or(
-                                        __.and(
-                                                __.as("b1").out("b").as("b2"),
-                                                __.as("c1").out("c").as("c2")
-                                        ),
-                                        __.or(
-                                                __.as("d1").out("d").as("d2"),
+                                __.and(
+                                        __.as("b1").out("b").as("b2"),
+                                        __.as("c1").out("c").as("c2")),
+                                __.as("d1").out("d").as("d2"),
+                                __.and(
+                                        __.as("e1").out("e").as("e2"),
+                                        __.as("f1").out("f").as("f2"),
+                                        __.as("g1").out("g").as("g2")),
+                                __.and(
+                                        __.as("h1").out("h").as("h2").or(
                                                 __.or(
+                                                        __.as("i1").out("i").as("i2"),
                                                         __.and(
-                                                                __.as("e1").out("e").as("e2"),
-                                                                __.and(
-                                                                        __.as("f1").out("f").as("f2"),
-                                                                        __.as("g1").out("g").as("g2")
-                                                                )
-                                                        ),
-                                                        __.and(
-                                                                __.as("h1").out("h").as("h2").or(
-                                                                        __.or(
-                                                                                __.as("i1").out("i").as("i2"),
-                                                                                __.and(
-                                                                                        __.as("j1").out("j").as("j2"),
-                                                                                        __.as("k1").out("k").as("k2")
-                                                                                )
-                                                                        )
-                                                                ),
-                                                                __.and(
-                                                                        __.as("l1").out("l").as("l2"),
-                                                                        __.and(
-                                                                                __.as("m1").out("m").as("m2"),
-                                                                                __.as("n1").out("n").as("n2")
-                                                                        )
-                                                                )
-                                                        )
-                                                )
-                                        )
-                                )
-                        )
+                                                                __.as("j1").out("j").as("j2"),
+                                                                __.as("k1").out("k").as("k2")))),
+                                __.as("l1").out("l").as("l2"),
+                                __.as("m1").out("m").as("m2"),
+                                __.as("n1").out("n").as("n2")))
                 }
         });
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/InlineFilterStrategyTest.java
@@ -22,20 +22,27 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.util.EmptyTraversal;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.P.eq;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.gt;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.inside;
 import static org.apache.tinkerpop.gremlin.process.traversal.P.lt;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.and;
@@ -56,8 +63,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-
-
 @RunWith(Parameterized.class)
 public class InlineFilterStrategyTest {
 
@@ -67,10 +72,16 @@ public class InlineFilterStrategyTest {
     @Parameterized.Parameter(value = 1)
     public Traversal optimized;
 
+    @Parameterized.Parameter(value = 2)
+    public List<TraversalStrategy> extras;
+
     @Test
     public void doTest() {
         final TraversalStrategies strategies = new DefaultTraversalStrategies();
         strategies.addStrategies(InlineFilterStrategy.instance());
+
+        extras.forEach(strategies::addStrategies);
+
         this.original.asAdmin().setStrategies(strategies);
         this.original.asAdmin().applyStrategies();
         assertEquals(this.optimized, this.original);
@@ -79,56 +90,66 @@ public class InlineFilterStrategyTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> generateTestParameters() {
 
-        return Arrays.asList(new Traversal[][]{
-                {has("age", 10).as("a").has("name", "marko").as("b").coin(0.5).as("c"), addHas(__.start(), "age", eq(10), "name", eq("marko")).as("a", "b").coin(0.5).as("c")},
+        return Arrays.asList(new Object[][]{
+                {has("age", 10).as("a").has("name", "marko").as("b").coin(0.5).as("c"), addHas(__.start(), "age", eq(10), "name", eq("marko")).as("a", "b").coin(0.5).as("c"), Collections.emptyList()},
                 //
-                {filter(out("knows")), filter(out("knows"))},
-                {filter(has("age", gt(10))).as("a"), has("age", gt(10)).as("a")},
-                {filter(has("age", gt(10)).as("b")).as("a"), has("age", gt(10)).as("b", "a")},
-                {filter(has("age", gt(10)).as("a")), has("age", gt(10)).as("a")},
-                {filter(and(has("age", gt(10)).as("a"), has("name", "marko"))), addHas(__.start(), "age", gt(10), "name", eq("marko")).as("a")},
+                {filter(out("knows")), filter(out("knows")), Collections.emptyList()},
+                {filter(has("age", gt(10))).as("a"), has("age", gt(10)).as("a"), Collections.emptyList()},
+                {filter(has("age", gt(10)).as("b")).as("a"), has("age", gt(10)).as("b", "a"), Collections.emptyList()},
+                {filter(has("age", gt(10)).as("a")), has("age", gt(10)).as("a"), Collections.emptyList()},
+                {filter(and(has("age", gt(10)).as("a"), has("name", "marko"))), addHas(__.start(), "age", gt(10), "name", eq("marko")).as("a"), Collections.emptyList()},
+                {filter(out("created").and().out("knows").or().in("knows")), filter(or(and(out("created"), out("knows")), __.in("knows"))), Collections.singletonList(ConnectiveStrategy.instance())},
                 //
-                {or(has("name", "marko"), has("age", 32)), or(has("name", "marko"), has("age", 32))},
-                {or(has("name", "marko"), has("name", "bob")), has("name", eq("marko").or(eq("bob")))},
-                {or(has("name", "marko"), has("name")), or(has("name", "marko"), has("name"))},
-                {or(has("age", 10), and(has("age", gt(20)), has("age", lt(100)))), has("age", eq(10).or(gt(20).and(lt(100))))},
-                {or(has("name", "marko"), filter(has("name", "bob"))), has("name", eq("marko").or(eq("bob")))},
-                {or(has("name", "marko"), filter(or(filter(has("name", "bob")), has("name", "stephen")))), has("name", eq("marko").or(eq("bob").or(eq("stephen"))))},
-                {or(has("name", "marko").as("a"), filter(or(filter(has("name", "bob")).as("b"), has("name", "stephen").as("c")))), has("name", eq("marko").or(eq("bob").or(eq("stephen")))).as("a", "b", "c")},
+                {or(has("name", "marko"), has("age", 32)), or(has("name", "marko"), has("age", 32)), Collections.emptyList()},
+                {or(has("name", "marko"), has("name", "bob")), has("name", eq("marko").or(eq("bob"))), Collections.emptyList()},
+                {or(has("name", "marko"), has("name")), or(has("name", "marko"), has("name")), Collections.emptyList()},
+                {or(has("age", 10), and(has("age", gt(20)), has("age", lt(100)))), has("age", eq(10).or(gt(20).and(lt(100)))), Collections.emptyList()},
+                {or(has("name", "marko"), filter(has("name", "bob"))), has("name", eq("marko").or(eq("bob"))), Collections.emptyList()},
+                {or(has("name", "marko"), filter(or(filter(has("name", "bob")), has("name", "stephen")))), has("name", eq("marko").or(eq("bob").or(eq("stephen")))), Collections.emptyList()},
+                {or(has("name", "marko").as("a"), filter(or(filter(has("name", "bob")).as("b"), has("name", "stephen").as("c")))), has("name", eq("marko").or(eq("bob").or(eq("stephen")))).as("a", "b", "c"), Collections.emptyList()},
                 //
-                {and(has("age", gt(10)), filter(has("age", 22))), addHas(__.start(), "age", gt(10), "age", eq(22))},
-                {and(has("age", gt(10)).as("a"), filter(has("age", 22).as("b")).as("c")).as("d"), addHas(__.start(), "age", gt(10), "age", eq(22)).as("a", "b", "c", "d")},
-                {and(has("age", gt(10)).as("a"), and(filter(has("age", 22).as("b")).as("c"), has("name", "marko").as("d"))), addHas(__.start(), "age", gt(10), "age", eq(22), "name", eq("marko")).as("a", "b", "c", "d")},
-                {and(has("age", gt(10)).as("a"), and(has("name", "stephen").as("b"), has("name", "marko").as("c")).as("d")).as("e"), addHas(__.start(), "age", gt(10), "name", eq("stephen"), "name", eq("marko")).as("a", "b", "c", "d", "e")},
-                {and(has("age", gt(10)), and(out("knows"), has("name", "marko"))), has("age", gt(10)).and(out("knows"), has("name", "marko"))},
-                {and(has("age", gt(20)), or(has("age", lt(10)), has("age", gt(100)))), addHas(__.start(), "age", gt(20), "age", lt(10).or(gt(100)))},
-                {and(has("age", gt(20)).as("a"), or(has("age", lt(10)), has("age", gt(100)).as("b"))), addHas(__.start(), "age", gt(20), "age", lt(10).or(gt(100))).as("a", "b")},
-                {and(has("age", gt(20)).as("a"), or(has("age", lt(10)).as("c"), has("age", gt(100)).as("b"))), addHas(__.start(), "age", gt(20), "age", lt(10).or(gt(100))).as("a", "b", "c")},
+                {has("name", "marko").and().has("name", "marko").and().has("name", "marko"), has("name", "marko").has("name", "marko").has("name", "marko"), Collections.emptyList()},
+                {filter(has("name", "marko")).and().filter(has("name", "marko")).and().filter(has("name", "marko")), has("name", "marko").has("name", "marko").has("name", "marko"), Collections.emptyList()},
+                {V().has("name", "marko").and().has("name", "marko").and().has("name", "marko"), V().has("name", "marko").has("name", "marko").has("name", "marko"), Collections.emptyList()},
+                {V().filter(has("name", "marko")).and().filter(has("name", "marko")).and().filter(has("name", "marko")), V().has("name", "marko").has("name", "marko").has("name", "marko"), Collections.emptyList()},
+                {has("name", "marko").and().has("name", "marko").and().has("name", "marko"), has("name", "marko").has("name", "marko").has("name", "marko"), Collections.singletonList(ConnectiveStrategy.instance())},
+                {V().filter(has("name", "marko")).and().filter(has("name", "marko")).and().filter(has("name", "marko")), and(V().has("name", "marko"), has("name", "marko"), has("name", "marko")), Collections.singletonList(ConnectiveStrategy.instance())},
+                {V().has("name", "marko").and().has("name", "marko").and().has("name", "marko"), and(V().has("name", "marko"), has("name", "marko"), has("name", "marko")), Collections.singletonList(ConnectiveStrategy.instance())},
+                {EmptyGraph.instance().traversal().V().filter(has("name", "marko")).and().filter(has("name", "marko")).and().filter(has("name", "marko")), EmptyGraph.instance().traversal().V().has("name", "marko").has("name", "marko").has("name", "marko"), Collections.singletonList(ConnectiveStrategy.instance())},
+                {EmptyGraph.instance().traversal().V().has("name", "marko").and().has("name", "marko").and().has("name", "marko"), EmptyGraph.instance().traversal().V().has("name", "marko").has("name", "marko").has("name", "marko"), Collections.singletonList(ConnectiveStrategy.instance())},
                 //
-                {V().match(as("a").has("age", 10), as("a").filter(has("name")).as("b")), V().has("age", 10).as("a").match(as("a").has("name").as("b"))},
-                {match(as("a").has("age", 10), as("a").filter(has("name")).as("b")), match(as("a").has("age", 10), as("a").has("name").as("b"))},
-                {match(as("a").has("age", 10).both().as("b"), as("b").out().as("c")), match(as("a").has("age", 10).both().as("b"), as("b").out().as("c"))},
-                {__.map(match(as("a").has("age", 10), as("a").filter(has("name")).as("b"))), __.map(match(as("a").has("age", 10), as("a").has("name").as("b")))},
-                {V().match(as("a").has("age", 10)), V().has("age", 10).as("a")},
-                {V().match(as("a").has("age", 10).has("name", "marko").as("b")), V().has("age", 10).has("name", "marko").as("a", "b")},
-                {V().match(as("a").has("age", 10).has("name", "marko").as("b"), as("a").out("knows").as("c")), V().has("age", 10).has("name", "marko").as("a", "b").match(as("a").out("knows").as("c"))},
-                {V().match(as("a").out("knows").as("c"), as("a").has("age", 10).has("name", "marko").as("b")), V().has("age", 10).has("name", "marko").as("a", "b").match(as("a").out("knows").as("c"))},
-                {V().match(as("a").out("knows").as("c"), as("a").has("age", 10).has("name", "marko").as("b"), as("a").has("name", "bob")), V().has("age", 10).has("name", "marko").has("name", "bob").as("a", "b").match(as("a").out("knows").as("c"))},
-                {V().match(as("a").has("age", 10).as("b"), as("a").filter(has("name")).as("b")), V().has("age", 10).as("a", "b").match(as("a").has("name").as("b"))},
+                {and(has("age", gt(10)), filter(has("age", 22))), addHas(__.start(), "age", gt(10), "age", eq(22)), Collections.emptyList()},
+                {and(has("age", gt(10)).as("a"), filter(has("age", 22).as("b")).as("c")).as("d"), addHas(__.start(), "age", gt(10), "age", eq(22)).as("a", "b", "c", "d"), Collections.emptyList()},
+                {and(has("age", gt(10)).as("a"), and(filter(has("age", 22).as("b")).as("c"), has("name", "marko").as("d"))), addHas(__.start(), "age", gt(10), "age", eq(22), "name", eq("marko")).as("a", "b", "c", "d"), Collections.emptyList()},
+                {and(has("age", gt(10)).as("a"), and(has("name", "stephen").as("b"), has("name", "marko").as("c")).as("d")).as("e"), addHas(__.start(), "age", gt(10), "name", eq("stephen"), "name", eq("marko")).as("a", "b", "c", "d", "e"), Collections.emptyList()},
+                {and(has("age", gt(10)), and(out("knows"), has("name", "marko"))), has("age", gt(10)).and(out("knows"), has("name", "marko")), Collections.emptyList()},
+                {and(has("age", gt(20)), or(has("age", lt(10)), has("age", gt(100)))), addHas(__.start(), "age", gt(20), "age", lt(10).or(gt(100))), Collections.emptyList()},
+                {and(has("age", gt(20)).as("a"), or(has("age", lt(10)), has("age", gt(100)).as("b"))), addHas(__.start(), "age", gt(20), "age", lt(10).or(gt(100))).as("a", "b"), Collections.emptyList()},
+                {and(has("age", gt(20)).as("a"), or(has("age", lt(10)).as("c"), has("age", gt(100)).as("b"))), addHas(__.start(), "age", gt(20), "age", lt(10).or(gt(100))).as("a", "b", "c"), Collections.emptyList()},
                 //
-                {filter(dedup()), filter(dedup())},
-                {filter(filter(drop())), filter(drop())},
-                {and(has("name"), limit(10).has("age")), and(has("name"), limit(10).has("age"))},
-                {filter(tail(10).as("a")), filter(tail(10).as("a"))},
+                {V().match(as("a").has("age", 10), as("a").filter(has("name")).as("b")), V().has("age", 10).as("a").match(as("a").has("name").as("b")), Collections.emptyList()},
+                {match(as("a").has("age", 10), as("a").filter(has("name")).as("b")), match(as("a").has("age", 10), as("a").has("name").as("b")), Collections.emptyList()},
+                {match(as("a").has("age", 10).both().as("b"), as("b").out().as("c")), match(as("a").has("age", 10).both().as("b"), as("b").out().as("c")), Collections.emptyList()},
+                {__.map(match(as("a").has("age", 10), as("a").filter(has("name")).as("b"))), __.map(match(as("a").has("age", 10), as("a").has("name").as("b"))), Collections.emptyList()},
+                {V().match(as("a").has("age", 10)), V().has("age", 10).as("a"), Collections.emptyList()},
+                {V().match(as("a").has("age", 10).has("name", "marko").as("b")), V().has("age", 10).has("name", "marko").as("a", "b"), Collections.emptyList()},
+                {V().match(as("a").has("age", 10).has("name", "marko").as("b"), as("a").out("knows").as("c")), V().has("age", 10).has("name", "marko").as("a", "b").match(as("a").out("knows").as("c")), Collections.emptyList()},
+                {V().match(as("a").out("knows").as("c"), as("a").has("age", 10).has("name", "marko").as("b")), V().has("age", 10).has("name", "marko").as("a", "b").match(as("a").out("knows").as("c")), Collections.emptyList()},
+                {V().match(as("a").out("knows").as("c"), as("a").has("age", 10).has("name", "marko").as("b"), as("a").has("name", "bob")), V().has("age", 10).has("name", "marko").has("name", "bob").as("a", "b").match(as("a").out("knows").as("c")), Collections.emptyList()},
+                {V().match(as("a").has("age", 10).as("b"), as("a").filter(has("name")).as("b")), V().has("age", 10).as("a", "b").match(as("a").has("name").as("b")), Collections.emptyList()},
                 //
-                {outE().hasLabel("knows").inV(), outE("knows").inV()},
-                {outE().hasLabel("knows").hasLabel("created").inV(), outE("knows").hasLabel("created").inV()},
-                {outE().or(hasLabel("knows"), hasLabel("created")).inV(), outE("knows", "created").inV()},
-                {outE().or(hasLabel("knows").as("a"), hasLabel("created").as("b")).as("c").inV(), outE("knows", "created").as("a", "b", "c").inV()},
-                {outE().hasLabel(P.eq("knows").or(P.gt("created"))).has("weight", gt(1.0)).inV(), addHas(outE(), T.label.getAccessor(), P.eq("knows").or(P.gt("created")), "weight", gt(1.0)).inV()},
-                {outE().hasLabel(P.eq("knows").or(P.eq("created"))).has("weight", gt(1.0)).inV(), outE("knows", "created").has("weight", gt(1.0)).inV()},
-                // {outE().or(has(T.label,P.within("knows","likes")).hasLabel("created")).inV(), outE("knows", "likes", "created").inV()},
-                {outE().hasLabel(P.within("knows", "created")).inV(), outE("knows", "created").inV()},
+                {filter(dedup()), filter(dedup()), Collections.emptyList()},
+                {filter(filter(drop())), filter(drop()), Collections.emptyList()},
+                {and(has("name"), limit(10).has("age")), and(has("name"), limit(10).has("age")), Collections.emptyList()},
+                {filter(tail(10).as("a")), filter(tail(10).as("a")), Collections.emptyList()},
+                //
+                {outE().hasLabel("knows").inV(), outE("knows").inV(), Collections.emptyList()},
+                {outE().hasLabel("knows").hasLabel("created").inV(), outE("knows").hasLabel("created").inV(), Collections.emptyList()},
+                {outE().or(hasLabel("knows"), hasLabel("created")).inV(), outE("knows", "created").inV(), Collections.emptyList()},
+                {outE().or(hasLabel("knows").as("a"), hasLabel("created").as("b")).as("c").inV(), outE("knows", "created").as("a", "b", "c").inV(), Collections.emptyList()},
+                {outE().hasLabel(P.eq("knows").or(P.gt("created"))).has("weight", gt(1.0)).inV(), addHas(outE(), T.label.getAccessor(), P.eq("knows").or(P.gt("created")), "weight", gt(1.0)).inV(), Collections.emptyList()},
+                {outE().hasLabel(P.eq("knows").or(P.eq("created"))).has("weight", gt(1.0)).inV(), outE("knows", "created").has("weight", gt(1.0)).inV(), Collections.emptyList()},
+                {outE().hasLabel(P.within("knows", "created")).inV(), outE("knows", "created").inV(), Collections.emptyList()},
         });
     }
 

--- a/gremlin-test/features/filter/And.feature
+++ b/gremlin-test/features/filter/And.feature
@@ -67,3 +67,14 @@ Feature: Step - and()
       | v[josh] |
       | v[ripple] |
       | v[peter]  |
+
+  Scenario: g_V_hasXname_markoX_and_hasXname_markoX_and_hasXname_markoX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().has("name", "marko").and().has("name", "marko").and().has("name", "marko")
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | v[marko] |

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
@@ -52,6 +53,8 @@ public abstract class AndTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_asXaX_andXselectXaX_selectXaXX();
 
+    public abstract Traversal<Vertex, Vertex> get_g_V_hasXname_markoX_and_hasXname_markoX_and_hasXname_markoX();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_andXhasXage_gt_27X__outE_count_gte_2X_name() {
@@ -73,7 +76,7 @@ public abstract class AndTest extends AbstractGremlinProcessTest {
     public void g_V_asXaX_outXknowsX_and_outXcreatedX_inXcreatedX_asXaX_name() {
         final Traversal<Vertex, Vertex> traversal = get_g_V_asXaX_outXknowsX_and_outXcreatedX_inXcreatedX_asXaX_name();
         printTraversalForm(traversal);
-        checkResults(Arrays.asList(convertToVertex(graph, "marko")), traversal);
+        checkResults(Collections.singletonList(convertToVertex(graph, "marko")), traversal);
     }
 
     @Test
@@ -83,6 +86,14 @@ public abstract class AndTest extends AbstractGremlinProcessTest {
         printTraversalForm(traversal);
         final List<Vertex> actual = traversal.toList();
         assertEquals(6, actual.size());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasXname_markoX_and_hasXname_markoX_and_hasXname_markoX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_hasXname_markoX_and_hasXname_markoX_and_hasXname_markoX();
+        printTraversalForm(traversal);
+        checkResults(Collections.singletonList(convertToVertex(graph, "marko")), traversal);
     }
 
     public static class Traversals extends AndTest {
@@ -105,6 +116,11 @@ public abstract class AndTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_asXaX_andXselectXaX_selectXaXX() {
             return g.V().as("a").and(select("a"), select("a"));
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasXname_markoX_and_hasXname_markoX_and_hasXname_markoX() {
+            return g.V().has("name", "marko").and().has("name", "marko").and().has("name", "marko");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2029

To fix the original issue, I basically rewrote `ConnectiveStrategy`. The infix notation of `and()` and `or()` now supports an arbitrary number of traversals and `ConnectiveStrategy` produces a traversal with correct `AND` and `OR` semantics.

The reason for targeting `master/` is that there were no strict semantics before and thus this needs to be considered a breaking change.

```
# BEHAVIOR

Input: a.or.b.and.c.or.d.and.e.or.f.and.g.and.h.or.i

## BEFORE
Output: or(a, or(and(b, c), or(and(d, e), or(and(and(f, g), h), i))))

## NOW
Output: or(a, and(b, c), and(d, e), and(f, g, h), i)
```

`docker/build.sh -t -i -n` passed.

VOTE +1