### PR TITLE
TINKERPOP-2161 - GraphBinary: use a single buffer instead of allocators

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,10 @@ This release also includes changes from <<release-3-3-6, 3.3.6>>.
 * Added easier to understand exceptions for connection problems in the Gremlin.Net driver.
 * Support configuring the type registry builder for GraphBinary.
 * Release working buffers in case of failure for GraphBinary.
+* GraphBinary: Use the same `ByteBuf` instance to write during serialization. Changed signature of write methods in type
+serializers.
+* Remove unused parameter in GraphBinary's `ResponseMessageSerializer`.
+
 
 [[release-3-4-0]]
 === TinkerPop 3.4.0 (Release Date: January 2, 2019)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,8 +35,7 @@ This release also includes changes from <<release-3-3-6, 3.3.6>>.
 * Added easier to understand exceptions for connection problems in the Gremlin.Net driver.
 * Support configuring the type registry builder for GraphBinary.
 * Release working buffers in case of failure for GraphBinary.
-* GraphBinary: Use the same `ByteBuf` instance to write during serialization. Changed signature of write methods in type
-serializers.
+* GraphBinary: Use the same `ByteBuf` instance to write during serialization. Changed signature of write methods in type serializers.
 * Remove unused parameter in GraphBinary's `ResponseMessageSerializer`.
 
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -37,6 +37,8 @@ In GraphBinary serialization, Java `write()` and `writeValue()` from `TypeSerial
 `ByteBuf` instance instead of an `ByteBufAllocator`, that way the same buffer instance gets reused during the write
 of a message. Additionally, we took the opportunity to remove the unused parameter from `ResponseMessageSerializer`.
 
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2161[TINKERPOP-2161]
+
 == TinkerPop 3.4.0
 
 *Release Date: January 2, 2019*

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -27,6 +27,16 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.4.1/CHANGELOG.asciidoc#release-3-4-1[changelog] for a complete list of all the modifications that are part of this release.
 
+=== Upgrading for Providers
+
+==== Graph Database Providers
+
+===== GraphBinary Serializer Changes
+
+In GraphBinary serialization, Java `write()` and `writeValue()` from `TypeSerializer<T>` interface now take a Netty's
+`ByteBuf` instance instead of an `ByteBufAllocator`, that way the same buffer instance gets reused during the write
+of a message. Additionally, we took the opportunity to remove the unused parameter from `ResponseMessageSerializer`.
+
 == TinkerPop 3.4.0
 
 *Release Date: January 2, 2019*

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GraphBinaryMessageSerializerV1.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GraphBinaryMessageSerializerV1.java
@@ -20,7 +20,6 @@ package org.apache.tinkerpop.gremlin.driver.ser;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryIo;
@@ -123,7 +122,7 @@ public class GraphBinaryMessageSerializerV1 extends AbstractMessageSerializer {
         final ByteBuf buffer = allocator.buffer();
 
         try {
-            responseSerializer.writeValue(responseMessage, buffer, writer, false);
+            responseSerializer.writeValue(responseMessage, buffer, writer);
         } catch (Exception ex) {
             buffer.release();
             throw ex;
@@ -153,7 +152,7 @@ public class GraphBinaryMessageSerializerV1 extends AbstractMessageSerializer {
 
     @Override
     public ResponseMessage deserializeResponse(final ByteBuf msg) throws SerializationException {
-        return responseSerializer.readValue(msg, reader, false);
+        return responseSerializer.readValue(msg, reader);
     }
 
     @Override

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/GraphBinaryWriter.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/GraphBinaryWriter.java
@@ -28,6 +28,7 @@ public class GraphBinaryWriter {
     private final TypeSerializerRegistry registry;
     private final static byte VALUE_FLAG_NULL = 1;
     private final static byte VALUE_FLAG_NONE = 0;
+    public final static byte VERSION_BYTE = (byte)0x81;
     private final static byte[] unspecifiedNullBytes = new byte[] { DataType.UNSPECIFIED_NULL.getCodeByte(), 0x01};
     private final static byte[] customTypeCodeBytes = new byte[] { DataType.CUSTOM.getCodeByte() };
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/RequestMessageSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/RequestMessageSerializer.java
@@ -49,17 +49,16 @@ public class RequestMessageSerializer {
         return builder.create();
     }
 
-    public ByteBuf writeValue(final RequestMessage value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.compositeBuffer(5).addComponents(true,
-                // Version
-                allocator.buffer(1).writeByte(0x81),
-                // RequestId
-                context.writeValue(value.getRequestId(), allocator, false),
-                // Op
-                context.writeValue(value.getOp(), allocator, false),
-                // Processor
-                context.writeValue(value.getProcessor(), allocator, false),
-                // Args
-                context.writeValue(value.getArgs(), allocator, false));
+    public void writeValue(final RequestMessage value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        // Version
+        buffer.writeByte(0x81);
+        // RequestId
+        context.writeValue(value.getRequestId(), buffer, false);
+        // Op
+        context.writeValue(value.getOp(), buffer, false);
+        // Processor
+        context.writeValue(value.getProcessor(), buffer, false);
+        // Args
+        context.writeValue(value.getArgs(), buffer, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/RequestMessageSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/RequestMessageSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 
@@ -51,7 +50,7 @@ public class RequestMessageSerializer {
 
     public void writeValue(final RequestMessage value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         // Version
-        buffer.writeByte(0x81);
+        buffer.writeByte(GraphBinaryWriter.VERSION_BYTE);
         // RequestId
         context.writeValue(value.getRequestId(), buffer, false);
         // Op

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/ResponseMessageSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/ResponseMessageSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseResult;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatus;
@@ -31,7 +30,7 @@ import java.util.UUID;
 
 public class ResponseMessageSerializer {
 
-    public ResponseMessage readValue(final ByteBuf buffer, final GraphBinaryReader context, final boolean nullable) throws SerializationException {
+    public ResponseMessage readValue(final ByteBuf buffer, final GraphBinaryReader context) throws SerializationException {
         final int version = buffer.readByte() & 0xff;
 
         if (version >>> 7 != 1) {
@@ -49,12 +48,12 @@ public class ResponseMessageSerializer {
                 .create();
     }
 
-    public void writeValue(final ResponseMessage value, final ByteBuf buffer, final GraphBinaryWriter context, final boolean nullable) throws SerializationException {
+    public void writeValue(final ResponseMessage value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         final ResponseResult result = value.getResult();
         final ResponseStatus status = value.getStatus();
 
         // Version
-        buffer.writeByte(0x81);
+        buffer.writeByte(GraphBinaryWriter.VERSION_BYTE);
         // Nullable request id
         context.writeValue(value.getRequestId(), buffer, true);
         // Status code

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/ResponseMessageSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/ResponseMessageSerializer.java
@@ -49,24 +49,23 @@ public class ResponseMessageSerializer {
                 .create();
     }
 
-    public ByteBuf writeValue(final ResponseMessage value, final ByteBufAllocator allocator, final GraphBinaryWriter context, final boolean nullable) throws SerializationException {
+    public void writeValue(final ResponseMessage value, final ByteBuf buffer, final GraphBinaryWriter context, final boolean nullable) throws SerializationException {
         final ResponseResult result = value.getResult();
         final ResponseStatus status = value.getStatus();
 
-        return allocator.compositeBuffer(8).addComponents(true,
-                // Version
-                allocator.buffer(1).writeByte(0x81),
-                // Nullable request id
-                context.writeValue(value.getRequestId(), allocator, true),
-                // Status code
-                context.writeValue(status.getCode().getValue(), allocator, false),
-                // Nullable status message
-                context.writeValue(status.getMessage(), allocator, true),
-                // Status attributes
-                context.writeValue(status.getAttributes(), allocator, false),
-                // Result meta
-                context.writeValue(result.getMeta(), allocator, false),
-                // Fully-qualified value
-                context.write(result.getData(), allocator));
+        // Version
+        buffer.writeByte(0x81);
+        // Nullable request id
+        context.writeValue(value.getRequestId(), buffer, true);
+        // Status code
+        context.writeValue(status.getCode().getValue(), buffer, false);
+        // Nullable status message
+        context.writeValue(status.getMessage(), buffer, true);
+        // Status attributes
+        context.writeValue(status.getAttributes(), buffer, false);
+        // Result meta
+        context.writeValue(result.getMeta(), buffer, false);
+        // Fully-qualified value
+        context.write(result.getData(), buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializer.java
@@ -49,10 +49,10 @@ public interface TypeSerializer<T> {
     /**
      * Writes the type code, information and value to a buffer using the provided allocator.
      */
-    ByteBuf write(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException;
+    void write(final T value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException;
 
     /**
      * Writes the value to a buffer, composed by the value flag and the sequence of bytes.
      */
-    ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context, final boolean nullable)throws SerializationException;
+    void writeValue(final T value, final ByteBuf buffer, final GraphBinaryWriter context, final boolean nullable) throws SerializationException;
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistry.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistry.java
@@ -159,7 +159,9 @@ public class TypeSerializerRegistry {
             new RegistryEntry<>(Year.class, SingleTypeSerializer.YearSerializer),
             new RegistryEntry<>(YearMonth.class, new YearMonthSerializer()),
             new RegistryEntry<>(ZonedDateTime.class, new ZonedDateTimeSerializer()),
-            new RegistryEntry<>(ZoneOffset.class, new ZoneOffsetSerializer()) };
+            new RegistryEntry<>(ZoneOffset.class, new ZoneOffsetSerializer())
+
+    };
 
     public static final TypeSerializerRegistry INSTANCE = build().create();
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigDecimalSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigDecimalSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -45,10 +43,8 @@ public class BigDecimalSerializer extends SimpleTypeSerializer<BigDecimal> {
     }
 
     @Override
-    protected ByteBuf writeValue(final BigDecimal value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.scale(), allocator, false));
-        result.addComponent(true, context.writeValue(value.unscaledValue(), allocator, false));
-        return result;
+    protected void writeValue(final BigDecimal value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.scale(), buffer, false);
+        context.writeValue(value.unscaledValue(), buffer, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigIntegerSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BigIntegerSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -44,8 +43,8 @@ public class BigIntegerSerializer extends SimpleTypeSerializer<BigInteger> {
     }
 
     @Override
-    protected ByteBuf writeValue(final BigInteger value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected void writeValue(final BigInteger value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         final byte[] twosComplement = value.toByteArray();
-        return allocator.buffer(4 + twosComplement.length).writeInt(twosComplement.length).writeBytes(twosComplement);
+        buffer.writeInt(twosComplement.length).writeBytes(twosComplement);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BindingSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/BindingSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -43,15 +41,8 @@ public class BindingSerializer extends SimpleTypeSerializer<Bytecode.Binding> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Bytecode.Binding value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-        try {
-            result.addComponent(true, context.writeValue(value.variable(), allocator, false));
-            result.addComponent(true, context.write(value.value(), allocator));
-        } catch (Exception ex) {
-            result.release();
-            throw ex;
-        }
-        return result;
+    protected void writeValue(final Bytecode.Binding value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.variable(), buffer, false);
+        context.write(value.value(), buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ByteBufferSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ByteBufferSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -45,8 +44,8 @@ public class ByteBufferSerializer extends SimpleTypeSerializer<ByteBuffer> {
     }
 
     @Override
-    protected ByteBuf writeValue(final ByteBuffer value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected void writeValue(final ByteBuffer value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         final byte[] bytes = value.array();
-        return allocator.buffer(4 + bytes.length).writeInt(bytes.length).writeBytes(bytes);
+        buffer.writeInt(bytes.length).writeBytes(bytes);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CharSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CharSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
@@ -61,8 +60,8 @@ public class CharSerializer extends SimpleTypeSerializer<Character> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Character value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected void writeValue(final Character value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         final String stringValue = Character.toString(value);
-        return Unpooled.wrappedBuffer(stringValue.getBytes(StandardCharsets.UTF_8));
+        buffer.writeBytes(stringValue.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ClassSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ClassSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class ClassSerializer extends SimpleTypeSerializer<Class> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Class value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return context.writeValue(value.getName(), allocator, false);
+    protected void writeValue(final Class value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.getName(), buffer, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CollectionSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CollectionSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -47,20 +45,11 @@ class CollectionSerializer extends SimpleTypeSerializer<Collection> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Collection value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size());
-        result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
+    protected void writeValue(final Collection value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeInt(value.size());
 
-        try {
-            for (Object item : value) {
-                result.addComponent(true, context.write(item, allocator));
-            }
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
+        for (Object item : value) {
+            context.write(item, buffer);
         }
-
-        return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DateSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DateSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
@@ -49,7 +48,7 @@ public class DateSerializer<T extends Date> extends SimpleTypeSerializer<T> {
     }
 
     @Override
-    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
-        return allocator.buffer(8).writeLong(value.getTime());
+    protected void writeValue(final T value, final ByteBuf buffer, final GraphBinaryWriter context) {
+        buffer.writeLong(value.getTime());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DurationSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/DurationSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class DurationSerializer extends SimpleTypeSerializer<Duration> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Duration value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(12).writeLong(value.getSeconds()).writeInt(value.getNano());
+    protected void writeValue(final Duration value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeLong(value.getSeconds()).writeInt(value.getNano());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EdgeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EdgeSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -59,30 +57,21 @@ public class EdgeSerializer extends SimpleTypeSerializer<Edge> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Edge value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(8);
+    protected void writeValue(final Edge value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
 
-        try {
-            result.addComponent(true, context.write(value.id(), allocator));
-            result.addComponent(true, context.writeValue(value.label(), allocator, false));
+        context.write(value.id(), buffer);
+        context.writeValue(value.label(), buffer, false);
 
-            result.addComponent(true, context.write(value.inVertex().id(), allocator));
-            result.addComponent(true, context.writeValue(value.inVertex().label(), allocator, false));
-            result.addComponent(true, context.write(value.outVertex().id(), allocator));
-            result.addComponent(true, context.writeValue(value.outVertex().label(), allocator, false));
+        context.write(value.inVertex().id(), buffer);
+        context.writeValue(value.inVertex().label(), buffer, false);
+        context.write(value.outVertex().id(), buffer);
+        context.writeValue(value.outVertex().label(), buffer, false);
 
-            // we don't serialize the parent Vertex for edges. they are "references", but we leave a place holder
-            // here as an option for the future as we've waffled this soooooooooo many times now
-            result.addComponent(true, context.write(null, allocator));
-            // we don't serialize properties for graph vertices/edges. they are "references", but we leave a place holder
-            // here as an option for the future as we've waffled this soooooooooo many times now
-            result.addComponent(true, context.write(null, allocator));
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
-        }
-        
-        return result;
+        // we don't serialize the parent Vertex for edges. they are "references", but we leave a place holder
+        // here as an option for the future as we've waffled this soooooooooo many times now
+        context.write(null, buffer);
+        // we don't serialize properties for graph vertices/edges. they are "references", but we leave a place holder
+        // here as an option for the future as we've waffled this soooooooooo many times now
+        context.write(null, buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EnumSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/EnumSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -68,7 +67,7 @@ public class EnumSerializer<E extends Enum> extends SimpleTypeSerializer<E> {
     }
 
     @Override
-    protected ByteBuf writeValue(final E value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return context.write(value.name(), allocator);
+    protected void writeValue(final E value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.write(value.name(), buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InetAddressSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InetAddressSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -50,8 +49,8 @@ public class InetAddressSerializer<T extends InetAddress> extends SimpleTypeSeri
     }
 
     @Override
-    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected void writeValue(final T value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         final byte[] bytes = value.getAddress();
-        return allocator.buffer(4 + bytes.length).writeInt(bytes.length).writeBytes(bytes);
+        buffer.writeInt(bytes.length).writeBytes(bytes);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InstantSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InstantSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class InstantSerializer extends SimpleTypeSerializer<Instant> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Instant value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(12).writeLong(value.getEpochSecond()).writeInt(value.getNano());
+    protected void writeValue(final Instant value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeLong(value.getEpochSecond()).writeInt(value.getNano());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LambdaSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LambdaSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -52,19 +50,9 @@ public class LambdaSerializer extends SimpleTypeSerializer<Lambda> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Lambda value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(3);
-
-        try {
-            result.addComponent(true, context.writeValue(value.getLambdaLanguage(), allocator, false));
-            result.addComponent(true, context.writeValue(value.getLambdaScript(), allocator, false));
-            result.addComponent(true, context.writeValue(value.getLambdaArguments(), allocator, false));
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
-        }
-
-        return result;
+    protected void writeValue(final Lambda value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.getLambdaLanguage(), buffer, false);
+        context.writeValue(value.getLambdaScript(), buffer, false);
+        context.writeValue(value.getLambdaArguments(), buffer, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ListSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ListSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class ListSerializer extends SimpleTypeSerializer<List> {
     }
 
     @Override
-    protected ByteBuf writeValue(final List value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return collectionSerializer.writeValue(value, allocator, context);
+    protected void writeValue(final List value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        collectionSerializer.writeValue(value, buffer, context);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class LocalDateSerializer extends SimpleTypeSerializer<LocalDate> {
     }
 
     @Override
-    protected ByteBuf writeValue(final LocalDate value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(6).writeInt(value.getYear()).writeByte(value.getMonthValue()).writeByte(value.getDayOfMonth());
+    protected void writeValue(final LocalDate value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeInt(value.getYear()).writeByte(value.getMonthValue()).writeByte(value.getDayOfMonth());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalDateTimeSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -45,10 +43,8 @@ public class LocalDateTimeSerializer extends SimpleTypeSerializer<LocalDateTime>
     }
 
     @Override
-    protected ByteBuf writeValue(final LocalDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.toLocalDate(), allocator, false));
-        result.addComponent(true, context.writeValue(value.toLocalTime(), allocator, false));
-        return result;
+    protected void writeValue(final LocalDateTime value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.toLocalDate(), buffer, false);
+        context.writeValue(value.toLocalTime(), buffer, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/LocalTimeSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class LocalTimeSerializer extends SimpleTypeSerializer<LocalTime> {
     }
 
     @Override
-    protected ByteBuf writeValue(final LocalTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(8).writeLong(value.toNanoOfDay());
+    protected void writeValue(final LocalTime value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeLong(value.toNanoOfDay());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapEntrySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapEntrySerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
@@ -38,7 +37,7 @@ public class MapEntrySerializer extends SimpleTypeSerializer<Map.Entry> implemen
     }
 
     @Override
-    protected ByteBuf writeValue(final Map.Entry value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected void writeValue(final Map.Entry value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         throw new SerializationException("A map entry should not be written individually");
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MapSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -28,6 +26,7 @@ import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class MapSerializer extends SimpleTypeSerializer<Map> {
     public MapSerializer() {
@@ -47,21 +46,12 @@ public class MapSerializer extends SimpleTypeSerializer<Map> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Map value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size() * 2);
-        result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
+    protected void writeValue(final Map value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeInt(value.size());
 
-        try {
-            for (Object key : value.keySet()) {
-                result.addComponent(true, context.write(key, allocator));
-                result.addComponent(true, context.write(value.get(key), allocator));
-            }
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
+        for (Map.Entry entry : (Set<Map.Entry>) value.entrySet()) {
+            context.write(entry.getKey(), buffer);
+            context.write(entry.getValue(), buffer);
         }
-
-        return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MonthDaySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/MonthDaySerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class MonthDaySerializer extends SimpleTypeSerializer<MonthDay> {
     }
 
     @Override
-    protected ByteBuf writeValue(final MonthDay value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(2).writeByte(value.getMonthValue()).writeByte(value.getDayOfMonth());
+    protected void writeValue(final MonthDay value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeByte(value.getMonthValue()).writeByte(value.getDayOfMonth());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetDateTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetDateTimeSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -46,10 +44,8 @@ public class OffsetDateTimeSerializer extends SimpleTypeSerializer<OffsetDateTim
     }
 
     @Override
-    protected ByteBuf writeValue(final OffsetDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.toLocalDateTime(), allocator, false));
-        result.addComponent(true, context.writeValue(value.getOffset(), allocator, false));
-        return result;
+    protected void writeValue(final OffsetDateTime value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.toLocalDateTime(), buffer, false);
+        context.writeValue(value.getOffset(), buffer, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/OffsetTimeSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -46,10 +44,8 @@ public class OffsetTimeSerializer extends SimpleTypeSerializer<OffsetTime> {
     }
 
     @Override
-    protected ByteBuf writeValue(final OffsetTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.toLocalTime(), allocator, false));
-        result.addComponent(true, context.writeValue(value.getOffset(), allocator, false));
-        return result;
+    protected void writeValue(final OffsetTime value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.toLocalTime(), buffer, false);
+        context.writeValue(value.getOffset(), buffer, false);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -111,7 +109,7 @@ public class PSerializer<T extends P> extends SimpleTypeSerializer<T> {
     }
 
     @Override
-    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected void writeValue(final T value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         // the predicate name is either a static method of P or an instance method when a type ConnectiveP
         final boolean isConnectedP = value instanceof ConnectiveP;
         final String predicateName = isConnectedP ?
@@ -121,15 +119,12 @@ public class PSerializer<T extends P> extends SimpleTypeSerializer<T> {
 
         final List<Object> argsAsList = args instanceof Collection ? new ArrayList<>((Collection) args) : Collections.singletonList(args);
         final int length = argsAsList.size();
-        final CompositeByteBuf result = allocator.compositeBuffer(2 + length);
 
-        result.addComponent(true, context.writeValue(predicateName, allocator, false));
-        result.addComponent(true, context.writeValue(length, allocator, false));
+        context.writeValue(predicateName, buffer, false);
+        context.writeValue(length, buffer, false);
 
         for (Object o : argsAsList) {
-            result.addComponent(true, context.write(o, allocator));
+            context.write(o, buffer);
         }
-
-        return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PathSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PathSerializer.java
@@ -18,10 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
-
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -59,17 +56,8 @@ public class PathSerializer extends SimpleTypeSerializer<Path> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Path value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-
-        try {
-            result.addComponent(true, context.write(value.labels(), allocator));
-            result.addComponent(true, context.write(value.objects(), allocator));
-        } catch (Exception ex) {
-            result.release();
-            throw ex;
-        }
-
-        return result;
+    protected void writeValue(final Path value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.write(value.labels(), buffer);
+        context.write(value.objects(), buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PeriodSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PeriodSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class PeriodSerializer extends SimpleTypeSerializer<Period> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Period value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(12).writeInt(value.getYears()).writeInt(value.getMonths()).writeInt(value.getDays());
+    protected void writeValue(final Period value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeInt(value.getYears()).writeInt(value.getMonths()).writeInt(value.getDays());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PropertySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PropertySerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -47,14 +45,11 @@ public class PropertySerializer extends SimpleTypeSerializer<Property> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Property value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(3);
-        result.addComponent(true, context.writeValue(value.key(), allocator, false));
-        result.addComponent(true, context.write(value.value(), allocator));
+    protected void writeValue(final Property value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.key(), buffer, false);
+        context.write(value.value(), buffer);
 
         // leave space for the parent reference element as it's not serialized for references
-        result.addComponent(true, context.write(null, allocator));
-
-        return result;
+        context.write(null, buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SetSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SetSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class SetSerializer extends SimpleTypeSerializer<Set>{
     }
 
     @Override
-    protected ByteBuf writeValue(final Set value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return collectionSerializer.writeValue(value, allocator, context);
+    protected void writeValue(final Set value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        collectionSerializer.writeValue(value, buffer, context);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SingleTypeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/SingleTypeSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
@@ -35,30 +33,28 @@ import java.util.function.Function;
  */
 public class SingleTypeSerializer<T> extends SimpleTypeSerializer<T> {
     public static final SingleTypeSerializer<Integer> IntSerializer =
-            new SingleTypeSerializer<>(4, DataType.INT, ByteBuf::readInt, (v, b) -> b.writeInt(v));
+            new SingleTypeSerializer<>(DataType.INT, ByteBuf::readInt, (v, b) -> b.writeInt(v));
     public static final SingleTypeSerializer<Long> LongSerializer =
-            new SingleTypeSerializer<>(8, DataType.LONG, ByteBuf::readLong, (v, b) -> b.writeLong(v));
+            new SingleTypeSerializer<>(DataType.LONG, ByteBuf::readLong, (v, b) -> b.writeLong(v));
     public static final SingleTypeSerializer<Double> DoubleSerializer =
-            new SingleTypeSerializer<>(8, DataType.DOUBLE, ByteBuf::readDouble, (v, b) -> b.writeDouble(v));
+            new SingleTypeSerializer<>(DataType.DOUBLE, ByteBuf::readDouble, (v, b) -> b.writeDouble(v));
     public static final SingleTypeSerializer<Float> FloatSerializer =
-            new SingleTypeSerializer<>(4, DataType.FLOAT, ByteBuf::readFloat, (v, b) -> b.writeFloat(v));
+            new SingleTypeSerializer<>(DataType.FLOAT, ByteBuf::readFloat, (v, b) -> b.writeFloat(v));
     public static final SingleTypeSerializer<Short> ShortSerializer =
-            new SingleTypeSerializer<>(2, DataType.SHORT, ByteBuf::readShort, (v, b) -> b.writeShort(v));
+            new SingleTypeSerializer<>(DataType.SHORT, ByteBuf::readShort, (v, b) -> b.writeShort(v));
     public static final SingleTypeSerializer<Boolean> BooleanSerializer =
-            new SingleTypeSerializer<>(1, DataType.BOOLEAN, ByteBuf::readBoolean, (v, b) -> b.writeBoolean(v));
+            new SingleTypeSerializer<>(DataType.BOOLEAN, ByteBuf::readBoolean, (v, b) -> b.writeBoolean(v));
     public static final SingleTypeSerializer<Byte> ByteSerializer =
-            new SingleTypeSerializer<>(1, DataType.BYTE, ByteBuf::readByte, (v, b) -> b.writeByte(v));
+            new SingleTypeSerializer<>(DataType.BYTE, ByteBuf::readByte, (v, b) -> b.writeByte(v));
     public static final SingleTypeSerializer<Year> YearSerializer =
-            new SingleTypeSerializer<>(4, DataType.YEAR, bb -> Year.of(bb.readInt()), (v, b) -> b.writeInt(v.getValue()));
+            new SingleTypeSerializer<>(DataType.YEAR, bb -> Year.of(bb.readInt()), (v, b) -> b.writeInt(v.getValue()));
 
-    private final int byteLength;
     private final Function<ByteBuf, T> readFunc;
     private final BiConsumer<T, ByteBuf> writeFunc;
 
-    private SingleTypeSerializer(final int byteLength, final DataType dataType, final Function<ByteBuf, T> readFunc,
+    private SingleTypeSerializer(final DataType dataType, final Function<ByteBuf, T> readFunc,
                                  final BiConsumer<T, ByteBuf> writeFunc) {
         super(dataType);
-        this.byteLength = byteLength;
         this.readFunc = readFunc;
         this.writeFunc = writeFunc;
     }
@@ -69,9 +65,7 @@ public class SingleTypeSerializer<T> extends SimpleTypeSerializer<T> {
     }
 
     @Override
-    protected ByteBuf writeValue(final T value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
-        final ByteBuf buffer = allocator.buffer(byteLength);
+    protected void writeValue(final T value, final ByteBuf buffer, final GraphBinaryWriter context) {
         writeFunc.accept(value, buffer);
-        return buffer;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/StringSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/StringSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
@@ -41,8 +39,8 @@ public class StringSerializer extends SimpleTypeSerializer<String> {
     }
 
     @Override
-    protected ByteBuf writeValue(final String value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
+    protected void writeValue(final String value, final ByteBuf buffer, final GraphBinaryWriter context) {
         final byte[] stringBytes = value.getBytes(StandardCharsets.UTF_8);
-        return allocator.buffer(4 + stringBytes.length).writeInt(stringBytes.length).writeBytes(stringBytes);
+        buffer.writeInt(stringBytes.length).writeBytes(stringBytes);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalExplanationSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalExplanationSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
@@ -51,7 +50,7 @@ public class TraversalExplanationSerializer extends SimpleTypeSerializer<Travers
     }
 
     @Override
-    protected ByteBuf writeValue(final TraversalExplanation value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
+    protected void writeValue(final TraversalExplanation value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
         throw new SerializationException("A TraversalExplanation should not be written individually");
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalMetricsSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalMetricsSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -48,18 +46,8 @@ public class TraversalMetricsSerializer extends SimpleTypeSerializer<TraversalMe
     }
 
     @Override
-    protected ByteBuf writeValue(TraversalMetrics value, ByteBufAllocator allocator, GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-
-        try {
-            result.addComponent(true, context.writeValue(value.getDuration(TimeUnit.NANOSECONDS), allocator, false));
-            result.addComponent(true, collectionSerializer.writeValue(value.getMetrics(), allocator, context));
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
-        }
-
-        return result;
+    protected void writeValue(TraversalMetrics value, ByteBuf buffer, GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.getDuration(TimeUnit.NANOSECONDS), buffer, false);
+        collectionSerializer.writeValue(value.getMetrics(), buffer, context);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalStrategySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraversalStrategySerializer.java
@@ -19,9 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
-import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
@@ -53,18 +50,9 @@ public class TraversalStrategySerializer extends SimpleTypeSerializer<TraversalS
     }
 
     @Override
-    protected ByteBuf writeValue(final TraversalStrategy value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-
-        try {
-            result.addComponent(true, context.writeValue(value.getClass(), allocator, false));
-            result.addComponent(true, context.writeValue(translateToBytecode(ConfigurationConverter.getMap(value.getConfiguration())), allocator, false));
-        } catch (Exception ex) {
-            result.release();
-            throw ex;
-        }
-
-        return result;
+    protected void writeValue(final TraversalStrategy value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.getClass(), buffer, false);
+        context.writeValue(translateToBytecode(ConfigurationConverter.getMap(value.getConfiguration())), buffer, false);
     }
 
     private static Map<Object,Object> translateToBytecode(final Map<Object,Object> conf) {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraverserSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TraverserSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -45,17 +43,8 @@ public class TraverserSerializer extends SimpleTypeSerializer<Traverser> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Traverser value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-
-        try {
-            result.addComponent(true, context.writeValue(value.bulk(), allocator, false));
-            result.addComponent(true, context.write(value.get(), allocator));
-        } catch (Exception ex) {
-            result.release();
-            throw ex;
-        }
-
-        return result;
+    protected void writeValue(final Traverser value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.bulk(), buffer, false);
+        context.write(value.get(), buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TreeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/TreeSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -45,23 +43,12 @@ public class TreeSerializer extends SimpleTypeSerializer<Tree> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Tree value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(1 + value.size() * 2);
-        result.addComponent(true, allocator.buffer(4).writeInt(value.size()));
+    protected void writeValue(final Tree value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeInt(value.size());
 
-        try {
-            for (Object key : value.keySet()) {
-                result.addComponents(
-                        true,
-                        context.write(key, allocator),
-                        context.writeValue(value.get(key), allocator, false));
-            }
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
+        for (Object key : value.keySet()) {
+            context.write(key, buffer);
+            context.writeValue(value.get(key), buffer, false);
         }
-
-        return result;
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/UUIDSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/UUIDSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
@@ -38,9 +36,7 @@ public class UUIDSerializer extends SimpleTypeSerializer<UUID> {
     }
 
     @Override
-    protected ByteBuf writeValue(final UUID value, final ByteBufAllocator allocator, final GraphBinaryWriter context) {
-        return allocator.buffer(16)
-                .writeLong(value.getMostSignificantBits())
-                .writeLong(value.getLeastSignificantBits());
+    protected void writeValue(final UUID value, final ByteBuf buffer, final GraphBinaryWriter context) {
+        buffer.writeLong(value.getMostSignificantBits()).writeLong(value.getLeastSignificantBits());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexPropertySerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexPropertySerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -53,25 +51,15 @@ public class VertexPropertySerializer extends SimpleTypeSerializer<VertexPropert
     }
 
     @Override
-    protected ByteBuf writeValue(final VertexProperty value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(5);
+    protected void writeValue(final VertexProperty value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.write(value.id(), buffer);
+        context.writeValue(value.label(), buffer, false);
+        context.write(value.value(), buffer);
 
-        try {
-            result.addComponent(true, context.write(value.id(), allocator));
-            result.addComponent(true, context.writeValue(value.label(), allocator, false));
-            result.addComponent(true, context.write(value.value(), allocator));
-
-            // we don't serialize the parent vertex even as a "reference", but, let's hold a place for it
-            result.addComponent(true, context.write(null, allocator));
-            // we don't serialize properties for graph elements. they are "references", but we leave a place holder
-            // here as an option for the future as we've waffled this soooooooooo many times now
-            result.addComponent(true, context.write(null, allocator));
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
-        }
-
-        return result;
+        // we don't serialize the parent vertex even as a "reference", but, let's hold a place for it
+        context.write(null, buffer);
+        // we don't serialize properties for graph elements. they are "references", but we leave a place holder
+        // here as an option for the future as we've waffled this soooooooooo many times now
+        context.write(null, buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/VertexSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -48,22 +46,9 @@ public class VertexSerializer extends SimpleTypeSerializer<Vertex> {
     }
 
     @Override
-    protected ByteBuf writeValue(final Vertex value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(3);
-
-        try {
-            result.addComponent(true, context.write(value.id(), allocator));
-            result.addComponent(true, context.writeValue(value.label(), allocator, false));
-
-            // we don't serialize properties for graph vertices/edges. they are "references", but we leave a place holder
-            // here as an option for the future as we've waffled this soooooooooo many times now
-            result.addComponent(true, context.write(null, allocator));
-        } catch (Exception ex) {
-            // We should release it as the ByteBuf is not going to be yielded for a reader
-            result.release();
-            throw ex;
-        }
-        
-        return result;
+    protected void writeValue(final Vertex value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.write(value.id(), buffer);
+        context.writeValue(value.label(), buffer, false);
+        context.write(null, buffer);
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/YearMonthSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/YearMonthSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -41,7 +40,7 @@ public class YearMonthSerializer extends SimpleTypeSerializer<YearMonth> {
     }
 
     @Override
-    protected ByteBuf writeValue(final YearMonth value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(2).writeInt(value.getYear()).writeByte(value.getMonthValue());
+    protected void writeValue(final YearMonth value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeInt(value.getYear()).writeByte(value.getMonthValue());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZoneOffsetSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZoneOffsetSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -42,7 +41,7 @@ public class ZoneOffsetSerializer extends SimpleTypeSerializer<ZoneOffset> {
     }
 
     @Override
-    protected ByteBuf writeValue(final ZoneOffset value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        return allocator.buffer(4).writeInt(value.getTotalSeconds());
+    protected void writeValue(final ZoneOffset value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        buffer.writeInt(value.getTotalSeconds());
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZonedDateTimeSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/ZonedDateTimeSerializer.java
@@ -19,8 +19,6 @@
 package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
@@ -46,10 +44,8 @@ public class ZonedDateTimeSerializer extends SimpleTypeSerializer<ZonedDateTime>
     }
 
     @Override
-    protected ByteBuf writeValue(final ZonedDateTime value, final ByteBufAllocator allocator, final GraphBinaryWriter context) throws SerializationException {
-        final CompositeByteBuf result = allocator.compositeBuffer(2);
-        result.addComponent(true, context.writeValue(value.toLocalDateTime(), allocator, false));
-        result.addComponent(true, context.writeValue(value.getOffset(), allocator, false));
-        return result;
+    protected void writeValue(final ZonedDateTime value, final ByteBuf buffer, final GraphBinaryWriter context) throws SerializationException {
+        context.writeValue(value.toLocalDateTime(), buffer, false);
+        context.writeValue(value.getOffset(), buffer, false);
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/GraphBinaryReaderWriterRoundTripTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/GraphBinaryReaderWriterRoundTripTest.java
@@ -294,7 +294,8 @@ public class GraphBinaryReaderWriterRoundTripTest {
     public void shouldWriteAndRead() throws Exception {
         // Test it multiple times as the type registry might change its internal state
         for (int i = 0; i < 5; i++) {
-            final ByteBuf buffer = writer.write(value, allocator);
+            final ByteBuf buffer = allocator.buffer();
+            writer.write(value, buffer);
             buffer.readerIndex(0);
             final Object result = reader.read(buffer);
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerFailureTests.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerFailureTests.java
@@ -1,116 +1,116 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package org.apache.tinkerpop.gremlin.driver.ser.binary;
-
-import io.netty.buffer.UnpooledByteBufAllocator;
-import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
-import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
-import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyPath;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
-import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalMetrics;
-import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceEdge;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferencePath;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
-import org.apache.tinkerpop.gremlin.util.function.Lambda;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-@RunWith(Parameterized.class)
-public class TypeSerializerFailureTests {
-
-    private final GraphBinaryWriter writer = new GraphBinaryWriter();
-    private final UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
-
-    @Parameterized.Parameters(name = "Value={0}")
-    public static Collection input() {
-        final Bytecode.Binding b = new Bytecode.Binding(null, "b");
-
-        final ReferenceVertex vertex = new ReferenceVertex("a vertex", null);
-
-        final Bytecode bytecode = new Bytecode();
-        bytecode.addStep(null);
-
-        final BulkSet<Object> bulkSet = new BulkSet<>();
-        bulkSet.add(vertex, 1L);
-
-        final MutableMetrics metrics = new MutableMetrics("a metric", null);
-
-        final Tree<Vertex> tree = new Tree<>();
-        tree.put(vertex, null);
-
-        // Provide instances that are malformed for serialization to fail
-        return Arrays.asList(
-                b,
-                vertex,
-                Collections.singletonMap("one", b),
-                bulkSet,
-                bytecode,
-                Collections.singletonList(vertex),
-                new ReferenceEdge("an edge", null, vertex, vertex),
-                Lambda.supplier(null),
-                metrics,
-                new DefaultTraversalMetrics(1L, Collections.singletonList(metrics)),
-                new DefaultRemoteTraverser<>(new Object(), 1L),
-                tree,
-                new ReferenceVertexProperty<>("a prop", null, "value"),
-                new InvalidPath()
-        );
-    }
-
-    @Parameterized.Parameter(value = 0)
-    public Object value;
-
-    @Test
-    public void shouldReleaseMemoryWhenFails() {
-        try {
-            writer.write(value, allocator);
-            fail("Should throw exception");
-        } catch (SerializationException | RuntimeException e) {
-            // Do nothing
-        }
-
-        assertEquals(0, allocator.metric().usedHeapMemory());
-    }
-
-    public static class InvalidPath extends ReferencePath {
-        public InvalidPath() {
-            super(EmptyPath.instance());
-        }
-
-        @Override
-        public List<Object> objects() {
-            return Collections.singletonList(new Object());
-        }
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// * http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.tinkerpop.gremlin.driver.ser.binary;
+//
+//import io.netty.buffer.UnpooledByteBufAllocator;
+//import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+//import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
+//import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+//import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+//import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyPath;
+//import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
+//import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalMetrics;
+//import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
+//import org.apache.tinkerpop.gremlin.structure.Vertex;
+//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceEdge;
+//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferencePath;
+//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
+//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
+//import org.apache.tinkerpop.gremlin.util.function.Lambda;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.Parameterized;
+//
+//import java.util.Arrays;
+//import java.util.Collection;
+//import java.util.Collections;
+//import java.util.List;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.fail;
+//
+//@RunWith(Parameterized.class)
+//public class TypeSerializerFailureTests {
+//
+//    private final GraphBinaryWriter writer = new GraphBinaryWriter();
+//    private final UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
+//
+//    @Parameterized.Parameters(name = "Value={0}")
+//    public static Collection input() {
+//        final Bytecode.Binding b = new Bytecode.Binding(null, "b");
+//
+//        final ReferenceVertex vertex = new ReferenceVertex("a vertex", null);
+//
+//        final Bytecode bytecode = new Bytecode();
+//        bytecode.addStep(null);
+//
+//        final BulkSet<Object> bulkSet = new BulkSet<>();
+//        bulkSet.add(vertex, 1L);
+//
+//        final MutableMetrics metrics = new MutableMetrics("a metric", null);
+//
+//        final Tree<Vertex> tree = new Tree<>();
+//        tree.put(vertex, null);
+//
+//        // Provide instances that are malformed for serialization to fail
+//        return Arrays.asList(
+//                b,
+//                vertex,
+//                Collections.singletonMap("one", b),
+//                bulkSet,
+//                bytecode,
+//                Collections.singletonList(vertex),
+//                new ReferenceEdge("an edge", null, vertex, vertex),
+//                Lambda.supplier(null),
+//                metrics,
+//                new DefaultTraversalMetrics(1L, Collections.singletonList(metrics)),
+//                new DefaultRemoteTraverser<>(new Object(), 1L),
+//                tree,
+//                new ReferenceVertexProperty<>("a prop", null, "value"),
+//                new InvalidPath()
+//        );
+//    }
+//
+//    @Parameterized.Parameter(value = 0)
+//    public Object value;
+//
+//    @Test
+//    public void shouldReleaseMemoryWhenFails() {
+//        try {
+//            writer.write(value, allocator);
+//            fail("Should throw exception");
+//        } catch (SerializationException | RuntimeException e) {
+//            // Do nothing
+//        }
+//
+//        assertEquals(0, allocator.metric().usedHeapMemory());
+//    }
+//
+//    public static class InvalidPath extends ReferencePath {
+//        public InvalidPath() {
+//            super(EmptyPath.instance());
+//        }
+//
+//        @Override
+//        public List<Object> objects() {
+//            return Collections.singletonList(new Object());
+//        }
+//    }
+//}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerFailureTests.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerFailureTests.java
@@ -1,116 +1,120 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one
-// * or more contributor license agreements.  See the NOTICE file
-// * distributed with this work for additional information
-// * regarding copyright ownership.  The ASF licenses this file
-// * to you under the Apache License, Version 2.0 (the
-// * "License"); you may not use this file except in compliance
-// * with the License.  You may obtain a copy of the License at
-// *
-// * http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing,
-// * software distributed under the License is distributed on an
-// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// * KIND, either express or implied.  See the License for the
-// * specific language governing permissions and limitations
-// * under the License.
-// */
-//
-//package org.apache.tinkerpop.gremlin.driver.ser.binary;
-//
-//import io.netty.buffer.UnpooledByteBufAllocator;
-//import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
-//import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
-//import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-//import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
-//import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyPath;
-//import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
-//import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalMetrics;
-//import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
-//import org.apache.tinkerpop.gremlin.structure.Vertex;
-//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceEdge;
-//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferencePath;
-//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
-//import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
-//import org.apache.tinkerpop.gremlin.util.function.Lambda;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.junit.runners.Parameterized;
-//
-//import java.util.Arrays;
-//import java.util.Collection;
-//import java.util.Collections;
-//import java.util.List;
-//
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.fail;
-//
-//@RunWith(Parameterized.class)
-//public class TypeSerializerFailureTests {
-//
-//    private final GraphBinaryWriter writer = new GraphBinaryWriter();
-//    private final UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
-//
-//    @Parameterized.Parameters(name = "Value={0}")
-//    public static Collection input() {
-//        final Bytecode.Binding b = new Bytecode.Binding(null, "b");
-//
-//        final ReferenceVertex vertex = new ReferenceVertex("a vertex", null);
-//
-//        final Bytecode bytecode = new Bytecode();
-//        bytecode.addStep(null);
-//
-//        final BulkSet<Object> bulkSet = new BulkSet<>();
-//        bulkSet.add(vertex, 1L);
-//
-//        final MutableMetrics metrics = new MutableMetrics("a metric", null);
-//
-//        final Tree<Vertex> tree = new Tree<>();
-//        tree.put(vertex, null);
-//
-//        // Provide instances that are malformed for serialization to fail
-//        return Arrays.asList(
-//                b,
-//                vertex,
-//                Collections.singletonMap("one", b),
-//                bulkSet,
-//                bytecode,
-//                Collections.singletonList(vertex),
-//                new ReferenceEdge("an edge", null, vertex, vertex),
-//                Lambda.supplier(null),
-//                metrics,
-//                new DefaultTraversalMetrics(1L, Collections.singletonList(metrics)),
-//                new DefaultRemoteTraverser<>(new Object(), 1L),
-//                tree,
-//                new ReferenceVertexProperty<>("a prop", null, "value"),
-//                new InvalidPath()
-//        );
-//    }
-//
-//    @Parameterized.Parameter(value = 0)
-//    public Object value;
-//
-//    @Test
-//    public void shouldReleaseMemoryWhenFails() {
-//        try {
-//            writer.write(value, allocator);
-//            fail("Should throw exception");
-//        } catch (SerializationException | RuntimeException e) {
-//            // Do nothing
-//        }
-//
-//        assertEquals(0, allocator.metric().usedHeapMemory());
-//    }
-//
-//    public static class InvalidPath extends ReferencePath {
-//        public InvalidPath() {
-//            super(EmptyPath.instance());
-//        }
-//
-//        @Override
-//        public List<Object> objects() {
-//            return Collections.singletonList(new Object());
-//        }
-//    }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.driver.ser.binary;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyPath;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalMetrics;
+import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceEdge;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferencePath;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
+import org.apache.tinkerpop.gremlin.util.function.Lambda;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class TypeSerializerFailureTests {
+
+    private final GraphBinaryWriter writer = new GraphBinaryWriter();
+    private final UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
+
+    @Parameterized.Parameters(name = "Value={0}")
+    public static Collection input() {
+        final Bytecode.Binding b = new Bytecode.Binding(null, "b");
+
+        final ReferenceVertex vertex = new ReferenceVertex("a vertex", null);
+
+        final Bytecode bytecode = new Bytecode();
+        bytecode.addStep(null);
+
+        final BulkSet<Object> bulkSet = new BulkSet<>();
+        bulkSet.add(vertex, 1L);
+
+        final MutableMetrics metrics = new MutableMetrics("a metric", null);
+
+        final Tree<Vertex> tree = new Tree<>();
+        tree.put(vertex, null);
+
+        // Provide instances that are malformed for serialization to fail
+        return Arrays.asList(
+                b,
+                vertex,
+                Collections.singletonMap("one", b),
+                bulkSet,
+                bytecode,
+                Collections.singletonList(vertex),
+                new ReferenceEdge("an edge", null, vertex, vertex),
+                Lambda.supplier(null),
+                metrics,
+                new DefaultTraversalMetrics(1L, Collections.singletonList(metrics)),
+                new DefaultRemoteTraverser<>(new Object(), 1L),
+                tree,
+                new ReferenceVertexProperty<>("a prop", null, "value"),
+                new InvalidPath()
+        );
+    }
+
+    @Parameterized.Parameter(value = 0)
+    public Object value;
+
+    @Test
+    public void shouldReleaseMemoryWhenFails() {
+        final ByteBuf buffer = allocator.buffer();
+        try {
+            writer.write(value, buffer);
+            fail("Should throw exception");
+        } catch (SerializationException | RuntimeException e) {
+            // We are the owner of the buffer, we should release it
+            buffer.release();
+        }
+
+        // Make sure all allocations where released
+        assertEquals(0, allocator.metric().usedHeapMemory());
+    }
+
+    public static class InvalidPath extends ReferencePath {
+        public InvalidPath() {
+            super(EmptyPath.instance());
+        }
+
+        @Override
+        public List<Object> objects() {
+            return Collections.singletonList(new Object());
+        }
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
@@ -1,161 +1,160 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one
-// * or more contributor license agreements.  See the NOTICE file
-// * distributed with this work for additional information
-// * regarding copyright ownership.  The ASF licenses this file
-// * to you under the Apache License, Version 2.0 (the
-// * "License"); you may not use this file except in compliance
-// * with the License.  You may obtain a copy of the License at
-// *
-// * http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing,
-// * software distributed under the License is distributed on an
-// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// * KIND, either express or implied.  See the License for the
-// * specific language governing permissions and limitations
-// * under the License.
-// */
-//package org.apache.tinkerpop.gremlin.driver.ser.binary;
-//
-//import io.netty.buffer.ByteBuf;
-//import io.netty.buffer.ByteBufAllocator;
-//import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
-//import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson;
-//import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePersonSerializer;
-//import org.apache.tinkerpop.gremlin.structure.Property;
-//import org.apache.tinkerpop.gremlin.structure.VertexProperty;
-//import org.junit.Test;
-//
-//import java.util.UUID;
-//
-//import static junit.framework.TestCase.assertEquals;
-//import static junit.framework.TestCase.assertSame;
-//
-//public class TypeSerializerRegistryTest {
-//
-//    @Test
-//    public void shouldResolveToUserProvidedForInterfaces_1() throws SerializationException {
-//        final TypeSerializer<VertexProperty> expected = new TestVertexPropertySerializer();
-//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-//                .add(VertexProperty.class, expected).create();
-//
-//        assertSame(expected, registry.getSerializer(VertexProperty.class));
-//        assertSame(expected, registry.getSerializer(DataType.VERTEXPROPERTY));
-//    }
-//
-//    @Test
-//    public void shouldResolveToUserProvidedForInterfaces_2() throws SerializationException {
-//        final TypeSerializer<Property> expected = new TestPropertySerializer();
-//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-//                .add(Property.class, expected).create();
-//
-//        assertSame(expected, registry.getSerializer(Property.class));
-//        assertSame(expected, registry.getSerializer(DataType.PROPERTY));
-//    }
-//
-//    @Test
-//    public void shouldResolveToUserProvidedForClasses() throws SerializationException {
-//        final TypeSerializer<UUID> expected = new TestUUIDSerializer();
-//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-//                .add(UUID.class, expected).create();
-//
-//        assertSame(expected, registry.getSerializer(UUID.class));
-//        assertSame(expected, registry.getSerializer(DataType.UUID));
-//    }
-//
-//    @Test
-//    public void shouldResolveToTheFirstSerializerForInterfaces() throws SerializationException {
-//        final TypeSerializer<VertexProperty> expectedForVertexProperty = new TestVertexPropertySerializer();
-//        final TypeSerializer<Property> expectedForProperty = new TestPropertySerializer();
-//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-//                .add(VertexProperty.class, expectedForVertexProperty)
-//                .add(Property.class, expectedForProperty).create();
-//
-//        assertSame(expectedForVertexProperty, registry.getSerializer(VertexProperty.class));
-//        assertSame(expectedForProperty, registry.getSerializer(Property.class));
-//        assertSame(expectedForVertexProperty, registry.getSerializer(DataType.VERTEXPROPERTY));
-//        assertSame(expectedForProperty, registry.getSerializer(DataType.PROPERTY));
-//    }
-//
-//    @Test
-//    public void shouldUseFallbackResolverWhenThereIsNoMatch() {
-//        final int[] called = {0};
-//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-//                .withFallbackResolver(t -> {
-//                    called[0]++;
-//                    return null;
-//                }).create();
-//
-//        String message = null;
-//        try {
-//            registry.getSerializer(SamplePerson.class);
-//        } catch (SerializationException ex) {
-//            message = ex.getMessage();
-//        }
-//
-//        assertEquals("Serializer for type org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson not found", message);
-//        assertEquals(1, called[0]);
-//    }
-//
-//    @Test
-//    public void shouldUseFallbackResolverReturnValue() throws SerializationException {
-//        TypeSerializer expected = new SamplePersonSerializer();
-//        final int[] called = {0};
-//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-//                .withFallbackResolver(t -> {
-//                    called[0]++;
-//                    return expected;
-//                }).create();
-//
-//        TypeSerializer<SamplePerson> serializer = registry.getSerializer(SamplePerson.class);
-//        assertEquals(1, called[0]);
-//        assertSame(expected, serializer);
-//    }
-//
-//    private static class TestVertexPropertySerializer extends TestBaseTypeSerializer<VertexProperty> {
-//
-//        @Override
-//        public DataType getDataType() {
-//            return DataType.VERTEXPROPERTY;
-//        }
-//    }
-//
-//    private static class TestPropertySerializer extends TestBaseTypeSerializer<Property> {
-//
-//        @Override
-//        public DataType getDataType() {
-//            return DataType.PROPERTY;
-//        }
-//    }
-//
-//    private static class TestUUIDSerializer extends TestBaseTypeSerializer<UUID> {
-//
-//        @Override
-//        public DataType getDataType() {
-//            return DataType.UUID;
-//        }
-//    }
-//
-//    private static abstract class TestBaseTypeSerializer<T> implements TypeSerializer<T> {
-//        @Override
-//        public T read(ByteBuf buffer, GraphBinaryReader context) {
-//            return null;
-//        }
-//
-//        @Override
-//        public T readValue(ByteBuf buffer, GraphBinaryReader context, boolean nullable) {
-//            return null;
-//        }
-//
-//        @Override
-//        public ByteBuf write(T value, ByteBufAllocator allocator, GraphBinaryWriter context) {
-//            return null;
-//        }
-//
-//        @Override
-//        public ByteBuf writeValue(T value, ByteBufAllocator allocator, GraphBinaryWriter context, boolean nullable) {
-//            return null;
-//        }
-//    }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.ser.binary;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson;
+import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePersonSerializer;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertSame;
+
+public class TypeSerializerRegistryTest {
+
+    @Test
+    public void shouldResolveToUserProvidedForInterfaces_1() throws SerializationException {
+        final TypeSerializer<VertexProperty> expected = new TestVertexPropertySerializer();
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .add(VertexProperty.class, expected).create();
+
+        assertSame(expected, registry.getSerializer(VertexProperty.class));
+        assertSame(expected, registry.getSerializer(DataType.VERTEXPROPERTY));
+    }
+
+    @Test
+    public void shouldResolveToUserProvidedForInterfaces_2() throws SerializationException {
+        final TypeSerializer<Property> expected = new TestPropertySerializer();
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .add(Property.class, expected).create();
+
+        assertSame(expected, registry.getSerializer(Property.class));
+        assertSame(expected, registry.getSerializer(DataType.PROPERTY));
+    }
+
+    @Test
+    public void shouldResolveToUserProvidedForClasses() throws SerializationException {
+        final TypeSerializer<UUID> expected = new TestUUIDSerializer();
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .add(UUID.class, expected).create();
+
+        assertSame(expected, registry.getSerializer(UUID.class));
+        assertSame(expected, registry.getSerializer(DataType.UUID));
+    }
+
+    @Test
+    public void shouldResolveToTheFirstSerializerForInterfaces() throws SerializationException {
+        final TypeSerializer<VertexProperty> expectedForVertexProperty = new TestVertexPropertySerializer();
+        final TypeSerializer<Property> expectedForProperty = new TestPropertySerializer();
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .add(VertexProperty.class, expectedForVertexProperty)
+                .add(Property.class, expectedForProperty).create();
+
+        assertSame(expectedForVertexProperty, registry.getSerializer(VertexProperty.class));
+        assertSame(expectedForProperty, registry.getSerializer(Property.class));
+        assertSame(expectedForVertexProperty, registry.getSerializer(DataType.VERTEXPROPERTY));
+        assertSame(expectedForProperty, registry.getSerializer(DataType.PROPERTY));
+    }
+
+    @Test
+    public void shouldUseFallbackResolverWhenThereIsNoMatch() {
+        final int[] called = {0};
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .withFallbackResolver(t -> {
+                    called[0]++;
+                    return null;
+                }).create();
+
+        String message = null;
+        try {
+            registry.getSerializer(SamplePerson.class);
+        } catch (SerializationException ex) {
+            message = ex.getMessage();
+        }
+
+        assertEquals("Serializer for type org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson not found", message);
+        assertEquals(1, called[0]);
+    }
+
+    @Test
+    public void shouldUseFallbackResolverReturnValue() throws SerializationException {
+        TypeSerializer expected = new SamplePersonSerializer();
+        final int[] called = {0};
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .withFallbackResolver(t -> {
+                    called[0]++;
+                    return expected;
+                }).create();
+
+        TypeSerializer<SamplePerson> serializer = registry.getSerializer(SamplePerson.class);
+        assertEquals(1, called[0]);
+        assertSame(expected, serializer);
+    }
+
+    private static class TestVertexPropertySerializer extends TestBaseTypeSerializer<VertexProperty> {
+
+        @Override
+        public DataType getDataType() {
+            return DataType.VERTEXPROPERTY;
+        }
+    }
+
+    private static class TestPropertySerializer extends TestBaseTypeSerializer<Property> {
+
+        @Override
+        public DataType getDataType() {
+            return DataType.PROPERTY;
+        }
+    }
+
+    private static class TestUUIDSerializer extends TestBaseTypeSerializer<UUID> {
+
+        @Override
+        public DataType getDataType() {
+            return DataType.UUID;
+        }
+    }
+
+    private static abstract class TestBaseTypeSerializer<T> implements TypeSerializer<T> {
+        @Override
+        public T read(ByteBuf buffer, GraphBinaryReader context) {
+            return null;
+        }
+
+        @Override
+        public T readValue(ByteBuf buffer, GraphBinaryReader context, boolean nullable) {
+            return null;
+        }
+
+        @Override
+        public void write(T value, ByteBuf buffer, GraphBinaryWriter context) {
+
+        }
+
+        @Override
+        public void writeValue(T value, ByteBuf buffer, GraphBinaryWriter context, boolean nullable) {
+
+        }
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
@@ -1,161 +1,161 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-package org.apache.tinkerpop.gremlin.driver.ser.binary;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
-import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson;
-import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePersonSerializer;
-import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.tinkerpop.gremlin.structure.VertexProperty;
-import org.junit.Test;
-
-import java.util.UUID;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertSame;
-
-public class TypeSerializerRegistryTest {
-
-    @Test
-    public void shouldResolveToUserProvidedForInterfaces_1() throws SerializationException {
-        final TypeSerializer<VertexProperty> expected = new TestVertexPropertySerializer();
-        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-                .add(VertexProperty.class, expected).create();
-
-        assertSame(expected, registry.getSerializer(VertexProperty.class));
-        assertSame(expected, registry.getSerializer(DataType.VERTEXPROPERTY));
-    }
-
-    @Test
-    public void shouldResolveToUserProvidedForInterfaces_2() throws SerializationException {
-        final TypeSerializer<Property> expected = new TestPropertySerializer();
-        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-                .add(Property.class, expected).create();
-
-        assertSame(expected, registry.getSerializer(Property.class));
-        assertSame(expected, registry.getSerializer(DataType.PROPERTY));
-    }
-
-    @Test
-    public void shouldResolveToUserProvidedForClasses() throws SerializationException {
-        final TypeSerializer<UUID> expected = new TestUUIDSerializer();
-        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-                .add(UUID.class, expected).create();
-
-        assertSame(expected, registry.getSerializer(UUID.class));
-        assertSame(expected, registry.getSerializer(DataType.UUID));
-    }
-
-    @Test
-    public void shouldResolveToTheFirstSerializerForInterfaces() throws SerializationException {
-        final TypeSerializer<VertexProperty> expectedForVertexProperty = new TestVertexPropertySerializer();
-        final TypeSerializer<Property> expectedForProperty = new TestPropertySerializer();
-        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-                .add(VertexProperty.class, expectedForVertexProperty)
-                .add(Property.class, expectedForProperty).create();
-
-        assertSame(expectedForVertexProperty, registry.getSerializer(VertexProperty.class));
-        assertSame(expectedForProperty, registry.getSerializer(Property.class));
-        assertSame(expectedForVertexProperty, registry.getSerializer(DataType.VERTEXPROPERTY));
-        assertSame(expectedForProperty, registry.getSerializer(DataType.PROPERTY));
-    }
-
-    @Test
-    public void shouldUseFallbackResolverWhenThereIsNoMatch() {
-        final int[] called = {0};
-        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-                .withFallbackResolver(t -> {
-                    called[0]++;
-                    return null;
-                }).create();
-
-        String message = null;
-        try {
-            registry.getSerializer(SamplePerson.class);
-        } catch (SerializationException ex) {
-            message = ex.getMessage();
-        }
-
-        assertEquals("Serializer for type org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson not found", message);
-        assertEquals(1, called[0]);
-    }
-
-    @Test
-    public void shouldUseFallbackResolverReturnValue() throws SerializationException {
-        TypeSerializer expected = new SamplePersonSerializer();
-        final int[] called = {0};
-        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
-                .withFallbackResolver(t -> {
-                    called[0]++;
-                    return expected;
-                }).create();
-
-        TypeSerializer<SamplePerson> serializer = registry.getSerializer(SamplePerson.class);
-        assertEquals(1, called[0]);
-        assertSame(expected, serializer);
-    }
-
-    private static class TestVertexPropertySerializer extends TestBaseTypeSerializer<VertexProperty> {
-
-        @Override
-        public DataType getDataType() {
-            return DataType.VERTEXPROPERTY;
-        }
-    }
-
-    private static class TestPropertySerializer extends TestBaseTypeSerializer<Property> {
-
-        @Override
-        public DataType getDataType() {
-            return DataType.PROPERTY;
-        }
-    }
-
-    private static class TestUUIDSerializer extends TestBaseTypeSerializer<UUID> {
-
-        @Override
-        public DataType getDataType() {
-            return DataType.UUID;
-        }
-    }
-
-    private static abstract class TestBaseTypeSerializer<T> implements TypeSerializer<T> {
-        @Override
-        public T read(ByteBuf buffer, GraphBinaryReader context) {
-            return null;
-        }
-
-        @Override
-        public T readValue(ByteBuf buffer, GraphBinaryReader context, boolean nullable) {
-            return null;
-        }
-
-        @Override
-        public ByteBuf write(T value, ByteBufAllocator allocator, GraphBinaryWriter context) {
-            return null;
-        }
-
-        @Override
-        public ByteBuf writeValue(T value, ByteBufAllocator allocator, GraphBinaryWriter context, boolean nullable) {
-            return null;
-        }
-    }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// * http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//package org.apache.tinkerpop.gremlin.driver.ser.binary;
+//
+//import io.netty.buffer.ByteBuf;
+//import io.netty.buffer.ByteBufAllocator;
+//import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+//import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson;
+//import org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePersonSerializer;
+//import org.apache.tinkerpop.gremlin.structure.Property;
+//import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+//import org.junit.Test;
+//
+//import java.util.UUID;
+//
+//import static junit.framework.TestCase.assertEquals;
+//import static junit.framework.TestCase.assertSame;
+//
+//public class TypeSerializerRegistryTest {
+//
+//    @Test
+//    public void shouldResolveToUserProvidedForInterfaces_1() throws SerializationException {
+//        final TypeSerializer<VertexProperty> expected = new TestVertexPropertySerializer();
+//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+//                .add(VertexProperty.class, expected).create();
+//
+//        assertSame(expected, registry.getSerializer(VertexProperty.class));
+//        assertSame(expected, registry.getSerializer(DataType.VERTEXPROPERTY));
+//    }
+//
+//    @Test
+//    public void shouldResolveToUserProvidedForInterfaces_2() throws SerializationException {
+//        final TypeSerializer<Property> expected = new TestPropertySerializer();
+//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+//                .add(Property.class, expected).create();
+//
+//        assertSame(expected, registry.getSerializer(Property.class));
+//        assertSame(expected, registry.getSerializer(DataType.PROPERTY));
+//    }
+//
+//    @Test
+//    public void shouldResolveToUserProvidedForClasses() throws SerializationException {
+//        final TypeSerializer<UUID> expected = new TestUUIDSerializer();
+//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+//                .add(UUID.class, expected).create();
+//
+//        assertSame(expected, registry.getSerializer(UUID.class));
+//        assertSame(expected, registry.getSerializer(DataType.UUID));
+//    }
+//
+//    @Test
+//    public void shouldResolveToTheFirstSerializerForInterfaces() throws SerializationException {
+//        final TypeSerializer<VertexProperty> expectedForVertexProperty = new TestVertexPropertySerializer();
+//        final TypeSerializer<Property> expectedForProperty = new TestPropertySerializer();
+//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+//                .add(VertexProperty.class, expectedForVertexProperty)
+//                .add(Property.class, expectedForProperty).create();
+//
+//        assertSame(expectedForVertexProperty, registry.getSerializer(VertexProperty.class));
+//        assertSame(expectedForProperty, registry.getSerializer(Property.class));
+//        assertSame(expectedForVertexProperty, registry.getSerializer(DataType.VERTEXPROPERTY));
+//        assertSame(expectedForProperty, registry.getSerializer(DataType.PROPERTY));
+//    }
+//
+//    @Test
+//    public void shouldUseFallbackResolverWhenThereIsNoMatch() {
+//        final int[] called = {0};
+//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+//                .withFallbackResolver(t -> {
+//                    called[0]++;
+//                    return null;
+//                }).create();
+//
+//        String message = null;
+//        try {
+//            registry.getSerializer(SamplePerson.class);
+//        } catch (SerializationException ex) {
+//            message = ex.getMessage();
+//        }
+//
+//        assertEquals("Serializer for type org.apache.tinkerpop.gremlin.driver.ser.binary.types.sample.SamplePerson not found", message);
+//        assertEquals(1, called[0]);
+//    }
+//
+//    @Test
+//    public void shouldUseFallbackResolverReturnValue() throws SerializationException {
+//        TypeSerializer expected = new SamplePersonSerializer();
+//        final int[] called = {0};
+//        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+//                .withFallbackResolver(t -> {
+//                    called[0]++;
+//                    return expected;
+//                }).create();
+//
+//        TypeSerializer<SamplePerson> serializer = registry.getSerializer(SamplePerson.class);
+//        assertEquals(1, called[0]);
+//        assertSame(expected, serializer);
+//    }
+//
+//    private static class TestVertexPropertySerializer extends TestBaseTypeSerializer<VertexProperty> {
+//
+//        @Override
+//        public DataType getDataType() {
+//            return DataType.VERTEXPROPERTY;
+//        }
+//    }
+//
+//    private static class TestPropertySerializer extends TestBaseTypeSerializer<Property> {
+//
+//        @Override
+//        public DataType getDataType() {
+//            return DataType.PROPERTY;
+//        }
+//    }
+//
+//    private static class TestUUIDSerializer extends TestBaseTypeSerializer<UUID> {
+//
+//        @Override
+//        public DataType getDataType() {
+//            return DataType.UUID;
+//        }
+//    }
+//
+//    private static abstract class TestBaseTypeSerializer<T> implements TypeSerializer<T> {
+//        @Override
+//        public T read(ByteBuf buffer, GraphBinaryReader context) {
+//            return null;
+//        }
+//
+//        @Override
+//        public T readValue(ByteBuf buffer, GraphBinaryReader context, boolean nullable) {
+//            return null;
+//        }
+//
+//        @Override
+//        public ByteBuf write(T value, ByteBufAllocator allocator, GraphBinaryWriter context) {
+//            return null;
+//        }
+//
+//        @Override
+//        public ByteBuf writeValue(T value, ByteBufAllocator allocator, GraphBinaryWriter context, boolean nullable) {
+//            return null;
+//        }
+//    }
+//}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CharSerializerTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/CharSerializerTest.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.driver.ser.binary.types;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class CharSerializerTest {
-    private final ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+    private final ByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
     private static final CharSerializer serializer = new CharSerializer();
 
     @Parameterized.Parameters(name = "Character={0}")
@@ -62,7 +63,8 @@ public class CharSerializerTest {
 
     @Test
     public void writeValueTest() throws SerializationException {
-        final ByteBuf actual= serializer.writeValue(charValue, allocator, null);
+        final ByteBuf actual = allocator.buffer();
+         serializer.writeValue(charValue, actual, null);
         final byte[] actualBytes = new byte[byteArray.length];
         actual.readBytes(actualBytes);
         assertTrue(Arrays.deepEquals(new byte[][]{byteArray}, new byte[][]{actualBytes}));

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphBinaryReaderWriterBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphBinaryReaderWriterBenchmark.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import org.apache.tinkerpop.benchmark.util.AbstractBenchmarkBase;
+import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
+import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@Warmup(time = 200, timeUnit = MILLISECONDS)
+public class GraphBinaryReaderWriterBenchmark extends AbstractBenchmarkBase {
+    private static GraphBinaryReader reader = new GraphBinaryReader();
+    private static GraphBinaryWriter writer = new GraphBinaryWriter();
+    private static UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
+
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+        public ByteBuf bytecodeBuffer1 = allocator.buffer(2048);
+        public ByteBuf bytecodeBuffer2 = allocator.buffer(2048);
+        public final Bytecode bytecode1 = new Bytecode();
+
+        public ByteBuf bufferWrite = allocator.buffer(2048);
+
+        public Bytecode bytecode2;
+
+        @Setup(Level.Trial)
+        public void doSetup() throws IOException, SerializationException {
+            bytecode1.addStep("V");
+            bytecode1.addStep("values", "name");
+            bytecode1.addStep("tail", 5);
+
+            Graph g = TinkerGraph.open();
+
+            bytecode2 = g.traversal()
+                    .addV("person")
+                    .property("name1", 1)
+                    .property("name2", UUID.randomUUID())
+                    .property("name3", InetAddress.getByAddress(new byte[] { 127, 0, 0, 1}))
+                    .property("name4", BigInteger.valueOf(33343455342245L))
+                    .property("name5", "kjlkdnvlkdrnvldnvndlrkvnlhkjdkgkrtnlkndblknlknonboirnlkbnrtbonrobinokbnrklnbkrnblktengotrngotkrnglkt")
+                    .property("name6", Instant.now())
+                    .property("name9", P.between(12, 15))
+                    .asAdmin().getBytecode();
+
+            writer.writeValue(bytecode1, bytecodeBuffer1, false);
+            writer.writeValue(bytecode2, bytecodeBuffer2, false);
+        }
+
+        @Setup(Level.Invocation)
+        public void setupInvocation() {
+            bytecodeBuffer1.readerIndex(0);
+            bytecodeBuffer2.readerIndex(0);
+            bufferWrite.readerIndex(0);
+            bufferWrite.writerIndex(0);
+        }
+
+        @TearDown(Level.Trial)
+        public void doTearDown() {
+            bytecodeBuffer1.release();
+            bytecodeBuffer2.release();
+            bufferWrite.release();
+        }
+    }
+
+    @Benchmark
+    public void writeBytecode1(BenchmarkState state) throws SerializationException {
+        writer.writeValue(state.bytecode1, state.bufferWrite, false);
+    }
+
+    @Benchmark
+    public void writeBytecode2(BenchmarkState state) throws SerializationException {
+        writer.writeValue(state.bytecode2, state.bufferWrite, false);
+    }
+
+    @Benchmark
+    public void readBytecode1(BenchmarkState state) throws SerializationException {
+        reader.readValue(state.bytecodeBuffer1, Bytecode.class, false);
+    }
+
+    @Benchmark
+    public void readBytecode2(BenchmarkState state) throws SerializationException {
+        reader.readValue(state.bytecodeBuffer2, Bytecode.class, false);
+    }
+}

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphBinaryReaderWriterBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphBinaryReaderWriterBenchmark.java
@@ -25,12 +25,10 @@ import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.driver.ser.binary.GraphBinaryWriter;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -77,7 +75,6 @@ public class GraphBinaryReaderWriterBenchmark extends AbstractBenchmarkBase {
                     .property("name4", BigInteger.valueOf(33343455342245L))
                     .property("name5", "kjlkdnvlkdrnvldnvndlrkvnlhkjdkgkrtnlkndblknlknonboirnlkbnrtbonrobinokbnrklnbkrnblktengotrngotkrnglkt")
                     .property("name6", Instant.now())
-                    .property("name9", P.between(12, 15))
                     .asAdmin().getBytecode();
 
             writer.writeValue(bytecode1, bytecodeBuffer1, false);

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphSONMapperBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphSONMapperBenchmark.java
@@ -20,7 +20,6 @@ package org.apache.tinkerpop.gremlin.driver;
 
 import org.apache.tinkerpop.benchmark.util.AbstractBenchmarkBase;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapper;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
@@ -74,7 +73,6 @@ public class GraphSONMapperBenchmark extends AbstractBenchmarkBase {
                     .property("name4", BigInteger.valueOf(33343455342245L))
                     .property("name5", "kjlkdnvlkdrnvldnvndlrkvnlhkjdkgkrtnlkndblknlknonboirnlkbnrtbonrobinokbnrklnbkrnblktengotrngotkrnglkt")
                     .property("name6", Instant.now())
-                    .property("name9", P.between(12, 15))
                     .asAdmin().getBytecode();
 
 

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphSONMapperBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/GraphSONMapperBenchmark.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.apache.tinkerpop.benchmark.util.AbstractBenchmarkBase;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapper;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONXModuleV3d0;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@Warmup(time = 200, timeUnit = MILLISECONDS)
+public class GraphSONMapperBenchmark extends AbstractBenchmarkBase {
+    private static final ObjectMapper mapper = GraphSONMapper.build()
+            .version(GraphSONVersion.V3_0)
+            .addCustomModule(GraphSONXModuleV3d0.build().create(false))
+            .create().createMapper();
+
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+
+        public byte[] bytecodeBytes1;
+        private byte[] bytecodeBytes2;
+        private final Bytecode bytecode1 = new Bytecode();
+        private Bytecode bytecode2;
+
+        @Setup(Level.Trial)
+        public void doSetup() throws IOException {
+            bytecode1.addStep("V");
+            bytecode1.addStep("values", "name");
+            bytecode1.addStep("tail", 5);
+
+            Graph g = TinkerGraph.open();
+
+            bytecode2 = g.traversal()
+                    .addV("person")
+                    .property("name1", 1)
+                    .property("name2", UUID.randomUUID())
+                    .property("name3", InetAddress.getByAddress(new byte[] { 127, 0, 0, 1}))
+                    .property("name4", BigInteger.valueOf(33343455342245L))
+                    .property("name5", "kjlkdnvlkdrnvldnvndlrkvnlhkjdkgkrtnlkndblknlknonboirnlkbnrtbonrobinokbnrklnbkrnblktengotrngotkrnglkt")
+                    .property("name6", Instant.now())
+                    .property("name9", P.between(12, 15))
+                    .asAdmin().getBytecode();
+
+
+            bytecodeBytes1 = mapper.writeValueAsBytes(bytecode1);
+            bytecodeBytes2 = mapper.writeValueAsBytes(bytecode2);
+        }
+
+        @TearDown(Level.Trial)
+        public void doTearDown() {
+        }
+    }
+
+    @Benchmark
+    public void readBytecode1(BenchmarkState state) throws IOException {
+        mapper.readValue(state.bytecodeBytes1, Bytecode.class);
+    }
+
+    @Benchmark
+    public void readBytecode2(BenchmarkState state) throws IOException {
+        mapper.readValue(state.bytecodeBytes2, Bytecode.class);
+    }
+
+    @Benchmark
+    public void writeBytecode1(BenchmarkState state) throws IOException {
+        mapper.writeValueAsString(state.bytecode1);
+    }
+
+    @Benchmark
+    public void writeBytecode2(BenchmarkState state) throws IOException {
+        mapper.writeValueAsBytes(state.bytecode2);
+    }
+}

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/SerializationBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/SerializationBenchmark.java
@@ -19,8 +19,8 @@
 package org.apache.tinkerpop.gremlin.driver;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.tinkerpop.benchmark.util.AbstractBenchmarkBase;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
@@ -32,11 +32,17 @@ import org.apache.tinkerpop.gremlin.driver.ser.binary.DataType;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@Warmup(time = 200, timeUnit = MILLISECONDS)
 public class SerializationBenchmark extends AbstractBenchmarkBase {
+
+    private static final UnpooledByteBufAllocator allocator = new UnpooledByteBufAllocator(false);
 
     private static final ByteBuf RequestMessageGraphSONBuffer1 = Unpooled.wrappedBuffer(
             ("{\"requestId\":{\"@type\":\"g:UUID\",\"@value\":\"9b6d17c0-c5a9-418e-bff6-a25fbb1b175e\"}," +
@@ -142,27 +148,25 @@ public class SerializationBenchmark extends AbstractBenchmarkBase {
 
     @Benchmark
     public void testWriteResponseBinary() throws SerializationException {
-        ByteBuf buffer = binarySerializer.serializeResponseAsBinary(response, ByteBufAllocator.DEFAULT);
+        final ByteBuf buffer = binarySerializer.serializeResponseAsBinary(response, allocator);
         buffer.release();
     }
 
     @Benchmark
     public void testWriteResponseGraphSON() throws SerializationException {
-        ByteBuf buffer = graphsonSerializer.serializeResponseAsBinary(response, ByteBufAllocator.DEFAULT);
+        final ByteBuf buffer = graphsonSerializer.serializeResponseAsBinary(response, allocator);
         buffer.release();
     }
 
     @Benchmark
     public void testWriteBytecodeBinary() throws SerializationException {
-
-        ByteBuf buffer = binarySerializer.serializeRequestAsBinary(request, ByteBufAllocator.DEFAULT);
+        final ByteBuf buffer = binarySerializer.serializeRequestAsBinary(request, allocator);
         buffer.release();
     }
 
     @Benchmark
     public void testWriteBytecodeGraphSON() throws SerializationException {
-
-        ByteBuf buffer = graphsonSerializer.serializeRequestAsBinary(request, ByteBufAllocator.DEFAULT);
+        final ByteBuf buffer = graphsonSerializer.serializeRequestAsBinary(request, allocator);
         buffer.release();
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2161
https://issues.apache.org/jira/browse/TINKERPOP-2153

Improve write path by reusing the same buffer.

For serializers this is an API change but given that GraphBinary was introduced recently, I think we can get away with it.