### PR TITLE
TINKERPOP-2118 Bump to groovy 2.4.16

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ This release also includes changes from <<release-3-2-11, 3.2.11>>.
 * Added `AnonymousTraversalSource` which provides a more unified means of constructing a `TraversalSource`.
 * Added `DriverRemoteConnection.using(Client)` to provide users better control over the number of connections being created.
 * Changed behavior of GraphSON deserializer in gremlin-python such that `g:Set` returns a Python `Set`.
+* Bumped to Groovy 2.4.16.
 * Fixed bug that prevented `TraversalExplanation` from serializing properly with GraphSON.
 * Changed behavior of `iterate()` in Python, Javascript and .NET to send `none()` thus avoiding unnecessary results being returned.
 * Provided for a configurable class map cache in the `GremlinGroovyScriptEngine` and exposed that in Gremlin Server.

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -18,7 +18,7 @@ This product includes software from the Spring Framework,
 under the Apache License 2.0 (see: StringUtils.containsWhitespace())
 
 ------------------------------------------------------------------------
-Apache Groovy 2.4.15 (AL ASF)
+Apache Groovy 2.4.16 (AL ASF)
 ------------------------------------------------------------------------
 This product includes/uses ANTLR (http://www.antlr2.org/)
 developed by Terence Parr 1989-2006

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -11,7 +11,7 @@ This product includes software from the Spring Framework,
 under the Apache License 2.0 (see: StringUtils.containsWhitespace())
 
 ------------------------------------------------------------------------
-Apache Groovy 2.4.15 (AL ASF)
+Apache Groovy 2.4.16 (AL ASF)
 ------------------------------------------------------------------------
 This product includes/uses ANTLR (http://www.antlr2.org/)
 developed by Terence Parr 1989-2006

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ limitations under the License.
         <commons.configuration.version>1.10</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.lang3.version>3.3.1</commons.lang3.version>
-        <groovy.version>2.4.15</groovy.version>
+        <groovy.version>2.4.16</groovy.version>
         <hadoop.version>2.7.2</hadoop.version>
         <java.tuples.version>1.2</java.tuples.version>
         <javadoc-plugin.version>2.10.4</javadoc-plugin.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2118

All tests pass with `docker/build.sh -t -i`

VOTE +1