### PR TITLE
TINKERPOP-2049 Added with(k) overload

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,7 +49,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Moved `Parameterizing` interface to the `org.apache.tinkerpop.gremlin.process.traversal.step` package with other marker interfaces of its type.
 * Replaced `Parameterizing.addPropertyMutations()` with `Configuring.configure()`.
 * Changed interface hierarchy for `Parameterizing` and `Mutating` interfaces as they are tightly related.
-* Introduced the `with()` step modulator which can supply configuration options to `Configuring` steps.
+* Introduced the `with(k,v)` and `with(k)` step modulators which can supply configuration options to `Configuring` steps.
 * Added `connectedComponent()` step and related `VertexProgram`.
 * Added `supportsUpsert()` option to `VertexFeatures` and `EdgeFeatures`.
 * `min()` and `max()` now support all types implementing `Comparable`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -2564,6 +2564,23 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     //// WITH-MODULATOR
 
     /**
+     * Provides a configuration to a step in the form of a key which is the same as {@code with(key, true)}. The key
+     * of the configuration must be step specific and therefore a configuration could be supplied that is not known to
+     * be valid until execution.
+     *
+     * @param key the key of the configuration to apply to a step
+     * @return the traversal with a modulated step
+     * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#with-step" target="_blank">Reference Documentation - With Step</a>
+     * @since 3.4.0
+     */
+    public default GraphTraversal<S,E> with(final String key) {
+        this.asAdmin().getBytecode().addStep(Symbols.with, key);
+        final Object[] configPair = { key, true };
+        ((Configuring) this.asAdmin().getEndStep()).configure(configPair);
+        return this;
+    }
+
+    /**
      * Provides a configuration to a step in the form of a key and value pair. The key of the configuration must be
      * step specific and therefore a configuration could be supplied that is not known to be valid until execution.
      *

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,7 +46,7 @@ public class GraphTraversalTest {
 
     private static Set<String> NO_GRAPH = new HashSet<>(Arrays.asList("asAdmin", "by", "read", "write", "with", "option", "iterate", "to", "from", "profile", "pageRank", "connectedComponent", "peerPressure", "shortestPath", "program", "none"));
     private static Set<String> NO_ANONYMOUS = new HashSet<>(Arrays.asList("start", "__"));
-    private static Set<String> IGNORES_BYTECODE = new HashSet<>(Arrays.asList("asAdmin", "read", "write", "iterate", "mapValues", "mapKeys"));
+    private static Set<String> IGNORES_BYTECODE = new HashSet<>(Arrays.asList("asAdmin", "read", "write", "iterate"));
 
     @Test
     public void shouldHaveMethodsOfGraphTraversalOnAnonymousGraphTraversal() {
@@ -100,10 +101,16 @@ public class GraphTraversalTest {
                 ///
                 if (stepMethod.getName().equals("by"))
                     traversal.order();
+                else if (stepMethod.getName().equals("with"))
+                    randomPossibleStep(random, traversal,
+                            GraphTraversal::V, GraphTraversal::shortestPath, GraphTraversal::pageRank,
+                            GraphTraversal::connectedComponent, GraphTraversal::peerPressure, t -> t.addE("link"),
+                            GraphTraversal::addV);
                 else if (stepMethod.getName().equals("option"))
                     traversal.branch(__.identity().out(randomString(random)));
                 else if (stepMethod.getName().equals("to") || stepMethod.getName().equals("from"))
                     traversal.addE(randomString(random));
+
                 if (stepMethod.getName().equals("range")) {
                     if (Scope.class.isAssignableFrom(stepMethod.getParameterTypes()[0])) {
                         list.add(arguments[0] = Scope.local);
@@ -166,7 +173,11 @@ public class GraphTraversalTest {
         }
     }
 
-    private final static String randomString(final Random random) {
+    private static void randomPossibleStep(final Random random, final GraphTraversal t, final Consumer<GraphTraversal>... possible) {
+        possible[random.nextInt(possible.length)].accept(t);
+    }
+
+    private static String randomString(final Random random) {
         String s = "";
         for (int i = 0; i < random.nextInt(10) + 1; i++) {
             s = (s + (char) (random.nextInt(100) + 1)).trim();

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -1724,6 +1724,15 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the with step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
+        public GraphTraversal<S, E> With (string key)
+        {
+            Bytecode.AddStep("with", key);
+            return Wrap<S, E>(this);
+        }
+
+        /// <summary>
+        ///     Adds the with step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
         public GraphTraversal<S, E> With (string key, object value)
         {
             Bytecode.AddStep("with", key, value);

--- a/gremlin-test/features/map/ShortestPath.feature
+++ b/gremlin-test/features/map/ShortestPath.feature
@@ -113,7 +113,7 @@ Feature: Step - shortestPath()
     Given the modern graph
     And the traversal of
       """
-      g.withComputer().V().shortestPath().with("~tinkerpop.shortestPath.includeEdges", true)
+      g.withComputer().V().shortestPath().with("~tinkerpop.shortestPath.includeEdges")
       """
     When iterated to list
     Then the result should be unordered
@@ -206,7 +206,7 @@ Feature: Step - shortestPath()
     And the traversal of
       """
       g.withComputer().V().shortestPath().
-          with("~tinkerpop.shortestPath.includeEdges", true).
+          with("~tinkerpop.shortestPath.includeEdges").
           with("~tinkerpop.shortestPath.edges", __.outE())
       """
     When iterated to list

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ShortestPathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ShortestPathTest.java
@@ -276,7 +276,7 @@ public abstract class ShortestPathTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Path> get_g_V_shortestPath_edgesIncluded() {
-            return g.V().shortestPath().with(includeEdges, true);
+            return g.V().shortestPath().with(includeEdges);
         }
 
         @Override
@@ -291,7 +291,7 @@ public abstract class ShortestPathTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Path> get_g_V_shortestPath_edgesIncluded_edgesXoutEX() {
-            return g.V().shortestPath().with(includeEdges, true).with(edges, __.outE());
+            return g.V().shortestPath().with(includeEdges).with(edges, __.outE());
         }
 
         @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2049

Makes flag-like uses of with() a bit more succinct. Basically, the shorthand of `with(k,true)` is simply `with(k)`.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1