### PR TITLE
TINKERPOP-1972 Fix inject step in Gremlin.Net

### DIFF
--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -22,6 +22,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using Gremlin.Net.Structure;
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
@@ -68,8 +69,8 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal<$method.t1, $method.t2> <%= toCSharpMethodName.call(method.methodName) %><%= method.tParam %> (<%= method.parameters %>)
         {
         <%  if (method.parameters.contains("params ")) {
-      %>    var args = new List<$method.argsListType>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
-            args.AddRange(<%= method.paramNames.last() %>);
+      %>    var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+            args.AddRange(<%= method.paramNames.last() %><% if (method.isArgsCastNecessary) { %>.Cast<object>()<% } %>);
             Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }
             else {

--- a/gremlin-dotnet/glv/GraphTraversalSource.template
+++ b/gremlin-dotnet/glv/GraphTraversalSource.template
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure;
@@ -131,8 +132,8 @@ namespace Gremlin.Net.Process.Traversal
         {
             var traversal = new GraphTraversal<$method.typeNameString>(TraversalStrategies, new Bytecode(Bytecode));
             <%  if (method.parameters.contains("params ")) {
-          %>var args = new List<$method.argsListType>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
-            args.AddRange(<%= method.paramNames.last() %>);
+          %>var args = new List<object>(<%= method.paramNames.init().size() %> + <%= method.paramNames.last() %>.Length) {<%= method.paramNames.init().join(", ") %>};
+            args.AddRange(<%= method.paramNames.last() %><% if (method.isArgsCastNecessary) { %>.Cast<object>()<% } %>);
             traversal.Bytecode.AddStep("<%= method.methodName %>", args.ToArray());<%
             }
             else {

--- a/gremlin-dotnet/glv/generate.groovy
+++ b/gremlin-dotnet/glv/generate.groovy
@@ -191,14 +191,12 @@ def getParamNames = { parameters ->
         }
 }
 
-def getArgsListType = { parameterString ->
-    def argsListType = "object"
+def isParamsArgCastNecessary = { parameterString ->
     if (parameterString.contains("params ")) {
         def paramsType = parameterString.substring(parameterString.indexOf("params ") + "params ".length(), parameterString.indexOf("[]"))
-        if (paramsType == "E" || paramsType == "S")
-            argsListType = paramsType
+        return paramsType == "E" || paramsType == "S" 
     }
-    argsListType
+    return false
 }
 
 def hasMethodNoGenericCounterPartInGraphTraversal = { method ->
@@ -270,8 +268,8 @@ def binding = ["pmethods": P.class.getMethods().
                             def tParam = getCSharpGenericTypeParam(t2)
                             def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
-                            def argsListType = getArgsListType(parameters)
-                            return ["methodName": javaMethod.name, "typeNameString": typeNameString, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
+                            def isArgsCastNecessary = isParamsArgCastNecessary(parameters)
+                            return ["methodName": javaMethod.name, "typeNameString": typeNameString, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "isArgsCastNecessary":isArgsCastNecessary]
                         },
                "graphStepMethods": GraphTraversal.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.
@@ -286,8 +284,8 @@ def binding = ["pmethods": P.class.getMethods().
                             def tParam = getCSharpGenericTypeParam(t2)
                             def parameters = getCSharpParamString(javaMethod, true)
                             def paramNames = getParamNames(javaMethod.parameters)
-                            def argsListType = getArgsListType(parameters)
-                            return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "argsListType":argsListType]
+                            def isArgsCastNecessary = isParamsArgCastNecessary(parameters)
+                            return ["methodName": javaMethod.name, "t1":t1, "t2":t2, "tParam":tParam, "parameters":parameters, "paramNames":paramNames, "isArgsCastNecessary":isArgsCastNecessary]
                         },
                "anonStepMethods": __.class.getMethods().
                         findAll { GraphTraversal.class.equals(it.returnType) }.

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using Gremlin.Net.Structure;
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
@@ -870,8 +871,8 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal<S, E> Inject (params E[] injections)
         {
-            var args = new List<E>(0 + injections.Length) {};
-            args.AddRange(injections);
+            var args = new List<object>(0 + injections.Length) {};
+            args.AddRange(injections.Cast<object>());
             Bytecode.AddStep("inject", args.ToArray());
             return Wrap<S, E>(this);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure;
@@ -307,8 +308,8 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal<S, S> Inject<S>(params S[] starts)
         {
             var traversal = new GraphTraversal<S, S>(TraversalStrategies, new Bytecode(Bytecode));
-            var args = new List<S>(0 + starts.Length) {};
-            args.AddRange(starts);
+            var args = new List<object>(0 + starts.Length) {};
+            args.AddRange(starts.Cast<object>());
             traversal.Bytecode.AddStep("inject", args.ToArray());
             return traversal;
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -38,10 +38,10 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
     public class GherkinTestRunner
     {
         private static readonly IDictionary<string, IgnoreReason> IgnoredScenarios =
-            new Dictionary<string, IgnoreReason>()
+            new Dictionary<string, IgnoreReason>
             {
-                { "g_injectX1X_chooseXisX1X__constantX10Xfold__foldX", IgnoreReason.NoReason },
-                { "g_injectX2X_chooseXisX1X__constantX10Xfold__foldX", IgnoreReason.NoReason }
+                // Add here the name of scenarios to ignore and the reason, e.g.
+                // { "g_injectX2X_chooseXisX1X__constantX10Xfold__foldX", IgnoreReason.NoReason }
             };
         
         private static class Keywords

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/TraversalParser.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/TraversalParser.cs
@@ -245,6 +245,14 @@ namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
                         // if we have the type of value we have the type of E2. 
                         genericParameterTypes.Add(info.ParameterType.Name, tokenParameter.GetParameterType());
                     }
+                    else if (IsParamsArray(info) && info.ParameterType.GetElementType().IsGenericParameter)
+                    {
+                        // Its a method where the type parameter comes from an params Array
+                        // e.g., Inject<S>(params S[] value)
+                        genericParameterTypes.Add(info.ParameterType.GetElementType().Name,
+                            tokenParameter.GetParameterType());
+                    }
+
                     if (info.ParameterType != tokenParameter.GetParameterType() && IsNumeric(info.ParameterType) &&
                         IsNumeric(tokenParameter.GetParameterType()))
                     {
@@ -252,6 +260,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
                         value = Convert.ChangeType(value, info.ParameterType);
                     }
                 }
+
                 if (IsParamsArray(info))
                 {
                     // For `params type[] value` we should provide an empty array
@@ -264,11 +273,19 @@ namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
                     {
                         // An array with the parameter values
                         // No more method parameters after this one
-                        var arr = Array.CreateInstance(info.ParameterType.GetElementType(), token.Parameters.Count - i);
+                        var elementType = info.ParameterType.GetElementType();
+
+                        if (elementType.IsGenericParameter)
+                        {
+                            // The Array element type is generic, so we use type of the value to specify it
+                            elementType = value.GetType();
+                        }
+
+                        var arr = Array.CreateInstance(elementType, token.Parameters.Count - i);
                         arr.SetValue(value, 0);
                         for (var j = 1; j < token.Parameters.Count - i; j++)
                         {
-                            arr.SetValue(token.Parameters[i + j].GetValue(), j);   
+                            arr.SetValue(token.Parameters[i + j].GetValue(), j);
                         }
                         value = arr;
                     }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
@@ -77,6 +77,18 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         }
 
         [Fact]
+        public void g_InjectX1_2_3X()
+        {
+            var g = new Graph().Traversal();
+
+            var bytecode = g.Inject(1, 2, 3).Bytecode;
+
+            Assert.Equal(1, bytecode.StepInstructions.Count);
+            Assert.Equal("inject", bytecode.StepInstructions[0].OperatorName);
+            Assert.Equal(3, bytecode.StepInstructions[0].Arguments.Length);
+        }
+
+        [Fact]
         public void AnonymousTraversal_Start_EmptyBytecode()
         {
             var bytecode = __.Start().Bytecode;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1972

We had two issues with the `inject` step in Gremlin.Net. The first one prevented the Gherkin test runner from executing scenarios that included an `inject` step. This was fixed by @jorgebay with the first commit in this PR. Thanks for that, Jorge!

The second issue was that the arguments passed to the `inject` step were always wrapped in an array which was caused by the fact that the `inject` step takes a `params` array with a generic member type. We created a `List<S>` for these arguments and provided that to the method `ByteCode.AddStep()` which expects a `params object[]` argument. Since the compiler can't convert `List<S>` into `object[]`, it simply treated the `List<S>` as the first argument which resulted in an `object[]` with just one element, namely the `List<S>`.
Simply using a `List<object>` for the arguments and then converting each argument to `object` fixes the problem.
This could also have affected other steps, but `inject` was the only one with such a generic `params` array which is probably why we didn't notice the problem before. 

All .NET tests, including the GLV scenarios, are now passing again 🎉

VOTE +1