### PR TITLE
Make readValue(..)/writeValue(..) protected

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigDecimalSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigDecimalSerializer.java
@@ -38,14 +38,14 @@ public class BigDecimalSerializer extends SimpleTypeSerializer<BigDecimal> {
     }
 
     @Override
-    BigDecimal readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected BigDecimal readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int scale = context.readValue(buffer, Integer.class, false);
         final BigInteger unscaled = context.readValue(buffer, BigInteger.class, false);
         return new BigDecimal(unscaled, scale);
     }
 
     @Override
-    public ByteBuf writeValue(final BigDecimal value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final BigDecimal value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.scale(), allocator, false));
         result.addComponent(true, context.writeValue(value.unscaledValue(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigIntegerSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigIntegerSerializer.java
@@ -37,14 +37,14 @@ public class BigIntegerSerializer extends SimpleTypeSerializer<BigInteger> {
     }
 
     @Override
-    BigInteger readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected BigInteger readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final byte[] bigIntBytes = new byte[buffer.readInt()];
         buffer.readBytes(bigIntBytes);
         return new BigInteger(bigIntBytes);
     }
 
     @Override
-    public ByteBuf writeValue(final BigInteger value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final BigInteger value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final byte[] twosComplement = value.toByteArray();
         return allocator.buffer(4 + twosComplement.length).writeInt(twosComplement.length).writeBytes(twosComplement);
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BindingSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BindingSerializer.java
@@ -37,13 +37,13 @@ public class BindingSerializer extends SimpleTypeSerializer<Bytecode.Binding> {
     }
 
     @Override
-    Bytecode.Binding readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Bytecode.Binding readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final String k = context.readValue(buffer, String.class, false);
         return new Bytecode.Binding<>(k, context.read(buffer));
     }
 
     @Override
-    public ByteBuf writeValue(final Bytecode.Binding value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Bytecode.Binding value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.variable(), allocator, false));
         result.addComponent(true, context.write(value.value(), allocator));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BulkSetSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BulkSetSerializer.java
@@ -38,7 +38,7 @@ public class BulkSetSerializer extends SimpleTypeSerializer<BulkSet> {
     }
 
     @Override
-    BulkSet readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected BulkSet readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int length = buffer.readInt();
 
         final BulkSet result = new BulkSet();
@@ -50,7 +50,7 @@ public class BulkSetSerializer extends SimpleTypeSerializer<BulkSet> {
     }
 
     @Override
-    public ByteBuf writeValue(final BulkSet value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final BulkSet value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final Map<Object,Long> raw = value.asBulk();
         final CompositeByteBuf result = allocator.compositeBuffer(1 + raw.size() * 2);
         result.addComponent(true, allocator.buffer(4).writeInt(raw.size()));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ByteBufferSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ByteBufferSerializer.java
@@ -37,7 +37,7 @@ public class ByteBufferSerializer extends SimpleTypeSerializer<ByteBuffer> {
     }
 
     @Override
-    ByteBuffer readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected ByteBuffer readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final ByteBuffer bb = ByteBuffer.allocate(buffer.readInt());
         buffer.readBytes(bb);
         bb.rewind();
@@ -45,7 +45,7 @@ public class ByteBufferSerializer extends SimpleTypeSerializer<ByteBuffer> {
     }
 
     @Override
-    public ByteBuf writeValue(final ByteBuffer value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final ByteBuffer value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final byte[] bytes = value.array();
         return allocator.buffer(4 + bytes.length).writeInt(bytes.length).writeBytes(bytes);
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ByteCodeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ByteCodeSerializer.java
@@ -35,7 +35,7 @@ public class ByteCodeSerializer extends SimpleTypeSerializer<Bytecode> {
     }
 
     @Override
-    public Bytecode readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Bytecode readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final Bytecode result = new Bytecode();
 
         final int stepsLength = buffer.readInt();
@@ -61,7 +61,7 @@ public class ByteCodeSerializer extends SimpleTypeSerializer<Bytecode> {
     }
 
     @Override
-    public ByteBuf writeValue(final Bytecode value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Bytecode value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final List<Bytecode.Instruction> steps = value.getStepInstructions();
         final List<Bytecode.Instruction> sources = value.getSourceInstructions();
         // 2 buffers for the length + plus 2 buffers per each step and source

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CharSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CharSerializer.java
@@ -34,7 +34,7 @@ public class CharSerializer extends SimpleTypeSerializer<Character> {
     }
 
     @Override
-    Character readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Character readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int firstByte = buffer.readByte() & 0xff;
         int byteLength = 1;
         // A byte with the first byte ON (10000000) signals that more bytes are needed to represent the UTF-8 char
@@ -61,7 +61,7 @@ public class CharSerializer extends SimpleTypeSerializer<Character> {
     }
 
     @Override
-    public ByteBuf writeValue(final Character value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Character value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final String stringValue = Character.toString(value);
         return Unpooled.wrappedBuffer(stringValue.getBytes(StandardCharsets.UTF_8));
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ClassSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ClassSerializer.java
@@ -31,7 +31,7 @@ public class ClassSerializer extends SimpleTypeSerializer<Class> {
     }
 
     @Override
-    Class readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Class readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final String name = context.readValue(buffer, String.class, false);
         try {
             return Class.forName(name);
@@ -41,7 +41,7 @@ public class ClassSerializer extends SimpleTypeSerializer<Class> {
     }
 
     @Override
-    public ByteBuf writeValue(final Class value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Class value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return context.writeValue(value.getName(), allocator, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CollectionSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CollectionSerializer.java
@@ -35,7 +35,7 @@ class CollectionSerializer extends SimpleTypeSerializer<Collection> {
     }
 
     @Override
-    Collection readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Collection readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int length = buffer.readInt();
 
         final ArrayList result = new ArrayList(length);
@@ -47,7 +47,7 @@ class CollectionSerializer extends SimpleTypeSerializer<Collection> {
     }
 
     @Override
-    public ByteBuf writeValue(final Collection value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Collection value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size());
         result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DateSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DateSerializer.java
@@ -44,12 +44,12 @@ public class DateSerializer<T extends Date> extends SimpleTypeSerializer<T> {
     }
 
     @Override
-    T readValue(final ByteBuf buffer, final GraphBinaryReader context) {
+    protected T readValue(final ByteBuf buffer, final GraphBinaryReader context) {
         return reader.apply(buffer.readLong());
     }
 
     @Override
-    public ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
+    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
         return allocator.buffer(8).writeLong(value.getTime());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DurationSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DurationSerializer.java
@@ -36,12 +36,12 @@ public class DurationSerializer extends SimpleTypeSerializer<Duration> {
     }
 
     @Override
-    Duration readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Duration readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return Duration.ofSeconds(buffer.readLong(), buffer.readInt());
     }
 
     @Override
-    public ByteBuf writeValue(final Duration value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Duration value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(12).writeLong(value.getSeconds()).writeInt(value.getNano());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EdgeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EdgeSerializer.java
@@ -38,7 +38,7 @@ public class EdgeSerializer extends SimpleTypeSerializer<Edge> {
     }
 
     @Override
-    public Edge readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Edge readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final Object id = context.read(buffer);
         final String label = context.readValue(buffer, String.class, false);
 
@@ -59,7 +59,7 @@ public class EdgeSerializer extends SimpleTypeSerializer<Edge> {
     }
 
     @Override
-    public ByteBuf writeValue(final Edge value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Edge value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(8);
         result.addComponent(true, context.write(value.id(), allocator));
         result.addComponent(true, context.writeValue(value.label(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EnumSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EnumSerializer.java
@@ -63,12 +63,12 @@ public class EnumSerializer<E extends Enum> extends SimpleTypeSerializer<E> {
     }
 
     @Override
-    E readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected E readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return readFunc.apply(context.read(buffer));
     }
 
     @Override
-    public ByteBuf writeValue(final E value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final E value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return context.write(value.name(), allocator);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/GraphSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/GraphSerializer.java
@@ -53,7 +53,7 @@ public class GraphSerializer extends SimpleTypeSerializer<Graph> {
     }
 
     @Override
-    Graph readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Graph readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
 
         if (null == openMethod)
             throw new SerializationException("TinkerGraph is an optional dependency to gremlin-driver - if deserializing Graph instances it must be explicitly added as a dependency");
@@ -110,7 +110,7 @@ public class GraphSerializer extends SimpleTypeSerializer<Graph> {
     }
 
     @Override
-    public ByteBuf writeValue(final Graph value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Graph value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         // this kinda looks scary memory-wise, but GraphBinary is about network derser so we are dealing with a
         // graph instance that should live in memory already - not expecting "big" stuff here.
         final List<Vertex> vertexList = IteratorUtils.list(value.vertices());

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InetAddressSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InetAddressSerializer.java
@@ -37,7 +37,7 @@ public class InetAddressSerializer<T extends InetAddress> extends SimpleTypeSeri
     }
 
     @Override
-    T readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected T readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int length = buffer.readInt();
         final byte[] bytes = new byte[length];
         buffer.readBytes(bytes);
@@ -50,7 +50,7 @@ public class InetAddressSerializer<T extends InetAddress> extends SimpleTypeSeri
     }
 
     @Override
-    public ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final byte[] bytes = value.getAddress();
         return allocator.buffer(4 + bytes.length).writeInt(bytes.length).writeBytes(bytes);
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InstantSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InstantSerializer.java
@@ -36,12 +36,12 @@ public class InstantSerializer extends SimpleTypeSerializer<Instant> {
     }
 
     @Override
-    Instant readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Instant readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return Instant.ofEpochSecond(buffer.readLong(), buffer.readInt());
     }
 
     @Override
-    public ByteBuf writeValue(final Instant value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Instant value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(12).writeLong(value.getEpochSecond()).writeInt(value.getNano());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LambdaSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LambdaSerializer.java
@@ -36,7 +36,7 @@ public class LambdaSerializer extends SimpleTypeSerializer<Lambda> {
     }
 
     @Override
-    Lambda readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Lambda readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final String lang = context.readValue(buffer, String.class, false);
         final String script = context.readValue(buffer, String.class, false);
         final int args = context.readValue(buffer, Integer.class, false);
@@ -52,7 +52,7 @@ public class LambdaSerializer extends SimpleTypeSerializer<Lambda> {
     }
 
     @Override
-    public ByteBuf writeValue(final Lambda value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Lambda value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(3);
         result.addComponent(true, context.writeValue(value.getLambdaLanguage(), allocator, false));
         result.addComponent(true, context.writeValue(value.getLambdaScript(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ListSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ListSerializer.java
@@ -35,13 +35,13 @@ public class ListSerializer extends SimpleTypeSerializer<List> {
     }
 
     @Override
-    public List readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected List readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         // The collection is a List<>
         return (List) collectionSerializer.readValue(buffer, context);
     }
 
     @Override
-    public ByteBuf writeValue(final List value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final List value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return collectionSerializer.writeValue(value, allocator, context);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateSerializer.java
@@ -36,12 +36,12 @@ public class LocalDateSerializer extends SimpleTypeSerializer<LocalDate> {
     }
 
     @Override
-    LocalDate readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected LocalDate readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return LocalDate.of(buffer.readInt(), buffer.readByte(), buffer.readByte());
     }
 
     @Override
-    public ByteBuf writeValue(final LocalDate value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final LocalDate value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(6).writeInt(value.getYear()).writeByte(value.getMonthValue()).writeByte(value.getDayOfMonth());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateTimeSerializer.java
@@ -39,13 +39,13 @@ public class LocalDateTimeSerializer extends SimpleTypeSerializer<LocalDateTime>
     }
 
     @Override
-    LocalDateTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected LocalDateTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return LocalDateTime.of(context.readValue(buffer, LocalDate.class, false),
                 context.readValue(buffer, LocalTime.class, false));
     }
 
     @Override
-    public ByteBuf writeValue(final LocalDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final LocalDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.toLocalDate(), allocator, false));
         result.addComponent(true, context.writeValue(value.toLocalTime(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalTimeSerializer.java
@@ -36,12 +36,12 @@ public class LocalTimeSerializer extends SimpleTypeSerializer<LocalTime> {
     }
 
     @Override
-    LocalTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected LocalTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return LocalTime.ofNanoOfDay(buffer.readLong());
     }
 
     @Override
-    public ByteBuf writeValue(final LocalTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final LocalTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(8).writeLong(value.toNanoOfDay());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapEntrySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapEntrySerializer.java
@@ -33,12 +33,12 @@ public class MapEntrySerializer extends SimpleTypeSerializer<Map.Entry> implemen
     }
 
     @Override
-    Map.Entry readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Map.Entry readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         throw new SerializationException("A map entry should not be read individually");
     }
 
     @Override
-    public ByteBuf writeValue(final Map.Entry value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Map.Entry value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         throw new SerializationException("A map entry should not be written individually");
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapSerializer.java
@@ -35,7 +35,7 @@ public class MapSerializer extends SimpleTypeSerializer<Map> {
     }
 
     @Override
-    public Map readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Map readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int length = buffer.readInt();
 
         final Map<Object,Object> result = new LinkedHashMap<>(length);
@@ -47,7 +47,7 @@ public class MapSerializer extends SimpleTypeSerializer<Map> {
     }
 
     @Override
-    public ByteBuf writeValue(final Map value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Map value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size() * 2);
         result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MetricsSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MetricsSerializer.java
@@ -39,7 +39,7 @@ public class MetricsSerializer extends SimpleTypeSerializer<Metrics> {
     }
 
     @Override
-    Metrics readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Metrics readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         // Consider using a custom implementation, like "DefaultMetrics"
         final MutableMetrics result = new MutableMetrics(
                 context.readValue(buffer, String.class, false),
@@ -55,7 +55,7 @@ public class MetricsSerializer extends SimpleTypeSerializer<Metrics> {
     }
 
     @Override
-    public ByteBuf writeValue(final Metrics value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Metrics value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.compositeBuffer(6).addComponents(true,
                 context.writeValue(value.getId(), allocator, false),
                 context.writeValue(value.getName(), allocator, false),

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MonthDaySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MonthDaySerializer.java
@@ -36,12 +36,12 @@ public class MonthDaySerializer extends SimpleTypeSerializer<MonthDay> {
     }
 
     @Override
-    MonthDay readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected MonthDay readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return MonthDay.of(buffer.readByte(), buffer.readByte());
     }
 
     @Override
-    public ByteBuf writeValue(final MonthDay value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final MonthDay value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(2).writeByte(value.getMonthValue()).writeByte(value.getDayOfMonth());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetDateTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetDateTimeSerializer.java
@@ -39,14 +39,14 @@ public class OffsetDateTimeSerializer extends SimpleTypeSerializer<OffsetDateTim
     }
 
     @Override
-    OffsetDateTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected OffsetDateTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final LocalDateTime ldt = context.readValue(buffer, LocalDateTime.class, false);
         final ZoneOffset zo = context.readValue(buffer, ZoneOffset.class, false);
         return OffsetDateTime.of(ldt, zo);
     }
 
     @Override
-    public ByteBuf writeValue(final OffsetDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final OffsetDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.toLocalDateTime(), allocator, false));
         result.addComponent(true, context.writeValue(value.getOffset(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetTimeSerializer.java
@@ -39,14 +39,14 @@ public class OffsetTimeSerializer extends SimpleTypeSerializer<OffsetTime> {
     }
 
     @Override
-    OffsetTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected OffsetTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final LocalTime ldt = context.readValue(buffer, LocalTime.class, false);
         final ZoneOffset zo = context.readValue(buffer, ZoneOffset.class, false);
         return OffsetTime.of(ldt, zo);
     }
 
     @Override
-    public ByteBuf writeValue(final OffsetTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final OffsetTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.toLocalTime(), allocator, false));
         result.addComponent(true, context.writeValue(value.getOffset(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PSerializer.java
@@ -50,7 +50,7 @@ public class PSerializer<T extends P> extends SimpleTypeSerializer<T> {
     }
 
     @Override
-    T readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected T readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final String predicateName = context.readValue(buffer, String.class, false);
         final int length = context.readValue(buffer, Integer.class, false);
         final Object[] args = new Object[length];
@@ -111,7 +111,7 @@ public class PSerializer<T extends P> extends SimpleTypeSerializer<T> {
     }
 
     @Override
-    public ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         // the predicate name is either a static method of P or an instance method when a type ConnectiveP
         final boolean isConnectedP = value instanceof ConnectiveP;
         final String predicateName = isConnectedP ?

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PathSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PathSerializer.java
@@ -43,7 +43,7 @@ public class PathSerializer extends SimpleTypeSerializer<Path> {
     }
 
     @Override
-    Path readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Path readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final MutablePath path = (MutablePath) MutablePath.make();
         final List<Set<String>> labels = context.read(buffer);
         final List<Object> objects = context.read(buffer);
@@ -59,7 +59,7 @@ public class PathSerializer extends SimpleTypeSerializer<Path> {
     }
 
     @Override
-    public ByteBuf writeValue(final Path value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Path value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.write(value.labels(), allocator));
         result.addComponent(true, context.write(value.objects(), allocator));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PeriodSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PeriodSerializer.java
@@ -36,12 +36,12 @@ public class PeriodSerializer extends SimpleTypeSerializer<Period> {
     }
 
     @Override
-    Period readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Period readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return Period.of(buffer.readInt(), buffer.readInt(), buffer.readInt());
     }
 
     @Override
-    public ByteBuf writeValue(final Period value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Period value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(12).writeInt(value.getYears()).writeInt(value.getMonths()).writeInt(value.getDays());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PropertySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PropertySerializer.java
@@ -38,7 +38,7 @@ public class PropertySerializer extends SimpleTypeSerializer<Property> {
     }
 
     @Override
-    Property readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Property readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final Property p = new ReferenceProperty<>(context.readValue(buffer, String.class, false), context.read(buffer));
 
         // discard the parent element as it's not serialized for references right now
@@ -47,7 +47,7 @@ public class PropertySerializer extends SimpleTypeSerializer<Property> {
     }
 
     @Override
-    public ByteBuf writeValue(final Property value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Property value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(3);
         result.addComponent(true, context.writeValue(value.key(), allocator, false));
         result.addComponent(true, context.write(value.value(), allocator));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SetSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SetSerializer.java
@@ -36,12 +36,12 @@ public class SetSerializer extends SimpleTypeSerializer<Set>{
     }
 
     @Override
-    Set readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Set readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return new HashSet<>(collectionSerializer.readValue(buffer, context));
     }
 
     @Override
-    public ByteBuf writeValue(final Set value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Set value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return collectionSerializer.writeValue(value, allocator, context);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SimpleTypeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SimpleTypeSerializer.java
@@ -66,7 +66,7 @@ public abstract class SimpleTypeSerializer<T> implements TypeSerializer<T> {
      * @return
      * @throws SerializationException
      */
-    abstract T readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException;
+    protected abstract T readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException;
 
     @Override
     public ByteBuf write(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
@@ -99,5 +99,5 @@ public abstract class SimpleTypeSerializer<T> implements TypeSerializer<T> {
      * @param context The binary writer.
      * @throws SerializationException
      */
-    public abstract ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException;
+    protected abstract ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException;
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SingleTypeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SingleTypeSerializer.java
@@ -69,7 +69,7 @@ public class SingleTypeSerializer<T> extends SimpleTypeSerializer<T> {
     }
 
     @Override
-    public ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
+    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
         final ByteBuf buffer = allocator.buffer(byteLength);
         writeFunc.accept(value, buffer);
         return buffer;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/StringSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/StringSerializer.java
@@ -33,13 +33,13 @@ public class StringSerializer extends SimpleTypeSerializer<String> {
     }
 
     @Override
-    public String readValue(final ByteBuf buffer, final GraphBinaryReader context) {
+    protected String readValue(final ByteBuf buffer, final GraphBinaryReader context) {
         final int length = buffer.readInt();
         return buffer.readCharSequence(length, StandardCharsets.UTF_8).toString();
     }
 
     @Override
-    public ByteBuf writeValue(final String value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
+    protected ByteBuf writeValue(final String value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
         final byte[] stringBytes = value.getBytes(StandardCharsets.UTF_8);
         return allocator.buffer(4 + stringBytes.length).writeInt(stringBytes.length).writeBytes(stringBytes);
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalExplanationSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalExplanationSerializer.java
@@ -46,12 +46,12 @@ public class TraversalExplanationSerializer extends SimpleTypeSerializer<Travers
     }
 
     @Override
-    TraversalExplanation readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected TraversalExplanation readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         throw new SerializationException("A TraversalExplanation should not be read individually");
     }
 
     @Override
-    public ByteBuf writeValue(final TraversalExplanation value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final TraversalExplanation value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         throw new SerializationException("A TraversalExplanation should not be written individually");
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalStrategySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalStrategySerializer.java
@@ -45,7 +45,7 @@ public class TraversalStrategySerializer extends SimpleTypeSerializer<TraversalS
     }
 
     @Override
-    TraversalStrategy readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected TraversalStrategy readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final Class<TraversalStrategy> clazz = context.readValue(buffer, Class.class, false);
         final Map config = context.readValue(buffer, Map.class, false);
 
@@ -53,7 +53,7 @@ public class TraversalStrategySerializer extends SimpleTypeSerializer<TraversalS
     }
 
     @Override
-    public ByteBuf writeValue(final TraversalStrategy value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final TraversalStrategy value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.getClass(), allocator, false));
         result.addComponent(true, context.writeValue(translateToBytecode(ConfigurationConverter.getMap(value.getConfiguration())), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraverserSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraverserSerializer.java
@@ -38,14 +38,14 @@ public class TraverserSerializer extends SimpleTypeSerializer<Traverser> {
     }
 
     @Override
-    Traverser readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Traverser readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final long bulk = context.readValue(buffer, Long.class, false);
         final Object v = context.read(buffer);
         return new DefaultRemoteTraverser<>(v, bulk);
     }
 
     @Override
-    public ByteBuf writeValue(final Traverser value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Traverser value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.bulk(), allocator, false));
         result.addComponent(true, context.write(value.get(), allocator));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TreeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TreeSerializer.java
@@ -33,7 +33,7 @@ public class TreeSerializer extends SimpleTypeSerializer<Tree> {
     }
 
     @Override
-    Tree readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Tree readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int length = buffer.readInt();
 
         final Tree result = new Tree();
@@ -45,7 +45,7 @@ public class TreeSerializer extends SimpleTypeSerializer<Tree> {
     }
 
     @Override
-    public ByteBuf writeValue(final Tree value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Tree value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size() * 2);
         result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/UUIDSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/UUIDSerializer.java
@@ -33,12 +33,12 @@ public class UUIDSerializer extends SimpleTypeSerializer<UUID> {
     }
 
     @Override
-    public UUID readValue(final ByteBuf buffer, final GraphBinaryReader context) {
+    protected UUID readValue(final ByteBuf buffer, final GraphBinaryReader context) {
         return new UUID(buffer.readLong(), buffer.readLong());
     }
 
     @Override
-    public ByteBuf writeValue(final UUID value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
+    protected ByteBuf writeValue(final UUID value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
         return allocator.buffer(16)
                 .writeLong(value.getMostSignificantBits())
                 .writeLong(value.getLeastSignificantBits());

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexPropertySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexPropertySerializer.java
@@ -38,7 +38,7 @@ public class VertexPropertySerializer extends SimpleTypeSerializer<VertexPropert
     }
 
     @Override
-    VertexProperty readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected VertexProperty readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final VertexProperty v = new ReferenceVertexProperty<>(context.read(buffer),
                 context.readValue(buffer, String.class, false),
                 context.read(buffer));
@@ -53,7 +53,7 @@ public class VertexPropertySerializer extends SimpleTypeSerializer<VertexPropert
     }
 
     @Override
-    public ByteBuf writeValue(final VertexProperty value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final VertexProperty value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(5);
         result.addComponent(true, context.write(value.id(), allocator));
         result.addComponent(true, context.writeValue(value.label(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexSerializer.java
@@ -37,7 +37,7 @@ public class VertexSerializer extends SimpleTypeSerializer<Vertex> {
     }
 
     @Override
-    public Vertex readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected Vertex readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final Vertex v = new ReferenceVertex(context.read(buffer), 
                                              context.readValue(buffer, String.class, false));
         
@@ -48,7 +48,7 @@ public class VertexSerializer extends SimpleTypeSerializer<Vertex> {
     }
 
     @Override
-    public ByteBuf writeValue(final Vertex value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final Vertex value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(3);
         result.addComponent(true, context.write(value.id(), allocator));
         result.addComponent(true, context.writeValue(value.label(), allocator, false));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/YearMonthSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/YearMonthSerializer.java
@@ -36,12 +36,12 @@ public class YearMonthSerializer extends SimpleTypeSerializer<YearMonth> {
     }
 
     @Override
-    YearMonth readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected YearMonth readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return YearMonth.of(buffer.readInt(), buffer.readByte());
     }
 
     @Override
-    public ByteBuf writeValue(final YearMonth value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final YearMonth value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(2).writeInt(value.getYear()).writeByte(value.getMonthValue());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZoneOffsetSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZoneOffsetSerializer.java
@@ -37,12 +37,12 @@ public class ZoneOffsetSerializer extends SimpleTypeSerializer<ZoneOffset> {
     }
 
     @Override
-    ZoneOffset readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected ZoneOffset readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         return ZoneOffset.ofTotalSeconds(buffer.readInt());
     }
 
     @Override
-    public ByteBuf writeValue(final ZoneOffset value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final ZoneOffset value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         return allocator.buffer(4).writeInt(value.getTotalSeconds());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZonedDateTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZonedDateTimeSerializer.java
@@ -39,14 +39,14 @@ public class ZonedDateTimeSerializer extends SimpleTypeSerializer<ZonedDateTime>
     }
 
     @Override
-    ZonedDateTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
+    protected ZonedDateTime readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final LocalDateTime ldt = context.readValue(buffer, LocalDateTime.class, false);
         final ZoneOffset zo = context.readValue(buffer, ZoneOffset.class, false);
         return ZonedDateTime.of(ldt, zo);
     }
 
     @Override
-    public ByteBuf writeValue(final ZonedDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected ByteBuf writeValue(final ZonedDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
         result.addComponent(true, context.writeValue(value.toLocalDateTime(), allocator, false));
         result.addComponent(true, context.writeValue(value.getOffset(), allocator, false));


### PR DESCRIPTION
This is so that simple custom type serializers can reuse the same logic
without having to put their type serializer into the same package
structure because readValue() was package-private.
Also I believe it makes sense to make writeValue() protected as well.