### PR TITLE
TINKERPOP-2135/2148 Fix removal of closed connections and add round-robin scheduling

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -79,7 +79,7 @@ namespace Gremlin.Net.Driver
 
         public int NrRequestsInFlight => _callbackByRequestId.Count;
 
-        public bool IsOpen => _webSocketConnection.IsOpen;
+        public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
 
         public Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/CopyOnWriteCollection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/CopyOnWriteCollection.cs
@@ -1,0 +1,85 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+
+namespace Gremlin.Net.Driver
+{
+    internal class CopyOnWriteCollection<T>
+    {
+        private static readonly T[] EmptyArray = new T[0];
+        
+        private volatile T[] _array = EmptyArray;
+        private readonly object _writeLock = new object();
+
+        public int Count => _array.Length;
+
+        public void AddRange(T[] items)
+        {
+            if (items == null || items.Length == 0)
+                return;
+            lock (_writeLock)
+            {
+                var newArray = new T[_array.Length + items.Length];
+                _array.CopyTo(newArray, 0);
+                Array.Copy(items, 0, newArray, _array.Length, items.Length);
+                _array = newArray;
+            }
+        }
+
+        public bool TryRemove(T item)
+        {
+            lock (_writeLock)
+            {
+                var index = Array.IndexOf(_array, item);
+                if (index < 0) return false;
+                if (_array.Length == 1 && index == 0)
+                {
+                    _array = EmptyArray;
+                    return true;
+                }
+
+                var newArray = new T[_array.Length - 1];
+                    
+                if (index != 0)
+                    Array.Copy(_array, 0, newArray, 0, index);
+                if (index < _array.Length - 1)
+                    Array.Copy(_array, index + 1, newArray, index, _array.Length - index - 1);
+                _array = newArray;
+                return true;
+            }
+        }
+
+        public T[] RemoveAndGetAll()
+        {
+            lock (_writeLock)
+            {
+                var old = _array;
+                _array = EmptyArray;
+                return old;
+            }
+        }
+
+        public T[] Snapshot => _array;
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Properties/AssemblyInfo.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Gremlin.Net.UnitTest, PublicKey=00240000048000009400000006020000002400005253413100040000010001009bbf7a5b9966d9207d8abb9d3d3e98f5e387b292742cfb791dc657357221c3ac9b38ab6dab89630dc8edb3cde84a107f493d192116a934afa463355eefd58b82fd08dc2616ee6074a74bf5845652864746e285bd04e2e1a87921e8e2c383d1b302e7bee1fd7cdab5fe2bbed8c6677624d63433548d43a873ab5650ed96fb0687")]

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/CopyOnWriteCollectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/CopyOnWriteCollectionTests.cs
@@ -1,0 +1,235 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Xunit;
+
+namespace Gremlin.Net.UnitTest.Driver
+{
+    public class CopyOnWriteCollectionTests
+    {
+        [Fact]
+        public void ShouldStartEmpty()
+        {
+            var collection = new CopyOnWriteCollection<int>();
+            
+            Assert.Equal(new int[0], collection.Snapshot);
+        }
+        
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void AddRangeShouldResultInExpectedCount(int expectedCount)
+        {
+            var items = Enumerable.Range(0, expectedCount).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            
+            collection.AddRange(items);
+            
+            Assert.Equal(expectedCount, collection.Count);
+        }
+        
+        [Fact]
+        public void AddRangeShouldAddNewItemsAfterOldItems()
+        {
+            var oldItems = Enumerable.Range(0, 5).ToArray();
+            var newItems = Enumerable.Range(0, 3).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(oldItems);
+            
+            collection.AddRange(newItems);
+
+            var expectedItems = new int[oldItems.Length + newItems.Length];
+            oldItems.CopyTo(expectedItems, 0);
+            newItems.CopyTo(expectedItems, oldItems.Length);
+            Assert.Equal(expectedItems, collection.Snapshot);
+        }
+
+        [Fact]
+        public void TryRemoveShouldReturnFalseForUnknownItem()
+        {
+            const int unknownItem = -1;
+            var knownItems = Enumerable.Range(0, 5).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(knownItems);
+            
+            Assert.False(collection.TryRemove(unknownItem));
+        }
+        
+        [Fact]
+        public void TryRemoveShouldNotChangeCountForUnknownItem()
+        {
+            const int unknownItem = -1;
+            var knownItems = Enumerable.Range(0, 5).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(knownItems);
+            
+            collection.TryRemove(unknownItem);
+            
+            Assert.Equal(knownItems.Length, collection.Count);
+        }
+
+        [Fact]
+        public void TryRemoveShouldReturnTrueForKnownItem()
+        {
+            var knownItems = Enumerable.Range(0, 5).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(knownItems);
+            
+            Assert.True(collection.TryRemove(knownItems[2]));
+        }
+        
+        [Fact]
+        public void TryRemoveShouldRemoveKnownItem()
+        {
+            var knownItems = Enumerable.Range(0, 5).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(knownItems);
+            
+            collection.TryRemove(knownItems[2]);
+            
+            Assert.DoesNotContain(knownItems[2], collection.Snapshot);
+        }
+        
+        [Fact]
+        public void TryRemoveShouldDecrementCountForKnownItem()
+        {
+            var knownItems = Enumerable.Range(0, 5).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(knownItems);
+            
+            collection.TryRemove(knownItems[2]);
+
+            Assert.Equal(knownItems.Length - 1, collection.Count);
+        }
+        
+        [Fact]
+        public void TryRemoveOfLastItemShouldEmptyTheArray()
+        {
+            var collection = new CopyOnWriteCollection<int>();
+            const int lastItem = 3;
+            collection.AddRange(new[] {lastItem});
+            
+            collection.TryRemove(lastItem);
+
+            Assert.Equal(new int[0], collection.Snapshot);
+        }
+        
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void SnapshotShouldReturnAddedItems(int nrItems)
+        {
+            var items = Enumerable.Range(0, nrItems).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(items);
+            
+            Assert.Equal(items, collection.Snapshot);
+        }
+        
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void RemoveAndGetAllShouldReturnAllItems(int nrItems)
+        {
+            var items = Enumerable.Range(0, nrItems).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(items);
+            
+            Assert.Equal(items, collection.RemoveAndGetAll());
+        }
+        
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void RemoveAndGetAllShouldEmptyTheArray(int nrItems)
+        {
+            var items = Enumerable.Range(0, nrItems).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(items);
+
+            collection.RemoveAndGetAll();
+            
+            Assert.Equal(new int[0], collection.Snapshot);
+        }
+
+        [Fact]
+        public void AddRangeShouldAllowParallelCalls()
+        {
+            var collection = new CopyOnWriteCollection<int>();
+            const int nrOfParallelOperations = 100;
+            var addRangeActions = new Action[nrOfParallelOperations];
+            var addedItems = new List<int>(nrOfParallelOperations * 3);
+            for (var i = 0; i < nrOfParallelOperations; i++)
+            {
+                var itemsToAdd = new[] {i, i + 1, i + 2};
+                addedItems.AddRange(itemsToAdd);
+                addRangeActions[i] = () => collection.AddRange(itemsToAdd);
+            }
+            
+            Parallel.Invoke(addRangeActions);
+            
+            AssertCollectionContainsExactlyUnordered(collection, addedItems);
+        }
+
+        private static void AssertCollectionContainsExactlyUnordered(CopyOnWriteCollection<int> collection, IEnumerable<int> expectedItems)
+        {
+            foreach (var item in expectedItems)
+            {
+                Assert.True(collection.TryRemove(item));
+            }
+            Assert.Equal(0, collection.Count);
+        }
+        
+        [Fact]
+        public void TryRemoveShouldAllowParallelCalls()
+        {
+            const int nrOfParallelOperations = 100;
+            var items = Enumerable.Range(0, nrOfParallelOperations).ToArray();
+            var collection = new CopyOnWriteCollection<int>();
+            collection.AddRange(items);
+            var tryRemoveActions = new Action[nrOfParallelOperations];
+            for (var i = 0; i < nrOfParallelOperations; i++)
+            {
+                var item = i;
+                tryRemoveActions[i] = () => collection.TryRemove(item);
+            }
+            
+            Parallel.Invoke(tryRemoveActions);
+            
+            Assert.Equal(0, collection.Count);
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2135
https://issues.apache.org/jira/browse/TINKERPOP-2148

A Custom copy-on-write (COW) collection is used to store the connections instead of a `ConcurrentBag`. This collection is heavily inspired by the `CopyOnWriteList` in the DataStax C# Driver for Apache Cassandra.
This collection allows for an efficient removal of closed connections which fixes TINKERPOP-2135. Some other operations like `Count` or the removal of all connections are also more efficient.

This new `CopyOnWriteCollection` also enables round-robin scheduling of requests over connections instead of searching for the least used connection which required iterating over all connections and led to
problems when multiple threads in parallel got the same connection and reached the max in process limit for that connection because of that.
So, this also fixes TINKERPOP-2148.

`InternalsVisibleTo` is added which allows us to test internal types like the new `CopyOnWriteCollection`. Right now, only this collection is tested like this, but we can add unit tests for other internal types in the
future, too.