### PR TITLE
Fix table rendering in Sparql reference docs.

### DIFF
--- a/docs/src/reference/compilers.asciidoc
+++ b/docs/src/reference/compilers.asciidoc
@@ -89,7 +89,7 @@ The SPARQL-Gremlin compiler supports the following prefixes to traverse the grap
 [cols=",",options="header",]
 |====================================
 |Prefix |Purpose
-|`v:<id|label|<name>>` |access to vertex id, label or property value
+|`v:<id\|label\|<name>>` |access to vertex id, label or property value
 |`e:<label>` |out-edge traversal
 |`p:<name>` |property traversal
 |====================================


### PR DESCRIPTION
The rendering was off due to the `|` characters in the table, this seems to fix it