### PR TITLE
TINKERPOP-2112 Fold property() so that T values can work in any order

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-7]]
 === TinkerPop 3.3.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Improved folding of `property()` step into related mutating steps.
 * Removed `gperfutils` dependencies from Gremlin Console.
 * Ensure `gremlin.sh` works when directories contain spaces
 * Enabled `ctrl+c` to interrupt long running processes in Gremlin Console.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -146,6 +146,7 @@ import org.apache.tinkerpop.gremlin.structure.PropertyType;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.function.ConstantSupplier;
 
 import java.util.ArrayList;
@@ -2081,13 +2082,44 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
         // if it can be detected that this call to property() is related to an addV/E() then we can attempt to fold
         // the properties into that step to gain an optimization for those graphs that support such capabilities.
-        final Step endStep = this.asAdmin().getEndStep();
-        if ((endStep instanceof AddVertexStep || endStep instanceof AddEdgeStep || endStep instanceof AddVertexStartStep || endStep instanceof AddEdgeStartStep) &&
-                keyValues.length == 0 && null == cardinality) {
+        Step endStep = this.asAdmin().getEndStep();
+
+        // always try to fold the property() into the initial "AddElementStep" as the performance will be better
+        // and as it so happens with T the value must be set by way of that approach otherwise you get an error.
+        // it should be safe to execute this loop this way as we'll either hit an "AddElementStep" or an "EmptyStep".
+        // if empty, it will just use the regular AddPropertyStep being tacked on to the end of the traversal as usual
+        while (endStep instanceof AddPropertyStep) {
+            endStep = endStep.getPreviousStep();
+        }
+
+        // edge properties can always be folded as there is no cardinality/metaproperties. for a vertex mutation,
+        // it's possible to fold the property() into the Mutating step if there are no metaproperties (i.e. keyValues)
+        // and if (1) the key is an instance of T OR OR (3) the key is a string and the cardinality is not specifiied.
+        // Note that checking for single cardinality of the argument doesn't work well because once folded we lose
+        // the cardinality argument associated to the key/value pair and then it relies on the graph. that
+        // means that if you do:
+        //
+        // g.addV().property(single, 'k',1).property(single,'k',2)
+        //
+        // you could end up with whatever the cardinality is for the key which might seem "wrong" if you were explicit
+        // about the specification of "single". it also isn't possible to check the Graph Features for cardinality
+        // as folding seems to have different behavior based on different graphs - we clearly don't have that aspect
+        // of things tested/enforced well.
+        //
+        // of additional note is the folding that occurs if the key is a Traversal. the key here is technically
+        // unknown until traversal execution as the anonymous traversal result isn't evaluated during traversal
+        // construction but during iteration. not folding to AddVertexStep creates different (breaking) traversal
+        // semantics than we've had in previous versions so right/wrong could be argued, but since it's a breaking
+        // change we'll just arbitrarily account for it to maintain the former behavior.
+        if ((endStep instanceof AddEdgeStep || endStep instanceof AddEdgeStartStep) ||
+                ((endStep instanceof AddVertexStep || endStep instanceof AddVertexStartStep) &&
+                  keyValues.length == 0 &&
+                  (key instanceof T || (key instanceof String && null == cardinality) || key instanceof Traversal))) {
             ((Mutating) endStep).addPropertyMutations(key, value);
         } else {
-            this.asAdmin().addStep(new AddPropertyStep(this.asAdmin(), cardinality, key, value));
-            ((AddPropertyStep) this.asAdmin().getEndStep()).addPropertyMutations(keyValues);
+            final AddPropertyStep<Element> addPropertyStep = new AddPropertyStep<>(this.asAdmin(), cardinality, key, value);
+            this.asAdmin().addStep(addPropertyStep);
+            addPropertyStep.addPropertyMutations(keyValues);
         }
         return this;
     }

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/MultiMetaNeo4jTrait.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/MultiMetaNeo4jTrait.java
@@ -131,7 +131,8 @@ public final class MultiMetaNeo4jTrait implements Neo4jTrait {
     }
 
     @Override
-    public <V> VertexProperty<V> setVertexProperty(Neo4jVertex vertex, VertexProperty.Cardinality cardinality, String key, V value, Object... keyValues) {
+    public <V> VertexProperty<V> setVertexProperty(final Neo4jVertex vertex, final VertexProperty.Cardinality cardinality,
+                                                   final String key, final V value, final Object... keyValues) {
         try {
             final Optional<VertexProperty<V>> optionalVertexProperty = ElementHelper.stageVertexProperty(vertex, cardinality, key, value, keyValues);
             if (optionalVertexProperty.isPresent()) return optionalVertexProperty.get();

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -75,6 +75,7 @@ import java.util.function.Supplier;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -647,6 +648,24 @@ public class TinkerGraphTest {
         for (Metrics i : m.getMetrics(1).getNested()) {
             assertThat(i.getDuration(TimeUnit.NANOSECONDS), greaterThan(0L));
         }
+    }
+
+    /**
+     * Just validating that property folding works nicely given TINKERPOP-2112
+     */
+    @Test
+    public void shouldFoldPropertyStepForTokens() {
+        final GraphTraversalSource g = TinkerGraph.open().traversal();
+
+        g.addV("person").property(VertexProperty.Cardinality.single, "k", "v").
+                property(T.id , "id").
+                property(VertexProperty.Cardinality.list, "l", 1).
+                property("x", "y").
+                property(VertexProperty.Cardinality.list, "l", 2).
+                property("m", "m", "mm", "mm").
+                property("y", "z").iterate();
+
+        assertThat(g.V("id").hasNext(), is(true));
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2112

Also optimizes a bit to capture additional possible folds to the "AddElementStep" that would have been otherwise missed before. This should enhance performance of certain mutation traversals depending on the positioning and parameterization of the `property()` steps as more folding will occur.

Note that the folding would work properly if the `T.id` was set in the first call to `property()` and that led to:

```text
gremlin> g.addV("person").
......1>   property(T.id , "id").
......2>   property(VertexProperty.Cardinality.single, "k", "v").
......3>   property(VertexProperty.Cardinality.list, "l", 1).
......4>   property("x", "y").
......5>   property(VertexProperty.Cardinality.list, "l", 2).
......6>   property("m", "m", "mm", "mm").
......7>   property("y", "z").profile()
==>Traversal Metrics
Step                                                               Count  Traversers       Time (ms)    % Dur
=============================================================================================================
AddVertexStartStep({label=[person], id=[id]})                          1           1           0.080     8.48
AddPropertyStep({key=[k], value=[v]})                                  1           1           0.137    14.50
AddPropertyStep({key=[l], value=[1]})                                  1           1           0.076     8.06
AddPropertyStep({key=[x], value=[y]})                                  1           1           0.087     9.25
AddPropertyStep({key=[l], value=[2]})                                  1           1           0.081     8.65
AddPropertyStep({mm=[mm], key=[m], value=[m]})                         1           1           0.381    40.29
AddPropertyStep({key=[y], value=[z]})                                  1           1           0.102    10.78
                                            >TOTAL                     -           -           0.947        -
```

rather than an error. After this change it now works either way, meaning `T.id` can be anywhere in the mix:

```text
gremlin> g.addV("person").
......1>   property(VertexProperty.Cardinality.single, "k", "v").
......2>   property(T.id , "id").
......3>   property(VertexProperty.Cardinality.list, "l", 1).
......4>   property("x", "y").
......5>   property(VertexProperty.Cardinality.list, "l", 2).
......6>   property("m", "m", "mm", "mm").
......7>   property("y", "z").profile()
==>Traversal Metrics
Step                                                               Count  Traversers       Time (ms)    % Dur
=============================================================================================================
AddVertexStartStep({id=[id], x=[y], label=[pers...                     1           1           0.195    26.49
AddPropertyStep({key=[k], value=[v]})                                  1           1           0.139    18.89
AddPropertyStep({key=[l], value=[1]})                                  1           1           0.147    19.97
AddPropertyStep({key=[l], value=[2]})                                  1           1           0.105    14.24
AddPropertyStep({mm=[mm], key=[m], value=[m]})                         1           1           0.151    20.42
                                            >TOTAL                     -           -           0.739        -
```

Of note in this second `profile()` is that the "y" property is folded all the way back to `AddVertexStep`.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1