### PR TITLE
TINKERPOP-2103 Remove deprecated submit() on RemoteConnection

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -79,6 +79,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Removed previously deprecated `RemoteStrategy.instance()` and the strategy no longer has any connection to `RemoteGraph`.
 * Removed previously deprecated methods in `SubgraphStrategy` and `PartitionStrategy` builders.
 * Removed previously deprecated Credentials DSL infrastructure.
+* Removed previously deprecated `RemoteConnection#submit(Traversal)` and `RemoteConnection#submit(Bytecode)` methods.
 * Removed previously deprecated `MutationListener#vertexPropertyChanged(Vertex, Property, Object, Object...)`.
 * Removed previously deprecated `OpSelectorHandler` constructor.
 * Removed previously deprecated `close()` from `GremlinGroovyScriptEngine` which no longer implements `AutoCloseable`.

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -445,7 +445,9 @@ The following deprecated classes, methods or fields have been removed in this ve
 
 * `gremlin-core`
 ** `org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer#GREMLIN_CORE`
-** `org.apache.tinkerpop.gremlin.process.remote.RemoteGraph` - moved to `gremlin-test`.
+** `org.apache.tinkerpop.gremlin.process.remote.RemoteGraph` - moved to `gremlin-test`
+** `org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.submit(Traversal)`
+** `org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.submit(Bytecode)`
 ** `org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy#identity()`
 ** `org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine`
 ** `org.apache.tinkerpop.gremlin.process.traversal.TraversalSource#withRemote(*)`
@@ -487,7 +489,8 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-1707[TINKERPOP-1707],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1954[TINKERPOP-1954],
 link:https://issues.apache.org/jira/browse/TINKERPOP-1986[TINKERPOP-1986],
 link:https://issues.apache.org/jira/browse/TINKERPOP-2079[TINKERPOP-2079],
-link:https://issues.apache.org/jira/browse/TINKERPOP-2080[TINKERPOP-2080]
+link:https://issues.apache.org/jira/browse/TINKERPOP-2080[TINKERPOP-2080],
+link:https://issues.apache.org/jira/browse/TINKERPOP-2103[TINKERPOP-2103]
 
 ==== Deprecated GraphSONMessageSerializerGremlinV2d0
 
@@ -707,7 +710,7 @@ long ago moved to the `Computer` infrastructure as methods for constructing a `T
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1143[TINKERPOP-1143]
 
-==== Upsert Graph Feature
+===== Upsert Graph Feature
 
 Some `Graph` implementations may be able to offer upsert functionality for vertices and edges, which can help improve
 usability and performance. To help make it clear to users that a graph operates in this fashion, the `supportsUpsert()`
@@ -726,7 +729,7 @@ should consider their own test suites carefully to ensure appropriate coverage.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1685[TINKERPOP-1685]
 
-==== TypeTranslator Changes
+===== TypeTranslator Changes
 
 The `TypeTranslator` experienced a change in its API and `GroovyTranslator` a change in expectations.
 
@@ -741,3 +744,13 @@ is "complete" - i.e. that it provides all the functionality to translate the typ
 the extension model described above is the easiest way to get going with a custom `TypeTranslator` approach.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2072[TINKERPOP-2072]
+
+==== Graph Driver Providers
+
+===== Deprecation Removal in RemoteConnection
+
+The two deprecated synchronous `submit()` methods on the `RemoteConnection` interface have been removed, which means
+that `RemoteConnection` implementations will need to implement `submitAsync(Bytecode)` if they have not already done
+so.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2103[TINKERPOP-2103]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteConnection.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteConnection.java
@@ -36,42 +36,10 @@ import java.util.concurrent.CompletableFuture;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public interface RemoteConnection extends AutoCloseable {
-
-    /**
-     * @deprecated As of release 3.2.2, replaced by {@link #submitAsync(Bytecode)}.
-     */
-    @Deprecated
-    public <E> Iterator<Traverser.Admin<E>> submit(final Traversal<?, E> traversal) throws RemoteConnectionException;
-
-    /**
-     * Submits {@link Traversal} {@link Bytecode} to a server and returns a {@link RemoteTraversal}.
-     * The {@link RemoteTraversal} is an abstraction over two types of results that can be returned as part of the
-     * response from the server: the results of the {@link Traversal} itself and the side-effects that it produced.
-     *
-     * @deprecated As of release 3.2.4, replaced by {@link #submitAsync(Bytecode)}.
-     */
-    @Deprecated
-    public <E> RemoteTraversal<?,E> submit(final Bytecode bytecode) throws RemoteConnectionException;
-
     /**
      * Submits {@link Traversal} {@link Bytecode} to a server and returns a promise of a {@link RemoteTraversal}.
      * The {@link RemoteTraversal} is an abstraction over two types of results that can be returned as part of the
      * response from the server: the results of the {@link Traversal} itself and the side-effects that it produced.
-     * <p/>
-     * The default implementation calls the {@link #submit(Bytecode)} method for backward compatibility, but generally
-     * speaking this method should be implemented directly as {@link #submit(Bytecode)} is not called directly by
-     * any part of TinkerPop. Even if the {@code RemoteConnection} itself is not capable of asynchronous behaviour, it
-     * should simply implement this method in a blocking form.
      */
-    public default <E> CompletableFuture<RemoteTraversal<?, E>> submitAsync(final Bytecode bytecode) throws RemoteConnectionException {
-        // default implementation for backward compatibility to 3.2.4 - this method will probably just become
-        // the new submit() in 3.3.x when the deprecation is removed
-        final CompletableFuture<RemoteTraversal<?, E>> promise = new CompletableFuture<>();
-        try {
-            promise.complete(submit(bytecode));
-        } catch (Exception t) {
-            promise.completeExceptionally(t);
-        }
-        return promise;
-    }
+    public <E> CompletableFuture<RemoteTraversal<?, E>> submitAsync(final Bytecode bytecode) throws RemoteConnectionException;
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -21,23 +21,16 @@ package org.apache.tinkerpop.gremlin.driver.remote;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
-import org.apache.tinkerpop.gremlin.driver.ResultSet;
-import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnectionException;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.RemoteTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 
 /**
  * A {@link RemoteConnection} implementation for Gremlin Server. Each {@code DriverServerConnection} is bound to one
@@ -179,39 +172,6 @@ public class DriverRemoteConnection implements RemoteConnection {
             return using(conf.getString("clusterConfigurationFile"), remoteTraversalSourceName);
         else {
             return using(Cluster.open(conf.subset("clusterConfiguration")), remoteTraversalSourceName);
-        }
-    }
-
-    /**
-     * @deprecated As of release 3.2.2, replaced by {@link #submitAsync(Bytecode)}.
-     */
-    @Deprecated
-    @Override
-    public <E> Iterator<Traverser.Admin<E>> submit(final Traversal<?, E> t) throws RemoteConnectionException {
-        try {
-            if (attachElements && !t.asAdmin().getStrategies().getStrategy(VertexProgramStrategy.class).isPresent()) {
-                if (!conf.isPresent()) throw new IllegalStateException("Traverser can't be reattached for testing");
-                final Graph graph = ((Supplier<Graph>) conf.get().getProperty("hidden.for.testing.only")).get();
-                return new DriverRemoteTraversal.AttachingTraverserIterator<>(client.submit(t.asAdmin().getBytecode()).iterator(), graph);
-            } else {
-                return new DriverRemoteTraversal.TraverserIterator<>(client.submit(t.asAdmin().getBytecode()).iterator());
-            }
-        } catch (Exception ex) {
-            throw new RemoteConnectionException(ex);
-        }
-    }
-
-    /**
-     * @deprecated As of release 3.2.4, replaced by {@link #submitAsync(Bytecode)}.
-     */
-    @Deprecated
-    @Override
-    public <E> RemoteTraversal<?,E> submit(final Bytecode bytecode) throws RemoteConnectionException {
-        try {
-            final ResultSet rs = client.submit(bytecode);
-            return new DriverRemoteTraversal<>(rs, client, attachElements, conf);
-        } catch (Exception ex) {
-            throw new RemoteConnectionException(ex);
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2103

These methods were long ago deprecated and aren't used anywhere within TinkerPop core.

All tests pass with `docker/build.sh -t -i`

VOTE +1