### PR TITLE
TINKERPOP-2139 Properly handle client side serialization exceptions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-6]]
 === TinkerPop 3.3.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added a new `ResponseStatusCode` for client-side serialization errors.
+* Improved handling of client-side serialization errors that were formerly just being logged rather than being raised.
 * Add Python `TraversalMetrics` and `Metrics` deserializers.
 * Masked sensitive configuration options in the logs of `KryoShimServiceLoader`.
 * Added `globalFunctionCacheEnabled` to the `GroovyCompilerGremlinPlugin` to allow that cache to be disabled.

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -962,7 +962,8 @@ Gremlin Server will send:
 |206 |PARTIAL CONTENT |The server successfully returned some content, but there is more in the stream to arrive - wait for a `SUCCESS` to signify the end of the stream.
 |401 |UNAUTHORIZED |The request attempted to access resources that the requesting user did not have access to.
 |407 |AUTHENTICATE |A challenge from the server for the client to authenticate its request.
-|498 |MALFORMED REQUEST | The request message was not properly formatted which means it could not be parsed at all or the "op" code was not recognized such that Gremlin Server could properly route it for processing.  Check the message format and retry the request.
+|497 |CLIENT SERIALIZATION ERROR |The request message contained an object that was not serializable.
+|498 |MALFORMED REQUEST |The request message was not properly formatted which means it could not be parsed at all or the "op" code was not recognized such that Gremlin Server could properly route it for processing.  Check the message format and retry the request.
 |499 |INVALID REQUEST ARGUMENTS |The request message was parseable, but the arguments supplied in the message were in conflict or incomplete. Check the message format and retry the request.
 |500 |SERVER ERROR |A general server error occurred that prevented the request from being processed.
 |597 |SCRIPT EVALUATION ERROR |The script submitted for processing evaluated in the `ScriptEngine` with errors and could not be processed.  Check the script submitted for syntax errors or other problems and then resubmit.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/NioGremlinRequestEncoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/NioGremlinRequestEncoder.java
@@ -19,7 +19,9 @@
 package org.apache.tinkerpop.gremlin.driver.handler;
 
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
+import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
@@ -63,7 +65,9 @@ public final class NioGremlinRequestEncoder extends MessageToByteEncoder<Object>
                 byteBuf.writeBytes(bytes);
             }
         } catch (Exception ex) {
-            logger.warn(String.format("An error occurred during serialization of this request [%s] - it could not be sent to the server.", requestMessage), ex);
+            throw new ResponseException(ResponseStatusCode.REQUEST_ERROR_SERIALIZATION, String.format(
+                    "An error occurred during serialization of this request [%s] - it could not be sent to the server - Reason: %s",
+                    requestMessage, ex));
         }
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketGremlinRequestEncoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketGremlinRequestEncoder.java
@@ -19,7 +19,9 @@
 package org.apache.tinkerpop.gremlin.driver.handler;
 
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
+import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
@@ -58,7 +60,9 @@ public final class WebSocketGremlinRequestEncoder extends MessageToMessageEncode
                 objects.add(new TextWebSocketFrame(textSerializer.serializeRequestAsString(requestMessage)));
             }
         } catch (Exception ex) {
-            logger.warn(String.format("An error occurred during serialization of this request [%s] - it could not be sent to the server.", requestMessage), ex);
+            throw new ResponseException(ResponseStatusCode.REQUEST_ERROR_SERIALIZATION, String.format(
+                    "An error occurred during serialization of this request [%s] - it could not be sent to the server - Reason: %s",
+                    requestMessage, ex));
         }
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/message/ResponseStatusCode.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/message/ResponseStatusCode.java
@@ -65,6 +65,11 @@ public enum ResponseStatusCode {
     AUTHENTICATE(407),
 
     /**
+     * The request message contains objects that were not serializable on the client side.
+     */
+    REQUEST_ERROR_SERIALIZATION(497),
+
+    /**
      * The request message was not properly formatted which means it could not be parsed at all or the "op" code was
      * not recognized such that Gremlin Server could properly route it for processing.  Check the message format and
      * retry the request.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2139

Prior to this change serialization exceptions were basically just logged because any failure would signal a bad host and mark it as dead, but that's not really what was happening obviously if the client was never even able to try to send the message to the host in the first place. These sorts of client exceptions are now handled better and actually throw an exception that the calling client can see and utilize while not killing the host.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1