### PR TITLE
TINKERPOP-2058 Contains predicates should rely on Compare predicates

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
+* Use `Compare.eq` in `Contains` predicates to ensure the same filter behavior for numeric values.
 * Added text predicates.
 * Removed groovy-sql
 * Rewrote `ConnectiveStrategy` to support an arbitrary number of infix notations in a single traversal.

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -29,6 +29,32 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.4.0/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Changed number comparison behavior of within()/without() predicates
+
+In previous versions `within()` and `without()` performed strict number comparisons; that means these predicates did not only compare number values, but also the time. This was inconsistent with
+how other predicates (like `eq, `gt`, etc.) work. All predicates will now ignore the number type and instead compare numbers only based on their value.
+
+Old behavior:
+
+```
+gremlin> g.V().has("age", eq(32L))
+==>v[4]
+gremlin> g.V().has("age", within(32L, 35L))
+gremlin>
+```
+
+New behavior:
+
+```
+gremlin> g.V().has("age", eq(32L))
+==>v[4]
+gremlin> g.V().has("age", within(32L, 35L))
+==>v[4]
+==>v[6]
+```
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2058[TINKERPOP-2058]
+
 ==== Added text predicates
 
 Gremlin now supports simple text predicates on top of the existing `P` predicates. Both, the new `TextP` text predicates and the old `P` predicates, can be chained using `and()` and `or()`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Contains.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Contains.java
@@ -18,18 +18,26 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+
 import java.util.Collection;
 import java.util.function.BiPredicate;
 
 /**
  * {@link Contains} is a {@link BiPredicate} that evaluates whether the first object is contained within (or not
- * within) the second collection object. For example:
+ * within) the second collection object. If the first object is a number, each element in the second collection
+ * will be compared to the first object using {@link Compare}'s {@code eq} predicate. This will ensure, that numbers
+ * are matched by their value only, ignoring the number type. For example:
  * <p/>
  * <pre>
  * gremlin Contains.within [gremlin, blueprints, furnace] == true
  * gremlin Contains.without [gremlin, rexster] == false
  * rexster Contains.without [gremlin, blueprints, furnace] == true
+ * 123 Contains.within [1, 2, 3] == false
+ * 100 Contains.within [1L, 10L, 100L] == true
  * </pre>
+ *
+ *
  *
  * @author Pierre De Wilde
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -44,7 +52,9 @@ public enum Contains implements BiPredicate<Object, Collection> {
     within {
         @Override
         public boolean test(final Object first, final Collection second) {
-            return second.contains(first);
+            return first instanceof Number
+                    ? IteratorUtils.anyMatch(second.iterator(), o -> Compare.eq.test(first, o))
+                    : second.contains(first);
         }
     },
 
@@ -56,7 +66,7 @@ public enum Contains implements BiPredicate<Object, Collection> {
     without {
         @Override
         public boolean test(final Object first, final Collection second) {
-            return !second.contains(first);
+            return !within.test(first, second);
         }
     };
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/ContainsTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/ContainsTest.java
@@ -43,7 +43,7 @@ public class ContainsTest {
                 {Contains.within, 10, Collections.emptyList(), false},
                 {Contains.without, 10, Collections.emptyList(), true},
                 {Contains.within, 100, Arrays.asList(1, 2, 3, 4, 10), false},
-                {Contains.without, 10l, Arrays.asList(1, 2, 3, 4, 10), true},    // no forgiveness
+                {Contains.without, 10L, Arrays.asList(1, 2, 3, 4, 10), false},
                 {Contains.within, "test", Arrays.asList(1, 2, 3, "test", 10), true},
                 {Contains.without, "testing", Arrays.asList(1, 2, 3, "test", 10), true}
         }));

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/PTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/PTest.java
@@ -127,7 +127,7 @@ public class PTest {
             assertEquals(expected, predicate.test(value));
             assertNotEquals(expected, predicate.clone().negate().test(value));
             assertNotEquals(expected, P.not(predicate.clone()).test(value));
-            if (value instanceof Number && !(predicate.biPredicate instanceof Contains)) {
+            if (value instanceof Number) {
                 assertEquals(expected, predicate.test(((Number) value).longValue()));
                 assertNotEquals(expected, predicate.clone().negate().test(((Number) value).longValue()));
                 assertNotEquals(expected, P.not(predicate).test(((Number) value).longValue()));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2058

If the object to be filtered is a number, `Contains` predicates will now scan the provided collection, comparing each element using `Compare.eq`. For non-numeric values `Contains.within` will still use `collection.contains()` in order to make use of search-optimized data types (e.g. `Set`).

This is a breaking change as the test suite previously ensured that number types had an effect on `Contains` predicates. This, however, was inconsistent with `Compare` predicates which ignore the number type.

`docker/build.sh -t -i -n` passed.

VOTE +1