### PR TITLE
TINKERPOP-2061 Added with() option for traversal configuration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,8 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Replaced `Parameterizing.addPropertyMutations()` with `Configuring.configure()`.
 * Changed interface hierarchy for `Parameterizing` and `Mutating` interfaces as they are tightly related.
 * Introduced the `with(k,v)` and `with(k)` step modulators which can supply configuration options to `Configuring` steps.
+* Added `OptionsStrategy` to allow traversals to take arbitrary traversal-wide configurations.
+* Introduced the `with(k,v)` and `with(k)` traveral source configuration options which can supply configuration options to the traversal.
 * Added `connectedComponent()` step and related `VertexProgram`.
 * Added `supportsUpsert()` option to `VertexFeatures` and `EdgeFeatures`.
 * `min()` and `max()` now support all types implementing `Comparable`.
@@ -560,7 +562,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * TINKERPOP-1988	minor error in documentation
 * TINKERPOP-1999	[Java][gremlin-driver] Query to a remote server via the websocket client hangs indefinitely if the server becomes unavailable
 * TINKERPOP-2005	Intermittent NullPointerException in response handling
-* TINKERPOP-2009	Pick.any and Pick.none should be exposed in Gremlin-JavaScript 
+* TINKERPOP-2009	Pick.any and Pick.none should be exposed in Gremlin-JavaScript
 * TINKERPOP-2030	KeepAlive task executed for every Connection.write call
 * TINKERPOP-2032	Update jython-standalone
 * TINKERPOP-2044	Cannot reconnect to Azure cosmos host that becomes available again

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -536,7 +536,15 @@ accessible to their custom steps. A user would write something like:
 
 [source,java]
 ----
-g.withStrategies(OptionsStrategy.build().with("specialLimit", 10000).create());
+g.withStrategies(OptionsStrategy.build().with("specialLimit", 10000).create()).V();
+----
+
+The `OptionsStrategy` is really only the carrier for the configurations and while users can choose to utilize that
+more verbose method for constructing it shown above, it is more elegantly constructed as follows using `with()`-step:
+
+[source,java]
+----
+g.with("specialLimit", 10000)).V();
 ----
 
 The graph provider could then access that value of "specialLimit" in their custom step (or elsewhere) as follows:

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -170,6 +170,7 @@ import java.util.function.Predicate;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public interface GraphTraversal<S, E> extends Traversal<S, E> {
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -52,6 +52,7 @@ import java.util.function.UnaryOperator;
  * Any DSL can be constructed based on the methods of both {@code GraphTraversalSource} and {@link GraphTraversal}.
  *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GraphTraversalSource implements TraversalSource {
     protected transient RemoteConnection connection;
@@ -116,6 +117,22 @@ public class GraphTraversalSource implements TraversalSource {
     }
 
     //// CONFIGURATIONS
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GraphTraversalSource with(final String key) {
+        return (GraphTraversalSource) TraversalSource.super.with(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GraphTraversalSource with(final String key, final Object value) {
+        return (GraphTraversalSource) TraversalSource.super.with(key, value);
+    }
 
     /**
      * {@inheritDoc}

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -73,6 +73,22 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 
+        public GraphTraversalSource With(string key)
+        {
+            var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
+                                                  new Bytecode(Bytecode));
+            source.Bytecode.AddSource("with", key);
+            return source;
+        }
+
+        public GraphTraversalSource With(string key, object value)
+        {
+            var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
+                                                  new Bytecode(Bytecode));
+            source.Bytecode.AddSource("with", key, value);
+            return source;
+        }
+
         public GraphTraversalSource WithBulk(bool useBulk)
         {
             var source = new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -199,9 +199,11 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var g = graph.Traversal().WithRemote(connection);
 
             var b = new Bindings();
-            var count = g.WithStrategies(new OptionsStrategy(options)).V().Count().Next();
+            var countWithStrategy = g.WithStrategies(new OptionsStrategy(options)).V().Count().Next();
+            Assert.Equal(6, countWithStrategy);
 
-            Assert.Equal(6, count);
+            var countWith = g.With("x", "test").With("y", true).V().Count().Next();
+            Assert.Equal(6, countWith);
         }
 
         [Fact]

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
@@ -63,6 +63,16 @@ class GraphTraversalSource {
   }
   
   /**
+   * Graph Traversal Source with method.
+   * @param {...Object} args
+   * @returns {GraphTraversalSource}
+   */
+  with_(...args) {
+    const b = new Bytecode(this.bytecode).addSource('with', args);
+    return new GraphTraversalSource(this.graph, new TraversalStrategies(this.traversalStrategies), b);
+  }
+  
+  /**
    * Graph Traversal Source withBulk method.
    * @param {...Object} args
    * @returns {GraphTraversalSource}

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -67,6 +67,11 @@ class GraphTraversalSource(object):
         source.bytecode.add_source("withStrategies", *args)
         return source
 
+    def with_(self, *args):
+        source = self.get_graph_traversal_source()
+        source.bytecode.add_source("with", *args)
+        return source
+
     def withoutStrategies(self, *args):
         source = self.get_graph_traversal_source()
         source.bytecode.add_source("withoutStrategies", *args)

--- a/gremlin-python/src/main/jython/tests/driver/test_client.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_client.py
@@ -79,6 +79,11 @@ def test_client_bytecode_options(client):
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
     assert len(result_set.all().result()) == 6
+    ##
+    t = g.with_("x", "test").with_("y", True).V()
+    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
+    result_set = client.submit(message)
+    assert len(result_set.all().result()) == 6
 
 
 def test_iterate_result_set(client):

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/OptionsStrategyTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/decoration/OptionsStrategyTest.java
@@ -42,11 +42,22 @@ public class OptionsStrategyTest {
     public void shouldAddOptionsToTraversal() {
         final Graph graph = TinkerGraph.open();
         final GraphTraversalSource optionedG = graph.traversal().withStrategies(OptionsStrategy.build().with("a", "test").with("b").create());
+        assertOptions(optionedG);
+    }
+
+    @Test
+    public void shouldAddOptionsToTraversalUsingWith() {
+        final Graph graph = TinkerGraph.open();
+        final GraphTraversalSource optionedG = graph.traversal().with("a", "test").with("b");
+        assertOptions(optionedG);
+    }
+
+    private static void assertOptions(final GraphTraversalSource optionedG) {
         GraphTraversal t = optionedG.inject(1);
         t = t.asAdmin().addStep(new MapStep<Object, Object>(t.asAdmin()) {
             @Override
             protected Object map(final Traverser.Admin<Object> traverser) {
-                final OptionsStrategy strategy = this.getTraversal().asAdmin().getStrategies().getStrategy(OptionsStrategy.class).get();
+                final OptionsStrategy strategy = traversal.asAdmin().getStrategies().getStrategy(OptionsStrategy.class).get();
                 return Arrays.asList(strategy.getOptions().get("a"), strategy.getOptions().get("b"));
             }
         });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2061

Basically just shorthands the direct use of `OptionStrategy` which is much more verbose and less nice to look at. See the upgrade doc changes in this PR for an example of usage.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1