### PR TITLE
TINKERPOP-2050 Added :bytecode command

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-2-11, 3.2.11>>.
 
+* Added `:bytecode` command to help developers debugging `Bytecode`-based traversals.
 * Fixed `PersistedOutputRDD` to eager persist RDD by adding `count()` action calls.
 * gremlin-python: the graphson deserializer for g:Set should return a python set
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -159,7 +159,34 @@ some other useful operations.  The following table outlines the most commonly us
 |:plugin |:pin |Plugin management functions to list, activate and deactivate available plugins.
 |:remote |:rem |Configures a "remote" context where Gremlin or results of Gremlin will be processed via usage of `:submit`.
 |:submit |:> |Submit Gremlin to the currently active context defined by `:remote`.
+|:bytecode |:bc |Provides options for translating and evaluating `Bytecode` for debugging purposes.
 |=========================================================
+
+Many of the above commands are described elsewhere or are generally self explanatory, but the `:bytecode` command
+could use some additional explanation. The following code shows example usage:
+
+[source,text]
+----
+gremlin> g = TinkerFactory.createModern().traversal()
+==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
+gremlin> :bytecode from g.V().out('knows')  <1>
+==>{"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}}
+gremlin> :bytecode translate g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <2>
+==>g.V().out("knows")
+gremlin> :bytecode eval g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <3>
+==>v[2]
+==>v[4]
+gremlin> :remote connect tinkerpop.server conf/remote.yaml
+==>Configured localhost/127.0.0.1:8182
+gremlin> :bytecode submit g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <4>
+==>v[2]
+==>v[4]
+----
+
+<1> Generates a GraphSON 3.0 representation of the traversal as bytecode.
+<2> Converts bytecode in GraphSON 3.0 format to a traversal string.
+<3> Converts bytecode in GraphSON 3.0 format to a traversal string which is evaluated against "g" where "g" should be a valid graph instance.
+<4> Converts bytecode in GraphSON 3.0 format to a traversal string and submits it remotely as a string to the current `:remote`.
 
 [[console-preferences]]
 === Console Preferences

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -167,26 +167,14 @@ could use some additional explanation. The following code shows example usage:
 
 [source,text]
 ----
-gremlin> g = TinkerFactory.createModern().traversal()
-==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
 gremlin> :bytecode from g.V().out('knows')  <1>
 ==>{"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}}
 gremlin> :bytecode translate g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <2>
 ==>g.V().out("knows")
-gremlin> :bytecode eval g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <3>
-==>v[2]
-==>v[4]
-gremlin> :remote connect tinkerpop.server conf/remote.yaml
-==>Configured localhost/127.0.0.1:8182
-gremlin> :bytecode submit g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <4>
-==>v[2]
-==>v[4]
 ----
 
 <1> Generates a GraphSON 3.0 representation of the traversal as bytecode.
 <2> Converts bytecode in GraphSON 3.0 format to a traversal string.
-<3> Converts bytecode in GraphSON 3.0 format to a traversal string which is evaluated against "g" where "g" should be a valid graph instance.
-<4> Converts bytecode in GraphSON 3.0 format to a traversal string and submits it remotely as a string to the current `:remote`.
 
 [[console-preferences]]
 === Console Preferences

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -41,9 +41,9 @@ help with both of these issues:
 ----
 gremlin> g = TinkerFactory.createModern().traversal()
 ==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
-gremlin> :bytecode from g.V().out('knows')  <1>
+gremlin> :bytecode from g.V().out('knows')
 ==>{"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}}
-gremlin> :bytecode translate g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <2>
+gremlin> :bytecode translate g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}}
 ==>g.V().out("knows")
 ----
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -27,6 +27,29 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.3.5/CHANGELOG.asciidoc#release-3-3-5[changelog] for a complete list of all the modifications that are part of this release.
 
+=== Upgrading for Users
+
+==== Bytecode Command
+
+The Gremlin Console now has a new `:bytecode` command to help users work more directly with Gremlin bytecode. The
+command is more of a debugging tool than something that would be used for every day purposes. It is sometimes helpful
+to look at Gremlin bytecode directly and the process for viewing it in human readable format is not a single step
+process. It is also not immediately clear how to convert bytecode to a Gremlin string. The `:bytecode` command aims to
+help with both of these issues:
+
+[source,text]
+----
+gremlin> g = TinkerFactory.createModern().traversal()
+==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
+gremlin> :bytecode from g.V().out('knows')  <1>
+==>{"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}}
+gremlin> :bytecode translate g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}} <2>
+==>g.V().out("knows")
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2050[TINKERPOP-2050],
+link:http://tinkerpop.apache.org/docs/3.3.5/reference/#_console_commands[Reference Documentation - Console Commands]
+
 == TinkerPop 3.3.4
 
 *Release Date: October 15, 2018*

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -22,6 +22,7 @@ import jline.TerminalFactory
 import jline.console.history.FileHistory
 
 import org.apache.commons.cli.Option
+import org.apache.tinkerpop.gremlin.console.commands.BytecodeCommand
 import org.apache.tinkerpop.gremlin.console.commands.GremlinSetCommand
 import org.apache.tinkerpop.gremlin.console.commands.InstallCommand
 import org.apache.tinkerpop.gremlin.console.commands.PluginCommand
@@ -90,6 +91,7 @@ class Console {
         groovy.register(new PluginCommand(groovy, mediator))
         groovy.register(new RemoteCommand(groovy, mediator))
         groovy.register(new SubmitCommand(groovy, mediator))
+        groovy.register(new BytecodeCommand(groovy, mediator))
 
         // hide output temporarily while imports execute
         showShellEvaluationOutput(false)

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.console.commands
+
+import org.apache.tinkerpop.gremlin.console.Mediator
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslator
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapper
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper
+import org.codehaus.groovy.tools.shell.ComplexCommandSupport
+import org.codehaus.groovy.tools.shell.Groovysh
+
+/**
+ * Commands that help work with Gremlin bytecode.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+class BytecodeCommand extends ComplexCommandSupport {
+
+    private final Mediator mediator
+
+    private final ObjectMapper mapper = GraphSONMapper.build().version(GraphSONVersion.V3_0).create().createMapper()
+
+    public BytecodeCommand(final Groovysh shell, final Mediator mediator) {
+        super(shell, ":bytecode", ":bc", ["eval", "from", "submit", "translate"])
+        this.mediator = mediator
+    }
+    
+    def Object do_from = { List<String> arguments ->
+        mediator.showShellEvaluationOutput(false)
+        def traversal = shell.execute(arguments.join(""))
+        if (!(traversal instanceof Traversal))
+            return "Argument does not resolve to a Traversal instance, was: " + traversal.class.simpleName
+
+        mediator.showShellEvaluationOutput(true)
+        return mapper.writeValueAsString(traversal.asAdmin().bytecode)
+    }
+    
+    def Object do_eval = { List<String> arguments ->
+        return shell.execute(do_translate(arguments))
+    }
+
+    def Object do_submit = { List<String> arguments ->
+        if (mediator.remotes.size() == 0) return "No remotes are configured.  Use :remote command."
+        return mediator.currentRemote().submit([do_translate(arguments)])
+    }
+
+
+    def Object do_translate = { List<String> arguments ->
+        def g = arguments[0]
+        return GroovyTranslator.of(g).translate(mapper.readValue(arguments.drop(1).join(""), Bytecode.class))
+    }
+}

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
@@ -40,7 +40,7 @@ class BytecodeCommand extends ComplexCommandSupport {
     private final ObjectMapper mapper = GraphSONMapper.build().version(GraphSONVersion.V3_0).create().createMapper()
 
     public BytecodeCommand(final Groovysh shell, final Mediator mediator) {
-        super(shell, ":bytecode", ":bc", ["eval", "from", "submit", "translate"])
+        super(shell, ":bytecode", ":bc", ["from", "translate"])
         this.mediator = mediator
     }
     
@@ -54,16 +54,6 @@ class BytecodeCommand extends ComplexCommandSupport {
         mediator.showShellEvaluationOutput(true)
         return mapper.writeValueAsString(traversal.asAdmin().bytecode)
     }
-    
-    def Object do_eval = { List<String> arguments ->
-        return shell.execute(do_translate(arguments))
-    }
-
-    def Object do_submit = { List<String> arguments ->
-        if (mediator.remotes.size() == 0) return "No remotes are configured.  Use :remote command."
-        return mediator.currentRemote().submit([do_translate(arguments)])
-    }
-
 
     def Object do_translate = { List<String> arguments ->
         def g = arguments[0]

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
@@ -46,7 +46,8 @@ class BytecodeCommand extends ComplexCommandSupport {
     
     def Object do_from = { List<String> arguments ->
         mediator.showShellEvaluationOutput(false)
-        def traversal = shell.execute(arguments.join(""))
+        def args = arguments.join("")
+        def traversal = args.startsWith("@") ? shell.interp.context.getVariable(args.substring(1)) : shell.execute(args)
         if (!(traversal instanceof Traversal))
             return "Argument does not resolve to a Traversal instance, was: " + traversal.class.simpleName
 
@@ -66,6 +67,8 @@ class BytecodeCommand extends ComplexCommandSupport {
 
     def Object do_translate = { List<String> arguments ->
         def g = arguments[0]
-        return GroovyTranslator.of(g).translate(mapper.readValue(arguments.drop(1).join(""), Bytecode.class))
+        def args = arguments.drop(1).join("")
+        def graphson = args.startsWith("@") ? shell.interp.context.getVariable(args.substring(1)) : args
+        return GroovyTranslator.of(g).translate(mapper.readValue(graphson, Bytecode.class))
     }
 }

--- a/gremlin-console/src/main/resources/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.properties
+++ b/gremlin-console/src/main/resources/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+command.description=Gremlin bytecode helper commands
+command.usage=[eval <g> <bytecode>|from <Traversal>|submit <<g> <bytecode>|translate <g> <bytecode>]
+command.help=Gremlin bytecode helper commands

--- a/gremlin-console/src/main/resources/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.properties
+++ b/gremlin-console/src/main/resources/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 command.description=Gremlin bytecode helper commands
-command.usage=[eval <g> <bytecode>|from <Traversal>|submit <<g> <bytecode>|translate <g> <bytecode>]
+command.usage=[from <Traversal>|translate <g> <bytecode>]
 command.help=Gremlin bytecode helper commands


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2050

Command options are as follows:

```text
gremlin> :bytecode from g.V().out('knows')
==>{"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}}
gremlin> :bytecode translate g {"@type":"g:Bytecode","@value":{"step":[["V"],["out","knows"]]}}
==>g.V().out("knows")
```

VOTE +1