### PR TITLE
TINKERPOP-2126 Made TraverserSet internals thread-safe

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-6]]
 === TinkerPop 3.3.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed a concurrency issue in `TraverserSet`
 
 
 [[release-3-3-5]]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/TraverserSet.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/TraverserSet.java
@@ -40,7 +40,7 @@ import java.util.Spliterator;
  */
 public class TraverserSet<S> extends AbstractSet<Traverser.Admin<S>> implements Set<Traverser.Admin<S>>, Queue<Traverser.Admin<S>>, Serializable {
 
-    private final Map<Traverser.Admin<S>, Traverser.Admin<S>> map = new LinkedHashMap<>();
+    private final Map<Traverser.Admin<S>, Traverser.Admin<S>> map = Collections.synchronizedMap(new LinkedHashMap<>());
 
     public TraverserSet() {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2126

This PR replaces the `LinkedHashMap` used by `TraverserSet` with a `SynchronizedMap`. I haven't added a test case, cause I really don't know how to consistently provoke a `ConcurrentModificationException`; however, a `ConcurrentModificationException` did happen several times in a provider implementation and it was caused by the `TraverserSet::toString()` method while Spark was a) processing a query and b) concurrently logging the current state. The way `TraverserSet::toString()` is implemented, it totally makes sense that this scenario would sooner or later hit a `ConcurrentModificationException` if we don't use a synchronized map.

`docker/build.sh -t -i` passed.

VOTE +1