### PR TITLE
TINKERPOP-2069 Document Gremlin.Net driver config

### DIFF
--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -576,9 +576,9 @@ internal class MyTypeReader : IGraphSONDeserializer
     }
 }
 
-var graphsonReader = new GraphSONReader(
+var graphsonReader = new GraphSON3Reader(
     new Dictionary<string, IGraphSONDeserializer> {{MyType.GraphsonType, new MyTypeReader()}});
-var graphsonWriter = new GraphSONWriter(
+var graphsonWriter = new GraphSON3Writer(
     new Dictionary<Type, IGraphSONSerializer> {{typeof(MyType), new MyClassWriter()}});
 
 var gremlinClient = new GremlinClient(new GremlinServer("localhost", 8182), graphsonReader, graphsonWriter);

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1302,6 +1302,7 @@ Gremlin-Console |PLAIN SASL (username/password) |3.0.0-incubating
 |Pluggable SASL |3.0.0-incubating
 |GSSAPI SASL (Kerberos) |3.3.0
 |Gremlin-Python |PLAIN SASL |3.2.2
+|Gremlin.Net |PLAIN SASL |3.2.7
 |Gremlin-Javascript |PLAIN SASL |3.3.0
 |=========================================================
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -343,7 +343,8 @@ A traversal source can be spawned with `RemoteStrategy` from an empty `Graph`.
 [source,csharp]
 ----
 var graph = new Graph();
-var g = graph.Traversal().WithRemote(new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182))));
+var remoteConnection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)));
+var g = graph.Traversal().WithRemote(remoteConnection);
 ----
 
 When a traversal from the `GraphTraversalSource` is iterated, the traversal’s `Bytecode` is sent over the wire via the registered
@@ -366,6 +367,35 @@ terminal/action methods off of `ITraversal`.
 * `ITraversal.ToList()`
 * `ITraversal.ToSet()`
 * `ITraversal.Iterate()`
+
+=== Configuration
+
+The following sections describe how the Gremlin.Net driver can be configured.
+
+==== Gremlin Server
+
+The connection properties for the Gremlin.Net driver can be passed to the `GremlinServer` instance as keyword arguments:
+
+[width="100%",cols="3,10,^2",options="header"]
+|=========================================================
+|Key |Description |Default
+|hostname |The hostname that the driver will connect to. |localhost
+|port |The port on which Gremlin Server can be reached. |8182
+|enableSsl |Determines if SSL should be enabled or not. If enabled on the server then it must be enabled on the client. |false
+|username |The username to submit on requests that require authentication. |_none_
+|password |The password to submit on requests that require authentication. |_none_
+|=========================================================
+
+==== GraphSON Serialization
+
+The Gremlin.Net driver uses by default GraphSON 3.0 but it is also possible to use GraphSON 2.0 which can be necessary
+when the server does not support GraphSON 3.0 yet:
+
+[source,csharp]
+----
+var client = new GremlinClient(new GremlinServer("localhost", 8182), new GraphSON2Reader(),
+    new GraphSON2Writer(), GremlinClient.GraphSON2MimeType);
+----
 
 === Static Enums and Methods
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
@@ -38,7 +38,8 @@ namespace Gremlin.Net.Driver
         /// <param name="enableSsl">Specifies whether SSL should be enabled.</param>
         /// <param name="username">The username to submit on requests that require authentication.</param>
         /// <param name="password">The password to submit on requests that require authentication.</param>
-        public GremlinServer(string hostname, int port = 8182, bool enableSsl = false, string username = null, string password = null)
+        public GremlinServer(string hostname = "localhost", int port = 8182, bool enableSsl = false,
+            string username = null, string password = null)
         {
             Uri = CreateUri(hostname, port, enableSsl);
             Username = username;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2069

This simply adds documentation on how to configure the Gremlin.Net driver to the reference docs. It also fixes a small mistake in the provider docs where we forgot to change the classes for GraphSON3 and it adds `localhost` as the default `hostname` to be consistent with the Java driver.

I built the docs with `./docker/build.sh -d`.

VOTE +1