### PR TITLE
TINKERPOP-2127: Add Python TraversalMetrics/Metrics deserializers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-6]]
 === TinkerPop 3.3.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Add python TraversalMetrics and Metrics deserializers
 * Masked sensitive configuration options in the logs of `KryoShimServiceLoader`.
 * Fixed a concurrency issue in `TraverserSet`
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
@@ -493,3 +493,19 @@ class PathDeserializer(_GraphSONTypeIO):
         labels = [set(label) for label in d["labels"]]
         objects = [reader.toObject(o) for o in d["objects"]]
         return Path(labels, objects)
+
+
+class TraversalMetricsDeserializer(_GraphSONTypeIO):
+    graphson_type = "g:TraversalMetrics"
+
+    @classmethod
+    def objectify(cls, d, reader):
+        return reader.toObject(d)
+
+
+class MetricsDeserializer(_GraphSONTypeIO):
+    graphson_type = "g:Metrics"
+
+    @classmethod
+    def objectify(cls, d, reader):
+        return reader.toObject(d)

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -580,3 +580,18 @@ class TDeserializer(_GraphSONTypeIO):
     @classmethod
     def objectify(cls, d, reader):
         return T[d]
+
+class TraversalMetricsDeserializer(_GraphSONTypeIO):
+    graphson_type = "g:TraversalMetrics"
+
+    @classmethod
+    def objectify(cls, d, reader):
+        return reader.toObject(d)
+
+
+class MetricsDeserializer(_GraphSONTypeIO):
+    graphson_type = "g:Metrics"
+
+    @classmethod
+    def objectify(cls, d, reader):
+        return reader.toObject(d)

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -65,8 +65,11 @@ class TestDriverRemoteConnection(object):
         assert 2 == len(results)
         assert 'josh' in results
         assert 'peter' in results
-        # # todo: need a traversal metrics deserializer
-        g.V().out().profile().next()
+        # #
+        results = g.V().out().profile().toList()
+        assert 1 == len(results)
+        assert 'metrics' in results[0]
+        assert 'dur' in results[0]
         # #
         results = g.V().has('name', 'peter').as_('a').out('created').as_('b').select('a', 'b').by(
             __.valueMap()).toList()

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -209,6 +209,19 @@ class TestGraphSONReader(object):
         assert isinstance(prop, uuid.UUID)
         assert str(prop) == '41d2e28a-20a4-4ab0-b379-d810dede3786'
 
+    def test_metrics(self):
+        prop = self.graphson_reader.readObject(
+            json.dumps([{'@type': 'g:TraversalMetrics', '@value': {'dur': 1.468594, 'metrics': [
+                {'@type': 'g:Metrics', '@value': {'dur': 1.380957, 'counts': {}, 'name': 'GraphStep(__.V())', 'annotations': {'percentDur': 94.03259171697556}, 'id': '4.0.0()'}},
+                {'@type': 'g:Metrics', '@value': {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}}
+            ]}}]))
+        assert isinstance(prop, list)
+        print(prop)
+        assert prop == [{'dur': 1.468594, 'metrics': [
+                {'dur': 1.380957, 'counts': {}, 'name': 'GraphStep(__.V())', 'annotations': {'percentDur': 94.03259171697556}, 'id': '4.0.0()'},
+                {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}
+                ]}]
+
 
 class TestGraphSONWriter(object):
     graphson_writer = GraphSONWriter()

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -216,7 +216,6 @@ class TestGraphSONReader(object):
                 {'@type': 'g:Metrics', '@value': {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}}
             ]}}]))
         assert isinstance(prop, list)
-        print(prop)
         assert prop == [{'dur': 1.468594, 'metrics': [
                 {'dur': 1.380957, 'counts': {}, 'name': 'GraphStep(__.V())', 'annotations': {'percentDur': 94.03259171697556}, 'id': '4.0.0()'},
                 {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -254,7 +254,6 @@ class TestGraphSONReader(object):
                 {'@type': 'g:Metrics', '@value': {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}}
             ]}}]))
         assert isinstance(prop, list)
-        print(prop)
         assert prop == [{'dur': 1.468594, 'metrics': [
                 {'dur': 1.380957, 'counts': {}, 'name': 'GraphStep(__.V())', 'annotations': {'percentDur': 94.03259171697556}, 'id': '4.0.0()'},
                 {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -247,6 +247,19 @@ class TestGraphSONReader(object):
         assert isinstance(prop, uuid.UUID)
         assert str(prop) == '41d2e28a-20a4-4ab0-b379-d810dede3786'
 
+    def test_metrics(self):
+        prop = self.graphson_reader.readObject(
+            json.dumps([{'@type': 'g:TraversalMetrics', '@value': {'dur': 1.468594, 'metrics': [
+                {'@type': 'g:Metrics', '@value': {'dur': 1.380957, 'counts': {}, 'name': 'GraphStep(__.V())', 'annotations': {'percentDur': 94.03259171697556}, 'id': '4.0.0()'}},
+                {'@type': 'g:Metrics', '@value': {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}}
+            ]}}]))
+        assert isinstance(prop, list)
+        print(prop)
+        assert prop == [{'dur': 1.468594, 'metrics': [
+                {'dur': 1.380957, 'counts': {}, 'name': 'GraphStep(__.V())', 'annotations': {'percentDur': 94.03259171697556}, 'id': '4.0.0()'},
+                {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}
+                ]}]
+
 
 class TestGraphSONWriter(object):
     graphson_writer = GraphSONWriter()


### PR DESCRIPTION
We only deserialize those types as a dict. Also, this should probably target tp34 when created.