### PR TITLE
TINKERPOP-2131 Gremlin.Net: Better explain connection pool exceptions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-3-6, 3.3.6>>.
 
 * Fixed up `SparqlStrategy` so that it could be used properly with `RemoteStrategy`.
+* Added easier to understand exceptions for connection problems in the Gremlin.Net driver.
 
 [[release-3-4-0]]
 === TinkerPop 3.4.0 (Release Date: January 2, 2019)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ConnectionPoolBusyException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ConnectionPoolBusyException.cs
@@ -1,0 +1,60 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+namespace Gremlin.Net.Driver.Exceptions
+{
+    /// <summary>
+    ///     The exception that is thrown when all connections in the pool have reached their maximum number of in-flight
+    ///     requests.
+    /// </summary>
+    public class ConnectionPoolBusyException : NoConnectionAvailableException
+    {
+        /// <summary>
+        ///     Gets the size of the connection pool.
+        /// </summary>
+        public int PoolSize { get; }
+
+        /// <summary>
+        ///     Gets the maximum number of in-flight requests that can occur on a connection.
+        /// </summary>
+        public int MaxInProcessPerConnection { get; }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ConnectionPoolBusyException" /> class.
+        /// </summary>
+        public ConnectionPoolBusyException(int poolSize, int maxInProcessPerConnection)
+            : base(CreateMessage(poolSize, maxInProcessPerConnection))
+        {
+            PoolSize = poolSize;
+            MaxInProcessPerConnection = maxInProcessPerConnection;
+        }
+
+        private static string CreateMessage(int poolSize, int maxInProcessPerConnection)
+        {
+            return $"All {poolSize} connections have reached their " +
+                   $"{nameof(ConnectionPoolSettings.MaxInProcessPerConnection)} limit of {maxInProcessPerConnection}." +
+                   $" Consider increasing either the {nameof(ConnectionPoolSettings.PoolSize)} or the " +
+                   $"{nameof(ConnectionPoolSettings.MaxInProcessPerConnection)} limit.";
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ServerUnavailableException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ServerUnavailableException.cs
@@ -1,0 +1,45 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+namespace Gremlin.Net.Driver.Exceptions
+{
+    /// <summary>
+    ///     The exception that is thrown when no connection is available to the <see cref="GremlinServer"/>.
+    /// </summary>
+    public class ServerUnavailableException : NoConnectionAvailableException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ServerUnavailableException" /> class.
+        /// </summary>
+        public ServerUnavailableException()
+            : base(CreateMessage())
+        {
+        }
+
+        private static string CreateMessage()
+        {
+            return
+                "No connection to the server available which most likely means that the server is completely unavailable.";
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/ConnectionPoolTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/ConnectionPoolTests.cs
@@ -63,15 +63,17 @@ namespace Gremlin.Net.IntegrationTest.Driver
         }
 
         [Fact]
-        public async Task ShouldThrowNoConnectionAvailableExceptionWhenNoConnectionIsAvailable()
+        public async Task ShouldThrowConnectionPoolBusyExceptionWhenPoolIsBusy()
         {
             const int nrParallelRequests = 2;
             using (var gremlinClient = CreateGremlinClient(connectionPoolSize: 1, maxInProcessPerConnection: 1))
             {
                 const int sleepTime = 100;
 
-                await Assert.ThrowsAsync<NoConnectionAvailableException>(() =>
+                var thrownException = await Assert.ThrowsAsync<ConnectionPoolBusyException>(() =>
                     ExecuteMultipleLongRunningRequestsInParallel(gremlinClient, nrParallelRequests, sleepTime));
+                Assert.Contains(nameof(ConnectionPoolSettings.MaxInProcessPerConnection), thrownException.Message);
+                Assert.Contains(nameof(ConnectionPoolSettings.PoolSize), thrownException.Message);
             }
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2131

Two new exception classes are added to better reveal the reason for a `NoConnectionAvailableException`:
* The pool is empty because the server is unavailable
    -> `ServerUnavailableException`
* All connections have reached the max in-flight requests limit
    -> `ConnectionPoolBusyException`
Both extend `NoConnectionAvailableException` so this is a non-breaking change.

VOTE +1