### PR TITLE
TINKERPOP-2038 Made the GremlinGroovyScriptEngine cache configurable

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ This release also includes changes from <<release-3-2-11, 3.2.11>>.
 * Display the remote stack trace in the Gremlin Console when scripts sent to the server fail.
 * Changed behavior of GraphSON deserializer in gremlin-python such that `g:Set` returns a Python `Set`.
 * Changed behavior of `iterate()` in Python, Javascript and .NET to send `none()` thus avoiding unnecessary results being returned.
+* Provided for a configurable class map cache in the `GremlinGroovyScriptEngine` and exposed that in Gremlin Server.
 
 [[release-3-3-4]]
 === TinkerPop 3.3.4 (Release Date: October 15, 2018)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1565,6 +1565,7 @@ The `GroovyCompilerGremlinPlugin` has a number of configuration options:
 |`compilerConfigurationOptions` |Allows configuration of the Groovy `CompilerConfiguration` object by taking a `Map` of key/value pairs where the "key" is a property to set on the `CompilerConfiguration`.
 |`enableThreadInterrupt` |Injects checks for thread interruption, thus allowing the script to potentially respect calls to `Thread.interrupt()`
 |`expectedCompilationTime` |The amount of time in milliseconds a script is allowed to compile before a warning message is sent to the logs.
+|`classMapCacheSpecification` |The cache specification for the `GremlinGroovyScriptEngine` class map cache - described in more detail in the <<gremlin-server-cache,Cache Management>> Section.
 |`extensions` | This setting is for use when `compilation` is configured with `COMPILE_STATIC` or `TYPE_CHECKED` and accepts a comma separated list of link:http://docs.groovy-lang.org/latest/html/documentation/#Typecheckingextensions-Workingwithextensions[type checking extensions] that can have the effect of securing calls to various methods.
 |=========================================================
 
@@ -1977,6 +1978,7 @@ List<Vertex> results = g.V().hasLabel("person").valueMap(true,'name').toList();
 
 Both of the above requests return a list of `Map` instances that contain the `id`, `label` and the "name" property.
 
+[[gremlin-server-cache]]
 ==== Cache Management
 
 If Gremlin Server processes a large number of unique scripts, the global function cache will grow beyond the memory
@@ -2007,6 +2009,25 @@ params.put("x",4);
 params.put("#jsr223.groovy.engine.keep.globals", "soft");
 client.submit("[1,2,3,x]", params);
 ----
+
+Gremlin Server also has a "class map" cache which holds compiled scripts which helps avoid recompilation costs on
+future requests. This cache can be tuned in the Gremlin Server configuration with the `GroovyCompilerGremlinPlugin`
+in the following fashion:
+
+[source,yaml]
+----
+scriptEngines: {
+  gremlin-groovy: {
+    plugins: { ...
+               org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPlugin: {classMapCacheSpecification: "initialCapacity=1000,maximumSize=10000"},
+               ...}
+----
+
+The specifics for this comma delimited format can be found
+link:https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.6.2/com/github/benmanes/caffeine/cache/CaffeineSpec.html[here].
+By default, the cache is set to `softValues` which means they are garbage collected in a globally least-recently-used
+manner as memory gets low. For production systems, it is likely that a more predictable strategy be taken as shown
+above with the use of the `maximumSize`.
 
 [[sessions]]
 ==== Considering Sessions

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -27,6 +27,16 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.3.5/CHANGELOG.asciidoc#release-3-3-5[changelog] for a complete list of all the modifications that are part of this release.
 
+=== Upgrading for Users
+
+==== Configurable Class Map Cache
+
+The "class map" cache in Gremlin Server (specifically the `GremlinGroovyScriptEngine`) that holds compiled scripts is
+now fully configurable via the `GroovyCompilerGremlinPlugin.classMapCacheSpecification`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2038[TINKERPOP-2038],
+link:http://tinkerpop.apache.org/docs/3.3.2/reference/#gremlin-server-cache[Reference Documentation - Cache Management]
+
 == TinkerPop 3.3.4
 
 *Release Date: October 15, 2018*

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/CompilationOptionsCustomizer.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/CompilationOptionsCustomizer.java
@@ -28,12 +28,41 @@ import org.apache.tinkerpop.gremlin.jsr223.Customizer;
 class CompilationOptionsCustomizer implements Customizer {
 
     private final long expectedCompilationTime;
+    private final String cacheSpecification;
 
-    public CompilationOptionsCustomizer(final long expectedCompilationTime) {
-        this.expectedCompilationTime = expectedCompilationTime;
+    private CompilationOptionsCustomizer(final Builder builder) {
+        this.expectedCompilationTime = builder.expectedCompilationTime;
+        this.cacheSpecification = builder.cacheSpecification;
     }
 
     public long getExpectedCompilationTime() {
         return expectedCompilationTime;
+    }
+
+    public String getClassMapCacheSpecification() {
+        return cacheSpecification;
+    }
+
+    public static Builder build() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private long expectedCompilationTime;
+        private String cacheSpecification = "softValues";
+
+        public Builder setExpectedCompilationTime(final long expectedCompilationTime) {
+            this.expectedCompilationTime = expectedCompilationTime;
+            return this;
+        }
+
+        public Builder setClassMapCacheSpecification(final String cacheSpecification) {
+            this.cacheSpecification = cacheSpecification;
+            return this;
+        }
+
+        public CompilationOptionsCustomizer create() {
+            return new CompilationOptionsCustomizer(this);
+        }
     }
 }

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
@@ -29,7 +29,6 @@ import groovy.lang.MissingMethodException;
 import groovy.lang.MissingPropertyException;
 import groovy.lang.Script;
 import groovy.lang.Tuple;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.groovy.loaders.GremlinLoader;
 import org.apache.tinkerpop.gremlin.jsr223.ConcurrentBindings;
 import org.apache.tinkerpop.gremlin.jsr223.CoreGremlinPlugin;
@@ -155,36 +154,7 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
     /**
      * Script to generated Class map.
      */
-    private final LoadingCache<String, Future<Class>> classMap = Caffeine.newBuilder().
-            softValues().
-            recordStats().
-            build(new CacheLoader<String, Future<Class>>() {
-        @Override
-        public Future<Class> load(final String script) throws Exception {
-            final long start = System.currentTimeMillis();
-
-            return CompletableFuture.supplyAsync(() -> {
-                try {
-                    return loader.parseClass(script, generateScriptName());
-                } catch (CompilationFailedException e) {
-                    final long finish = System.currentTimeMillis();
-                    log.error("Script compilation FAILED {} took {}ms {}", script, finish - start, e);
-                    failedCompilationCount.incrementAndGet();
-                    throw e;
-                } finally {
-                    final long time = System.currentTimeMillis() - start;
-                    if (time > expectedCompilationTime) {
-                        //We warn if a script took longer than a few seconds. Repeatedly seeing these warnings is a sign that something is wrong.
-                        //Scripts with a large numbers of parameters often trigger this and should be avoided.
-                        log.warn("Script compilation {} took {}ms", script, time);
-                        longRunCompilationCount.incrementAndGet();
-                    } else {
-                        log.debug("Script compilation {} took {}ms", script, time);
-                    }
-                }
-            }, Runnable::run);
-        }
-    });
+    private final LoadingCache<String, Future<Class>> classMap;
 
     /**
      * Global closures map - this is used to simulate a single global functions namespace
@@ -269,6 +239,11 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
         expectedCompilationTime = compilationOptionsCustomizerProvider.isPresent() ?
                 compilationOptionsCustomizerProvider.get().getExpectedCompilationTime() : 5000;
 
+        classMap = Caffeine.from(compilationOptionsCustomizerProvider.isPresent() ?
+                compilationOptionsCustomizerProvider.get().getClassMapCacheSpecification() : "softValues").
+                recordStats().
+                build(new GroovyCacheLoader());
+
         typeCheckingEnabled = listOfCustomizers.stream()
                 .anyMatch(p -> p instanceof TypeCheckedGroovyCustomizer || p instanceof CompileStaticGroovyCustomizer);
 
@@ -298,7 +273,7 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
         // extract the named traversalsource prior to that happening so that bytecode bindings can share the same
         // namespace as global bindings (e.g. traversalsources and graphs).
         if (traversalSource.equals(HIDDEN_G))
-            throw new IllegalArgumentException("The traversalSource cannot have the name " + HIDDEN_G+ " - it is reserved");
+            throw new IllegalArgumentException("The traversalSource cannot have the name " + HIDDEN_G + " - it is reserved");
 
         if (bindings.containsKey(HIDDEN_G))
             throw new IllegalArgumentException("Bindings cannot include " + HIDDEN_G + " - it is reserved");
@@ -832,5 +807,34 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
             throw new ScriptException(exp);
         }
         return buf.toString();
+    }
+
+    private final class GroovyCacheLoader implements CacheLoader<String, Future<Class>> {
+        @Override
+        public Future<Class> load(final String script) throws Exception {
+            final long start = System.currentTimeMillis();
+
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    return loader.parseClass(script, generateScriptName());
+                } catch (CompilationFailedException e) {
+                    final long finish = System.currentTimeMillis();
+                    log.error("Script compilation FAILED {} took {}ms {}", script, finish - start, e);
+                    failedCompilationCount.incrementAndGet();
+                    throw e;
+                } finally {
+                    final long time = System.currentTimeMillis() - start;
+                    if (time > expectedCompilationTime) {
+                        //We warn if a script took longer than a few seconds. Repeatedly seeing these warnings is a sign that something is wrong.
+                        //Scripts with a large numbers of parameters often trigger this and should be avoided.
+                        log.warn("Script compilation {} took {}ms", script, time);
+                        longRunCompilationCount.incrementAndGet();
+                    } else {
+                        log.debug("Script compilation {} took {}ms", script, time);
+                    }
+                }
+            }, Runnable::run);
+
+        }
     }
 }

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
@@ -60,14 +60,16 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
         private Compilation compilation = Compilation.NONE;
         private String extensions = null;
         private int expectedCompilationTime = 5000;
+        private String cacheSpec = "softValues";
 
         private Map<String,Object> keyValues = Collections.emptyMap();
 
         /**
          * If the time it takes to compile a script exceeds the specified time then a warning is written to the logs.
-         * Defaults to 5000ms.
+         * Defaults to 5000ms and must be greater than zero.
          */
         public Builder expectedCompilationTime(final int timeInMillis) {
+            if (expectedCompilationTime <= 0) throw new IllegalArgumentException("expectedCompilationTime must be greater than zero");
             this.expectedCompilationTime = timeInMillis;
             return this;
         }
@@ -113,6 +115,34 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
             return this;
         }
 
+        /**
+         * Sets the cache specification for the class map which holds compiled scripts and uses the comma separated
+         * syntax of the caffeine cache for configuration.
+         * <ul>
+         *   <li>{@code initialCapacity=[integer]}: sets {@code Caffeine.initialCapacity}.
+         *   <li>{@code maximumSize=[long]}: sets {@code Caffeine.maximumSize}.
+         *   <li>{@code maximumWeight=[long]}: sets {@code Caffeine.maximumWeight}.
+         *   <li>{@code expireAfterAccess=[duration]}: sets {@code Caffeine.expireAfterAccess}.
+         *   <li>{@code expireAfterWrite=[duration]}: sets {@code Caffeine.expireAfterWrite}.
+         *   <li>{@code refreshAfterWrite=[duration]}: sets {@code Caffeine.refreshAfterWrite}.
+         *   <li>{@code weakKeys}: sets {@code Caffeine.weakKeys}.
+         *   <li>{@code weakValues}: sets {@code Caffeine.weakValues}.
+         *   <li>{@code softValues}: sets {@code Caffeine.softValues}.
+         *   <li>{@code recordStats}: sets {@code Caffeine.recordStats}.
+         * </ul>
+         * Durations are represented by an integer, followed by one of "d", "h", "m", or "s", representing
+         * days, hours, minutes, or seconds respectively. Whitespace before and after commas and equal signs is
+         * ignored. Keys may not be repeated; it is also illegal to use the following pairs of keys in a single value:
+         * <ul>
+         *   <li>{@code maximumSize} and {@code maximumWeight}
+         *   <li>{@code weakValues} and {@code softValues}
+         * </ul>
+         */
+        public Builder classMapCacheSpecification(final String cacheSpec) {
+            this.cacheSpec = cacheSpec;
+            return this;
+        }
+
         Customizer[] asCustomizers() {
             final List<Customizer> list = new ArrayList<>();
 
@@ -128,8 +158,9 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
             if (timeInMillis > 0)
                 list.add(new TimedInterruptGroovyCustomizer(timeInMillis));
 
-            if (expectedCompilationTime > 0)
-                list.add(new CompilationOptionsCustomizer(expectedCompilationTime));
+            list.add(CompilationOptionsCustomizer.build().
+                    setExpectedCompilationTime(expectedCompilationTime > 0 ? expectedCompilationTime : 5000).
+                    setClassMapCacheSpecification(cacheSpec).create());
 
             if (compilation == Compilation.COMPILE_STATIC)
                 list.add(new CompileStaticGroovyCustomizer(extensions));
@@ -137,8 +168,6 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
                 list.add(new TypeCheckedGroovyCustomizer(extensions));
             else if (compilation != Compilation.NONE)
                 throw new IllegalStateException("Use of unknown compilation type: " + compilation);
-
-            if (list.isEmpty()) throw new IllegalStateException("No customizer options have been selected for this plugin");
 
             final Customizer[] customizers = new Customizer[list.size()];
             list.toArray(customizers);

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineCompilationOptionsTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineCompilationOptionsTest.java
@@ -32,7 +32,8 @@ public class GremlinGroovyScriptEngineCompilationOptionsTest {
 
     @Test
     public void shouldRegisterLongCompilation() throws Exception {
-        final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(new CompilationOptionsCustomizer(10));
+        final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(
+                CompilationOptionsCustomizer.build().setExpectedCompilationTime(10).create());
 
         final int numberOfParameters = 3000;
         final Bindings b = new SimpleBindings();

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPluginTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPluginTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -47,23 +48,19 @@ public class GroovyCompilerGremlinPluginTest {
     @Test
     public void shouldConfigureWithCompileStatic() {
         final GroovyCompilerGremlinPlugin plugin = GroovyCompilerGremlinPlugin.build().
-                expectedCompilationTime(0).
                 compilation(GroovyCompilerGremlinPlugin.Compilation.COMPILE_STATIC).create();
         final Optional<Customizer[]> customizers = plugin.getCustomizers("gremlin-groovy");
         assertThat(customizers.isPresent(), is(true));
-        assertEquals(1, customizers.get().length);
-        assertThat(customizers.get()[0], instanceOf(CompileStaticGroovyCustomizer.class));
+        assertEquals(1, Stream.of(customizers.get()).filter(c -> c instanceof CompileStaticGroovyCustomizer).count());
     }
 
     @Test
     public void shouldConfigureWithTypeChecked() {
         final GroovyCompilerGremlinPlugin plugin = GroovyCompilerGremlinPlugin.build().
-                expectedCompilationTime(0).
                 compilation(GroovyCompilerGremlinPlugin.Compilation.TYPE_CHECKED).create();
         final Optional<Customizer[]> customizers = plugin.getCustomizers("gremlin-groovy");
         assertThat(customizers.isPresent(), is(true));
-        assertEquals(1, customizers.get().length);
-        assertThat(customizers.get()[0], instanceOf(TypeCheckedGroovyCustomizer.class));
+        assertEquals(1, Stream.of(customizers.get()).filter(c -> c instanceof TypeCheckedGroovyCustomizer).count());
     }
 
     @Test
@@ -71,12 +68,10 @@ public class GroovyCompilerGremlinPluginTest {
         final Map<String,Object> conf = new HashMap<>();
         conf.put("Debug", true);
         final GroovyCompilerGremlinPlugin plugin = GroovyCompilerGremlinPlugin.build().
-                expectedCompilationTime(0).
                 compilerConfigurationOptions(conf).create();
         final Optional<Customizer[]> customizers = plugin.getCustomizers("gremlin-groovy");
         assertThat(customizers.isPresent(), is(true));
-        assertEquals(1, customizers.get().length);
-        assertThat(customizers.get()[0], instanceOf(ConfigurationGroovyCustomizer.class));
+        assertEquals(1, Stream.of(customizers.get()).filter(c -> c instanceof ConfigurationGroovyCustomizer).count());
 
         final CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
         assertThat(compilerConfiguration.getDebug(), is(false));
@@ -90,48 +85,40 @@ public class GroovyCompilerGremlinPluginTest {
     @Test
     public void shouldConfigureWithInterpreterMode() {
         final GroovyCompilerGremlinPlugin plugin = GroovyCompilerGremlinPlugin.build().
-                expectedCompilationTime(0).
                 enableInterpreterMode(true).create();
         final Optional<Customizer[]> customizers = plugin.getCustomizers("gremlin-groovy");
         assertThat(customizers.isPresent(), is(true));
-        assertEquals(1, customizers.get().length);
-        assertThat(customizers.get()[0], instanceOf(InterpreterModeGroovyCustomizer.class));
+        assertEquals(1, Stream.of(customizers.get()).filter(c -> c instanceof InterpreterModeGroovyCustomizer).count());
     }
 
     @Test
     public void shouldConfigureWithThreadInterrupt() {
         final GroovyCompilerGremlinPlugin plugin = GroovyCompilerGremlinPlugin.build().
-                expectedCompilationTime(0).
                 enableThreadInterrupt(true).create();
         final Optional<Customizer[]> customizers = plugin.getCustomizers("gremlin-groovy");
         assertThat(customizers.isPresent(), is(true));
-        assertEquals(1, customizers.get().length);
-        assertThat(customizers.get()[0], instanceOf(ThreadInterruptGroovyCustomizer.class));
+        assertEquals(1, Stream.of(customizers.get()).filter(c -> c instanceof ThreadInterruptGroovyCustomizer).count());
     }
 
     @Test
     public void shouldConfigureWithTimedInterrupt() {
         final GroovyCompilerGremlinPlugin plugin = GroovyCompilerGremlinPlugin.build().
-                expectedCompilationTime(0).
                 timedInterrupt(60000).create();
         final Optional<Customizer[]> customizers = plugin.getCustomizers("gremlin-groovy");
         assertThat(customizers.isPresent(), is(true));
-        assertEquals(1, customizers.get().length);
-        assertThat(customizers.get()[0], instanceOf(TimedInterruptGroovyCustomizer.class));
+        assertEquals(1, Stream.of(customizers.get()).filter(c -> c instanceof TimedInterruptGroovyCustomizer).count());
     }
 
     @Test
     public void shouldConfigureWithCompilationOptions() {
         final GroovyCompilerGremlinPlugin plugin = GroovyCompilerGremlinPlugin.build().
+                classMapCacheSpecification("initialCapacity=1000,maximumSize=1000").
                 expectedCompilationTime(30000).create();
         final Optional<Customizer[]> customizers = plugin.getCustomizers("gremlin-groovy");
         assertThat(customizers.isPresent(), is(true));
         assertEquals(1, customizers.get().length);
         assertThat(customizers.get()[0], instanceOf(CompilationOptionsCustomizer.class));
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void shouldNotConfigureIfNoSettingsAreSupplied() {
-        GroovyCompilerGremlinPlugin.build().expectedCompilationTime(0).create();
+        assertEquals(30000, ((CompilationOptionsCustomizer) customizers.get()[0]).getExpectedCompilationTime());
+        assertEquals("initialCapacity=1000,maximumSize=1000", ((CompilationOptionsCustomizer) customizers.get()[0]).getClassMapCacheSpecification());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2038

Exposed as a configuration option on the GroovyCompilerGremlinPlugin where the config is set via a Caffeine specification string.

All tests pass with `docker/build.sh -t -i`

VOTE +1