### PR TITLE
TINKERPOP-2078 Added AnonymousTraversalSource

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,8 +26,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-2-11, 3.2.11>>.
 
 * Fixed `PersistedOutputRDD` to eager persist RDD by adding `count()` action calls.
-* gremlin-python: the graphson deserializer for g:Set should return a python set
+* Deserialized `g:Set` to a Python `Set` in GraphSON in `gremlin-python`.
 * Display the remote stack trace in the Gremlin Console when scripts sent to the server fail.
+* Added `AnonymousTraversalSource` which provides a more unified means of constructing a `TraversalSource`.
 * Changed behavior of GraphSON deserializer in gremlin-python such that `g:Set` returns a Python `Set`.
 * Changed behavior of `iterate()` in Python, Javascript and .NET to send `none()` thus avoiding unnecessary results being returned.
 

--- a/docs/site/home/gremlin.html
+++ b/docs/site/home/gremlin.html
@@ -338,7 +338,7 @@ g.V().hasLabel("person").
           <pre style="padding:10px;"><code class="language-gremlin">Graph graph = GraphFactory.open(...);
 GraphTraversalSource g;
 g = graph.traversal();                                                         // local OLTP
-g = graph.traversal().withRemote(DriverRemoteConnection.using("server.yaml"))  // remote OLTP
+g = traversal().withRemote(DriverRemoteConnection.using("localhost", 8182))    // remote
 g = graph.traversal().withComputer(SparkGraphComputer.class);                  // distributed OLAP
 g = graph.traversal().withComputer(GiraphGraphComputer.class);                 // distributed OLAP</code>
 </pre>

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1001,12 +1001,13 @@ WebSocket configuration, which supports streaming, if that type of use case is r
 </dependency>
 ----
 
-image:remote-graph.png[width=145,float=left] A `TraversalSource` has several `withRemote()` methods which provide an
-interesting alternative to the other methods for connecting to Gremlin Server. It is interesting in that all other
-methods involve construction of a `String` representation of the `Traversal` which is then submitted as a script
-to Gremlin Server (via driver or HTTP). This approach is quite akin to SQL, where query strings are embedded into code
-and submitted to a database server. While there are patterns for taking this approach that can lead to maintainable
-application code, using `withRemote()` could be a better method as it brings some good benefits with it:
+image:remote-graph.png[width=145,float=left] A `TraversalSource` can be configured for "remote" execution which
+provides an interesting alternative to the other methods for connecting to Gremlin Server. It is interesting in that
+all other methods involve construction of a `String` representation of the `Traversal` which is then submitted as a
+script to Gremlin Server (via driver or HTTP). This approach is quite akin to SQL, where query strings are embedded
+into code and submitted to a database server. While there are patterns for taking this approach that can lead to
+maintainable application code, using a "remote" traversal could be a better method as it brings some good benefits
+with it:
 
 * Get auto-complete when writing traversals in an IDE.
 * Get compile-time errors in traversal writing.
@@ -1030,31 +1031,29 @@ connecting to Gremlin Server. Please see the <<connecting-via-java, "Connecting 
 information on those classes and their usage. Finally, the `gremlin.remote.driver.sourceName` setting tells the
 `DriverRemoteConnection` the name of the `TraversalSource` in Gremlin Server to connect to.
 
-IMPORTANT: Gremlin Server supports configurable serialization options. The `withRemote()` feature works best with
-Gryo serialization. While it is compatible with GraphSON, unknown incompatibilities may arise
-
 Gremlin Server needs to be running for this example to work. Use the following configuration:
 
 [source,bourne]
 $ bin/gremlin-server.sh conf/gremlin-server-modern.yaml
 
-To configure a "remote" traversal, there first needs to be a `TraversalSource`. A `TraversalSource` can be generated
-from any `Graph` instance with the `traversal()` method. Of course, any traversals generated from this source using the
-`withRemote()` configuration option will not execute against the local graph. That could be confusing and it may be
-easier to think of the local graph as being "empty". To that end, it is recommended that when using `withRemote()`,
-the `TraversalSource` be generated with `EmptyGraph` as follows:
+There are several ways to configure a "remote" traversal, but the most direct way is to use the helper methods on
+`AnonymousTraversalSource`. These methods can be statically imported:
+
+[source,java]
+import static org.apache.tinkerpop.gremlin.process.traversal.TraversalSourceFactory.traversal;
+
+to allow for syntax as follows:
 
 [gremlin-groovy]
 ----
-graph = EmptyGraph.instance()
-g = graph.traversal().withRemote('conf/remote-graph.properties')
+g = traversal().withRemote('conf/remote-graph.properties')
 g.V().valueMap(true)
 g.close()
 ----
 
-Note the call to `close()` above. The call to `withRemote()` internally instantiates a `Client` instance that can only
-be released by "closing" the `GraphTraversalSource`. It is important to take that step to release resources created
-in that step.
+Note the call to `close()` above. The construction of "g" using the properties file internally instantiates a
+`Client` instance that can only be released by "closing" the `GraphTraversalSource`. It is important to take that
+step to release resources created in that step.
 
 If working with multiple remote `TraversalSource` instances it is more efficient to construct a `Cluster` object and
 then re-use it.
@@ -1062,8 +1061,7 @@ then re-use it.
 [gremlin-groovy]
 ----
 cluster = Cluster.open('conf/remote-objects.yaml')
-graph = EmptyGraph.instance()
-g = graph.traversal().withRemote(DriverRemoteConnection.using(cluster, "g"))
+g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"))
 g.V().valueMap(true)
 g.close()
 cluster.close()
@@ -1087,7 +1085,7 @@ Gremlin-Groovy, use `Bindings`.
 ----
 cluster = Cluster.open('conf/remote-objects.yaml')
 b = Bindings.instance()
-g = EmptyGraph.instance().traversal().withRemote(DriverRemoteConnection.using(cluster, "g"))
+g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"))
 g.V(b.of('id',1)).out('created').values('name')
 g.V(b.of('id',4)).out('created').values('name')
 g.V(b.of('id',4)).out('created').values('name').getBytecode()
@@ -1955,9 +1953,7 @@ ResultSet results = client.submit("g.V().hasLabel('person')");
 
 // no properties returned from g.V().hasLabel("person") because this is using
 // Bytecode API with reference detachment
-Graph graph = EmptyGraph.instance();
-GraphTraversalSource g = graph.traversal().
-                               withRemote('conf/remote-graph.properties');
+GraphTraversalSource g = traversal().withRemote('conf/remote-graph.properties');
 List<Vertex> results = g.V().hasLabel("person").toList();
 ----
 
@@ -1969,9 +1965,7 @@ Cluster cluster = Cluster.open();
 Client client = cluster.connect();
 ResultSet results = client.submit("g.V().hasLabel('person').valueMap(true,'name')");
 
-Graph graph = EmptyGraph.instance();
-GraphTraversalSource g = graph.traversal().
-                               withRemote('conf/remote-graph.properties');
+GraphTraversalSource g = traversal().withRemote('conf/remote-graph.properties');
 List<Vertex> results = g.V().hasLabel("person").valueMap(true,'name').toList();
 ----
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1040,7 +1040,7 @@ There are several ways to configure a "remote" traversal, but the most direct wa
 `AnonymousTraversalSource`. These methods can be statically imported:
 
 [source,java]
-import static org.apache.tinkerpop.gremlin.process.traversal.TraversalSourceFactory.traversal;
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 
 to allow for syntax as follows:
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -100,7 +100,7 @@ Gremlin-Python users will typically make use of the following classes.
 
 [source,python]
 >>> from gremlin_python import statics
->>> from gremlin_python.structure.graph import traversal
+>>> from gremlin_python.process.anonymous_traversal_source import traversal
 >>> from gremlin_python.process.graph_traversal import __
 >>> from gremlin_python.process.strategies import *
 >>> from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
@@ -485,11 +485,11 @@ in Gremlin-Java. The `GraphTraversalSource` requires a RemoteConnection implemen
 [source,javascript]
 ----
 const gremlin = require('gremlin');
-const traversal = gremlin.structure.Graph.traversal;
+const traversal = gremlin.process.AnonymousTraversalSource.traversal;
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 ----
 
-A traversal source can be spawned with `RemoteStrategy` from an empty `Graph`.
+A traversal source can be spawned with `RemoteStrategy` from an `AnonymousTraversalSource`.
 
 [source,javascript]
 ----

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -100,7 +100,7 @@ Gremlin-Python users will typically make use of the following classes.
 
 [source,python]
 >>> from gremlin_python import statics
->>> from gremlin_python.structure.graph import Graph
+>>> from gremlin_python.structure.graph import traversal
 >>> from gremlin_python.process.graph_traversal import __
 >>> from gremlin_python.process.strategies import *
 >>> from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
@@ -155,11 +155,8 @@ $ bin/gremlin-server.sh conf/gremlin-server-modern-py.yaml
 NOTE: The command to use `install` need only be executed once to gather `gremlin-python` dependencies into Gremlin Servers'
 path. Future starts of Gremlin Server will not require that command.
 
-Within the CPython console, an empty `Graph` is created and a traversal source is spawned with `RemoteStrategy`.
-
 [source,python]
->>> graph = Graph()
->>> g = graph.traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
+>>> g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 
 When a traversal from the `GraphTraversalSource` is iterated, the traversal's `Bytecode` is sent over the wire
 via the registered `RemoteConnection`. The bytecode is used to construct the equivalent traversal at the remote traversal source.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -155,6 +155,9 @@ $ bin/gremlin-server.sh conf/gremlin-server-modern-py.yaml
 NOTE: The command to use `install` need only be executed once to gather `gremlin-python` dependencies into Gremlin Servers'
 path. Future starts of Gremlin Server will not require that command.
 
+Within CPython console, a `GraphTraversalSource` is created from the anonymous `traversal()` method where the "g"
+provided to the `DriverRemoteConnection` corresponds to the name of a `GraphTraversalSource` on the remote end.
+
 [source,python]
 >>> g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 
@@ -343,7 +346,7 @@ follows:
 using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 ----
 
-which will expose a static `traversal()` method which can be used as follows to yield a `GraphTraversalSource` assigned
+which will expose a static `Traversal()` method which can be used as follows to yield a `GraphTraversalSource` assigned
 to "g" and configured to connect to Gremlin Server at "localhost:8182":
 
 [source,csharp]

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -335,12 +335,20 @@ When Gremlin Server is running, Gremlin.Net can communicate with Gremlin Server 
 
 IMPORTANT: Gremlin.Net is not compatible with GraphSON 1.0.
 
-A traversal source can be spawned with `RemoteStrategy` from an empty `Graph`.
+A traversal source can be spawned anonymously using an `AnonymousTraversalSource` which can be statically imported as
+follows:
 
 [source,csharp]
 ----
-var graph = new Graph();
-var g = graph.Traversal().WithRemote(new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182))));
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+----
+
+which will expose a static `traversal()` method which can be used as follows to yield a `GraphTraversalSource` assigned
+to "g" and configured to connect to Gremlin Server at "localhost:8182":
+
+[source,csharp]
+----
+var g = Traversal().WithRemote(new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182))));
 ----
 
 When a traversal from the `GraphTraversalSource` is iterated, the traversal’s `Bytecode` is sent over the wire via the registered
@@ -474,7 +482,7 @@ in Gremlin-Java. The `GraphTraversalSource` requires a RemoteConnection implemen
 [source,javascript]
 ----
 const gremlin = require('gremlin');
-const Graph = gremlin.structure.Graph;
+const traversal = gremlin.structure.Graph.traversal;
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 ----
 
@@ -482,8 +490,7 @@ A traversal source can be spawned with `RemoteStrategy` from an empty `Graph`.
 
 [source,javascript]
 ----
-const graph = new Graph();
-const g = graph.traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
+const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
 ----
 
 Gremlin-JavaScript supports plain text SASL authentication, you can set it on the connection options.
@@ -491,7 +498,7 @@ Gremlin-JavaScript supports plain text SASL authentication, you can set it on th
 [source,javascript]
 ----
 const authenticator = new gremlin.driver.auth.PlainTextSaslAuthenticator('myuser', 'mypassword');
-const g = graph.traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin', { authenticator });
+const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin', { authenticator });
 ----
 
 When a traversal from the `GraphTraversalSource` is iterated, the traversal’s `Bytecode` is sent over the wire via

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -27,6 +27,31 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.3.5/CHANGELOG.asciidoc#release-3-3-5[changelog] for a complete list of all the modifications that are part of this release.
 
+=== Upgrading for Users
+
+==== AnonymousTraversalSource
+
+The `AnonymousTraversalSource` provides for a more unified syntax for `TraversalSource` construction by placing greater
+user emphasis on the creation of the source rather than the `Graph` it is connected to. It has a number of different
+static `traversal()` methods available and when imported as:
+
+[source,java]
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+
+allows `TraversalSource` construction syntax such as:
+
+[source,text]
+----
+gremlin> g = traversal().withGraph(TinkerFactory.createModern())
+==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
+gremlin> g = traversal().withRemote('conf/remote-graph.properties')
+==>graphtraversalsource[emptygraph[empty], standard]
+gremlin> g = traversal().withRemote(DriverRemoteConnection.using('localhost',8182))
+==>graphtraversalsource[emptygraph[empty], standard]
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2078[TINKERPOP-2078]
+
 == TinkerPop 3.3.4
 
 *Release Date: October 15, 2018*

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -50,6 +50,10 @@ gremlin> g = traversal().withRemote(DriverRemoteConnection.using('localhost',818
 ==>graphtraversalsource[emptygraph[empty], standard]
 ----
 
+Typically, this syntax is used for "remote" traversal construction for bytecode based requests, but has the option to
+bind a local `Graph` instance to it as well. It doesn't save much typing to do so obviously, so it may not be best
+used in that situation. Python, Javascript and .NET have similar syntax.
+
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2078[TINKERPOP-2078]
 
 == TinkerPop 3.3.4

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
@@ -25,6 +25,8 @@ import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.List;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+
 public class Service implements AutoCloseable {
 
     private final int port = Integer.parseInt(System.getProperty("port", "45940"));
@@ -38,9 +40,7 @@ public class Service implements AutoCloseable {
      * Construct a remote GraphTraversalSource using the above created Cluster instance that will connect to Gremlin
      * Server.
      */
-    private final GraphTraversalSource g = EmptyGraph.instance().
-                                                      traversal().
-                                                      withRemote(DriverRemoteConnection.using(cluster));
+    private final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));
 
     /**
      * Create Service as a singleton given the simplicity of App.

--- a/gremlin-console/conf/remote-graph.properties
+++ b/gremlin-console/conf/remote-graph.properties
@@ -18,8 +18,7 @@
 ##############################################################
 # This configuration is meant for use with withRemote().
 #
-# graph = EmptyGraph.instance()
-# g = graph.traversal().withRemote('conf/remote-graph.properties')
+# g = traversal('conf/remote-graph.properties')
 #
 # This file will work with:
 # - gremlin-server.yaml

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
@@ -62,6 +62,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.SackFunctions;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Translator;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
@@ -239,6 +240,7 @@ public final class CoreImports {
         CLASS_IMPORTS.add(ReadOnlyStrategy.class);
         CLASS_IMPORTS.add(StandardVerificationStrategy.class);
         // graph traversal
+        CLASS_IMPORTS.add(AnonymousTraversalSource.class);
         CLASS_IMPORTS.add(__.class);
         CLASS_IMPORTS.add(GraphTraversal.class);
         CLASS_IMPORTS.add(GraphTraversalSource.class);
@@ -279,6 +281,7 @@ public final class CoreImports {
 
         uniqueMethods(IoCore.class).forEach(METHOD_IMPORTS::add);
         uniqueMethods(P.class).forEach(METHOD_IMPORTS::add);
+        uniqueMethods(AnonymousTraversalSource.class).forEach(METHOD_IMPORTS::add);
         uniqueMethods(__.class).filter(m -> !m.getName().equals("__")).forEach(METHOD_IMPORTS::add);
         uniqueMethods(Computer.class).forEach(METHOD_IMPORTS::add);
         uniqueMethods(TimeUtil.class).forEach(METHOD_IMPORTS::add);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/EmbeddedRemoteConnection.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/EmbeddedRemoteConnection.java
@@ -40,8 +40,7 @@ import java.util.Iterator;
  * GraphTraversalSource g = graph.traversal();
  *
  * // setup the remote as normal but give it the embedded "g" so that it executes against that
- * final Graph remote = EmptyGraph.instance();
- * GraphTraversalSource simulatedRemoteG = remote.traversal().withRemote(new EmbeddedRemoteConnection(g));
+ * GraphTraversalSource simulatedRemoteG = TraversalSourceFactory.traversal(new EmbeddedRemoteConnection(g));
  * assertEquals(6, simulatedRemoteG.V().count().next().intValue());
  * }
  * </pre>

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/AnonymousTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/AnonymousTraversalSource.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+
+/**
+ * Provides a unified way to construct a {@link TraversalSource} from the perspective of the traversal. In this syntax
+ * the user is creating the source and binding it to a reference which is either an existing {@link Graph} instance
+ * or a {@link RemoteConnection}.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class AnonymousTraversalSource<T extends TraversalSource> {
+
+    private final Class<T> traversalSourceClass;
+
+    private AnonymousTraversalSource(final Class<T> traversalSourceClass) {
+        this.traversalSourceClass = traversalSourceClass;
+    }
+
+    /**
+     * Constructs an {@code AnonymousTraversalSource} which will then be configured to spawn a
+     * {@link GraphTraversalSource}.
+     */
+    public static AnonymousTraversalSource<GraphTraversalSource> traversal() {
+        return traversal(GraphTraversalSource.class);
+    }
+
+    /**
+     * Constructs an {@code AnonymousTraversalSource} which will then be configured to spawn the specified
+     * {@link TraversalSource}.
+     */
+    public static <T extends TraversalSource> AnonymousTraversalSource<T> traversal(final Class<T> traversalSourceClass) {
+        return new AnonymousTraversalSource<>(traversalSourceClass);
+    }
+
+    /**
+     * Creates the specified {@link TraversalSource} binding a {@link RemoteConnection} as its reference such that
+     * traversals spawned from it will execute over that reference.
+     */
+    public T withRemote(final String configFile) throws Exception {
+        // for now, this method simply uses the deprecated approach. when this approach is removed we just need to
+        // make it possible to set a RemoteConnection directly on TraversalSource construction.
+        return (T) withGraph(EmptyGraph.instance()).withRemote(configFile);
+    }
+
+    /**
+     * Creates the specified {@link TraversalSource} binding a {@link RemoteConnection} as its reference such that
+     * traversals spawned from it will execute over that reference.
+     */
+    public T withRemote(final Configuration conf) {
+        // for now, this method simply uses the deprecated approach. when this approach is removed we just need to
+        // make it possible to set a RemoteConnection directly on TraversalSource construction.
+        return (T) withGraph(EmptyGraph.instance()).withRemote(conf);
+    }
+
+    /**
+     * Creates the specified {@link TraversalSource} binding a {@link RemoteConnection} as its reference such that
+     * traversals spawned from it will execute over that reference.
+     */
+    public T withRemote(final RemoteConnection remoteConnection) {
+        // for now, this method simply uses the deprecated approach. when this approach is removed we just need to
+        // make it possible to set a RemoteConnection directly on TraversalSource construction.
+        return (T) withGraph(EmptyGraph.instance()).withRemote(remoteConnection);
+    }
+
+    /**
+     * Creates the specified {@link TraversalSource} binding a {@link Graph} as its reference such that traversals
+     * spawned from it will execute over that reference.
+     */
+    public T withGraph(final Graph graph) {
+        try {
+            return traversalSourceClass.getConstructor(Graph.class).newInstance(graph);
+        } catch (final Exception e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
@@ -344,7 +344,11 @@ public interface TraversalSource extends Cloneable, AutoCloseable {
      * Expects key for {@link #GREMLIN_REMOTE_CONNECTION_CLASS} as well as any configuration required by
      * the underlying {@link RemoteConnection} which will be instantiated. Note that the {@code Configuration} object
      * is passed down without change to the creation of the {@link RemoteConnection} instance.
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
      */
+    @Deprecated
     public default TraversalSource withRemote(final Configuration conf) {
         if (!conf.containsKey(GREMLIN_REMOTE_CONNECTION_CLASS))
             throw new IllegalArgumentException("Configuration must contain the '" + GREMLIN_REMOTE_CONNECTION_CLASS + "' key");
@@ -364,7 +368,11 @@ public interface TraversalSource extends Cloneable, AutoCloseable {
     /**
      * Configures the {@code TraversalSource} as a "remote" to issue the {@link Traversal} for execution elsewhere.
      * Calls {@link #withRemote(Configuration)} after reading the properties file specified.
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(String)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
      */
+    @Deprecated
     public default TraversalSource withRemote(final String configFile) throws Exception {
         return withRemote(new PropertiesConfiguration(configFile));
     }
@@ -375,7 +383,10 @@ public interface TraversalSource extends Cloneable, AutoCloseable {
      * {@link RemoteConnection#close()} on them when the {@code TraversalSource} itself is closed.
      *
      * @param connection the {@link RemoteConnection} instance to use to submit the {@link Traversal}.
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(RemoteConnection)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
      */
+    @Deprecated
     public TraversalSource withRemote(final RemoteConnection connection);
 
     public default Optional<Class> getAnonymousTraversalClass() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
@@ -271,24 +272,36 @@ public class GraphTraversalSource implements TraversalSource {
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
      */
     @Override
+    @Deprecated
     public GraphTraversalSource withRemote(final Configuration conf) {
         return (GraphTraversalSource) TraversalSource.super.withRemote(conf);
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(String)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
      */
     @Override
+    @Deprecated
     public GraphTraversalSource withRemote(final String configFile) throws Exception {
         return (GraphTraversalSource) TraversalSource.super.withRemote(configFile);
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(RemoteConnection)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
      */
     @Override
+    @Deprecated
     public GraphTraversalSource withRemote(final RemoteConnection connection) {
         // check if someone called withRemote() more than once, so just release resources on the initial
         // connection as you can't have more than one. maybe better to toss IllegalStateException??

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
@@ -25,9 +25,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.Read
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -41,7 +41,7 @@ public class GraphTraversalSourceTest {
     @Test
     public void shouldCloseRemoteConnectionOnWithRemote() throws Exception {
         final RemoteConnection mock = mock(RemoteConnection.class);
-        final GraphTraversalSource g = EmptyGraph.instance().traversal().withRemote(mock);
+        final GraphTraversalSource g = traversal().withRemote(mock);
         g.close();
 
         verify(mock, times(1)).close();
@@ -51,7 +51,7 @@ public class GraphTraversalSourceTest {
     public void shouldNotAllowLeakRemoteConnectionsIfMultipleAreCreated() throws Exception {
         final RemoteConnection mock1 = mock(RemoteConnection.class);
         final RemoteConnection mock2 = mock(RemoteConnection.class);
-        EmptyGraph.instance().traversal().withRemote(mock1).withRemote(mock2);
+        traversal().withRemote(mock1).withRemote(mock2);
     }
 
     @Test

--- a/gremlin-dotnet/glv/P.template
+++ b/gremlin-dotnet/glv/P.template
@@ -22,11 +22,8 @@
 #endregion
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace Gremlin.Net.Process.Traversal
 {
@@ -101,9 +98,9 @@ namespace Gremlin.Net.Process.Traversal
         }
 <% } %>
 
-        private static T[] ToGenericArray<T>(ICollection<T> collection)
+        private static TT[] ToGenericArray<TT>(ICollection<TT> collection)
         {
-            return collection?.ToArray() ?? new T[0];;
+            return collection?.ToArray() ?? new TT[0];
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
@@ -26,6 +26,8 @@ using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Remote;
 using Gremlin.Net.Structure;
 
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+
 namespace Gremlin.Net.Template
 {
     internal class Program
@@ -37,7 +39,7 @@ namespace Gremlin.Net.Template
         {
             using (var client = new GremlinClient(new GremlinServer(GremlinServerHostname, GremlinServerPort)))
             {
-                var g = new Graph().Traversal().WithRemote(new DriverRemoteConnection(client));
+                var g = Traversal().WithRemote(new DriverRemoteConnection(client));
                 var service = new Service(g);
                 var creators = service.FindCreatorsOfSoftware("lop");
                 foreach (var c in creators)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/AnonymousTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/AnonymousTraversalSource.cs
@@ -1,0 +1,48 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using Gremlin.Net.Structure;
+
+namespace Gremlin.Net.Process.Traversal
+{
+    /// <summary>
+    ///     Provides a method for creating a <see cref="GraphTraversalSource"/> that does not spawn from a
+    ///     <see cref="Graph"/> instance. 
+    /// </summary>
+    public class AnonymousTraversalSource {
+
+        private AnonymousTraversalSource()
+        {
+        }
+
+        /// <summary>
+        ///     Generates a reusable <see cref="GraphTraversalSource" /> instance.
+        /// </summary>
+        /// <returns>A graph traversal source.</returns>
+        public static GraphTraversalSource Traversal_()
+        {
+            return new GraphTraversalSource();
+        }
+    }
+
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/AnonymousTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/AnonymousTraversalSource.cs
@@ -39,7 +39,7 @@ namespace Gremlin.Net.Process.Traversal
         ///     Generates a reusable <see cref="GraphTraversalSource" /> instance.
         /// </summary>
         /// <returns>A graph traversal source.</returns>
-        public static GraphTraversalSource Traversal_()
+        public static GraphTraversalSource Traversal()
         {
             return new GraphTraversalSource();
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
@@ -22,11 +22,8 @@
 #endregion
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace Gremlin.Net.Process.Traversal
 {
@@ -169,9 +166,9 @@ namespace Gremlin.Net.Process.Traversal
         }
 
 
-        private static T[] ToGenericArray<T>(ICollection<T> collection)
+        private static TT[] ToGenericArray<TT>(ICollection<TT> collection)
         {
-            return collection?.ToArray() ?? new T[0];;
+            return collection?.ToArray() ?? new TT[0];
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
@@ -34,7 +34,9 @@ namespace Gremlin.Net.Structure
         /// <summary>
         ///     Generates a reusable <see cref="GraphTraversalSource" /> instance.
         /// </summary>
+        /// <
         /// <returns>A graph traversal source.</returns>
+        [ObsoleteAttribute("As of release 3.3.5, replaced by AnonymousTraversalSource.Traversal() called statically.", false)]
         public GraphTraversalSource Traversal()
         {
             return new GraphTraversalSource();

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
@@ -34,7 +34,6 @@ namespace Gremlin.Net.Structure
         /// <summary>
         ///     Generates a reusable <see cref="GraphTraversalSource" /> instance.
         /// </summary>
-        /// <
         /// <returns>A graph traversal source.</returns>
         [ObsoleteAttribute("As of release 3.3.5, replaced by AnonymousTraversalSource.Traversal() called statically.", false)]
         public GraphTraversalSource Traversal()

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Graph.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System;
 using Gremlin.Net.Process.Traversal;
 
 namespace Gremlin.Net.Structure

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
@@ -26,7 +26,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using Gherkin.Ast;
 using Gremlin.Net.IntegrationTest.Gherkin.Attributes;
@@ -35,6 +34,8 @@ using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure;
 using Newtonsoft.Json.Linq;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Gherkin
 {
@@ -83,7 +84,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             }
             var data = ScenarioData.GetByGraphName(graphName);
             _graphName = graphName;
-            _g = new Graph().Traversal().WithRemote(data.Connection);
+            _g = Traversal_().WithRemote(data.Connection);
         }
 
         [Given("using the parameter (\\w+) defined as \"(.*)\"")]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
@@ -84,7 +84,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             }
             var data = ScenarioData.GetByGraphName(graphName);
             _graphName = graphName;
-            _g = Traversal_().WithRemote(data.Connection);
+            _g = Traversal().WithRemote(data.Connection);
         }
 
         [Given("using the parameter (\\w+) defined as \"(.*)\"")]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/ScenarioData.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/ScenarioData.cs
@@ -31,6 +31,8 @@ using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure;
 
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+
 namespace Gremlin.Net.IntegrationTest.Gherkin
 {
     internal class ScenarioData
@@ -68,14 +70,14 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
 
         public static void CleanEmptyData()
         {
-            var g = new Graph().Traversal().WithRemote(GetByGraphName("empty").Connection);
+            var g = Traversal_().WithRemote(GetByGraphName("empty").Connection);
             g.V().Drop().Iterate();
         }
 
         public static void ReloadEmptyData()
         {
             var graphData = Lazy.Value._dataPerGraph["empty"];
-            var g = new Graph().Traversal().WithRemote(graphData.Connection);
+            var g = Traversal_().WithRemote(graphData.Connection);
             graphData.Vertices = GetVertices(g);
             graphData.Edges = GetEdges(g);
         }
@@ -95,7 +97,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             return new ScenarioData(GraphNames.Select(name =>
             {
                 var connection = ConnectionFactory.CreateRemoteConnection($"g{name}");
-                var g = new Graph().Traversal().WithRemote(connection);
+                var g = Traversal_().WithRemote(connection);
                 return new ScenarioDataPerGraph(name, connection, GetVertices(g), GetEdges(g));
             }).ToDictionary(x => x.Name));
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/ScenarioData.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/ScenarioData.cs
@@ -70,14 +70,14 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
 
         public static void CleanEmptyData()
         {
-            var g = Traversal_().WithRemote(GetByGraphName("empty").Connection);
+            var g = Traversal().WithRemote(GetByGraphName("empty").Connection);
             g.V().Drop().Iterate();
         }
 
         public static void ReloadEmptyData()
         {
             var graphData = Lazy.Value._dataPerGraph["empty"];
-            var g = Traversal_().WithRemote(graphData.Connection);
+            var g = Traversal().WithRemote(graphData.Connection);
             graphData.Vertices = GetVertices(g);
             graphData.Edges = GetEdges(g);
         }
@@ -97,7 +97,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             return new ScenarioData(GraphNames.Select(name =>
             {
                 var connection = ConnectionFactory.CreateRemoteConnection($"g{name}");
-                var g = Traversal_().WithRemote(connection);
+                var g = Traversal().WithRemote(connection);
                 return new ScenarioDataPerGraph(name, connection, GetVertices(g), GetEdges(g));
             }).ToDictionary(x => x.Name));
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/TraversalEvaluationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/TraversalEvaluationTests.cs
@@ -103,7 +103,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
                 Tuple.Create("g.V().as(\"a\").out().as(\"a\").out().as(\"a\").select(\"a\").by(__.unfold().values(\"name\").fold()).tail(Scope.local, 2)", 9),
                 Tuple.Create("g.V().coin(1.0)", 2)
             };
-            var g = Traversal_();
+            var g = Traversal();
             foreach (var tuple in traversalTexts)
             {
                 var traversal = TraversalParser.GetTraversal(tuple.Item1, g, null);

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/TraversalEvaluationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/TraversalEvaluation/TraversalEvaluationTests.cs
@@ -23,8 +23,9 @@
 
 using System;
 using System.Linq;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
 {
@@ -102,7 +103,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin.TraversalEvaluation
                 Tuple.Create("g.V().as(\"a\").out().as(\"a\").out().as(\"a\").select(\"a\").by(__.unfold().values(\"name\").fold()).tail(Scope.local, 2)", 9),
                 Tuple.Create("g.V().coin(1.0)", 2)
             };
-            var g = new Graph().Traversal();
+            var g = Traversal_();
             foreach (var tuple in traversalTexts)
             {
                 var traversal = TraversalParser.GetTraversal(tuple.Item1, g, null);

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
@@ -22,8 +22,9 @@
 #endregion
 
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
 {
@@ -32,7 +33,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void GraphTraversalStepsShouldUnrollParamsParameters()
         {
-            var g = new Graph().Traversal();
+            var g = Traversal_();
 
             var bytecode = g.V().HasLabel("firstLabel", "secondLabel", "thirdLabel").Bytecode;
 
@@ -44,7 +45,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_V_OutXcreatedX()
         {
-            var g = new Graph().Traversal();
+            var g = Traversal_();
 
             var bytecode = g.V().Out("created").Bytecode;
 
@@ -59,7 +60,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_WithSackX1X_E_GroupCount_ByXweightX()
         {
-            var g = new Graph().Traversal();
+            var g = Traversal_();
 
             var bytecode = g.WithSack(1).E().GroupCount<double>().By("weight").Bytecode;
 
@@ -79,7 +80,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_InjectX1_2_3X()
         {
-            var g = new Graph().Traversal();
+            var g = Traversal_();
 
             var bytecode = g.Inject(1, 2, 3).Bytecode;
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
@@ -24,8 +24,6 @@
 using Gremlin.Net.Process.Traversal;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
 {
     public class BytecodeGenerationTests
@@ -33,7 +31,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void GraphTraversalStepsShouldUnrollParamsParameters()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.V().HasLabel("firstLabel", "secondLabel", "thirdLabel").Bytecode;
 
@@ -45,7 +43,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_V_OutXcreatedX()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.V().Out("created").Bytecode;
 
@@ -60,7 +58,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_WithSackX1X_E_GroupCount_ByXweightX()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.WithSack(1).E().GroupCount<double>().By("weight").Bytecode;
 
@@ -80,7 +78,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_InjectX1_2_3X()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.Inject(1, 2, 3).Bytecode;
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
@@ -29,8 +29,6 @@ using Gremlin.Net.Process.Traversal.Strategy.Optimization;
 using Gremlin.Net.Process.Traversal.Strategy.Verification;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
 {
     public class StrategiesTests
@@ -38,7 +36,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithoutStrategies_AfterWithStrategiesWasCalled_WithStrategiesNotAffected()
         {
-            var g = Traversal_().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
+            var g = AnonymousTraversalSource.Traversal().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
@@ -56,7 +54,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeMultipleStrategiesInBytecodeWhenGivenToWithoutStrategies()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy), typeof(LazyBarrierStrategy)).Bytecode;
 
@@ -70,7 +68,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeOneStrategyInBytecodeWhenGivenToWithoutStrategies()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
@@ -83,7 +81,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeConfigurationInBytecodeWhenGivenToWithStrategies()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.WithStrategies(new MatchAlgorithmStrategy("greedy")).Bytecode;
 
@@ -98,7 +96,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeMultipleStrategiesInBytecodeWhenGivenToWithStrategies()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy()).Bytecode;
 
@@ -112,7 +110,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeOneStrategyInBytecodeWhenGivenToWithStrategies()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.WithStrategies(new ReadOnlyStrategy()).Bytecode;
 
@@ -128,7 +126,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithStrategies_Strategies_ApplyToReusedGraphTraversalSource()
         {
-            var g = Traversal_().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
+            var g = AnonymousTraversalSource.Traversal().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
 
             var bytecode = g.V().Bytecode;
 
@@ -144,7 +142,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithStrategies_StrategyWithTraversalInConfig_IncludeTraversalInInConfigInBytecode()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             var bytecode = g.WithStrategies(new SubgraphStrategy(__.Has("name", "marko"))).Bytecode;
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
@@ -27,8 +27,9 @@ using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Process.Traversal.Strategy.Finalization;
 using Gremlin.Net.Process.Traversal.Strategy.Optimization;
 using Gremlin.Net.Process.Traversal.Strategy.Verification;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
 {
@@ -37,8 +38,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithoutStrategies_AfterWithStrategiesWasCalled_WithStrategiesNotAffected()
         {
-            var graph = new Graph();
-            var g = graph.Traversal().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
+            var g = Traversal_().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
@@ -56,8 +56,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeMultipleStrategiesInBytecodeWhenGivenToWithoutStrategies()
         {
-            var graph = new Graph();
-            var g = graph.Traversal();
+            var g = Traversal_();
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy), typeof(LazyBarrierStrategy)).Bytecode;
 
@@ -71,8 +70,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeOneStrategyInBytecodeWhenGivenToWithoutStrategies()
         {
-            var graph = new Graph();
-            var g = graph.Traversal();
+            var g = Traversal_();
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
@@ -85,8 +83,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeConfigurationInBytecodeWhenGivenToWithStrategies()
         {
-            var graph = new Graph();
-            var g = graph.Traversal();
+            var g = Traversal_();
 
             var bytecode = g.WithStrategies(new MatchAlgorithmStrategy("greedy")).Bytecode;
 
@@ -101,8 +98,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeMultipleStrategiesInBytecodeWhenGivenToWithStrategies()
         {
-            var graph = new Graph();
-            var g = graph.Traversal();
+            var g = Traversal_();
 
             var bytecode = g.WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy()).Bytecode;
 
@@ -116,8 +112,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeOneStrategyInBytecodeWhenGivenToWithStrategies()
         {
-            var graph = new Graph();
-            var g = graph.Traversal();
+            var g = Traversal_();
 
             var bytecode = g.WithStrategies(new ReadOnlyStrategy()).Bytecode;
 
@@ -133,8 +128,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithStrategies_Strategies_ApplyToReusedGraphTraversalSource()
         {
-            var graph = new Graph();
-            var g = graph.Traversal().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
+            var g = Traversal_().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
 
             var bytecode = g.V().Bytecode;
 
@@ -150,8 +144,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithStrategies_StrategyWithTraversalInConfig_IncludeTraversalInInConfigInBytecode()
         {
-            var graph = new Graph();
-            var g = graph.Traversal();
+            var g = Traversal_();
 
             var bytecode = g.WithStrategies(new SubgraphStrategy(__.Has("name", "marko"))).Bytecode;
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
@@ -25,8 +25,6 @@ using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
     public class EnumTests
@@ -37,7 +35,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseOrderDecrInByStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var orderedAges = g.V().Values<int>("age").Order().By(Order.Desc).ToList();
 
@@ -48,7 +46,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseTLabelInHasStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var personsCount = g.V().Has(T.Label, "person").Count().Next();
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
@@ -23,8 +23,9 @@
 
 using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -35,9 +36,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldUseOrderDecrInByStep()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var orderedAges = g.V().Values<int>("age").Order().By(Order.Desc).ToList();
 
@@ -47,9 +47,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldUseTLabelInHasStep()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var personsCount = g.V().Has(T.Label, "person").Count().Next();
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
@@ -25,8 +25,6 @@ using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
     public class GraphTraversalSourceTests
@@ -37,7 +35,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseSideEffectSpecifiedInWithSideEffect()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var results = g.WithSideEffect("a", new List<string> {"josh", "peter"})
                 .V(1)

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
@@ -23,8 +23,9 @@
 
 using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -35,9 +36,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldUseSideEffectSpecifiedInWithSideEffect()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var results = g.WithSideEffect("a", new List<string> {"josh", "peter"})
                 .V(1)

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -28,8 +28,6 @@ using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
     public class GraphTraversalTests
@@ -40,7 +38,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Count()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var count = g.V().Count().Next();
 
@@ -51,7 +49,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_VX1X_Next()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var vertex = g.V(1).Next();
 
@@ -63,7 +61,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_VX1X_NextTraverser()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var traverser = g.V(1).NextTraverser();
 
@@ -74,7 +72,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_VX1X_ToList()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var list = g.V(1).ToList();
 
@@ -85,7 +83,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_RepeatXBothX_TimesX5X_NextX10X()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var result = g.V().Repeat(__.Both()).Times(5).Next(10);
 
@@ -96,7 +94,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_RepeatXOutX_TimesX2X_ValuesXNameX()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var t = g.V().Repeat(__.Out()).Times(2).Values<string>("name");
             var names = t.ToList();
@@ -110,7 +108,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShortestPathTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var shortestPath =
                 g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit<Vertex>(1).Path().Next();
@@ -123,7 +121,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ValueMapTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var result = g.V(1).ValueMap<string, IList<object>>().Next();
             Assert.Equal(
@@ -139,7 +137,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ValueMapWithListConversionTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var result = g.V(1).ValueMap<string, IList<int>>("age").Next();
             Assert.Equal(new Dictionary<string, IList<int>>
@@ -152,7 +150,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void GroupedEdgePropertyConversionTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
             var result = g.V().HasLabel("software").Group<string, double>().By("name")
                           .By(__.BothE().Values<double>("weight").Mean<double>()).Next();
             Assert.Equal(new Dictionary<string, double>
@@ -166,7 +164,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseBindingsInTraversal()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var b = new Bindings();
             var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
@@ -178,7 +176,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldExecuteAsynchronouslyWhenPromiseIsCalled()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var count = await g.V().Count().Promise(t => t.Next());
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -21,12 +21,14 @@
 
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -37,9 +39,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_Count()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var count = g.V().Count().Next();
 
@@ -49,9 +50,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_VX1X_Next()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var vertex = g.V(1).Next();
 
@@ -62,9 +62,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_VX1X_NextTraverser()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var traverser = g.V(1).NextTraverser();
 
@@ -74,9 +73,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_VX1X_ToList()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var list = g.V(1).ToList();
 
@@ -86,9 +84,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_RepeatXBothX_TimesX5X_NextX10X()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var result = g.V().Repeat(__.Both()).Times(5).Next(10);
 
@@ -98,9 +95,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_RepeatXOutX_TimesX2X_ValuesXNameX()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var t = g.V().Repeat(__.Out()).Times(2).Values<string>("name");
             var names = t.ToList();
@@ -113,9 +109,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShortestPathTest()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var shortestPath =
                 g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit<Vertex>(1).Path().Next();
@@ -127,9 +122,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ValueMapTest()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var result = g.V(1).ValueMap<string, IList<object>>().Next();
             Assert.Equal(
@@ -144,9 +138,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ValueMapWithListConversionTest()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var result = g.V(1).ValueMap<string, IList<int>>("age").Next();
             Assert.Equal(new Dictionary<string, IList<int>>
@@ -158,9 +151,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void GroupedEdgePropertyConversionTest()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
             var result = g.V().HasLabel("software").Group<string, double>().By("name")
                           .By(__.BothE().Values<double>("weight").Mean<double>()).Next();
             Assert.Equal(new Dictionary<string, double>
@@ -173,9 +165,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldUseBindingsInTraversal()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var b = new Bindings();
             var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
@@ -186,9 +177,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public async Task ShouldExecuteAsynchronouslyWhenPromiseIsCalled()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var count = await g.V().Count().Promise(t => t.Next());
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
@@ -24,8 +24,6 @@
 using Gremlin.Net.Process.Traversal;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
     public class PredicateTests
@@ -36,7 +34,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUsePredicatesCombinedWithPAndInHasStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var count = g.V().Has("age", P.Gt(30).And(P.Lt(35))).Count().Next();
 
@@ -47,7 +45,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUsePWithinInHasStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var count = g.V().Has("name", P.Within("josh", "vadas")).Count().Next();
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
@@ -22,8 +22,9 @@
 #endregion
 
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -34,9 +35,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldUsePredicatesCombinedWithPAndInHasStep()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var count = g.V().Has("age", P.Gt(30).And(P.Lt(35))).Count().Next();
 
@@ -46,9 +46,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldUsePWithinInHasStep()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var count = g.V().Has("name", P.Within("josh", "vadas")).Count().Next();
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/SideEffectTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/SideEffectTests.cs
@@ -22,13 +22,12 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -39,9 +38,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldReturnCachedSideEffectWhenGetIsCalledAfterClose()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
             var t = g.V().Aggregate("a").Iterate();
 
             t.SideEffects.Get("a");
@@ -54,9 +52,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldThrowWhenGetIsCalledAfterCloseAndNoSideEffectsAreCachec()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
             var t = g.V().Aggregate("a").Iterate();
 
             t.SideEffects.Close();
@@ -66,9 +63,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldThrowWhenGetIsCalledAfterDisposeAndNoSideEffectsAreCachec()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
             var t = g.V().Aggregate("a").Iterate();
 
             t.SideEffects.Dispose();
@@ -78,9 +74,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldThrowWhenGetIsCalledWithAnUnknownKey()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
             var t = g.V().Iterate();
 
             Assert.Throws<KeyNotFoundException>(() => t.SideEffects.Get("m"));
@@ -89,9 +84,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldReturnAnEmptyCollectionWhenKeysIsCalledForTraversalWithoutSideEffect()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var t = g.V().Iterate();
             var keys = t.SideEffects.Keys();
@@ -102,9 +96,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldReturnCachedKeysWhenForCloseAfterSomeGet()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
             var t = g.V().Aggregate("a").Aggregate("b").Iterate();
 
             t.SideEffects.Get("a");
@@ -119,9 +112,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void ShouldReturnSideEffectKeyWhenKeysIsCalledForNamedGroupCount()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
             var t = g.V().Out("created").GroupCount("m").By("name").Iterate();
 
             var keys = t.SideEffects.Keys();
@@ -134,9 +126,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public async Task ShouldReturnSideEffectsKeysWhenKeysIsCalledOnTraversalThatExecutedAsynchronously()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var t = await g.V().Aggregate("a").Promise(x => x);
             var keys = t.SideEffects.Keys();
@@ -148,9 +139,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public async Task ShouldReturnSideEffectValueWhenGetIsCalledOnTraversalThatExecutedAsynchronously()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var t = await g.V().Aggregate("a").Promise(x => x);
             var value = t.SideEffects.Get("a");
@@ -161,9 +151,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public async Task ShouldNotThrowWhenCloseIsCalledOnTraversalThatExecutedAsynchronously()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection);
+            var g = Traversal_().WithRemote(connection);
 
             var t = await g.V().Aggregate("a").Promise(x => x);
             t.SideEffects.Close();

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/SideEffectTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/SideEffectTests.cs
@@ -25,9 +25,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Gremlin.Net.Process.Traversal;
 using Xunit;
-
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -39,7 +38,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldReturnCachedSideEffectWhenGetIsCalledAfterClose()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
             var t = g.V().Aggregate("a").Iterate();
 
             t.SideEffects.Get("a");
@@ -53,7 +52,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldThrowWhenGetIsCalledAfterCloseAndNoSideEffectsAreCachec()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
             var t = g.V().Aggregate("a").Iterate();
 
             t.SideEffects.Close();
@@ -64,7 +63,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldThrowWhenGetIsCalledAfterDisposeAndNoSideEffectsAreCachec()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
             var t = g.V().Aggregate("a").Iterate();
 
             t.SideEffects.Dispose();
@@ -75,7 +74,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldThrowWhenGetIsCalledWithAnUnknownKey()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
             var t = g.V().Iterate();
 
             Assert.Throws<KeyNotFoundException>(() => t.SideEffects.Get("m"));
@@ -85,7 +84,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldReturnAnEmptyCollectionWhenKeysIsCalledForTraversalWithoutSideEffect()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var t = g.V().Iterate();
             var keys = t.SideEffects.Keys();
@@ -97,7 +96,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldReturnCachedKeysWhenForCloseAfterSomeGet()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
             var t = g.V().Aggregate("a").Aggregate("b").Iterate();
 
             t.SideEffects.Get("a");
@@ -113,7 +112,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldReturnSideEffectKeyWhenKeysIsCalledForNamedGroupCount()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
             var t = g.V().Out("created").GroupCount("m").By("name").Iterate();
 
             var keys = t.SideEffects.Keys();
@@ -127,7 +126,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldReturnSideEffectsKeysWhenKeysIsCalledOnTraversalThatExecutedAsynchronously()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var t = await g.V().Aggregate("a").Promise(x => x);
             var keys = t.SideEffects.Keys();
@@ -140,7 +139,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldReturnSideEffectValueWhenGetIsCalledOnTraversalThatExecutedAsynchronously()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var t = await g.V().Aggregate("a").Promise(x => x);
             var value = t.SideEffects.Get("a");
@@ -152,7 +151,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldNotThrowWhenCloseIsCalledOnTraversalThatExecutedAsynchronously()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var t = await g.V().Aggregate("a").Promise(x => x);
             t.SideEffects.Close();

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
@@ -28,8 +28,6 @@ using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Process.Traversal.Strategy.Verification;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -41,7 +39,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Count_Next_WithVertexLabelSubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")));
 
@@ -54,7 +52,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_E_Count_Next_WithVertexAndEdgeLabelSubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person"),
                         edgeCriterion: __.HasLabel("created")));
@@ -68,7 +66,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Label_Dedup_Count_Next_WithVertexLabelSubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")));
 
@@ -81,7 +79,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Label_Dedup_Next_WWithVertexLabelSubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")));
 
@@ -94,7 +92,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Count_Next_WithVertexHasPropertySubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.Has("name", "marko")));
 
@@ -107,7 +105,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_E_Count_Next_WithEdgeLimitSubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(edgeCriterion: __.Limit<object>(0)));
 
@@ -120,7 +118,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Label_Dedup_Next_WithVertexHasPropertySubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.Has("name", "marko")));
 
@@ -133,7 +131,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_ValuesXnameX_Next_WithVertexHasPropertySubgraphStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_()
+            var g = AnonymousTraversalSource.Traversal()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.Has("name", "marko")));
 
@@ -146,7 +144,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Count_Next_WithComputer()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection).WithComputer();
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection).WithComputer();
 
             var count = g.V().Count().Next();
 
@@ -157,7 +155,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_E_Count_Next_WithComputer()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection).WithComputer();
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection).WithComputer();
 
             var count = g.E().Count().Next();
 
@@ -168,7 +166,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldThrowWhenModifyingTraversalSourceWithReadOnlyStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection).WithStrategies(new ReadOnlyStrategy());
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection).WithStrategies(new ReadOnlyStrategy());
 
             await Assert.ThrowsAsync<ResponseException>(async () => await g.AddV("person").Promise(t => t.Next()));
         }
@@ -177,7 +175,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void WithoutStrategiesShouldNeutralizeWithStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = Traversal_().WithRemote(connection)
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection)
                 .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")))
                 .WithoutStrategies(typeof(SubgraphStrategy));
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
@@ -26,8 +26,10 @@ using Gremlin.Net.Driver.Exceptions;
 using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Process.Traversal.Strategy.Verification;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
@@ -38,10 +40,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_Count_Next_WithVertexLabelSubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")));
 
@@ -53,10 +53,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_E_Count_Next_WithVertexAndEdgeLabelSubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person"),
                         edgeCriterion: __.HasLabel("created")));
@@ -69,10 +67,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_Label_Dedup_Count_Next_WithVertexLabelSubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")));
 
@@ -84,10 +80,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_Label_Dedup_Next_WWithVertexLabelSubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")));
 
@@ -99,10 +93,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_Count_Next_WithVertexHasPropertySubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.Has("name", "marko")));
 
@@ -114,10 +106,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_E_Count_Next_WithEdgeLimitSubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(edgeCriterion: __.Limit<object>(0)));
 
@@ -129,10 +119,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_Label_Dedup_Next_WithVertexHasPropertySubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.Has("name", "marko")));
 
@@ -144,10 +132,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_ValuesXnameX_Next_WithVertexHasPropertySubgraphStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g =
-                graph.Traversal()
+            var g = Traversal_()
                     .WithRemote(connection)
                     .WithStrategies(new SubgraphStrategy(vertexCriterion: __.Has("name", "marko")));
 
@@ -159,9 +145,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_V_Count_Next_WithComputer()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection).WithComputer();
+            var g = Traversal_().WithRemote(connection).WithComputer();
 
             var count = g.V().Count().Next();
 
@@ -171,9 +156,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void g_E_Count_Next_WithComputer()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection).WithComputer();
+            var g = Traversal_().WithRemote(connection).WithComputer();
 
             var count = g.E().Count().Next();
 
@@ -183,9 +167,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public async Task ShouldThrowWhenModifyingTraversalSourceWithReadOnlyStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection).WithStrategies(new ReadOnlyStrategy());
+            var g = Traversal_().WithRemote(connection).WithStrategies(new ReadOnlyStrategy());
 
             await Assert.ThrowsAsync<ResponseException>(async () => await g.AddV("person").Promise(t => t.Next()));
         }
@@ -193,9 +176,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public void WithoutStrategiesShouldNeutralizeWithStrategy()
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = graph.Traversal().WithRemote(connection)
+            var g = Traversal_().WithRemote(connection)
                 .WithStrategies(new SubgraphStrategy(vertexCriterion: __.HasLabel("person")))
                 .WithoutStrategies(typeof(SubgraphStrategy));
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/Dsl/DslTest.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/Dsl/DslTest.cs
@@ -21,11 +21,12 @@
 
 #endregion
 
-using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure;
 using Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.Dsl 
 {
@@ -88,9 +89,8 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.Dsl
         [Fact]
         public void ShouldUseDsl() 
         {
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
-            var social = graph.Traversal().WithRemote(connection);
+            var social = Traversal_().WithRemote(connection);
 
             Assert.NotNull(social.Persons("marko").Knows("josh").Next());
             Assert.Equal(27, social.Persons("marko").YoungestFriendsAge().Next());

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/Dsl/DslTest.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/Dsl/DslTest.cs
@@ -26,8 +26,6 @@ using Gremlin.Net.Structure;
 using Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.Dsl 
 {
 
@@ -90,7 +88,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.Dsl
         public void ShouldUseDsl() 
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var social = Traversal_().WithRemote(connection);
+            var social = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             Assert.NotNull(social.Persons("marko").Knows("josh").Next());
             Assert.Equal(27, social.Persons("marko").YoungestFriendsAge().Next());

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
@@ -41,7 +41,7 @@ namespace Gremlin.Net.Template.IntegrationTest
         {
             using (var client = CreateClient())
             {
-                var g = Traversal_().WithRemote(new DriverRemoteConnection(client, TestTraversalSource));
+                var g = Traversal().WithRemote(new DriverRemoteConnection(client, TestTraversalSource));
                 var service = new Service(g);
             
                 var creators = service.FindCreatorsOfSoftware("lop");

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
@@ -24,8 +24,9 @@
 using System.Collections.Generic;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Remote;
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.Template.IntegrationTest
 {
@@ -40,7 +41,7 @@ namespace Gremlin.Net.Template.IntegrationTest
         {
             using (var client = CreateClient())
             {
-                var g = new Graph().Traversal().WithRemote(new DriverRemoteConnection(client, TestTraversalSource));
+                var g = Traversal_().WithRemote(new DriverRemoteConnection(client, TestTraversalSource));
                 var service = new Service(g);
             
                 var creators = service.FindCreatorsOfSoftware("lop");

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using Gremlin.Net.Process.Traversal;
 using Xunit;
 
 using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
@@ -32,7 +33,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         [Fact]
         public void ShouldBeIndependentFromReturnedGraphTraversalModififyingBytecode()
         {
-            var g = Traversal_();
+            var g = AnonymousTraversalSource.Traversal();
 
             g.V().Has("someKey", "someValue").Drop();
 
@@ -43,7 +44,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         [Fact]
         public void ShouldBeIndependentFromReturnedGraphTraversalSourceModififyingBytecode()
         {
-            var g1 = Traversal_();
+            var g1 = AnonymousTraversalSource.Traversal();
 
             var g2 = g1.WithSideEffect("someSideEffectKey", "someSideEffectValue");
 
@@ -55,7 +56,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         [Fact]
         public void ShouldBeIndependentFromReturnedGraphTraversalSourceModififyingTraversalStrategies()
         {
-            var gLocal = Traversal_();
+            var gLocal = AnonymousTraversalSource.Traversal();
 
             var gRemote = gLocal.WithRemote(null);
 

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
@@ -21,8 +21,9 @@
 
 #endregion
 
-using Gremlin.Net.Structure;
 using Xunit;
+
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.UnitTest.Process.Traversal
 {
@@ -31,8 +32,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         [Fact]
         public void ShouldBeIndependentFromReturnedGraphTraversalModififyingBytecode()
         {
-            var graph = new Graph();
-            var g = graph.Traversal();
+            var g = Traversal_();
 
             g.V().Has("someKey", "someValue").Drop();
 
@@ -43,8 +43,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         [Fact]
         public void ShouldBeIndependentFromReturnedGraphTraversalSourceModififyingBytecode()
         {
-            var graph = new Graph();
-            var g1 = graph.Traversal();
+            var g1 = Traversal_();
 
             var g2 = g1.WithSideEffect("someSideEffectKey", "someSideEffectValue");
 
@@ -56,8 +55,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         [Fact]
         public void ShouldBeIndependentFromReturnedGraphTraversalSourceModififyingTraversalStrategies()
         {
-            var graph = new Graph();
-            var gLocal = graph.Traversal();
+            var gLocal = Traversal_();
 
             var gRemote = gLocal.WithRemote(null);
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -102,18 +103,20 @@ public class DriverRemoteConnection implements RemoteConnection {
     }
 
     /**
-     * Creates a {@link DriverRemoteConnection} using a new {@link Cluster} instance created from the supplied
-     * configuration file. When {@link #close()} is called, this new {@link Cluster} is also closed. By default,
-     * this method will bind the {@link RemoteConnection} to a graph on the server named "graph".
+     * Creates a {@link DriverRemoteConnection} using a new {@link Cluster} instance created from the supplied host
+     * and port and binds it to a remote {@link GraphTraversalSource} named "g". When {@link #close()} is called,
+     * this new {@link Cluster} is also closed. By default, this method will bind the {@link RemoteConnection} to a
+     * graph on the server named "graph".
      */
     public static DriverRemoteConnection using(final String host, final int port) {
         return using(Cluster.build(host).port(port).create(), DEFAULT_TRAVERSAL_SOURCE);
     }
 
     /**
-     * Creates a {@link DriverRemoteConnection} using a new {@link Cluster} instance created from the supplied
-     * configuration file. When {@link #close()} is called, this new {@link Cluster} is also closed. By default,
-     * this method will bind the {@link RemoteConnection} to the specified graph traversal source name.
+     * Creates a {@link DriverRemoteConnection} using a new {@link Cluster} instance created from the supplied host
+     * port and aliases it to the specified remote {@link GraphTraversalSource}. When {@link #close()} is called, this
+     * new {@link Cluster} is also closed. By default, this method will bind the {@link RemoteConnection} to the
+     * specified graph traversal source name.
      */
     public static DriverRemoteConnection using(final String host, final int port, final String remoteTraversalSourceName) {
         return using(Cluster.build(host).port(port).create(), remoteTraversalSourceName);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -102,6 +102,24 @@ public class DriverRemoteConnection implements RemoteConnection {
     }
 
     /**
+     * Creates a {@link DriverRemoteConnection} using a new {@link Cluster} instance created from the supplied
+     * configuration file. When {@link #close()} is called, this new {@link Cluster} is also closed. By default,
+     * this method will bind the {@link RemoteConnection} to a graph on the server named "graph".
+     */
+    public static DriverRemoteConnection using(final String host, final int port) {
+        return using(Cluster.build(host).port(port).create(), DEFAULT_TRAVERSAL_SOURCE);
+    }
+
+    /**
+     * Creates a {@link DriverRemoteConnection} using a new {@link Cluster} instance created from the supplied
+     * configuration file. When {@link #close()} is called, this new {@link Cluster} is also closed. By default,
+     * this method will bind the {@link RemoteConnection} to the specified graph traversal source name.
+     */
+    public static DriverRemoteConnection using(final String host, final int port, final String remoteTraversalSourceName) {
+        return using(Cluster.build(host).port(port).create(), remoteTraversalSourceName);
+    }
+
+    /**
      * Creates a {@link DriverRemoteConnection} from an existing {@link Cluster} instance. When {@link #close()} is
      * called, the {@link Cluster} is left open for the caller to close. By default, this method will bind the
      * {@link RemoteConnection} to a graph on the server named "graph".

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
@@ -36,6 +36,7 @@ const Client = require('./lib/driver/client');
 const ResultSet = require('./lib/driver/result-set');
 const Authenticator = require('./lib/driver/auth/authenticator');
 const PlainTextSaslAuthenticator = require('./lib/driver/auth/plain-text-sasl-authenticator');
+const AnonymousTraversalSource = require('./lib/process/anonymous-traversal');
 
 module.exports = {
   driver: {
@@ -73,7 +74,8 @@ module.exports = {
     GraphTraversalSource: gt.GraphTraversalSource,
     statics: gt.statics,
     Translator,
-    traversal: gt.traversal
+    traversal: AnonymousTraversalSource.traversal,
+    AnonymousTraversalSource
   },
   structure: {
     io: {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
@@ -72,7 +72,8 @@ module.exports = {
     GraphTraversal: gt.GraphTraversal,
     GraphTraversalSource: gt.GraphTraversalSource,
     statics: gt.statics,
-    Translator
+    Translator,
+    traversal: gt.traversal
   },
   structure: {
     io: {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/anonymous-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/anonymous-traversal.js
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+'use strict';
+
+const graphTraversalModule = require('./graph-traversal');
+const TraversalStrategies = require('./traversal-strategy').TraversalStrategies;
+const GraphTraversalSource = graphTraversalModule.GraphTraversalSource;
+const Graph = require('../structure/graph').Graph;
+
+/**
+ * Provides a unified way to construct a <code>TraversalSource</code> from the perspective of the traversal. In this
+ * syntax the user is creating the source and binding it to a reference which is either an existing <code>Graph</code>
+ * instance or a <code>RemoteConnection</code>.
+ */
+class AnonymousTraversalSource {
+
+  /**
+   * Constructs an {@code AnonymousTraversalSource} which will then be configured to spawn a
+   * {@link GraphTraversalSource}.
+   * @returns {AnonymousTraversalSource}.
+   */
+  static traversal() {
+    return new AnonymousTraversalSource();
+  }
+
+  /**
+   * Creates the specified {@link GraphTraversalSource{ binding a {@link RemoteConnection} as its reference such that
+   * traversals spawned from it will execute over that reference.
+   * @param {GraphTraversalSource} remoteConnection
+   * @return {GraphTraversalSource}
+   */
+  withRemote(remoteConnection) {
+    return this.withGraph(new Graph()).withRemote(remoteConnection);
+  }
+
+  /**
+   * Creates the specified {@link GraphTraversalSource} binding a {@link Graph} as its reference such that traversals
+   * spawned from it will execute over that reference.
+   * @param {Graph} graph
+   * @return {GraphTraversalSource}
+   */
+  withGraph(graph) {
+    return new GraphTraversalSource(graph, new TraversalStrategies());
+  }
+}
+
+module.exports = AnonymousTraversalSource;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
@@ -47,6 +47,7 @@ class GraphTraversalSource {
   /**
    * @param remoteConnection
    * @returns {GraphTraversalSource}
+   * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
    */
   withRemote(remoteConnection) {
     const traversalStrategy = new TraversalStrategies(this.traversalStrategies);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
@@ -159,20 +159,11 @@ function areEqual(obj1, obj2) {
   return false;
 }
 
-/**
-* Returns an anonymous traversal source.
-* @returns {GraphTraversalSource}
-*/
-function traversal() {
-  return new gt.GraphTraversalSource(new Graph(), new TraversalStrategies());
-}
-
 module.exports = {
   Edge: Edge,
   Graph: Graph,
   Path: Path,
   Property: Property,
   Vertex: Vertex,
-  VertexProperty: VertexProperty,
-  traversal
+  VertexProperty: VertexProperty
 };

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
@@ -29,6 +29,7 @@ class Graph {
   /**
    * Returns the graph traversal source.
    * @returns {GraphTraversalSource}
+   * @deprecated As of release 3.3.5, replaced by the traversal() anonymous function.
    */
   traversal() {
     return new gt.GraphTraversalSource(this, new TraversalStrategies());

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
@@ -158,11 +158,20 @@ function areEqual(obj1, obj2) {
   return false;
 }
 
+/**
+* Returns an anonymous traversal source.
+* @returns {GraphTraversalSource}
+*/
+function traversal() {
+  return new gt.GraphTraversalSource(new Graph(), new TraversalStrategies());
+}
+
 module.exports = {
   Edge: Edge,
   Graph: Graph,
   Path: Path,
   Property: Property,
   Vertex: Vertex,
-  VertexProperty: VertexProperty
+  VertexProperty: VertexProperty,
+  traversal
 };

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -30,9 +30,9 @@ const graphModule = require('../../lib/structure/graph');
 const graphTraversalModule = require('../../lib/process/graph-traversal');
 const traversalModule = require('../../lib/process/traversal');
 const utils = require('../../lib/utils');
-const Graph = graphModule.Graph;
 const Path = graphModule.Path;
 const __ = graphTraversalModule.statics;
+const traversal = graphModule.traversal;
 const t = traversalModule.t;
 
 // Determines whether the feature maps (m[]), are deserialized as objects (true) or maps (false).
@@ -84,7 +84,7 @@ defineSupportCode(function(methods) {
     }
     this.graphName = graphName;
     const data = this.getData();
-    this.g = new Graph().traversal().withRemote(data.connection);
+    this.g = traversal().withRemote(data.connection);
     if (graphName === 'empty') {
       return this.cleanEmptyGraph();
     }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -30,9 +30,9 @@ const graphModule = require('../../lib/structure/graph');
 const graphTraversalModule = require('../../lib/process/graph-traversal');
 const traversalModule = require('../../lib/process/traversal');
 const utils = require('../../lib/utils');
+const traversal = require('../../lib/process/anonymous-traversal').traversal;
 const Path = graphModule.Path;
 const __ = graphTraversalModule.statics;
-const traversal = graphModule.traversal;
 const t = traversalModule.t;
 
 // Determines whether the feature maps (m[]), are deserialized as objects (true) or maps (false).

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/world.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/world.js
@@ -26,8 +26,8 @@ const defineSupportCode = require('cucumber').defineSupportCode;
 const helper = require('../helper');
 const graphModule = require('../../lib/structure/graph');
 const graphTraversalModule = require('../../lib/process/graph-traversal');
-const Graph = graphModule.Graph;
 const __ = graphTraversalModule.statics;
+const traversal = graphModule.traversal;
 
 defineSupportCode(function (methods) {
   const cache = {};
@@ -51,7 +51,7 @@ defineSupportCode(function (methods) {
 
   TinkerPopWorld.prototype.cleanEmptyGraph = function () {
     const connection = this.cache['empty'].connection;
-    const g = new Graph().traversal().withRemote(connection);
+    const g = traversal().withRemote(connection);
     return g.V().drop().toList();
   };
 
@@ -99,12 +99,12 @@ defineSupportCode(function (methods) {
 });
 
 function getVertices(connection) {
-  const g = new Graph().traversal().withRemote(connection);
+  const g = traversal().withRemote(connection);
   return g.V().group().by('name').by(__.tail()).next().then(it => it.value);
 }
 
 function getEdges(connection) {
-  const g = new Graph().traversal().withRemote(connection);
+  const g = traversal().withRemote(connection);
   return g.E().group()
     .by(__.project("o", "l", "i").by(__.outV().values("name")).by(__.label()).by(__.inV().values("name")))
     .by(__.tail())

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/world.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/world.js
@@ -24,10 +24,9 @@
 
 const defineSupportCode = require('cucumber').defineSupportCode;
 const helper = require('../helper');
-const graphModule = require('../../lib/structure/graph');
+const traversal = require('../../lib/process/anonymous-traversal').traversal;
 const graphTraversalModule = require('../../lib/process/graph-traversal');
 const __ = graphTraversalModule.statics;
-const traversal = graphModule.traversal;
 
 defineSupportCode(function (methods) {
   const cache = {};

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
@@ -24,8 +24,8 @@
 
 const assert = require('assert');
 const graphModule = require('../../lib/structure/graph');
-const Graph = graphModule.Graph;
 const Vertex = graphModule.Vertex;
+const traversal = require('../../lib/structure/graph').traversal;
 const utils = require('../../lib/utils');
 const helper = require('../helper');
 
@@ -41,7 +41,7 @@ describe('Traversal', function () {
   });
   describe('#toList()', function () {
     it('should submit the traversal and return a list', function () {
-      var g = new Graph().traversal().withRemote(connection);
+      var g = traversal().withRemote(connection);
       return g.V().toList().then(function (list) {
         assert.ok(list);
         assert.strictEqual(list.length, 6);
@@ -51,14 +51,14 @@ describe('Traversal', function () {
   });
   describe('#next()', function () {
     it('should submit the traversal and return an iterator', function () {
-      var g = new Graph().traversal().withRemote(connection);
-      var traversal = g.V().count();
-      return traversal.next()
+      var g = traversal().withRemote(connection);
+      var t = g.V().count();
+      return t.next()
         .then(function (item) {
           assert.ok(item);
           assert.strictEqual(item.done, false);
           assert.strictEqual(typeof item.value, 'number');
-          return traversal.next();
+          return t.next();
         }).then(function (item) {
           assert.ok(item);
           assert.strictEqual(item.done, true);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
@@ -25,7 +25,7 @@
 const assert = require('assert');
 const graphModule = require('../../lib/structure/graph');
 const Vertex = graphModule.Vertex;
-const traversal = require('../../lib/structure/graph').traversal;
+const traversal = require('../../lib/process/anonymous-traversal').traversal;
 const utils = require('../../lib/utils');
 const helper = require('../helper');
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/exports-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/exports-test.js
@@ -51,6 +51,8 @@ describe('API', function () {
     assert.strictEqual(typeof glvModule.process.scope, 'object');
     assert.strictEqual(typeof glvModule.process.t, 'object');
     assert.ok(glvModule.process.statics);
+    validateConstructor(glvModule.process, 'AnonymousTraversalSource');
+    assert.strictEqual(typeof glvModule.process.traversal, 'function');
   });
   it('should expose fields under structure', function () {
     assert.ok(glvModule.structure);

--- a/gremlin-python/src/main/jython/gremlin_python/process/anonymous_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/anonymous_traversal.py
@@ -1,0 +1,48 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+'''
+
+__author__ = 'Stephen Mallette (http://stephen.genoprime.com)'
+
+from gremlin_python.structure.graph import Graph
+from gremlin_python.process.graph_traversal import GraphTraversalSource
+from gremlin_python.process.traversal import TraversalStrategies
+from .. import statics
+
+
+class AnonymousTraversalSource(object):
+
+    def __init__(self, traversal_source_class=GraphTraversalSource):
+        self.traversal_source_class = traversal_source_class
+
+    @classmethod
+    def traversal(cls, traversal_source_class=GraphTraversalSource):
+        return AnonymousTraversalSource(traversal_source_class)
+
+    def withGraph(self, graph):
+        return self.traversal_source_class(graph, TraversalStrategies.global_cache[graph.__class__])
+
+    def withRemote(self, remote_connection):
+        return self.withGraph(Graph()).withRemote(remote_connection)
+
+
+def traversal(traversal_source_class=GraphTraversalSource):
+    return AnonymousTraversalSource.traversal(traversal_source_class)
+
+
+statics.add_static('traversal', traversal)

--- a/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
@@ -21,6 +21,7 @@ __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
 from gremlin_python.process.graph_traversal import GraphTraversalSource
 from gremlin_python.process.traversal import TraversalStrategies
+from .. import statics
 
 
 class Graph(object):
@@ -127,3 +128,17 @@ class Path(object):
 
     def __len__(self):
         return len(self.objects)
+
+
+'''
+ANONYMOUS TRAVERSAL SOURCE
+'''
+
+
+def traversal(traversal_source_class=None):
+    if not traversal_source_class:
+        traversal_source_class = GraphTraversalSource
+    return traversal_source_class(Graph(), TraversalStrategies.global_cache[Graph])
+
+
+statics.add_static('traversal', traversal)

--- a/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
@@ -22,6 +22,7 @@ __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 from gremlin_python.process.graph_traversal import GraphTraversalSource
 from gremlin_python.process.traversal import TraversalStrategies
 from .. import statics
+import warnings
 
 
 class Graph(object):
@@ -30,6 +31,8 @@ class Graph(object):
             TraversalStrategies.global_cache[self.__class__] = TraversalStrategies()
 
     def traversal(self, traversal_source_class=None):
+        warnings.warn("As of release 3.3.5, replaced by the anonymous traversal() function.", DeprecationWarning)
+
         if not traversal_source_class:
             traversal_source_class = GraphTraversalSource
         return traversal_source_class(self, TraversalStrategies.global_cache[self.__class__])

--- a/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/graph.py
@@ -21,7 +21,6 @@ __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
 from gremlin_python.process.graph_traversal import GraphTraversalSource
 from gremlin_python.process.traversal import TraversalStrategies
-from .. import statics
 import warnings
 
 
@@ -31,7 +30,9 @@ class Graph(object):
             TraversalStrategies.global_cache[self.__class__] = TraversalStrategies()
 
     def traversal(self, traversal_source_class=None):
-        warnings.warn("As of release 3.3.5, replaced by the anonymous traversal() function.", DeprecationWarning)
+        warnings.warn(
+            "As of release 3.3.5, replaced by the gremlin_python.process.anonymous_traversal.traversal() function.",
+            DeprecationWarning)
 
         if not traversal_source_class:
             traversal_source_class = GraphTraversalSource
@@ -131,17 +132,3 @@ class Path(object):
 
     def __len__(self):
         return len(self.objects)
-
-
-'''
-ANONYMOUS TRAVERSAL SOURCE
-'''
-
-
-def traversal(traversal_source_class=None):
-    if not traversal_source_class:
-        traversal_source_class = GraphTraversalSource
-    return traversal_source_class(Graph(), TraversalStrategies.global_cache[Graph])
-
-
-statics.add_static('traversal', traversal)

--- a/gremlin-python/src/main/jython/radish/feature_steps.py
+++ b/gremlin-python/src/main/jython/radish/feature_steps.py
@@ -19,7 +19,8 @@ under the License.
 
 import json
 import re
-from gremlin_python.structure.graph import Graph, Path
+from gremlin_python.structure.graph import Path
+from gremlin_python.structure.graph import traversal
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.traversal import Barrier, Cardinality, P, Pop, Scope, Column, Order, Direction, T, Pick, Operator
 from radish import given, when, then
@@ -49,7 +50,7 @@ ignores = []
 @given("the {graph_name:w} graph")
 def choose_graph(step, graph_name):
     step.context.graph_name = graph_name
-    step.context.g = Graph().traversal().withRemote(step.context.remote_conn[graph_name])
+    step.context.g = traversal().withRemote(step.context.remote_conn[graph_name])
 
 
 @given("the graph initializer of")
@@ -266,14 +267,14 @@ def _make_traversal(g, traversal_string, params):
 
 
 def __create_lookup_v(remote):
-    g = Graph().traversal().withRemote(remote)
+    g = traversal().withRemote(remote)
 
     # hold a map of name/vertex for use in asserting results
     return g.V().group().by('name').by(tail()).next()
 
 
 def __create_lookup_e(remote):
-    g = Graph().traversal().withRemote(remote)
+    g = traversal().withRemote(remote)
 
     # hold a map of the "name"/edge for use in asserting results - "name" in this context is in the form of
     # outgoingV-label->incomingV

--- a/gremlin-python/src/main/jython/radish/feature_steps.py
+++ b/gremlin-python/src/main/jython/radish/feature_steps.py
@@ -20,7 +20,7 @@ under the License.
 import json
 import re
 from gremlin_python.structure.graph import Path
-from gremlin_python.structure.graph import traversal
+from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.traversal import Barrier, Cardinality, P, Pop, Scope, Column, Order, Direction, T, Pick, Operator
 from radish import given, when, then
@@ -55,12 +55,12 @@ def choose_graph(step, graph_name):
 
 @given("the graph initializer of")
 def initialize_graph(step):
-    traversal = _make_traversal(step.context.g, step.text, {})
+    t = _make_traversal(step.context.g, step.text, {})
 
     # just be sure that the traversal returns something to prove that it worked to some degree. probably
     # is overkill to try to assert the complete success of this init operation. presumably the test
     # suite would fail elsewhere if this didn't work which would help identify a problem.
-    result = traversal.toList()
+    result = t.toList()
     assert len(result) > 0
 
     # add the first result - if a map - to the bindings. this is useful for cases when parameters for
@@ -231,8 +231,8 @@ def _table_assertion(data, result, ctx, ordered):
         assert_that(len(results_to_test), is_(0))
 
 
-def _translate(traversal):
-    replaced = traversal.replace("\n", "")
+def _translate(traversal_):
+    replaced = traversal_.replace("\n", "")
     replaced = regex_all.sub(r"Pop.all_", replaced)
     replaced = regex_and.sub(r"\1and_(", replaced)
     replaced = regex_from.sub(r"\1from_(", replaced)

--- a/gremlin-python/src/main/jython/radish/terrain.py
+++ b/gremlin-python/src/main/jython/radish/terrain.py
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 '''
 
-from gremlin_python.structure.graph import Graph
+from gremlin_python.structure.graph import traversal
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
@@ -78,7 +78,7 @@ def prepare_traversal_source(scenario):
 
     remote = DriverRemoteConnection('ws://localhost:45940/gremlin', "ggraph", message_serializer=s)
     scenario.context.remote_conn["empty"] = remote
-    g = Graph().traversal().withRemote(remote)
+    g = traversal().withRemote(remote)
     g.V().drop().iterate()
 
 
@@ -98,14 +98,14 @@ def __create_remote(server_graph_name):
 
 
 def __create_lookup_v(remote):
-    g = Graph().traversal().withRemote(remote)
+    g = traversal().withRemote(remote)
 
     # hold a map of name/vertex for use in asserting results
     return g.V().group().by('name').by(tail()).next()
 
 
 def __create_lookup_e(remote):
-    g = Graph().traversal().withRemote(remote)
+    g = traversal().withRemote(remote)
 
     # hold a map of the "name"/edge for use in asserting results - "name" in this context is in the form of
     # outgoingV-label->incomingV

--- a/gremlin-python/src/main/jython/radish/terrain.py
+++ b/gremlin-python/src/main/jython/radish/terrain.py
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 '''
 
-from gremlin_python.structure.graph import traversal
+from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -28,7 +28,7 @@ from gremlin_python.process.traversal import Traverser
 from gremlin_python.process.traversal import TraversalStrategy
 from gremlin_python.process.traversal import P
 from gremlin_python.process.graph_traversal import __
-from gremlin_python.structure.graph import Graph
+from gremlin_python.structure.graph import traversal
 from gremlin_python.structure.graph import Vertex
 from gremlin_python.process.strategies import SubgraphStrategy
 
@@ -39,7 +39,7 @@ class TestDriverRemoteConnection(object):
     def test_traversals(self, remote_connection):
         statics.load_statics(globals())
         assert "remoteconnection[ws://localhost:45940/gremlin,gmodern]" == str(remote_connection)
-        g = Graph().traversal().withRemote(remote_connection)
+        g = traversal().withRemote(remote_connection)
 
         assert long(6) == g.V().count().toList()[0]
         # #
@@ -86,7 +86,7 @@ class TestDriverRemoteConnection(object):
     def test_iteration(self, remote_connection):
         statics.load_statics(globals())
         assert "remoteconnection[ws://localhost:45940/gremlin,gmodern]" == str(remote_connection)
-        g = Graph().traversal().withRemote(remote_connection)
+        g = traversal().withRemote(remote_connection)
 
         t = g.V().count()
         assert t.hasNext()
@@ -124,7 +124,7 @@ class TestDriverRemoteConnection(object):
     def test_strategies(self, remote_connection):
         statics.load_statics(globals())
         #
-        g = Graph().traversal().withRemote(remote_connection). \
+        g = traversal().withRemote(remote_connection). \
             withStrategies(TraversalStrategy("SubgraphStrategy",
                                              {"vertices": __.hasLabel("person"),
                                               "edges": __.hasLabel("created")}))
@@ -134,14 +134,14 @@ class TestDriverRemoteConnection(object):
         assert 4 == g.V().filter(lambda: ("lambda x: True", "gremlin-python")).count().next()
         assert "person" == g.V().label().dedup().next()
         #
-        g = Graph().traversal().withRemote(remote_connection). \
+        g = traversal().withRemote(remote_connection). \
             withStrategies(SubgraphStrategy(vertices=__.hasLabel("person"), edges=__.hasLabel("created")))
         assert 4 == g.V().count().next()
         assert 0 == g.E().count().next()
         assert 1 == g.V().label().dedup().count().next()
         assert "person" == g.V().label().dedup().next()
         #
-        g = Graph().traversal().withRemote(remote_connection). \
+        g = traversal().withRemote(remote_connection). \
             withStrategies(SubgraphStrategy(edges=__.hasLabel("created")))
         assert 6 == g.V().count().next()
         assert 4 == g.E().count().next()
@@ -155,14 +155,14 @@ class TestDriverRemoteConnection(object):
         assert "person" == g.V().label().next()
         assert "marko" == g.V().name.next()
         #
-        g = Graph().traversal().withRemote(remote_connection).withComputer()
+        g = traversal().withRemote(remote_connection).withComputer()
         assert 6 == g.V().count().next()
         assert 6 == g.E().count().next()
 
     def test_side_effects(self, remote_connection):
         statics.load_statics(globals())
         #
-        g = Graph().traversal().withRemote(remote_connection)
+        g = traversal().withRemote(remote_connection)
         ###
         t = g.V().hasLabel("project").name.iterate()
         assert 0 == len(t.side_effects.keys())
@@ -224,7 +224,7 @@ class TestDriverRemoteConnection(object):
         g.V().has("name", "marko").outE("knows").where(__.inV().has("name", "peter")).drop().iterate()
 
     def test_side_effect_close(self, remote_connection):
-        g = Graph().traversal().withRemote(remote_connection)
+        g = traversal().withRemote(remote_connection)
         t = g.V().aggregate('a').aggregate('b')
         t.toList()
 
@@ -256,7 +256,7 @@ class TestDriverRemoteConnection(object):
             t.side_effects.value_lambda('b')
 
     def test_promise(self, remote_connection):
-        g = Graph().traversal().withRemote(remote_connection)
+        g = traversal().withRemote(remote_connection)
         future = g.V().aggregate('a').promise()
         t = future.result()
         assert len(t.toList()) == 6
@@ -274,7 +274,7 @@ def test_in_tornado_app(remote_connection):
     def go():
         conn = DriverRemoteConnection(
             'ws://localhost:45940/gremlin', 'gmodern', pool_size=4)
-        g = Graph().traversal().withRemote(conn)
+        g = traversal().withRemote(conn)
         yield gen.sleep(0)
         assert len(g.V().toList()) == 6
         conn.close()

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -28,7 +28,7 @@ from gremlin_python.process.traversal import Traverser
 from gremlin_python.process.traversal import TraversalStrategy
 from gremlin_python.process.traversal import P
 from gremlin_python.process.graph_traversal import __
-from gremlin_python.structure.graph import traversal
+from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.structure.graph import Vertex
 from gremlin_python.process.strategies import SubgraphStrategy
 

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
@@ -18,13 +18,11 @@ under the License.
 '''
 import sys
 from threading import Thread
-
-import pytest
 from six.moves import queue
 
 from gremlin_python.driver.driver_remote_connection import (
     DriverRemoteConnection)
-from gremlin_python.structure.graph import traversal
+from gremlin_python.process.anonymous_traversal import traversal
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection_threaded.py
@@ -24,7 +24,7 @@ from six.moves import queue
 
 from gremlin_python.driver.driver_remote_connection import (
     DriverRemoteConnection)
-from gremlin_python.structure.graph import Graph
+from gremlin_python.structure.graph import traversal
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
@@ -63,7 +63,7 @@ def _executor(q, conn):
         conn = DriverRemoteConnection(
             'ws://localhost:45940/gremlin', 'gmodern', pool_size=4)
     try:
-        g = Graph().traversal().withRemote(conn)
+        g = traversal().withRemote(conn)
         future = g.V().promise()
         t = future.result()
         assert len(t.toList()) == 6

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/RemoteGraphProvider.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/RemoteGraphProvider.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteGraph;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
 import org.apache.tinkerpop.gremlin.server.ServerTestHelper;
@@ -118,7 +119,7 @@ public class RemoteGraphProvider extends AbstractGraphProvider implements AutoCl
         // concerns and will be likely relegated to the test module so that OptOut can continue to work and we can
         // full execute the process tests. we should be able to clean this up considerably when RemoteGraph can be
         // moved with breaking change.
-        return super.traversal(graph).withRemote(((RemoteGraph) graph).getConnection());
+        return AnonymousTraversalSource.traversal().withRemote(((RemoteGraph) graph).getConnection());
     }
 
     public static void startServer() throws Exception {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -60,7 +60,6 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.hamcrest.CoreMatchers;
@@ -73,7 +72,6 @@ import java.lang.reflect.Field;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -91,6 +89,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPlugin.Compilation.COMPILE_STATIC;
 import static org.apache.tinkerpop.gremlin.process.traversal.TraversalSource.GREMLIN_REMOTE_CONNECTION_CLASS;
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -397,8 +396,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldTimeOutRemoteTraversal() throws Exception {
-        final Graph graph = EmptyGraph.instance();
-        final GraphTraversalSource g = graph.traversal().withRemote(conf);
+        final GraphTraversalSource g = traversal().withRemote(conf);
 
         try {
             // tests sleeping thread
@@ -1207,8 +1205,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldSupportLambdasUsingWithRemote() throws Exception {
-        final Graph graph = EmptyGraph.instance();
-        final GraphTraversalSource g = graph.traversal().withRemote(conf);
+        final GraphTraversalSource g = traversal().withRemote(conf);
         g.addV("person").property("age", 20).iterate();
         g.addV("person").property("age", 10).iterate();
         assertEquals(50L, g.V().hasLabel("person").map(Lambda.function("it.get().value('age') + 10")).sum().next());
@@ -1216,8 +1213,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldGetSideEffectKeysUsingWithRemote() throws Exception {
-        final Graph graph = EmptyGraph.instance();
-        final GraphTraversalSource g = graph.traversal().withRemote(conf);
+        final GraphTraversalSource g = traversal().withRemote(conf);
         g.addV("person").property("age", 20).iterate();
         g.addV("person").property("age", 10).iterate();
         final GraphTraversal traversal = g.V().aggregate("a").aggregate("b");
@@ -1249,8 +1245,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldCloseSideEffectsUsingWithRemote() throws Exception {
-        final Graph graph = EmptyGraph.instance();
-        final GraphTraversalSource g = graph.traversal().withRemote(conf);
+        final GraphTraversalSource g = traversal().withRemote(conf);
         g.addV("person").property("age", 20).iterate();
         g.addV("person").property("age", 10).iterate();
         final GraphTraversal traversal = g.V().aggregate("a").aggregate("b");
@@ -1300,8 +1295,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldBlockWhenGettingSideEffectKeysUsingWithRemote() throws Exception {
-        final Graph graph = EmptyGraph.instance();
-        final GraphTraversalSource g = graph.traversal().withRemote(conf);
+        final GraphTraversalSource g = traversal().withRemote(conf);
         g.addV("person").property("age", 20).iterate();
         g.addV("person").property("age", 10).iterate();
         final GraphTraversal traversal = g.V().aggregate("a")
@@ -1343,8 +1337,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldBlockWhenGettingSideEffectValuesUsingWithRemote() throws Exception {
-        final Graph graph = EmptyGraph.instance();
-        final GraphTraversalSource g = graph.traversal().withRemote(conf);
+        final GraphTraversalSource g = traversal().withRemote(conf);
         g.addV("person").property("age", 20).iterate();
         g.addV("person").property("age", 10).iterate();
         final GraphTraversal traversal = g.V().aggregate("a")
@@ -1386,8 +1379,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldDoNonBlockingPromiseWithRemote() throws Exception {
-        final Graph graph = EmptyGraph.instance();
-        final GraphTraversalSource g = graph.traversal().withRemote(conf);
+        final GraphTraversalSource g = traversal().withRemote(conf);
         g.addV("person").property("age", 20).promise(Traversal::iterate).join();
         g.addV("person").property("age", 10).promise(Traversal::iterate).join();
         assertEquals(50L, g.V().hasLabel("person").map(Lambda.function("it.get().value('age') + 10")).sum().promise(t -> t.next()).join());

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/jsr223/GremlinEnabledScriptEngineTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/jsr223/GremlinEnabledScriptEngineTest.java
@@ -35,12 +35,10 @@ import javax.script.SimpleBindings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineSuite.ENGINE_TO_TEST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AnyOf.anyOf;
-import static org.hamcrest.core.CombinableMatcher.either;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeThat;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/CoreTraversalTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/CoreTraversalTest.java
@@ -33,7 +33,6 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -42,14 +41,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.inject;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.GraphFeatures.FEATURE_TRANSACTIONS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -298,8 +295,7 @@ public class CoreTraversalTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void shouldAllowEmbeddedRemoteConnectionUsage() {
-        final Graph remote = EmptyGraph.instance();
-        final GraphTraversalSource simulatedRemoteG = remote.traversal().withRemote(new EmbeddedRemoteConnection(g));
+        final GraphTraversalSource simulatedRemoteG = traversal().withRemote(new EmbeddedRemoteConnection(g));
         assertEquals(6, simulatedRemoteG.V().count().next().intValue());
         assertEquals("marko", simulatedRemoteG.V().has("name", "marko").values("name").next());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2078

Basically replaces `EmptyGraph.instance().withRemote()` for `traversal().withRemote()` which is a bit more intuitive.

```text
gremlin> g = traversal().withGraph(TinkerFactory.createModern())
==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
gremlin> g = traversal().withRemote('conf/remote-graph.properties')
==>graphtraversalsource[emptygraph[empty], standard]
gremlin> g = traversal().withRemote(DriverRemoteConnection.using('localhost',8182))
==>graphtraversalsource[emptygraph[empty], standard]
```

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

All tests pass with `docker/build.sh -t -i`

VOTE +1