### PR TITLE
uses the directly field instead of getter method

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
@@ -89,13 +89,13 @@ public abstract class AbstractGremlinScriptEngineFactory implements GremlinScrip
     @Override
     public Object getParameter(final String key) {
         if (key.equals(ScriptEngine.ENGINE)) {
-            return this.getEngineName();
+            return engineName;
         } else if (key.equals(ScriptEngine.ENGINE_VERSION)) {
             return this.getEngineVersion();
         } else if (key.equals(ScriptEngine.NAME)) {
             return engineName;
         } else if (key.equals(ScriptEngine.LANGUAGE)) {
-            return this.getLanguageName();
+            return languageName;
         } else if (key.equals(ScriptEngine.LANGUAGE_VERSION)) {
             return this.getLanguageVersion();
         } else

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/DefaultGremlinScriptEngineManager.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/DefaultGremlinScriptEngineManager.java
@@ -428,7 +428,7 @@ public class DefaultGremlinScriptEngineManager implements GremlinScriptEngineMan
 
                     globalScope.put(kv.getKey(), kv.getValue());
                 });
-        engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
+        engine.setBindings(globalScope, ScriptContext.GLOBAL_SCOPE);
 
         // merge in bindings that are marked with engine scope. there typically won't be any of these but it's just
         // here for completeness. bindings will typically apply with global scope only as engine scope will generally

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -319,9 +319,9 @@ public final class GraphFilter implements Cloneable, Serializable {
     public boolean equals(final Object object) {
         if (!(object instanceof GraphFilter))
             return false;
-        else if (((GraphFilter) object).hasVertexFilter() && !((GraphFilter) object).getVertexFilter().equals(this.vertexFilter))
+        else if (((GraphFilter) object).hasVertexFilter() && !((GraphFilter) object).vertexFilter.equals(this.vertexFilter))
             return false;
-        else if (((GraphFilter) object).hasEdgeFilter() && !((GraphFilter) object).getEdgeFilter().equals(this.edgeFilter))
+        else if (((GraphFilter) object).hasEdgeFilter() && !((GraphFilter) object).edgeFilter.equals(this.edgeFilter))
             return false;
         else
             return true;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/IncrementalBulkLoader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/IncrementalBulkLoader.java
@@ -49,12 +49,12 @@ public class IncrementalBulkLoader implements BulkLoader {
     public Vertex getOrCreateVertex(final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
         final Iterator<Vertex> iterator = useUserSuppliedIds()
                 ? g.V().hasId(vertex.id())
-                : g.V().has(vertex.label(), getVertexIdProperty(), vertex.id().toString());
+                : g.V().has(vertex.label(), bulkLoaderVertexId, vertex.id().toString());
         return iterator.hasNext()
                 ? iterator.next()
                 : useUserSuppliedIds()
                 ? g.addV(vertex.label()).property(T.id, vertex.id()).next()
-                : g.addV(vertex.label()).property(getVertexIdProperty(), vertex.id().toString()).next();
+                : g.addV(vertex.label()).property(bulkLoaderVertexId, vertex.id().toString()).next();
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/MemoryTraversalSideEffects.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/MemoryTraversalSideEffects.java
@@ -166,7 +166,7 @@ public final class MemoryTraversalSideEffects implements TraversalSideEffects {
         final Set<MemoryComputeKey> keys = new HashSet<>();
         final TraversalSideEffects sideEffects =
                 traversal.getSideEffects() instanceof MemoryTraversalSideEffects ?
-                        ((MemoryTraversalSideEffects) traversal.getSideEffects()).getSideEffects() :
+                        ((MemoryTraversalSideEffects) traversal.getSideEffects()).sideEffects :
                         traversal.getSideEffects();
         sideEffects.keys().
                 stream().

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/ComputerGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/ComputerGraph.java
@@ -62,11 +62,11 @@ public final class ComputerGraph implements Graph {
     }
 
     public static ComputerVertex vertexProgram(final Vertex starVertex, VertexProgram vertexProgram) {
-        return new ComputerGraph(State.VERTEX_PROGRAM, starVertex, Optional.of(vertexProgram)).getStarVertex();
+        return new ComputerGraph(State.VERTEX_PROGRAM, starVertex, Optional.of(vertexProgram)).starVertex;
     }
 
     public static ComputerVertex mapReduce(final Vertex starVertex) {
-        return new ComputerGraph(State.MAP_REDUCE, starVertex, Optional.empty()).getStarVertex();
+        return new ComputerGraph(State.MAP_REDUCE, starVertex, Optional.empty()).starVertex;
     }
 
     public ComputerVertex getStarVertex() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/P.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/P.java
@@ -84,8 +84,8 @@ public class P<V> implements Predicate<V>, Serializable, Cloneable {
     public boolean equals(final Object other) {
         return other instanceof P &&
                 ((P) other).getClass().equals(this.getClass()) &&
-                ((P) other).getBiPredicate().equals(this.biPredicate) &&
-                ((((P) other).getOriginalValue() == null && this.originalValue == null) || ((P) other).getOriginalValue().equals(this.originalValue));
+                ((P) other).biPredicate.equals(this.biPredicate) &&
+                ((((P) other).originalValue == null && this.originalValue == null) || ((P) other).originalValue.equals(this.originalValue));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -18,12 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.dsl.graph;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
@@ -41,6 +39,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.Optional;
 import java.util.function.BinaryOperator;
@@ -88,6 +87,12 @@ public class GraphTraversalSource implements TraversalSource {
 
     public GraphTraversalSource(final Graph graph) {
         this(graph, TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+    }
+
+    public GraphTraversalSource(final RemoteConnection connection) {
+        this(EmptyGraph.instance(), TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class).clone());
+        this.connection = connection;
+        this.strategies.addStrategies(new RemoteStrategy(connection));
     }
 
     @Override
@@ -276,59 +281,15 @@ public class GraphTraversalSource implements TraversalSource {
         if (useBulk)
             return this;
         final GraphTraversalSource clone = this.clone();
-        RequirementsStrategy.addRequirements(clone.getStrategies(), TraverserRequirement.ONE_BULK);
+        RequirementsStrategy.addRequirements(clone.strategies, TraverserRequirement.ONE_BULK);
         clone.bytecode.addSource(Symbols.withBulk, useBulk);
         return clone;
     }
 
     public GraphTraversalSource withPath() {
         final GraphTraversalSource clone = this.clone();
-        RequirementsStrategy.addRequirements(clone.getStrategies(), TraverserRequirement.PATH);
+        RequirementsStrategy.addRequirements(clone.strategies, TraverserRequirement.PATH);
         clone.bytecode.addSource(Symbols.withPath);
-        return clone;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Override
-    @Deprecated
-    public GraphTraversalSource withRemote(final Configuration conf) {
-        return (GraphTraversalSource) TraversalSource.super.withRemote(conf);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(String)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Override
-    @Deprecated
-    public GraphTraversalSource withRemote(final String configFile) throws Exception {
-        return (GraphTraversalSource) TraversalSource.super.withRemote(configFile);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(RemoteConnection)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Override
-    @Deprecated
-    public GraphTraversalSource withRemote(final RemoteConnection connection) {
-        // check if someone called withRemote() more than once, so just release resources on the initial
-        // connection as you can't have more than one. maybe better to toss IllegalStateException??
-        if (this.connection != null)
-            throw new IllegalStateException(String.format("TraversalSource already configured with a RemoteConnection [%s]", connection));
-
-        final GraphTraversalSource clone = this.clone();
-        clone.connection = connection;
-        clone.strategies.addStrategies(new RemoteStrategy(connection));
         return clone;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.dsl.graph;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
@@ -39,7 +41,6 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.Optional;
 import java.util.function.BinaryOperator;
@@ -87,12 +88,6 @@ public class GraphTraversalSource implements TraversalSource {
 
     public GraphTraversalSource(final Graph graph) {
         this(graph, TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
-    }
-
-    public GraphTraversalSource(final RemoteConnection connection) {
-        this(EmptyGraph.instance(), TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class).clone());
-        this.connection = connection;
-        this.strategies.addStrategies(new RemoteStrategy(connection));
     }
 
     @Override
@@ -290,6 +285,50 @@ public class GraphTraversalSource implements TraversalSource {
         final GraphTraversalSource clone = this.clone();
         RequirementsStrategy.addRequirements(clone.getStrategies(), TraverserRequirement.PATH);
         clone.bytecode.addSource(Symbols.withPath);
+        return clone;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
+     */
+    @Override
+    @Deprecated
+    public GraphTraversalSource withRemote(final Configuration conf) {
+        return (GraphTraversalSource) TraversalSource.super.withRemote(conf);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(String)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
+     */
+    @Override
+    @Deprecated
+    public GraphTraversalSource withRemote(final String configFile) throws Exception {
+        return (GraphTraversalSource) TraversalSource.super.withRemote(configFile);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(RemoteConnection)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
+     */
+    @Override
+    @Deprecated
+    public GraphTraversalSource withRemote(final RemoteConnection connection) {
+        // check if someone called withRemote() more than once, so just release resources on the initial
+        // connection as you can't have more than one. maybe better to toss IllegalStateException??
+        if (this.connection != null)
+            throw new IllegalStateException(String.format("TraversalSource already configured with a RemoteConnection [%s]", connection));
+
+        final GraphTraversalSource clone = this.clone();
+        clone.connection = connection;
+        clone.strategies.addStrategies(new RemoteStrategy(connection));
         return clone;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
@@ -253,7 +253,7 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
     public static <A, B, C extends Traversal<A, B>> C addRepeatToTraversal(final C traversal, final String loopName, final Traversal.Admin<B, B> repeatTraversal) {
         addRepeatToTraversal(traversal, repeatTraversal);
         final Step<?, B> step = traversal.asAdmin().getEndStep();
-        ((RepeatStep) step).setLoopName(loopName);
+        ((RepeatStep) step).loopName = loopName;
         return traversal;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -93,7 +93,7 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
     }
 
     public static boolean isStartStep(final Step<?, ?> step) {
-        return step instanceof GraphStep && ((GraphStep) step).isStartStep();
+        return step instanceof GraphStep && ((GraphStep) step).isStart;
     }
 
     public boolean returnsVertex() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
@@ -127,7 +127,7 @@ public abstract class ReducingBarrierStep<S, E> extends AbstractStep<S, E> imple
 
     @Override
     public MemoryComputeKey<E> getMemoryComputeKey() {
-        return MemoryComputeKey.of(this.getId(), this.getBiOperator(), false, true);
+        return MemoryComputeKey.of(this.getId(), this.reducingBiOperator, false, true);
     }
 
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -137,7 +137,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
         }
         this.finalEndStep = this.getEndStep();
         // finalize requirements
-        if (this.getParent() instanceof EmptyStep) {
+        if (this.parent instanceof EmptyStep) {
             this.requirements = null;
             this.getTraverserRequirements();
         }
@@ -149,14 +149,14 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
         if (null == this.requirements) {
             // if (!this.locked) this.applyStrategies();
             this.requirements = EnumSet.noneOf(TraverserRequirement.class);
-            for (final Step<?, ?> step : this.getSteps()) {
+            for (final Step<?, ?> step : this.unmodifiableSteps) {
                 this.requirements.addAll(step.getRequirements());
             }
             if (!this.requirements.contains(TraverserRequirement.LABELED_PATH) && TraversalHelper.hasLabels(this))
                 this.requirements.add(TraverserRequirement.LABELED_PATH);
-            if (!this.getSideEffects().keys().isEmpty())
+            if (!this.sideEffects.keys().isEmpty())
                 this.requirements.add(TraverserRequirement.SIDE_EFFECTS);
-            if (null != this.getSideEffects().getSackInitialValue())
+            if (null != this.sideEffects.getSackInitialValue())
                 this.requirements.add(TraverserRequirement.SACK);
             if (this.requirements.contains(TraverserRequirement.ONE_BULK))
                 this.requirements.remove(TraverserRequirement.BULK);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLWriterHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLWriterHelper.java
@@ -220,7 +220,7 @@ final class GraphMLWriterHelper {
             StringBuilder s = new StringBuilder();
             for (; indentStep > 0; indentStep--)
                 s.append(' ');
-            setIndentStep(s.toString());
+            this.indentStep = s.toString();
         }
 
         public void setIndentStep(String s) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/AbstractGraphSONTypeSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/AbstractGraphSONTypeSerializer.java
@@ -82,7 +82,7 @@ public abstract class AbstractGraphSONTypeSerializer extends TypeSerializer {
 
     protected void writeTypePrefix(final JsonGenerator jsonGenerator, final String s) throws IOException {
         jsonGenerator.writeStartObject();
-        jsonGenerator.writeStringField(this.getPropertyName(), s);
+        jsonGenerator.writeStringField(propertyName, s);
         jsonGenerator.writeFieldName(this.valuePropertyName);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapper.java
@@ -100,7 +100,7 @@ public class GraphSONMapper implements Mapper<ObjectMapper> {
         if (version == GraphSONVersion.V3_0 || (version == GraphSONVersion.V2_0 && typeInfo != TypeInfo.NO_TYPES)) {
             final GraphSONTypeIdResolver graphSONTypeIdResolver = new GraphSONTypeIdResolver();
             final TypeResolverBuilder typer = new GraphSONTypeResolverBuilder(version)
-                    .typesEmbedding(getTypeInfo())
+                    .typesEmbedding(this.typeInfo)
                     .valuePropertyName(GraphSONTokens.VALUEPROP)
                     .init(JsonTypeInfo.Id.CUSTOM, graphSONTypeIdResolver)
                     .typeProperty(GraphSONTokens.VALUETYPE);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeIdResolver.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeIdResolver.java
@@ -57,11 +57,11 @@ public class GraphSONTypeIdResolver implements TypeIdResolver {
             // and for which creating a default type is failing because it may fall into a
             // a self-referencing never-ending loop. Temporarily we force Tree<Element>
             // which should cover all the usage TinkerPop would do of the Trees anyway.
-            getIdToType().put(name, TypeFactory.defaultInstance().constructType(new TypeReference<Tree<? extends Element>>() {}));
+            idToType.put(name, TypeFactory.defaultInstance().constructType(new TypeReference<Tree<? extends Element>>() {}));
         } else {
-            getIdToType().put(name, TypeFactory.defaultInstance().constructType(clasz));
+            idToType.put(name, TypeFactory.defaultInstance().constructType(clasz));
         }
-        getTypeToId().put(clasz, name);
+        typeToId.put(clasz, name);
         return this;
     }
 
@@ -76,13 +76,13 @@ public class GraphSONTypeIdResolver implements TypeIdResolver {
 
     @Override
     public String idFromValueAndType(final Object o, final Class<?> aClass) {
-        if (!getTypeToId().containsKey(aClass)) {
+        if (!typeToId.containsKey(aClass)) {
             // If one wants to serialize an object with a type, but hasn't registered
             // a typeID for that class, fail.
             throw new IllegalArgumentException(String.format("Could not find a type identifier for the class : %s. " +
                     "Make sure the value to serialize has a type identifier registered for its class.", aClass));
         } else {
-            return getTypeToId().get(aClass);
+            return typeToId.get(aClass);
         }
     }
 
@@ -94,8 +94,8 @@ public class GraphSONTypeIdResolver implements TypeIdResolver {
     @Override
     public JavaType typeFromId(final DatabindContext databindContext, final String s) {
         // Get the type from the string from the stored Map. If not found, default to deserialize as a String.
-        return getIdToType().containsKey(s)
-                ? getIdToType().get(s)
+        return idToType.containsKey(s)
+                ? idToType.get(s)
                 // TODO: shouldn't we fail instead, if the type is not found? Or log something?
                 : databindContext.constructType(String.class);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/Lambda.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/Lambda.java
@@ -77,7 +77,7 @@ public interface Lambda extends Serializable {
         @Override
         public boolean equals(final Object object) {
             return object instanceof Lambda &&
-                    ((Lambda) object).getLambdaArguments() == this.getLambdaArguments() &&
+                    ((Lambda) object).getLambdaArguments() == this.lambdaArguments &&
                     ((Lambda) object).getLambdaScript().equals(this.lambdaSource) &&
                     ((Lambda) object).getLambdaLanguage().equals(this.lambdaLanguage);
         }


### PR DESCRIPTION
Hello everyone, I still studying the code to help more in the project, then I found a small performance improvement. That is access the field directly instead of using the getter setter.



```java
@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(3)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Thread)
public class ClientBenchmark {


    private final ObjectMapper mapper = GraphSONMapper.build().version(GraphSONVersion.V3_0).create().createMapper();
    private final Graph graph = TinkerFactory.createModern();
    private final Optional<Vertex> vertex = graph.traversal().V().tryNext();

    @Setup
    public void setup() {
    }

    @Benchmark
    public String write() throws JsonProcessingException {
        return mapper.writeValueAsString(vertex);
    }


}
```


* Benchmark.write  avgt   60  192,218  ns/op
* Benchmark.write  avgt   60  212,345  ns/op (around 10% faster)




```java
@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(3)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Thread)
public class ClientBenchmark {


    private final ObjectMapper mapper = GraphSONMapper.build().version(GraphSONVersion.V3_0).create().createMapper();
    private final Graph graph = TinkerFactory.createModern();
    private final Vertex vertex = graph.traversal().V().next();

    @Setup
    public void setup() {
    }

    @Benchmark
    public String write() throws JsonProcessingException {
        return mapper.writeValueAsString(vertex);
    }


}
```

Original code:    avgt   60  1938,602 ± 50,353  ns/op
The code changed: avgt   60  2144,034 ± 51,190  ns/op  (10% faster)
