### PR TITLE
TINKERPOP-2172 Fix PartitionStrategy to apply to AddEdgeStartStep

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bumped `commons-codec` to 1.12.
 * Fixed concurrency issues in `TraverserSet.toString()` and `ObjectWritable.toString()`.
 * Fixed a bug in `InlineFilterStrategy` that mixed up and's and or's when folding merging conditions together.
+* Fixed a bug in `PartitionStrategy` where `addE()` as a start step was not applying the partition.
 * Improved handling of failing `Authenticator` instances thus improving server responses to drivers.
 * Improved performance of `JavaTranslator` by reducing calls to `Method.getParameters()`.
 * Implemented `EarlyLimitStrategy` which is supposed to significantly reduce backend operations for queries that use `range()`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
@@ -195,7 +196,8 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
 
         final List<Step> stepsToInsertPropertyMutations = traversal.getSteps().stream().filter(step ->
                 step instanceof AddEdgeStep || step instanceof AddVertexStep ||
-                        step instanceof AddVertexStartStep || (includeMetaProperties && step instanceof AddPropertyStep)
+                step instanceof AddEdgeStartStep || step instanceof AddVertexStartStep ||
+                (includeMetaProperties && step instanceof AddPropertyStep)
         ).collect(Collectors.toList());
 
         stepsToInsertPropertyMutations.forEach(step -> {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -297,7 +297,8 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final GraphTraversalSource source = g.withStrategies(partitionStrategy);
         final Vertex v1 = source.addV().property("any", "thing").next();
         final Vertex v2 = source.addV().property("some", "thing").next();
-        final Edge e = source.withSideEffect("v2", v2).V(v1.id()).addE("connectsTo").from("v2").property("every", "thing").next();
+        final Edge e1 = source.withSideEffect("v2", v2).V(v1.id()).addE("connectsTo").from("v2").property("every", "thing").next();
+        final Edge e2 = source.addE("relatesTo").from(v2).to(v1).property("every", "thing").next();
 
         assertNotNull(v1);
         assertEquals("thing", g.V(v1).values("any").next());
@@ -307,10 +308,15 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         assertEquals("thing", g.V(v2).values("some").next());
         assertEquals("A", g.V(v2).values(partition).next());
 
-        assertNotNull(e);
-        assertEquals("thing", g.E(e).values("every").next());
-        assertEquals("connectsTo", e.label());
-        assertEquals("A", g.E(e).values(partition).next());
+        assertNotNull(e1);
+        assertEquals("thing", g.E(e1).values("every").next());
+        assertEquals("connectsTo", e1.label());
+        assertEquals("A", g.E(e1).values(partition).next());
+
+        assertNotNull(e2);
+        assertEquals("thing", g.E(e2).values("every").next());
+        assertEquals("relatesTo", e2.label());
+        assertEquals("A", g.E(e2).values(partition).next());
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -297,7 +297,7 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
         final GraphTraversalSource source = g.withStrategies(partitionStrategy);
         final Vertex v1 = source.addV().property("any", "thing").next();
         final Vertex v2 = source.addV().property("some", "thing").next();
-        final Edge e1 = source.withSideEffect("v2", v2).V(v1.id()).addE("connectsTo").from("v2").property("every", "thing").next();
+        final Edge e1 = source.V(v1).addE("connectsTo").from(v2).property("every", "thing").next();
         final Edge e2 = source.addE("relatesTo").from(v2).to(v1).property("every", "thing").next();
 
         assertNotNull(v1);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2172

Fix PartitionStrategy to apply to traversal started with addE step. I cherry-picked from #1078 to get this on `tp33` and fix up some other odds/ends.

VOTE +1