### PR TITLE
TINKERPOP-2140 Add CI smoke test for Docker build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ jdk:
   - oraclejdk8
 sudo: required
 dist: trusty
+services:
+  - docker
 cache:
   directories:
     - $HOME/mvn-home
@@ -34,3 +36,4 @@ jobs:
     - script:
       - "mvn clean install -q -DskipTests"
       - "travis_wait 60 mvn verify -pl :spark-gremlin -DskipIntegrationTests=false"
+    - script: "docker/build.sh"

--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -76,7 +76,7 @@ if [ -r "settings.xml" ]; then
   cp settings.xml ~/.m2/
 fi
 
-mvn clean install process-resources ${TINKERPOP_BUILD_OPTIONS} || exit 1
+mvn clean install process-resources --batch-mode ${TINKERPOP_BUILD_OPTIONS} || exit 1
 [ -z "${BUILD_JAVA_DOCS}" ] || mvn process-resources -Djavadoc || exit 1
 
 if [ ! -z "${BUILD_USER_DOCS}" ]; then


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2140

This additional Travis build job checks whether the Docker build still works.

The job took 21 minutes [on Travis](https://travis-ci.org/apache/tinkerpop/builds/484445855) which is still faster than the Spark job which took 26 minutes. So, this doesn't negatively impact our build times on Travis.

This could also have been a CTR commit, but maybe someone wants to review. Otherwise I'll merge it with lazy consensus.

VOTE +1