### PR TITLE
TINKERPOP-2077: Add default create() method to VertexProgram.Builder

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
@@ -242,7 +242,7 @@ public interface VertexProgram<M> extends Cloneable {
 
         public <P extends VertexProgram> P create(final Graph graph);
         
-        default <P extends VertexProgram> P create() {
+        default public <P extends VertexProgram> P create() {
           return this.create(null);
         }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
@@ -241,6 +241,10 @@ public interface VertexProgram<M> extends Cloneable {
         public Builder configure(final Object... keyValues);
 
         public <P extends VertexProgram> P create(final Graph graph);
+        
+        default <P extends VertexProgram> P create() {
+          return this.create(null);
+        }
 
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -2562,10 +2562,6 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
                 return (VertexProgramQ) VertexProgram.createVertexProgram(graph, configuration);
             }
 
-            public VertexProgramQ create() {
-                return create(null);
-            }
-
             public Builder property(final String name) {
                 configuration.setProperty(PROPERTY_CFG_KEY, name);
                 return this;
@@ -2863,10 +2859,6 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
                     ConfigurationUtils.append(graph.configuration().subset(SIMPLE_VERTEX_PROGRAM_CFG_PREFIX), configuration);
                 }
                 return (VertexProgramR) VertexProgram.createVertexProgram(graph, configuration);
-            }
-
-            public VertexProgramR create() {
-                return create(null);
             }
 
             public Builder direction(final Direction direction) {


### PR DESCRIPTION
Adds a default create() method to the VertexProgram.Builder so that users don't need to specify null when no Graph is needed.