### PR TITLE
TINKERPOP-1435 GraphSON extended module support for gremlin-python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `globalFunctionCacheEnabled` to the `GroovyCompilerGremlinPlugin` to allow that cache to be disabled.
 * Added `globalFunctionCacheEnabled` override to `SessionOpProcessor` configuration.
 * Added status code to `GremlinServerError` so that it would be more directly accessible during failures.
+* Added GraphSON serialization support for `Duration`, `Char`, `ByteBuffer`, `Byte`, `BigInteger` and `BigDecimal` in `gremlin-python`.
 * Fixed concurrency issues in `TraverserSet.toString()` and `ObjectWritable.toString()`.
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.
 * Improved handling of failing `Authenticator` instances thus improving server responses to drivers.

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
@@ -23,12 +23,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.rules.TestName;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -44,15 +44,12 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringStartsWith.startsWith;
@@ -288,5 +285,61 @@ public class GraphSONMapperEmbeddedTypeTest extends AbstractGraphSONTest {
     public void shouldHandleZonedOffset() throws Exception  {
         final ZoneOffset o  = ZonedDateTime.now().getOffset();
         assertEquals(o, serializeDeserialize(mapper, o, ZoneOffset.class));
+    }
+
+    @Test
+    public void shouldHandleBigInteger() throws Exception  {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+        
+        final BigInteger o = new BigInteger("123456789987654321123456789987654321");
+        assertEquals(o, serializeDeserialize(mapper, o, BigInteger.class));
+    }
+
+    @Test
+    public void shouldReadBigIntegerAsString() throws Exception {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+
+        final BigInteger o = new BigInteger("123456789987654321123456789987654321");
+        assertEquals(o, mapper.readValue("{\"@type\": \"gx:BigInteger\", \"@value\": \"123456789987654321123456789987654321\"}", Object.class));
+    }
+
+    @Test
+    public void shouldReadBigIntegerAsNumber() throws Exception {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+
+        // this was the original GraphSON 2.0/3.0 format published for BigInteger but jackson is flexible enough to
+        // do it as a string. the string approach is probably better for most language variants so while this tests
+        // enforces this approach but leaves open the opportunity to accept either. at some point in the future
+        // perhaps it can switch fully - TINKERPOP-2156
+        final BigInteger o = new BigInteger("123456789987654321123456789987654321");
+        assertEquals(o, mapper.readValue("{\"@type\": \"gx:BigInteger\", \"@value\": 123456789987654321123456789987654321}", Object.class));
+    }
+
+    @Test
+    public void shouldHandleBigDecimal() throws Exception  {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+
+        final BigDecimal o = new BigDecimal("123456789987654321123456789987654321");
+        assertEquals(o, serializeDeserialize(mapper, o, BigDecimal.class));
+    }
+
+    @Test
+    public void shouldReadBigDecimalAsString() throws Exception {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+
+        final BigDecimal o = new BigDecimal("123456789987654321123456789987654321");
+        assertEquals(o, mapper.readValue("{\"@type\": \"gx:BigDecimal\", \"@value\": \"123456789987654321123456789987654321\"}", Object.class));
+    }
+
+    @Test
+    public void shouldReadBigDecimalAsNumber() throws Exception {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+
+        // this was the original GraphSON 2.0/3.0 format published for BigDecimal but jackson is flexible enough to
+        // do it as a string. the string approach is probably better for most language variants so while this tests
+        // enforces this approach but leaves open the opportunity to accept either. at some point in the future
+        // perhaps it can switch fully - TINKERPOP-2156
+        final BigDecimal o = new BigDecimal("123456789987654321123456789987654321");
+        assertEquals(o, mapper.readValue("{\"@type\": \"gx:BigDecimal\", \"@value\": 123456789987654321123456789987654321}", Object.class));
     }
 }

--- a/gremlin-python/src/main/jython/gremlin_python/statics.py
+++ b/gremlin-python/src/main/jython/gremlin_python/statics.py
@@ -52,6 +52,7 @@ class timestamp(float):
     """
     pass
 
+
 class SingleByte(int):
     """
     Provides a way to pass a single byte via GraphSON.
@@ -61,6 +62,17 @@ class SingleByte(int):
             int.__new__(cls, b)
         else:
             raise ValueError("value must be between -128 and 127 inclusive")
+
+
+class SingleChar(str):
+    """
+    Provides a way to pass a single character via GraphSON.
+    """
+    def __new__(cls, c):
+        if len(b) == 1:
+            str.__new__(cls, c)
+        else:
+            raise ValueError("string must contain a single character")
 
 
 staticMethods = {}

--- a/gremlin-python/src/main/jython/gremlin_python/statics.py
+++ b/gremlin-python/src/main/jython/gremlin_python/statics.py
@@ -32,9 +32,11 @@ if six.PY3:
     ListType = list
     DictType = dict
     SetType = set
+    ByteBufferType = bytes
 else:
     long = long
     SetType = set
+    ByteBufferType = bytearray
     from types import FloatType
     from types import IntType
     from types import LongType

--- a/gremlin-python/src/main/jython/gremlin_python/statics.py
+++ b/gremlin-python/src/main/jython/gremlin_python/statics.py
@@ -50,6 +50,16 @@ class timestamp(float):
     """
     pass
 
+class SingleByte(int):
+    """
+    Provides a way to pass a single byte via GraphSON.
+    """
+    def __new__(cls, b):
+        if -128 <= b < 128:
+            int.__new__(cls, b)
+        else:
+            raise ValueError("value must be between -128 and 127 inclusive")
+
 
 staticMethods = {}
 staticEnums = {}

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
@@ -28,7 +28,7 @@ import six
 from aenum import Enum
 
 from gremlin_python import statics
-from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType
+from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, SingleByte
 from gremlin_python.process.traversal import Binding, Bytecode, P, Traversal, Traverser, TraversalStrategy
 from gremlin_python.structure.graph import Edge, Property, Vertex, VertexProperty, Path
 
@@ -483,6 +483,22 @@ class Int32IO(Int64IO):
     python_type = IntType
     graphson_type = "g:Int32"
     graphson_base_type = "Int32"
+
+
+class ByteIO(_NumberIO):
+    python_type = SingleByte
+    graphson_type = "gx:Byte"
+    graphson_base_type = "Byte"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        if isinstance(n, bool):  # because isinstance(False, int) and isinstance(True, int)
+            return n
+        return GraphSONUtil.typedValue(cls.graphson_base_type, n, "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return int.__new__(SingleByte, v)
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
@@ -29,7 +29,7 @@ import six
 from aenum import Enum
 
 from gremlin_python import statics
-from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, SingleByte, ByteBufferType
+from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, SingleByte, ByteBufferType, SingleChar
 from gremlin_python.process.traversal import Binding, Bytecode, P, Traversal, Traverser, TraversalStrategy
 from gremlin_python.structure.graph import Edge, Property, Vertex, VertexProperty, Path
 
@@ -513,7 +513,21 @@ class ByteBufferIO(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, v, _):
-        return cls.python_type(v, "ascii")
+        return cls.python_type(v, "utf8")
+
+
+class CharIO(_GraphSONTypeIO):
+    python_type = SingleChar
+    graphson_type = "gx:Char"
+    graphson_base_type = "Char"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        return GraphSONUtil.typedValue(cls.graphson_base_type, n, "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return str.__new__(SingleChar, v)
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
@@ -21,6 +21,7 @@ import json
 import time
 import uuid
 import math
+import base64
 from collections import OrderedDict
 from decimal import *
 
@@ -28,7 +29,7 @@ import six
 from aenum import Enum
 
 from gremlin_python import statics
-from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, SingleByte
+from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, SingleByte, ByteBufferType
 from gremlin_python.process.traversal import Binding, Bytecode, P, Traversal, Traverser, TraversalStrategy
 from gremlin_python.structure.graph import Edge, Property, Vertex, VertexProperty, Path
 
@@ -499,6 +500,20 @@ class ByteIO(_NumberIO):
     @classmethod
     def objectify(cls, v, _):
         return int.__new__(SingleByte, v)
+
+
+class ByteBufferIO(_GraphSONTypeIO):
+    python_type = ByteBufferType
+    graphson_type = "gx:ByteBuffer"
+    graphson_base_type = "ByteBuffer"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        return GraphSONUtil.typedValue(cls.graphson_base_type, "".join(chr(x) for x in n), "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return cls.python_type(v, "ascii")
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
@@ -24,9 +24,11 @@ import math
 import base64
 from collections import OrderedDict
 from decimal import *
+from datetime import timedelta
 
 import six
 from aenum import Enum
+from isodate import parse_duration, duration_isoformat
 
 from gremlin_python import statics
 from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, SingleByte, ByteBufferType, SingleChar
@@ -528,6 +530,20 @@ class CharIO(_GraphSONTypeIO):
     @classmethod
     def objectify(cls, v, _):
         return str.__new__(SingleChar, v)
+
+
+class DurationIO(_GraphSONTypeIO):
+    python_type = timedelta
+    graphson_type = "gx:Duration"
+    graphson_base_type = "Duration"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        return GraphSONUtil.typedValue(cls.graphson_base_type, duration_isoformat(n), "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return parse_duration(v)
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -29,7 +29,7 @@ import six
 from aenum import Enum
 
 from gremlin_python import statics
-from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, DictType, ListType, SetType
+from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, DictType, ListType, SetType, SingleByte
 from gremlin_python.process.traversal import Binding, Bytecode, P, Traversal, Traverser, TraversalStrategy, T
 from gremlin_python.structure.graph import Edge, Property, Vertex, VertexProperty, Path
 
@@ -564,6 +564,22 @@ class Int32IO(Int64IO):
     python_type = IntType
     graphson_type = "g:Int32"
     graphson_base_type = "Int32"
+
+
+class ByteIO(_NumberIO):
+    python_type = SingleByte
+    graphson_type = "gx:Byte"
+    graphson_base_type = "Byte"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        if isinstance(n, bool):  # because isinstance(False, int) and isinstance(True, int)
+            return n
+        return GraphSONUtil.typedValue(cls.graphson_base_type, n, "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return int.__new__(SingleByte, v)
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -32,7 +32,7 @@ from aenum import Enum
 from isodate import parse_duration, duration_isoformat
 
 from gremlin_python import statics
-from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, DictType, ListType, SetType, SingleByte, ByteBufferType
+from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, DictType, ListType, SetType, SingleByte, ByteBufferType, SingleChar
 from gremlin_python.process.traversal import Binding, Bytecode, P, Traversal, Traverser, TraversalStrategy, T
 from gremlin_python.structure.graph import Edge, Property, Vertex, VertexProperty, Path
 
@@ -597,6 +597,20 @@ class ByteBufferIO(_GraphSONTypeIO):
     @classmethod
     def objectify(cls, v, _):
         return cls.python_type(v, "utf8")
+
+
+class CharIO(_GraphSONTypeIO):
+    python_type = SingleChar
+    graphson_type = "gx:Char"
+    graphson_base_type = "Char"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        return GraphSONUtil.typedValue(cls.graphson_base_type, n, "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return str.__new__(SingleChar, v)
 
 
 class DurationIO(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -21,6 +21,7 @@ import json
 import time
 import uuid
 import math
+import base64
 from collections import OrderedDict
 from decimal import *
 import logging
@@ -29,7 +30,7 @@ import six
 from aenum import Enum
 
 from gremlin_python import statics
-from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, DictType, ListType, SetType, SingleByte
+from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, DictType, ListType, SetType, SingleByte, ByteBufferType
 from gremlin_python.process.traversal import Binding, Bytecode, P, Traversal, Traverser, TraversalStrategy, T
 from gremlin_python.structure.graph import Edge, Property, Vertex, VertexProperty, Path
 
@@ -580,6 +581,20 @@ class ByteIO(_NumberIO):
     @classmethod
     def objectify(cls, v, _):
         return int.__new__(SingleByte, v)
+
+
+class ByteBufferIO(_GraphSONTypeIO):
+    python_type = ByteBufferType
+    graphson_type = "gx:ByteBuffer"
+    graphson_base_type = "ByteBuffer"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        return GraphSONUtil.typedValue(cls.graphson_base_type, "".join(chr(x) for x in n), "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return cls.python_type(v, "ascii")
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -22,6 +22,7 @@ import time
 import uuid
 import math
 from collections import OrderedDict
+from decimal import *
 import logging
 
 import six
@@ -503,6 +504,37 @@ class FloatIO(_NumberIO):
         return cls.python_type(v)
 
 
+class BigDecimalIO(_NumberIO):
+    python_type = Decimal
+    graphson_type = "gx:BigDecimal"
+    graphson_base_type = "BigDecimal"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        if isinstance(n, bool):  # because isinstance(False, int) and isinstance(True, int)
+            return n
+        elif math.isnan(n):
+            return GraphSONUtil.typedValue(cls.graphson_base_type, "NaN", "gx")
+        elif math.isinf(n) and n > 0:
+            return GraphSONUtil.typedValue(cls.graphson_base_type, "Infinity", "gx")
+        elif math.isinf(n) and n < 0:
+            return GraphSONUtil.typedValue(cls.graphson_base_type, "-Infinity", "gx")
+        else:
+            return GraphSONUtil.typedValue(cls.graphson_base_type, str(n), "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        if isinstance(v, str):
+            if v == 'NaN':
+                return Decimal('nan')
+            elif v == "Infinity":
+                return Decimal('inf')
+            elif v == "-Infinity":
+                return Decimal('-inf')
+
+        return Decimal(v)
+
+
 class DoubleIO(FloatIO):
     graphson_type = "g:Double"
     graphson_base_type = "Double"
@@ -513,17 +545,25 @@ class Int64IO(_NumberIO):
     graphson_type = "g:Int64"
     graphson_base_type = "Int64"
 
+    @classmethod
+    def dictify(cls, n, writer):
+        # if we exceed Java long range then we need a BigInteger
+        if isinstance(n, bool):
+            return n
+        elif n < -9223372036854775808 or n > 9223372036854775807:
+            return GraphSONUtil.typedValue("BigInteger", str(n), "gx")
+        else:
+            return GraphSONUtil.typedValue(cls.graphson_base_type, n)
 
-class Int32IO(_NumberIO):
+
+class BigIntegerIO(Int64IO):
+    graphson_type = "gx:BigInteger"
+
+
+class Int32IO(Int64IO):
     python_type = IntType
     graphson_type = "g:Int32"
     graphson_base_type = "Int32"
-
-    @classmethod
-    def dictify(cls, n, writer):
-        if isinstance(n, bool):
-            return n
-        return GraphSONUtil.typedValue(cls.graphson_base_type, n)
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -594,7 +594,7 @@ class ByteBufferIO(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, v, _):
-        return cls.python_type(v, "ascii")
+        return cls.python_type(v, "utf8")
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -25,9 +25,11 @@ import base64
 from collections import OrderedDict
 from decimal import *
 import logging
+from datetime import timedelta
 
 import six
 from aenum import Enum
+from isodate import parse_duration, duration_isoformat
 
 from gremlin_python import statics
 from gremlin_python.statics import FloatType, FunctionType, IntType, LongType, TypeType, DictType, ListType, SetType, SingleByte, ByteBufferType
@@ -595,6 +597,20 @@ class ByteBufferIO(_GraphSONTypeIO):
     @classmethod
     def objectify(cls, v, _):
         return cls.python_type(v, "utf8")
+
+
+class DurationIO(_GraphSONTypeIO):
+    python_type = timedelta
+    graphson_type = "gx:Duration"
+    graphson_base_type = "Duration"
+
+    @classmethod
+    def dictify(cls, n, writer):
+        return GraphSONUtil.typedValue(cls.graphson_base_type, duration_isoformat(n), "gx")
+
+    @classmethod
+    def objectify(cls, v, _):
+        return parse_duration(v)
 
 
 class VertexDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -47,7 +47,8 @@ version = __version__.version
 install_requires = [
     'aenum>=1.4.5',
     'tornado>=4.4.1,<5.0',
-    'six>=1.10.0'
+    'six>=1.10.0',
+    'isodate>=0.6.0'
 ]
 
 if sys.version_info < (3,2):

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -277,6 +277,12 @@ class TestGraphSONReader(object):
                 {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}
                 ]}]
 
+    def test_bytebuffer(self):
+        bb = self.graphson_reader.readObject(
+            json.dumps({"@type": "gx:ByteBuffer", "@value": "c29tZSBieXRlcyBmb3IgeW91"}))
+        assert isinstance(bb, ByteBufferType)
+        assert ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii") == bb
+
 
 class TestGraphSONWriter(object):
     graphson_writer = GraphSONWriter()
@@ -433,6 +439,12 @@ class TestGraphSONWriter(object):
         expected = json.dumps({'@type': 'g:UUID', '@value': "41d2e28a-20a4-4ab0-b379-d810dede3786"}, separators=(',', ':'))
         prop = uuid.UUID("41d2e28a-20a4-4ab0-b379-d810dede3786")
         output = self.graphson_writer.writeObject(prop)
+        assert expected == output
+
+    def test_bytebuffer(self):
+        expected = json.dumps({'@type': 'gx:ByteBuffer', '@value': 'c29tZSBieXRlcyBmb3IgeW91'}, separators=(',', ':'))
+        bb = ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii")
+        output = self.graphson_writer.writeObject(bb)
         assert expected == output
 
 

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -24,6 +24,7 @@ import time
 import json
 import uuid
 import math
+from decimal import *
 
 from mock import Mock
 
@@ -90,6 +91,55 @@ class TestGraphSONReader(object):
         }))
         assert isinstance(x, float)
         assert math.isinf(x) and x < 0
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": 31.2
+        }))
+        assert isinstance(x, Decimal)
+        assert Decimal(31.2) == x
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": 123456789987654321123456789987654321
+        }))
+        assert isinstance(x, Decimal)
+        assert Decimal('123456789987654321123456789987654321') == x
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": "NaN"
+        }))
+        assert isinstance(x, Decimal)
+        assert math.isnan(x)
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": "Infinity"
+        }))
+        assert isinstance(x, Decimal)
+        assert math.isinf(x) and x > 0
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": "-Infinity"
+        }))
+        assert isinstance(x, Decimal)
+        assert math.isinf(x) and x < 0
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigInteger",
+            "@value": 31
+        }))
+        assert isinstance(x, long)
+        assert 31 == x
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigInteger",
+            "@value": 123456789987654321123456789987654321
+        }))
+        assert isinstance(x, long)
+        assert 123456789987654321123456789987654321 == x
 
     def test_graph(self):
         vertex = self.graphson_reader.readObject("""
@@ -239,6 +289,12 @@ class TestGraphSONWriter(object):
         assert {"@type": "g:Double", "@value": "NaN"} == json.loads(self.graphson_writer.writeObject(float('nan')))
         assert {"@type": "g:Double", "@value": "Infinity"} == json.loads(self.graphson_writer.writeObject(float('inf')))
         assert {"@type": "g:Double", "@value": "-Infinity"} == json.loads(self.graphson_writer.writeObject(float('-inf')))
+        assert {"@type": "gx:BigDecimal", "@value": "123456789987654321123456789987654321"} == json.loads(self.graphson_writer.writeObject(Decimal('123456789987654321123456789987654321')))
+        assert {"@type": "gx:BigDecimal", "@value": "NaN"} == json.loads(self.graphson_writer.writeObject(Decimal('nan')))
+        assert {"@type": "gx:BigDecimal", "@value": "Infinity"} == json.loads(self.graphson_writer.writeObject(Decimal('inf')))
+        assert {"@type": "gx:BigDecimal", "@value": "-Infinity"} == json.loads(self.graphson_writer.writeObject(Decimal('-inf')))
+        assert {"@type": "gx:BigInteger", "@value": "123456789987654321123456789987654321"} == json.loads(self.graphson_writer.writeObject(long(123456789987654321123456789987654321)))
+        assert {"@type": "gx:BigInteger", "@value": "123456789987654321123456789987654321"} == json.loads(self.graphson_writer.writeObject(123456789987654321123456789987654321))
         assert """true""" == self.graphson_writer.writeObject(True)
 
     def test_P(self):

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -259,6 +259,11 @@ class TestGraphSONReader(object):
         assert isinstance(dt, timestamp)
         assert float(dt) == 1481750076.295
 
+    def test_duration(self):
+        d = self.graphson_reader.readObject(json.dumps({"@type": "gx:Duration", "@value": "PT120H"}))
+        assert isinstance(d, datetime.timedelta)
+        assert d == datetime.timedelta(hours=120)
+
     def test_uuid(self):
         prop = self.graphson_reader.readObject(
             json.dumps({'@type': 'g:UUID', '@value': "41d2e28a-20a4-4ab0-b379-d810dede3786"}))
@@ -438,6 +443,12 @@ class TestGraphSONWriter(object):
         expected = json.dumps({"@type": "g:Timestamp", "@value": 1481750076295}, separators=(',', ':'))
         ts = timestamp(1481750076295 / 1000.0)
         output = self.graphson_writer.writeObject(ts)
+        assert expected == output
+
+    def test_duration(self):
+        expected = json.dumps({"@type": "gx:Duration", "@value": "P5D"}, separators=(',', ':'))
+        d = datetime.timedelta(hours=120)
+        output = self.graphson_writer.writeObject(d)
         assert expected == output
 
     def test_uuid(self):

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -281,7 +281,12 @@ class TestGraphSONReader(object):
         bb = self.graphson_reader.readObject(
             json.dumps({"@type": "gx:ByteBuffer", "@value": "c29tZSBieXRlcyBmb3IgeW91"}))
         assert isinstance(bb, ByteBufferType)
-        assert ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii") == bb
+        assert ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "utf8") == bb
+
+    def test_char(self):
+        c = self.graphson_reader.readObject(json.dumps({"@type": "gx:Char", "@value": "L"}))
+        assert isinstance(c, SingleChar)
+        assert chr(76) == c
 
 
 class TestGraphSONWriter(object):
@@ -443,8 +448,14 @@ class TestGraphSONWriter(object):
 
     def test_bytebuffer(self):
         expected = json.dumps({'@type': 'gx:ByteBuffer', '@value': 'c29tZSBieXRlcyBmb3IgeW91'}, separators=(',', ':'))
-        bb = ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii")
+        bb = ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "utf8")
         output = self.graphson_writer.writeObject(bb)
+        assert expected == output
+
+    def test_char(self):
+        expected = json.dumps({'@type': 'gx:Char', '@value': 'L'}, separators=(',', ':'))
+        c = str.__new__(SingleChar, chr(76))
+        output = self.graphson_writer.writeObject(c)
         assert expected == output
 
 

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -44,6 +44,12 @@ class TestGraphSONReader(object):
 
     def test_number_input(self):
         x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:Byte",
+            "@value": 1
+        }))
+        assert isinstance(x, SingleByte)
+        assert 1 == x
+        x = self.graphson_reader.readObject(json.dumps({
             "@type": "g:Int32",
             "@value": 31
         }))
@@ -283,6 +289,7 @@ class TestGraphSONWriter(object):
         assert """true""" == self.graphson_writer.writeObject(True)
 
     def test_numbers(self):
+        assert {"@type": "gx:Byte", "@value": 1} == json.loads(self.graphson_writer.writeObject(int.__new__(SingleByte, 1)))
         assert {"@type": "g:Int64", "@value": 2} == json.loads(self.graphson_writer.writeObject(long(2)))
         assert {"@type": "g:Int32", "@value": 1} == json.loads(self.graphson_writer.writeObject(1))
         assert {"@type": "g:Double", "@value": 3.2} == json.loads(self.graphson_writer.writeObject(3.2))

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -24,6 +24,7 @@ import time
 import json
 import uuid
 import math
+from decimal import *
 
 from mock import Mock
 
@@ -127,6 +128,55 @@ class TestGraphSONReader(object):
         }))
         assert isinstance(x, float)
         assert math.isinf(x) and x < 0
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": 31.2
+        }))
+        assert isinstance(x, Decimal)
+        assert Decimal(31.2) == x
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": 123456789987654321123456789987654321
+        }))
+        assert isinstance(x, Decimal)
+        assert Decimal('123456789987654321123456789987654321') == x
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": "NaN"
+        }))
+        assert isinstance(x, Decimal)
+        assert math.isnan(x)
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": "Infinity"
+        }))
+        assert isinstance(x, Decimal)
+        assert math.isinf(x) and x > 0
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigDecimal",
+            "@value": "-Infinity"
+        }))
+        assert isinstance(x, Decimal)
+        assert math.isinf(x) and x < 0
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigInteger",
+            "@value": 31
+        }))
+        assert isinstance(x, long)
+        assert 31 == x
+        ##
+        x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:BigInteger",
+            "@value": 123456789987654321123456789987654321
+        }))
+        assert isinstance(x, long)
+        assert 123456789987654321123456789987654321 == x
 
     def test_graph(self):
         vertex = self.graphson_reader.readObject("""
@@ -287,6 +337,15 @@ class TestGraphSONWriter(object):
         assert {"@type": "g:Int64", "@value": 2} == json.loads(self.graphson_writer.writeObject(long(2)))
         assert {"@type": "g:Int32", "@value": 1} == json.loads(self.graphson_writer.writeObject(1))
         assert {"@type": "g:Double", "@value": 3.2} == json.loads(self.graphson_writer.writeObject(3.2))
+        assert {"@type": "g:Double", "@value": "NaN"} == json.loads(self.graphson_writer.writeObject(float('nan')))
+        assert {"@type": "g:Double", "@value": "Infinity"} == json.loads(self.graphson_writer.writeObject(float('inf')))
+        assert {"@type": "g:Double", "@value": "-Infinity"} == json.loads(self.graphson_writer.writeObject(float('-inf')))
+        assert {"@type": "gx:BigDecimal", "@value": "123456789987654321123456789987654321"} == json.loads(self.graphson_writer.writeObject(Decimal('123456789987654321123456789987654321')))
+        assert {"@type": "gx:BigDecimal", "@value": "NaN"} == json.loads(self.graphson_writer.writeObject(Decimal('nan')))
+        assert {"@type": "gx:BigDecimal", "@value": "Infinity"} == json.loads(self.graphson_writer.writeObject(Decimal('inf')))
+        assert {"@type": "gx:BigDecimal", "@value": "-Infinity"} == json.loads(self.graphson_writer.writeObject(Decimal('-inf')))
+        assert {"@type": "gx:BigInteger", "@value": "123456789987654321123456789987654321"} == json.loads(self.graphson_writer.writeObject(long(123456789987654321123456789987654321)))
+        assert {"@type": "gx:BigInteger", "@value": "123456789987654321123456789987654321"} == json.loads(self.graphson_writer.writeObject(123456789987654321123456789987654321))
         assert """true""" == self.graphson_writer.writeObject(True)
 
     def test_P(self):

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -319,7 +319,7 @@ class TestGraphSONReader(object):
         bb = self.graphson_reader.readObject(
             json.dumps({"@type": "gx:ByteBuffer", "@value": "c29tZSBieXRlcyBmb3IgeW91"}))
         assert isinstance(bb, ByteBufferType)
-        assert ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii") == bb
+        assert ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "utf8") == bb
 
 
 class TestGraphSONWriter(object):
@@ -497,7 +497,7 @@ class TestGraphSONWriter(object):
 
     def test_bytebuffer(self):
         expected = json.dumps({'@type': 'gx:ByteBuffer', '@value': 'c29tZSBieXRlcyBmb3IgeW91'}, separators=(',', ':'))
-        bb = ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii")
+        bb = ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "utf8")
         output = self.graphson_writer.writeObject(bb)
         assert expected == output
 

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -81,6 +81,12 @@ class TestGraphSONReader(object):
 
     def test_number_input(self):
         x = self.graphson_reader.readObject(json.dumps({
+            "@type": "gx:Byte",
+            "@value": 1
+        }))
+        assert isinstance(x, SingleByte)
+        assert 1 == x
+        x = self.graphson_reader.readObject(json.dumps({
             "@type": "g:Int32",
             "@value": 31
         }))
@@ -334,6 +340,7 @@ class TestGraphSONWriter(object):
         assert """true""" == self.graphson_writer.writeObject(True)
 
     def test_numbers(self):
+        assert {"@type": "gx:Byte", "@value": 1} == json.loads(self.graphson_writer.writeObject(int.__new__(SingleByte, 1)))
         assert {"@type": "g:Int64", "@value": 2} == json.loads(self.graphson_writer.writeObject(long(2)))
         assert {"@type": "g:Int32", "@value": 1} == json.loads(self.graphson_writer.writeObject(1))
         assert {"@type": "g:Double", "@value": 3.2} == json.loads(self.graphson_writer.writeObject(3.2))

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -315,6 +315,12 @@ class TestGraphSONReader(object):
                 {'dur': 0.087637, 'counts': {}, 'name': 'ReferenceElementStep', 'annotations': {'percentDur': 5.967408283024444}, 'id': '3.0.0()'}
                 ]}]
 
+    def test_bytebuffer(self):
+        bb = self.graphson_reader.readObject(
+            json.dumps({"@type": "gx:ByteBuffer", "@value": "c29tZSBieXRlcyBmb3IgeW91"}))
+        assert isinstance(bb, ByteBufferType)
+        assert ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii") == bb
+
 
 class TestGraphSONWriter(object):
     graphson_writer = GraphSONWriter()
@@ -487,6 +493,12 @@ class TestGraphSONWriter(object):
         expected = json.dumps({'@type': 'g:UUID', '@value': "41d2e28a-20a4-4ab0-b379-d810dede3786"}, separators=(',', ':'))
         prop = uuid.UUID("41d2e28a-20a4-4ab0-b379-d810dede3786")
         output = self.graphson_writer.writeObject(prop)
+        assert expected == output
+
+    def test_bytebuffer(self):
+        expected = json.dumps({'@type': 'gx:ByteBuffer', '@value': 'c29tZSBieXRlcyBmb3IgeW91'}, separators=(',', ':'))
+        bb = ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "ascii")
+        output = self.graphson_writer.writeObject(bb)
         assert expected == output
 
 

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -326,6 +326,11 @@ class TestGraphSONReader(object):
         assert isinstance(bb, ByteBufferType)
         assert ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "utf8") == bb
 
+    def test_char(self):
+        c = self.graphson_reader.readObject(json.dumps({"@type": "gx:Char", "@value": "L"}))
+        assert isinstance(c, SingleChar)
+        assert chr(76) == c
+
 
 class TestGraphSONWriter(object):
     graphson_writer = GraphSONWriter()
@@ -510,6 +515,12 @@ class TestGraphSONWriter(object):
         expected = json.dumps({'@type': 'gx:ByteBuffer', '@value': 'c29tZSBieXRlcyBmb3IgeW91'}, separators=(',', ':'))
         bb = ByteBufferType("c29tZSBieXRlcyBmb3IgeW91", "utf8")
         output = self.graphson_writer.writeObject(bb)
+        assert expected == output
+
+    def test_char(self):
+        expected = json.dumps({'@type': 'gx:Char', '@value': 'L'}, separators=(',', ':'))
+        c = str.__new__(SingleChar, chr(76))
+        output = self.graphson_writer.writeObject(c)
         assert expected == output
 
 

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -297,6 +297,11 @@ class TestGraphSONReader(object):
         assert isinstance(dt, timestamp)
         assert float(dt) == 1481750076.295
 
+    def test_duration(self):
+        d = self.graphson_reader.readObject(json.dumps({"@type": "gx:Duration", "@value": "PT120H"}))
+        assert isinstance(d, datetime.timedelta)
+        assert d == datetime.timedelta(hours=120)
+
     def test_uuid(self):
         prop = self.graphson_reader.readObject(
             json.dumps({'@type': 'g:UUID', '@value': "41d2e28a-20a4-4ab0-b379-d810dede3786"}))
@@ -487,6 +492,12 @@ class TestGraphSONWriter(object):
         expected = json.dumps({"@type": "g:Timestamp", "@value": 1481750076295}, separators=(',', ':'))
         ts = timestamp(1481750076295 / 1000.0)
         output = self.graphson_writer.writeObject(ts)
+        assert expected == output
+
+    def test_duration(self):
+        expected = json.dumps({"@type": "gx:Duration", "@value": "P5D"}, separators=(',', ':'))
+        d = datetime.timedelta(hours=120)
+        output = self.graphson_writer.writeObject(d)
         assert expected == output
 
     def test_uuid(self):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1435

Implemented `Duration`, `Char`, `ByteBuffer`, `Byte`, `BigInteger` and `BigDecimal` which were the most critical ones right now. Tried to do `InetAddress` but there didn't seem to be anything in Python suitable to handled that type except for `ip_address` but it wouldn't parse things like "localhost" and other things that Java will so it seemed a bit incompatible. Also ignored all the `java.time.*` things for now...wonder if those shouldn't just be deprecated....

Builds with `mvn clean install && mvn verify -pl gremlin-python`

VOTE +1