### PR TITLE
TINKERPOP-2068 bump jackson-databind to 2.9.7 [tp32]

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-2-11]]
 === TinkerPop 3.2.11 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Bumped to Jackson Databind 2.9.7
 
 
 [[release-3-2-10]]

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <!-- Update the shade plugin config whenever you change this version; update what exactly? -->
-            <version>2.9.6</version>
+            <version>2.9.7</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2068

security fix

`docker/build.sh -i -t -n` SUCCESS

VOTE +1