### PR TITLE
TINKERPOP-1913 Make status attributes available

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,11 +38,10 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Bumped to Netty 4.1.25.
 * Bumped to Spark 2.3.1.
 * Modified Gremlin Server to return a "host" status attribute on responses.
-* Added ability to the Java driver to retrieve status attributes returned from the server on the `ResultSet` object.
-* Modified remote traversals to retreive status attributes from traversal side-effects.
+* Added ability to the Java, .NET and Python drivers to retrieve status attributes returned from the server on the `ResultSet` object.
+* Modified remote traversals to retrieve status attributes from traversal side-effects.
 * Deprecated two `submit()`-related methods on the Java driver `Client` class.
-* Modified Gremlin.Net `ResponseException` to include status code and status attributes.
-* Modified Java driver's `ResponseException` to include status code and status attributes.
+* Modified Java and Gremlin.Net `ResponseException` to include status code and status attributes.
 * Modified the return type for `IGremlinClient.SubmitAsync()` to be a `ResultSet` rather than an `IReadOnlyCollection`.
 * Added `Client.submit()` overloads that accept per-request `RequestOptions`.
 * Added sparql-gremlin.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,7 +37,13 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Maintained order of annotations in metrics returned from `profile()`-step.
 * Bumped to Netty 4.1.25.
 * Bumped to Spark 2.3.1.
+* Modified Gremlin Server to return a "host" status attribute on responses.
+* Added ability to the Java driver to retrieve status attributes returned from the server on the `ResultSet` object.
+* Modified remote traversals to retreive status attributes from traversal side-effects.
 * Deprecated two `submit()`-related methods on the Java driver `Client` class.
+* Modified Gremlin.Net `ResponseException` to include status code and status attributes.
+* Modified Java driver's `ResponseException` to include status code and status attributes.
+* Modified the return type for `IGremlinClient.SubmitAsync()` to be a `ResultSet` rather than an `IReadOnlyCollection`.
 * Added `Client.submit()` overloads that accept per-request `RequestOptions`.
 * Added sparql-gremlin.
 * Fixed a bug in dynamic Gryo registration where registrations that did not have serializers would fail.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Modified remote traversals to retrieve status attributes from traversal side-effects.
 * Deprecated two `submit()`-related methods on the Java driver `Client` class.
 * Modified Java and Gremlin.Net `ResponseException` to include status code and status attributes.
+* Modified Python `GremlinServerError` to include status attributes.
 * Modified the return type for `IGremlinClient.SubmitAsync()` to be a `ResultSet` rather than an `IReadOnlyCollection`.
 * Added `Client.submit()` overloads that accept per-request `RequestOptions`.
 * Added sparql-gremlin.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,7 +39,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Bumped to Spark 2.3.1.
 * Modified Gremlin Server to return a "host" status attribute on responses.
 * Added ability to the Java, .NET and Python drivers to retrieve status attributes returned from the server on the `ResultSet` object.
-* Modified remote traversals to retrieve status attributes from traversal side-effects.
+* Modified remote traversals to retrieve status attributes from traversal side-effects in Python and Java drivers.
 * Deprecated two `submit()`-related methods on the Java driver `Client` class.
 * Modified Java and Gremlin.Net `ResponseException` to include status code and status attributes.
 * Modified Python `GremlinServerError` to include status attributes.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,12 +38,11 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Bumped to Netty 4.1.25.
 * Bumped to Spark 2.3.1.
 * Modified Gremlin Server to return a "host" status attribute on responses.
-* Added ability to the Java, .NET and Python drivers to retrieve status attributes returned from the server on the `ResultSet` object.
-* Modified remote traversals to retrieve status attributes from traversal side-effects in Python and Java drivers.
-* Deprecated two `submit()`-related methods on the Java driver `Client` class.
+* Added ability to the Java, .NET and Python drivers to retrieve status attributes returned from the server.
 * Modified Java and Gremlin.Net `ResponseException` to include status code and status attributes.
 * Modified Python `GremlinServerError` to include status attributes.
 * Modified the return type for `IGremlinClient.SubmitAsync()` to be a `ResultSet` rather than an `IReadOnlyCollection`.
+* Deprecated two `submit()`-related methods on the Java driver `Client` class.
 * Added `Client.submit()` overloads that accept per-request `RequestOptions`.
 * Added sparql-gremlin.
 * Fixed a bug in dynamic Gryo registration where registrations that did not have serializers would fail.

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -71,6 +71,16 @@ g.sparql("""SELECT ?name ?age
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1878[TINKERPOP-1878],
 link:http://tinkerpop.apache.org/docs/3.4.0/reference/#sparql-gremlin[Reference Documentation]
 
+==== Status Attributes
+
+The Gremlin Server protocol allows for status attributes to be returned in responses. These attributes were typically
+for internal use, but were designed with extensibility in mind so that providers could place return their own
+attributes to calling clients. Unfortunately, unless the client was being used with protocol level requests (which
+wasn't convenient) those attributes were essentially hidden from view. As of this version however, status attributes
+are fully retrievable for both successful requests and exceptions.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1913[TINKERPOP-1913]
+
 ==== with() Step
 
 This version of TinkerPop introduces the `with()`-step to Gremlin. It isn't really a step but is instead a step

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -78,9 +78,10 @@ namespace Gremlin.Net.Driver
             await _webSocketConnection.SendMessageAsync(serializedMsg).ConfigureAwait(false);
         }
 
-        private async Task<IReadOnlyCollection<T>> ReceiveAsync<T>()
+        private async Task<ResultSet<T>> ReceiveAsync<T>()
         {
-            ResultSet<T> resultSet = new ResultSet<T>();
+            ResultSet<T> resultSet = null;
+            Dictionary<string, object> statusAttributes = null;
             ResponseStatus status;
             IAggregator aggregator = null;
             var isAggregatingSideEffects = false;
@@ -118,12 +119,13 @@ namespace Gremlin.Net.Driver
 
                 if (status.Code == ResponseStatusCode.Success || status.Code == ResponseStatusCode.NoContent)
                 {
-                    resultSet.StatusAttributes = receivedMsg.Status.Attributes;
+                    statusAttributes = receivedMsg.Status.Attributes;
                 }
 
             } while (status.Code == ResponseStatusCode.PartialContent || status.Code == ResponseStatusCode.Authenticate);
 
-            resultSet.Data = isAggregatingSideEffects ? new List<T> {(T) aggregator.GetAggregatedResult()} : result;
+
+            resultSet = new ResultSet<T>(isAggregatingSideEffects ? new List<T> { (T)aggregator.GetAggregatedResult() } : result, statusAttributes);
                 
             return resultSet;
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -53,7 +53,7 @@ namespace Gremlin.Net.Driver
             _messageSerializer = new JsonMessageSerializer(mimeType);
         }
 
-        public async Task<IReadOnlyCollection<T>> SubmitAsync<T>(RequestMessage requestMessage)
+        public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             await SendAsync(requestMessage).ConfigureAwait(false);
             return await ReceiveAsync<T>().ConfigureAwait(false);

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ResponseException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ResponseException.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using Gremlin.Net.Driver.Messages;
 
 namespace Gremlin.Net.Driver.Exceptions
 {
@@ -34,15 +35,24 @@ namespace Gremlin.Net.Driver.Exceptions
         /// <summary>
         ///     Initializes a new instance of the <see cref="ResponseException" /> class.
         /// </summary>
-        /// <param name="statusAttributes">The status attributes as returned by the server.</param>
+        /// <param name="statusCode">The status code returned by the server.</param>
+        /// <param name="statusAttributes">The status attributes from the gremlin response.</param>
         /// <param name="message">The error message string.</param>
-        public ResponseException(IReadOnlyDictionary<string, object> statusAttributes, string message) : base(message)
+        public ResponseException(ResponseStatusCode statusCode,
+                                 IReadOnlyDictionary<string, object> statusAttributes,
+                                 string message) : base(message)
         {
             StatusAttributes = statusAttributes;
+            StatusCode = statusCode;
         }
 
         /// <summary>
-        /// Gets or sets the status attributes from the gremlin response
+        /// Gets the status code returned from the server.
+        /// </summary>
+        public ResponseStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets the status attributes from the gremlin response
         /// </summary>
         public IReadOnlyDictionary<string, object> StatusAttributes { get; }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ResponseException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ResponseException.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 
 namespace Gremlin.Net.Driver.Exceptions
 {
@@ -33,9 +34,16 @@ namespace Gremlin.Net.Driver.Exceptions
         /// <summary>
         ///     Initializes a new instance of the <see cref="ResponseException" /> class.
         /// </summary>
+        /// <param name="statusAttributes">The status attributes as returned by the server.</param>
         /// <param name="message">The error message string.</param>
-        public ResponseException(string message) : base(message)
+        public ResponseException(IReadOnlyDictionary<string, object> statusAttributes, string message) : base(message)
         {
+            StatusAttributes = statusAttributes;
         }
+
+        /// <summary>
+        /// Gets or sets the status attributes from the gremlin response
+        /// </summary>
+        public IReadOnlyDictionary<string, object> StatusAttributes { get; }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ResponseException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ResponseException.cs
@@ -42,17 +42,17 @@ namespace Gremlin.Net.Driver.Exceptions
                                  IReadOnlyDictionary<string, object> statusAttributes,
                                  string message) : base(message)
         {
-            StatusAttributes = statusAttributes;
             StatusCode = statusCode;
+            StatusAttributes = statusAttributes;
         }
 
         /// <summary>
-        /// Gets the status code returned from the server.
+        ///     Gets the status code returned from the server.
         /// </summary>
         public ResponseStatusCode StatusCode { get; }
 
         /// <summary>
-        /// Gets the status attributes from the gremlin response
+        ///     Gets the status attributes from the gremlin response
         /// </summary>
         public IReadOnlyDictionary<string, object> StatusAttributes { get; }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -68,7 +68,7 @@ namespace Gremlin.Net.Driver
         public int NrConnections => _connectionPool.NrConnections;
 
         /// <inheritdoc />
-        public async Task<IReadOnlyCollection<T>> SubmitAsync<T>(RequestMessage requestMessage)
+        public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             using (var connection = await _connectionPool.GetAvailableConnectionAsync().ConfigureAwait(false))
             {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClientExtensions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClientExtensions.cs
@@ -121,12 +121,12 @@ namespace Gremlin.Net.Driver
         /// <param name="gremlinClient">The <see cref="IGremlinClient" /> that submits the request.</param>
         /// <param name="requestScript">The Gremlin request script to send.</param>
         /// <param name="bindings">Bindings for parameters used in the requestScript.</param>
-        /// <returns>A collection of the data returned from the server.</returns>
+        /// <returns>A <see cref="ResultSet{T}"/> containing the data and status attributes returned from the server.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
-        public static async Task<IReadOnlyCollection<T>> SubmitAsync<T>(this IGremlinClient gremlinClient,
+        public static async Task<ResultSet<T>> SubmitAsync<T>(this IGremlinClient gremlinClient,
             string requestScript,
             Dictionary<string, object> bindings = null)
         {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/IConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/IConnection.cs
@@ -30,6 +30,6 @@ namespace Gremlin.Net.Driver
 {
     internal interface IConnection : IDisposable
     {
-        Task<IReadOnlyCollection<T>> SubmitAsync<T>(RequestMessage requestMessage);
+        Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/IGremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/IGremlinClient.cs
@@ -38,11 +38,11 @@ namespace Gremlin.Net.Driver
         /// </summary>
         /// <typeparam name="T">The type of the expected results.</typeparam>
         /// <param name="requestMessage">The <see cref="RequestMessage" /> to send.</param>
-        /// <returns>A collection of the data returned from the server.</returns>
+        /// <returns>A <see cref="ResultSet{T}"/> containing the data and status attributes returned from the server.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
-        Task<IReadOnlyCollection<T>> SubmitAsync<T>(RequestMessage requestMessage);
+        Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatus.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatus.cs
@@ -44,7 +44,7 @@ namespace Gremlin.Net.Driver.Messages
         public static void ThrowIfStatusIndicatesError(this ResponseStatus status)
         {
             if (status.Code.IndicatesError())
-                throw new ResponseException($"{status.Code}: {status.Message}");
+                throw new ResponseException(status.Attributes, $"{status.Code}: {status.Message}");
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatus.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatus.cs
@@ -44,7 +44,7 @@ namespace Gremlin.Net.Driver.Messages
         public static void ThrowIfStatusIndicatesError(this ResponseStatus status)
         {
             if (status.Code.IndicatesError())
-                throw new ResponseException(status.Attributes, $"{status.Code}: {status.Message}");
+                throw new ResponseException(status.Code, status.Attributes, $"{status.Code}: {status.Message}");
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatusCode.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatusCode.cs
@@ -26,62 +26,72 @@ using System;
 namespace Gremlin.Net.Driver.Messages
 {
     /// <summary>
-    /// Represents the various status codes that Gremlin Server returns.
+    ///     Represents the various status codes that Gremlin Server returns.
     /// </summary>
     public enum ResponseStatusCode
     {
         /// <summary>
-        /// The server successfully processed a request to completion - there are no messages remaining in this stream.
+        ///     The server successfully processed a request to completion - there are no messages remaining in this
+        ///     stream.
         /// </summary>
         Success = 200,
         
         /// <summary>
-        /// The server processed the request but there is no result to return (e.g. an Iterator with no elements) - there are no messages remaining in this stream.
+        ///     The server processed the request but there is no result to return (e.g. an Iterator with no elements)
+        ///     - there are no messages remaining in this stream.
         /// </summary>
         NoContent = 204,
         
         /// <summary>
-        /// The server successfully returned some content, but there is more in the stream to arrive - wait for a SUCCESS to signify the end of the stream.
+        ///     The server successfully returned some content, but there is more in the stream to arrive - wait for a
+        ///     SUCCESS to signify the end of the stream.
         /// </summary>
         PartialContent = 206,
 
         /// <summary>
-        /// The request attempted to access resources that the requesting user did not have access to.
+        ///     The request attempted to access resources that the requesting user did not have access to.
         /// </summary>
         Unauthorized = 401,
 
         /// <summary>
-        /// A challenge from the server for the client to authenticate its request.
+        ///     A challenge from the server for the client to authenticate its request.
         /// </summary>
         Authenticate = 407,
 
         /// <summary>
-        /// The request message was not properly formatted which means it could not be parsed at all or the "op" code was not recognized such that Gremlin Server could properly route it for processing. Check the message format and retry the request.
+        ///     The request message was not properly formatted which means it could not be parsed at all or the "op" code
+        ///     was not recognized such that Gremlin Server could properly route it for processing. Check the message format
+        ///     and retry the request.
         /// </summary>
         MalformedRequest = 498,
 
         /// <summary>
-        /// The request message was parseable, but the arguments supplied in the message were in conflict or incomplete. Check the message format and retry the request.
+        ///     The request message was parseable, but the arguments supplied in the message were in conflict or incomplete.
+        ///     Check the message format and retry the request.
         /// </summary>
         InvalidRequestArguments = 499,
 
         /// <summary>
-        /// A general server error occurred that prevented the request from being processed.
+        ///     A general server error occurred that prevented the request from being processed.
         /// </summary>
         ServerError = 500,
 
         /// <summary>
-        /// The script submitted for processing evaluated in the ScriptEngine with errors and could not be processed. Check the script submitted for syntax errors or other problems and then resubmit.
+        ///     The script submitted for processing evaluated in the ScriptEngine with errors and could not be processed.
+        ///     Check the script submitted for syntax errors or other problems and then resubmit.
         /// </summary>
         ScriptEvaluationError = 597,
 
         /// <summary>
-        /// The server exceeded one of the timeout settings for the request and could therefore only partially responded or did not respond at all.
+        ///     The server exceeded one of the timeout settings for the request and could therefore only partially responded
+        ///     or did not respond at all.
         /// </summary>
         ServerTimeout = 598,
 
         /// <summary>
-        /// The server was not capable of serializing an object that was returned from the script supplied on the request. Either transform the object into something Gremlin Server can process within the script or install mapper serialization classes to Gremlin Server.
+        ///     The server was not capable of serializing an object that was returned from the script supplied on the request.
+        ///     Either transform the object into something Gremlin Server can process within the script or install mapper
+        ///     serialization classes to Gremlin Server.
         /// </summary>
         ServerSerializationError = 599
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatusCode.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/ResponseStatusCode.cs
@@ -25,18 +25,64 @@ using System;
 
 namespace Gremlin.Net.Driver.Messages
 {
-    internal enum ResponseStatusCode
+    /// <summary>
+    /// Represents the various status codes that Gremlin Server returns.
+    /// </summary>
+    public enum ResponseStatusCode
     {
+        /// <summary>
+        /// The server successfully processed a request to completion - there are no messages remaining in this stream.
+        /// </summary>
         Success = 200,
+        
+        /// <summary>
+        /// The server processed the request but there is no result to return (e.g. an Iterator with no elements) - there are no messages remaining in this stream.
+        /// </summary>
         NoContent = 204,
+        
+        /// <summary>
+        /// The server successfully returned some content, but there is more in the stream to arrive - wait for a SUCCESS to signify the end of the stream.
+        /// </summary>
         PartialContent = 206,
+
+        /// <summary>
+        /// The request attempted to access resources that the requesting user did not have access to.
+        /// </summary>
         Unauthorized = 401,
+
+        /// <summary>
+        /// A challenge from the server for the client to authenticate its request.
+        /// </summary>
         Authenticate = 407,
+
+        /// <summary>
+        /// The request message was not properly formatted which means it could not be parsed at all or the "op" code was not recognized such that Gremlin Server could properly route it for processing. Check the message format and retry the request.
+        /// </summary>
         MalformedRequest = 498,
+
+        /// <summary>
+        /// The request message was parseable, but the arguments supplied in the message were in conflict or incomplete. Check the message format and retry the request.
+        /// </summary>
         InvalidRequestArguments = 499,
+
+        /// <summary>
+        /// A general server error occurred that prevented the request from being processed.
+        /// </summary>
         ServerError = 500,
+
+        /// <summary>
+        /// The script submitted for processing evaluated in the ScriptEngine with errors and could not be processed. Check the script submitted for syntax errors or other problems and then resubmit.
+        /// </summary>
         ScriptEvaluationError = 597,
+
+        /// <summary>
+        /// The server exceeded one of the timeout settings for the request and could therefore only partially responded or did not respond at all.
+        /// </summary>
         ServerTimeout = 598,
+
+        /// <summary>
+        /// The server was not capable of serializing an object that was returned from the script supplied on the request. Either transform the object into something Gremlin Server can process within the script or install mapper serialization classes to Gremlin Server.
+        /// </summary>
         ServerSerializationError = 599
     }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ProxyConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ProxyConnection.cs
@@ -39,7 +39,7 @@ namespace Gremlin.Net.Driver
             _releaseAction = releaseAction;
         }
 
-        public async Task<IReadOnlyCollection<T>> SubmitAsync<T>(RequestMessage requestMessage)
+        public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             return await _realConnection.SubmitAsync<T>(requestMessage).ConfigureAwait(false);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
@@ -51,19 +51,19 @@ namespace Gremlin.Net.Driver
             this.StatusAttributes = attributes;
         }
 
-        /// <inheritdoc cref="IReadOnlyCollection{T}"/>
+        /// <inheritdoc />
         public IEnumerator<T> GetEnumerator()
         {
             return _data.GetEnumerator();
         }
 
-        /// <inheritdoc cref="IReadOnlyCollection{T}"/>
+        /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _data.GetEnumerator();
         }
 
-        /// <inheritdoc cref="IReadOnlyCollection{T}"/>
+        /// <inheritdoc />
         public int Count => _data.Count;
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
@@ -28,7 +28,8 @@ using System.Collections.Generic;
 namespace Gremlin.Net.Driver
 {
     /// <summary>
-    /// Ashiwni
+    /// A ResultSet is returned from the submission of a Gremlin script to the server and represents the results provided by the server
+    /// ResultSet includes enumerable data and status attributes.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public sealed class ResultSet<T> : IReadOnlyCollection<T>

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
@@ -27,8 +27,8 @@ using System.Collections.Generic;
 namespace Gremlin.Net.Driver
 {
     /// <summary>
-    /// A ResultSet is returned from the submission of a Gremlin script to the server and represents the results provided by the server
-    /// ResultSet includes enumerable data and status attributes.
+    ///     A ResultSet is returned from the submission of a Gremlin script to the server and represents the results
+    ///     provided by the server. ResultSet includes enumerable data and status attributes.
     /// </summary>
     /// <typeparam name="T">Type of the result elements</typeparam>
     public sealed class ResultSet<T> : IReadOnlyCollection<T>
@@ -36,12 +36,12 @@ namespace Gremlin.Net.Driver
         private readonly IReadOnlyCollection<T> _data;
 
         /// <summary>
-        /// Gets or sets the status attributes from the gremlin response
+        ///     Gets or sets the status attributes from the gremlin response
         /// </summary>
         public IReadOnlyDictionary<string, object> StatusAttributes { get; }
 
         /// <summary>
-        /// Initializes a new instance of the ResultSet class for the specified data and status attributes.
+        ///     Initializes a new instance of the ResultSet class for the specified data and status attributes.
         /// </summary>
         /// <param name="data"></param>
         /// <param name="attributes"></param>
@@ -51,22 +51,19 @@ namespace Gremlin.Net.Driver
             this.StatusAttributes = attributes;
         }
 
-        /// <summary>Returns an enumerator that iterates through the collection.</summary>
-        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        /// <inheritdoc cref="IReadOnlyCollection{T}"/>
         public IEnumerator<T> GetEnumerator()
         {
             return _data.GetEnumerator();
         }
 
-        /// <summary>Returns an enumerator that iterates through a collection.</summary>
-        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        /// <inheritdoc cref="IReadOnlyCollection{T}"/>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _data.GetEnumerator();
         }
 
-        /// <summary>Gets the number of elements in the collection.</summary>
-        /// <returns>The number of elements in the collection. </returns>
+        /// <inheritdoc cref="IReadOnlyCollection{T}"/>
         public int Count => _data.Count;
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
@@ -31,18 +31,29 @@ namespace Gremlin.Net.Driver
     /// A ResultSet is returned from the submission of a Gremlin script to the server and represents the results provided by the server
     /// ResultSet includes enumerable data and status attributes.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">Type of the result elements</typeparam>
     public sealed class ResultSet<T> : IReadOnlyCollection<T>
     {
         /// <summary>
-        ///  Gets and Sets the read only collection
+        ///  Gets or sets the data from the response
         /// </summary>
-        public IReadOnlyCollection<T> Data { get; set; }
+        public IReadOnlyCollection<T> Data { get; }
 
         /// <summary>
-        /// Gets or Sets the status attributes from the gremlin response
+        /// Gets or sets the status attributes from the gremlin response
         /// </summary>
-        public Dictionary<string, object> StatusAttributes { get; set; }
+        public Dictionary<string, object> StatusAttributes { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the ResultSet class for the specified data and status attributes.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="attributes"></param>
+        public ResultSet(IReadOnlyCollection<T> data, Dictionary<string, object> attributes)
+        {
+            this.Data = data;
+            this.StatusAttributes = attributes;
+        }
 
         /// <summary>Returns an enumerator that iterates through the collection.</summary>
         /// <returns>An enumerator that can be used to iterate through the collection.</returns>
@@ -71,9 +82,9 @@ namespace Gremlin.Net.Driver
         /// <summary>
         /// Casts a IReadOnlyCollection to ResultSet
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="data"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">Type of the result elements</typeparam>
+        /// <param name="data"> result data</param>
+        /// <returns>IReadOnlyCollection as ResultSet</returns>
         public static ResultSet<T> AsResultSet<T>(this IReadOnlyCollection<T> data)
         {
             if (!(data is ResultSet<T> resultSet))

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
@@ -1,0 +1,87 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using Gremlin.Net.Driver.Exceptions;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Gremlin.Net.Driver
+{
+    /// <summary>
+    /// Ashiwni
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public sealed class ResultSet<T> : IReadOnlyCollection<T>
+    {
+        /// <summary>
+        ///  Gets and Sets the read only collection
+        /// </summary>
+        public IReadOnlyCollection<T> Data { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the status attributes from the gremlin response
+        /// </summary>
+        public Dictionary<string, object> StatusAttributes { get; set; }
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this.Data.GetEnumerator();
+        }
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        /// <summary>Gets the number of elements in the collection.</summary>
+        /// <returns>The number of elements in the collection. </returns>
+        public int Count => this.Data.Count;
+    }
+
+    /// <summary>
+    /// Extension for IReadOnlyCollection 
+    /// </summary>
+    public static class ResultSetExtensions
+    {
+        /// <summary>
+        /// Casts a IReadOnlyCollection to ResultSet
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static ResultSet<T> AsResultSet<T>(this IReadOnlyCollection<T> data)
+        {
+            if (!(data is ResultSet<T> resultSet))
+            {
+                throw new ResponseException($"IReadOnlyCollection is not of type ResultSet");
+            }
+
+            return resultSet;
+        }
+    }
+
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ResultSet.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using Gremlin.Net.Driver.Exceptions;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -34,24 +33,21 @@ namespace Gremlin.Net.Driver
     /// <typeparam name="T">Type of the result elements</typeparam>
     public sealed class ResultSet<T> : IReadOnlyCollection<T>
     {
-        /// <summary>
-        ///  Gets or sets the data from the response
-        /// </summary>
-        public IReadOnlyCollection<T> Data { get; }
+        private readonly IReadOnlyCollection<T> _data;
 
         /// <summary>
         /// Gets or sets the status attributes from the gremlin response
         /// </summary>
-        public Dictionary<string, object> StatusAttributes { get; }
+        public IReadOnlyDictionary<string, object> StatusAttributes { get; }
 
         /// <summary>
         /// Initializes a new instance of the ResultSet class for the specified data and status attributes.
         /// </summary>
         /// <param name="data"></param>
         /// <param name="attributes"></param>
-        public ResultSet(IReadOnlyCollection<T> data, Dictionary<string, object> attributes)
+        public ResultSet(IReadOnlyCollection<T> data, IReadOnlyDictionary<string, object> attributes)
         {
-            this.Data = data;
+            _data = data;
             this.StatusAttributes = attributes;
         }
 
@@ -59,41 +55,18 @@ namespace Gremlin.Net.Driver
         /// <returns>An enumerator that can be used to iterate through the collection.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            return this.Data.GetEnumerator();
+            return _data.GetEnumerator();
         }
 
         /// <summary>Returns an enumerator that iterates through a collection.</summary>
         /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return _data.GetEnumerator();
         }
 
         /// <summary>Gets the number of elements in the collection.</summary>
         /// <returns>The number of elements in the collection. </returns>
-        public int Count => this.Data.Count;
+        public int Count => _data.Count;
     }
-
-    /// <summary>
-    /// Extension for IReadOnlyCollection 
-    /// </summary>
-    public static class ResultSetExtensions
-    {
-        /// <summary>
-        /// Casts a IReadOnlyCollection to ResultSet
-        /// </summary>
-        /// <typeparam name="T">Type of the result elements</typeparam>
-        /// <param name="data"> result data</param>
-        /// <returns>IReadOnlyCollection as ResultSet</returns>
-        public static ResultSet<T> AsResultSet<T>(this IReadOnlyCollection<T> data)
-        {
-            if (!(data is ResultSet<T> resultSet))
-            {
-                throw new ResponseException($"IReadOnlyCollection is not of type ResultSet");
-            }
-
-            return resultSet;
-        }
-    }
-
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
@@ -177,9 +177,8 @@ namespace Gremlin.Net.IntegrationTest.Driver
             using (var gremlinClient = new GremlinClient(gremlinServer))
             {
                 var requestMsg = _requestMessageProvider.GetDummyMessage();
-                var response = await gremlinClient.SubmitAsync<int>(requestMsg);
+                var resultSet = await gremlinClient.SubmitAsync<int>(requestMsg);
 
-                var resultSet = response.AsResultSet();
                 Assert.NotNull(resultSet.StatusAttributes);
 
                 var values= resultSet.StatusAttributes["@value"] as JArray;

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
@@ -30,6 +30,8 @@ using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.IntegrationTest.Util;
 using Xunit;
 using Gremlin.Net.Structure.IO.GraphSON;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 namespace Gremlin.Net.IntegrationTest.Driver
 {
@@ -174,16 +176,14 @@ namespace Gremlin.Net.IntegrationTest.Driver
             var gremlinServer = new GremlinServer(TestHost, TestPort);
             using (var gremlinClient = new GremlinClient(gremlinServer))
             {
-                var expectedResult = new List<int> { 1, 2, 3, 4, 5 };
-                var requestMsg = $"{nameof(expectedResult)}";
-                var bindings = new Dictionary<string, object> { { nameof(expectedResult), expectedResult } };
-
-                var response = await gremlinClient.SubmitAsync<int>(requestMsg, bindings);
+                var requestMsg = _requestMessageProvider.GetDummyMessage();
+                var response = await gremlinClient.SubmitAsync<int>(requestMsg);
 
                 var resultSet = response.AsResultSet();
-
                 Assert.NotNull(resultSet.StatusAttributes);
 
+                var values= resultSet.StatusAttributes["@value"] as JArray;
+                Assert.True(values.First.ToString().Equals("host"));
             }
         }
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
@@ -29,6 +29,7 @@ using Gremlin.Net.Driver.Exceptions;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.IntegrationTest.Util;
 using Xunit;
+using Gremlin.Net.Structure.IO.GraphSON;
 
 namespace Gremlin.Net.IntegrationTest.Driver
 {
@@ -164,6 +165,25 @@ namespace Gremlin.Net.IntegrationTest.Driver
                 var response = await gremlinClient.SubmitAsync<int>(requestMsg, bindings);
 
                 Assert.Equal(expectedResult, response);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldReturnResponseAttributes()
+        {
+            var gremlinServer = new GremlinServer(TestHost, TestPort);
+            using (var gremlinClient = new GremlinClient(gremlinServer))
+            {
+                var expectedResult = new List<int> { 1, 2, 3, 4, 5 };
+                var requestMsg = $"{nameof(expectedResult)}";
+                var bindings = new Dictionary<string, object> { { nameof(expectedResult), expectedResult } };
+
+                var response = await gremlinClient.SubmitAsync<int>(requestMsg, bindings);
+
+                var resultSet = response.AsResultSet();
+
+                Assert.NotNull(resultSet.StatusAttributes);
+
             }
         }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
@@ -260,9 +260,18 @@ final class Handler {
                     }
                 }
 
-                // as this is a non-PARTIAL_CONTENT code - the stream is done
-                if (response.getStatus().getCode() != ResponseStatusCode.PARTIAL_CONTENT)
+                // the last message in a OK stream could have meta-data that is useful to the result. note that error
+                // handling of the status attributes is handled separately above
+                if (statusCode == ResponseStatusCode.SUCCESS || statusCode == ResponseStatusCode.NO_CONTENT) {
+                    // in 3.4.0 this should get refactored. i think the that the markComplete() could just take the
+                    // status attributes as its argument - need to investigate that further
+                    queue.statusAttributes = response.getStatus().getAttributes();
+                }
+
+                // as this is a non-PARTIAL_CONTENT code - the stream is done.
+                if (statusCode != ResponseStatusCode.PARTIAL_CONTENT) {
                     pending.remove(response.getRequestId()).markComplete();
+                }
             } finally {
                 // in the event of an exception above the exception is tossed and handled by whatever channelpipeline
                 // error handling is at play.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
@@ -260,18 +260,9 @@ final class Handler {
                     }
                 }
 
-                // the last message in a OK stream could have meta-data that is useful to the result. note that error
-                // handling of the status attributes is handled separately above
-                if (statusCode == ResponseStatusCode.SUCCESS || statusCode == ResponseStatusCode.NO_CONTENT) {
-                    // in 3.4.0 this should get refactored. i think the that the markComplete() could just take the
-                    // status attributes as its argument - need to investigate that further
-                    queue.statusAttributes = response.getStatus().getAttributes();
-                }
-
                 // as this is a non-PARTIAL_CONTENT code - the stream is done.
                 if (statusCode != ResponseStatusCode.PARTIAL_CONTENT) {
-                    queue.statusAttributes = response.getStatus().getAttributes();
-                    pending.remove(response.getRequestId()).markComplete();
+                    pending.remove(response.getRequestId()).markComplete(response.getStatus().getAttributes());
                 }
             } finally {
                 // in the event of an exception above the exception is tossed and handled by whatever channelpipeline

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultQueue.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultQueue.java
@@ -56,6 +56,8 @@ final class ResultQueue {
 
     private final Queue<Pair<CompletableFuture<List<Result>>,Integer>> waiting = new ConcurrentLinkedQueue<>();
 
+    Map<String,Object> statusAttributes = null;
+
     public ResultQueue(final LinkedBlockingQueue<Result> resultLinkedBlockingQueue, final CompletableFuture<Void> readComplete) {
         this.resultLinkedBlockingQueue = resultLinkedBlockingQueue;
         this.readComplete = readComplete;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
@@ -21,8 +21,10 @@ package org.apache.tinkerpop.gremlin.driver;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -71,6 +73,16 @@ public final class ResultSet implements Iterable<Result> {
 
     public Host getHost() {
         return host;
+    }
+
+    /**
+     * Returns a future that will complete when {@link #allItemsAvailable()} is {@code true} and will contain the
+     * attributes from the response.
+     */
+    public CompletableFuture<Map<String,Object>> statusAttributes() {
+        final CompletableFuture<Map<String,Object>> attrs = new CompletableFuture<>();
+        readCompleted.thenRun(() -> attrs.complete(null == resultQueue.statusAttributes ? Collections.emptyMap() : resultQueue.statusAttributes));
+        return attrs;
     }
 
     /**

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
@@ -81,7 +81,7 @@ public final class ResultSet implements Iterable<Result> {
      */
     public CompletableFuture<Map<String,Object>> statusAttributes() {
         final CompletableFuture<Map<String,Object>> attrs = new CompletableFuture<>();
-        readCompleted.thenRun(() -> attrs.complete(null == resultQueue.statusAttributes ? Collections.emptyMap() : resultQueue.statusAttributes));
+        readCompleted.thenRun(() -> attrs.complete(null == resultQueue.getStatusAttributes() ? Collections.emptyMap() : resultQueue.getStatusAttributes()));
         return attrs;
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/exception/ResponseException.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/exception/ResponseException.java
@@ -20,27 +20,37 @@ package org.apache.tinkerpop.gremlin.driver.exception;
 
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class ResponseException extends Exception {
-    private ResponseStatusCode responseStatusCode;
-    private String remoteStackTrace = null;
-    private List<String> remoteExceptionHierarchy = null;
+    private final ResponseStatusCode responseStatusCode;
+    private final String remoteStackTrace;
+    private final List<String> remoteExceptionHierarchy;
+    private final Map<String,Object> attributes;
 
     public ResponseException(final ResponseStatusCode responseStatusCode, final String serverMessage) {
-        super(serverMessage);
-        this.responseStatusCode = responseStatusCode;
+        this(responseStatusCode, serverMessage, null, null);
     }
 
     public ResponseException(final ResponseStatusCode responseStatusCode, final String serverMessage,
                              final List<String> remoteExceptionHierarchy, final String remoteStackTrace) {
-        this(responseStatusCode, serverMessage);
-        this.remoteExceptionHierarchy = remoteExceptionHierarchy;
+        this(responseStatusCode, serverMessage, remoteExceptionHierarchy, remoteStackTrace, null);
+    }
+
+    public ResponseException(final ResponseStatusCode responseStatusCode, final String serverMessage,
+                             final List<String> remoteExceptionHierarchy, final String remoteStackTrace,
+                             final Map<String,Object> statusAttributes) {
+        super(serverMessage);
+        this.responseStatusCode = responseStatusCode;
+        this.remoteExceptionHierarchy = remoteExceptionHierarchy != null ? Collections.unmodifiableList(remoteExceptionHierarchy) : null;
         this.remoteStackTrace = remoteStackTrace;
+        this.attributes = statusAttributes != null ? Collections.unmodifiableMap(statusAttributes) : null;
     }
 
     public ResponseStatusCode getResponseStatusCode() {
@@ -60,5 +70,12 @@ public class ResponseException extends Exception {
      */
     public Optional<List<String>> getRemoteExceptionHierarchy() {
         return Optional.ofNullable(remoteExceptionHierarchy);
+    }
+
+    /**
+     * Gets any status attributes from the response.
+     */
+    public Optional<Map<String, Object>> getStatusAttributes() {
+        return Optional.ofNullable(attributes);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversal.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversal.java
@@ -66,9 +66,7 @@ public class DriverRemoteTraversal<S, E> extends AbstractRemoteTraversal<S, E> {
         }
 
         this.rs = rs;
-        this.sideEffects = new DriverRemoteTraversalSideEffects(client,
-                rs.getOriginalRequestMessage().getRequestId(),
-                rs.getHost(), rs.allItemsAvailableAsync());
+        this.sideEffects = new DriverRemoteTraversalSideEffects(client,rs);
     }
 
     /**

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -57,7 +57,7 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
     private final CompletableFuture<Map<String,Object>> statusAttributes;
 
     /**
-     * @deprecated As of release 3.3.2, replaced by {@link #DriverRemoteTraversalSideEffects(Client, ResultSet)}
+     * @deprecated As of release 3.4.0, replaced by {@link #DriverRemoteTraversalSideEffects(Client, ResultSet)}
      */
     @Deprecated
     public DriverRemoteTraversalSideEffects(final Client client, final UUID serverSideEffect, final Host host,

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalSideEffects.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Host;
 import org.apache.tinkerpop.gremlin.driver.Result;
+import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.AbstractRemoteTraversalSideEffects;
@@ -53,13 +54,37 @@ public class DriverRemoteTraversalSideEffects extends AbstractRemoteTraversalSid
     private boolean closed = false;
     private boolean retrievedAllKeys = false;
     private final CompletableFuture<Void> ready;
+    private final CompletableFuture<Map<String,Object>> statusAttributes;
 
+    /**
+     * @deprecated As of release 3.3.2, replaced by {@link #DriverRemoteTraversalSideEffects(Client, ResultSet)}
+     */
+    @Deprecated
     public DriverRemoteTraversalSideEffects(final Client client, final UUID serverSideEffect, final Host host,
                                             final CompletableFuture<Void> ready) {
         this.client = client;
         this.serverSideEffect = serverSideEffect;
         this.host = host;
         this.ready = ready;
+        this.statusAttributes = CompletableFuture.completedFuture(Collections.emptyMap());
+    }
+
+    public DriverRemoteTraversalSideEffects(final Client client, final ResultSet rs) {
+        this.client = client;
+        this.serverSideEffect = rs.getOriginalRequestMessage().getRequestId();
+        this.host = rs.getHost();
+        this.ready = rs.allItemsAvailableAsync();
+        this.statusAttributes = rs.statusAttributes();
+    }
+
+    /**
+     * Gets the status attributes from the response from the server. This method will block until all results have
+     * been retrieved.
+     */
+    public Map<String,Object> statusAttributes() {
+        // wait for the read to complete (i.e. iteration on the server) before allowing the caller to get the
+        // attribute. simply following the pattern from other methods here for now.
+        return statusAttributes.join();
     }
 
     @Override

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/AbstractResultQueueTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/AbstractResultQueueTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.driver;
 
 import org.junit.Before;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -84,7 +85,7 @@ public abstract class AbstractResultQueueTest {
                 }
             }
 
-            if (markDone) resultQueue.markComplete();
+            if (markDone) resultQueue.markComplete(Collections.emptyMap());
 
         }, "ResultQueueTest-job-submitter");
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultQueueTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultQueueTest.java
@@ -45,6 +45,10 @@ import static org.junit.Assert.fail;
  */
 public class ResultQueueTest extends AbstractResultQueueTest {
 
+    private static final Map<String,Object> ATTRIBUTES = new HashMap<String,Object>() {{
+        put("this", "that");
+    }};
+
     @Test
     public void shouldGetSizeUntilError() throws Exception {
         final Thread t = addToQueue(100, 10, true, false, 1);
@@ -135,7 +139,7 @@ public class ResultQueueTest extends AbstractResultQueueTest {
         resultQueue.add(new Result("test3"));
 
         assertThat(future.isDone(), is(false));
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
         assertThat(future.isDone(), is(true));
 
         final List<Result> results = future.get();
@@ -145,6 +149,7 @@ public class ResultQueueTest extends AbstractResultQueueTest {
         assertEquals(3, results.size());
 
         assertThat(resultQueue.isEmpty(), is(true));
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
     @Test
@@ -242,7 +247,7 @@ public class ResultQueueTest extends AbstractResultQueueTest {
         resultQueue.add(new Result("test2"));
         resultQueue.add(new Result("test3"));
 
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
 
         // you might want 30 but there are only three
         final CompletableFuture<List<Result>> future = resultQueue.await(30);
@@ -255,6 +260,7 @@ public class ResultQueueTest extends AbstractResultQueueTest {
         assertEquals(3, results.size());
 
         assertThat(resultQueue.isEmpty(), is(true));
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
     @Test
@@ -307,12 +313,14 @@ public class ResultQueueTest extends AbstractResultQueueTest {
         resultQueue.addSideEffect(Tokens.VAL_AGGREGATE_TO_BULKSET, new DefaultRemoteTraverser<>("belinda", 6));
         assertThat(o.isDone(), is(false));
 
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
 
         assertThat(o.isDone(), is(true));
         final BulkSet<String> bulkSet = o.get().get(0).get(BulkSet.class);
         assertEquals(4, bulkSet.get("brian"));
         assertEquals(6, bulkSet.get("belinda"));
+
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
     @Test
@@ -329,13 +337,15 @@ public class ResultQueueTest extends AbstractResultQueueTest {
         resultQueue.addSideEffect(Tokens.VAL_AGGREGATE_TO_LIST, "dave");
         assertThat(o.isDone(), is(false));
 
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
 
         assertThat(o.isDone(), is(true));
         final List<String> list = o.get().get(0).get(ArrayList.class);
         assertEquals("stephen", list.get(0));
         assertEquals("daniel", list.get(1));
         assertEquals("dave", list.get(2));
+
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
     @Test
@@ -352,13 +362,15 @@ public class ResultQueueTest extends AbstractResultQueueTest {
         resultQueue.addSideEffect(Tokens.VAL_AGGREGATE_TO_SET, "dave");
         assertThat(o.isDone(), is(false));
 
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
 
         assertThat(o.isDone(), is(true));
         final Set<String> set = o.get().get(0).get(HashSet.class);
         assertThat(set.contains("stephen"), is(true));
         assertThat(set.contains("daniel"), is(true));
         assertThat(set.contains("dave"), is(true));
+
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
     @Test
@@ -376,13 +388,15 @@ public class ResultQueueTest extends AbstractResultQueueTest {
             assertThat(o.isDone(), is(false));
         });
 
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
 
         assertThat(o.isDone(), is(true));
         final Map<String, String> list = o.get().get(0).get(HashMap.class);
         assertEquals("stephen", list.get("s"));
         assertEquals("daniel", list.get("d"));
         assertEquals("marko", list.get("m"));
+
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
 
@@ -398,12 +412,14 @@ public class ResultQueueTest extends AbstractResultQueueTest {
 
         resultQueue.addSideEffect(Tokens.VAL_AGGREGATE_TO_NONE, m);
 
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
 
         assertThat(o.isDone(), is(true));
         final Map<String, String> list = o.get().get(0).get(HashMap.class);
         assertEquals("stephen", list.get("s"));
         assertEquals("daniel", list.get("d"));
         assertEquals("marko", list.get("m"));
+
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultSetTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultSetTest.java
@@ -43,27 +43,15 @@ import static org.junit.Assert.fail;
  */
 public class ResultSetTest extends AbstractResultQueueTest {
 
+    private static final Map<String,Object> ATTRIBUTES = new HashMap<String,Object>() {{
+        put("this", "that");
+    }};
+
     private ResultSet resultSet;
 
     @Before
     public void setupThis() {
         resultSet = new ResultSet(resultQueue, pool, readCompleted, RequestMessage.build("traversal").create(), null);
-    }
-
-    @Test
-    public void shouldReturnResponseAttributes() throws Exception {
-        resultQueue.statusAttributes = new HashMap<String,Object>() {{
-            put("test",123);
-            put("junk","here");
-        }};
-
-        final CompletableFuture<Map<String,Object>> attrs = resultSet.statusAttributes();
-        readCompleted.complete(null);
-
-        final Map<String,Object> m = attrs.get();
-        assertEquals(123, m.get("test"));
-        assertEquals("here", m.get("junk"));
-        assertEquals(2, m.size());
     }
 
     @Test
@@ -132,7 +120,7 @@ public class ResultSetTest extends AbstractResultQueueTest {
         resultQueue.add(new Result("test3"));
 
         assertThat(future.isDone(), is(false));
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
         assertThat(future.isDone(), is(true));
 
         final List<Result> results = future.get();
@@ -143,6 +131,8 @@ public class ResultSetTest extends AbstractResultQueueTest {
 
         assertThat(resultSet.allItemsAvailable(), is(true));
         assertEquals(0, resultSet.getAvailableItemCount());
+
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
     @Test
@@ -153,7 +143,7 @@ public class ResultSetTest extends AbstractResultQueueTest {
         resultQueue.add(new Result("test3"));
 
         assertThat(future.isDone(), is(false));
-        resultQueue.markComplete();
+        resultQueue.markComplete(ATTRIBUTES);
 
         final List<Result> results = future.get();
         assertEquals("test1", results.get(0).getString());
@@ -164,6 +154,8 @@ public class ResultSetTest extends AbstractResultQueueTest {
         assertThat(future.isDone(), is(true));
         assertThat(resultSet.allItemsAvailable(), is(true));
         assertEquals(0, resultSet.getAvailableItemCount());
+
+        assertEquals("that", resultQueue.getStatusAttributes().get("this"));
     }
 
     @Test

--- a/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
@@ -52,8 +52,8 @@ class DriverRemoteConnection(RemoteConnection):
     def submit(self, bytecode):
         result_set = self._client.submit(bytecode)
         results = result_set.all().result()
-        side_effects = RemoteTraversalSideEffects(result_set.request_id,
-                                                  self._client)
+        side_effects = RemoteTraversalSideEffects(result_set.request_id, self._client,
+                                                  result_set.status_attributes)
         return RemoteTraversal(iter(results), side_effects)
 
     def submitAsync(self, bytecode):
@@ -64,8 +64,8 @@ class DriverRemoteConnection(RemoteConnection):
             try:
                 result_set = f.result()
                 results = result_set.all().result()
-                side_effects = RemoteTraversalSideEffects(result_set.request_id,
-                                                          self._client)
+                side_effects = RemoteTraversalSideEffects(result_set.request_id, self._client,
+                                                          result_set.status_attributes)
                 future.set_result(RemoteTraversal(iter(results), side_effects))
             except Exception as e:
                 future.set_exception(e)

--- a/gremlin-python/src/main/jython/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/protocol.py
@@ -90,6 +90,7 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
         elif status_code in [200, 206]:
             result_set.stream.put_nowait(data)
             if status_code == 200:
+                result_set.status_attributes = message['status']['attributes']
                 del results_dict[request_id]
             return status_code
         else:

--- a/gremlin-python/src/main/jython/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/protocol.py
@@ -31,7 +31,13 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 
 class GremlinServerError(Exception):
-    pass
+    def __init__(self, status):
+        super(GremlinServerError, self).__init__("{0}: {1}".format(status["code"], status["message"]))
+        self._status_attributes = status["attributes"]
+
+    @property
+    def status_attributes(self):
+        return self._status_attributes        
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -95,5 +101,4 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
             return status_code
         else:
             del results_dict[request_id]
-            raise GremlinServerError(
-                "{0}: {1}".format(status_code, message["status"]["message"]))
+            raise GremlinServerError(message["status"])

--- a/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/remote_connection.py
@@ -63,12 +63,17 @@ class RemoteTraversal(traversal.Traversal):
 
 
 class RemoteTraversalSideEffects(traversal.TraversalSideEffects):
-    def __init__(self, side_effect, client):
+    def __init__(self, side_effect, client, status_attributes):
         self._side_effect = side_effect
         self._client = client
         self._keys = set()
         self._side_effects = {}
         self._closed = False
+        self._status_attributes = status_attributes
+
+    @property
+    def status_attributes(self):
+        return self._status_attributes
 
     def keys(self):
         if not self._closed:

--- a/gremlin-python/src/main/jython/gremlin_python/driver/resultset.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/resultset.py
@@ -28,6 +28,7 @@ class ResultSet:
         self._request_id = request_id
         self._done = None
         self._aggregate_to = None
+        self._status_attributes = {}
 
     @property
     def aggregate_to(self):
@@ -36,6 +37,14 @@ class ResultSet:
     @aggregate_to.setter
     def aggregate_to(self, val):
         self._aggregate_to = val
+
+    @property
+    def status_attributes(self):
+        return self._status_attributes
+
+    @status_attributes.setter
+    def status_attributes(self, val):
+        self._status_attributes = val
 
     @property
     def request_id(self):

--- a/gremlin-python/src/main/jython/tests/driver/test_client.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_client.py
@@ -52,6 +52,16 @@ def test_client_eval_traversal(client):
     assert len(client.submit('g.V()').all().result()) == 6
 
 
+def test_client_error(client):
+    try:
+        # should fire an exception
+        client.submit('1/0').all().result()
+        assert False
+    except GremlinServerError as ex:
+        assert 'exceptions' in ex.status_attributes
+        assert 'stackTrace' in ex.status_attributes
+
+
 def test_client_bytecode(client):
     g = Graph().traversal()
     t = g.V()

--- a/gremlin-python/src/main/jython/tests/driver/test_client.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_client.py
@@ -19,6 +19,7 @@ under the License.
 import pytest
 
 from gremlin_python.driver.client import Client
+from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.driver.request import RequestMessage
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.structure.graph import Graph
@@ -35,6 +36,8 @@ def test_connection(connection):
     results = future.result()
     assert len(results) == 6
     assert isinstance(results, list)
+    assert results_set.done.done()
+    assert 'host' in results_set.status_attributes
 
 
 def test_client_simple_eval(client):

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -183,6 +183,10 @@ class TestDriverRemoteConnection(object):
         assert 1 == m["ripple"]
         assert isinstance(m["lop"], long)
         assert isinstance(m["ripple"], long)
+
+        # check status attributes
+        assert "host" in t.side_effects.status_attributes
+
         ##
         t = g.V().out("created").groupCount("m").by("name").name.aggregate("n")
         results = t.toSet()

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -238,7 +238,7 @@ public abstract class AbstractOpProcessor implements OpProcessor {
      *
      * @param itty a reference to the current {@link Iterator} of results - it is not meant to be forwarded in
      *             this method
-     * @deprecated As of release 3.3.2, replaced by {@link #generateResultMetaData(ChannelHandlerContext, RequestMessage, ResponseStatusCode, Iterator, Settings)}
+     * @deprecated As of release 3.4.0, replaced by {@link #generateResultMetaData(ChannelHandlerContext, RequestMessage, ResponseStatusCode, Iterator, Settings)}
      */
     @Deprecated
     protected Map<String, Object> generateMetaData(final ChannelHandlerContext ctx, final RequestMessage msg,

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -67,7 +68,6 @@ public abstract class AbstractOpProcessor implements OpProcessor {
      *
      * @param context The Gremlin Server {@link Context} object containing settings, request message, etc.
      * @param itty The result to iterator
-     * @throws TimeoutException if the time taken to serialize the entire result set exceeds the allowable time.
      * @see #handleIterator(ResponseHandlerContext, Iterator)
      */
     protected void handleIterator(final Context context, final Iterator itty) throws InterruptedException {
@@ -146,7 +146,9 @@ public abstract class AbstractOpProcessor implements OpProcessor {
                     // thread that processed the eval of the script so, we have to push serialization down into that
                     Frame frame = null;
                     try {
-                        frame = makeFrame(rhc, msg, serializer, useBinary, aggregate, code, generateMetaData(ctx, msg, code, itty));
+                        frame = makeFrame(rhc, msg, serializer, useBinary, aggregate, code,
+                                generateResultMetaData(ctx, msg, code, itty, settings),
+                                generateStatusAttributes(ctx, msg, code, itty, settings));
                     } catch (Exception ex) {
                         // a frame may use a Bytebuf which is a countable release - if it does not get written
                         // downstream it needs to be released here
@@ -231,36 +233,71 @@ public abstract class AbstractOpProcessor implements OpProcessor {
     }
 
     /**
-     * Generates meta-data to put on a {@link ResponseMessage}.
+     * Generates response result meta-data to put on a {@link ResponseMessage}.
      *
      * @param itty a reference to the current {@link Iterator} of results - it is not meant to be forwarded in
      *             this method
+     * @deprecated As of release 3.3.2, replaced by {@link #generateResultMetaData(ChannelHandlerContext, RequestMessage, ResponseStatusCode, Iterator, Settings)}
      */
-    protected Map<String,Object> generateMetaData(final ChannelHandlerContext ctx, final RequestMessage msg,
-                                                  final ResponseStatusCode code, final Iterator itty) {
+    @Deprecated
+    protected Map<String, Object> generateMetaData(final ChannelHandlerContext ctx, final RequestMessage msg,
+                                                   final ResponseStatusCode code, final Iterator itty) {
         return Collections.emptyMap();
     }
 
     /**
-     * Caution: {@link #makeFrame(ResponseHandlerContext, RequestMessage, MessageSerializer, boolean, List, ResponseStatusCode, Map)}
+     * Generates response result meta-data to put on a {@link ResponseMessage}.
+     *
+     * @param itty a reference to the current {@link Iterator} of results - it is not meant to be forwarded in
+     *             this method
+     */
+    protected Map<String, Object> generateResultMetaData(final ChannelHandlerContext ctx, final RequestMessage msg,
+                                                         final ResponseStatusCode code, final Iterator itty,
+                                                         final Settings settings) {
+        return generateMetaData(ctx, msg, code, itty);
+    }
+
+    /**
+     * Generates response status meta-data to put on a {@link ResponseMessage}.
+     *
+     * @param itty a reference to the current {@link Iterator} of results - it is not meant to be forwarded in
+     *             this method
+     */
+    protected Map<String, Object> generateStatusAttributes(final ChannelHandlerContext ctx, final RequestMessage msg,
+                                                           final ResponseStatusCode code, final Iterator itty,
+                                                           final Settings settings) {
+        // only return server metadata on the last message
+        if (itty.hasNext()) return Collections.emptyMap();
+
+        final Map<String, Object> metaData = new HashMap<>();
+        metaData.put(Tokens.ARGS_HOST, ctx.channel().remoteAddress().toString());
+
+        return metaData;
+    }
+
+    /**
+     * Caution: {@link #makeFrame(ResponseHandlerContext, RequestMessage, MessageSerializer, boolean, List, ResponseStatusCode, Map, Map)}
      * should be used instead of this method whenever a {@link ResponseHandlerContext} is available.
      */
     protected static Frame makeFrame(final ChannelHandlerContext ctx, final RequestMessage msg,
                                      final MessageSerializer serializer, final boolean useBinary, final List<Object> aggregate,
-                                     final ResponseStatusCode code, final Map<String,Object> responseMetaData) throws Exception {
+                                     final ResponseStatusCode code, final Map<String,Object> responseMetaData,
+                                     final Map<String,Object> statusAttributes) throws Exception {
         final Context context = new Context(msg, ctx, null, null, null, null); // dummy context, good only for writing response messages to the channel
         final ResponseHandlerContext rhc = new ResponseHandlerContext(context);
-        return makeFrame(rhc, msg, serializer, useBinary, aggregate, code, responseMetaData);
+        return makeFrame(rhc, msg, serializer, useBinary, aggregate, code, responseMetaData, statusAttributes);
     }
 
     protected static Frame makeFrame(final ResponseHandlerContext rhc, final RequestMessage msg,
                                      final MessageSerializer serializer, final boolean useBinary, final List<Object> aggregate,
-                                     final ResponseStatusCode code, final Map<String,Object> responseMetaData) throws Exception {
+                                     final ResponseStatusCode code, final Map<String,Object> responseMetaData,
+                                     final Map<String,Object> statusAttributes) throws Exception {
         final ChannelHandlerContext ctx = rhc.getContext().getChannelHandlerContext();
         try {
             if (useBinary) {
                 return new Frame(serializer.serializeResponseAsBinary(ResponseMessage.build(msg)
                         .code(code)
+                        .statusAttributes(statusAttributes)
                         .responseMetaData(responseMetaData)
                         .result(aggregate).create(), ctx.alloc()));
             } else {
@@ -269,6 +306,7 @@ public abstract class AbstractOpProcessor implements OpProcessor {
                 final MessageTextSerializer textSerializer = (MessageTextSerializer) serializer;
                 return new Frame(textSerializer.serializeResponseAsString(ResponseMessage.build(msg)
                         .code(code)
+                        .statusAttributes(statusAttributes)
                         .responseMetaData(responseMetaData)
                         .result(aggregate).create()));
             }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -99,6 +99,7 @@ public abstract class AbstractOpProcessor implements OpProcessor {
             if (managedTransactionsForRequest) attemptCommit(msg, context.getGraphManager(), settings.strictTransactionManagement);
             rhc.writeAndFlush(ResponseMessage.build(msg)
                     .code(ResponseStatusCode.NO_CONTENT)
+                    .statusAttributes(generateStatusAttributes(ctx, msg, ResponseStatusCode.NO_CONTENT, itty, settings))
                     .create());
             return;
         }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -451,6 +451,9 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
     @Override
     protected Map<String, Object> generateMetaData(final ChannelHandlerContext ctx, final RequestMessage msg,
                                                    final ResponseStatusCode code, final Iterator itty) {
+        // leaving this overriding the deprecated version of this method because it provides a decent test to those
+        // who might have their own OpProcessor implementations that apply meta-data. leaving this alone helps validate
+        // that the upgrade path is clean. we can remove this in 3.4.0
         Map<String, Object> metaData = Collections.emptyMap();
         if (itty instanceof SideEffectIterator) {
             final SideEffectIterator traversalIterator = (SideEffectIterator) itty;
@@ -460,6 +463,9 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                 metaData.put(Tokens.ARGS_SIDE_EFFECT_KEY, key);
                 metaData.put(Tokens.ARGS_AGGREGATE_TO, traversalIterator.getSideEffectAggregator());
             }
+        } else {
+            // this is a standard traversal iterator
+            metaData = super.generateMetaData(ctx, msg, code, itty);
         }
 
         return metaData;
@@ -532,7 +538,9 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                     // thread that processed the eval of the script so, we have to push serialization down into that
                     Frame frame = null;
                     try {
-                        frame = makeFrame(ctx, msg, serializer, useBinary, aggregate, code, generateMetaData(ctx, msg, code, itty));
+                        frame = makeFrame(ctx, msg, serializer, useBinary, aggregate, code,
+                                generateResultMetaData(ctx, msg, code, itty, settings),
+                                generateStatusAttributes(ctx, msg, code, itty, settings));
                     } catch (Exception ex) {
                         // a frame may use a Bytebuf which is a countable release - if it does not get written
                         // downstream it needs to be released here

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -453,7 +453,7 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                                                    final ResponseStatusCode code, final Iterator itty) {
         // leaving this overriding the deprecated version of this method because it provides a decent test to those
         // who might have their own OpProcessor implementations that apply meta-data. leaving this alone helps validate
-        // that the upgrade path is clean. we can remove this in 3.4.0
+        // that the upgrade path is clean.  it can be removed at the next breaking change 3.5.0
         Map<String, Object> metaData = Collections.emptyMap();
         if (itty instanceof SideEffectIterator) {
             final SideEffectIterator traversalIterator = (SideEffectIterator) itty;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -491,6 +491,7 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
             }
             ctx.writeAndFlush(ResponseMessage.build(msg)
                     .code(ResponseStatusCode.NO_CONTENT)
+                    .statusAttributes(generateStatusAttributes(ctx, msg, ResponseStatusCode.NO_CONTENT, itty, settings))
                     .create());
             return;
         }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -90,8 +90,15 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
     }
 
     @Test
-    public void shouldReturnResponseAttributes() throws Exception {
-        final ResultSet results = client.submit("g.V()");
+    public void shouldReturnResponseAttributesViaNoContent() throws Exception {
+        final ResultSet results = client.submit("[]");
+        final Map<String,Object> attr = results.statusAttributes().get(20000, TimeUnit.MILLISECONDS);
+        assertThat(attr.containsKey(Tokens.ARGS_HOST), is(true));
+    }
+
+    @Test
+    public void shouldReturnResponseAttributesViaSuccess() throws Exception {
+        final ResultSet results = client.submit("gmodern.V()");
         final Map<String,Object> attr = results.statusAttributes().get(20000, TimeUnit.MILLISECONDS);
         assertThat(attr.containsKey(Tokens.ARGS_HOST), is(true));
     }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
+import org.apache.tinkerpop.gremlin.driver.Tokens;
 import org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin;
@@ -53,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -85,6 +87,13 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
     @After
     public void afterTest() {
         cluster.close();
+    }
+
+    @Test
+    public void shouldReturnResponseAttributes() throws Exception {
+        final ResultSet results = client.submit("g.V()");
+        final Map<String,Object> attr = results.statusAttributes().get(20000, TimeUnit.MILLISECONDS);
+        assertThat(attr.containsKey(Tokens.ARGS_HOST), is(true));
     }
 
     @Test

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -1174,7 +1174,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
-    public void shouldGetSideEffectKeysUsingWithRemote() throws Exception {
+    public void shouldGetSideEffectKeysAndStatusUsingWithRemote() throws Exception {
         final Graph graph = EmptyGraph.instance();
         final GraphTraversalSource g = graph.traversal().withRemote(conf);
         g.addV("person").property("age", 20).iterate();
@@ -1182,6 +1182,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         final GraphTraversal traversal = g.V().aggregate("a").aggregate("b");
         traversal.iterate();
         final DriverRemoteTraversalSideEffects se = (DriverRemoteTraversalSideEffects) traversal.asAdmin().getSideEffects();
+        assertThat(se.statusAttributes().containsKey(Tokens.ARGS_HOST), is(true));
 
         // Get keys
         final Set<String> sideEffectKeys = se.keys();
@@ -1204,6 +1205,11 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
         final BulkSet localBSideEffects = se.get("b");
         assertThat(localBSideEffects.isEmpty(), is(false));
+
+        final GraphTraversal gdotv = g.V();
+        gdotv.toList();
+        final DriverRemoteTraversalSideEffects gdotvSe = (DriverRemoteTraversalSideEffects) gdotv.asAdmin().getSideEffects();
+        assertThat(gdotvSe.statusAttributes().containsKey(Tokens.ARGS_HOST), is(true));
     }
 
     @Test

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessorTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessorTest.java
@@ -39,7 +39,7 @@ public class AbstractOpProcessorTest {
 
         try {
             // Induce a NullPointerException to validate error response message writing
-            AbstractOpProcessor.makeFrame(ctx, request, null, true, null, ResponseStatusCode.PARTIAL_CONTENT, null);
+            AbstractOpProcessor.makeFrame(ctx, request, null, true, null, ResponseStatusCode.PARTIAL_CONTENT, null, null);
             fail("Expected a NullPointerException");
         } catch (NullPointerException expected) {
             // nop


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1913

Status attributes have always been returned from Gremlin Server but they haven't been easy to access unless you were working with the lower end of the protocol. They are now available in a fairly wide number of ways across most of the various drivers in a fairly consistent fashion. The current gap in this feature is related to gremlin-javascript probably needs #922 - [TINKERPOP-1959](https://issues.apache.org/jira/browse/TINKERPOP-1959) so that we even have a "ResultSet" of sorts to hold the status attributes and make them available. 

Note that the travis error seems to be weirdness in travis:

```text
[ERROR] Failures:
[ERROR] org.apache.tinkerpop.gremlin.spark.structure.io.SparkContextStorageCheck.shouldSupportDirectoryFileDistinction(org.apache.tinkerpop.gremlin.spark.structure.io.SparkContextStorageCheck)
[ERROR]   Run 1: SparkContextStorageCheck.shouldSupportDirectoryFileDistinction:95->AbstractStorageCheck.checkFileDirectoryDistinction:143
``` 

don't think that's anything that's really failing.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1