### PR TITLE
TINKERPOP-2064 Expose response attributes in JavaScript Driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,7 +44,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Bumped to Spark 2.3.1.
 * Bumped to Groovy 2.5.2.
 * Modified Gremlin Server to return a "host" status attribute on responses.
-* Added ability to the Java, .NET and Python drivers to retrieve status attributes returned from the server.
+* Added ability to the Java, .NET, Python and JavaScript drivers to retrieve status attributes returned from the server.
 * Modified Java and Gremlin.Net `ResponseException` to include status code and status attributes.
 * Modified Python `GremlinServerError` to include status attributes.
 * Modified the return type for `IGremlinClient.SubmitAsync()` to be a `ResultSet` rather than an `IReadOnlyCollection`.
@@ -85,6 +85,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Removed previously deprecated `LambdaCollectingBarrierStep.Consumers` enum.
 * Removed previously deprecated `HasContainer#makeHasContainers(String, P)`
 * Removed support for Giraph.
+* Removed previously deprecated JavaScript Driver property `traversers` of the `ResultSet`.
 
 == TinkerPop 3.3.0 (Gremlin Symphony #40 in G Minor)
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -193,7 +193,7 @@ class Connection {
     switch (response.status.code) {
       case responseStatusCode.noContent:
         this._clearHandler(response.requestId);
-        return handler.callback(null, new ResultSet(utils.emptyArray));
+        return handler.callback(null, new ResultSet(utils.emptyArray, response.status.attributes));
       case responseStatusCode.partialContent:
         handler.result = handler.result || [];
         handler.result.push.apply(handler.result, response.result.data);
@@ -206,7 +206,7 @@ class Connection {
           handler.result = response.result.data;
         }
         this._clearHandler(response.requestId);
-        return handler.callback(null, new ResultSet(handler.result));
+        return handler.callback(null, new ResultSet(handler.result, response.status.attributes));
     }
   }
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/result-set.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/result-set.js
@@ -24,6 +24,8 @@
 
 const util = require('util');
 const inspect = util.inspect.custom || 'inspect';
+const utils = require('../utils');
+const emptyMap = Object.freeze(new utils.ImmutableMap());
 
 /**
  * Represents the response returned from the execution of a Gremlin traversal or script.
@@ -33,8 +35,9 @@ class ResultSet {
   /**
    * Creates a new instance of {@link ResultSet}.
    * @param {Array} items
+   * @param {Map} [attributes]
    */
-  constructor(items) {
+  constructor(items, attributes) {
     if (!Array.isArray(items)) {
       throw new TypeError('items must be an Array instance');
     }
@@ -42,18 +45,16 @@ class ResultSet {
     this._items = items;
 
     /**
+     * Gets a Map representing the attributes of the response.
+     * @type {Map}
+     */
+    this.attributes = attributes || emptyMap;
+
+    /**
      * Gets the amount of items in the result.
      * @type {Number}
      */
     this.length = items.length;
-
-    /**
-     * Access the raw result items via a property.
-     * @deprecated It will be removed in Apache TinkerPop version 3.4.
-     * Use <code>toArray()</code> or iterate directly from the <code>ResultSet</code>.
-     * @type {Array}
-     */
-    this.traversers = items;
   }
 
   /**

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
@@ -56,3 +56,21 @@ exports.getUuid = function getUuid() {
 };
 
 exports.emptyArray = Object.freeze([]);
+
+class ImmutableMap extends Map {
+  constructor(iterable) {
+    super(iterable);
+  }
+
+  set(){
+    return this;
+  }
+
+  ['delete'](){
+    return false;
+  }
+
+  clear() { }
+}
+
+exports.ImmutableMap = ImmutableMap;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
@@ -66,5 +66,13 @@ describe('Client', function () {
           assert.strictEqual(result.first(), 'Cardinality:set');
         });
     });
+
+    it('should retrieve the attributes', () => {
+      return client.submit(new Bytecode().addStep('V', []).addStep('tail', []))
+        .then(rs => {
+          assert.ok(rs.attributes instanceof Map);
+          assert.ok(rs.attributes.get('host'));
+        });
+    });
   });
 });

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/result-set-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/result-set-test.js
@@ -76,11 +76,18 @@ describe('ResultSet', function () {
     });
   });
 
-  describe('#traversers', () => {
-    it('should expose deprecated property', () => {
-      const items = [ 'a', 'b' ];
-      // Traversers property is going to be removed in upcoming versions
-      assert.strictEqual(new ResultSet(items).traversers, items);
+  describe('#attributes', () => {
+    it('should default to an empty Map when not defined', () => {
+      const rs = new ResultSet([]);
+      assert.ok(rs.attributes instanceof Map);
+      assert.strictEqual(rs.attributes.size, 0);
+    });
+
+    it('should return the attributes when defined', () => {
+      const attributes = new Map([['a', 1], ['b', 1]]);
+      const rs = new ResultSet([], attributes);
+      assert.ok(rs.attributes instanceof Map);
+      assert.strictEqual(rs.attributes, attributes);
     });
   });
 });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2064

Exposed response attributes in the `ResultSet` class of the JavaScript Driver.

Additionally, I've taken the opportunity to remove the deprecated property `traversers` from `ResultSet`.

VOTE +1