### PR TITLE
TINKERPOP-2169 Responses exceeding maxContentLength cause subsequent queries to hang

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -365,7 +365,7 @@ public abstract class Client {
      */
     public final static class ClusteredClient extends Client {
 
-        private ConcurrentMap<Host, ConnectionPool> hostConnectionPools = new ConcurrentHashMap<>();
+        protected ConcurrentMap<Host, ConnectionPool> hostConnectionPools = new ConcurrentHashMap<>();
         private final AtomicReference<CompletableFuture<Void>> closing = new AtomicReference<>(null);
 
         ClusteredClient(final Cluster cluster, final Client.Settings settings) {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -18,10 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
-import io.netty.handler.codec.CodecException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
-import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -29,9 +26,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.ws.Response;
-import java.io.IOException;
 import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -80,7 +74,6 @@ final class Connection {
     public final AtomicInteger borrowed = new AtomicInteger(0);
     private final AtomicReference<Class<Channelizer>> channelizerClass = new AtomicReference<>(null);
 
-    private volatile boolean isDead = false;
     private final int maxInProcess;
 
     private final String connectionLabel;
@@ -133,8 +126,14 @@ final class Connection {
         return Math.max(0, maxInProcess - pending.size());
     }
 
+    /**
+     * Consider a connection as dead if the underlying channel is not connected.
+     *
+     * Note: A dead connection does not necessarily imply that the server is unavailable. Additional checks
+     * should be performed to mark the server host as unavailable.
+     */
     public boolean isDead() {
-        return isDead;
+        return (channel !=null && !channel.isActive());
     }
 
     boolean isClosing() {
@@ -205,11 +204,7 @@ final class Connection {
                         if (logger.isDebugEnabled())
                             logger.debug(String.format("Write on connection %s failed", thisConnection.getConnectionInfo()), f.cause());
 
-                        // if there is a ResponseException the write failed because of something to do with the server
-                        // or client side serialization - neither of these things mean that the host is dead. the
-                        // connection should be reusable.
-                        thisConnection.isDead = ExceptionUtils.indexOfThrowable(f.cause(), ResponseException.class) == -1;
-                        thisConnection.returnToPool();
+                        handleConnectionCleanupOnError(thisConnection, f.cause());
 
                         cluster.executor().submit(() -> future.completeExceptionally(f.cause()));
                     } else {
@@ -225,24 +220,11 @@ final class Connection {
 
                         // the callback for when the read failed. a failed read means the request went to the server
                         // and came back with a server-side error of some sort.  it means the server is responsive
-                        // so this isn't going to be like a dead host situation which is handled above on a failed
+                        // so this isn't going to be like a potentially dead host situation which is handled above on a failed
                         // write operation.
-                        //
-                        // in the event of an IOException (typically means that the Connection might have
-                        // been closed from the server side - this is typical in situations like when a request is
-                        // sent that exceeds maxContentLength and the server closes the channel on its side) or other
-                        // exceptions that indicate a non-recoverable state for the Connection object
-                        // (a netty CorruptedFrameException is a good example of that), the Connection cannot simply
-                        // be returned to the pool as future uses will end with refusal from the server and make it
-                        // appear as a dead host as the write will not succeed. instead, the Connection needs to be
-                        // replaced in these scenarios which destroys the dead channel on the client and allows a new
-                        // one to be reconstructed.
                         readCompleted.exceptionally(t -> {
-                            if (t instanceof IOException || t instanceof CodecException) {
-                                if (pool != null) pool.replaceConnection(thisConnection);
-                            } else {
-                                thisConnection.returnToPool();
-                            }
+
+                            handleConnectionCleanupOnError(thisConnection, t);
 
                             // close was signaled in closeAsync() but there were pending messages at that time. attempt
                             // the shutdown if the returned result cleared up the last pending message
@@ -291,6 +273,23 @@ final class Connection {
         }
     }
 
+    /*
+     * In the event of an IOException (typically means that the Connection might have been closed from the server side
+     * - this is typical in situations like when a request is sent that exceeds maxContentLength and the server closes
+     * the channel on its side) or other exceptions that indicate a non-recoverable state for the Connection object
+     * (a netty CorruptedFrameException is a good example of that), the Connection cannot simply be returned to the
+     * pool as future uses will end with refusal from the server and make it appear as a dead host as the write will
+     * not succeed. Instead, the Connection needs to be replaced in these scenarios which destroys the dead channel
+     * on the client and allows a new one to be reconstructed.
+     */
+    private void handleConnectionCleanupOnError(final Connection thisConnection, final Throwable t) {
+        if (thisConnection.isDead()) {
+            if (pool != null) pool.replaceConnection(thisConnection);
+        } else {
+            thisConnection.returnToPool();
+        }
+    }
+
     private boolean isOkToClose() {
         return pending.isEmpty() || (channel !=null && !channel.isOpen()) || !pool.host.isAvailable();
     }
@@ -309,6 +308,8 @@ final class Connection {
         // be called once. once shutdown is initiated, it shouldn't be executed a second time or else it sends more
         // messages at the server and leads to ugly log messages over there.
         if (shutdownInitiated.compareAndSet(false, true)) {
+            final String connectionInfo = this.getConnectionInfo();
+
             // maybe this should be delegated back to the Client implementation??? kinda weird to instanceof here.....
             if (client instanceof Client.SessionedClient) {
                 final boolean forceClose = client.getSettings().getSession().get().isForceClosed();
@@ -340,10 +341,14 @@ final class Connection {
 
             final ChannelPromise promise = channel.newPromise();
             promise.addListener(f -> {
-                if (f.cause() != null)
+                if (f.cause() != null) {
                     future.completeExceptionally(f.cause());
-                else
+                } else {
+                    if (logger.isDebugEnabled())
+                        logger.debug("{} destroyed successfully.", connectionInfo);
+
                     future.complete(null);
+                }
             });
 
             channel.close(promise);
@@ -352,7 +357,7 @@ final class Connection {
 
     public String getConnectionInfo() {
         return String.format("Connection{host=%s, isDead=%s, borrowed=%s, pending=%s}",
-                pool.host, isDead, borrowed, pending.size());
+                pool.host, isDead(), borrowed, pending.size());
     }
 
     @Override

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -98,7 +98,7 @@ final class ConnectionPool {
             // ok if we don't get it initialized here - when a request is attempted in a connection from the
             // pool it will try to create new connections as needed.
             logger.debug("Could not initialize connections in pool for {} - pool size at {}", host, this.connections.size());
-            considerUnavailable();
+            considerHostUnavailable();
         }
 
         this.open = new AtomicInteger(connections.size());
@@ -171,9 +171,10 @@ final class ConnectionPool {
         if (isClosed()) throw new ConnectionException(host.getHostUri(), host.getAddress(), "Pool is shutdown");
 
         final int borrowed = connection.borrowed.decrementAndGet();
+
         if (connection.isDead()) {
             logger.debug("Marking {} as dead", this.host);
-            considerUnavailable();
+            this.replaceConnection(connection);
         } else {
             if (bin.contains(connection) && borrowed == 0) {
                 logger.debug("{} is already in the bin and it has no inflight requests so it is safe to close", connection);
@@ -228,6 +229,13 @@ final class ConnectionPool {
         final CompletableFuture<Void> future = killAvailableConnections();
         closeFuture.set(future);
         return future;
+    }
+
+    /**
+     * Required for testing
+     */
+    int numConnectionsWaitingToCleanup() {
+        return bin.size();
     }
 
     private CompletableFuture<Void> killAvailableConnections() {
@@ -293,7 +301,7 @@ final class ConnectionPool {
         } catch (ConnectionException ce) {
             logger.debug("Connections were under max, but there was an error creating the connection.", ce);
             open.decrementAndGet();
-            considerUnavailable();
+            considerHostUnavailable();
             return false;
         }
 
@@ -317,16 +325,18 @@ final class ConnectionPool {
 
     private void definitelyDestroyConnection(final Connection connection) {
         // only add to the bin for future removal if its not already there.
-        if (!bin.contains(connection)) {
+        if (!bin.contains(connection) && !connection.isClosing()) {
             bin.add(connection);
             connections.remove(connection);
             open.decrementAndGet();
         }
 
-        // only close the connection for good once it is done being borrowed
-        if (connection.borrowed.get() == 0 && bin.remove(connection)) {
-            connection.closeAsync();
-            logger.debug("{} destroyed", connection.getConnectionInfo());
+        // only close the connection for good once it is done being borrowed or when it is dead
+        if (connection.isDead() || connection.borrowed.get() == 0) {
+            if(bin.remove(connection)) {
+                connection.closeAsync();
+                logger.debug("{} destroyed", connection.getConnectionInfo());
+            }
         }
     }
 
@@ -372,14 +382,13 @@ final class ConnectionPool {
 
         // if we timeout borrowing a connection that might mean the host is dead (or the timeout was super short).
         // either way supply a function to reconnect
-        this.considerUnavailable();
+        this.considerHostUnavailable();
 
-        throw new TimeoutException();
+        throw new TimeoutException("Timed-out waiting for connection on " + host + " - possibly unavailable");
     }
 
-    private void considerUnavailable() {
-        // called when a connection is "dead" such that a "dead" connection means the host itself is basically
-        // "dead".  that's probably ok for now, but this decision should likely be more flexible.
+    public void considerHostUnavailable() {
+        // called when a connection is "dead" due to a non-recoverable error.
         host.makeUnavailable(this::tryReconnect);
 
         // if the host is unavailable then we should release the connections

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
@@ -71,6 +71,8 @@ public final class Host {
     void makeUnavailable(final Function<Host, Boolean> reconnect) {
         isAvailable = false;
 
+        logger.warn("Marking {} as unavailable. Trying to reconnect.", this);
+
         // only do a connection re-attempt if one is not already in progress
         if (retryInProgress.compareAndSet(Boolean.FALSE, Boolean.TRUE)) {
             retryThread = this.cluster.executor().scheduleAtFixedRate(() -> {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import io.netty.handler.codec.CorruptedFrameException;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.tinkerpop.gremlin.server.AbstractGremlinServerIntegrationTest;
+import org.apache.tinkerpop.gremlin.server.TestClientFactory;
+import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrationTest {
+    private Log4jRecordingAppender recordingAppender = null;
+    private Level previousLogLevel;
+
+    @Before
+    public void setupForEachTest() {
+        recordingAppender = new Log4jRecordingAppender();
+        final Logger rootLogger = Logger.getRootLogger();
+
+        if (name.getMethodName().equals("shouldCloseConnectionDeadDueToUnRecoverableError")) {
+            final org.apache.log4j.Logger connectionLogger = org.apache.log4j.Logger.getLogger(Connection.class);
+            previousLogLevel = connectionLogger.getLevel();
+            connectionLogger.setLevel(Level.DEBUG);
+        }
+
+        rootLogger.addAppender(recordingAppender);
+    }
+
+    @After
+    public void teardownForEachTest() {
+        final Logger rootLogger = Logger.getRootLogger();
+
+        if (name.getMethodName().equals("shouldCloseConnectionDeadDueToUnRecoverableError")) {
+            final org.apache.log4j.Logger connectionLogger = org.apache.log4j.Logger.getLogger(Connection.class);
+            connectionLogger.setLevel(previousLogLevel);
+        }
+
+        rootLogger.removeAppender(recordingAppender);
+    }
+
+    /**
+     * Reproducer for TINKERPOP-2169
+     */
+    @Test
+    public void shouldCloseConnectionDeadDueToUnRecoverableError() throws Exception {
+        // Set a low value of maxContentLength to intentionally trigger CorruptedFrameException
+        final Cluster cluster = TestClientFactory.build()
+                                                 .maxContentLength(64)
+                                                 .minConnectionPoolSize(1)
+                                                 .maxConnectionPoolSize(2)
+                                                 .create();
+        final Client.ClusteredClient client = cluster.connect();
+
+        try {
+            // Add the test data so that the g.V() response could exceed maxContentLength
+            client.submit("g.inject(1).repeat(__.addV()).times(10).count()").all().get();
+            try {
+                client.submit("g.V().fold()").all().get();
+
+                fail("Should throw an exception.");
+            } catch (Exception re) {
+                assertThat(re.getCause() instanceof CorruptedFrameException, is(true));
+            }
+
+            // Assert that the host has not been marked unavailable
+            Assert.assertEquals(1, cluster.availableHosts().size());
+
+            // Assert that there is no connection leak and all connections have been closed
+            Assert.assertEquals(0, client.hostConnectionPools.values().stream()
+                                                             .findFirst().get()
+                                                             .numConnectionsWaitingToCleanup());
+
+            // Assert that the connection has been destroyed. Specifically check for the string with
+            // isDead=true indicating the connection that was closed due to CorruptedFrameException.
+            assertThat(recordingAppender.logContainsAny("^(?!.*(isDead=false)).*isDead=true.*destroyed successfully.$"), is(true));
+        } finally {
+            cluster.close();
+        }
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -119,7 +119,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
         if (name.getMethodName().equals("shouldKeepAliveForWebSockets")) {
             final org.apache.log4j.Logger webSocketClientHandlerLogger = org.apache.log4j.Logger.getLogger(WebSocketClientHandler.class);
-            previousLogLevel = webSocketClientHandlerLogger.getLevel();
             webSocketClientHandlerLogger.setLevel(previousLogLevel);
         }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -67,9 +67,7 @@ import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.lang.reflect.Field;
-import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -86,7 +84,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import static org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPlugin.Compilation.COMPILE_STATIC;
 import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE;
 import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE_CONNECTION_CLASS;
@@ -98,18 +95,16 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-
 /**
  * Integration tests for server-side settings and processing.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegrationTest {
-
     private static final String PEM_SERVER_KEY = "src/test/resources/server.key.pk8";
     private static final String PEM_SERVER_CRT = "src/test/resources/server.crt";
     private static final String PEM_CLIENT_KEY = "src/test/resources/client.key.pk8";
@@ -1104,7 +1099,10 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             // it seems ok to pass in this case.
         } catch (Exception re) {
             final Throwable root = ExceptionUtils.getRootCause(re);
-            assertEquals("Connection reset by peer", root.getMessage());
+            // Netty closes the channel to the server on a non-recoverable error such as CorruptedFrameException
+            // and the connection is subsequently destroyed. Each of the pending requests are given an error with
+            // the following error message.
+            assertEquals("Connection to server is no longer active", root.getMessage());
 
             // validate that we can still send messages to the server
             assertEquals(2, client.submit("1+1").all().join().get(0).getInt());
@@ -1126,10 +1124,12 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
         try {
             // try to re-issue a request now that the server is down
-            client.submit("1+1").all().join();
-            fail();
+            client.submit("g").all().join();
+            fail("Should throw an exception.");
         } catch (RuntimeException re) {
-            assertThat(re.getCause().getCause() instanceof ClosedChannelException, is(true));
+            // Client would have no active connections to the host, hence it would encounter a timeout
+            // trying to find an alive connection to the host.
+            assertThat(re.getCause().getCause() instanceof TimeoutException, is(true));
 
             //
             // should recover when the server comes back

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -144,7 +144,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         if (name.getMethodName().equals("shouldPingChannelIfClientDies")||
                 name.getMethodName().equals("shouldCloseChannelIfClientDoesntRespond")) {
             final org.apache.log4j.Logger webSocketClientHandlerLogger = org.apache.log4j.Logger.getLogger(OpSelectorHandler.class);
-            previousLogLevel = webSocketClientHandlerLogger.getLevel();
             webSocketClientHandlerLogger.setLevel(previousLogLevel);
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2169
https://issues.apache.org/jira/browse/TINKERPOP-2173

Similar pull request associated with master branch: #1081  

This pull request corresponds to branch tp33.

**Problem**
1. On receiving a CorruptedFrameException, the current code does not decrement the borrowed count on the connection and marks the connection for destruction. However, the connection never gets destroyed since the it can only be destroyed when the borrowed count is 0. This leads to unnecessary connections waiting in the bin to be cleared.
2. If a connection is serving multiple requests and one of the requests gets a CorruptedFrameException, Netty closes the underlying channel and thus, other requests on the same channel receive a ChannelClosed exception. The current code marks the server host as unavailable (thus closing out other connections for the host as well) on a ChannelClosed exception whereas that is not necessarily true. Marking the host as unavailable is too aggressive in this scenario.

** Changes**
1. Connection.isDead() logic now consists of checking the underlying channel.
2. If a connection is dead, destroy the connection, irrespective of the number of borrowed items. Informing the inflight (pending) request futures about this is already done by the response handler.
3. If a connection is returned to the pool and it is dead, replace the connection. Do not consider the host as unavailable since a single connection dead does not imply a dead host.
4. Add a warning log whenever a host is marked as unavailable.
5. Replace the connection on ClosedChannel exception.
6. Reset the logging level in the integration tests after each test execution.

**Testing**
1. Added a test to reproduce the leak (Problem#1). The test fails before the fixes and passes after the fixes.
2. `mvn verify -DskipIntegrationTests=false` & `mvn verify install` is successful for gremlin-server & gremlin-driver
