### PR TITLE
 Optimizes Set with enum using the EnumSet implementation [tp32]

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/RequirementsStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/RequirementsStep.java
@@ -23,7 +23,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -36,7 +37,13 @@ public final class RequirementsStep<S> extends AbstractStep<S, S> {
 
     public RequirementsStep(final Traversal.Admin traversal, final Set<TraverserRequirement> requirements) {
         super(traversal);
-        this.requirements = new HashSet<>(requirements);
+
+        if (requirements == null || requirements.isEmpty()) {
+            this.requirements = EnumSet.noneOf(TraverserRequirement.class);
+        } else {
+            this.requirements = EnumSet.copyOf(requirements);
+        }
+
     }
 
     public void addRequirement(final TraverserRequirement requirement) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/RequirementsStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/RequirementsStrategy.java
@@ -29,7 +29,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -37,7 +37,7 @@ import java.util.Set;
  */
 public final class RequirementsStrategy extends AbstractTraversalStrategy<TraversalStrategy.DecorationStrategy> implements TraversalStrategy.DecorationStrategy {
 
-    private final Set<TraverserRequirement> requirements = new HashSet<>();
+    private final Set<TraverserRequirement> requirements = EnumSet.noneOf(TraverserRequirement.class);
 
     private RequirementsStrategy() {
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -37,7 +37,7 @@ import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -148,7 +148,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     public Set<TraverserRequirement> getTraverserRequirements() {
         if (null == this.requirements) {
             // if (!this.locked) this.applyStrategies();
-            this.requirements = new HashSet<>();
+            this.requirements = EnumSet.noneOf(TraverserRequirement.class);
             for (final Step<?, ?> step : this.getSteps()) {
                 this.requirements.addAll(step.getRequirements());
             }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -51,6 +51,7 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -594,7 +595,7 @@ public final class TraversalHelper {
     }
 
     public static Set<Scoping.Variable> getVariableLocations(final Traversal.Admin<?, ?> traversal) {
-        return TraversalHelper.getVariableLocations(new HashSet<>(), traversal);
+        return TraversalHelper.getVariableLocations(EnumSet.noneOf(Scoping.Variable.class), traversal);
     }
 
     private static Set<Scoping.Variable> getVariableLocations(final Set<Scoping.Variable> variables, final Traversal.Admin<?, ?> traversal) {


### PR DESCRIPTION
This PR replaces the HashSet implementation to [EnumSet](https://docs.oracle.com/javase/7/docs/api/java/util/EnumSet.html) that as its documentation says:

> A specialized Set implementation for use with enum types. All of the elements in an enum set must come from a single enum type that is specified, explicitly or implicitly, when the set is created. Enum sets are represented internally as bit vectors. This representation is extremely compact and efficient. The space and time performance of this class should be good enough to allow its use as a high-quality, typesafe alternative to traditional int-based "bit flags." Even bulk operations (such as containsAll and retainAll) should run very quickly if their argument is also an enum set.

That is a continuation of the PR: https://github.com/apache/tinkerpop/pull/948 that has the same benchmark value.
