### PR TITLE
TINKERPOP-2092 Deprecated default serializer fields

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ This release also includes changes from <<release-3-2-11, 3.2.11>>.
 
 * Fixed `PersistedOutputRDD` to eager persist RDD by adding `count()` action calls.
 * Deserialized `g:Set` to a Python `Set` in GraphSON in `gremlin-python`.
+* Deprecated `Serializers.DEFAULT_RESULT_SERIALIZER` and `DEFAULT_REQUEST_SERIALIZER`.
 * Display the remote stack trace in the Gremlin Console when scripts sent to the server fail.
 * Added `AnonymousTraversalSource` which provides a more unified means of constructing a `TraversalSource`.
 * Changed behavior of GraphSON deserializer in gremlin-python such that `g:Set` returns a Python `Set`.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/Serializers.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/Serializers.java
@@ -43,14 +43,20 @@ public enum Serializers {
      * Default serializer for results returned from Gremlin Server. This implementation must be of type
      * {@link org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer} so that it can be compatible with text-based
      * websocket messages.
+     *
+     * @deprecated As of release 3.3.5, not replaced, simply specify the exact version of the serializer to use.
      */
+    @Deprecated
     public static final MessageSerializer DEFAULT_RESULT_SERIALIZER = new GraphSONMessageSerializerV1d0();
 
     /**
      * Default serializer for requests received by Gremlin Server. This implementation must be of type
      * {@link org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer} so that it can be compatible with text-based
      * websocket messages.
+     *
+     * @deprecated As of release 3.3.5, not replaced, simply specify the exact version of the serializer to use.
      */
+    @Deprecated
     public static final MessageSerializer DEFAULT_REQUEST_SERIALIZER = new GraphSONMessageSerializerV1d0();
 
     Serializers(final String mimeType) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
@@ -47,7 +47,6 @@ class GraphTraversalSource {
   /**
    * @param remoteConnection
    * @returns {GraphTraversalSource}
-   * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
    */
   withRemote(remoteConnection) {
     const traversalStrategy = new TraversalStrategies(this.traversalStrategies);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/NioGremlinBinaryRequestDecoder.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/NioGremlinBinaryRequestDecoder.java
@@ -23,7 +23,6 @@ import io.netty.util.CharsetUtil;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
-import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
@@ -37,7 +36,6 @@ import java.util.Map;
  */
 public class NioGremlinBinaryRequestDecoder extends ReplayingDecoder<NioGremlinBinaryRequestDecoder.DecoderState> {
     private static final Logger logger = LoggerFactory.getLogger(NioGremlinBinaryRequestDecoder.class);
-
     private final Map<String, MessageSerializer> serializers;
     private int messageLength;
 
@@ -59,7 +57,9 @@ public class NioGremlinBinaryRequestDecoder extends ReplayingDecoder<NioGremlinB
                     final ByteBuf contentTypeFrame = messageFrame.readBytes(contentTypeLength);
                     final String contentType = contentTypeFrame.toString(CharsetUtil.UTF_8);
 
-                    final MessageSerializer serializer = select(contentType, Serializers.DEFAULT_REQUEST_SERIALIZER);
+                    // the default serializer to use has been GraphSON 1.0 to this point (which was probably bad),
+                    // so maintain that for 3.3.x
+                    final MessageSerializer serializer = select(contentType, ServerSerializers.DEFAULT_SERIALIZER);
 
                     // it's important to re-initialize these channel attributes as they apply globally to the channel. in
                     // other words, the next request to this channel might not come with the same configuration and mixed

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/ServerSerializers.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/ServerSerializers.java
@@ -18,22 +18,22 @@
  */
 package org.apache.tinkerpop.gremlin.server.handler;
 
-import io.netty.handler.codec.http.HttpMessage;
-
-import static io.netty.handler.codec.http.HttpHeaders.Names.UPGRADE;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0;
+import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 
 /**
- * A class to handle common WebSocket operations.
- *
- * @author Keith Lohnes lohnesk@gmail.com
+ * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-final class WebSocketHandlerUtil {
+final class ServerSerializers {
 
-    static boolean isWebSocket(final HttpMessage msg) {
-        final String connectionHeader = msg.headers().get(CONNECTION);
-        final String upgradeHeader = msg.headers().get(UPGRADE);
-        return (null != connectionHeader && connectionHeader.equalsIgnoreCase("Upgrade")) ||
-               (null != upgradeHeader && upgradeHeader.equalsIgnoreCase("WebSocket"));
-    }
+    private ServerSerializers() {}
+
+    /**
+     * Default serializer used by the server when the serializer requested does not match what is on the server.
+     * Using GraphSON 1.0 on 3.3.5 because that's what it has long been set to in previous versions on
+     * {@link Serializers#DEFAULT_RESULT_SERIALIZER} which is now deprecated.
+     */
+    static final MessageSerializer DEFAULT_SERIALIZER = new GraphSONMessageSerializerV1d0();
+
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/StateKey.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/StateKey.java
@@ -29,7 +29,10 @@ import io.netty.util.AttributeKey;
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public class StateKey {
+public final class StateKey {
+
+    private StateKey() {}
+
     /**
      * The key for the current serializer requested by the client.
      */

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsGremlinBinaryRequestDecoder.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsGremlinBinaryRequestDecoder.java
@@ -21,7 +21,6 @@ package org.apache.tinkerpop.gremlin.server.handler;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
-import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -65,7 +64,7 @@ public class WsGremlinBinaryRequestDecoder extends MessageToMessageDecoder<Binar
         try {
             messageBytes.readBytes(contentTypeBytes);
             final String contentType = contentTypeBytes.toString(UTF8);
-            final MessageSerializer serializer = select(contentType, Serializers.DEFAULT_REQUEST_SERIALIZER);
+            final MessageSerializer serializer = select(contentType, ServerSerializers.DEFAULT_SERIALIZER);
 
             // it's important to re-initialize these channel attributes as they apply globally to the channel. in
             // other words, the next request to this channel might not come with the same configuration and mixed

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsGremlinCloseRequestDecoder.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsGremlinCloseRequestDecoder.java
@@ -22,7 +22,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
-import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
@@ -65,7 +64,7 @@ public class WsGremlinCloseRequestDecoder extends MessageToMessageDecoder<CloseW
         try {
             messageBytes.readBytes(contentTypeBytes);
             final String contentType = contentTypeBytes.toString(UTF8);
-            final MessageSerializer serializer = select(contentType, Serializers.DEFAULT_REQUEST_SERIALIZER);
+            final MessageSerializer serializer = select(contentType, ServerSerializers.DEFAULT_SERIALIZER);
 
             // it's important to re-initialize these channel attributes as they apply globally to the channel. in
             // other words, the next request to this channel might not come with the same configuration and mixed

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsGremlinTextRequestDecoder.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsGremlinTextRequestDecoder.java
@@ -22,7 +22,6 @@ import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
-import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
@@ -53,7 +52,7 @@ public class WsGremlinTextRequestDecoder extends MessageToMessageDecoder<TextWeb
     protected void decode(final ChannelHandlerContext channelHandlerContext, final TextWebSocketFrame frame, final List<Object> objects) throws Exception {
         try {
             // the default serializer must be a MessageTextSerializer instance to be compatible with this decoder
-            final MessageTextSerializer serializer = (MessageTextSerializer) select("application/json", Serializers.DEFAULT_REQUEST_SERIALIZER);
+            final MessageTextSerializer serializer = (MessageTextSerializer) select("application/json", ServerSerializers.DEFAULT_SERIALIZER);
 
             // it's important to re-initialize these channel attributes as they apply globally to the channel. in
             // other words, the next request to this channel might not come with the same configuration and mixed


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2092

Left defaults on GraphSON 1.0 on the server so as to avoid a breaking change. Expect a follow on PR after this merges to change the default to GraphSON 3.0.

Ran full build with Gremlin Server integration tests

VOTE +1