### PR TITLE
TINKERPOP-2167 Traversals as async iterables in gremlin-javascript

### DIFF
--- a/gremlin-javascript/glv/TraversalSource.template
+++ b/gremlin-javascript/glv/TraversalSource.template
@@ -37,6 +37,13 @@ class Traversal {
     this._traversersIteratorIndex = 0;
   }
 
+  /**
+   * Async iterable method implementation.
+   */
+  [Symbol.asyncIterator]() {
+    return this
+  }
+
   /** @returns {Bytecode} */
   getBytecode() {
     return this.bytecode;

--- a/gremlin-javascript/glv/TraversalSource.template
+++ b/gremlin-javascript/glv/TraversalSource.template
@@ -24,6 +24,7 @@
 
 const utils = require('../utils');
 const itemDone = Object.freeze({ value: null, done: true });
+const asyncIteratorSymbol = Symbol.asyncIterator || Symbol('@@asyncIterator');
 
 class Traversal {
   constructor(graph, traversalStrategies, bytecode) {
@@ -40,8 +41,8 @@ class Traversal {
   /**
    * Async iterable method implementation.
    */
-  [Symbol.asyncIterator]() {
-    return this
+  [asyncIteratorSymbol]() {
+    return this;
   }
 
   /** @returns {Bytecode} */

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -37,6 +37,13 @@ class Traversal {
     this._traversersIteratorIndex = 0;
   }
 
+  /**
+   * Async iterable method implementation.
+   */
+  [Symbol.asyncIterator]() {
+    return this
+  }
+
   /** @returns {Bytecode} */
   getBytecode() {
     return this.bytecode;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -24,6 +24,7 @@
 
 const utils = require('../utils');
 const itemDone = Object.freeze({ value: null, done: true });
+const asyncIteratorSymbol = Symbol.asyncIterator || Symbol('@@asyncIterator');
 
 class Traversal {
   constructor(graph, traversalStrategies, bytecode) {
@@ -40,8 +41,8 @@ class Traversal {
   /**
    * Async iterable method implementation.
    */
-  [Symbol.asyncIterator]() {
-    return this
+  [asyncIteratorSymbol]() {
+    return this;
   }
 
   /** @returns {Bytecode} */

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
@@ -122,6 +122,15 @@ describe('Traversal', function () {
     });
   });
 
+  if (Symbol.asyncIterator) {
+    describe('@@asyncIterator', function () {
+      it('should expose the async iterator', function () {
+        const traversal = new t.Traversal(null, null, null);
+        assert.strictEqual(typeof traversal[Symbol.asyncIterator], 'function');
+      });
+    });
+  }
+
   describe('#toList()', function () {
 
     it('should apply the strategies and return a Promise with an array', function () {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2167

Summary of changes:
- Added `[Symbol.asyncIterator]` member to the Traversal class to support `for await ... of` loops (async iterables)

Change was tested by modifying the latest published version of `gremlin` on npm. Reviewed current tests for `gremlin-javascript` and saw none that might conflict.