### PR TITLE
TINKERPOP-2174 Improve Docker Image Security

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-6]]
 === TinkerPop 3.3.6 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Docker images use user `gremlin` instead of `root`
 * Added a new `ResponseStatusCode` for client-side serialization errors.
 * Refactored use of `commons-lang` to use `common-lang3` only, though dependencies may still use `commons-lang`.
 * Bumped `commons-lang3`to 3.8.1.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM ubuntu:trusty
 
-MAINTAINER Daniel Kuppitz <me@gremlin.guru>
+LABEL maintainer="Daniel Kuppitz <me@gremlin.guru>"
 
 RUN apt-get update \
     && apt-get -y install software-properties-common python-software-properties apt-transport-https curl dpkg \

--- a/docker/hadoop/Dockerfile.template
+++ b/docker/hadoop/Dockerfile.template
@@ -17,7 +17,7 @@
 
 FROM tinkerpop:base
 
-MAINTAINER Daniel Kuppitz <me@gremlin.guru>
+LABEL maintainer="Daniel Kuppitz <me@gremlin.guru>"
 
 ENV HADOOP_VERSION HADOOP_VERSION
 

--- a/gremlin-console/Dockerfile
+++ b/gremlin-console/Dockerfile
@@ -15,17 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM openjdk:8u151-jre-alpine3.7
+FROM openjdk:8-jre-alpine
+
+LABEL maintainer="dev@tinkerpop.apache.org"
 
 ARG GREMLIN_CONSOLE_DIR
 
-RUN apk add --update \
-    bash \
-    && rm -rf /var/cache/apk/*
+RUN apk add --no-cache --update bash
 
 COPY src/main/docker/docker-entrypoint.sh /
 COPY ${GREMLIN_CONSOLE_DIR} /opt/gremlin-console
 
 WORKDIR /opt/gremlin-console
+
+RUN addgroup -S gremlin && adduser -S -s /bin/false -G gremlin gremlin
+RUN chown -R gremlin:gremlin /opt/gremlin-console
+USER gremlin
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/gremlin-server/Dockerfile
+++ b/gremlin-server/Dockerfile
@@ -15,14 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM openjdk:8u151-jre-alpine3.7
+FROM openjdk:8-jre-alpine
+
+LABEL maintainer="dev@tinkerpop.apache.org"
 
 ARG GREMLIN_SERVER_DIR
 
-RUN apk add --update \
+RUN apk add --no-cache --update \
     bash \
-    perl \
-    && rm -rf /var/cache/apk/*
+    perl
 
 COPY src/main/docker/docker-entrypoint.sh /
 COPY ${GREMLIN_SERVER_DIR} /opt/gremlin-server
@@ -30,6 +31,10 @@ COPY ${GREMLIN_SERVER_DIR} /opt/gremlin-server
 WORKDIR /opt/gremlin-server
 
 EXPOSE 8182
+
+RUN addgroup -S gremlin && adduser -S -s /bin/false -G gremlin gremlin
+RUN chown -R gremlin:gremlin /opt/gremlin-server
+USER gremlin
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["conf/gremlin-server.yaml"]


### PR DESCRIPTION

https://issues.apache.org/jira/browse/TINKERPOP-2174

- use least privileged user:group -  `gremlin`
- use the dynamic tag to get the latest image: `openjdk:8-jre-alpine`

also snuck in some non-security ones:
- replaced deprecated `MAINTAINER` with `LABEL maintainer...`
- use  `--no-cache` instead of `rm -rf /var/cache/apk/*`

Tested gremlin-console and gremlin-server images.

VOTE +1
