### PR TITLE
TINKERPOP-1992 count has negative time in profile

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `globalFunctionCacheEnabled` override to `SessionOpProcessor` configuration.
 * Added status code to `GremlinServerError` so that it would be more directly accessible during failures.
 * Added GraphSON serialization support for `Duration`, `Char`, `ByteBuffer`, `Byte`, `BigInteger` and `BigDecimal` in `gremlin-python`.
+* Added `ProfilingAware` interface to allow steps to be notified that `profile()` was being called.
+* Fixed bug where `profile()` could produce negative timings when `group()` contained a reducing barrier.
 * Bumped `httpclient` to 4.5.7.
 * Bumped `slf4j` to 1.7.25.
 * Bumped `commons-codec` to 1.12.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ProfilingAware.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ProfilingAware.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step;
+
+import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroupStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Marks a {@link Step} as one that is aware of profiling. A good example of where this is important is with
+ * {@link GroupStep} which needs to track and hold a {@link Barrier}, which is important for the
+ * {@link ProfileStrategy} to know about. Once the {@link ProfileStep} is injected the {@link Barrier} needs to be
+ * recalculated so that the timer can be properly started on the associated {@link ProfileStep}. Without that indirect
+ * start of the timer, the operation related to the {@link Barrier} will not be properly accounted for and when
+ * metrics are normalized it is possible to end up with a negative timing.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public interface ProfilingAware {
+
+    /**
+     * Prepares the step for any internal changes that might help ensure that profiling will work as expected.
+     */
+    public void prepareForProfiling();
+
+    /**
+     * A helper class which holds a {@link Barrier} and it's related {@link ProfileStep} so that the latter can have
+     * its timer started and stopped appropriately.
+     */
+    public static final class ProfiledBarrier implements Barrier {
+
+        private final Barrier barrier;
+        private final ProfileStep profileStep;
+
+        public ProfiledBarrier(final Barrier barrier, final ProfileStep profileStep) {
+            this.barrier = barrier;
+            this.profileStep = profileStep;
+        }
+
+        @Override
+        public void processAllStarts() {
+            this.profileStep.start();
+            this.barrier.processAllStarts();
+            this.profileStep.stop();
+        }
+
+        @Override
+        public boolean hasNextBarrier() {
+            this.profileStep.start();
+            final boolean b = this.barrier.hasNextBarrier();
+            this.profileStep.stop();
+            return b;
+        }
+
+        @Override
+        public Object nextBarrier() throws NoSuchElementException {
+            this.profileStep.start();
+            final Object o = this.barrier.nextBarrier();
+            this.profileStep.stop();
+            return o;
+        }
+
+        @Override
+        public void addBarrier(final Object barrier) {
+            this.barrier.addBarrier(barrier);
+        }
+
+        @Override
+        public MemoryComputeKey getMemoryComputeKey() {
+            return this.barrier.getMemoryComputeKey();
+        }
+
+        @Override
+        public void done() {
+            this.barrier.done();
+        }
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
@@ -82,6 +82,9 @@ public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>> 
             final Step step = steps.get(ix);
             if (step instanceof Barrier && !(step instanceof LocalBarrier)) {
                 final Barrier b = (Barrier) step;
+
+                // when profile() is enabled the step needs to be wrapped up with the barrier so that the timer on
+                // the ProfileStep is properly triggered
                 if (ix < steps.size() - 1 && steps.get(ix + 1) instanceof ProfileStep)
                     return new ProfilingAware.ProfiledBarrier(b, (ProfileStep) steps.get(ix + 1));
                 else

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
@@ -126,7 +126,12 @@ public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>> 
 
         // reset the barrierStep as there are now ProfileStep instances present and the timers won't start right
         // without specific configuration through wrapping both the Barrier and ProfileStep in ProfiledBarrier
-        if (resetBarrierForProfiling) barrierStep = determineBarrierStep(valueTraversal);
+        if (resetBarrierForProfiling) {
+            barrierStep = determineBarrierStep(valueTraversal);
+
+            // the barrier only needs to be reset once
+            resetBarrierForProfiling = false;
+        }
 
         if (null == this.barrierStep) {
             if (this.valueTraversal.hasNext())

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
@@ -100,7 +100,12 @@ public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implem
 
         // reset the barrierStep as there are now ProfileStep instances present and the timers won't start right
         // without specific configuration through wrapping both the Barrier and ProfileStep in ProfiledBarrier
-        if (resetBarrierForProfiling) barrierStep = GroupStep.determineBarrierStep(valueTraversal);
+        if (resetBarrierForProfiling) {
+            barrierStep = GroupStep.determineBarrierStep(valueTraversal);
+
+            // the barrier only needs to be reset once
+            resetBarrierForProfiling = false;
+        }
 
         if (null == this.barrierStep) {
             if (this.valueTraversal.hasNext())

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
@@ -24,9 +24,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ProfilingAware;
 import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroupStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
@@ -42,12 +44,13 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implements SideEffectCapable<Map<K, ?>, Map<K, V>>, TraversalParent, ByModulating {
+public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implements SideEffectCapable<Map<K, ?>, Map<K, V>>, TraversalParent, ByModulating, ProfilingAware {
 
     private char state = 'k';
     private Traversal.Admin<S, K> keyTraversal;
     private Traversal.Admin<S, V> valueTraversal;
     private Barrier barrierStep;
+    private boolean resetBarrierForProfiling = false;
     ///
     private String sideEffectKey;
 
@@ -60,6 +63,15 @@ public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implem
                 new GroupStep.GroupBiOperator<>(null == this.barrierStep ?
                         Operator.assign :
                         this.barrierStep.getMemoryComputeKey().getReducer()));
+    }
+
+    /**
+     * Reset the {@link Barrier} on the step to be wrapped in a {@link ProfilingAware.ProfiledBarrier} which can
+     * properly start/stop the timer on the associated {@link ProfileStep}.
+     */
+    @Override
+    public void prepareForProfiling() {
+        resetBarrierForProfiling = barrierStep != null;
     }
 
     @Override
@@ -85,6 +97,11 @@ public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implem
         final Map<K, V> map = new HashMap<>(1);
         this.valueTraversal.reset();
         this.valueTraversal.addStart(traverser);
+
+        // reset the barrierStep as there are now ProfileStep instances present and the timers won't start right
+        // without specific configuration through wrapping both the Barrier and ProfileStep in ProfiledBarrier
+        if (resetBarrierForProfiling) barrierStep = GroupStep.determineBarrierStep(valueTraversal);
+
         if (null == this.barrierStep) {
             if (this.valueTraversal.hasNext())
                 map.put(TraversalUtil.applyNullable(traverser, this.keyTraversal), (V) this.valueTraversal.next());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ProfileStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ProfileStep.java
@@ -46,6 +46,15 @@ public final class ProfileStep<S> extends AbstractStep<S, S> implements MemoryCo
         return metrics;
     }
 
+    public void start() {
+        this.initializeIfNeeded();
+        this.metrics.start();
+    }
+
+    public void stop() {
+        this.metrics.stop();
+    }
+
     @Override
     public Traverser.Admin<S> next() {
         Traverser.Admin<S> start = null;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ProfileStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ProfileStep.java
@@ -46,15 +46,6 @@ public final class ProfileStep<S> extends AbstractStep<S, S> implements MemoryCo
         return metrics;
     }
 
-    public void start() {
-        this.initializeIfNeeded();
-        this.metrics.start();
-    }
-
-    public void stop() {
-        this.metrics.stop();
-    }
-
     @Override
     public Traverser.Admin<S> next() {
         Traverser.Admin<S> start = null;
@@ -117,6 +108,21 @@ public final class ProfileStep<S> extends AbstractStep<S, S> implements MemoryCo
         final ProfileStep<S> clone = (ProfileStep<S>) super.clone();
         clone.metrics = null;
         return clone;
+    }
+
+    /**
+     * Starts the metrics timer.
+     */
+    public void start() {
+        this.initializeIfNeeded();
+        this.metrics.start();
+    }
+
+    /**
+     * Stops the metrics timer.
+     */
+    public void stop() {
+        this.metrics.stop();
     }
 
     /////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ProfileStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ProfileStrategy.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.VertexPr
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ProfilingAware;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileSideEffectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
@@ -57,7 +58,13 @@ public final class ProfileStrategy extends AbstractTraversalStrategy<TraversalSt
                 if (steps.get(i * 2) instanceof ProfileSideEffectStep)
                     break;
                 // Create and inject ProfileStep
-                traversal.addStep((i * 2) + 1, new ProfileStep(traversal));
+                final ProfileStep profileStepToAdd = new ProfileStep(traversal);
+                traversal.addStep((i * 2) + 1, profileStepToAdd);
+
+                final Step stepToBeProfiled = traversal.getSteps().get(i * 2);
+                if (stepToBeProfiled instanceof ProfilingAware) {
+                    ((ProfilingAware) stepToBeProfiled).prepareForProfiling();
+                }
             }
         }
     }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -24,6 +24,9 @@ import org.apache.tinkerpop.gremlin.GraphHelper;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.util.Metrics;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -66,9 +69,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -622,6 +628,25 @@ public class TinkerGraphTest {
         assertNotSame("cloned elements should reference to different objects",
             original.traversal().V().has("name", "stephen").next(),
             clone.traversal().V().has("name", "stephen").next());
+    }
+
+    /**
+     * This isn't a TinkerGraph specific test, but TinkerGraph is probably best suited for the testing of this
+     * particular problem originally noted in TINKERPOP-1992.
+     */
+    @Test
+    public void shouldProperlyTimeReducingBarrierForProfile() {
+        final GraphTraversalSource g = TinkerFactory.createModern().traversal();
+
+        TraversalMetrics m = g.V().group().by().by(__.bothE().count()).profile().next();
+        for (Metrics i : m.getMetrics(1).getNested()) {
+            assertThat(i.getDuration(TimeUnit.NANOSECONDS), greaterThan(0L));
+        }
+
+        m = g.withComputer().V().group().by().by(__.bothE().count()).profile().next();
+        for (Metrics i : m.getMetrics(1).getNested()) {
+            assertThat(i.getDuration(TimeUnit.NANOSECONDS), greaterThan(0L));
+        }
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1992

Not sure if this the best way to do this but basically introduced an interface called `ProfilingAware` that makes it so that `ProfileStrategy` can notify that step that "profiling" is happening so that the step has a chance to get its life in order. For this particular problem, that meant that `group()` needed to reset its reducing barrier step (if present) for its value traversal (i.e. second `by()` modulator) so that it could internally start the profile timer (which doesn't happen otherwise. 

Tested manually for both OLTP and OLAP and it all worked.

All tests pass with `docker/build.sh -t -i`

VOTE +1