### PR TITLE
TINKERPOP-2037 removed groovy-sql

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
 * Added text predicates.
+* Removed groovy-sql
 * Rewrote `ConnectiveStrategy` to support an arbitrary number of infix notations in a single traversal.
 * GraphSON `MessageSerializer`s will automatically register the GremlinServerModule to a provided GraphSONMapper.
 * Removed support for `-i` option in Gremlin Server which was previously deprecated.

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -44,6 +44,25 @@ gremlin> g.V().has("person","name", containing("o").and(gte("j").and(endingWith(
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2041[TINKERPOP-2041]
 
+==== Removed groovy-sql dependency
+
+Gremlin Console and Gremlin Server no longer include groovy-sql.  If you depend on groovy-sql,
+you can install it in Gremlin Console or Gremlin Server using the plugin system.
+
+Console:
+```
+:install org.codehaus.groovy groovy-sql 2.5.2
+```
+
+Server:
+```
+bin/gremlin-server.sh install org.codehaus.groovy groovy-sql 2.5.2
+```
+
+If your project depended on groovy-sql transitively, simply include it in your project's build file (e.g. maven: pom.xml).
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2037[TINKERPOP-2037]
+
 ==== Changed infix behavior
 
 The infix notation of `and()` and `or()` now supports an arbitrary number of traversals and `ConnectiveStrategy` produces a traversal with proper AND and OR semantics.

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -56,19 +56,6 @@ limitations under the License.
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-sql</artifactId>
-            <version>${groovy.version}</version>
-            <classifier>indy</classifier>
-            <exclusions>
-                <!-- exclude non-indy type -->
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>


### PR DESCRIPTION

Removed unused groovy-sql dependency.

https://issues.apache.org/jira/browse/TINKERPOP-2037

`sh docker/build.sh -i -t` BUILD SUCCESS

VOTE +1
