### PR TITLE
TINKERPOP-2144 Better handle Authenticator failures

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Masked sensitive configuration options in the logs of `KryoShimServiceLoader`.
 * Fixed a concurrency issue in `TraverserSet`
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.
+* Improved handling of failing `Authenticator` instances thus improving server responses to drivers.
 
 [[release-3-3-5]]
 === TinkerPop 3.3.5 (Release Date: January 2, 2019)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/Krb5Authenticator.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/Krb5Authenticator.java
@@ -131,7 +131,7 @@ public class Krb5Authenticator implements Authenticator {
          * or ACL's of a storage backend.
          */
         @Override
-        public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+        public void handle(final Callback[] callbacks) throws UnsupportedCallbackException {
             logger.debug("Krb5 AuthorizeCallback number: " + callbacks.length);
             AuthorizeCallback ac = null;
             for (Callback callback : callbacks) {
@@ -142,15 +142,15 @@ public class Krb5Authenticator implements Authenticator {
                 }
             }
             if (ac != null) {
-                String authid = ac.getAuthenticationID();
-                String authzid = ac.getAuthorizationID();
+                final String authid = ac.getAuthenticationID();
+                final String authzid = ac.getAuthorizationID();
                 if (authid.equals(authzid)) {   // Check whether the service ticket belongs to the authenticated user
                     ac.setAuthorized(true);
                 } else {
                     ac.setAuthorized(false);
                 }
                 if (ac.isAuthorized()) {        // Get user name from his principal name
-                    String[] authidParts = authid.split("@");
+                    final String[] authidParts = authid.split("@");
                     ac.setAuthorizedID(authidParts[0]);
                 }
             }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAuthenticationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/SaslAuthenticationHandler.java
@@ -75,12 +75,25 @@ public class SaslAuthenticationHandler extends AbstractAuthenticationHandler {
             final Attribute<Authenticator.SaslNegotiator> negotiator = ctx.attr(StateKey.NEGOTIATOR);
             final Attribute<RequestMessage> request = ctx.attr(StateKey.REQUEST_MESSAGE);
             if (negotiator.get() == null) {
-                // First time through so save the request and send an AUTHENTICATE challenge with no data
-                negotiator.set(authenticator.newSaslNegotiator(getRemoteInetAddress(ctx)));
-                request.set(requestMessage);
-                final ResponseMessage authenticate = ResponseMessage.build(requestMessage)
-                        .code(ResponseStatusCode.AUTHENTICATE).create();
-                ctx.writeAndFlush(authenticate);
+                try {
+                    // First time through so save the request and send an AUTHENTICATE challenge with no data
+                    negotiator.set(authenticator.newSaslNegotiator(getRemoteInetAddress(ctx)));
+                    request.set(requestMessage);
+                    final ResponseMessage authenticate = ResponseMessage.build(requestMessage)
+                            .code(ResponseStatusCode.AUTHENTICATE).create();
+                    ctx.writeAndFlush(authenticate);
+                } catch (Exception ex) {
+                    // newSaslNegotiator can cause troubles - if we don't catch and respond nicely the driver seems
+                    // to hang until timeout which isn't so nice. treating this like a server error as it means that
+                    // the Authenticator isn't really ready to deal with requests for some reason.
+                    logger.error("{} is not ready to handle requests - check it's configuration or related services",
+                            authenticator.getClass().getSimpleName());
+
+                    final ResponseMessage error = ResponseMessage.build(requestMessage)
+                            .statusMessage("Authenticator is not ready to handle requests")
+                            .code(ResponseStatusCode.SERVER_ERROR).create();
+                    ctx.writeAndFlush(error);
+                }
             } else {
                 if (requestMessage.getOp().equals(Tokens.OPS_AUTHENTICATION) && requestMessage.getArgs().containsKey(Tokens.ARGS_SASL)) {
                     
@@ -105,7 +118,7 @@ public class SaslAuthenticationHandler extends AbstractAuthenticationHandler {
                             if (authenticationSettings.enableAuditLog) {
                                 String address = ctx.channel().remoteAddress().toString();
                                 if (address.startsWith("/") && address.length() > 1) address = address.substring(1);
-                                String[] authClassParts = authenticator.getClass().toString().split("[.]");
+                                final String[] authClassParts = authenticator.getClass().toString().split("[.]");
                                 auditLogger.info("User {} with address {} authenticated by {}",
                                         user.getName(), address, authClassParts[authClassParts.length - 1]);
                             }
@@ -144,14 +157,14 @@ public class SaslAuthenticationHandler extends AbstractAuthenticationHandler {
         }
     }
 
-    private InetAddress getRemoteInetAddress(ChannelHandlerContext ctx)
+    private InetAddress getRemoteInetAddress(final ChannelHandlerContext ctx)
     {
-        Channel channel = ctx.channel();
+        final Channel channel = ctx.channel();
 
         if (null == channel)
             return null;
 
-        SocketAddress genericSocketAddr = channel.remoteAddress();
+        final SocketAddress genericSocketAddr = channel.remoteAddress();
 
         if (null == genericSocketAddr || !(genericSocketAddr instanceof InetSocketAddress))
             return null;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -29,7 +29,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
-import org.apache.tinkerpop.gremlin.server.OpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.server.Context;
@@ -39,7 +38,6 @@ import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.util.MetricManager;
 import org.apache.tinkerpop.gremlin.util.function.ThrowingConsumer;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-import io.netty.channel.ChannelHandlerContext;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +53,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import static com.codahale.metrics.MetricRegistry.name;
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
@@ -99,13 +100,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
         final Cluster cluster = TestClientFactory.build().credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
-        try {
-            assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
-            assertEquals(3, client.submit("1+2").all().get().get(0).getInt());
-            assertEquals(4, client.submit("1+3").all().get().get(0).getInt());
-        } finally {
-            cluster.close();
-        }
+        assertConnection(cluster, client);
     }
 
     @Test
@@ -115,13 +110,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
                 .credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
-        try {
-            assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
-            assertEquals(3, client.submit("1+2").all().get().get(0).getInt());
-            assertEquals(4, client.submit("1+3").all().get().get(0).getInt());
-        } finally {
-            cluster.close();
-        }
+        assertConnection(cluster, client);
     }
 
     @Test
@@ -181,13 +170,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
                 .credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
-        try {
-            assertEquals(3, client.submit("1+2").all().get().get(0).getInt());
-            assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
-            assertEquals(4, client.submit("1+3").all().get().get(0).getInt());
-        } finally {
-            cluster.close();
-        }
+        assertConnection(cluster, client);
     }
 
     @Test
@@ -196,13 +179,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
                 .credentials("stephen", "password").create();
         final Client client = cluster.connect();
 
-        try {
-            assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
-            assertEquals(3, client.submit("1+2").all().get().get(0).getInt());
-            assertEquals(4, client.submit("1+3").all().get().get(0).getInt());
-        } finally {
-            cluster.close();
-        }
+        assertConnection(cluster, client);
     }
 
     @Test
@@ -235,6 +212,16 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
             final Map vpName = (Map)client.submit("v.property('name')").all().get().get(0).getObject();
             assertEquals("stephen", vpName.get("value"));
+        } finally {
+            cluster.close();
+        }
+    }
+
+    private static void assertConnection(final Cluster cluster, final Client client) throws InterruptedException, ExecutionException {
+        try {
+            assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
+            assertEquals(3, client.submit("1+2").all().get().get(0).getInt());
+            assertEquals(4, client.submit("1+3").all().get().get(0).getInt());
         } finally {
             cluster.close();
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2144

Failures occurred on the first round of a SASL request when the negotiator was being created and if an exception was tossed there neither the server nor driver handled the situation well. By explicitly capturing and handling it, we can now properly assert results in kerberos tests without having to try to assert server logs which wasn't always dependable for some reason. This change should prevent random failures around kerberos tests which has long been a problem.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1