### PR TITLE
TINKERPOP-2065 iterate() now sends NoneStep

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-2-11, 3.2.11>>.
 
 * Fixed `PersistedOutputRDD` to eager persist RDD by adding `count()` action calls.
-* gremlin-python: the graphson deserializer for g:Set should return a python set
+* Changed behavior of GraphSON deserializer in gremlin-python such that `g:Set` returns a Python `Set`.
+* Changed behavior of `iterate()` in Python, Javascript and .NET to send `none()` thus avoiding unnecessary results being returned.
 
 [[release-3-3-4]]
 === TinkerPop 3.3.4 (Release Date: October 15, 2018)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
@@ -194,6 +194,7 @@ namespace Gremlin.Net.Process.Traversal
         /// <returns>The fully drained traversal.</returns>
         public ITraversal<S, E> Iterate()
         {
+            Bytecode.AddStep("none");
             while (MoveNext())
             {
             }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversal.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversal.cs
@@ -34,6 +34,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
             var traversers = new List<Traverser>(traverserObjs.Count);
             traverserObjs.ForEach(o => traversers.Add(new Traverser(o)));
             Traversers = traversers;
+            Bytecode = new Bytecode();
         }
 
         public TestTraversal(IReadOnlyList<object> traverserObjs, IReadOnlyList<long> traverserBulks)
@@ -41,6 +42,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
             var traversers = new List<Traverser>(traverserObjs.Count);
             traversers.AddRange(traverserObjs.Select((t, i) => new Traverser(t, traverserBulks[i])));
             Traversers = traversers;
+            Bytecode = new Bytecode();
         }
 
         public TestTraversal(IList<ITraversalStrategy> traversalStrategies)

--- a/gremlin-javascript/glv/TraversalSource.template
+++ b/gremlin-javascript/glv/TraversalSource.template
@@ -62,6 +62,7 @@ class Traversal {
    * @returns {Promise}
    */
   iterate() {
+    this.bytecode.addStep('none');
     return this._applyStrategies().then(() => {
       let it;
       while ((it = this._getNext()) && !it.done) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -62,6 +62,7 @@ class Traversal {
    * @returns {Promise}
    */
   iterate() {
+    this.bytecode.addStep('none');
     return this._applyStrategies().then(() => {
       let it;
       while ((it = this._getNext()) && !it.done) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
@@ -26,6 +26,7 @@ const assert = require('assert');
 const expect = require('chai').expect;
 const graph = require('../../lib/structure/graph');
 const t = require('../../lib/process/traversal');
+const Bytecode = require('../../lib/process/bytecode');
 const TraversalStrategies = require('../../lib/process/traversal-strategy').TraversalStrategies;
 
 describe('Traversal', function () {
@@ -185,7 +186,7 @@ describe('Traversal', function () {
       };
       const strategies = new TraversalStrategies();
       strategies.addStrategy(strategyMock);
-      const traversal = new t.Traversal(null, strategies, null);
+      const traversal = new t.Traversal(null, strategies, new Bytecode());
       return traversal.iterate().then(() => {
         assert.strictEqual(applied, true);
       });

--- a/gremlin-python/glv/TraversalSource.template
+++ b/gremlin-python/glv/TraversalSource.template
@@ -60,6 +60,7 @@ class Traversal(object):
         return set(iter(self))
 
     def iterate(self):
+        self.bytecode.add_step("none")
         while True:
             try: self.nextTraverser()
             except StopIteration: return self

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -60,6 +60,7 @@ class Traversal(object):
         return set(iter(self))
 
     def iterate(self):
+        self.bytecode.add_step("none")
         while True:
             try: self.nextTraverser()
             except StopIteration: return self


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2065

Fixed this for python, .NET and js. This means that results will no longer be sent back from the server to the client (i.e. no client side iteration).

Builds with `mvn clean install`

VOTE +1