### PR TITLE
Changed loop break check to break out of the connection creation loop

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -70,7 +70,7 @@ namespace Gremlin.Net.Driver
             while (true)
             {
                 var nrOpened = Interlocked.CompareExchange(ref _nrConnections, PoolEmpty, PoolEmpty);
-                if (nrOpened == _poolSize) break;
+                if (nrOpened >= _poolSize) break;
                 if (nrOpened != PoolPopulationInProgress)
                 {
                     await PopulatePoolAsync().ConfigureAwait(false);
@@ -81,7 +81,7 @@ namespace Gremlin.Net.Driver
         private async Task PopulatePoolAsync()
         {
             var nrOpened = Interlocked.CompareExchange(ref _nrConnections, PoolPopulationInProgress, PoolEmpty);
-            if (nrOpened == PoolPopulationInProgress || nrOpened == _poolSize) return;
+            if (nrOpened == PoolPopulationInProgress || nrOpened >= _poolSize) return;
 
             try
             {


### PR DESCRIPTION
Changed loop break check to break out of the connection creation loop if greater than or equal to the expected amount of connections are created. A situation exists where unless exactly the expected amount of connections are made when checked, an infinite loop of connections may be opened.