### PR TITLE
Minor fixups to #1001 performance enhancements

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/AbstractGremlinScriptEngineFactory.java
@@ -52,7 +52,7 @@ public abstract class AbstractGremlinScriptEngineFactory implements GremlinScrip
     }
 
     @Override
-    public String getEngineName() {
+    public final String getEngineName() {
         return engineName;
     }
 
@@ -67,7 +67,7 @@ public abstract class AbstractGremlinScriptEngineFactory implements GremlinScrip
     }
 
     @Override
-    public String getLanguageName() {
+    public final String getLanguageName() {
         return languageName;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/DefaultGremlinScriptEngineManager.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/DefaultGremlinScriptEngineManager.java
@@ -428,7 +428,7 @@ public class DefaultGremlinScriptEngineManager implements GremlinScriptEngineMan
 
                     globalScope.put(kv.getKey(), kv.getValue());
                 });
-        engine.setBindings(globalScope, ScriptContext.GLOBAL_SCOPE);
+        engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
 
         // merge in bindings that are marked with engine scope. there typically won't be any of these but it's just
         // here for completeness. bindings will typically apply with global scope only as engine scope will generally

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/P.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/P.java
@@ -84,8 +84,8 @@ public class P<V> implements Predicate<V>, Serializable, Cloneable {
     public boolean equals(final Object other) {
         return other instanceof P &&
                 ((P) other).getClass().equals(this.getClass()) &&
-                ((P) other).biPredicate.equals(this.biPredicate) &&
-                ((((P) other).originalValue == null && this.originalValue == null) || ((P) other).originalValue.equals(this.originalValue));
+                ((P) other).getBiPredicate().equals(this.biPredicate) &&
+                ((((P) other).getOriginalValue() == null && this.originalValue == null) || ((P) other).getOriginalValue().equals(this.originalValue));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -283,14 +283,14 @@ public class GraphTraversalSource implements TraversalSource {
         if (useBulk)
             return this;
         final GraphTraversalSource clone = this.clone();
-        RequirementsStrategy.addRequirements(clone.strategies, TraverserRequirement.ONE_BULK);
+        RequirementsStrategy.addRequirements(clone.getStrategies(), TraverserRequirement.ONE_BULK);
         clone.bytecode.addSource(Symbols.withBulk, useBulk);
         return clone;
     }
 
     public GraphTraversalSource withPath() {
         final GraphTraversalSource clone = this.clone();
-        RequirementsStrategy.addRequirements(clone.strategies, TraverserRequirement.PATH);
+        RequirementsStrategy.addRequirements(clone.getStrategies(), TraverserRequirement.PATH);
         clone.bytecode.addSource(Symbols.withPath);
         return clone;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
@@ -127,7 +127,7 @@ public abstract class ReducingBarrierStep<S, E> extends AbstractStep<S, E> imple
 
     @Override
     public MemoryComputeKey<E> getMemoryComputeKey() {
-        return MemoryComputeKey.of(this.getId(), this.reducingBiOperator, false, true);
+        return MemoryComputeKey.of(this.getId(), this.getBiOperator(), false, true);
     }
 
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -137,7 +137,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
         }
         this.finalEndStep = this.getEndStep();
         // finalize requirements
-        if (this.parent instanceof EmptyStep) {
+        if (this.getParent() instanceof EmptyStep) {
             this.requirements = null;
             this.getTraverserRequirements();
         }
@@ -149,14 +149,14 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
         if (null == this.requirements) {
             // if (!this.locked) this.applyStrategies();
             this.requirements = EnumSet.noneOf(TraverserRequirement.class);
-            for (final Step<?, ?> step : this.unmodifiableSteps) {
+            for (final Step<?, ?> step : this.getSteps()) {
                 this.requirements.addAll(step.getRequirements());
             }
             if (!this.requirements.contains(TraverserRequirement.LABELED_PATH) && TraversalHelper.hasLabels(this))
                 this.requirements.add(TraverserRequirement.LABELED_PATH);
-            if (!this.sideEffects.keys().isEmpty())
+            if (!this.getSideEffects().keys().isEmpty())
                 this.requirements.add(TraverserRequirement.SIDE_EFFECTS);
-            if (null != this.sideEffects.getSackInitialValue())
+            if (null != this.getSideEffects().getSackInitialValue())
                 this.requirements.add(TraverserRequirement.SACK);
             if (this.requirements.contains(TraverserRequirement.ONE_BULK))
                 this.requirements.remove(TraverserRequirement.BULK);


### PR DESCRIPTION
Reverted changes where field access might have caused class extensions to misbehave. Made methods final where possible to prevent extension followed by improper operations of methods that now use fields. No need to VOTE on this. 