### PR TITLE
Fix error in 'The First Five Minutes' section

### DIFF
--- a/docs/src/tutorials/getting-started/index.asciidoc
+++ b/docs/src/tutorials/getting-started/index.asciidoc
@@ -151,7 +151,7 @@ g.V(1).out('knows').has('age', gt(30)).values('name')    <7>
 <4> Get the edges with the label "knows" for the vertex with the unique identifier of "1".
 <5> Get the names of the people that the vertex with the unique identifier of "1" "knows".
 <6> Note that when one uses `outE().inV()` as shown in the previous command, this can be shortened to just `out()`
-(similar to `inE().inV()` and `in` for incoming edges).
+(similar to `inE().outV()` and `in()` for incoming edges).
 <7> Get the names of the people vertex "1" knows who are over the age of 30.
 
 IMPORTANT: A `Traversal` is essentially an `Iterator` so if you have code like `x = g.V()`, the `x` does not contain


### PR DESCRIPTION
[The First Five Minutes](https://tinkerpop.apache.org/docs/current/tutorials/getting-started/#_the_first_five_minutes) section contains a small error.

`inE().inV()` is not equivalent to `in()`, `inE().outV()` is.

Example showing this:

```
gremlin> graph = TinkerFactory.createModern()
==>tinkergraph[vertices:6 edges:6]

gremlin> g = graph.traversal()
==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]

gremlin> g.V(3).inE().inV()
==>v[3]
==>v[3]
==>v[3]

gremlin> g.V(3).inE().outV()
==>v[1]
==>v[4]
==>v[6]

gremlin> g.V(3).in()
==>v[1]
==>v[4]
==>v[6]
```

