### PR TITLE
TINKERPOP-2106 throw TimeoutException instead of TraversalInterruptedException

### DIFF
--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalInterruptedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,8 @@ import javax.script.Compilable;
 import javax.script.CompiledScript;
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
+
+import java.io.InterruptedIOException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -285,7 +288,9 @@ public class GremlinExecutor implements AutoCloseable {
 
                 // thread interruptions will typically come as the result of a timeout, so in those cases,
                 // check for that situation and convert to TimeoutException
-                if (root instanceof InterruptedException) {
+                if (root instanceof InterruptedException
+                        || root instanceof TraversalInterruptedException
+                        || root instanceof InterruptedIOException) {
                     lifeCycle.getAfterTimeout().orElse(afterTimeout).accept(bindings);
                     evaluationFuture.completeExceptionally(new TimeoutException(
                             String.format("Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]: %s", scriptEvalTimeOut, script, root.getMessage())));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2106

When gremlin executes timeout, it throws an error "TraversalInterruptedException: null".
According to our user feedback(https://github.com/hugegraph/hugegraph/issues/102), the message is not easy to understand. we think it is clearer if it prompts timeout error directly.

This commit converts some InterruptedException to a TimeoutException.