### PR TITLE
TINKERPOP-2113 Fix P.Within() for list arguments in Gremlin.NET

### DIFF
--- a/gremlin-dotnet/glv/P.template
+++ b/gremlin-dotnet/glv/P.template
@@ -22,7 +22,7 @@
 #endregion
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
-using System.Collections.Generic;
+using System.Collections;
 using System.Linq;
 
 namespace Gremlin.Net.Process.Traversal
@@ -91,16 +91,16 @@ namespace Gremlin.Net.Process.Traversal
 <% } %><% pmethods.findAll{ it in ["within", "without"] }.each { method -> %>
         public static P <%= toCSharpMethodName.call(method) %>(params object[] args)
         {
-            if (args.Length == 1 && args[0] is ICollection<object> collection)
+            if (args.Length == 1 && args[0] is ICollection collection)
                 return new P("<%= method %>", ToGenericArray(collection));
             else
                 return new P("<%= method %>", args);
         }
 <% } %>
 
-        private static TT[] ToGenericArray<TT>(ICollection<TT> collection)
+        private static object[] ToGenericArray(IEnumerable collection)
         {
-            return collection?.ToArray() ?? new TT[0];
+            return collection?.Cast<object>().ToArray() ?? new object[0];
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/P.cs
@@ -22,7 +22,7 @@
 #endregion
 
 // THIS IS A GENERATED FILE - DO NOT MODIFY THIS FILE DIRECTLY - see pom.xml
-using System.Collections.Generic;
+using System.Collections;
 using System.Linq;
 
 namespace Gremlin.Net.Process.Traversal
@@ -151,7 +151,7 @@ namespace Gremlin.Net.Process.Traversal
 
         public static P Within(params object[] args)
         {
-            if (args.Length == 1 && args[0] is ICollection<object> collection)
+            if (args.Length == 1 && args[0] is ICollection collection)
                 return new P("within", ToGenericArray(collection));
             else
                 return new P("within", args);
@@ -159,16 +159,16 @@ namespace Gremlin.Net.Process.Traversal
 
         public static P Without(params object[] args)
         {
-            if (args.Length == 1 && args[0] is ICollection<object> collection)
+            if (args.Length == 1 && args[0] is ICollection collection)
                 return new P("without", ToGenericArray(collection));
             else
                 return new P("without", args);
         }
 
 
-        private static TT[] ToGenericArray<TT>(ICollection<TT> collection)
+        private static object[] ToGenericArray(IEnumerable collection)
         {
-            return collection?.ToArray() ?? new TT[0];
+            return collection?.Cast<object>().ToArray() ?? new object[0];
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
 using Xunit;
 
@@ -48,6 +49,18 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
             var count = g.V().Has("name", P.Within("josh", "vadas")).Count().Next();
+
+            Assert.Equal(2, count);
+        }
+        
+        [Fact]
+        public void ShouldUsePWithinWithListArgumentInHasStep()
+        {
+            var connection = _connectionFactory.CreateRemoteConnection();
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var names = new List<string> {"josh", "vadas"};
+
+            var count = g.V().Has("name", P.Within(names)).Count().Next();
 
             Assert.Equal(2, count);
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2113

This was apparently pretty much the same bug as with the problems we had earlier with the `inject()` step ([TINKERPOP-1972](https://issues.apache.org/jira/browse/TINKERPOP-1972)). So, the fix was also basically the same.

All .NET tests pass.

VOTE +1