### PR TITLE
TINKERPOP-2119 Add C# code examples in doc as code

### DIFF
--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -532,52 +532,9 @@ any .NET language and registering them with the `GremlinClient`.
 
 [source,csharp]
 ----
-internal class MyType
-{
-    public static string GraphsonPrefix = "providerx";
-    public static string GraphsonBaseType = "MyType";
-    public static string GraphsonType = GraphSONUtil.FormatTypeName(GraphsonPrefix, GraphsonBaseType);
+include::../../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Dev/Provider/IndexTests.cs[tags=myTypeSerialization]
 
-    public MyType(int x, int y)
-    {
-        X = x;
-        Y = y;
-    }
-
-    public int X { get; }
-    public int Y { get; }
-}
-
-internal class MyClassWriter : IGraphSONSerializer
-{
-    public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)
-    {
-        MyType myType = objectData;
-        var valueDict = new Dictionary<string, object>
-        {
-            {"x", myType.X},
-            {"y", myType.Y}
-        };
-        return GraphSONUtil.ToTypedValue(nameof(TestClass), valueDict, MyType.GraphsonPrefix);
-    }
-}
-
-internal class MyTypeReader : IGraphSONDeserializer
-{
-    public dynamic Objectify(JToken graphsonObject, GraphSONReader reader)
-    {
-        var x = reader.ToObject(graphsonObject["x"]);
-        var y = reader.ToObject(graphsonObject["y"]);
-        return new MyType(x, y);
-    }
-}
-
-var graphsonReader = new GraphSON3Reader(
-    new Dictionary<string, IGraphSONDeserializer> {{MyType.GraphsonType, new MyTypeReader()}});
-var graphsonWriter = new GraphSON3Writer(
-    new Dictionary<Type, IGraphSONSerializer> {{typeof(MyType), new MyClassWriter()}});
-
-var gremlinClient = new GremlinClient(new GremlinServer("localhost", 8182), graphsonReader, graphsonWriter);
+include::../../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Dev/Provider/IndexTests.cs[tags=supportingGremlinNetIO]
 ----
 
 [[remoteconnection-implementations]]

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -564,22 +564,7 @@ def list = g.V().has('person','name','marko').out('knows').toList()
 ----
 [source,csharp]
 ----
-// script
-var gremlinServer = new GremlinServer("localhost", 8182);
-using (var gremlinClient = new GremlinClient(gremlinServer))
-{
-    var bindings = new Dictionary<string, object>
-    {
-        {"name", "marko"}
-    };
-
-    var response =
-        await gremlinClient.SubmitWithSingleResultAsync<object>("g.V().has('person','name',name).out('knows')", bindings);
-}
-
-// bytecode
-var g = Traversal().WithRemote(new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182))));
-var list = g.V().Has("person","name","marko").Out("knows").toList();
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinApplicationsTests.cs[tags=connectingViaDrivers]
 ----
 [source,javascript]
 ----

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -974,8 +974,7 @@ the remote end.
 
 [source,csharp]
 ----
-var remoteConnection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)));
-var g = Traversal().WithRemote(remoteConnection);
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=connecting]
 ----
 
 === Common Imports
@@ -985,17 +984,7 @@ provide most of the typical functionality required to use Gremlin:
 
 [source,csharp]
 ----
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-using static Gremlin.Net.Process.Traversal.P;
-using static Gremlin.Net.Process.Traversal.Order;
-using static Gremlin.Net.Process.Traversal.Operator.*;
-using static Gremlin.Net.Process.Traversal.Order.*;
-using static Gremlin.Net.Process.Traversal.Pop.*;
-using static Gremlin.Net.Process.Traversal.Scope.*;
-using static Gremlin.Net.Process.Traversal.TextP.*;
-using static Gremlin.Net.Process.Traversal.Column.*;
-using static Gremlin.Net.Process.Traversal.Direction.*;
-using static Gremlin.Net.Process.Traversal.T.*;
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=commonImports]
 ----
 
 === Configuration
@@ -1019,8 +1008,7 @@ when the server does not support GraphSON 3.0 yet:
 
 [source,csharp]
 ----
-var client = new GremlinClient(new GremlinServer("localhost", 8182), new GraphSON2Reader(),
-    new GraphSON2Writer(), GremlinClient.GraphSON2MimeType);
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=serialization]
 ----
 
 === Traversal Strategies
@@ -1030,22 +1018,7 @@ class along with a collection of subclasses that mirror the standard Gremlin-Jav
 
 [source,csharp]
 ----
-g = g.WithStrategies(new SubgraphStrategy(vertices: HasLabel("person"),
-    edges: Has("weight", Gt(0.5))));
-var names = g.V().Values("name").ToList();  // names: [marko, vadas, josh, peter]
-
-g = g.WithoutStrategies(typeof(SubgraphStrategy));
-names = g.V().Values("name").ToList(); // names: [marko, vadas, lop, josh, ripple, peter]
-
-var edgeValueMaps = g.V().OutE().ValueMap().With(WithOptions.Tokens).ToList();
-// edgeValueMaps: [[label:created, id:9, weight:0.4], [label:knows, id:7, weight:0.5], [label:knows, id:8, weight:1.0],
-//     [label:created, id:10, weight:1.0], [label:created, id:11, weight:0.4], [label:created, id:12, weight:0.2]]
-
-g = g.WithComputer(workers: 2, vertices: Has("name", "marko"));
-names = g.V().Values("name").ToList();  // names: [marko]
-
-edgeValueMaps = g.V().OutE().ValueMap().With(WithOptions.Tokens).ToList();
-// edgeValueMaps: [[label:created, id:9, weight:0.4], [label:knows, id:7, weight:0.5], [label:knows, id:8, weight:1.0]]
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=traversalStrategies]
 ----
 
 NOTE: Many of the TraversalStrategy classes in Gremlin.Net are proxies to the respective strategy on Apache TinkerPop’s
@@ -1081,20 +1054,14 @@ Gremlin scripts are sent to the server from a `IGremlinClient` instance.  A `IGr
 
 [source,csharp]
 ----
-var gremlinServer = new GremlinServer("localhost", 8182);
-using (var gremlinClient = new GremlinClient(gremlinServer))
-{
-    var response = await gremlinClient.SubmitWithSingleResultAsync<string>("g.V().has('person','name','marko')");
-}
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=submittingScripts]
 ----
 
 If the remote system has authentication and SSL enabled, then the `GremlinServer` object can be configured as follows:
 
 [source,csharp]
 ----
-var username = "username";
-var password = "password";
-var gremlinServer = new GremlinServer(TestHost, TestPort, enableSsl: true username: username, password: password);
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=submittingScriptsWithAuthentication]
 ----
 
 === Domain Specific Languages
@@ -1111,60 +1078,7 @@ second static class to deal with when writing traversals rather than just callin
 
 [source,csharp]
 ----
-namespace Dsl
-{
-
-    public static class SocialTraversalExtensions
-    {
-        public static GraphTraversal<Vertex,Vertex> Knows(this GraphTraversal<Vertex,Vertex> t, string personName)
-        {
-            return t.Out("knows").HasLabel("person").Has("name", personName);
-        }
-
-        public static GraphTraversal<Vertex, int> YoungestFriendsAge(this GraphTraversal<Vertex,Vertex> t)
-        {
-            return t.Out("knows").HasLabel("person").Values<int>("age").Min<int>();
-        }
-
-        public static GraphTraversal<Vertex,long> CreatedAtLeast(this GraphTraversal<Vertex,Vertex> t, long number)
-        {
-            return t.OutE("created").Count().Is(P.Gte(number));
-        }
-    }
-
-    public static class __Social
-    {
-        public static GraphTraversal<object,Vertex> Knows(string personName)
-        {
-            return __.Out("knows").HasLabel("person").Has("name", personName);
-        }
-
-        public static GraphTraversal<object, int> YoungestFriendsAge()
-        {
-            return __.Out("knows").HasLabel("person").Values<int>("age").Min<int>();
-        }
-
-        public static GraphTraversal<object,long> CreatedAtLeast(long number)
-        {
-            return __.OutE("created").Count().Is(P.Gte(number));
-        }
-    }
-
-    public static class SocialTraversalSourceExtensions
-    {
-        public static GraphTraversal<Vertex,Vertex> Persons(this GraphTraversalSource g, params string[] personNames)
-        {
-            GraphTraversal<Vertex,Vertex> t = g.V().HasLabel("person");
-
-            if (personNames.Length > 0)
-            {
-                t = t.Has("name", P.Within(personNames));
-            }
-
-            return t;
-        }
-    }
-}
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDsl.cs[tags=dsl]
 ----
 
 Note the creation of `__Social` as the Social DSL's "extension" to the available ways in which to spawn anonymous
@@ -1173,21 +1087,14 @@ requirement. To use the DSL, bring it into scope with the `using` directive:
 
 [source,csharp]
 ----
-using Dsl;
-using static Dsl.__Social;
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDslTests.cs[tags=dslUsing]
 ----
 
 and then it can be called from the application as follows:
 
 [source,csharp]
 ----
-var graph = new Graph();
-var connection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)));
-var social = graph.Traversal().WithRemote(connection);
-
-social.Persons("marko").Knows("josh");
-social.Persons("marko").YoungestFriendsAge();
-social.Persons().Filter(CreatedAtLeast(2)).Count();
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDslTests.cs[tags=dslExamples]
 ----
 
 [[gremlin-dotnet-template]]

--- a/docs/src/reference/intro.asciidoc
+++ b/docs/src/reference/intro.asciidoc
@@ -390,10 +390,9 @@ def g = traversal().withRemote('conf/remote-graph.properties')
 ----
 [source,csharp]
 ----
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs[tags=traversalSourceUsing]
 
-var g = Traversal().WithRemote(
-              new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182))));
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs[tags=traversalSourceCreation]
 ----
 [source,javascript]
 ----
@@ -478,9 +477,7 @@ g.V(v1).addE('knows').to(v2).property('weight',0.75).iterate()
 ----
 [source,csharp]
 ----
-Vertex v1 = g.AddV("person").Property("name","marko").Next();
-Vertex v2 = g.AddV("person").Property("name","stephen").Next();
-g.V(v1).AddE("knows").To(v2).Property("weight",0.75).Iterate();
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs[tags=basicGremlinAdds]
 ----
 [source,java]
 ----
@@ -519,8 +516,7 @@ peopleMarkoKnows = g.V().has('person','name','marko').out('knows').toList()
 ----
 [source,csharp]
 ----
-Vertex marko = g.V().has("person","name","marko").Next()
-List<Vertex> peopleMarkoKnows = g.V().has("person","name","marko").out("knows").ToList()
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs[tags=basicGremlinMarkoKnows]
 ----
 [source,java]
 ----

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Dev/Provider/IndexTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Dev/Provider/IndexTests.cs
@@ -1,0 +1,91 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Structure.IO.GraphSON;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Gremlin.Net.IntegrationTest.Docs.Dev.Provider
+{
+// tag::myTypeSerialization[]
+internal class MyType
+{
+    public static string GraphsonPrefix = "providerx";
+    public static string GraphsonBaseType = "MyType";
+    public static string GraphsonType = GraphSONUtil.FormatTypeName(GraphsonPrefix, GraphsonBaseType);
+
+    public MyType(int x, int y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public int X { get; }
+    public int Y { get; }
+}
+
+internal class MyClassWriter : IGraphSONSerializer
+{
+    public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)
+    {
+        MyType myType = objectData;
+        var valueDict = new Dictionary<string, object>
+        {
+            {"x", myType.X},
+            {"y", myType.Y}
+        };
+        return GraphSONUtil.ToTypedValue(nameof(TestClass), valueDict, MyType.GraphsonPrefix);
+    }
+}
+
+internal class MyTypeReader : IGraphSONDeserializer
+{
+    public dynamic Objectify(JToken graphsonObject, GraphSONReader reader)
+    {
+        var x = reader.ToObject(graphsonObject["x"]);
+        var y = reader.ToObject(graphsonObject["y"]);
+        return new MyType(x, y);
+    }
+}
+// end::myTypeSerialization[]
+    
+    public class IndexTests
+    {
+        [Fact(Skip="No Server under localhost")]
+        public void SupportingGremlinNetIOTests()
+        {
+// tag::supportingGremlinNetIO[]
+var graphsonReader = new GraphSON3Reader(
+    new Dictionary<string, IGraphSONDeserializer> {{MyType.GraphsonType, new MyTypeReader()}});
+var graphsonWriter = new GraphSON3Writer(
+    new Dictionary<Type, IGraphSONSerializer> {{typeof(MyType), new MyClassWriter()}});
+
+var gremlinClient = new GremlinClient(new GremlinServer("localhost", 8182), graphsonReader, graphsonWriter);
+// end::supportingGremlinNetIO[]
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinApplicationsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinApplicationsTests.cs
@@ -1,0 +1,62 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+using Xunit;
+
+namespace Gremlin.Net.IntegrationTest.Docs.Reference
+{
+    public class GremlinApplicationsTests
+    {
+        [Fact(Skip="No Server under localhost")]
+        public async Task ConnectingViaDriversTest()
+        {
+// tag::connectingViaDrivers[]
+// script
+var gremlinServer = new GremlinServer("localhost", 8182);
+using (var gremlinClient = new GremlinClient(gremlinServer))
+{
+    var bindings = new Dictionary<string, object>
+    {
+        {"name", "marko"}
+    };
+
+    var response =
+        await gremlinClient.SubmitWithSingleResultAsync<object>("g.V().has('person','name',name).out('knows')",
+            bindings);
+}
+
+// bytecode
+using (var gremlinClient = new GremlinClient(new GremlinServer("localhost", 8182)))
+{
+    var g = Traversal().WithRemote(new DriverRemoteConnection(gremlinClient));
+    var list = g.V().Has("person", "name", "marko").Out("knows").ToList();
+}
+// end::connectingViaDrivers[]
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDsl.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDsl.cs
@@ -23,12 +23,10 @@
 
 using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure;
-using Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection;
-using Xunit;
 
-namespace Gremlin.Net.IntegrationTest.Process.Traversal.Dsl 
+// tag::dsl[]
+namespace Dsl 
 {
-
     public static class SocialTraversalExtensions
     {
         public static GraphTraversal<Vertex,Vertex> Knows(this GraphTraversal<Vertex,Vertex> t, string personName) 
@@ -79,22 +77,5 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.Dsl
             return t;
         }
     }
-
-    public class DslTest 
-    {
-        private readonly RemoteConnectionFactory _connectionFactory = new RemoteConnectionFactory();
-        
-        [Fact]
-        public void ShouldUseDsl() 
-        {
-            var connection = _connectionFactory.CreateRemoteConnection();
-            var social = AnonymousTraversalSource.Traversal().WithRemote(connection);
-
-            Assert.NotNull(social.Persons("marko").Knows("josh").Next());
-            Assert.Equal(27, social.Persons("marko").YoungestFriendsAge().Next());
-            Assert.Equal(4, social.Persons().Count().Next());
-            Assert.Equal(2, social.Persons("marko", "josh").Count().Next());
-            Assert.Equal(1, social.Persons().Filter(__Social.CreatedAtLeast(2)).Count().Next());
-        }
-    }
 }
+// end::dsl[]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDslTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDslTests.cs
@@ -1,0 +1,67 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+// tag::dslUsing[]
+using Dsl;
+using static Dsl.__Social;
+// end::dslUsing[]
+using Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection;
+using Gremlin.Net.Process.Traversal;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+using Xunit;
+
+namespace Gremlin.Net.IntegrationTest.Docs.Reference
+{
+    public class GremlinApplicationsDslTests
+    {
+        private readonly RemoteConnectionFactory _connectionFactory = new RemoteConnectionFactory();
+
+        [Fact(Skip = "No Server under localhost")]
+        public void DslTest()
+        {
+// tag::dslExamples[]
+var connection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)));
+var social = Traversal().WithRemote(connection);
+
+social.Persons("marko").Knows("josh");
+social.Persons("marko").YoungestFriendsAge();
+social.Persons().Filter(CreatedAtLeast(2)).Count();
+// end::dslExamples[]
+        }
+        
+        [Fact]
+        public void ShouldUseDsl() 
+        {
+            var connection = _connectionFactory.CreateRemoteConnection();
+            var social = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            Assert.NotNull(social.Persons("marko").Knows("josh").Next());
+            Assert.Equal(27, social.Persons("marko").YoungestFriendsAge().Next());
+            Assert.Equal(4, social.Persons().Count().Next());
+            Assert.Equal(2, social.Persons("marko", "josh").Count().Next());
+            Assert.Equal(1, social.Persons().Filter(__Social.CreatedAtLeast(2)).Count().Next());
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
@@ -1,0 +1,120 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+using Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection;
+using Gremlin.Net.Process.Traversal;
+using Gremlin.Net.Process.Traversal.Step.Util;
+using Gremlin.Net.Process.Traversal.Strategy.Decoration;
+using Gremlin.Net.Structure.IO.GraphSON;
+using Xunit;
+// tag::commonImports[]
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+using static Gremlin.Net.Process.Traversal.__;
+using static Gremlin.Net.Process.Traversal.P;
+using static Gremlin.Net.Process.Traversal.Order;
+using static Gremlin.Net.Process.Traversal.Operator;
+using static Gremlin.Net.Process.Traversal.Order;
+using static Gremlin.Net.Process.Traversal.Pop;
+using static Gremlin.Net.Process.Traversal.Scope;
+using static Gremlin.Net.Process.Traversal.TextP;
+using static Gremlin.Net.Process.Traversal.Column;
+using static Gremlin.Net.Process.Traversal.Direction;
+using static Gremlin.Net.Process.Traversal.T;
+// end::commonImports[]
+
+namespace Gremlin.Net.IntegrationTest.Docs.Reference
+{
+    public class GremlinVariantsTests
+    {
+        private readonly GraphTraversalSource g = Traversal()
+            .WithRemote(new RemoteConnectionFactory().CreateRemoteConnection());
+        
+        [Fact(Skip="No Server under localhost")]
+        public void ConnectingTest()
+        {
+// tag::connecting[]
+var remoteConnection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)));
+var g = Traversal().WithRemote(remoteConnection);
+// end::connecting[]
+        }
+        
+        [Fact(Skip="No Server under localhost")]
+        public void SerializationTest()
+        {
+// tag::serialization[]
+var client = new GremlinClient(new GremlinServer("localhost", 8182), new GraphSON2Reader(),
+    new GraphSON2Writer(), GremlinClient.GraphSON2MimeType);
+// end::serialization[]
+        }
+        
+        [Fact(Skip="We can't apply strategies")]
+        public void TraversalStrategiesTest()
+        {
+            var g = this.g;
+// tag::traversalStrategies[]
+g = g.WithStrategies(new SubgraphStrategy(vertices: HasLabel("person"),
+    edges: Has("weight", Gt(0.5))));
+var names = g.V().Values<string>("name").ToList();  // names: [marko, vadas, josh, peter]
+
+g = g.WithoutStrategies(typeof(SubgraphStrategy));
+names = g.V().Values<string>("name").ToList(); // names: [marko, vadas, lop, josh, ripple, peter]
+
+var edgeValueMaps = g.V().OutE().ValueMap<object, object>().With(WithOptions.Tokens).ToList();
+// edgeValueMaps: [[label:created, id:9, weight:0.4], [label:knows, id:7, weight:0.5], [label:knows, id:8, weight:1.0],
+//     [label:created, id:10, weight:1.0], [label:created, id:11, weight:0.4], [label:created, id:12, weight:0.2]]
+
+g = g.WithComputer(workers: 2, vertices: Has("name", "marko"));
+names = g.V().Values<string>("name").ToList();  // names: [marko]
+
+edgeValueMaps = g.V().OutE().ValueMap<object, object>().With(WithOptions.Tokens).ToList();
+// edgeValueMaps: [[label:created, id:9, weight:0.4], [label:knows, id:7, weight:0.5], [label:knows, id:8, weight:1.0]]
+// end::traversalStrategies[]
+        }
+        
+        [Fact(Skip="No Server under localhost")]
+        public async Task SubmittingScriptsTest()
+        {
+// tag::submittingScripts[]
+var gremlinServer = new GremlinServer("localhost", 8182);
+using (var gremlinClient = new GremlinClient(gremlinServer))
+{
+    var response =
+        await gremlinClient.SubmitWithSingleResultAsync<string>("g.V().has('person','name','marko')");
+}
+// end::submittingScripts[]
+        }
+
+        [Fact(Skip = "No Server under localhost")]
+        public async Task SubmittingScriptsWithAuthenticationTest()
+        {
+// tag::submittingScriptsWithAuthentication[]
+var username = "username";
+var password = "password";
+var gremlinServer = new GremlinServer("localhost", 8182, true, username, password);
+// end::submittingScriptsWithAuthentication[]
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs
@@ -1,0 +1,71 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+using Gremlin.Net.Process.Traversal;
+// tag::traversalSourceUsing[]
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+// end::traversalSourceUsing[]
+using Xunit;
+using Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection;
+
+namespace Gremlin.Net.IntegrationTest.Docs.Reference
+{
+    public class IntroTests
+    {
+        private readonly GraphTraversalSource g = Traversal()
+            .WithRemote(new RemoteConnectionFactory().CreateRemoteConnection());
+
+        [Fact(Skip="No Server under localhost")]
+        public void TraversalSourceCreationTest()
+        {
+// tag::traversalSourceCreation[]
+var g = Traversal().WithRemote(
+    new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182))));
+// end::traversalSourceCreation[]
+        }
+        
+        [Fact(Skip="Graph manipulation would break other tests")]
+        public void BasicGremlinAddsTest()
+        {
+// tag::basicGremlinAdds[]
+var v1 = g.AddV("person").Property("name", "marko").Next();
+var v2 = g.AddV("person").Property("name", "stephen").Next();
+g.V(v1).AddE("knows").To(v2).Property("weight", 0.75).Iterate();
+// end::basicGremlinAdds[]
+        }
+
+        [Fact]
+        public void BasicGremlinMarkoKnowsTest()
+        {
+// tag::basicGremlinMarkoKnows[]
+var marko = g.V().Has("person", "name", "marko").Next();
+var peopleMarkoKnows = g.V().Has("person", "name", "marko").Out("knows").ToList();
+// end::basicGremlinMarkoKnows[]
+
+            Assert.Equal("person", marko.Label);
+            Assert.Equal(2, peopleMarkoKnows.Count);
+        }
+    }
+}                                                            


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2119

I moved most of the code examples from the docs into C# source files from where they are now included in the docs. The examples are mostly added as tests. Although I had to disable (`skip`) most of these tests for now as they try to connect to a server running on `localhost:8182` where no server is listening in our test environment. Nevertheless, this ensures even for these disabled tests that the example code at least compiles and I could already find some more errors in these examples.

We should from now one only add C# code examples to the docs by adding them as source code and then including them in the AsciiDoc to ensure that our examples in the docs always work and always match their respective version of Gremlin.Net.

Only one C# code listing is still left directly in the docs as it includes numbers as references which are then referenced in the text below (for the lambda solution). We could of course replace these numbers simply by line numbers, but I didn't want to do that for just one example as it would break the style of the other examples.

I verified that the changes in the docs look as expected manually after generating the docs with `docker/build.sh -d` and the .NET tests all pass.

VOTE +1