### PR TITLE
TINKERPOP-2179: Have SerializationException extend IOException [master]

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InetAddressSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/InetAddressSerializer.java
@@ -44,7 +44,7 @@ public class InetAddressSerializer<T extends InetAddress> extends SimpleTypeSeri
         try {
             return (T) InetAddress.getByAddress(bytes);
         } catch (UnknownHostException uhe) {
-            throw new SerializationException(uhe);
+            throw new SerializationException("Cannot deserialize InetAddress value", uhe);
         }
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/types/PSerializer.java
@@ -74,7 +74,7 @@ public class PSerializer<T extends P> extends SimpleTypeSerializer<T> {
         try {
             return f.apply(args);
         } catch (Exception ex) {
-            throw new SerializationException(ex);
+            throw new SerializationException(String.format("Can't deserialize value into the predicate: '%s'", predicateName), ex);
         }
     }
 
@@ -99,7 +99,7 @@ public class PSerializer<T extends P> extends SimpleTypeSerializer<T> {
                     try {
                         m = classOfP.getMethod(predicateName, Object.class);
                     } catch (NoSuchMethodException ex2) {
-                        throw new SerializationException("not found");
+                        throw new SerializationException(String.format("Can't find predicate method: '%s'", predicateName), ex2);
                     }
                 }
             }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SerializationExceptionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SerializationExceptionTest.java
@@ -16,23 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.tinkerpop.gremlin.driver.ser;
+package org.apache.tinkerpop.gremlin.driver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+import org.junit.Test;
 
 import java.io.IOException;
 
-/**
- * @author Stephen Mallette (http://stephen.genoprime.com)
- */
-public class SerializationException extends IOException {
-    public SerializationException(final String msg) {
-        super(msg);
+public class SerializationExceptionTest {
+
+    @Test
+    public void testSerializationException() {
+        try {
+            throwException();
+            fail("Serialization exception should have been thrown and caught");
+        } catch (IOException e) {
+            assertEquals(e.getMessage(), "no bueno");
+        }
     }
 
-    public SerializationException(final Throwable t) {
-        super(t);
-    }
-
-    public SerializationException(String message, Throwable cause) {
-        super(message, cause);
+    private static void throwException() throws SerializationException {
+        throw new SerializationException("no bueno");
     }
 }


### PR DESCRIPTION
Same as #1083 but with some minor changes to some errors thrown in the GraphBinary serialization.

I did a `merge -s ours` of the branch `TINKERPOP-2179` to this branch first and then added another commit https://github.com/apache/tinkerpop/commit/00954a92fec41eb19626f050585ad1f300dbd9bf. A merge without the `-s ours` was causing conflicts in all the pom.xml for some reason?