### PR TITLE
Add link to Elixir language driver

### DIFF
--- a/docs/site/home/index.html
+++ b/docs/site/home/index.html
@@ -270,6 +270,7 @@ limitations under the License.
             <li><a href="https://github.com/marcelocf/gremlin_client">gremlin_client</a> (ruby) - A Gremlin Server driver for Ruby.</li>
             <li><a href="http://tinkerpop.apache.org/docs/current/reference/#connecting-via-java">gremlin-driver</a> (java) - A Gremlin Server driver for Java.</li>
             <li><a href="https://github.com/qasaur/gremgo">gremgo</a> (go) - A Gremlin Server driver for Go.</li>
+            <li><a href="https://github.com/Revmaker/gremlex">gremlex</a> (elixir) - A Gremlin Server driver for Elixir.</li>
             <li><a href="http://tinkerpop.apache.org/docs/current/reference/#gremlin-DotNet">Gremlin.Net</a> (.NET - C#) - Gremlin Server driver for .NET.</li>
             <li><a href="https://github.com/PommeVerte/gremlin-php">gremlin-php</a> (php) - A Gremlin Server driver for PHP.</li>
             <li><a href="http://tinkerpop.apache.org/docs/current/reference/#gremlin-python">gremlin-python</a> (python) - Gremlin Server driver for Python.</li>


### PR DESCRIPTION
We have an Elixir language driver for Gremlin and would like the community to be aware of it.