### PR TITLE
TINKERPOP-2056 Use NumberHelper in Compare

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Compare.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Compare.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
-import java.math.BigDecimal;
 import java.util.function.BiPredicate;
 
 /**
@@ -28,14 +27,13 @@ import java.util.function.BiPredicate;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
  * @author Matt Frantz (http://github.com/mhfrantz)
+ * @author Daniel Kuppitz (http://gemlin.guru)
  */
 public enum Compare implements BiPredicate<Object, Object> {
+
     /**
-     * Evaluates if the first object is equal to the second.  If both are of type {@link Number} but not of the
-     * same class (i.e. double for the first object and long for the second object) both values are converted to
-     * {@link BigDecimal} so that it can be evaluated via {@link BigDecimal#compareTo}.  Otherwise they are evaluated
-     * via {@link Object#equals(Object)}.  Testing against {@link Number#doubleValue()} enables the compare
-     * operations to be a bit more forgiving with respect to comparing different number types.
+     * Evaluates if the first object is equal to the second. If both are of type {@link Number}, {@link NumberHelper}
+     * will be used for the comparison, thus enabling the comparison of only values, ignoring the number types.
      *
      * @since 3.0.0-incubating
      */
@@ -43,8 +41,7 @@ public enum Compare implements BiPredicate<Object, Object> {
         @Override
         public boolean test(final Object first, final Object second) {
             return null == first ? null == second : (first instanceof Number && second instanceof Number
-                    && !first.getClass().equals(second.getClass())
-                    ? big((Number) first).compareTo(big((Number) second)) == 0
+                    ? NumberHelper.compare((Number) first, (Number) second) == 0
                     : first.equals(second));
         }
 
@@ -58,11 +55,8 @@ public enum Compare implements BiPredicate<Object, Object> {
     },
 
     /**
-     * Evaluates if the first object is not equal to the second.  If both are of type {@link Number} but not of the
-     * same class (i.e. double for the first object and long for the second object) both values are converted to
-     * {@link BigDecimal} so that it can be evaluated via {@link BigDecimal#equals}.  Otherwise they are evaluated
-     * via {@link Object#equals(Object)}.  Testing against {@link Number#doubleValue()} enables the compare
-     * operations to be a bit more forgiving with respect to comparing different number types.
+     * Evaluates if the first object is not equal to the second. If both are of type {@link Number}, {@link NumberHelper}
+     * will be used for the comparison, thus enabling the comparison of only values, ignoring the number types.
      *
      * @since 3.0.0-incubating
      */
@@ -82,11 +76,8 @@ public enum Compare implements BiPredicate<Object, Object> {
     },
 
     /**
-     * Evaluates if the first object is greater than the second.  If both are of type {@link Number} but not of the
-     * same class (i.e. double for the first object and long for the second object) both values are converted to
-     * {@link BigDecimal} so that it can be evaluated via {@link BigDecimal#compareTo}.  Otherwise they are evaluated
-     * via {@link Comparable#compareTo(Object)}.  Testing against {@link BigDecimal#compareTo} enables the compare
-     * operations to be a bit more forgiving with respect to comparing different number types.
+     * Evaluates if the first object is greater than the second. If both are of type {@link Number}, {@link NumberHelper}
+     * will be used for the comparison, thus enabling the comparison of only values, ignoring the number types.
      *
      * @since 3.0.0-incubating
      */
@@ -94,8 +85,8 @@ public enum Compare implements BiPredicate<Object, Object> {
         @Override
         public boolean test(final Object first, final Object second) {
             return null != first && null != second && (
-                    first instanceof Number && second instanceof Number && !first.getClass().equals(second.getClass())
-                            ? big((Number) first).compareTo(big((Number) second)) > 0
+                    first instanceof Number && second instanceof Number
+                            ? NumberHelper.compare((Number) first, (Number) second) > 0
                             : ((Comparable) first).compareTo(second) > 0);
         }
 
@@ -109,11 +100,8 @@ public enum Compare implements BiPredicate<Object, Object> {
     },
 
     /**
-     * Evaluates if the first object is greater-equal to the second.  If both are of type {@link Number} but not of the
-     * same class (i.e. double for the first object and long for the second object) both values are converted to
-     * {@link BigDecimal} so that it can be evaluated via {@link BigDecimal#compareTo}.  Otherwise they are evaluated
-     * via {@link Comparable#compareTo(Object)}.  Testing against {@link BigDecimal#compareTo} enables the compare
-     * operations to be a bit more forgiving with respect to comparing different number types.
+     * Evaluates if the first object is greater-equal to the second. If both are of type {@link Number}, {@link NumberHelper}
+     * will be used for the comparison, thus enabling the comparison of only values, ignoring the number types.
      *
      * @since 3.0.0-incubating
      */
@@ -133,11 +121,8 @@ public enum Compare implements BiPredicate<Object, Object> {
     },
 
     /**
-     * Evaluates if the first object is less than the second.  If both are of type {@link Number} but not of the
-     * same class (i.e. double for the first object and long for the second object) both values are converted to
-     * {@link BigDecimal} so that it can be evaluated via {@link BigDecimal#compareTo}.  Otherwise they are evaluated
-     * via {@link Comparable#compareTo(Object)}.  Testing against {@link BigDecimal#compareTo} enables the compare
-     * operations to be a bit more forgiving with respect to comparing different number types.
+     * Evaluates if the first object is less than the second. If both are of type {@link Number}, {@link NumberHelper}
+     * will be used for the comparison, thus enabling the comparison of only values, ignoring the number types.
      *
      * @since 3.0.0-incubating
      */
@@ -145,8 +130,8 @@ public enum Compare implements BiPredicate<Object, Object> {
         @Override
         public boolean test(final Object first, final Object second) {
             return null != first && null != second && (
-                    first instanceof Number && second instanceof Number && !first.getClass().equals(second.getClass())
-                            ? big((Number) first).compareTo(big((Number) second)) < 0
+                    first instanceof Number && second instanceof Number
+                            ? NumberHelper.compare((Number) first, (Number) second) < 0
                             : ((Comparable) first).compareTo(second) < 0);
         }
 
@@ -160,11 +145,8 @@ public enum Compare implements BiPredicate<Object, Object> {
     },
 
     /**
-     * Evaluates if the first object is less-equal to the second.  If both are of type {@link Number} but not of the
-     * same class (i.e. double for the first object and long for the second object) both values are converted to
-     * {@link BigDecimal} so that it can be evaluated via {@link BigDecimal#compareTo}.  Otherwise they are evaluated
-     * via {@link Comparable#compareTo(Object)}.  Testing against {@link BigDecimal#compareTo} enables the compare
-     * operations to be a bit more forgiving with respect to comparing different number types.
+     * Evaluates if the first object is less-equal to the second. If both are of type {@link Number}, {@link NumberHelper}
+     * will be used for the comparison, thus enabling the comparison of only values, ignoring the number types.
      *
      * @since 3.0.0-incubating
      */
@@ -188,11 +170,4 @@ public enum Compare implements BiPredicate<Object, Object> {
      */
     @Override
     public abstract Compare negate();
-
-    /**
-     * Convert Number to BigDecimal.
-     */
-    private static BigDecimal big(final Number n) {
-        return new BigDecimal(n.toString());
-    }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/PTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/PTest.java
@@ -29,6 +29,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Random;
 import java.util.function.Predicate;
 
@@ -109,8 +110,13 @@ public class PTest {
         @Test
         public void shouldTest() {
             assertEquals(expected, predicate.test(value));
-            assertEquals(!expected, predicate.clone().negate().test(value));
-            assertEquals(!expected, P.not(predicate).test(value));
+            assertNotEquals(expected, predicate.clone().negate().test(value));
+            assertNotEquals(expected, P.not(predicate.clone()).test(value));
+            if (value instanceof Number && !(predicate.biPredicate instanceof Contains)) {
+                assertEquals(expected, predicate.test(((Number) value).longValue()));
+                assertNotEquals(expected, predicate.clone().negate().test(((Number) value).longValue()));
+                assertNotEquals(expected, P.not(predicate).test(((Number) value).longValue()));
+            }
         }
 
         @Before


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2056

Instead of converting all numbers to `BigDecimal`, `Compare` predicates now use `NumberHelper` for numerical comparisons.

`docker/build.sh -t -i -n` passed.

VOTE +1