### PR TITLE
TINKERPOP-2110 Added option to change path for java driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ This release also includes changes from <<release-3-2-11, 3.2.11>>.
 * Fixed a bug in `CoalesceStep` which squared the bulk if the step followed a `Barrier` step.
 * Fixed a bug in `GroupStep` that assigned wrong reducing bi-operators
 * Added `:bytecode` command to help developers debugging `Bytecode`-based traversals.
+* Added option to set the path for the URI on the Java driver.
 * Fixed `PersistedOutputRDD` to eager persist RDD by adding `count()` action calls.
 * Deserialized `g:Set` to a Python `Set` in GraphSON in `gremlin-python`.
 * Deprecated `StarGraph.builder()` and `StarGraph.Builder.build()` in favor of the more common "builder" patterns of `build()` and `create()` respectively.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -799,6 +799,7 @@ The following table describes the various configuration options for the Gremlin 
 |jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors
 |password |The password to submit on requests that require authentication. |_none_
+|path |The URL path to the Gremlin Server. |_/gremlin_
 |port |The port of the Gremlin Server to connect to. The same port will be applied for all hosts. |8192
 |protocol |Sets the `AuthProperties.Property.PROTOCOL` properties for authentication to Gremlin Server. |_none_
 |serializer.className |The fully qualified class name of the `MessageSerializer` that will be used to communicate with the server. Note that the serializer configured on the client should be supported by the server configuration. |_none_

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
@@ -48,7 +48,7 @@ public final class Host {
     Host(final InetSocketAddress address, final Cluster cluster) {
         this.cluster = cluster;
         this.address = address;
-        this.hostUri = makeUriFromAddress(address, cluster.connectionPoolSettings().enableSsl);
+        this.hostUri = makeUriFromAddress(address, cluster.getPath(), cluster.connectionPoolSettings().enableSsl);
         hostLabel = String.format("Host{address=%s, hostUri=%s}", address, hostUri);
     }
 
@@ -90,10 +90,10 @@ public final class Host {
         makeAvailable();
     }
 
-    private static URI makeUriFromAddress(final InetSocketAddress addy, final boolean ssl) {
+    private static URI makeUriFromAddress(final InetSocketAddress addy, final String path, final boolean ssl) {
         try {
             final String scheme = ssl ? "wss" : "ws";
-            return new URI(scheme, null, addy.getHostName(), addy.getPort(), "/gremlin", null, null);
+            return new URI(scheme, null, addy.getHostName(), addy.getPort(), path, null, null);
         } catch (URISyntaxException use) {
             throw new RuntimeException(String.format("URI for host could not be constructed from: %s", addy), use);
         }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -48,6 +48,11 @@ final class Settings {
     public int port = 8182;
 
     /**
+     * The path to the Gremlin service which is defaulted to "/gremlin".
+     */
+    public String path = "/gremlin";
+
+    /**
      * The list of hosts that the driver will connect to.
      */
     public List<String> hosts = new ArrayList<>();

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/HostTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/HostTest.java
@@ -31,11 +31,19 @@ import static org.junit.Assert.assertEquals;
 public class HostTest {
 
     @Test
-    public void shouldConstructHost() {
+    public void shouldConstructHostWithDefaultPath() {
         final InetSocketAddress addy = new InetSocketAddress("localhost", 8182);
         final Host host = new Host(addy, Cluster.open());
         final URI webSocketUri = host.getHostUri();
         assertEquals("ws://localhost:8182/gremlin", webSocketUri.toString());
+    }
+
+    @Test
+    public void shouldConstructHostWithCustomPath() {
+        final InetSocketAddress addy = new InetSocketAddress("localhost", 8183);
+        final Host host = new Host(addy, Cluster.build().port(8183).path("/argh").create());
+        final URI webSocketUri = host.getHostUri();
+        assertEquals("ws://localhost:8183/argh", webSocketUri.toString());
     }
 
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
-import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
@@ -95,7 +95,8 @@ public class WebSocketChannelizer extends AbstractChannelizer {
 
         pipeline.addLast(PIPELINE_HTTP_RESPONSE_ENCODER, new HttpResponseEncoder());
 
-        pipeline.addLast(PIPELINE_REQUEST_HANDLER, new WebSocketServerProtocolHandler(GREMLIN_ENDPOINT, null, false, settings.maxContentLength));
+        pipeline.addLast(PIPELINE_REQUEST_HANDLER, new WebSocketServerProtocolHandler(GREMLIN_ENDPOINT,
+                null, false, settings.maxContentLength));
 
         if (logger.isDebugEnabled())
             pipeline.addLast(new LoggingHandler("log-aggregator-encoder", LogLevel.DEBUG));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2110

Builds with `mvn clean install && mvn verify -pl gremlin-driver,gremlin-server -DskipIntegrationTests=false`

VOTE +1