### PR TITLE
TINKERPOP-2080 Removed withRemote from TraversalSource

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * `MutationListener#vertexPropertyChanged(Vertex, VertexProperty, Object, Object...)` no longer has a default implementation.
 * Deprecated `GraphSONMessageSerializerV2d0` as it is now analogous to `GraphSONMessageSerializerGremlinV2d0`.
 * Moved previously deprecated `RemoteGraph` to `gremlin-test` as it is now just a testing component.
+* Removed previously deprecated `TraversalSource.withRemote()`.
 * Removed previously deprecated `RemoteStrategy.instance()` and the strategy no longer has any connection to `RemoteGraph`.
 * Removed previously deprecated methods in `SubgraphStrategy` and `PartitionStrategy` builders.
 * Removed previously deprecated Credentials DSL infrastructure.

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -448,7 +448,9 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.process.remote.RemoteGraph` - moved to `gremlin-test`.
 ** `org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy#identity()`
 ** `org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine`
+** `org.apache.tinkerpop.gremlin.process.traversal.TraversalSource#withRemote(*)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.engine.*`
+** `org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource#withRemote(*)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy.Builder#addReadPartition(String)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy.Builder#edgeCriterion(Traversal)`
 ** `org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy.Builder#vertexCriterion(Traversal)`
@@ -484,7 +486,8 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-1705[TINKERPOP-1705],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1707[TINKERPOP-1707],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1954[TINKERPOP-1954],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1986[TINKERPOP-1986],
-link:https://issues.apache.org/jira/browse/TINKERPOP-2079[TINKERPOP-2079]
+link:https://issues.apache.org/jira/browse/TINKERPOP-2079[TINKERPOP-2079],
+link:https://issues.apache.org/jira/browse/TINKERPOP-2080[TINKERPOP-2080]
 
 ==== Deprecated GraphSONMessageSerializerGremlinV2d0
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
@@ -18,19 +18,15 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
-import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SackStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SideEffectStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.util.function.ConstantSupplier;
 
-import java.lang.reflect.Constructor;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
@@ -373,56 +369,6 @@ public interface TraversalSource extends Cloneable, AutoCloseable {
         clone.getBytecode().addSource(TraversalSource.Symbols.withSack, initialValue, mergeOperator);
         return clone;
     }
-
-    /**
-     * Configures the {@code TraversalSource} as a "remote" to issue the {@link Traversal} for execution elsewhere.
-     * Expects key for {@link #GREMLIN_REMOTE_CONNECTION_CLASS} as well as any configuration required by
-     * the underlying {@link RemoteConnection} which will be instantiated. Note that the {@code Configuration} object
-     * is passed down without change to the creation of the {@link RemoteConnection} instance.
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Deprecated
-    public default TraversalSource withRemote(final Configuration conf) {
-        if (!conf.containsKey(GREMLIN_REMOTE_CONNECTION_CLASS))
-            throw new IllegalArgumentException("Configuration must contain the '" + GREMLIN_REMOTE_CONNECTION_CLASS + "' key");
-
-        final RemoteConnection remoteConnection;
-        try {
-            final Class<? extends RemoteConnection> clazz = Class.forName(conf.getString(GREMLIN_REMOTE_CONNECTION_CLASS)).asSubclass(RemoteConnection.class);
-            final Constructor<? extends RemoteConnection> ctor = clazz.getConstructor(Configuration.class);
-            remoteConnection = ctor.newInstance(conf);
-        } catch (Exception ex) {
-            throw new IllegalStateException(ex);
-        }
-
-        return withRemote(remoteConnection);
-    }
-
-    /**
-     * Configures the {@code TraversalSource} as a "remote" to issue the {@link Traversal} for execution elsewhere.
-     * Calls {@link #withRemote(Configuration)} after reading the properties file specified.
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(String)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Deprecated
-    public default TraversalSource withRemote(final String configFile) throws Exception {
-        return withRemote(new PropertiesConfiguration(configFile));
-    }
-
-    /**
-     * Configures the {@code TraversalSource} as a "remote" to issue the {@link Traversal} for execution elsewhere.
-     * Implementations should track {@link RemoteConnection} instances that are created and call
-     * {@link RemoteConnection#close()} on them when the {@code TraversalSource} itself is closed.
-     *
-     * @param connection the {@link RemoteConnection} instance to use to submit the {@link Traversal}.
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(RemoteConnection)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Deprecated
-    public TraversalSource withRemote(final RemoteConnection connection);
 
     public default Optional<Class> getAnonymousTraversalClass() {
         return Optional.empty();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -18,12 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.dsl.graph;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
@@ -41,6 +39,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.Optional;
 import java.util.function.BinaryOperator;
@@ -88,6 +87,12 @@ public class GraphTraversalSource implements TraversalSource {
 
     public GraphTraversalSource(final Graph graph) {
         this(graph, TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+    }
+
+    public GraphTraversalSource(final RemoteConnection connection) {
+        this(EmptyGraph.instance(), TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class).clone());
+        this.connection = connection;
+        this.strategies.addStrategies(new RemoteStrategy(connection));
     }
 
     @Override
@@ -285,50 +290,6 @@ public class GraphTraversalSource implements TraversalSource {
         final GraphTraversalSource clone = this.clone();
         RequirementsStrategy.addRequirements(clone.getStrategies(), TraverserRequirement.PATH);
         clone.bytecode.addSource(Symbols.withPath);
-        return clone;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(Configuration)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Override
-    @Deprecated
-    public GraphTraversalSource withRemote(final Configuration conf) {
-        return (GraphTraversalSource) TraversalSource.super.withRemote(conf);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(String)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Override
-    @Deprecated
-    public GraphTraversalSource withRemote(final String configFile) throws Exception {
-        return (GraphTraversalSource) TraversalSource.super.withRemote(configFile);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated As of release 3.3.5, replaced by {@link AnonymousTraversalSource#withRemote(RemoteConnection)}.
-     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-2078">TINKERPOP-2078</a>
-     */
-    @Override
-    @Deprecated
-    public GraphTraversalSource withRemote(final RemoteConnection connection) {
-        // check if someone called withRemote() more than once, so just release resources on the initial
-        // connection as you can't have more than one. maybe better to toss IllegalStateException??
-        if (this.connection != null)
-            throw new IllegalStateException(String.format("TraversalSource already configured with a RemoteConnection [%s]", connection));
-
-        final GraphTraversalSource clone = this.clone();
-        clone.connection = connection;
-        clone.getStrategies().addStrategies(new RemoteStrategy(connection));
         return clone;
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSourceTest.java
@@ -47,13 +47,6 @@ public class GraphTraversalSourceTest {
         verify(mock, times(1)).close();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void shouldNotAllowLeakRemoteConnectionsIfMultipleAreCreated() throws Exception {
-        final RemoteConnection mock1 = mock(RemoteConnection.class);
-        final RemoteConnection mock2 = mock(RemoteConnection.class);
-        traversal().withRemote(mock1).withRemote(mock2);
-    }
-
     @Test
     public void shouldSupportMapBasedStrategies() throws Exception {
         GraphTraversalSource g = EmptyGraph.instance().traversal();

--- a/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSource.java
+++ b/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSource.java
@@ -18,15 +18,12 @@
  */
 package org.apache.tinkerpop.gremlin.sparql.process.traversal.dsl.sparql;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
-import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.ConstantStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectStep;
 import org.apache.tinkerpop.gremlin.sparql.process.traversal.strategy.SparqlStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -91,33 +88,6 @@ public class SparqlTraversalSource implements TraversalSource {
     @SuppressWarnings({"unchecked"})
     public SparqlTraversalSource withoutStrategies(final Class<? extends TraversalStrategy>... traversalStrategyClasses) {
         return (SparqlTraversalSource) TraversalSource.super.withoutStrategies(traversalStrategyClasses);
-    }
-
-    @Override
-    public SparqlTraversalSource withRemote(final Configuration conf) {
-        return (SparqlTraversalSource) TraversalSource.super.withRemote(conf);
-    }
-
-    @Override
-    public SparqlTraversalSource withRemote(final String configFile) throws Exception {
-        return (SparqlTraversalSource) TraversalSource.super.withRemote(configFile);
-    }
-
-    @Override
-    public SparqlTraversalSource withRemote(final RemoteConnection connection) {
-        try {
-            // check if someone called withRemote() more than once, so just release resources on the initial
-            // connection as you can't have more than one. maybe better to toss IllegalStateException??
-            if (this.connection != null)
-                this.connection.close();
-        } catch (Exception ignored) {
-            // not sure there's anything to do here
-        }
-
-        this.connection = connection;
-        final TraversalSource clone = this.clone();
-        clone.getStrategies().addStrategies(new RemoteStrategy(connection));
-        return (SparqlTraversalSource) clone;
     }
 
     /**

--- a/sparql-gremlin/src/test/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSourceTest.java
+++ b/sparql-gremlin/src/test/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSourceTest.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.sparql.process.traversal.dsl.sparql;
 
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.sparql.process.traversal.strategy.SparqlStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2080

Users should now be using `AnonymousTraversalSource` which is the more unified way to create the `TraversalSource` instance.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1