### PR TITLE
TINKERPOP-2154 GraphBinary: Release working buffers on failure

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ This release also includes changes from <<release-3-3-6, 3.3.6>>.
 * Added fallback resolver to `TypeSerializerRegistry` for GraphBinary.
 * Added easier to understand exceptions for connection problems in the Gremlin.Net driver.
 * Support configuring the type registry builder for GraphBinary.
+* Release working buffers in case of failure for GraphBinary.
 
 [[release-3-4-0]]
 === TinkerPop 3.4.0 (Release Date: January 2, 2019)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BindingSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BindingSerializer.java
@@ -45,8 +45,13 @@ public class BindingSerializer extends SimpleTypeSerializer<Bytecode.Binding> {
     @Override
     protected ByteBuf writeValue(final Bytecode.Binding value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.variable(), allocator, false));
-        result.addComponent(true, context.write(value.value(), allocator));
+        try {
+            result.addComponent(true, context.writeValue(value.variable(), allocator, false));
+            result.addComponent(true, context.write(value.value(), allocator));
+        } catch (Exception ex) {
+            result.release();
+            throw ex;
+        }
         return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BulkSetSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BulkSetSerializer.java
@@ -55,9 +55,15 @@ public class BulkSetSerializer extends SimpleTypeSerializer<BulkSet> {
         final CompositeByteBuf result = allocator.compositeBuffer(1 + raw.size() * 2);
         result.addComponent(true, allocator.buffer(4).writeInt(raw.size()));
 
-        for (Object key : raw.keySet()) {
-            result.addComponents(true, context.write(key, allocator),
-                    allocator.buffer(8).writeLong(value.get(key)));
+        try {
+            for (Object key : raw.keySet()) {
+                result.addComponents(true, context.write(key, allocator),
+                        allocator.buffer(8).writeLong(value.get(key)));
+            }
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
         }
 
         return result;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CollectionSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CollectionSerializer.java
@@ -51,8 +51,14 @@ class CollectionSerializer extends SimpleTypeSerializer<Collection> {
         final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size());
         result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
 
-        for (Object item : value) {
-            result.addComponent(true, context.write(item, allocator));
+        try {
+            for (Object item : value) {
+                result.addComponent(true, context.write(item, allocator));
+            }
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
         }
 
         return result;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CustomTypeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CustomTypeSerializer.java
@@ -22,9 +22,6 @@ import org.apache.tinkerpop.gremlin.driver.ser.binary.TypeSerializer;
 
 /**
  * Represents a serializer for a custom (provider specific) serializer.
- * <p>
- *     Note that invocations to
- * </p>
  * @param <T>
  */
 public interface CustomTypeSerializer<T> extends TypeSerializer<T> {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EdgeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EdgeSerializer.java
@@ -61,20 +61,27 @@ public class EdgeSerializer extends SimpleTypeSerializer<Edge> {
     @Override
     protected ByteBuf writeValue(final Edge value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(8);
-        result.addComponent(true, context.write(value.id(), allocator));
-        result.addComponent(true, context.writeValue(value.label(), allocator, false));
 
-        result.addComponent(true, context.write(value.inVertex().id(), allocator));
-        result.addComponent(true, context.writeValue(value.inVertex().label(), allocator, false));
-        result.addComponent(true, context.write(value.outVertex().id(), allocator));
-        result.addComponent(true, context.writeValue(value.outVertex().label(), allocator, false));
-        
-        // we don't serialize the parent Vertex for edges. they are "references", but we leave a place holder
-        // here as an option for the future as we've waffled this soooooooooo many times now
-        result.addComponent(true, context.write(null, allocator));
-        // we don't serialize properties for graph vertices/edges. they are "references", but we leave a place holder
-        // here as an option for the future as we've waffled this soooooooooo many times now
-        result.addComponent(true, context.write(null, allocator));
+        try {
+            result.addComponent(true, context.write(value.id(), allocator));
+            result.addComponent(true, context.writeValue(value.label(), allocator, false));
+
+            result.addComponent(true, context.write(value.inVertex().id(), allocator));
+            result.addComponent(true, context.writeValue(value.inVertex().label(), allocator, false));
+            result.addComponent(true, context.write(value.outVertex().id(), allocator));
+            result.addComponent(true, context.writeValue(value.outVertex().label(), allocator, false));
+
+            // we don't serialize the parent Vertex for edges. they are "references", but we leave a place holder
+            // here as an option for the future as we've waffled this soooooooooo many times now
+            result.addComponent(true, context.write(null, allocator));
+            // we don't serialize properties for graph vertices/edges. they are "references", but we leave a place holder
+            // here as an option for the future as we've waffled this soooooooooo many times now
+            result.addComponent(true, context.write(null, allocator));
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
+        }
         
         return result;
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LambdaSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LambdaSerializer.java
@@ -54,9 +54,17 @@ public class LambdaSerializer extends SimpleTypeSerializer<Lambda> {
     @Override
     protected ByteBuf writeValue(final Lambda value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(3);
-        result.addComponent(true, context.writeValue(value.getLambdaLanguage(), allocator, false));
-        result.addComponent(true, context.writeValue(value.getLambdaScript(), allocator, false));
-        result.addComponent(true, context.writeValue(value.getLambdaArguments(), allocator, false));
+
+        try {
+            result.addComponent(true, context.writeValue(value.getLambdaLanguage(), allocator, false));
+            result.addComponent(true, context.writeValue(value.getLambdaScript(), allocator, false));
+            result.addComponent(true, context.writeValue(value.getLambdaArguments(), allocator, false));
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
+        }
+
         return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PathSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PathSerializer.java
@@ -61,8 +61,15 @@ public class PathSerializer extends SimpleTypeSerializer<Path> {
     @Override
     protected ByteBuf writeValue(final Path value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.write(value.labels(), allocator));
-        result.addComponent(true, context.write(value.objects(), allocator));
+
+        try {
+            result.addComponent(true, context.write(value.labels(), allocator));
+            result.addComponent(true, context.write(value.objects(), allocator));
+        } catch (Exception ex) {
+            result.release();
+            throw ex;
+        }
+
         return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalMetricsSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalMetricsSerializer.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -48,8 +49,17 @@ public class TraversalMetricsSerializer extends SimpleTypeSerializer<TraversalMe
 
     @Override
     protected ByteBuf writeValue(TraversalMetrics value, ByteBufAllocator allocator, GraphBinaryWriter context) throws SerializationException {
-        return allocator.compositeBuffer(2).addComponents(true,
-                context.writeValue(value.getDuration(TimeUnit.NANOSECONDS), allocator, false),
-                collectionSerializer.writeValue(value.getMetrics(), allocator, context));
+        final CompositeByteBuf result = allocator.compositeBuffer(2);
+
+        try {
+            result.addComponent(true, context.writeValue(value.getDuration(TimeUnit.NANOSECONDS), allocator, false));
+            result.addComponent(true, collectionSerializer.writeValue(value.getMetrics(), allocator, context));
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
+        }
+
+        return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalStrategySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalStrategySerializer.java
@@ -55,8 +55,15 @@ public class TraversalStrategySerializer extends SimpleTypeSerializer<TraversalS
     @Override
     protected ByteBuf writeValue(final TraversalStrategy value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.getClass(), allocator, false));
-        result.addComponent(true, context.writeValue(translateToBytecode(ConfigurationConverter.getMap(value.getConfiguration())), allocator, false));
+
+        try {
+            result.addComponent(true, context.writeValue(value.getClass(), allocator, false));
+            result.addComponent(true, context.writeValue(translateToBytecode(ConfigurationConverter.getMap(value.getConfiguration())), allocator, false));
+        } catch (Exception ex) {
+            result.release();
+            throw ex;
+        }
+
         return result;
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraverserSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraverserSerializer.java
@@ -47,8 +47,15 @@ public class TraverserSerializer extends SimpleTypeSerializer<Traverser> {
     @Override
     protected ByteBuf writeValue(final Traverser value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.bulk(), allocator, false));
-        result.addComponent(true, context.write(value.get(), allocator));
+
+        try {
+            result.addComponent(true, context.writeValue(value.bulk(), allocator, false));
+            result.addComponent(true, context.write(value.get(), allocator));
+        } catch (Exception ex) {
+            result.release();
+            throw ex;
+        }
+
         return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TreeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TreeSerializer.java
@@ -49,11 +49,17 @@ public class TreeSerializer extends SimpleTypeSerializer<Tree> {
         final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size() * 2);
         result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
 
-        for (Object key : value.keySet()) {
-            result.addComponents(
-                    true,
-                    context.write(key, allocator),
-                    context.writeValue(value.get(key), allocator, false));
+        try {
+            for (Object key : value.keySet()) {
+                result.addComponents(
+                        true,
+                        context.write(key, allocator),
+                        context.writeValue(value.get(key), allocator, false));
+            }
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
         }
 
         return result;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexPropertySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexPropertySerializer.java
@@ -55,15 +55,22 @@ public class VertexPropertySerializer extends SimpleTypeSerializer<VertexPropert
     @Override
     protected ByteBuf writeValue(final VertexProperty value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(5);
-        result.addComponent(true, context.write(value.id(), allocator));
-        result.addComponent(true, context.writeValue(value.label(), allocator, false));
-        result.addComponent(true, context.write(value.value(), allocator));
 
-        // we don't serialize the parent vertex even as a "reference", but, let's hold a place for it
-        result.addComponent(true, context.write(null, allocator));
-        // we don't serialize properties for graph elements. they are "references", but we leave a place holder
-        // here as an option for the future as we've waffled this soooooooooo many times now
-        result.addComponent(true, context.write(null, allocator));
+        try {
+            result.addComponent(true, context.write(value.id(), allocator));
+            result.addComponent(true, context.writeValue(value.label(), allocator, false));
+            result.addComponent(true, context.write(value.value(), allocator));
+
+            // we don't serialize the parent vertex even as a "reference", but, let's hold a place for it
+            result.addComponent(true, context.write(null, allocator));
+            // we don't serialize properties for graph elements. they are "references", but we leave a place holder
+            // here as an option for the future as we've waffled this soooooooooo many times now
+            result.addComponent(true, context.write(null, allocator));
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
+        }
 
         return result;
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexSerializer.java
@@ -50,12 +50,19 @@ public class VertexSerializer extends SimpleTypeSerializer<Vertex> {
     @Override
     protected ByteBuf writeValue(final Vertex value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
         final CompositeByteBuf result = allocator.compositeBuffer(3);
-        result.addComponent(true, context.write(value.id(), allocator));
-        result.addComponent(true, context.writeValue(value.label(), allocator, false));
-        
-        // we don't serialize properties for graph vertices/edges. they are "references", but we leave a place holder
-        // here as an option for the future as we've waffled this soooooooooo many times now
-        result.addComponent(true, context.write(null, allocator));
+
+        try {
+            result.addComponent(true, context.write(value.id(), allocator));
+            result.addComponent(true, context.writeValue(value.label(), allocator, false));
+
+            // we don't serialize properties for graph vertices/edges. they are "references", but we leave a place holder
+            // here as an option for the future as we've waffled this soooooooooo many times now
+            result.addComponent(true, context.write(null, allocator));
+        } catch (Exception ex) {
+            // We should release it as the ByteBuf is not going to be yielded for a reader
+            result.release();
+            throw ex;
+        }
         
         return result;
     }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerFailureTests.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerFailureTests.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tinkerpop.gremlin.driver.ser.binary;
 
 import io.netty.buffer.UnpooledByteBufAllocator;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2154

Ensures that reference counts of allocated buffers are set to 0 when there is a failure during serialization.

Includes a test for memory allocation when introducing failures.

VOTE +1