### PR TITLE
TINKERPOP-2070: Introduce Connection and ResultSet abstractions

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -562,3 +562,26 @@ const __ = gremlin.process.statics;
 
 g.V().repeat(__.out()).times(2).values("name").fold().toList();
 ----
+
+=== Submit Gremlin Scripts
+
+Additionally, you can also send parametrized Gremlin scripts to the server as strings, using the
+`Client` class in Gremlin-JavaScript.
+
+
+[source,javascript]
+----
+const gremlin = require('gremlin');
+const client = new gremlin.driver.Client('ws://localhost:8182/gremlin', { traversalSource: 'g' });
+
+const result1 = await client.submit('g.V(vid)', { vid: 1 });
+const vertex = result1.first();
+
+const result2 = await client.submit('g.V().hasLabel(label).tail(n)', { label: 'person', n: 3 });
+
+// ResultSet is an iterable
+for (const vertex of result2) {
+  console.log(vertex.id);
+}
+
+----

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -112,18 +112,19 @@ Gremlin Javascript can now submit script, with optional bindings, using the `Cli
 [source,javascript]
 ----
 const gremlin = require('gremlin');
-const connection = new gremlin.driver.Client('ws://localhost:8182/gremlin', { traversalSource: 'g' });
+const client = new gremlin.driver.Client('ws://localhost:8182/gremlin', { traversalSource: 'g' });
 
-connection.submit('g.V().tail()')
-    .then(response => {
-        console.log(response.traversers.length);
-        console.log(response.traversers[0]);
+client.submit('g.V().tail()')
+    .then(result => {
+        console.log(result.length);
+        console.log(result.toArray()[0]);
     });
 
-connection.submit('g.V(vid)', {vid: 1})
-    .then(response => {
-        console.log(response.traversers.length);
-        console.log(response.traversers[0]);
+client.submit('g.V(vid)', { vid: 1 })
+    .then(result => {
+        console.log(result.length);
+        // Get the first item
+        console.log(result.first());
     });
 ----
 
@@ -133,16 +134,16 @@ and also allows translation of bytecode steps into script:
 ----
 const gremlin = require('gremlin');
 const graph = new gremlin.process.Graph();
-const connection = new gremlin.driver.Client('ws://localhost:8182/gremlin', { traversalSource: 'g' });
+const client = new gremlin.driver.Client('ws://localhost:8182/gremlin', { traversalSource: 'g' });
 const translator = new gremlin.process.Translator('g');
 
 const g = graph.traversal();
 const script = translator.translate(g.V().tail().getBytecode());
 
-connection.submit(script)
-    .then(response => {
-        console.log(response.traversers.length);
-        console.log(response.traversers[0]);
+client.submit(script)
+    .then(result => {
+        console.log(result.length);
+        console.log(result.first());
     });
 ----
 

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -179,37 +179,37 @@ limitations under the License.
                         </goals>
                     </execution>
                     <execution>
-                        <id>npm install</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install</arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm test</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>test</arguments>
-                            <failOnError>true</failOnError>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm test gherkin features</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run-script features</arguments>
-                            <failOnError>true</failOnError>
-                        </configuration>
-                    </execution>
+                    <id>npm install</id>
+                    <phase>generate-test-resources</phase>
+                    <goals>
+                        <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                        <arguments>install</arguments>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>npm test</id>
+                    <phase>integration-test</phase>
+                    <goals>
+                        <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                        <arguments>test --exit</arguments>
+                        <failOnError>true</failOnError>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>npm test gherkin features</id>
+                    <phase>integration-test</phase>
+                    <goals>
+                        <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                        <arguments>run-script features</arguments>
+                        <failOnError>true</failOnError>
+                    </configuration>
+                </execution>
                 </executions>
                 <configuration>
                     <skip>${skipTests}</skip>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -179,37 +179,37 @@ limitations under the License.
                         </goals>
                     </execution>
                     <execution>
-                    <id>npm install</id>
-                    <phase>generate-test-resources</phase>
-                    <goals>
-                        <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                        <arguments>install</arguments>
-                    </configuration>
-                </execution>
-                <execution>
-                    <id>npm test</id>
-                    <phase>integration-test</phase>
-                    <goals>
-                        <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                        <arguments>test --exit</arguments>
-                        <failOnError>true</failOnError>
-                    </configuration>
-                </execution>
-                <execution>
-                    <id>npm test gherkin features</id>
-                    <phase>integration-test</phase>
-                    <goals>
-                        <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                        <arguments>run-script features</arguments>
-                        <failOnError>true</failOnError>
-                    </configuration>
-                </execution>
+                        <id>npm install</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>test --exit</arguments>
+                            <failOnError>true</failOnError>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm test gherkin features</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run-script features</arguments>
+                            <failOnError>true</failOnError>
+                        </configuration>
+                    </execution>
                 </executions>
                 <configuration>
                     <skip>${skipTests}</skip>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
@@ -33,6 +33,7 @@ const Translator = require('./lib/process/translator');
 const utils = require('./lib/utils');
 const DriverRemoteConnection = require('./lib/driver/driver-remote-connection');
 const Client = require('./lib/driver/client');
+const ResultSet = require('./lib/driver/result-set');
 const Authenticator = require('./lib/driver/auth/authenticator');
 const PlainTextSaslAuthenticator = require('./lib/driver/auth/plain-text-sasl-authenticator');
 
@@ -41,15 +42,16 @@ module.exports = {
     RemoteConnection: rc.RemoteConnection,
     RemoteStrategy: rc.RemoteStrategy,
     RemoteTraversal: rc.RemoteTraversal,
-    DriverRemoteConnection: DriverRemoteConnection,
-    Client: Client,
+    DriverRemoteConnection,
+    Client,
+    ResultSet,
     auth: {
-      Authenticator: Authenticator,
-      PlainTextSaslAuthenticator: PlainTextSaslAuthenticator
+      Authenticator,
+      PlainTextSaslAuthenticator
     }
   },
   process: {
-    Bytecode: Bytecode,
+    Bytecode,
     EnumValue: t.EnumValue,
     P: t.P,
     Traversal: t.Traversal,
@@ -70,7 +72,7 @@ module.exports = {
     GraphTraversal: gt.GraphTraversal,
     GraphTraversalSource: gt.GraphTraversalSource,
     statics: gt.statics,
-    Translator: Translator
+    Translator
   },
   structure: {
     io: {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -61,7 +61,7 @@ class Client {
    * @returns {Promise}
    */
   submit(message, bindings) {
-    if (typeof message === 'string' || message instanceof String) {
+    if (typeof message === 'string') {
       const args = {
         'gremlin': message,
         'bindings': bindings, 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -18,12 +18,16 @@
  */
 'use strict';
 
-const DriverRemoteConnection = require('./driver-remote-connection');
+const Connection = require('./connection');
 const Bytecode = require('../process/bytecode');
 
+/**
+ * A {@link Client} contains methods to send messages to a Gremlin Server.
+ */
 class Client {
+
   /**
-   * Creates a new instance of DriverRemoteConnection.
+   * Creates a new instance of {@link Client}.
    * @param {String} url The resource uri.
    * @param {Object} [options] The connection options.
    * @param {Array} [options.ca] Trusted certificates.
@@ -39,7 +43,7 @@ class Client {
    */
   constructor(url, options) {
     this._options = options;
-    this._connection = new DriverRemoteConnection(url, options);
+    this._connection = new Connection(url, options);
   }
 
   /**
@@ -53,7 +57,7 @@ class Client {
   /**
    * Send a request to the Gremlin Server, can send a script or bytecode steps.
    * @param {Bytecode|string} message The bytecode or script to send
-   * @param {Object} bindings The script bindings, if any.
+   * @param {Object} [bindings] The script bindings, if any.
    * @returns {Promise}
    */
   submit(message, bindings) {
@@ -62,7 +66,7 @@ class Client {
         'gremlin': message,
         'bindings': bindings, 
         'language': 'gremlin-groovy',
-        'accept': 'application/vnd.gremlin-v2.0+json',
+        'accept': this._connection.mimeType,
         'aliases': { 'g': this._options.traversalSource || 'g' }
       };
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -1,0 +1,265 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+/**
+ * @author Jorge Bay Gondra
+ */
+'use strict';
+
+const WebSocket = require('ws');
+const util = require('util');
+const utils = require('../utils');
+const serializer = require('../structure/io/graph-serializer');
+
+const responseStatusCode = {
+  success: 200,
+  noContent: 204,
+  partialContent: 206,
+  authenticationChallenge:  407,
+};
+
+const defaultMimeType = 'application/vnd.gremlin-v3.0+json';
+
+/**
+ * Represents a single connection to a Gremlin Server.
+ */
+class Connection {
+
+  /**
+   * Creates a new instance of {@link Connection}.
+   * @param {String} url The resource uri.
+   * @param {Object} [options] The connection options.
+   * @param {Array} [options.ca] Trusted certificates.
+   * @param {String|Array|Buffer} [options.cert] The certificate key.
+   * @param {String} [options.mimeType] The mime type to use.
+   * @param {String|Buffer} [options.pfx] The private key, certificate, and CA certs.
+   * @param {GraphSONReader} [options.reader] The reader to use.
+   * @param {Boolean} [options.rejectUnauthorized] Determines whether to verify or not the server certificate.
+   * @param {String} [options.traversalSource] The traversal source. Defaults to: 'g'.
+   * @param {GraphSONWriter} [options.writer] The writer to use.
+   * @param {Authenticator} [options.authenticator] The authentication handler to use.
+   * @param {Object} [options.headers] An associative array containing the additional header key/values for the initial request.
+   * @constructor
+   */
+  constructor(url, options) {
+    this.url = url;
+    options = options || {};
+    this._ws = new WebSocket(url, {
+      headers: options.headers,
+      ca: options.ca,
+      cert: options.cert,
+      pfx: options.pfx,
+      rejectUnauthorized: options.rejectUnauthorized
+    });
+
+    this._ws.on('open', () => {
+      this.isOpen = true;
+      if (this._openCallback) {
+        this._openCallback();
+      }
+    });
+
+    this._ws.on('message', data => this._handleMessage(data));
+
+    // A map containing the request id and the handler
+    this._responseHandlers = {};
+    this._reader = options.reader || new serializer.GraphSONReader();
+    this._writer = options.writer || new serializer.GraphSONWriter();
+    this._openPromise = null;
+    this._openCallback = null;
+    this._closePromise = null;
+
+    /**
+     * Gets the MIME type.
+     * @type {String}
+     */
+    this.mimeType = options.mimeType || defaultMimeType;
+
+    this._header = String.fromCharCode(this.mimeType.length) + this.mimeType;
+    this.isOpen = false;
+    this.traversalSource = options.traversalSource || 'g';
+    this._authenticator = options.authenticator;
+  }
+
+  /**
+   * Opens the connection, if its not already opened.
+   * @returns {Promise}
+   */
+  open() {
+    if (this._closePromise) {
+      return this._openPromise = Promise.reject(new Error('Connection has been closed'));
+    }
+    if (this.isOpen) {
+      return Promise.resolve();
+    }
+    if (this._openPromise) {
+      return this._openPromise;
+    }
+    return this._openPromise = new Promise((resolve, reject) => {
+      // Set the callback that will be invoked once the WS is opened
+      this._openCallback = err => err ? reject(err) : resolve();
+    });
+  }
+
+  /** @override */
+  submit(bytecode, op, args, requestId, processor) {
+    return this.open().then(() => new Promise((resolve, reject) => {
+      if (requestId === null || requestId === undefined) {
+        requestId = utils.getUuid();
+        this._responseHandlers[requestId] = {
+          callback: (err, result) => err ? reject(err) : resolve(result),
+          result: null
+        };
+      }
+
+      const message = Buffer.from(this._header + JSON.stringify(this._getRequest(requestId, bytecode, op, args, processor)));
+      this._ws.send(message);
+    }));
+  }
+
+  _getRequest(id, bytecode, op, args, processor) {
+    if (args) {
+      args = this._adaptArgs(args, true);
+    }
+
+    return ({
+      'requestId': { '@type': 'g:UUID', '@value': id },
+      'op': op || 'bytecode',
+      // if using op eval need to ensure processor stays unset if caller didn't set it.
+      'processor': (!processor && op !== 'eval') ? 'traversal' : processor,
+      'args': args || {
+        'gremlin': this._writer.adaptObject(bytecode),
+        'aliases': { 'g': this.traversalSource }
+      }
+    });
+  }
+
+  _handleMessage(data) {
+    const response = this._reader.read(JSON.parse(data.toString()));
+    if (response.requestId === null || response.requestId === undefined) {
+      // There was a serialization issue on the server that prevented the parsing of the request id
+      // We invoke any of the pending handlers with an error
+      Object.keys(this._responseHandlers).forEach(requestId => {
+        const handler = this._responseHandlers[requestId];
+        this._clearHandler(requestId);
+        if (response.status !== undefined && response.status.message) {
+          return handler.callback(
+            new Error(util.format(
+              'Server error (no request information): %s (%d)', response.status.message, response.status.code)));
+        } else {
+          return handler.callback(new Error(util.format('Server error (no request information): %j', response)));
+        }
+      });
+      return;
+    }
+
+    const handler = this._responseHandlers[response.requestId];
+
+    if (!handler) {
+      // The handler for a given request id was not found
+      // It was probably invoked earlier due to a serialization issue.
+      return;
+    }
+
+    if (response.status.code === responseStatusCode.authenticationChallenge && this._authenticator) {
+      this._authenticator.evaluateChallenge(response.result.data).then(res => {
+        return this.submit(null, 'authentication', res, response.requestId);
+      }).catch(handler.callback);
+
+      return;
+    }
+    else if (response.status.code >= 400) {
+      // callback in error
+      return handler.callback(
+        new Error(util.format('Server error: %s (%d)', response.status.message, response.status.code)));
+    }
+    switch (response.status.code) {
+      case responseStatusCode.noContent:
+        this._clearHandler(response.requestId);
+        return handler.callback(null, { traversers: []});
+      case responseStatusCode.partialContent:
+        handler.result = handler.result || [];
+        handler.result.push.apply(handler.result, response.result.data);
+        break;
+      default:
+        if (handler.result) {
+          handler.result.push.apply(handler.result, response.result.data);
+        }
+        else {
+          handler.result = response.result.data;
+        }
+        this._clearHandler(response.requestId);
+        return handler.callback(null, { traversers: handler.result });
+    }
+  }
+
+  /**
+   * Clears the internal state containing the callback and result buffer of a given request.
+   * @param requestId
+   * @private
+   */
+  _clearHandler(requestId) {
+    delete this._responseHandlers[requestId];
+  }
+
+  /**
+   * Takes the given args map and ensures all arguments are passed through to _write.adaptObject
+   * @param {Object} args Map of arguments to process.
+   * @param {Boolean} protocolLevel Determines whether it's a protocol level binding.
+   * @returns {Object}
+   * @private
+   */
+  _adaptArgs(args, protocolLevel) {
+    if (args instanceof Object) {
+      let newObj = {};
+      Object.keys(args).forEach((key) => {
+        // bindings key (at the protocol-level needs special handling. without this, it wraps the generated Map
+        // in another map for types like EnumValue. Could be a nicer way to do this but for now it's solving the
+        // problem with script submission of non JSON native types
+        if (protocolLevel && key === 'bindings')
+          newObj[key] = this._adaptArgs(args[key], false);
+        else
+          newObj[key] = this._writer.adaptObject(args[key]);
+      });
+
+      return newObj;
+    }
+
+    return args;
+  }
+
+  /**
+   * Closes the Connection.
+   * @return {Promise}
+   */
+  close() {
+    if (!this._closePromise) {
+      this._closePromise = new Promise(resolve => {
+        this._ws.on('close', function () {
+          this.isOpen = false;
+          resolve();
+        });
+        this._ws.close();
+      });
+    }
+    return this._closePromise;
+  }
+}
+
+module.exports = Connection;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -26,6 +26,7 @@ const WebSocket = require('ws');
 const util = require('util');
 const utils = require('../utils');
 const serializer = require('../structure/io/graph-serializer');
+const ResultSet = require('./result-set');
 
 const responseStatusCode = {
   success: 200,
@@ -192,7 +193,7 @@ class Connection {
     switch (response.status.code) {
       case responseStatusCode.noContent:
         this._clearHandler(response.requestId);
-        return handler.callback(null, { traversers: []});
+        return handler.callback(null, new ResultSet(utils.emptyArray));
       case responseStatusCode.partialContent:
         handler.result = handler.result || [];
         handler.result.push.apply(handler.result, response.result.data);
@@ -205,7 +206,7 @@ class Connection {
           handler.result = response.result.data;
         }
         this._clearHandler(response.requestId);
-        return handler.callback(null, { traversers: handler.result });
+        return handler.callback(null, new ResultSet(handler.result));
     }
   }
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -22,7 +22,9 @@
  */
 'use strict';
 
-const RemoteConnection = require('./remote-connection').RemoteConnection;
+const rcModule = require('./remote-connection');
+const RemoteConnection = rcModule.RemoteConnection;
+const RemoteTraversal = rcModule.RemoteTraversal;
 const Client = require('./client');
 
 /**
@@ -58,7 +60,7 @@ class DriverRemoteConnection extends RemoteConnection {
 
   /** @override */
   submit(bytecode) {
-    return this._client.submit(bytecode);
+    return this._client.submit(bytecode).then(result => new RemoteTraversal(result.toArray()));
   }
 
   /** @override */

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -22,23 +22,16 @@
  */
 'use strict';
 
-const WebSocket = require('ws');
-const util = require('util');
-const t = require('../process/traversal');
 const RemoteConnection = require('./remote-connection').RemoteConnection;
-const utils = require('../utils');
-const serializer = require('../structure/io/graph-serializer');
-const responseStatusCode = {
-  success: 200,
-  noContent: 204,
-  partialContent: 206,
-  authenticationChallenge:  407,
-};
-const defaultMimeType = 'application/vnd.gremlin-v3.0+json';
+const Client = require('./client');
 
+/**
+ * Represents the default {@link RemoteConnection} implementation.
+ */
 class DriverRemoteConnection extends RemoteConnection {
+
   /**
-   * Creates a new instance of DriverRemoteConnection.
+   * Creates a new instance of {@link DriverRemoteConnection}.
    * @param {String} url The resource uri.
    * @param {Object} [options] The connection options.
    * @param {Array} [options.ca] Trusted certificates.
@@ -55,204 +48,23 @@ class DriverRemoteConnection extends RemoteConnection {
    */
   constructor(url, options) {
     super(url);
-    options = options || {};
-    this._ws = new WebSocket(url, {
-      headers: options.headers,
-      ca: options.ca,
-      cert: options.cert,
-      pfx: options.pfx,
-      rejectUnauthorized: options.rejectUnauthorized
-    });
-    this._ws.on('open', () => {
-      this.isOpen = true;
-      if (this._openCallback) {
-        this._openCallback();
-      }
-    });
-    this._ws.on('message', data => this._handleMessage(data));
-    // A map containing the request id and the handler
-    this._responseHandlers = {};
-    this._reader = options.reader || new serializer.GraphSONReader();
-    this._writer = options.writer || new serializer.GraphSONWriter();
-    this._openPromise = null;
-    this._openCallback = null;
-    this._closePromise = null;
-    const mimeType = options.mimeType || defaultMimeType;
-    this._header = String.fromCharCode(mimeType.length) + mimeType;
-    this.isOpen = false;
-    this.traversalSource = options.traversalSource || 'g';
-
-    if (options.authenticator) {
-      this._authenticator = options.authenticator;
-    }
-  }
-
-  /**
-   * Opens the connection, if its not already opened.
-   * @returns {Promise}
-   */
-  open() {
-    if (this._closePromise) {
-      return this._openPromise = Promise.reject(new Error('Connection has been closed'));
-    }
-    if (this.isOpen) {
-      return Promise.resolve();
-    }
-    if (this._openPromise) {
-      return this._openPromise;
-    }
-    return this._openPromise = new Promise((resolve, reject) => {
-      // Set the callback that will be invoked once the WS is opened
-      this._openCallback = err => err ? reject(err) : resolve();
-    });
+    this._client = new Client(url, options);
   }
 
   /** @override */
-  submit(bytecode, op, args, requestId, processor) {
-    return this.open().then(() => new Promise((resolve, reject) => {
-      if (requestId === null || requestId === undefined) {
-        requestId = utils.getUuid();
-        this._responseHandlers[requestId] = {
-          callback: (err, result) => err ? reject(err) : resolve(result),
-          result: null
-        };
-      }
-
-      const message = bufferFromString(this._header + JSON.stringify(this._getRequest(requestId, bytecode, op, args, processor)));
-      this._ws.send(message);
-    }));
+  open() {
+    return this._client.open();
   }
 
-  _getRequest(id, bytecode, op, args, processor) {
-    if (args) {
-      args = this._adaptArgs(args, true);
-    }
-
-    return ({
-      'requestId': { '@type': 'g:UUID', '@value': id },
-      'op': op || 'bytecode',
-      // if using op eval need to ensure processor stays unset if caller didn't set it.
-      'processor': (!processor && op !== 'eval') ? 'traversal' : processor,
-      'args': args || {
-        'gremlin': this._writer.adaptObject(bytecode),
-        'aliases': { 'g': this.traversalSource }
-      }
-    });
+  /** @override */
+  submit(bytecode) {
+    return this._client.submit(bytecode);
   }
 
-  _handleMessage(data) {
-    const response = this._reader.read(JSON.parse(data.toString()));
-    if (response.requestId === null || response.requestId === undefined) {
-        // There was a serialization issue on the server that prevented the parsing of the request id
-        // We invoke any of the pending handlers with an error
-        Object.keys(this._responseHandlers).forEach(requestId => {
-          const handler = this._responseHandlers[requestId];
-          this._clearHandler(requestId);
-          if (response.status !== undefined && response.status.message) {
-            return handler.callback(
-              new Error(util.format(
-                'Server error (no request information): %s (%d)', response.status.message, response.status.code)));
-          } else {
-            return handler.callback(new Error(util.format('Server error (no request information): %j', response)));
-          }
-        });
-        return;
-    }
-
-    const handler = this._responseHandlers[response.requestId];
-
-    if (!handler) {
-      // The handler for a given request id was not found
-      // It was probably invoked earlier due to a serialization issue.
-      return;
-    }
-
-    if (response.status.code === responseStatusCode.authenticationChallenge && this._authenticator) {
-      this._authenticator.evaluateChallenge(response.result.data).then(res => {
-        return this.submit(null, 'authentication', res, response.requestId);
-      }).catch(handler.callback);
-
-      return;
-    }
-    else if (response.status.code >= 400) {
-      // callback in error
-      return handler.callback(
-        new Error(util.format('Server error: %s (%d)', response.status.message, response.status.code)));
-    }
-    switch (response.status.code) {
-      case responseStatusCode.noContent:
-        this._clearHandler(response.requestId);
-        return handler.callback(null, { traversers: []});
-      case responseStatusCode.partialContent:
-        handler.result = handler.result || [];
-        handler.result.push.apply(handler.result, response.result.data);
-        break;
-      default:
-        if (handler.result) {
-          handler.result.push.apply(handler.result, response.result.data);
-        }
-        else {
-          handler.result = response.result.data;
-        }
-        this._clearHandler(response.requestId);
-        return handler.callback(null, { traversers: handler.result });
-    }
-  }
-
-  /**
-   * Clears the internal state containing the callback and result buffer of a given request.
-   * @param requestId
-   * @private
-   */
-  _clearHandler(requestId) {
-    delete this._responseHandlers[requestId];
-  }
-
-  /**
-   * Takes the given args map and ensures all arguments are passed through to _write.adaptObject
-   * @param {Object} args Map of arguments to process
-   * @returns {Object}
-   * @private
-   */
-  _adaptArgs(args, protocolLevel) {
-    if (args instanceof Object) {
-      let newObj = {};
-      Object.keys(args).forEach((key) => {
-        // bindings key (at the protocol-level needs special handling. without this, it wraps the generated Map
-        // in another map for types like EnumValue. Could be a nicer way to do this but for now it's solving the
-        // problem with script submission of non JSON native types
-        if (protocolLevel && key === 'bindings')
-          newObj[key] = this._adaptArgs(args[key], false);
-        else
-          newObj[key] = this._writer.adaptObject(args[key]);
-      });
-
-      return newObj;
-    }
-
-    return args;
-  }
-
-  /**
-   * Closes the Connection.
-   * @return {Promise}
-   */
+  /** @override */
   close() {
-    if (!this._closePromise) {
-      this._closePromise = new Promise(resolve => {
-        this._ws.on('close', function () {
-          this.isOpen = false;
-          resolve();
-        });
-        this._ws.close();
-      });
-    }
-    return this._closePromise;
+    return this._client.close();
   }
 }
-
-const bufferFromString = (Int8Array.from !== Buffer.from && Buffer.from) || function newBuffer(text) {
-  return new Buffer(text, 'utf8');
-};
 
 module.exports = DriverRemoteConnection;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/remote-connection.js
@@ -25,23 +25,40 @@
 const t = require('../process/traversal');
 const TraversalStrategy = require('../process/traversal-strategy').TraversalStrategy;
 
+/**
+ * Represents an abstraction of a "connection" to a "server" that is capable of processing a traversal and
+ * returning results.
+ */
 class RemoteConnection {
   constructor(url) {
     this.url = url;
   }
 
   /**
-   * @abstract
-   * @param {Bytecode} bytecode
-   * @param {String} op Operation to perform, defaults to bytecode.
-   * @param {Object} args The arguments for the operation. Defaults to an associative array containing values for "aliases" and "gremlin" keys.
-   * @param {String} requestId A requestId for the current request. If none provided then a requestId is generated internally.
-   * @param {String} processor The processor to use on the connection.
+   * Opens the connection, if its not already opened.
    * @returns {Promise}
    */
-  submit(bytecode, op, args, requestId, processor) {
-    throw new Error('submit() was not implemented');
+  open() {
+    throw new Error('open() must be implemented');
+  }
+
+  /**
+   * Submits the <code>Bytecode</code> provided and returns a <code>RemoteTraversal</code>.
+   * @abstract
+   * @param {Bytecode} bytecode
+   * @returns {Promise} Returns a <code>Promise</code> that resolves to a <code>RemoteTraversal</code>.
+   */
+  submit(bytecode) {
+    throw new Error('submit() must be implemented');
   };
+
+  /**
+   * Closes the connection, if its not already opened.
+   * @returns {Promise}
+   */
+  close() {
+    throw new Error('close() must be implemented');
+  }
 }
 
 class RemoteTraversal extends t.Traversal {
@@ -75,8 +92,4 @@ class RemoteStrategy extends TraversalStrategy {
   }
 }
 
-module.exports = {
-  RemoteConnection: RemoteConnection,
-  RemoteStrategy: RemoteStrategy,
-  RemoteTraversal: RemoteTraversal
-};
+module.exports = { RemoteConnection, RemoteStrategy, RemoteTraversal };

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/remote-connection.js
@@ -61,6 +61,9 @@ class RemoteConnection {
   }
 }
 
+/**
+ * Represents a traversal as a result of a {@link RemoteConnection} submission.
+ */
 class RemoteTraversal extends t.Traversal {
   constructor(traversers, sideEffects) {
     super(null, null, null);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/result-set.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/result-set.js
@@ -1,0 +1,92 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+/**
+ * @author Jorge Bay Gondra
+ */
+'use strict';
+
+const util = require('util');
+const inspect = util.inspect.custom || 'inspect';
+
+/**
+ * Represents the response returned from the execution of a Gremlin traversal or script.
+ */
+class ResultSet {
+
+  /**
+   * Creates a new instance of {@link ResultSet}.
+   * @param {Array} items
+   */
+  constructor(items) {
+    if (!Array.isArray(items)) {
+      throw new TypeError('items must be an Array instance');
+    }
+
+    this._items = items;
+
+    /**
+     * Gets the amount of items in the result.
+     * @type {Number}
+     */
+    this.length = items.length;
+
+    /**
+     * Access the raw result items via a property.
+     * @deprecated It will be removed in Apache TinkerPop version 3.4.
+     * Use <code>toArray()</code> or iterate directly from the <code>ResultSet</code>.
+     * @type {Array}
+     */
+    this.traversers = items;
+  }
+
+  /**
+   * Gets the iterator associated with this instance.
+   * @returns {Iterator}
+   */
+  [Symbol.iterator]() {
+    return this._items[Symbol.iterator]();
+  }
+
+  /**
+   * Provides a representation useful for debug and tracing.
+   */
+  [inspect]() {
+    return this._items;
+  }
+
+  /**
+   * Gets an array of result items.
+   * @returns {Array}
+   */
+  toArray() {
+    return this._items;
+  }
+
+  /**
+   * Returns the first item.
+   * @returns {Object|null}
+   */
+  first() {
+    const item = this._items[0];
+    return item !== undefined ? item : null;
+  }
+}
+
+module.exports = ResultSet;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
@@ -31,7 +31,7 @@ exports.toLong = function toLong(value) {
 
 const Long = exports.Long = function Long(value) {
   if (typeof value !== 'string' && typeof value !== 'number') {
-    throw new TypeError('Ty')
+    throw new TypeError('The value must be a string or a number');
   }
   this.value = value.toString();
 };
@@ -53,4 +53,6 @@ exports.getUuid = function getUuid() {
     hex.substr(12, 4) + '-' +
     hex.substr(16, 4) + '-' +
     hex.substr(20, 12));
-}
+};
+
+exports.emptyArray = Object.freeze([]);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
@@ -21,18 +21,18 @@
  * @author Jorge Bay Gondra
  */
 'use strict';
-const os = require('os');
 
 const DriverRemoteConnection = require('../lib/driver/driver-remote-connection');
 const Client = require('../lib/driver/client');
 const PlainTextSaslAuthenticator = require('../lib/driver/auth/plain-text-sasl-authenticator');
 
+/** @returns {DriverRemoteConnection} */
 exports.getConnection = function getConnection(traversalSource) {
   return new DriverRemoteConnection('ws://localhost:45940/gremlin', { traversalSource: traversalSource });
 };
 
-exports.getSecureConnectionWithPlainTextSaslAuthenticator = function getConnection(traversalSource) {
-  const authenticator = new PlainTextSaslAuthenticator('stephen', 'password');
+exports.getSecureConnectionWithPlainTextSaslAuthenticator = (traversalSource, username, password) => {
+  const authenticator = new PlainTextSaslAuthenticator(username, password);
   return new DriverRemoteConnection('ws://localhost:45941/gremlin', { 
     traversalSource: traversalSource, 
     authenticator: authenticator, 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
@@ -26,20 +26,23 @@ const DriverRemoteConnection = require('../lib/driver/driver-remote-connection')
 const Client = require('../lib/driver/client');
 const PlainTextSaslAuthenticator = require('../lib/driver/auth/plain-text-sasl-authenticator');
 
+const serverUrl = 'ws://localhost:45940/gremlin';
+const serverAuthUrl = 'ws://localhost:45941/gremlin';
+
 /** @returns {DriverRemoteConnection} */
 exports.getConnection = function getConnection(traversalSource) {
-  return new DriverRemoteConnection('ws://localhost:45940/gremlin', { traversalSource: traversalSource });
+  return new DriverRemoteConnection(serverUrl, { traversalSource });
 };
 
 exports.getSecureConnectionWithPlainTextSaslAuthenticator = (traversalSource, username, password) => {
   const authenticator = new PlainTextSaslAuthenticator(username, password);
-  return new DriverRemoteConnection('ws://localhost:45941/gremlin', { 
-    traversalSource: traversalSource, 
-    authenticator: authenticator, 
-    rejectUnauthorized: false 
+  return new DriverRemoteConnection(serverAuthUrl, {
+    traversalSource,
+    authenticator,
+    rejectUnauthorized: false
   });
 };
 
 exports.getClient = function getClient(traversalSource) {
-  return new Client('ws://localhost:45940/gremlin', { traversalSource: traversalSource });
+  return new Client(serverUrl, { traversalSource });
 };

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
@@ -38,35 +38,32 @@ describe('Client', function () {
   describe('#submit()', function () {
     it('should send bytecode', function () {
       return client.submit(new Bytecode().addStep('V', []).addStep('tail', []))
-        .then(function (response) {
-          assert.ok(response);
-          assert.ok(response.traversers);
-          assert.strictEqual(response.traversers.length, 1);
-          assert.ok(response.traversers[0].object instanceof graphModule.Vertex);
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.length, 1);
+          assert.ok(result.first().object instanceof graphModule.Vertex);
         });
     });
     it('should send and parse a script', function () {
       return client.submit('g.V().tail()')
-        .then(function (response) {
-          assert.ok(response);
-          assert.ok(response.traversers);
-          assert.strictEqual(response.traversers.length, 1);
-          assert.ok(response.traversers[0] instanceof graphModule.Vertex);
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.length, 1);
+          assert.ok(result.first() instanceof graphModule.Vertex);
         });
     });
     it('should send and parse a script with bindings', function () {
       return client.submit('x + x', { x: 3 })
-        .then(function (response) {
-          assert.ok(response);
-          assert.ok(response.traversers);
-          assert.strictEqual(response.traversers[0], 6);
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.first(), 6);
         });
     });
     it('should send and parse a script with non-native javascript bindings', function () {
       return client.submit('card.class.simpleName + ":" + card', { card: t.cardinality.set } )
-        .then(function (response) {
-          assert.ok(response);
-          assert.strictEqual(response.traversers[0], 'Cardinality:set');
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.first(), 'Cardinality:set');
         });
     });
   });

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
@@ -25,19 +25,19 @@ const graphModule = require('../../lib/structure/graph');
 const helper = require('../helper');
 const t = require('../../lib/process/traversal');
 
-let connection;
+let client;
 
 describe('Client', function () {
   before(function () {
-    connection = helper.getClient('gmodern');
-    return connection.open();
+    client = helper.getClient('gmodern');
+    return client.open();
   });
   after(function () {
-    return connection.close();
+    return client.close();
   });
   describe('#submit()', function () {
     it('should send bytecode', function () {
-      return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
+      return client.submit(new Bytecode().addStep('V', []).addStep('tail', []))
         .then(function (response) {
           assert.ok(response);
           assert.ok(response.traversers);
@@ -46,7 +46,7 @@ describe('Client', function () {
         });
     });
     it('should send and parse a script', function () {
-      return connection.submit('g.V().tail()')
+      return client.submit('g.V().tail()')
         .then(function (response) {
           assert.ok(response);
           assert.ok(response.traversers);
@@ -55,7 +55,7 @@ describe('Client', function () {
         });
     });
     it('should send and parse a script with bindings', function () {
-      return connection.submit('x + x', { x: 3 })
+      return client.submit('x + x', { x: 3 })
         .then(function (response) {
           assert.ok(response);
           assert.ok(response.traversers);
@@ -63,7 +63,7 @@ describe('Client', function () {
         });
     });
     it('should send and parse a script with non-native javascript bindings', function () {
-      return connection.submit('card.class.simpleName + ":" + card', { card: t.cardinality.set } )
+      return client.submit('card.class.simpleName + ":" + card', { card: t.cardinality.set } )
         .then(function (response) {
           assert.ok(response);
           assert.strictEqual(response.traversers[0], 'Cardinality:set');

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/remote-connection-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/remote-connection-tests.js
@@ -37,6 +37,7 @@ describe('DriverRemoteConnection', function () {
   after(function () {
     return connection.close();
   });
+
   describe('#submit()', function () {
     it('should send the request and parse the response', function () {
       return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
@@ -21,43 +21,38 @@
 
 const assert = require('assert');
 const Bytecode = require('../../lib/process/bytecode');
-const graphModule = require('../../lib/structure/graph');
 const helper = require('../helper');
 
 let connection;
 
-describe('DriverRemoteConnectionWithPlainTextSaslAuthenticator', function () {
-  before(function () {
+describe('DriverRemoteConnection', function () {
+  context('with PlainTextSaslAuthenticator', function () {
     this.timeout(20000);
-    connection = helper.getSecureConnectionWithPlainTextSaslAuthenticator(null);
-    return connection.open();
-  });
-  after(function () {
-    return connection.close();
-  });
-  describe('#submit()', function () {
-    it('should send the request with valid credentials and parse the response', function () {
-      return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
-        .then(function (response) {
-          assert.ok(response);
-          assert.ok(response.traversers);
-        });
+
+    afterEach(function () {
+      return connection.close();
     });
-    it('should send the request with invalid credentials and parse the response error', function () {
-      connection._authenticator._options.mechanism._options.username = 'Bob';
-      return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
-        .catch(function (err) {
-          assert.ok(err);
-          assert.ok(err.message.indexOf('401') > 0);
-        });
-    });
-    it('should send incorrect configuration to the authenticator and parse the response error', function () {
-      delete connection._authenticator._options.mechanism._options.username;
-      delete connection._authenticator._options.mechanism._options.password;
-      return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
-        .catch(function (err) {
-          assert.ok(err);
-        });
+
+    describe('#submit()', function () {
+      it('should send the request with valid credentials and parse the response', function () {
+        connection = helper.getSecureConnectionWithPlainTextSaslAuthenticator(null, 'stephen', 'password');
+
+        return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
+          .then(function (response) {
+            assert.ok(response);
+            assert.ok(response.traversers);
+          });
+      });
+
+      it('should send the request with invalid credentials and parse the response error', function () {
+        connection = helper.getSecureConnectionWithPlainTextSaslAuthenticator(null, 'Bob', 'password');
+
+        return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
+          .catch(function (err) {
+            assert.ok(err);
+            assert.ok(err.message.indexOf('401') > 0);
+          });
+      });
     });
   });
 });

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/exports-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/exports-test.js
@@ -66,10 +66,16 @@ describe('API', function () {
   });
   it('should expose fields under driver', function () {
     assert.ok(glvModule.driver);
-    assert.strictEqual(typeof glvModule.driver.RemoteConnection, 'function');
-    assert.strictEqual(typeof glvModule.driver.RemoteStrategy, 'function');
-    assert.strictEqual(typeof glvModule.driver.RemoteTraversal, 'function');
-    assert.strictEqual(typeof glvModule.driver.DriverRemoteConnection, 'function');
-    assert.strictEqual(glvModule.driver.DriverRemoteConnection.name, 'DriverRemoteConnection');
+    validateConstructor(glvModule.driver, 'RemoteConnection');
+    validateConstructor(glvModule.driver, 'RemoteStrategy');
+    validateConstructor(glvModule.driver, 'RemoteTraversal');
+    validateConstructor(glvModule.driver, 'DriverRemoteConnection');
+    validateConstructor(glvModule.driver, 'Client');
+    validateConstructor(glvModule.driver, 'ResultSet');
   });
 });
+
+function validateConstructor(parent, name) {
+  assert.strictEqual(typeof parent[name], 'function');
+  assert.strictEqual(parent[name].name, name);
+}

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/result-set-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/result-set-test.js
@@ -1,0 +1,86 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+/**
+ * @author Jorge Bay Gondra
+ */
+'use strict';
+
+const assert = require('assert');
+const util = require('util');
+const ResultSet = require('../../lib/driver/result-set');
+
+describe('ResultSet', function () {
+
+  describe('#toArray()', () => {
+    it('should return an array of items', () => {
+      const items = [ 'a', 'b' ];
+      const result = new ResultSet(items);
+      assert.ok(Array.isArray(result.toArray()));
+      assert.deepStrictEqual(result.toArray(), items);
+    });
+  });
+
+  describe('#length', () => {
+    it('should return the length of the items', () => {
+      const items = [ 'a', 'b', 1, 0 ];
+      const result = new ResultSet(items);
+      assert.strictEqual(result.length, items.length);
+    });
+  });
+
+  describe('#first()', () => {
+    it('should return the first item when there are one or more than one item', () => {
+      assert.strictEqual(new ResultSet(['a', 'b']).first(), 'a');
+      assert.strictEqual(new ResultSet(['z']).first(), 'z');
+    });
+
+    it('should return null when there are no items', () => {
+      assert.strictEqual(new ResultSet([]).first(), null);
+    });
+  });
+
+  describe('#[Symbol.iterator]()', () => {
+    it('should support be iterable', () => {
+      const items = [ 1, 2, 3 ];
+      const result = new ResultSet(items);
+      const obtained = [];
+      for (let item of result) {
+        obtained.push(item);
+      }
+
+      assert.deepStrictEqual(obtained, items);
+      assert.deepStrictEqual(Array.from(result), items);
+    });
+  });
+
+  describe('#[util.inspect.custom]()', () => {
+    it('should return the Array representation', () => {
+      assert.strictEqual(util.inspect(new ResultSet([ 1, 2, 3 ])), '[ 1, 2, 3 ]');
+    });
+  });
+
+  describe('#traversers', () => {
+    it('should expose deprecated property', () => {
+      const items = [ 'a', 'b' ];
+      // Traversers property is going to be removed in upcoming versions
+      assert.strictEqual(new ResultSet(items).traversers, items);
+    });
+  });
+});


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2070

Extract `Connection` implementation out of the `DriverRemoteConnection`.

The `DriverRemoteConnection` now uses a `Client` instance, a `Client` instance may contain one or more `Connection` instances, similar to the Python and .NET glv.

Introduce `ResultSet` that is aligned to other GLVs: 
- `Client` and `Connection` `submit()` methods return a `ResultSet` instance
- `DriverRemoteConnection` submissions returns an instance of `RemoteTraversal`.

This is a large-ish refactor but it doesn't represent a breaking change for the user.

Additionally, I've identified an issue when we introduced script submission support in gremlin-javascript (my bad!): We exposed a property named `traversers` (see previous code examples). I've maintained that property and marked it as deprecated, to be removed in 3.4, and updated all code examples to stop referencing to it.