### PR TITLE
TINKERPOP-2149 Add fallback resolver to TypeSerializerRegistry

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ This release also includes changes from <<release-3-3-6, 3.3.6>>.
 * Added GraphBinary serializer for TraversalMetrics
 * Fixed up `SparqlStrategy` so that it could be used properly with `RemoteStrategy`.
 * Fixed `ByteBuffer` serialization for GraphBinary.
+* Added fallback resolver to `TypeSerializerRegistry` for GraphBinary.
 * Added easier to understand exceptions for connection problems in the Gremlin.Net driver.
 
 [[release-3-4-0]]

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/sample/SamplePerson.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/sample/SamplePerson.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * A sample custom data type containing few properties.
  */
-class SamplePerson {
+public class SamplePerson {
     private final String name;
     private final Date birthDate;
 


### PR DESCRIPTION
Provide a way to resolve the `TypeSerializer` instance to use when there isn't any direct match.

VOTE +1