### PR TITLE
Optimizes Map with enum using the EnumMap implementation [tp32]

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -80,7 +81,7 @@ public final class GraphFilter implements Cloneable, Serializable {
 
     private Traversal.Admin<Vertex, Vertex> vertexFilter = null;
     private Traversal.Admin<Vertex, Edge> edgeFilter = null;
-    private Map<Direction, Map<String, Legal>> edgeLegality = new HashMap<>();
+    private Map<Direction, Map<String, Legal>> edgeLegality = new EnumMap<>(Direction.class);
     private boolean allowNoEdges = false;
 
     public GraphFilter() {
@@ -118,7 +119,7 @@ public final class GraphFilter implements Cloneable, Serializable {
             throw GraphComputer.Exceptions.edgeFilterAccessesAdjacentVertices(edgeFilter);
         this.edgeFilter = edgeFilter.asAdmin().clone();
         ////
-        this.edgeLegality = new HashMap<>();
+        this.edgeLegality = new EnumMap<>(Direction.class);
         this.edgeLegality.put(Direction.OUT, new HashMap<>());
         this.edgeLegality.put(Direction.IN, new HashMap<>());
         this.edgeLegality.put(Direction.BOTH, new HashMap<>());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/optimization/GraphFilterStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/optimization/GraphFilterStrategy.java
@@ -39,7 +39,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -77,7 +77,7 @@ public final class GraphFilterStrategy extends AbstractTraversalStrategy<Travers
             return null; // if the traversal is an edge traversal, don't filter (this can be made less stringent)
         if (TraversalHelper.hasStepOfAssignableClassRecursively(LambdaHolder.class, traversal))
             return null; // if the traversal contains lambdas, don't filter as you don't know what is being accessed by the lambdas
-        final Map<Direction, Set<String>> directionLabels = new HashMap<>();
+        final Map<Direction, Set<String>> directionLabels = new EnumMap<>(Direction.class);
         final Set<String> outLabels = new HashSet<>();
         final Set<String> inLabels = new HashSet<>();
         final Set<String> bothLabels = new HashSet<>();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.structure.util.star;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,7 +35,7 @@ import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedSeri
  */
 public final class StarGraphGryoSerializer extends ShadedSerializerAdapter<StarGraph>  {
 
-    private static final Map<Direction, StarGraphGryoSerializer> CACHE = new HashMap<>();
+    private static final Map<Direction, StarGraphGryoSerializer> CACHE = new EnumMap<>(Direction.class);
 
     static {
         CACHE.put(Direction.BOTH, new StarGraphGryoSerializer(Direction.BOTH));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.structure.util.star;
 
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +34,7 @@ import org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedSeri
  */
 public final class StarGraphGryoSerializer extends ShadedSerializerAdapter<StarGraph>  {
 
-    private static final Map<Direction, StarGraphGryoSerializer> CACHE = new EnumMap<>(Direction.class);
+    private static final Map<Direction, StarGraphGryoSerializer> CACHE = new HashMap<>();
 
     static {
         CACHE.put(Direction.BOTH, new StarGraphGryoSerializer(Direction.BOTH));


### PR DESCRIPTION
This PR replaces the HashMap implementation to [EnumMap](https://docs.oracle.com/javase/8/docs/api/java/util/EnumMap.html) that as its documentation says:

> A specialized Map implementation for use with enum type keys. All of the keys in an enum map must come from a single enum type that is specified, explicitly or implicitly, when the map is created. Enum maps are represented internally as arrays. This representation is extremely compact and efficient.