### PR TITLE
TINKERPOP-2138 Provide way to disable the global function cache

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.3.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Masked sensitive configuration options in the logs of `KryoShimServiceLoader`.
+* Added `globalFunctionCacheEnabled` to the `GroovyCompilerGremlinPlugin` to allow that cache to be disabled.
+* Added `globalFunctionCacheEnabled` override to `SessionOpProcessor` configuration.
 * Fixed a concurrency issue in `TraverserSet`
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1270,6 +1270,7 @@ The `SessionOpProcessor` provides a way to interact with Gremlin Server over a <
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Name |Description |Default
+|globalFunctionCacheEnabled |Determines if the script engine cache for global functions is enabled and behaves as an override to the plugin specific setting of the same name. |true
 |maxParameters |Maximum number of parameters that can be passed on the request. |16
 |perGraphCloseTimeout |Time in milliseconds to wait for each configured graph to close any open transactions when the session is killed. |10000
 |sessionTimeout |Time in milliseconds before a session will time out. |28800000
@@ -1586,6 +1587,7 @@ The `GroovyCompilerGremlinPlugin` has a number of configuration options:
 |`compilerConfigurationOptions` |Allows configuration of the Groovy `CompilerConfiguration` object by taking a `Map` of key/value pairs where the "key" is a property to set on the `CompilerConfiguration`.
 |`enableThreadInterrupt` |Injects checks for thread interruption, thus allowing the script to potentially respect calls to `Thread.interrupt()`
 |`expectedCompilationTime` |The amount of time in milliseconds a script is allowed to compile before a warning message is sent to the logs.
+|`globalFunctionCacheEnabled` |Determines if the global function cache is enabled. By default, this value is `true` - described in more detail in the <<gremlin-server-cache,Cache Management>> Section.
 |`classMapCacheSpecification` |The cache specification for the `GremlinGroovyScriptEngine` class map cache - described in more detail in the <<gremlin-server-cache,Cache Management>> Section.
 |`extensions` | This setting is for use when `compilation` is configured with `COMPILE_STATIC` or `TYPE_CHECKED` and accepts a comma separated list of link:http://docs.groovy-lang.org/latest/html/documentation/#Typecheckingextensions-Workingwithextensions[type checking extensions] that can have the effect of securing calls to various methods.
 |=========================================================
@@ -2022,10 +2024,12 @@ Cluster cluster = Cluster.open();
 Client client = cluster.connect();
 
 Map<String,Object> params = new HashMap<>();
-params.put("x",4);
 params.put("#jsr223.groovy.engine.keep.globals", "soft");
-client.submit("[1,2,3,x]", params);
+client.submit("def addItUp(x,y){x+y}", params);
 ----
+
+In cases where maintaining the expense of the global function cache is unecessary this cache can be disabled with the
+`globalFunctionCacheEnabled` configuration on the `GroovyCompilerGremlinPlugin`.
 
 Gremlin Server also has a "class map" cache which holds compiled scripts which helps avoid recompilation costs on
 future requests. This cache can be tuned in the Gremlin Server configuration with the `GroovyCompilerGremlinPlugin`

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/CompilationOptionsCustomizer.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/CompilationOptionsCustomizer.java
@@ -29,10 +29,12 @@ class CompilationOptionsCustomizer implements Customizer {
 
     private final long expectedCompilationTime;
     private final String cacheSpecification;
+    private final boolean globalFunctionCacheEnabled;
 
     private CompilationOptionsCustomizer(final Builder builder) {
         this.expectedCompilationTime = builder.expectedCompilationTime;
         this.cacheSpecification = builder.cacheSpecification;
+        this.globalFunctionCacheEnabled = builder.globalFunctionCacheEnabled;
     }
 
     public long getExpectedCompilationTime() {
@@ -43,6 +45,10 @@ class CompilationOptionsCustomizer implements Customizer {
         return cacheSpecification;
     }
 
+    public boolean isGlobalFunctionCacheEnabled() {
+        return globalFunctionCacheEnabled;
+    }
+
     public static Builder build() {
         return new Builder();
     }
@@ -50,6 +56,7 @@ class CompilationOptionsCustomizer implements Customizer {
     public static class Builder {
         private long expectedCompilationTime;
         private String cacheSpecification = "softValues";
+        private boolean globalFunctionCacheEnabled = true;
 
         public Builder setExpectedCompilationTime(final long expectedCompilationTime) {
             this.expectedCompilationTime = expectedCompilationTime;
@@ -58,6 +65,11 @@ class CompilationOptionsCustomizer implements Customizer {
 
         public Builder setClassMapCacheSpecification(final String cacheSpecification) {
             this.cacheSpecification = cacheSpecification;
+            return this;
+        }
+
+        public Builder enableGlobalFunctionCache(final boolean enabled) {
+            this.globalFunctionCacheEnabled = enabled;
             return this;
         }
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
@@ -194,6 +194,8 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
     private final ImportGroovyCustomizer importGroovyCustomizer;
     private final List<GroovyCustomizer> groovyCustomizers;
 
+    private final boolean globalFunctionCacheEnabled;
+
     private final boolean interpreterModeEnabled;
     private final long expectedCompilationTime;
     private final Translator.ScriptTranslator.TypeTranslator typeTranslator;
@@ -236,11 +238,13 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
         final Optional<CompilationOptionsCustomizer> compilationOptionsCustomizerProvider = listOfCustomizers.stream()
                 .filter(p -> p instanceof CompilationOptionsCustomizer)
                 .map(p -> (CompilationOptionsCustomizer) p).findFirst();
-        expectedCompilationTime = compilationOptionsCustomizerProvider.isPresent() ?
-                compilationOptionsCustomizerProvider.get().getExpectedCompilationTime() : 5000;
+        expectedCompilationTime = compilationOptionsCustomizerProvider.
+                map(CompilationOptionsCustomizer::getExpectedCompilationTime).orElse(5000L);
+        globalFunctionCacheEnabled = compilationOptionsCustomizerProvider.
+                map(CompilationOptionsCustomizer::isGlobalFunctionCacheEnabled).orElse(true);
 
-        classMap = Caffeine.from(compilationOptionsCustomizerProvider.isPresent() ?
-                compilationOptionsCustomizerProvider.get().getClassMapCacheSpecification() : "softValues").
+        classMap = Caffeine.from(compilationOptionsCustomizerProvider.
+                map(CompilationOptionsCustomizer::getClassMapCacheSpecification).orElse("softValues")).
                 recordStats().
                 build(new GroovyCacheLoader());
 
@@ -254,8 +258,8 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
         final Optional<TranslatorCustomizer> translatorCustomizer = listOfCustomizers.stream().
                 filter(p -> p instanceof TranslatorCustomizer).
                 map(p -> (TranslatorCustomizer) p).findFirst();
-        typeTranslator = translatorCustomizer.isPresent() ? translatorCustomizer.get().createTypeTranslator() :
-                Translator.ScriptTranslator.TypeTranslator.identity();
+        typeTranslator = translatorCustomizer.map(TranslatorCustomizer::createTypeTranslator).
+                orElse(Translator.ScriptTranslator.TypeTranslator.identity());
 
         createClassLoader();
     }
@@ -357,20 +361,23 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
      */
     @Override
     public Object eval(final String script, final ScriptContext context) throws ScriptException {
-        try {
-            final String val = (String) context.getAttribute(KEY_REFERENCE_TYPE, ScriptContext.ENGINE_SCOPE);
-            ReferenceBundle bundle = ReferenceBundle.getHardBundle();
-            if (val != null && val.length() > 0) {
-                if (val.equalsIgnoreCase(REFERENCE_TYPE_SOFT)) {
-                    bundle = ReferenceBundle.getSoftBundle();
-                } else if (val.equalsIgnoreCase(REFERENCE_TYPE_WEAK)) {
-                    bundle = ReferenceBundle.getWeakBundle();
-                } else if (val.equalsIgnoreCase(REFERENCE_TYPE_PHANTOM)) {
-                    bundle = ReferenceBundle.getPhantomBundle();
+
+        if (globalFunctionCacheEnabled) {
+            try {
+                final String val = (String) context.getAttribute(KEY_REFERENCE_TYPE, ScriptContext.ENGINE_SCOPE);
+                ReferenceBundle bundle = ReferenceBundle.getHardBundle();
+                if (val != null && val.length() > 0) {
+                    if (val.equalsIgnoreCase(REFERENCE_TYPE_SOFT)) {
+                        bundle = ReferenceBundle.getSoftBundle();
+                    } else if (val.equalsIgnoreCase(REFERENCE_TYPE_WEAK)) {
+                        bundle = ReferenceBundle.getWeakBundle();
+                    } else if (val.equalsIgnoreCase(REFERENCE_TYPE_PHANTOM)) {
+                        bundle = ReferenceBundle.getPhantomBundle();
+                    }
                 }
-            }
-            globalClosures.setBundle(bundle);
-        } catch (ClassCastException cce) { /*ignore.*/ }
+                globalClosures.setBundle(bundle);
+            } catch (ClassCastException cce) { /*ignore.*/ }
+        }
 
         try {
             registerBindingTypes(context);
@@ -632,9 +639,12 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
                 return scriptClass;
             } else {
                 final Script scriptObject = InvokerHelper.createScript(scriptClass, binding);
-                for (Method m : scriptClass.getMethods()) {
-                    final String name = m.getName();
-                    globalClosures.put(name, new MethodClosure(scriptObject, name));
+
+                if (globalFunctionCacheEnabled) {
+                    for (Method m : scriptClass.getMethods()) {
+                        final String name = m.getName();
+                        globalClosures.put(name, new MethodClosure(scriptObject, name));
+                    }
                 }
 
                 final MetaClass oldMetaClass = scriptObject.getMetaClass();
@@ -679,7 +689,7 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl
                     if (localVars != null) {
                         localVars.entrySet().forEach(e -> {
                             // closures need to be cached for later use
-                            if (e.getValue() instanceof Closure)
+                            if (globalFunctionCacheEnabled && e.getValue() instanceof Closure)
                                 globalClosures.put(e.getKey(), (Closure) e.getValue());
 
                             context.setAttribute(e.getKey(), e.getValue(), ScriptContext.ENGINE_SCOPE);

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
@@ -61,6 +61,7 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
         private String extensions = null;
         private int expectedCompilationTime = 5000;
         private String cacheSpec = "softValues";
+        private boolean globalFunctionCacheEnabled = true;
 
         private Map<String,Object> keyValues = Collections.emptyMap();
 
@@ -143,6 +144,14 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
             return this;
         }
 
+        /**
+         * Determines if the global function cache in the script engine is enabled or not. It is enabled by default.
+         */
+        public Builder globalFunctionCacheEnabled(final boolean enabled) {
+            this.globalFunctionCacheEnabled = enabled;
+            return this;
+        }
+
         Customizer[] asCustomizers() {
             final List<Customizer> list = new ArrayList<>();
 
@@ -159,6 +168,7 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
                 list.add(new TimedInterruptGroovyCustomizer(timeInMillis));
 
             list.add(CompilationOptionsCustomizer.build().
+                    enableGlobalFunctionCache(globalFunctionCacheEnabled).
                     setExpectedCompilationTime(expectedCompilationTime > 0 ? expectedCompilationTime : 5000).
                     setClassMapCacheSpecification(cacheSpec).create());
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.driver.Tokens;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPlugin;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.server.Context;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
@@ -77,6 +78,12 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
     public static final String CONFIG_PER_GRAPH_CLOSE_TIMEOUT = "perGraphCloseTimeout";
 
     /**
+     * Configuration setting that behaves as an override to the global script engine setting of the same name that is
+     * provided to the {@link GroovyCompilerGremlinPlugin}.
+     */
+    public static final String CONFIG_GLOBAL_FUNCTION_CACHE_ENABLED = "globalFunctionCacheEnabled";
+
+    /**
      * Default timeout for a session is eight hours.
      */
     public static final long DEFAULT_SESSION_TIMEOUT = 28800000;
@@ -95,6 +102,7 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
             put(CONFIG_SESSION_TIMEOUT, DEFAULT_SESSION_TIMEOUT);
             put(CONFIG_PER_GRAPH_CLOSE_TIMEOUT, DEFAULT_PER_GRAPH_CLOSE_TIMEOUT);
             put(CONFIG_MAX_PARAMETERS, DEFAULT_MAX_PARAMETERS);
+            put(CONFIG_GLOBAL_FUNCTION_CACHE_ENABLED, true);
         }};
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2138

Added a new `globalFunctionCacheEnabled` configuration to the `GroovyCompilerGremlinPlugin` and an overriding setting for sessions on `SessionOpProcessor` that disables the global function cache.  In cases where you don't need the cache (i.e. don't use global functions) it does remove a bit of reflection based processing from every single script request and obviously saves on memory formerly used by the cache. 

All tests pass with `docker/build.sh -t -n -i`

VOTE +1