### PR TITLE
TINKERPOP-2163 Improved performance of JavaTranslator method selection

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed concurrency issues in `TraverserSet.toString()` and `ObjectWritable.toString()`.
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.
 * Improved handling of failing `Authenticator` instances thus improving server responses to drivers.
+* Improved performance of `JavaTranslator` by reducing calls to `Method.getParameters()`.
 * Implemented `EarlyLimitStrategy` which is supposed to significantly reduce backend operations for queries that use `range()`.
 
 [[release-3-3-5]]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2163

Every time I think there's nothing else to squeeze out of this class I find something new. This time I cached results of `Method.getParameters()` as well as varargs checks. The former offered the bigger benefit as calls to that method forced a `clone()` of the parameter array, but the latter also helped.

Prior to the change on `tp33` we were getting:

```text
Benchmark                                             Mode  Cnt        Score       Error  Units
JavaTranslatorBenchmark.testTranslationLong          thrpt   20    25812.057 ±   504.233  ops/s
JavaTranslatorBenchmark.testTranslationMedium        thrpt   20   316019.034 ± 13852.097  ops/s
JavaTranslatorBenchmark.testTranslationShort         thrpt   20  1403109.145 ± 41460.176  ops/s
JavaTranslatorBenchmark.testTranslationWithStrategy  thrpt   20    49316.015 ±  1701.437  ops/s
```

and now, with this change, we're looking at:

```text
Benchmark                                             Mode  Cnt        Score       Error  Units
JavaTranslatorBenchmark.testTranslationLong          thrpt   20    30270.986 ±   553.973  ops/s
JavaTranslatorBenchmark.testTranslationMedium        thrpt   20   385286.380 ±  6572.709  ops/s
JavaTranslatorBenchmark.testTranslationShort         thrpt   20  1724457.005 ± 11173.083  ops/s
JavaTranslatorBenchmark.testTranslationWithStrategy  thrpt   20    60989.899 ±   533.268  ops/s
```

That's roughly 20% improvement. Not bad.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1

