### PR TITLE
Add request pipelining and a fixed ConnectionPool size TINKERPOP-1775 and TINKERPOP-1774

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-3-3, 3.3.3>>.
 
 * Changed Python "bindings" to use an actual `Bindings` object rather than a 2-tuple.
+* Improved the Gremlin.NET driver: It now uses request pipelining and its `ConnectionPool` has a fixed size.
 * Implemented `IndexStep` which allows to transform local collections into indexed collections or maps.
 * Made `valueMap()` aware of `by` and `with` modulators and deprecated `valueMap(boolean)` overloads.
 * Use `Compare.eq` in `Contains` predicates to ensure the same filter behavior for numeric values.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1003,6 +1003,22 @@ The connection properties for the Gremlin.Net driver can be passed to the `Greml
 |password |The password to submit on requests that require authentication. |_none_
 |=========================================================
 
+==== Connection Pool
+
+It is also possible to configure the `ConnectionPool` of the Gremlin.Net driver.
+These configuration options can be set as properties
+on the `ConnectionPoolSettings` instance that can be passed to the `GremlinClient`:
+
+[width="100%",cols="3,10,^2",options="header"]
+|=========================================================
+|Key |Description |Default
+|PoolSize |The size of the connection pool. |4
+|MaxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |32
+|=========================================================
+
+A `NoConnectionAvailableException` is thrown if all connections have reached the `MaxInProcessPerConnection` limit
+when a new request comes in.
+
 ==== Serialization
 
 The Gremlin.Net driver uses by default GraphSON 3.0 but it is also possible to use GraphSON 2.0 which can be necessary

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -29,9 +29,22 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.4.0/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Gremlin.NET Driver Improvements
+
+The Gremlin.NET driver now uses request pipelining. This allows connections to be reused for different requests in parallel which should lead to better utilization of connections.
+The `ConnectionPool` now also has a fixed size whereas it could previously create an unlimited number of connections.
+Each `Connection` can handle up to `MaxInProcessPerConnection` requests in parallel.
+If this limit is reached for all connections, then a `NoConnectionAvailableException` is thrown which makes this a breaking change.
+
+These settings can be set as properties on the `ConnectionPoolSettings` instance that can be passed to the `GremlinClient`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1774[TINKERPOP-1774],
+link:https://issues.apache.org/jira/browse/TINKERPOP-1775[TINKERPOP-1775],
+link:http://tinkerpop.apache.org/docs/3.4.0/reference/#_connection_pool[Reference Documentation]
+
 ==== Indexing of collections
 
-TinkerPOp 3.4.0 adds a new `index()`-step, which allows users to transform simple collections into index collections or maps.
+TinkerPop 3.4.0 adds a new `index()`-step, which allows users to transform simple collections into index collections or maps.
 
 ```
 gremlin> g.V().hasLabel("software").values("name").fold().

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -124,8 +124,10 @@ namespace Gremlin.Net.Driver
             }
             catch (Exception e)
             {
-                _callbackByRequestId[receivedMsg.RequestId].HandleFailure(e);
-                _callbackByRequestId.TryRemove(receivedMsg.RequestId, out _);
+                if (_callbackByRequestId.TryRemove(receivedMsg.RequestId, out var responseHandler))
+                {
+                    responseHandler.HandleFailure(e);
+                }
             }
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
@@ -1,0 +1,75 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using Gremlin.Net.Driver.Exceptions;
+
+namespace Gremlin.Net.Driver
+{
+    /// <summary>
+    ///     Holds settings for the <see cref="ConnectionPool"/>.
+    /// </summary>
+    public class ConnectionPoolSettings
+    {
+        private int _poolSize = DefaultPoolSize;
+        private int _maxInProcessPerConnection = DefaultMaxInProcessPerConnection;
+        private const int DefaultPoolSize = 4;
+        private const int DefaultMaxInProcessPerConnection = 32;
+
+        /// <summary>
+        ///     Gets or sets the size of the connection pool.
+        /// </summary>
+        /// <remarks>
+        ///     The default value is 4.
+        /// </remarks>
+        public int PoolSize
+        {
+            get => _poolSize;
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(PoolSize), "PoolSize must be > 0!");
+                _poolSize = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the maximum number of in-flight requests that can occur on a connection.
+        /// </summary>
+        /// <remarks>
+        ///     The default value is 32. A <see cref="NoConnectionAvailableException" /> is thrown if this limit is reached on
+        ///     all connections when a new request comes in.
+        /// </remarks>
+        public int MaxInProcessPerConnection
+        {
+            get => _maxInProcessPerConnection;
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(MaxInProcessPerConnection),
+                        "MaxInProcessPerConnection must be > 0!");
+                _maxInProcessPerConnection = value;
+            }
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/NoConnectionAvailableException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/NoConnectionAvailableException.cs
@@ -1,0 +1,56 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+
+namespace Gremlin.Net.Driver.Exceptions
+{
+    /// <summary>
+    ///     The exception that is thrown when no connection is available to service a request.
+    /// </summary>
+    public class NoConnectionAvailableException : Exception
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NoConnectionAvailableException" /> class.
+        /// </summary>
+        public NoConnectionAvailableException()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NoConnectionAvailableException" /> class.
+        /// </summary>
+        public NoConnectionAvailableException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NoConnectionAvailableException" /> class.
+        /// </summary>
+        public NoConnectionAvailableException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -54,19 +54,22 @@ namespace Gremlin.Net.Driver
         /// <param name="graphSONReader">A <see cref="GraphSONReader" /> instance to read received GraphSON data.</param>
         /// <param name="graphSONWriter">a <see cref="GraphSONWriter" /> instance to write GraphSON data.</param>
         /// <param name="mimeType">The GraphSON version mime type, defaults to latest supported by the server.</param>
+        /// <param name="connectionPoolSettings">The <see cref="ConnectionPoolSettings"/> for the connection pool.</param>
         /// <param name="webSocketConfiguration">
         ///     A delegate that will be invoked with the <see cref="ClientWebSocketOptions" />
         ///     object used to configure WebSocket connections.
         /// </param>
         public GremlinClient(GremlinServer gremlinServer, GraphSONReader graphSONReader = null,
             GraphSONWriter graphSONWriter = null, string mimeType = null,
+            ConnectionPoolSettings connectionPoolSettings = null,
             Action<ClientWebSocketOptions> webSocketConfiguration = null)
         {
             var reader = graphSONReader ?? new GraphSON3Reader();
             var writer = graphSONWriter ?? new GraphSON3Writer();
             var connectionFactory = new ConnectionFactory(gremlinServer, reader, writer, mimeType ?? DefaultMimeType,
                 webSocketConfiguration);
-            _connectionPool = new ConnectionPool(connectionFactory);
+            _connectionPool =
+                new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());            
         }
 
         /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/SingleMessageResultReceiver.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/SingleMessageResultReceiver.cs
@@ -1,0 +1,88 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver.Messages;
+using Gremlin.Net.Driver.ResultsAggregation;
+using Gremlin.Net.Structure.IO.GraphSON;
+using Newtonsoft.Json.Linq;
+
+namespace Gremlin.Net.Driver
+{
+    internal class ResponseHandlerForSingleRequestMessage<T> : IResponseHandlerForSingleRequestMessage
+    {
+        public Task<ResultSet<T>> Result => _tcs.Task;
+
+        private readonly TaskCompletionSource<ResultSet<T>> _tcs =
+            new TaskCompletionSource<ResultSet<T>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly GraphSONReader _graphSONReader;
+        private bool _isAggregatingSideEffects;
+        private IAggregator _aggregator;
+        private readonly List<T> _result = new List<T>();
+
+        public ResponseHandlerForSingleRequestMessage(GraphSONReader graphSonReader)
+        {
+            _graphSONReader = graphSonReader;
+        }
+
+        public void HandleReceived(ResponseMessage<JToken> received)
+        {
+            var receivedData = typeof(T) == typeof(JToken)
+                ? new[] {received.Result.Data}
+                : _graphSONReader.ToObject(received.Result.Data);
+            foreach (var d in receivedData)
+            {
+                if (received.Result.Meta.ContainsKey(Tokens.ArgsSideEffectKey))
+                {
+                    if (_aggregator == null)
+                        _aggregator =
+                            new AggregatorFactory().GetAggregatorFor(
+                                (string) received.Result.Meta[Tokens.ArgsAggregateTo]);
+                    _aggregator.Add(d);
+                    _isAggregatingSideEffects = true;
+                }
+                else
+                {
+                    _result.Add(d);
+                }
+            }
+        }
+
+        public void Finalize(Dictionary<string, object> statusAttributes)
+        {
+            var resultSet =
+                new ResultSet<T>(
+                    _isAggregatingSideEffects ? new List<T> {(T) _aggregator.GetAggregatedResult()} : _result,
+                    statusAttributes);
+            _tcs.SetResult(resultSet);
+        }
+
+        public void HandleFailure(Exception objException)
+        {
+            _tcs.TrySetException(objException);
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/SingleMessageResultReceiver.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/SingleMessageResultReceiver.cs
@@ -77,7 +77,7 @@ namespace Gremlin.Net.Driver
                 new ResultSet<T>(
                     _isAggregatingSideEffects ? new List<T> {(T) _aggregator.GetAggregatedResult()} : _result,
                     statusAttributes);
-            _tcs.SetResult(resultSet);
+            _tcs.TrySetResult(resultSet);
         }
 
         public void HandleFailure(Exception objException)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
@@ -51,5 +51,17 @@ namespace Gremlin.Net.Process
                 throw;
             }
         }
+        
+        /// <summary>
+        /// Designed for Tasks that were started but the result should not be awaited upon (fire and forget).
+        /// </summary>
+        public static void Forget(this Task task)
+        {
+            // Avoid compiler warning CS4014 and Unobserved exceptions
+            task?.ContinueWith(t =>
+            {
+                t.Exception?.Handle(_ => true);
+            }, TaskContinuationOptions.ExecuteSynchronously);
+        }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/ConnectionPoolTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/ConnectionPoolTests.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Exceptions;
 using Gremlin.Net.IntegrationTest.Util;
 using Xunit;
 
@@ -39,52 +40,50 @@ namespace Gremlin.Net.IntegrationTest.Driver
         private async Task ExecuteMultipleLongRunningRequestsInParallel(IGremlinClient gremlinClient, int nrRequests,
             int requestRunningTimeInMs)
         {
-            var longRunningRequestMsg = _requestMessageProvider.GetSleepMessage(requestRunningTimeInMs);
             var tasks = new List<Task>(nrRequests);
             for (var i = 0; i < nrRequests; i++)
-                tasks.Add(gremlinClient.SubmitAsync(longRunningRequestMsg));
+            {
+                tasks.Add(gremlinClient.SubmitAsync(_requestMessageProvider.GetSleepMessage(requestRunningTimeInMs)));
+            }
+                
             await Task.WhenAll(tasks);
         }
 
-        [Fact]
-        public async Task ShouldReuseConnectionForSequentialRequests()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void ShouldCreateConfiguredNrConnections(int connectionPoolSize)
         {
-            var gremlinServer = new GremlinServer(TestHost, TestPort);
-            using (var gremlinClient = new GremlinClient(gremlinServer))
+            using (var gremlinClient = CreateGremlinClient(connectionPoolSize))
             {
-                await gremlinClient.SubmitAsync("");
-                await gremlinClient.SubmitAsync("");
-
                 var nrConnections = gremlinClient.NrConnections;
-                Assert.Equal(1, nrConnections);
+                Assert.Equal(connectionPoolSize, nrConnections);
             }
         }
 
         [Fact]
-        public void ShouldOnlyCreateConnectionWhenNecessary()
+        public async Task ShouldThrowNoConnectionAvailableExceptionWhenNoConnectionIsAvailable()
         {
-            var gremlinServer = new GremlinServer(TestHost, TestPort);
-            using (var gremlinClient = new GremlinClient(gremlinServer))
+            const int nrParallelRequests = 2;
+            using (var gremlinClient = CreateGremlinClient(connectionPoolSize: 1, maxInProcessPerConnection: 1))
             {
-                var nrConnections = gremlinClient.NrConnections;
-                Assert.Equal(0, nrConnections);
+                const int sleepTime = 100;
+
+                await Assert.ThrowsAsync<NoConnectionAvailableException>(() =>
+                    ExecuteMultipleLongRunningRequestsInParallel(gremlinClient, nrParallelRequests, sleepTime));
             }
         }
 
-        [Fact]
-        public async Task ShouldExecuteParallelRequestsOnDifferentConnections()
+        private static GremlinClient CreateGremlinClient(int connectionPoolSize = 2, int maxInProcessPerConnection = 4)
         {
             var gremlinServer = new GremlinServer(TestHost, TestPort);
-            using (var gremlinClient = new GremlinClient(gremlinServer))
-            {
-                var sleepTime = 50;
-                var nrParallelRequests = 5;
-
-                await ExecuteMultipleLongRunningRequestsInParallel(gremlinClient, nrParallelRequests, sleepTime);
-
-                var nrConnections = gremlinClient.NrConnections;
-                Assert.Equal(nrParallelRequests, nrConnections);
-            }
+            return new GremlinClient(gremlinServer,
+                connectionPoolSettings: new ConnectionPoolSettings
+                {
+                    PoolSize = connectionPoolSize,
+                    MaxInProcessPerConnection = maxInProcessPerConnection
+                });
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
@@ -31,9 +31,6 @@ using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.IntegrationTest.Util;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Gremlin.Net.Structure.IO.GraphSON;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
 
 namespace Gremlin.Net.IntegrationTest.Driver
 {

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -178,14 +178,13 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             // smoke test to validate serialization of OptionsStrategy. no way to really validate this from an integration
             // test perspective because there's no way to access the internals of the strategy via bytecode
-            var graph = new Graph();
             var connection = _connectionFactory.CreateRemoteConnection();
             var options = new Dictionary<string,object>
             {
                 {"x", "test"},
                 {"y", true}
             };
-            var g = graph.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var b = new Bindings();
             var countWithStrategy = g.WithStrategies(new OptionsStrategy(options)).V().Count().Next();

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
@@ -44,7 +44,9 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
         public IRemoteConnection CreateRemoteConnection(string traversalSource)
         {
-            var c = new DriverRemoteConnectionImpl(new GremlinClient(new GremlinServer(TestHost, TestPort)),
+            var c = new DriverRemoteConnectionImpl(
+                new GremlinClient(new GremlinServer(TestHost, TestPort),
+                    connectionPoolSettings: new ConnectionPoolSettings {PoolSize = 2}),
                 traversalSource);
             _connections.Add(c);
             return c;

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionPoolSettingsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionPoolSettingsTests.cs
@@ -1,0 +1,51 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using Gremlin.Net.Driver;
+using Xunit;
+
+namespace Gremlin.Net.UnitTest.Driver
+{
+    public class ConnectionPoolSettingsTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-100)]
+        public void ShouldThrowForInvalidPoolSize(int invalidPoolSize)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ConnectionPoolSettings {PoolSize = invalidPoolSize});
+        }
+        
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-100)]
+        public void ShouldThrowForInvalidMaxInProcessPerConnection(int invalidMaxInProcessPerConnection)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ConnectionPoolSettings
+                {MaxInProcessPerConnection = invalidMaxInProcessPerConnection});
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,7 @@ limitations under the License.
                         <exclude>**/node/node</exclude>
                         <exclude>**/npm-debug.log</exclude>
                         <exclude>**/_site/**</exclude>
+                        <exclude>**/.idea/**</exclude>
                     </excludes>
                     <licenses>
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1774
https://issues.apache.org/jira/browse/TINKERPOP-1775

This allows connections to be reused for different requests in parallel which should lead to better utilization of connections / lower resource usage. The `ConnectionPool` now also has a fixed size whereas it could previously create an unlimited number of connections. Each `Connection` can handle up to `MaxInProcessPerConnection` requests in parallel.
If this limit is reached for all connections, then a `NoConnectionAvailableException` is thrown which makes this a breaking change.

This change fixes both issues together as discussed in PR #903.

All tests pass with `./docker/build.sh -t -i` and I verified that the changed docs look as expected with `./docker/build.sh -d`.