### PR TITLE
TINKERPOP-2088 Enable SourceLink for Gremlin.Net

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ install:
   - mvn -version
 
 before_install:
+  - sudo apt-get install -y dpkg # workaround for travis-ci/travis-ci#9361
   - wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
   - sudo dpkg -i packages-microsoft-prod.deb
   - sudo apt-get install apt-transport-https
   - sudo apt-get update
-  - sudo apt-get install dotnet-sdk-2.1
+  - sudo apt-get install dotnet-sdk-2.2
 
 jobs:
   include:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,17 +20,16 @@ FROM ubuntu:trusty
 MAINTAINER Daniel Kuppitz <me@gremlin.guru>
 
 RUN apt-get update \
-    && apt-get -y install software-properties-common python-software-properties apt-transport-https \
+    && apt-get -y install software-properties-common python-software-properties apt-transport-https curl \
     && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
     && add-apt-repository -y ppa:webupd8team/java \
-    && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list' \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893 \
+    && sh -c 'curl -s https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb' \
+    && sh -c 'dpkg -i packages-microsoft-prod.deb' \
     && sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list' \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
     && apt-get update \
-    && apt-get install -y oracle-java8-installer curl gawk git maven openssh-server subversion zip \
-    && sh -c 'curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg' \
-    && apt-get install -y --force-yes dotnet-sdk-2.1.101 python python-dev python3-dev python-pip build-essential mono-devel \
+    && apt-get install -y oracle-java8-installer gawk git maven openssh-server subversion zip \
+    && apt-get install -y --force-yes dotnet-sdk-2.2 python python-dev python3-dev python-pip build-essential mono-devel \
     && pip install virtualenv virtualenvwrapper \
     && pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* /var/cache/oracle-jdk8-installer

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -103,7 +103,7 @@ See the <<release-environment,Release Environment>> section for more information
 [[dotnet-environment]]
 === DotNet Environment
 
-The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=2.1.101) to work with the
+The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=2.1.300) to work with the
 `gremlin-dotnet` module. If .NET Core SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
 

--- a/gremlin-dotnet/glv/Gremlin.Net.csproj.template
+++ b/gremlin-dotnet/glv/Gremlin.Net.csproj.template
@@ -46,9 +46,12 @@ https://groups.google.com/forum/#!forum/gremlin-users</Description>
     <PackageLicenseUrl>https://github.com/apache/tinkerpop/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>http://tinkerpop.apache.org/docs/current/images/gremlin-dotnet-logo_256x256.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/apache/tinkerpop</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>    
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>\$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -46,9 +46,12 @@ https://groups.google.com/forum/#!forum/gremlin-users</Description>
     <PackageLicenseUrl>https://github.com/apache/tinkerpop/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>http://tinkerpop.apache.org/docs/current/images/gremlin-dotnet-logo_256x256.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/apache/tinkerpop</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>    
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2088

This requires contributors to update to .NET Core SDK 2.1.300 or newer.
Travis and the Docker build now use the most recent SDK 2.2.

SourceLink should make it easier for users to debug Gremlin.Net within their application as they get better access to the source code of Gremlin.Net during debugging. That is why the .NET open-source library guidance recommends to enable it for libraries.

The generated NuGet package includes a reference to our git repository as well as the commit that belongs to the version included in the package:
![tinkerpop-2088-sourcelink](https://user-images.githubusercontent.com/21224336/50451924-51b24680-0937-11e9-85b0-cca9f06774e0.jpg)

I verified that the Docker build still works with `docker/build.sh`.

VOTE +1

NOTE: We don't need to merge this for the upcoming release, especially since we have have a code freeze (although we don't strictly follow that for GLVs). I just had some spare time to work on this, but we can also merge it after the 3.3.5 release.