### PR TITLE
TINKERPOP-2171 Allow sparql() to be extended with Gremlin steps.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ This release also includes changes from <<release-3-3-6, 3.3.6>>.
 * Release working buffers in case of failure for GraphBinary.
 * GraphBinary: Use the same `ByteBuf` instance to write during serialization. Changed signature of write methods in type serializers.
 * Remove unused parameter in GraphBinary's `ResponseMessageSerializer`.
+* Changed `SparqlTraversalSource` so as to enable Gremlin steps to be used to process results from the `sparql()` step.
 * GraphBinary: Cache expression to obtain the method in `PSerializer`.
 
 [[release-3-4-0]]

--- a/docs/src/reference/compilers.asciidoc
+++ b/docs/src/reference/compilers.asciidoc
@@ -413,3 +413,20 @@ WHERE {
   ?software v:lang ?lang .
   ?software v:name ?name . }""")
 ----
+
+[[sparql-with-gremlin]]
+=== With Gremlin
+
+The `sparql()`-step takes a SPARQL query and returns a result. That result can be further processed by standard Gremlin
+steps, which introduces some interesting possibilities.
+
+[gremlin-groovy,modern]
+----
+g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }")
+g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }").select("name")
+g.sparql("SELECT * WHERE { }").out("knows").values("name")
+g.withSack(1.0f).sparql("SELECT * WHERE { }").
+  repeat(outE().sack(mult).by("weight").inV()).
+    times(2).
+  sack()
+----

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -27,6 +27,44 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.4.1/CHANGELOG.asciidoc#release-3-4-1[changelog] for a complete list of all the modifications that are part of this release.
 
+=== Upgrading for Users
+
+==== Mix SPARQL and Gremlin
+
+In the initial release of `sparql-gremlin` it was only possible to execute a SPARQL query and have it translate to
+Gremlin. Therefore, it was only possible to write a query like this:
+
+```text
+gremlin> g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }")
+==>[name:marko,age:29]
+==>[name:vadas,age:27]
+==>[name:josh,age:32]
+==>[name:peter,age:35]
+gremlin> g.sparql("SELECT * WHERE { }")
+==>v[1]
+==>v[2]
+==>v[3]
+==>v[4]
+==>v[5]
+==>v[6]
+```
+
+In this release, however, it is now possible to further process that result with Gremlin steps:
+
+```text
+gremlin> g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }").select("name")
+==>marko
+==>vadas
+==>josh
+==>peter
+gremlin> g.sparql("SELECT * WHERE { }").out("knows").values("name")
+==>vadas
+==>josh
+```
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2171[TINKERPOP-2171],
+link:http://tinkerpop.apache.org/docs/3.4.1/reference/#sparql-with-gremlin[Reference Documentation]
+
 === Upgrading for Providers
 
 ==== Graph Database Providers

--- a/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSource.java
+++ b/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSource.java
@@ -19,13 +19,17 @@
 package org.apache.tinkerpop.gremlin.sparql.process.traversal.dsl.sparql;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.process.computer.Computer;
+import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectStep;
 import org.apache.tinkerpop.gremlin.sparql.process.traversal.strategy.SparqlStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -33,121 +37,167 @@ import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
+import java.util.function.BinaryOperator;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
 /**
  * A {@link TraversalSource} implementation that spawns {@link SparqlTraversal} instances.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public class SparqlTraversalSource implements TraversalSource {
-    protected transient RemoteConnection connection;
-    protected final Graph graph;
-    protected TraversalStrategies strategies;
-    protected Bytecode bytecode = new Bytecode();
+public class SparqlTraversalSource extends GraphTraversalSource {
 
     public SparqlTraversalSource(final Graph graph, final TraversalStrategies traversalStrategies) {
-        this.graph = graph;
-        this.strategies = traversalStrategies;
+        super(graph, traversalStrategies);
     }
 
     public SparqlTraversalSource(final Graph graph) {
-        this(graph, TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+        super(graph);
     }
 
     public SparqlTraversalSource(final RemoteConnection connection) {
-        this(EmptyGraph.instance(), TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class).clone());
-        this.connection = connection;
-        this.strategies.addStrategies(new RemoteStrategy(connection));
-    }
-
-    @Override
-    public TraversalStrategies getStrategies() {
-        return this.strategies;
-    }
-
-    @Override
-    public Graph getGraph() {
-        return this.graph;
-    }
-
-    @Override
-    public Bytecode getBytecode() {
-        return this.bytecode;
+        super(connection);
     }
 
     @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
     public SparqlTraversalSource clone() {
-        try {
-            final SparqlTraversalSource clone = (SparqlTraversalSource) super.clone();
-            clone.strategies = this.strategies.clone();
-            clone.bytecode = this.bytecode.clone();
-            return clone;
-        } catch (final CloneNotSupportedException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
+        return (SparqlTraversalSource) super.clone();
     }
 
     //// CONFIGURATIONS
 
+
+    @Override
+    public SparqlTraversalSource with(final String key) {
+        return (SparqlTraversalSource) super.with(key);
+    }
+
+    @Override
+    public SparqlTraversalSource with(final String key, final Object value) {
+        return (SparqlTraversalSource) super.with(key, value);
+    }
+
+    @Override
+    public SparqlTraversalSource withComputer(final Computer computer) {
+        return (SparqlTraversalSource) super.withComputer(computer);
+    }
+
+    @Override
+    public SparqlTraversalSource withComputer(final Class<? extends GraphComputer> graphComputerClass) {
+        return (SparqlTraversalSource) super.withComputer(graphComputerClass);
+    }
+
+    @Override
+    public SparqlTraversalSource withComputer() {
+        return (SparqlTraversalSource) super.withComputer();
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSideEffect(final String key, final Supplier<A> initialValue, final BinaryOperator<A> reducer) {
+        return (SparqlTraversalSource) super.withSideEffect(key, initialValue, reducer);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSideEffect(final String key, final A initialValue, final BinaryOperator<A> reducer) {
+        return (SparqlTraversalSource) super.withSideEffect(key, initialValue, reducer);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSideEffect(final String key, final A initialValue) {
+        return (SparqlTraversalSource) super.withSideEffect(key, initialValue);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSideEffect(final String key, final Supplier<A> initialValue) {
+        return (SparqlTraversalSource) super.withSideEffect(key, initialValue);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final Supplier<A> initialValue, final UnaryOperator<A> splitOperator, final BinaryOperator<A> mergeOperator) {
+        return (SparqlTraversalSource) super.withSack(initialValue, splitOperator, mergeOperator);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final A initialValue, final UnaryOperator<A> splitOperator, final BinaryOperator<A> mergeOperator) {
+        return (SparqlTraversalSource) super.withSack(initialValue, splitOperator, mergeOperator);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final A initialValue) {
+        return (SparqlTraversalSource) super.withSack(initialValue);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final Supplier<A> initialValue) {
+        return (SparqlTraversalSource) super.withSack(initialValue);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final Supplier<A> initialValue, final UnaryOperator<A> splitOperator) {
+        return (SparqlTraversalSource) super.withSack(initialValue, splitOperator);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final A initialValue, final UnaryOperator<A> splitOperator) {
+        return (SparqlTraversalSource) super.withSack(initialValue, splitOperator);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final Supplier<A> initialValue, final BinaryOperator<A> mergeOperator) {
+        return (SparqlTraversalSource) super.withSack(initialValue, mergeOperator);
+    }
+
+    @Override
+    public <A> SparqlTraversalSource withSack(final A initialValue, final BinaryOperator<A> mergeOperator) {
+        return (SparqlTraversalSource) super.withSack(initialValue, mergeOperator);
+    }
+
+    @Override
+    public SparqlTraversalSource withBulk(final boolean useBulk) {
+        return (SparqlTraversalSource) super.withBulk(useBulk);
+    }
+
+    @Override
+    public SparqlTraversalSource withPath() {
+        return (SparqlTraversalSource) super.withPath();
+    }
+
     @Override
     public SparqlTraversalSource withStrategies(final TraversalStrategy... traversalStrategies) {
-        return (SparqlTraversalSource) TraversalSource.super.withStrategies(traversalStrategies);
+        return (SparqlTraversalSource) super.withStrategies(traversalStrategies);
     }
 
     @Override
     @SuppressWarnings({"unchecked"})
     public SparqlTraversalSource withoutStrategies(final Class<? extends TraversalStrategy>... traversalStrategyClasses) {
-        return (SparqlTraversalSource) TraversalSource.super.withoutStrategies(traversalStrategyClasses);
+        return (SparqlTraversalSource) super.withoutStrategies(traversalStrategyClasses);
     }
 
     @Override
     public SparqlTraversalSource withRemote(final Configuration conf) {
-        return (SparqlTraversalSource) TraversalSource.super.withRemote(conf);
+        return (SparqlTraversalSource) super.withRemote(conf);
     }
 
     @Override
     public SparqlTraversalSource withRemote(final String configFile) throws Exception {
-        return (SparqlTraversalSource) TraversalSource.super.withRemote(configFile);
+        return (SparqlTraversalSource) super.withRemote(configFile);
     }
 
     @Override
     public SparqlTraversalSource withRemote(final RemoteConnection connection) {
-        try {
-            // check if someone called withRemote() more than once, so just release resources on the initial
-            // connection as you can't have more than one. maybe better to toss IllegalStateException??
-            if (this.connection != null)
-                this.connection.close();
-        } catch (Exception ignored) {
-            // not sure there's anything to do here
-        }
-        this.connection = connection;
-        final TraversalSource clone = this.clone();
-        clone.getStrategies().addStrategies(new RemoteStrategy(connection));
-        return (SparqlTraversalSource) clone;
+        return (SparqlTraversalSource) super.withRemote(connection);
     }
 
     /**
      * The start step for a SPARQL based traversal that accepts a string representation of the query to execute.
      */
-    public <S> SparqlTraversal<S,?> sparql(final String query) {
+    public <S> GraphTraversal<S,?> sparql(final String query) {
         final SparqlTraversalSource clone = this.withStrategies(SparqlStrategy.instance()).clone();
 
         // the inject() holds the sparql which the SparqlStrategy then detects and converts to a traversal
         clone.bytecode.addStep(GraphTraversal.Symbols.inject, query);
-        final SparqlTraversal.Admin<S, S> traversal = new DefaultSparqlTraversal<>(clone);
+        final GraphTraversal.Admin<S, S> traversal = new DefaultGraphTraversal(clone);
         return traversal.addStep(new InjectStep<>(traversal, query));
-    }
-
-    public Transaction tx() {
-        return this.graph.tx();
-    }
-
-    @Override
-    public void close() throws Exception {
-        if (connection != null) connection.close();
-    }
-
-    @Override
-    public String toString() {
-        return StringFactory.traversalSourceString(this);
     }
 }

--- a/sparql-gremlin/src/test/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSourceTest.java
+++ b/sparql-gremlin/src/test/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/dsl/sparql/SparqlTraversalSourceTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.sparql.process.traversal.dsl.sparql;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
@@ -28,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.Operator.mult;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
@@ -42,6 +46,25 @@ public class SparqlTraversalSourceTest {
     private static final SparqlTraversalSource g = graph.traversal(SparqlTraversalSource.class);
     private static final GraphTraversalSource _g = graph.traversal();
 
+    @Test
+    public void shouldStartWithSparqlReturningMapAndEndWithGremlin() {
+        final List<?> x = g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }").select("name").toList();
+        assertThat(x, containsInAnyOrder("marko", "vadas", "josh", "peter"));
+    }
+
+    @Test
+    public void shouldStartWithSparqlReturningVertexAndEndWithGremlin() {
+        final List<?> x = g.sparql("SELECT * WHERE { }").out("knows").values("name").toList();
+        assertThat(x, containsInAnyOrder("vadas", "josh"));
+    }
+
+    @Test
+    public void shouldStartWithSparqlUsingSacksAndEndWithGremlin() {
+        final List<?> x = g.withSack(1.0f).sparql("SELECT * WHERE { }").repeat(
+                (Traversal) outE().sack(mult).by("weight").inV()).times(2).sack().toList();
+        assertThat(x, containsInAnyOrder(1.0, 0.4));
+    }
+    
     @Test
     public void shouldFindAllPersonsNamesAndAges() {
         final List<?> x = g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }").toList();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2171

Allows `sparql()` step to be followed by Gremlin steps:

```text
gremlin> g.sparql("SELECT * WHERE { }").out("knows").values("name")
==>vadas
==>josh
```

All tests pass with `docker/build.sh -t -i`

VOTE +1
