### PR TITLE
TINKERPOP-2104 Allow ImportCustomizer to handle fields

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Use `Compare.eq` in `Contains` predicates to ensure the same filter behavior for numeric values.
 * Added `OptionsStrategy` to allow traversals to take arbitrary traversal-wide configurations.
 * Added text predicates.
+* Allowed `ImportCustomizer` to accept fields.
 * Removed groovy-sql dependency.
 * Modified `Mutating` steps so that they are no longer marked as `final`.
 * Rewrote `ConnectiveStrategy` to support an arbitrary number of infix notations in a single traversal.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -102,6 +102,7 @@ class Console {
         imports.getClassPackages().collect { Mediator.IMPORT_SPACE + it.getName() + Mediator.IMPORT_WILDCARD }.each { groovy.execute(it) }
         imports.getMethodClasses().collect { Mediator.IMPORT_STATIC_SPACE + it.getCanonicalName() + Mediator.IMPORT_WILDCARD}.each{ groovy.execute(it) }
         imports.getEnumClasses().collect { Mediator.IMPORT_STATIC_SPACE + it.getCanonicalName() + Mediator.IMPORT_WILDCARD}.each{ groovy.execute(it) }
+        imports.getFieldClasses().collect { Mediator.IMPORT_STATIC_SPACE + it.getCanonicalName() + Mediator.IMPORT_WILDCARD}.each{ groovy.execute(it) }
 
         final InteractiveShellRunner runner = new InteractiveShellRunner(groovy, handlePrompt)
         runner.setErrorHandler(handleError)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreGremlinPlugin.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreGremlinPlugin.java
@@ -33,6 +33,7 @@ public final class CoreGremlinPlugin implements GremlinPlugin {
 
     private static final ImportCustomizer gremlinCore = DefaultImportCustomizer.build()
             .addClassImports(CoreImports.getClassImports())
+            .addFieldImports(CoreImports.getFieldImports())
             .addEnumImports(CoreImports.getEnumImports())
             .addMethodImports(CoreImports.getMethodImports()).create();
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
@@ -139,6 +139,7 @@ import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.javatuples.Pair;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
@@ -153,6 +154,7 @@ import java.util.stream.Stream;
 public final class CoreImports {
 
     private final static Set<Class> CLASS_IMPORTS = new LinkedHashSet<>();
+    private final static Set<Field> FIELD_IMPORTS = new LinkedHashSet<>();
     private final static Set<Method> METHOD_IMPORTS = new LinkedHashSet<>();
     private final static Set<Enum> ENUM_IMPORTS = new LinkedHashSet<>();
 
@@ -334,6 +336,10 @@ public final class CoreImports {
 
     public static Set<Enum> getEnumImports() {
         return Collections.unmodifiableSet(ENUM_IMPORTS);
+    }
+
+    public static Set<Field> getFieldImports() {
+        return Collections.unmodifiableSet(FIELD_IMPORTS);
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/DefaultImportCustomizer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/DefaultImportCustomizer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.jsr223;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,23 +36,33 @@ public class DefaultImportCustomizer implements ImportCustomizer {
     private final Set<Class> classImports;
     private final Set<Method> methodImports;
     private final Set<Enum> enumImports;
+    private final Set<Field> fieldImports;
 
     private DefaultImportCustomizer(final Builder builder) {
         classImports = builder.classImports;
         methodImports = builder.methodImports;
         enumImports = builder.enumImports;
+        fieldImports = builder.fieldImports;
     }
 
+    @Override
     public Set<Class> getClassImports() {
         return Collections.unmodifiableSet(classImports);
     }
 
+    @Override
     public Set<Method> getMethodImports() {
         return Collections.unmodifiableSet(methodImports);
     }
 
+    @Override
     public Set<Enum> getEnumImports() {
         return Collections.unmodifiableSet(enumImports);
+    }
+
+    @Override
+    public Set<Field> getFieldImports() {
+        return Collections.unmodifiableSet(fieldImports);
     }
 
     public static Builder build() {
@@ -62,6 +73,7 @@ public class DefaultImportCustomizer implements ImportCustomizer {
         private Set<Class> classImports = new LinkedHashSet<>();
         private Set<Method> methodImports = new LinkedHashSet<>();
         private Set<Enum> enumImports = new LinkedHashSet<>();
+        private Set<Field> fieldImports = new LinkedHashSet<>();
 
         private Builder() {}
 
@@ -100,6 +112,24 @@ public class DefaultImportCustomizer implements ImportCustomizer {
             return this;
         }
 
+        /**
+         * Adds fields that are meant to be imported statically to the engine. When adding fields be sure that
+         * the classes of those fields are added to the {@link #addClassImports(Class[])} or
+         * {@link #addClassImports(Collection)}. If they are not added then the certain {@code ScriptEngine} instances
+         * may have problems importing the methods (e.g. gremlin-python).
+         */
+        public Builder addFieldImports(final Field... field) {
+            fieldImports.addAll(Arrays.asList(field));
+            return this;
+        }
+
+        /**
+         * Overload to {@link #addFieldImports(Field...)}.
+         */
+        public Builder addFieldImports(final Collection<Field> fields) {
+            fieldImports.addAll(fields);
+            return this;
+        }
 
         /**
          * Adds methods that are meant to be imported statically to the engine. When adding methods be sure that

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/ImportCustomizer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/ImportCustomizer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.jsr223;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -47,6 +48,11 @@ public interface ImportCustomizer extends Customizer {
     public Set<Enum> getEnumImports();
 
     /**
+     * Gets the set of fields to be imported to the {@link GremlinScriptEngine}.
+     */
+    public Set<Field> getFieldImports();
+
+    /**
      * Gets the set of packages from the {@link #getClassImports()}.
      */
     public default Set<Package> getClassPackages() {
@@ -65,5 +71,12 @@ public interface ImportCustomizer extends Customizer {
      */
     public default Set<Class> getEnumClasses() {
         return getEnumImports().stream().map(Enum::getDeclaringClass).collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Gets the set of fields from the {@link #getFieldImports()}.
+     */
+    public default Set<Class> getFieldClasses() {
+        return getFieldImports().stream().map(Field::getDeclaringClass).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/DefaultImportCustomizerTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/DefaultImportCustomizerTest.java
@@ -18,14 +18,15 @@
  */
 package org.apache.tinkerpop.gremlin.jsr223;
 
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.WithOptions;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.DayOfWeek;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
@@ -35,13 +36,17 @@ import static org.junit.Assert.assertEquals;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class DefaultImportCustomizerTest {
+
     @Test
     public void shouldReturnAssignedImports() throws Exception {
         final Method abs = Math.class.getMethod("abs", double.class);
         final Enum dayOfWeekEnum = DayOfWeek.SATURDAY;
         final Enum tEnum = T.id;
+        final Field fieldLabels = WithOptions.class.getDeclaredField("labels");
+
         final ImportCustomizer imports = DefaultImportCustomizer.build()
                 .addClassImports(java.awt.Color.class, java.awt.AlphaComposite.class)
+                .addFieldImports(fieldLabels)
                 .addMethodImports(abs)
                 .addEnumImports(dayOfWeekEnum, tEnum).create();
 
@@ -59,6 +64,11 @@ public class DefaultImportCustomizerTest {
         assertThat(imports.getEnumImports(), hasItems(dayOfWeekEnum, tEnum));
         assertEquals(2, imports.getEnumClasses().size());
         assertThat(imports.getEnumClasses(), hasItems(T.class, DayOfWeek.class));
+
+        assertEquals(1, imports.getFieldImports().size());
+        assertThat(imports.getFieldImports(), hasItems(fieldLabels));
+        assertEquals(1, imports.getFieldClasses().size());
+        assertThat(imports.getFieldClasses(), hasItems(WithOptions.class));
     }
 
     @Test

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ImportGroovyCustomizer.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ImportGroovyCustomizer.java
@@ -59,6 +59,7 @@ class ImportGroovyCustomizer implements GroovyCustomizer {
                     .filter(m -> !m.getDeclaringClass().equals(__.class))
                     .forEach(m -> ic.addStaticImport(m.getDeclaringClass().getCanonicalName(), m.getName()));
             customizer.getEnumImports().forEach(m -> ic.addStaticImport(m.getDeclaringClass().getCanonicalName(), m.name()));
+            customizer.getFieldImports().forEach(f -> ic.addStaticImport(f.getDeclaringClass().getCanonicalName(), f.getName()));
         }
 
         return ic;

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyScriptEngineSetup.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyScriptEngineSetup.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.jsr223.ScriptEngineCache;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
@@ -55,6 +56,10 @@ public class GroovyScriptEngineSetup {
 
             for (Method m : CoreImports.getMethodImports()) {
                 staticImports.add(m.getDeclaringClass());
+            }
+
+            for (Field f : CoreImports.getFieldImports()) {
+                staticImports.add(f.getDeclaringClass());
             }
 
             for (Class<?> c : staticImports) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2104

We can now import `Field` instances to the `ScriptEngine` which allows for import of public fields from classes like `WithOptions`:

```text
gremlin> labels
==>2
```

Note that I only allowed for the ability to do this and didn't bother to add any new imports. For `WithOptions` it would just create a bunch of conflicts with existing tokens (e.g. keys, values, etc).

All tests pass with `docker/build.sh -t -n -i`

 VOTE +1

