### PR TITLE
TINKERPOP-2159 EventStrategy doesn't handle multi-valued properties

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Modified Java driver to use IP address rather than hostname to create connections.
 * Fixed potential for `NullPointerException` with empty identifiers in `GraphStep`.
 * Postpone the timing of transport creation to `connection.write` in Gremlin Python.
+* Made `EventStrategy` compatible with multi-valued properties.
 
 [[release-3-3-8]]
 === TinkerPop 3.3.8 (Release Date: August 5, 2019)

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3484,6 +3484,12 @@ l = new ConsoleMutationListener(graph)
 strategy = EventStrategy.build().addListener(l).create()
 g = graph.traversal().withStrategies(strategy)
 g.addV().property('name','stephen')
+g.V().has('name','stephen').
+  property(list, 'location', 'centreville', 'startTime', 1990, 'endTime', 2000).
+  property(list, 'location', 'dulles', 'startTime', 2000, 'endTime', 2006).
+  property(list, 'location', 'purcellville', 'startTime', 2006)
+g.V().has('name','stephen').
+  property(set, 'location', 'purcellville', 'startTime', 2006, 'endTime', 2019)
 g.E().drop()
 ----
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -113,6 +113,19 @@ gremlin> g.V().hasLabel('person').aggregate('p').out('created').union(fold(),cap
 
 link:https://issues.apache.org/jira/browse/TINKERPOP-2265[TINKERPOP-2265]
 
+==== EventStrategy
+
+Prior TinkerPop 3.3.6 `EventStrategy` did not work with multi-properties. The `EventStrategy` behavior for single-valued properties has not changed; if a property is added to a multi-valued
+`VertexProperty`, then a `VertexPropertyChangedEvent` will be now be fired. The arguments passed to the event depend on the cardinality type.
+
+[width="100%",cols="2"]
+|=========================================================
+|`Cardinality.list` | Since properties will always be added and never be overwritten, the old property passed to the change event will always be an empty property.
+|`Cardinality.set`  | The old property passed to the change event will be empty if no other property with the same value exists, otherwise, it will be the existing property.
+|=========================================================
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2159[TINKERPOP-2159]
+
 == TinkerPop 3.3.7
 
 *Release Date: May 28, 2019*


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2159

Fixed multi-valued property handling in `EventStrategy` / `AddPropertyStep`. The `EventStrategy` output for the traversals added in `TinkerGraphPlayTest.testPlayDK()` is as follows:

```
Vertex [v[1]] added to graph [tinkergraph[vertices:1 edges:0]]
Vertex [v[1]] property [vp[name->null]] change to [name1] in graph [tinkergraph[vertices:1 edges:0]]
Vertex [v[1]] property [vp[name->name1]] change to [name2] in graph [tinkergraph[vertices:1 edges:0]]
Vertex [v[1]] property [vp[name->name2]] change to [name2] in graph [tinkergraph[vertices:1 edges:0]]
Vertex [v[2]] added to graph [tinkergraph[vertices:2 edges:0]]
Vertex [v[2]] property [vp[name->null]] change to [name1] in graph [tinkergraph[vertices:2 edges:0]]
Vertex [v[2]] property [vp[name->null]] change to [name2] in graph [tinkergraph[vertices:2 edges:0]]
Vertex [v[2]] property [vp[name->null]] change to [name2] in graph [tinkergraph[vertices:2 edges:0]]
Vertex [v[3]] added to graph [tinkergraph[vertices:3 edges:0]]
Vertex [v[3]] property [vp[name->null]] change to [name1] in graph [tinkergraph[vertices:3 edges:0]]
Vertex [v[3]] property [vp[name->null]] change to [name2] in graph [tinkergraph[vertices:3 edges:0]]
Vertex [v[3]] property [vp[name->name2]] change to [name2] in graph [tinkergraph[vertices:3 edges:0]]
```

It's not quite right as the old property will always be `vp[name->null]` when `Cardinality.list` is used or when `Cardinality.set` is used and the value doesn't exist yet. However, I think that's the only to make it work without any major breaking changes.