### PR TITLE
fix: Path#toString() variable reference bug

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
@@ -128,7 +128,7 @@ class Path {
   }
 
   toString() {
-    return 'path[' + objects.join(", ") +  ']';
+    return 'path[' + this.objects.join(", ") +  ']';
   }
 
   equals(other) {


### PR DESCRIPTION
I'm going through the process of creating typescript definitions for the javascript library, and I noticed a bug in Path#toString(). It incorrectly attempts to call a non-existant local `objects` variable instead of calling the class property `this.objects`.