### PR TITLE
Fix NPE is not thrown when null id is set to AbstractStep

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/AbstractStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/AbstractStep.java
@@ -54,7 +54,7 @@ public abstract class AbstractStep<S, E> implements Step<S, E> {
 
     @Override
     public void setId(final String id) {
-        Objects.nonNull(id);
+        Objects.requireNonNull(id);
         this.id = id;
     }
 


### PR DESCRIPTION
This PR removes the redundant `Objects.nonNull(id);` call for `setId` method.