### PR TITLE
TINKERPOP-2125 Extend release validation script

### DIFF
--- a/bin/validate-distribution.sh
+++ b/bin/validate-distribution.sh
@@ -136,6 +136,20 @@ echo "OK"
 
 if [ "${TYPE}" = "SOURCE" ]; then
 cd ${DIR_NAME}
+echo -n "* checking source files ... "
+find . -type f | xargs -n1 -I {} file {} --mime | grep 'charset=binary' | cut -f1 -d: |
+  grep -Pv '^\./docs/(static|(site/home))/images/((icons|logos|policy|resources)/)?[^/]*\.(png|jpg|ico|pdf)$' |
+  grep -Pv '^./gremlin-dotnet/src/images/[^/]*\.(png|ico)$' |
+  grep -Pv '^./gremlin-dotnet/.*\.snk$' |
+  grep -Pv '^./gremlin-server/src/test/resources/[^/]*\.(p12|jks)$' |
+  grep -Pv '/(resources|data)/.*\.(kryo|json)$' > ../binary-files.txt
+if [ -s ../binary-files.txt ]; then
+  echo "Found unexpected binary files (see $(cd .. ; pwd)/binary-files.txt)"
+  exit 1
+else
+  rm -f ../binary-files.txt
+  echo "OK"
+fi
 echo -n "* building project ... "
 touch {gremlin-dotnet,gremlin-dotnet/src,gremlin-dotnet/test,gremlin-python,gremlin-javascript}/.glv
 LOG_FILE="${TMP_DIR}/mvn-clean-install-${VERSION}.log"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2125

Added source file check in release validation script.

VOTE +/-0

At this point, the validation does not pass. We need to make a decision on what to do with the following files:

```
./docs/static/images/gremlin-characters.pdf
./docs/static/images/gremlintron.pdf
./docs/static/images/gremlin-sacks.pdf
./docs/static/images/gremlin-gym.pdf
```

Do we whitelist them or should they be removed from the repository?