### PR TITLE
TINKERPOP-2126 Fixed concurrency issue in `ObjectWritable::toString()`.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,7 +30,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `globalFunctionCacheEnabled` to the `GroovyCompilerGremlinPlugin` to allow that cache to be disabled.
 * Added `globalFunctionCacheEnabled` override to `SessionOpProcessor` configuration.
 * Added status code to `GremlinServerError` so that it would be more directly accessible during failures.
-* Fixed a concurrency issue in `TraverserSet`.
+* Fixed concurrency issues in `TraverserSet.toString()` and `ObjectWritable.toString()`.
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.
 
 [[release-3-3-5]]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ FROM ubuntu:trusty
 MAINTAINER Daniel Kuppitz <me@gremlin.guru>
 
 RUN apt-get update \
-    && apt-get -y install software-properties-common python-software-properties apt-transport-https curl \
+    && apt-get -y install software-properties-common python-software-properties apt-transport-https curl dpkg \
     && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
     && add-apt-repository -y ppa:webupd8team/java \
     && sh -c 'curl -s https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb' \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2126

So, apparently, Spark 2.4.0 has some background logging going on, where it takes objects out of memory and dumps their `toString()` into the log. I don't think we can control when Spark is going to do that, so we have to work around it by making our `toString()` methods thread-safe or handle each `ConcurrentModificationException`. Guaranteeing thread-safety was easy for `TraverserSet` but turned out to be tricky (impossible?) for `ObjectWritable` as it's totally unclear where the objects are coming from and/or where they get modified while Spark is trying to log them.

I don't think we can make any arbitrary object thread-safe, but we can easily catch the `ConcurrentModificationException` and retry until we succeed. `while (true)` looks a bit scary, but I don't think that this can ever become an infinite loop.

`docker/build.sh -t -i -n` passed (as well as the external provider tests that consistently triggered the concurrency exceptions).

VOTE +1