### PR TITLE
TINKERPOP-2039 Bump to Groovy 2.5.2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Maintained order of annotations in metrics returned from `profile()`-step.
 * Bumped to Netty 4.1.25.
 * Bumped to Spark 2.3.1.
+* Bumped to Groovy 2.5.2.
 * Modified Gremlin Server to return a "host" status attribute on responses.
 * Added ability to the Java, .NET and Python drivers to retrieve status attributes returned from the server.
 * Modified Java and Gremlin.Net `ResponseException` to include status code and status attributes.

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -41,11 +41,6 @@ limitations under the License.
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
             <version>${project.version}</version>

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -18,10 +18,11 @@
  */
 package org.apache.tinkerpop.gremlin.console
 
+import groovy.cli.picocli.CliBuilder
+import groovy.cli.picocli.OptionAccessor
 import jline.TerminalFactory
 import jline.console.history.FileHistory
 
-import org.apache.commons.cli.Option
 import org.apache.tinkerpop.gremlin.console.commands.GremlinSetCommand
 import org.apache.tinkerpop.gremlin.console.commands.InstallCommand
 import org.apache.tinkerpop.gremlin.console.commands.PluginCommand
@@ -43,8 +44,8 @@ import org.codehaus.groovy.tools.shell.Groovysh
 import org.codehaus.groovy.tools.shell.IO
 import org.codehaus.groovy.tools.shell.InteractiveShellRunner
 import org.codehaus.groovy.tools.shell.commands.SetCommand
-import org.codehaus.groovy.tools.shell.util.HelpFormatter
 import org.fusesource.jansi.Ansi
+import picocli.CommandLine
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -400,21 +401,22 @@ class Console {
 
         IO io = new IO(System.in, System.out, System.err)
 
-        final CliBuilder cli = new CliBuilder(usage: 'gremlin.sh [options] [...]', formatter: new HelpFormatter(), stopAtNonOption: false)
+        final CliBuilder cli = new CliBuilder()
+        cli.stopAtNonOption = false
+        cli.name = "gremlin.sh"
 
         // note that the inclusion of -l is really a setting handled by gremlin.sh and not by Console class itself.
         // it is mainly listed here for informational purposes when the user starts things up with -h
-        cli.with {
-            h(longOpt: 'help', "Display this help message")
-            v(longOpt: 'version', "Display the version")
-            l("Set the logging level of components that use standard logging output independent of the Console")
-            V(longOpt: 'verbose', "Enable verbose Console output")
-            Q(longOpt: 'quiet', "Suppress superfluous Console output")
-            D(longOpt: 'debug', "Enabled debug Console output")
-            i(longOpt: 'interactive', argName: "SCRIPT ARG1 ARG2 ...", args: Option.UNLIMITED_VALUES, valueSeparator: ' ' as char, "Execute the specified script and leave the console open on completion")
-            e(longOpt: 'execute', argName: "SCRIPT ARG1 ARG2 ...", args: Option.UNLIMITED_VALUES, valueSeparator: ' ' as char, "Execute the specified script (SCRIPT ARG1 ARG2 ...) and close the console on completion")
-            C(longOpt: 'color', "Disable use of ANSI colors")
-        }
+        cli.h(type: Boolean, longOpt: 'help', "Display this help message")
+        cli.v(type: Boolean,longOpt: 'version', "Display the version")
+        cli.l("Set the logging level of components that use standard logging output independent of the Console")
+        cli.V(type: Boolean, longOpt: 'verbose', "Enable verbose Console output")
+        cli.Q(type: Boolean, longOpt: 'quiet', "Suppress superfluous Console output")
+        cli.D(type: Boolean, longOpt: 'debug', "Enabled debug Console output")
+        cli.i(type: List, longOpt: 'interactive', arity: "1..*", argName: "SCRIPT ARG1 ARG2 ...", "Execute the specified script and leave the console open on completion")
+        cli.e(type: List, longOpt: 'execute', argName: "SCRIPT ARG1 ARG2 ...", "Execute the specified script (SCRIPT ARG1 ARG2 ...) and close the console on completion")
+        cli.C(type: Boolean, longOpt: 'color', "Disable use of ANSI colors")
+        
         OptionAccessor options = cli.parse(args)
 
         if (options == null) {
@@ -450,7 +452,7 @@ class Console {
             println("-i and -e options are mutually exclusive - provide one or the other")
             System.exit(0)
         }
-
+        
         def scriptAndArgs = parseArgs(options.e ? ["-e", "--execute"] : ["-i", "--interactive"], args, cli)
         new Console(io, scriptAndArgs, !options.e)
     }
@@ -472,7 +474,7 @@ class Console {
                 def parsedSet = []
                 for (ix; ix < normalizedArgs.length; ix++) {
                     // this is a do nothing as there's no arguments to the option or it's the start of a new option
-                    if (cli.options.options.any { "-" + it.opt == normalizedArgs[ix] || "--" + it.longOpt == normalizedArgs[ix] }) {
+                    if (cli.savedTypeOptions.values().any { "-" + it.opt == normalizedArgs[ix] || "--" + it.longOpt == normalizedArgs[ix] }) {
                         // rollback the counter now that we hit the next option
                         ix--
                         break

--- a/gremlin-dotnet/pom.xml
+++ b/gremlin-dotnet/pom.xml
@@ -52,7 +52,7 @@ limitations under the License.
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                         <version>${groovy.version}</version>
-                        <classifier>indy</classifier>
+                        <type>pom</type>
                         <scope>runtime</scope>
                     </dependency>
                     <dependency>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                         <version>${groovy.version}</version>
-                        <classifier>indy</classifier>
+                        <type>pom</type>
                         <scope>runtime</scope>
                     </dependency>
                 </dependencies>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -464,7 +464,7 @@ limitations under the License.
                                 <groupId>org.codehaus.groovy</groupId>
                                 <artifactId>groovy-all</artifactId>
                                 <version>${groovy.version}</version>
-                                <classifier>indy</classifier>
+                                <type>pom</type>
                                 <scope>runtime</scope>
                             </dependency>
                             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ limitations under the License.
         <commons.configuration.version>1.10</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.lang3.version>3.3.1</commons.lang3.version>
-        <groovy.version>2.4.15</groovy.version>
+        <groovy.version>2.5.2</groovy.version>
         <hadoop.version>2.7.2</hadoop.version>
         <java.tuples.version>1.2</java.tuples.version>
         <javadoc-plugin.version>2.10.4</javadoc-plugin.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2039

Required some minor changes to the Console as the CliBuilder is no longer the recommended approach for Groovy - had to use picocli classes instead. Still couldn't make the command line parsing work exclusively under picocli - I think we have somewhat nonstandard options in our command line.

Performed manual tests and builds with `mvn clean install && mvn verify -pl gremlin-console -DskipIntegrationTests=false`.

VOTE +1