### PR TITLE
TINKERPOP-2044 Configurable traversal to validate host connectivity.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added synchronized `Map` to Gryo 1.0 registrations.
 * Added `Triple` to Gryo 1.0 registrations.
 * Improved escaping of special characters in strings passed to the `GroovyTranslator`.
+* Added `Cluster` configuration option to set a custom validation script to use to test server connectivity in the Java driver.
 * Improved ability of `GroovyTranslator` to handle more types supported by GraphSON.
 * Improved ability of `GroovyTranslator` to handle custom types.
 * Added better internal processing of `Column` in `by(Function)`.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -750,6 +750,7 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.sslSkipCertValidation |Configures the `TrustManager` to trust all certs without any validation. Should not be used in production.|false
 |connectionPool.trustStore |File location for a SSL Certificate Chain to use when SSL is enabled. If this value is not provided and SSL is enabled, the default `TrustManager` will be used. |_none_
 |connectionPool.trustStorePassword |The password of the `trustStore` if it is password-protected |_none_
+|connectionPool.validationRequest |A script that is used to test server connectivity. A good script to use is one that evaluates quickly and returns no data. The default simply returns an empty string, but if a graph is required by a particular provider, a good traversal might be `g.inject()`. |_''_
 |hosts |The list of hosts that the driver will connect to. |localhost
 |jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -387,7 +387,6 @@ final class ConnectionPool {
 
         // let the load-balancer know that the host is acting poorly
         this.cluster.loadBalancingStrategy().onUnavailable(host);
-
     }
 
     /**
@@ -400,7 +399,7 @@ final class ConnectionPool {
         Connection connection = null;
         try {
             connection = borrowConnection(cluster.connectionPoolSettings().maxWaitForConnection, TimeUnit.MILLISECONDS);
-            final RequestMessage ping = RequestMessage.build(Tokens.OPS_EVAL).add(Tokens.ARGS_GREMLIN, "''").create();
+            final RequestMessage ping = client.buildMessage(cluster.validationRequest()).create();
             final CompletableFuture<ResultSet> f = new CompletableFuture<>();
             connection.write(ping, f);
             f.get().all().get();

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -243,6 +243,8 @@ final class Settings {
             if (connectionPoolConf.containsKey("keepAliveInterval"))
                 cpSettings.keepAliveInterval = connectionPoolConf.getLong("keepAliveInterval");
 
+            if (connectionPoolConf.containsKey("validationRequest"))
+                cpSettings.validationRequest = connectionPoolConf.getString("validationRequest");
 
             settings.connectionPool = cpSettings;
         }
@@ -258,28 +260,28 @@ final class Settings {
 
         /**
          * The trusted certificate in PEM format.
-         * @deprecated As of release 3.2.10, replaced by {@link trustStore}
+         * @deprecated As of release 3.2.10, replaced by {@link #trustStore}
          */
         @Deprecated
         public String trustCertChainFile = null;
 
         /**
          * The X.509 certificate chain file in PEM format.
-         * @deprecated As of release 3.2.10, replaced by {@link keyStore}
+         * @deprecated As of release 3.2.10, replaced by {@link #keyStore}
          */
         @Deprecated
         public String keyCertChainFile = null;
 
         /**
          * The PKCS#8 private key file in PEM format.
-         * @deprecated As of release 3.2.10, replaced by {@link keyStore}
+         * @deprecated As of release 3.2.10, replaced by {@link #keyStore}
          */
         @Deprecated
         public String keyFile = null;
 
         /**
          * The password of the {@link #keyFile}, or {@code null} if it's not password-protected.
-         * @deprecated As of release 3.2.10, replaced by {@link keyStorePassword}
+         * @deprecated As of release 3.2.10, replaced by {@link #keyStorePassword}
          */
         @Deprecated
         public String keyPassword = null;
@@ -418,6 +420,11 @@ final class Settings {
          * {@link org.apache.tinkerpop.gremlin.driver.Channelizer.WebSocketChannelizer}.
          */
         public String channelizer = Channelizer.WebSocketChannelizer.class.getName();
+
+        /**
+         * A valid Gremlin script that can be used to test remote operations.
+         */
+        public String validationRequest = "''";
 
         /**
          * @deprecated as of 3.1.1-incubating, and not replaced as this property was never implemented internally

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
@@ -69,6 +71,7 @@ public class SettingsTest {
         conf.setProperty("connectionPool.reconnectInitialDelay", 1000);
         conf.setProperty("connectionPool.resultIterationBatchSize", 1100);
         conf.setProperty("connectionPool.channelizer", "channelizer0");
+        conf.setProperty("connectionPool.validationRequest", "g.inject()");
 
         final Settings settings = Settings.from(conf);
 
@@ -82,7 +85,7 @@ public class SettingsTest {
         assertEquals(Arrays.asList("255.0.0.1", "255.0.0.2", "255.0.0.3"), settings.hosts);
         assertEquals("my.serializers.MySerializer", settings.serializer.className);
         assertEquals("thing", settings.serializer.config.get("any"));
-        assertEquals(true, settings.connectionPool.enableSsl);
+        assertThat(settings.connectionPool.enableSsl, is(true));
         assertEquals("X.509", settings.connectionPool.keyCertChainFile);
         assertEquals("PKCS#8", settings.connectionPool.keyFile);
         assertEquals("password1", settings.connectionPool.keyPassword);
@@ -94,7 +97,7 @@ public class SettingsTest {
         assertEquals("password3", settings.connectionPool.trustStorePassword);
         assertEquals(Arrays.asList("TLSv1.1","TLSv1.2"), settings.connectionPool.sslEnabledProtocols);
         assertEquals(Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"), settings.connectionPool.sslCipherSuites);
-        assertEquals(true, settings.connectionPool.sslSkipCertValidation);
+        assertThat(settings.connectionPool.sslSkipCertValidation, is(true));
         assertEquals(100, settings.connectionPool.minSize);
         assertEquals(200, settings.connectionPool.maxSize);
         assertEquals(300, settings.connectionPool.minSimultaneousUsagePerConnection);
@@ -107,5 +110,6 @@ public class SettingsTest {
         assertEquals(1000, settings.connectionPool.reconnectInitialDelay);
         assertEquals(1100, settings.connectionPool.resultIterationBatchSize);
         assertEquals("channelizer0", settings.connectionPool.channelizer);
+        assertEquals("g.inject()", settings.connectionPool.validationRequest);
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -285,10 +285,35 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
-    public void shouldEventuallySucceedOnSameServer() throws Exception {
+    public void shouldEventuallySucceedOnSameServerWithDefault() throws Exception {
         stopServer();
 
         final Cluster cluster = TestClientFactory.open();
+        final Client client = cluster.connect();
+
+        try {
+            client.submit("1+1").all().join().get(0).getInt();
+            fail("Should not have gone through because the server is not running");
+        } catch (Exception i) {
+            final Throwable root = ExceptionUtils.getRootCause(i);
+            assertThat(root, instanceOf(TimeoutException.class));
+        }
+
+        startServer();
+
+        // default reconnect time is 1 second so wait some extra time to be sure it has time to try to bring it
+        // back to life
+        TimeUnit.SECONDS.sleep(3);
+        assertEquals(2, client.submit("1+1").all().join().get(0).getInt());
+
+        cluster.close();
+    }
+
+    @Test
+    public void shouldEventuallySucceedOnSameServerWithScript() throws Exception {
+        stopServer();
+
+        final Cluster cluster = TestClientFactory.build().validationRequest("g.inject()").create();
         final Client client = cluster.connect();
 
         try {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2044

The user can now configure the script used to validate the operations of the remote.

```text
Cluster cluster = Cluster.build().validationRequest("g.inject()").create()
```

Builds with `mvn clean install -pl gremlin-driver && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1