### PR TITLE
TINKERPOP-2055 Support NaN and Infinity in GraphSON

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added support for GraphSON serialization of `Date` in Javascript.
 * Added synchronized `Map` to Gryo 1.0 registrations.
 * Added `Triple` to Gryo 1.0 registrations.
+* Added support for `Double.NaN`, `Double.POSITIVE_INFINITY` and `Double.NEGATIVE_INFINITY`.
 * Improved escaping of special characters in strings passed to the `GroovyTranslator`.
 * Added better internal processing of `Column` in `by(Function)`.
 * Added `hasNext()` support on `Traversal` for `gremlin-python`.

--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -1491,6 +1491,8 @@ types. By default, TinkerPop types will have the namespace "g" (or "gx" for "ext
 
 ==== Double
 
+While the `@value` is expected to be a JSON number, it might also be a `String` of `NaN`, `Infinity` or `-Infinity`.
+
 [source,json]
 ----
 {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2d0.java
@@ -677,7 +677,7 @@ class GraphSONSerializersV2d0 {
         }
 
         @Override
-        public Integer deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        public Integer deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
             return jsonParser.getIntValue();
         }
 
@@ -694,8 +694,21 @@ class GraphSONSerializersV2d0 {
         }
 
         @Override
-        public Double deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
-            return jsonParser.getDoubleValue();
+        public Double deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+            if (jsonParser.getCurrentToken().isNumeric())
+                return jsonParser.getDoubleValue();
+            else  {
+                final String numberText = jsonParser.getValueAsString();
+                if ("NaN".equalsIgnoreCase(numberText))
+                    return Double.NaN;
+                else if ("-Infinity".equals(numberText) || "-INF".equalsIgnoreCase(numberText))
+                    return Double.NEGATIVE_INFINITY;
+                else if ("Infinity".equals(numberText) || "INF".equals(numberText))
+                    return Double.POSITIVE_INFINITY;
+                else
+                    throw new IllegalStateException("Double value unexpected: " + numberText);
+            }
+
         }
 
         @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
@@ -42,7 +42,9 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -70,6 +72,19 @@ public class GraphSONMapperEmbeddedTypeTest extends AbstractGraphSONTest {
 
     @Parameterized.Parameter(0)
     public String version;
+
+    @Test
+    public void shouldHandleNumberConstants() throws Exception {
+        assumeThat(version, startsWith("v2"));
+
+        final List<Object> o = new ArrayList<>();
+        o.add(123.321d);
+        o.add(Double.NaN);
+        o.add(Double.NEGATIVE_INFINITY);
+        o.add(Double.POSITIVE_INFINITY);
+
+        assertEquals(o, serializeDeserialize(mapper, o, List.class));
+    }
 
     @Test
     public void shouldHandleBiFunctionLambda() throws Exception {

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONReaderTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONReaderTests.cs
@@ -24,11 +24,9 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure;
 using Gremlin.Net.Structure.IO.GraphSON;
 using Moq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -175,6 +173,42 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
             var deserializedValue = reader.ToObject(jObject);
 
             Assert.Equal(31.2, deserializedValue);
+        }
+
+        [Fact]
+        public void ShouldDeserializeNaN()
+        {
+            var serializedValue = "{\"@type\":\"g:Double\",\"@value\":'NaN'}";
+            var reader = CreateStandardGraphSONReader();
+
+            var jObject = JObject.Parse(serializedValue);
+            var deserializedValue = reader.ToObject(jObject);
+
+            Assert.Equal(Double.NaN, deserializedValue);
+        }
+
+        [Fact]
+        public void ShouldDeserializePositiveInfinity()
+        {
+            var serializedValue = "{\"@type\":\"g:Double\",\"@value\":'Infinity'}";
+            var reader = CreateStandardGraphSONReader();
+
+            var jObject = JObject.Parse(serializedValue);
+            var deserializedValue = reader.ToObject(jObject);
+
+            Assert.Equal(Double.PositiveInfinity, deserializedValue);
+        }
+
+        [Fact]
+        public void ShouldDeserializeNegativeInfinity()
+        {
+            var serializedValue = "{\"@type\":\"g:Double\",\"@value\":'-Infinity'}";
+            var reader = CreateStandardGraphSONReader();
+
+            var jObject = JObject.Parse(serializedValue);
+            var deserializedValue = reader.ToObject(jObject);
+
+            Assert.Equal(Double.NegativeInfinity, deserializedValue);
         }
 
         [Fact]

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONWriterTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSONWriterTests.cs
@@ -81,6 +81,36 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON
         }
 
         [Fact]
+        public void ShouldSerializeNaN()
+        {
+            var writer = CreateStandardGraphSONWriter();
+
+            var graphSon = writer.WriteObject(Double.NaN);
+
+            Assert.Equal("{\"@type\":\"g:Double\",\"@value\":\"NaN\"}", graphSon);
+        }
+
+        [Fact]
+        public void ShouldSerializePositiveInfinity()
+        {
+            var writer = CreateStandardGraphSONWriter();
+
+            var graphSon = writer.WriteObject(Double.PositiveInfinity);
+
+            Assert.Equal("{\"@type\":\"g:Double\",\"@value\":\"Infinity\"}", graphSon);
+        }
+
+        [Fact]
+        public void ShouldSerializeNegativeInfinity()
+        {
+            var writer = CreateStandardGraphSONWriter();
+
+            var graphSon = writer.WriteObject(Double.NegativeInfinity);
+
+            Assert.Equal("{\"@type\":\"g:Double\",\"@value\":\"-Infinity\"}", graphSon);
+        }
+
+        [Fact]
         public void ShouldSerializeDecimal()
         {
             var writer = CreateStandardGraphSONWriter();

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/type-serializers.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/type-serializers.js
@@ -49,11 +49,37 @@ class TypeSerializer {
 
 class NumberSerializer extends TypeSerializer {
   serialize(item) {
-    return item;
+    if (isNaN(item)) {
+      return {
+        [typeKey]: 'g:Double',
+        [valueKey]: 'NaN'
+      };
+    } else if (item === Number.POSITIVE_INFINITY) {
+      return {
+        [typeKey]: 'g:Double',
+        [valueKey]: 'Infinity'
+      };
+    } else if (item === Number.NEGATIVE_INFINITY) {
+      return {
+        [typeKey]: 'g:Double',
+        [valueKey]: '-Infinity'
+      };
+    } else {
+      return item;
+    }
   }
 
   deserialize(obj) {
-    return parseFloat(obj[valueKey]);
+    var val = obj[valueKey];
+    if (val === 'NaN') {
+      return NaN;
+    } else if (val === 'Infinity') {
+      return Number.POSITIVE_INFINITY;
+    } else if (val === '-Infinity') {
+      return Number.NEGATIVE_INFINITY;
+    } else {
+      return parseFloat(val);
+    }
   }
 
   canBeUsedFor(value) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
@@ -46,6 +46,30 @@ describe('GraphSONReader', function () {
       assert.strictEqual(result, item[1]);
     });
   });
+  it('should parse GraphSON Nan from GraphSON', function () {
+      const reader = new GraphSONReader();
+      var result = reader.read({
+                "@type": "g:Double",
+                "@value": "NaN"
+              });
+      assert.ok(isNaN(result));
+  });
+  it('should parse GraphSON -Infinity and Nan from GraphSON', function () {
+      const reader = new GraphSONReader();
+      var result = reader.read({
+                "@type": "g:Double",
+                "@value": "-Infinity"
+              });
+      assert.strictEqual(result, Number.NEGATIVE_INFINITY);
+  });
+  it('should parse GraphSON Infinity and Nan from GraphSON', function () {
+      const reader = new GraphSONReader();
+      var result = reader.read({
+                "@type": "g:Double",
+                "@value": "Infinity"
+              });
+      assert.strictEqual(result, Number.POSITIVE_INFINITY);
+  });
   it('should parse Date', function() {
     const obj = { "@type" : "g:Date", "@value" : 1481750076295 };
     const reader = new GraphSONReader();
@@ -101,6 +125,21 @@ describe('GraphSONWriter', function () {
   it('should write numbers', function () {
     const writer = new GraphSONWriter();
     assert.strictEqual(writer.write(2), '2');
+  });
+  it('should write NaN', function () {
+    const writer = new GraphSONWriter();
+    const expected = JSON.stringify({ "@type" : "g:Double", "@value" : "NaN" });
+    assert.strictEqual(writer.write(NaN), expected);
+  });
+  it('should write Infinity', function () {
+    const writer = new GraphSONWriter();
+    const expected = JSON.stringify({ "@type" : "g:Double", "@value" : "Infinity" });
+    assert.strictEqual(writer.write(Number.POSITIVE_INFINITY), expected);
+  });
+  it('should write -Infinity', function () {
+    const writer = new GraphSONWriter();
+    const expected = JSON.stringify({ "@type" : "g:Double", "@value" : "-Infinity" });
+    assert.strictEqual(writer.write(Number.NEGATIVE_INFINITY), expected);
   });
   it('should write Date', function() {
     const writer = new GraphSONWriter();

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
@@ -46,7 +46,7 @@ describe('GraphSONReader', function () {
       assert.strictEqual(result, item[1]);
     });
   });
-  it('should parse GraphSON Nan from GraphSON', function () {
+  it('should parse GraphSON NaN from GraphSON', function () {
       const reader = new GraphSONReader();
       var result = reader.read({
                 "@type": "g:Double",
@@ -54,7 +54,7 @@ describe('GraphSONReader', function () {
               });
       assert.ok(isNaN(result));
   });
-  it('should parse GraphSON -Infinity and Nan from GraphSON', function () {
+  it('should parse GraphSON -Infinity from GraphSON', function () {
       const reader = new GraphSONReader();
       var result = reader.read({
                 "@type": "g:Double",
@@ -62,7 +62,7 @@ describe('GraphSONReader', function () {
               });
       assert.strictEqual(result, Number.NEGATIVE_INFINITY);
   });
-  it('should parse GraphSON Infinity and Nan from GraphSON', function () {
+  it('should parse GraphSON Infinity from GraphSON', function () {
       const reader = new GraphSONReader();
       var result = reader.read({
                 "@type": "g:Double",

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphson.py
@@ -20,6 +20,7 @@ import datetime
 import json
 import time
 import uuid
+import math
 from collections import OrderedDict
 
 import six
@@ -380,6 +381,31 @@ class FloatIO(_NumberIO):
     python_type = FloatType
     graphson_type = "g:Float"
     graphson_base_type = "Float"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        if isinstance(n, bool):  # because isinstance(False, int) and isinstance(True, int)
+            return n
+        elif math.isnan(n):
+            return GraphSONUtil.typedValue(cls.graphson_base_type, "NaN")
+        elif math.isinf(n) and n > 0:
+            return GraphSONUtil.typedValue(cls.graphson_base_type, "Infinity")
+        elif math.isinf(n) and n < 0:
+            return GraphSONUtil.typedValue(cls.graphson_base_type, "-Infinity")
+        else:
+            return GraphSONUtil.typedValue(cls.graphson_base_type, n)
+
+    @classmethod
+    def objectify(cls, v, _):
+        if isinstance(v, str):
+            if v == 'NaN':
+                return float('nan')
+            elif v == "Infinity":
+                return float('inf')
+            elif v == "-Infinity":
+                return float('-inf')
+
+        return cls.python_type(v)
 
 
 class DoubleIO(FloatIO):

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphson.py
@@ -22,6 +22,7 @@ import datetime
 import time
 import json
 import uuid
+import math
 
 from mock import Mock
 
@@ -70,6 +71,27 @@ class TestGraphSONReader(object):
         }))
         assert isinstance(x, float)
         assert 31.2 == x
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "g:Double",
+            "@value": "NaN"
+        }))
+        assert isinstance(x, float)
+        assert math.isnan(x)
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "g:Double",
+            "@value": "Infinity"
+        }))
+        assert isinstance(x, float)
+        assert math.isinf(x) and x > 0
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "g:Double",
+            "@value": "-Infinity"
+        }))
+        assert isinstance(x, float)
+        assert math.isinf(x) and x < 0
 
     def test_graph(self):
         vertex = self.graphson_reader.readObject(
@@ -163,6 +185,9 @@ class TestGraphSONWriter(object):
         assert {"@type": "g:Int64", "@value": 2} == json.loads(self.graphson_writer.writeObject(long(2)))
         assert {"@type": "g:Int32", "@value": 1} == json.loads(self.graphson_writer.writeObject(1))
         assert {"@type": "g:Double", "@value": 3.2} == json.loads(self.graphson_writer.writeObject(3.2))
+        assert {"@type": "g:Double", "@value": "NaN"} == json.loads(self.graphson_writer.writeObject(float('nan')))
+        assert {"@type": "g:Double", "@value": "Infinity"} == json.loads(self.graphson_writer.writeObject(float('inf')))
+        assert {"@type": "g:Double", "@value": "-Infinity"} == json.loads(self.graphson_writer.writeObject(float('-inf')))
         assert """true""" == self.graphson_writer.writeObject(True)
 
     def test_P(self):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2055

GraphSON wasn't supporting NaN and Infinity but Gryo was. Merging to tp33 and forward will require some additional commits for GraphSON 3.0.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1