### PR TITLE
TINKERPOP-2134 Bump to Groovy 2.5.6

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ This release also includes changes from <<release-3-3-6, 3.3.6>>.
 * Added fallback resolver to `TypeSerializerRegistry` for GraphBinary.
 * Added easier to understand exceptions for connection problems in the Gremlin.Net driver.
 * Support configuring the type registry builder for GraphBinary.
+* Bump to Groovy 2.5.6.
 * Release working buffers in case of failure for GraphBinary.
 
 [[release-3-4-0]]

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ limitations under the License.
         <commons.configuration.version>1.10</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.lang3.version>3.3.1</commons.lang3.version>
-        <groovy.version>2.5.4</groovy.version>
+        <groovy.version>2.5.6</groovy.version>
         <hadoop.version>2.7.2</hadoop.version>
         <java.tuples.version>1.2</java.tuples.version>
         <javadoc-plugin.version>2.10.4</javadoc-plugin.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2134

I bumped this a long time ago - actually started with 2.5.5, but that version seemed to do something unstable to spark for some reason?? before i had time to really investigate 2.5.6 came out so I figured I'd just try that. The spark issue stopped but then there was other build problems with docker so I laid off issuing the PR again. After a number of investigations/fixes around the docker failures which seemed unrelated to this Groovy change, I've finally gotten some consecutive clean docker runs. Still not completely sure that Groovy ever had anything to do with the problem. I'd appreciate if reviewers could do some docker runs themselves to see what their environments show, but other than that, I'm going to go with:

All tests pass with `docker/build.sh -t -n -i`

VOTE +1