### PR TITLE
TINKERPOP-2130 Fix default parameter assignment in Connection ctor

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -70,7 +70,7 @@ class Connection extends EventEmitter {
     super();
 
     this.url = url;
-    this.options = options || {};
+    this.options = options = options || {};
 
     // A map containing the request id and the handler
     this._responseHandlers = {};


### PR DESCRIPTION
Fixes the bug reported [here](https://issues.apache.org/jira/browse/TINKERPOP-2130).
The issue was that default empty options object was directly assigned to this.options instead of to the options argument itself.