### PR TITLE
Bump dependencies for httpclient, commons-codec, slf4j

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `globalFunctionCacheEnabled` override to `SessionOpProcessor` configuration.
 * Added status code to `GremlinServerError` so that it would be more directly accessible during failures.
 * Added GraphSON serialization support for `Duration`, `Char`, `ByteBuffer`, `Byte`, `BigInteger` and `BigDecimal` in `gremlin-python`.
+* Bumped `httpclient` to 4.5.7.
+* Bumped `slf4j` to 1.7.25.
+* Bumped `commons-codec` to 1.12.
 * Fixed concurrency issues in `TraverserSet.toString()` and `ObjectWritable.toString()`.
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.
 * Improved handling of failing `Authenticator` instances thus improving server responses to drivers.

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -40,6 +40,11 @@ limitations under the License.
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <!-- commons-codec is a dependency of httpclient - excluded in root pom to bring all commons-codec versions inline -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>

--- a/gremlin-console/src/main/static/LICENSE
+++ b/gremlin-console/src/main/static/LICENSE
@@ -223,9 +223,9 @@ MIT Licenses
 
 The Apache TinkerPop project bundles the following components under the MIT License:
 
-     JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.21 - http://www.slf4j.org) - for details, see licenses/slf4j
-     SLF4J API Module (org.slf4j:slf4j-api:1.7.21 - http://www.slf4j.org) - for details, see licenses/slf4j
-     SLF4J LOG4J-12 Binding (org.slf4j:slf4j-log4j12:1.7.21 - http://www.slf4j.org) - for details, see licenses/slf4j
+     JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
+     SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
+     SLF4J LOG4J-12 Binding (org.slf4j:slf4j-log4j12:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
      Foundation stylesheet for CodeRay (http://foundation.zurb.com) - for details, see licenses/foundation
      normalize.css 2.1.2 (http://necolas.github.io/normalize.css/) - for details, see licenses/normalize
 

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -5,11 +5,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------
-Apache Commons Codec 1.9 (AL ASF)
+Apache Commons Codec 1.12 (AL ASF)
 ------------------------------------------------------------------------
 src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
 contains test data from http://aspell.net/test/orig/batch0.tab.
 Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+
+The content of package org.apache.commons.codec.language.bm has been translated
+from the original php source code available at http://stevemorse.org/phoneticinfo.htm
+with permission from the original authors.
+Original source copyright:
+Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
 
 ------------------------------------------------------------------------
 Apache Commons Lang 3.3.1/2.6 (AL ASF)

--- a/gremlin-console/src/main/static/licenses/slf4j
+++ b/gremlin-console/src/main/static/licenses/slf4j
@@ -1,4 +1,4 @@
- Copyright (c) 2004-2013 QOS.ch
+ Copyright (c) 2004-2017 QOS.ch
  All rights reserved.
 
  Permission is hereby granted, free  of charge, to any person obtaining

--- a/gremlin-server/src/main/static/LICENSE
+++ b/gremlin-server/src/main/static/LICENSE
@@ -223,9 +223,9 @@ MIT Licenses
 
 The Apache TinkerPop project bundles the following components under the MIT License:
 
-     JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.21 - http://www.slf4j.org) - for details, see licenses/slf4j
-     SLF4J API Module (org.slf4j:slf4j-api:1.7.21 - http://www.slf4j.org) - for details, see licenses/slf4j
-     SLF4J LOG4J-12 Binding (org.slf4j:slf4j-log4j12:1.7.21 - http://www.slf4j.org) - for details, see licenses/slf4j
+     JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
+     SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
+     SLF4J LOG4J-12 Binding (org.slf4j:slf4j-log4j12:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
      Foundation stylesheet for CodeRay (http://foundation.zurb.com) - for details, see licenses/foundation
      normalize.css 2.1.2 (http://necolas.github.io/normalize.css/) - for details, see licenses/normalize
 

--- a/gremlin-server/src/main/static/licenses/slf4j
+++ b/gremlin-server/src/main/static/licenses/slf4j
@@ -1,4 +1,4 @@
- Copyright (c) 2004-2013 QOS.ch
+ Copyright (c) 2004-2017 QOS.ch
  All rights reserved.
 
  Permission is hereby granted, free  of charge, to any person obtaining

--- a/gremlin-test/pom.xml
+++ b/gremlin-test/pom.xml
@@ -34,7 +34,6 @@ limitations under the License.
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -102,12 +102,10 @@ limitations under the License.
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ limitations under the License.
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
         <netty.version>4.0.56.Final</netty.version>
-        <slf4j.version>1.7.21</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <spark.version>2.2.0</spark.version>
 
@@ -727,7 +727,14 @@ limitations under the License.
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.5</version>
+                <version>4.5.7</version>
+                <exclusions>
+                    <!-- bring commons-codec in line with TinkerPop -->
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
@@ -780,6 +787,16 @@ limitations under the License.
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.3</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.5</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.12</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Didn't bother to create a JIRA ticket for this as these are basically a batch of lesser version bumps and other pom maintenance type updates. Unified the commons-codec version throughout TinkerPop and setup more reusable dependencyManagement configuration in the parent pom. Updated license/notice as needed given these changes.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1