### PR TITLE
TINKERPOP-2075 Added ReferenceElementStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ This release also includes changes from <<release-3-3-3, 3.3.3>>.
 * Use `Compare.eq` in `Contains` predicates to ensure the same filter behavior for numeric values.
 * Added `OptionsStrategy` to allow traversals to take arbitrary traversal-wide configurations.
 * Added text predicates.
+* Added `ReferenceElementStrategy` to auto-detach elements to "reference" from a traversal.
 * Allowed `ImportCustomizer` to accept fields.
 * Removed groovy-sql dependency.
 * Modified `Mutating` steps so that they are no longer marked as `final`.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -975,11 +975,11 @@ The following table describes the various YAML configuration options that Gremli
 |metrics.csvReporter.fileName |The file to write metrics to. |_none_
 |metrics.csvReporter.interval |Time in milliseconds between reports of metrics to file. |180000
 |metrics.gangliaReporter.addressingMode |Set to `MULTICAST` or `UNICAST`. |_none_
-|metrics.gangliaReporter.enabled |Turns on Ganglia reporting of metrics. Additional link:http://tinkerpop.apache.org/docs/3.3.0/reference/#metrics[setup] is required. |false
+|metrics.gangliaReporter.enabled |Turns on Ganglia reporting of metrics. Additional link:http://tinkerpop.apache.org/docs/x.y.z/reference/#metrics[setup] is required. |false
 |metrics.gangliaReporter.host |Define the Ganglia host to report Metrics to. |localhost
 |metrics.gangliaReporter.interval |Time in milliseconds between reports of metrics for Ganglia. |180000
 |metrics.gangliaReporter.port |Define the Ganglia port to report Metrics to. |8649
-|metrics.graphiteReporter.enabled |Turns on Graphite reporting of metrics. Additional link:http://tinkerpop.apache.org/docs/3.3.0/reference/#metrics[setup] is required. |false
+|metrics.graphiteReporter.enabled |Turns on Graphite reporting of metrics. Additional link:http://tinkerpop.apache.org/docs/x.y.z/reference/#metrics[setup] is required. |false
 |metrics.graphiteReporter.host |Define the Graphite host to report Metrics to. |localhost
 |metrics.graphiteReporter.interval |Time in milliseconds between reports of metrics for Graphite. |180000
 |metrics.graphiteReporter.port |Define the Graphite port to report Metrics to. |2003
@@ -1772,6 +1772,11 @@ List<Vertex> results = g.V().hasLabel("person").valueMap('name').with(WithOption
 ----
 
 Both of the above requests return a list of `Map` instances that contain the `id`, `label` and the "name" property.
+
+IMPORTANT: The example graph configurations pre-packaged with Gremlin Server utilize `ReferenceElementStrategy`
+which convert all graph elements to references by initializing "g" using
+`withStrategies(ReferenceElementStrategy.instance()`. Consider utilizing `ReferenceElementStrategy` whenever creating
+a `GraphTraversalSource` in Java to ensure the most portable Gremlin.
 
 [[gremlin-server-cache]]
 ==== Cache Management

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -125,6 +125,41 @@ gremlin> g.V().has("age", within(32L, 35L))
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2058[TINKERPOP-2058]
 
+==== ReferenceElementStrategy
+
+Gremlin Server has had some inconsistent behavior in the serialization of the results it returns. Remote traversals
+based on Gremlin bytecode always detach returned graph elements to "reference" (i.e. removes properties and only
+include the `id` and `label`), but scripts would detach graph elements and include the properties. For 3.4.0,
+TinkerPop introduces the `ReferenceElementStrategy` which can be configured on a `GraphTraversalSource` to always
+detach to "reference".
+
+[source,text]
+----
+gremlin> graph = TinkerFactory.createModern()
+==>tinkergraph[vertices:6 edges:6]
+gremlin> g = graph.traversal().withStrategies(ReferenceElementStrategy.instance())
+==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
+gremlin> v = g.V().has('person','name','marko').next()
+==>v[1]
+gremlin> v.class
+==>class org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex
+gremlin> v.properties()
+gremlin>
+----
+
+The packaged initialization scripts that come with Gremlin Server now pre-configure the sample graphs with this
+strategy to ensure that both scripts and bytecode based requests over any protocol (HTTP, websocket, etc) and
+serialization format all return a "reference". To revert to the old form, simply remove the strategy in the
+initialization script.
+
+It is recommended that users choose to configure their `GraphTraversalSource` instances with `ReferenceElementStrategy`
+as working with "references" only is the recommended method for developing applications with TinkerPop. In the future,
+it is possible that `ReferenceElementStrategy` will be configured by default for all graphs on or off Gremlin Server,
+so it would be best to start utilizing it now and grooming existing Gremlin and related application code to account
+for it.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2075[TINKERPOP-2075]
+
 ==== Added text predicates
 
 Gremlin now supports simple text predicates on top of the existing `P` predicates. Both, the new `TextP` text predicates and the old `P` predicates, can be chained using `and()` and `or()`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/CoreImports.java
@@ -80,6 +80,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.Elemen
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ReferenceElementStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.MatchAlgorithmStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
@@ -250,6 +251,7 @@ public final class CoreImports {
         CLASS_IMPORTS.add(ComputerVerificationStrategy.class);
         CLASS_IMPORTS.add(LambdaRestrictionStrategy.class);
         CLASS_IMPORTS.add(ReadOnlyStrategy.class);
+        CLASS_IMPORTS.add(ReferenceElementStrategy.class);
         CLASS_IMPORTS.add(StandardVerificationStrategy.class);
         // graph traversal
         CLASS_IMPORTS.add(AnonymousTraversalSource.class);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ReferenceElementStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ReferenceElementStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.MapStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileSideEffectStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
+
+import java.util.Optional;
+
+/**
+ * A strategy that detaches traversers with graph elements as references (i.e. without properties - just {@code id}
+ * and {@code label}.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public final class ReferenceElementStrategy extends AbstractTraversalStrategy<TraversalStrategy.FinalizationStrategy> implements TraversalStrategy.FinalizationStrategy {
+
+    private static final ReferenceElementStrategy INSTANCE = new ReferenceElementStrategy();
+
+    private ReferenceElementStrategy() {}
+
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        if (traversal.getParent() == EmptyStep.instance()) {
+            final Optional<ProfileSideEffectStep> profileStep = TraversalHelper.getFirstStepOfAssignableClass(ProfileSideEffectStep.class, traversal);
+            final int index = profileStep.map(step -> traversal.getSteps().indexOf(step))
+                    .orElseGet(() -> traversal.getSteps().size());
+            traversal.addStep(index, new ReferenceElementStep<>(traversal));
+        }
+    }
+
+    public static ReferenceElementStrategy instance() {
+        return INSTANCE;
+    }
+
+    public static class ReferenceElementStep<S, E> extends MapStep<S, E> {
+
+        public ReferenceElementStep(final Traversal.Admin traversal) {
+            super(traversal);
+        }
+
+        @Override
+        protected E map(final Traverser.Admin<S> traverser) {
+            return ReferenceFactory.detach(traverser.get());
+        }
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ReferenceElementStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ReferenceElementStrategyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ReferenceElementStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.junit.Test;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class ReferenceElementStrategyTest {
+
+    private static final GraphTraversalSource g = traversal().withGraph(EmptyGraph.instance()).
+            withStrategies(ReferenceElementStrategy.instance());
+
+    @Test
+    public void shouldAppendOneReferenceElementStep() {
+        final Traversal<Vertex, ?> t = g.V().union(out(), in()).groupCount();
+        t.asAdmin().applyStrategies();
+        assertThat((t.asAdmin().getEndStep() instanceof ReferenceElementStrategy.ReferenceElementStep), is(true));
+        assertEquals(1, TraversalHelper.getStepsOfAssignableClass(ReferenceElementStrategy.ReferenceElementStep.class, t.asAdmin()).size());
+    }
+}

--- a/gremlin-server/scripts/empty-sample-secure.groovy
+++ b/gremlin-server/scripts/empty-sample-secure.groovy
@@ -47,4 +47,9 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-globals << [g : graph.traversal()]
+// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
+// to "references" (i.e. just id and label without properties). this strategy was added
+// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
+// serialization formats aligning it with TinkerPop recommended practices for writing
+// Gremlin.
+globals << [g : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]

--- a/gremlin-server/scripts/empty-sample.groovy
+++ b/gremlin-server/scripts/empty-sample.groovy
@@ -37,4 +37,9 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-globals << [g : graph.traversal()]
+// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
+// to "references" (i.e. just id and label without properties). this strategy was added
+// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
+// serialization formats aligning it with TinkerPop recommended practices for writing
+// Gremlin.
+globals << [g : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]

--- a/gremlin-server/scripts/generate-classic.groovy
+++ b/gremlin-server/scripts/generate-classic.groovy
@@ -30,4 +30,9 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-globals << [g : graph.traversal()]
+// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
+// to "references" (i.e. just id and label without properties). this strategy was added
+// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
+// serialization formats aligning it with TinkerPop recommended practices for writing
+// Gremlin.
+globals << [g : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]

--- a/gremlin-server/scripts/generate-modern-readonly.groovy
+++ b/gremlin-server/scripts/generate-modern-readonly.groovy
@@ -30,4 +30,9 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-globals << [g : graph.traversal().withStrategies(ReadOnlyStrategy.instance())]
+// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
+// to "references" (i.e. just id and label without properties). this strategy was added
+// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
+// serialization formats aligning it with TinkerPop recommended practices for writing
+// Gremlin.
+globals << [g : graph.traversal().withStrategies(ReadOnlyStrategy.instance(), ReferenceElementStrategy.instance())]

--- a/gremlin-server/scripts/generate-modern.groovy
+++ b/gremlin-server/scripts/generate-modern.groovy
@@ -30,4 +30,9 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-globals << [g : graph.traversal()]
+// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
+// to "references" (i.e. just id and label without properties). this strategy was added
+// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
+// serialization formats aligning it with TinkerPop recommended practices for writing
+// Gremlin.
+globals << [g : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]

--- a/gremlin-server/scripts/load-sample.groovy
+++ b/gremlin-server/scripts/load-sample.groovy
@@ -36,4 +36,9 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-globals << [g : graph.traversal()]
+// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
+// to "references" (i.e. just id and label without properties). this strategy was added
+// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
+// serialization formats aligning it with TinkerPop recommended practices for writing
+// Gremlin.
+globals << [g : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]

--- a/gremlin-server/scripts/spark.groovy
+++ b/gremlin-server/scripts/spark.groovy
@@ -44,4 +44,10 @@ globals << [hook : [
 //
 // Please see conf/gremlin-server-spark.yaml for a working example of a config file that will
 // work with this init script.
-globals << [g : graph.traversal().withComputer(SparkGraphComputer)]
+//
+// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
+// to "references" (i.e. just id and label without properties). this strategy was added
+// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
+// serialization formats aligning it with TinkerPop recommended practices for writing
+// Gremlin.
+globals << [g : graph.traversal().withComputer(SparkGraphComputer).withStrategies(ReferenceElementStrategy.instance())]

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -135,7 +135,7 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
 
     @Test
     public void shouldHandleVertexResult() throws Exception {
-        final ResultSet results = client.submit("gmodern.V(1).next()");
+        final ResultSet results = client.submit("gmodern.withoutStrategies(ReferenceElementStrategy).V(1).next()");
         final Vertex v = results.all().get().get(0).getVertex();
         assertThat(v, instanceOf(DetachedVertex.class));
 
@@ -165,28 +165,28 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
 
     @Test
     public void shouldHandleVertexPropertyResult() throws Exception {
-        final ResultSet results = client.submit("gmodern.V().properties('name').next()");
+        final ResultSet results = client.submit("gmodern.withoutStrategies(ReferenceElementStrategy).V().properties('name').next()");
         final VertexProperty<String> v = results.all().get().get(0).getVertexProperty();
         assertThat(v, instanceOf(DetachedVertexProperty.class));
     }
 
     @Test
     public void shouldHandleEdgeResult() throws Exception {
-        final ResultSet results = client.submit("gmodern.E().next()");
+        final ResultSet results = client.submit("gmodern.withoutStrategies(ReferenceElementStrategy).E().next()");
         final Edge e = results.all().get().get(0).getEdge();
         assertThat(e, instanceOf(DetachedEdge.class));
     }
 
     @Test
     public void shouldHandlePropertyResult() throws Exception {
-        final ResultSet results = client.submit("gmodern.E().properties('weight').next()");
+        final ResultSet results = client.submit("gmodern.withoutStrategies(ReferenceElementStrategy).E().properties('weight').next()");
         final Property<Double> p = results.all().get().get(0).getProperty();
         assertThat(p, instanceOf(DetachedProperty.class));
     }
 
     @Test
     public void shouldHandlePathResult() throws Exception {
-        final ResultSet results = client.submit("gmodern.V().out().path()");
+        final ResultSet results = client.submit("gmodern.withoutStrategies(ReferenceElementStrategy).V().out().path()");
         final Path p = results.all().get().get(0).getPath();
         assertThat(p, instanceOf(DetachedPath.class));
     }

--- a/gremlin-server/src/test/scripts/generate-all.groovy
+++ b/gremlin-server/src/test/scripts/generate-all.groovy
@@ -60,10 +60,10 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // add default TraversalSource instances for each graph instance
-globals << [gclassic : classic.traversal()]
-globals << [gmodern : modern.traversal()]
-globals << [g : graph.traversal()]
-globals << [gcrew : crew.traversal()]
-globals << [ggraph : graph.traversal()]
-globals << [ggrateful : grateful.traversal()]
-globals << [gsink : sink.traversal()]
+globals << [gclassic : classic.traversal().withStrategies(ReferenceElementStrategy.instance())]
+globals << [gmodern : modern.traversal().withStrategies(ReferenceElementStrategy.instance())]
+globals << [g : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]
+globals << [gcrew : crew.traversal().withStrategies(ReferenceElementStrategy.instance())]
+globals << [ggraph : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]
+globals << [ggrateful : grateful.traversal().withStrategies(ReferenceElementStrategy.instance())]
+globals << [gsink : sink.traversal().withStrategies(ReferenceElementStrategy.instance())]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2075

This strategy converts all graph elements to references. Configured this strategy in Gremlin Server by default for the example graphs. Made a few minor updates to tests that were assuming the return of "detached" elements.

All tests pass with `docker/build.sh -t -i`

VOTE +1