### PR TITLE
TINKERPOP-2181 Allow ctrl+c to break a command in Gremlin Console

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,7 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.3.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Ensure `gremlin.sh` works when directories contain spaces
-
+* Enabled `ctrl+c` to interrupt long running processes in Gremlin Console.
 
 [[release-3-3-6]]
 === TinkerPop 3.3.6 (Release Date: March 18, 2019)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -181,6 +181,31 @@ with local commands, but may record session outputs differently for `:remote` co
 `:record` it may be best to manually create a `Cluster` object and issue commands that way so that they evaluate
 locally in the shell.
 
+=== Interrupting Evaluations
+
+If there is some input that is taking too long to evaluate or to iterate through, use `ctrl+c` to attempt to interrupt
+that process. It is an "attempt" in the sense that the long running process is only informed of the interruption by
+the user and must respond to it (as with any call to `interrupt()` on a `Thread`). A `Traversal` will typically respond
+to such requests as do most commands, including `:remote` operations.
+
+[source,text]
+----
+gremlin> java.util.stream.IntStream.range(0, 1000).iterator()
+==>0
+==>1
+==>2
+==>3
+==>4
+...
+==>348
+==>349
+==>350
+==>351
+==>352
+Execution interrupted by ctrl+c
+gremlin>
+----
+
 [[console-preferences]]
 === Console Preferences
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -27,6 +27,23 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.3.7/CHANGELOG.asciidoc#release-3-3-7[changelog] for a complete list of all the modifications that are part of this release.
 
+== Upgrading for Users
+
+==== Gremlin Console Interrupt
+
+There are occasions where a traversal (or other evaluation) takes longer than expected to complete. Common examples
+of these situations typically include:
+
+* Accidentally executing `g.V()` (i.e. full graph scan) on a very large graph as an OLTP style traversal.
+* Not terminating a `repeat()` properly which results in an infinite loop.
+* Bad data might create a cycle in the graph where one wasn't expected.
+* Failing to properly bound a traversal's path through one or more supernodes.
+
+In earlier versions, the only option was to kill the Gremlin Console (typically with `ctrl+c`), but as of this version
+`ctrl+c` will be intercepted and attempt to interrupt whatever process is currently executing.
+
+See link:https://issues.apache.org/jira/browse/TINKERPOP-2181[TINKERPOP-2181]
+
 == TinkerPop 3.3.6
 
 *Release Date: March 18, 2019*

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -47,6 +47,10 @@ import org.codehaus.groovy.tools.shell.InteractiveShellRunner
 import org.codehaus.groovy.tools.shell.commands.SetCommand
 import org.codehaus.groovy.tools.shell.util.HelpFormatter
 import org.fusesource.jansi.Ansi
+import sun.misc.Signal
+import sun.misc.SignalHandler
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -79,8 +83,20 @@ class Console {
 
         final Mediator mediator = new Mediator(this)
 
-        // make sure that remotes are closed if console takes a ctrl-c
+        // make sure that remotes are closed on jvm shutdown
         addShutdownHook { mediator.close() }
+
+        // try to grab ctrl+c to interrupt an evaluation.
+        final Thread main = Thread.currentThread()
+        Signal.handle(new Signal("INT"), new SignalHandler() {
+            @Override
+            void handle(final Signal signal) {
+                if (mediator.evaluating.get()) {
+                    io.out.println("Execution interrupted by ctrl+c")
+                    main.interrupt()
+                }
+            }
+        })
 
         groovy = new GremlinGroovysh(mediator)
 
@@ -184,6 +200,7 @@ class Console {
     private def handleResultShowNothing = { args -> null }
 
     private def handleResultIterate = { result ->
+
         try {
             // necessary to save persist history to file
             groovy.getHistory().flush()
@@ -192,16 +209,34 @@ class Console {
         }
 
         while (true) {
+            // give ctrl+c a chance
+            Thread.yield()
+
+            // if this is true then ctrl+c was triggered
+            if (Thread.interrupted()) {
+                this.tempIterator = Collections.emptyIterator()
+                return null
+            }
+
             if (this.tempIterator.hasNext()) {
-                int counter = 0;
+                int counter = 0
                 while (this.tempIterator.hasNext() && (Preferences.maxIteration == -1 || counter < Preferences.maxIteration)) {
+                    // give ctrl+c a chance
+                    Thread.yield()
+
+                    // if this is true then ctrl+c was triggered
+                    if (Thread.interrupted()) {
+                        this.tempIterator = Collections.emptyIterator()
+                        return null
+                    }
+
                     printResult(tempIterator.next())
-                    counter++;
+                    counter++
                 }
                 if (this.tempIterator.hasNext())
-                    io.out.println(Colorizer.render(Preferences.resultPromptColor,ELLIPSIS));
-                this.tempIterator = Collections.emptyIterator();
-                return null
+                    io.out.println(Colorizer.render(Preferences.resultPromptColor,ELLIPSIS))
+                this.tempIterator = Collections.emptyIterator()
+                break
             } else {
                 try {
                     // if the result is an empty iterator then the tempIterator needs to be set to one, as a
@@ -217,29 +252,29 @@ class Console {
                     if (result instanceof Iterator) {
                         this.tempIterator = (Iterator) result
                         if (!this.tempIterator.hasNext()) {
-                            this.tempIterator = Collections.emptyIterator();
+                            this.tempIterator = Collections.emptyIterator()
                             return null
                         }
                     } else if (result instanceof Iterable) {
                         this.tempIterator = ((Iterable) result).iterator()
                         if (!this.tempIterator.hasNext()) {
-                            this.tempIterator = Collections.emptyIterator();
+                            this.tempIterator = Collections.emptyIterator()
                             return null
                         }
                     } else if (result instanceof Object[]) {
                         this.tempIterator = new ArrayIterator((Object[]) result)
                         if (!this.tempIterator.hasNext()) {
-                            this.tempIterator = Collections.emptyIterator();
+                            this.tempIterator = Collections.emptyIterator()
                             return null
                         }
                     } else if (result instanceof Map) {
                         this.tempIterator = ((Map) result).entrySet().iterator()
                         if (!this.tempIterator.hasNext()) {
-                            this.tempIterator = Collections.emptyIterator();
+                            this.tempIterator = Collections.emptyIterator()
                             return null
                         }
                     } else if (result instanceof TraversalExplanation) {
-                        final int width = TerminalFactory.get().getWidth();
+                        final int width = TerminalFactory.get().getWidth()
                         io.out.println(Colorizer.render(Preferences.resultPromptColor,(buildResultPrompt() + result.prettyPrint(width < 20 ? 80 : width))))
                         return null
                     } else {
@@ -272,7 +307,7 @@ class Console {
         } else if (object instanceof Edge) {
             return Colorizer.render(Preferences.edgeColor, object.toString())
         } else if (object instanceof Iterable) {
-            List<String> buf = new ArrayList<>();
+            List<String> buf = new ArrayList<>()
             def pathIter = object.iterator()
             while (pathIter.hasNext()) {
                 Object n = pathIter.next()
@@ -280,7 +315,7 @@ class Console {
             }
             return ("[" + buf.join(",") + "]")
         } else if (object instanceof Map) {
-            List<String> buf = new ArrayList<>();
+            List<String> buf = new ArrayList<>()
             object.each{k, v ->
                 buf.add(colorizeResult(k) + ":" + colorizeResult(v))
             }
@@ -297,7 +332,7 @@ class Console {
     }
 
     private def handleError = { err ->
-        this.tempIterator = Collections.emptyIterator();
+        this.tempIterator = Collections.emptyIterator()
         if (err instanceof Throwable) {
             try {
                 final Throwable e = (Throwable) err
@@ -368,9 +403,9 @@ class Console {
 
                 File file = new File(scriptFile)
                 if (!file.exists() && !file.isAbsolute()) {
-                    final String userWorkingDir = System.getProperty("user.working_dir");
+                    final String userWorkingDir = System.getProperty("user.working_dir")
                     if (userWorkingDir != null) {
-                        file = new File(userWorkingDir, scriptFile);
+                        file = new File(userWorkingDir, scriptFile)
                     }
                 }
                 int lineNumber = 0

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
@@ -20,6 +20,8 @@ package org.apache.tinkerpop.gremlin.console
 
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteAcceptor
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
@@ -28,6 +30,11 @@ class Mediator {
     public final List<RemoteAcceptor> remotes = []
     public int position
     public boolean localEvaluation = true
+
+    /**
+     * Determines when the Console is evaluating/iterating input/result.
+     */
+    public AtomicBoolean evaluating = new AtomicBoolean(false)
 
     private final Console console
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2181

Pretty self-explanatory:

```text
gremlin> java.util.stream.IntStream.range(0, 10000).iterator()
==>0
==>1
==>2
==>3
==>4
...
==>348
==>349
==>350
==>351
==>352
Execution interrupted by ctrl+c
==>353
gremlin> Thread.sleep(5000)
Execution interrupted by ctrl+c
sleep interrupted
Type ':help' or ':h' for help.
Display stack trace? [yN]n
gremlin> g = TinkerGraph.open().traversal()
==>graphtraversalsource[tinkergraph[vertices:0 edges:0], standard]
gremlin> g.addV().as('a').addE('link').to('a')
==>e[1][0-link->0]
gremlin> g.V().repeat(out('link'))
Execution interrupted by ctrl+c
org.apache.tinkerpop.gremlin.process.traversal.util.TraversalInterruptedException
Type ':help' or ':h' for help.
Display stack trace? [yN]n
gremlin> :remote connect tinkerpop.server conf/remote.yaml
==>Configured localhost/127.0.0.1:8182
gremlin> :> g.addV().as('a').addE('link').to('a')
==>e[1][0-link->0]
gremlin> :> g.V().repeat(out('link'))
Execution interrupted by ctrl+c
org.apache.tinkerpop.gremlin.jsr223.console.RemoteException
Type ':help' or ':h' for help.
Display stack trace? [yN]n
gremlin> :remote console
==>All scripts will now be sent to Gremlin Server - [localhost/127.0.0.1:8182] - type ':remote console' to return to local mode
gremlin> g.V().repeat(out('link'))
Execution interrupted by ctrl+c
org.apache.tinkerpop.gremlin.jsr223.console.RemoteException
Type ':help' or ':h' for help.
Display stack trace? [yN]n
```

Right now it will only interrupt things that respect an actual interruption so while all of the above works nicely, something like `while(true){}` will not. This issue appears fixable on 3.4.x but not 3.3.x given some changes to groovysh in the 2.5.x line which is not available for 3.3.x and still on 2.4.x.  Backporting those changes and/or working around not having those changes is pretty ugly unfortunately. After some thought, I think that we should just take this PR as-is and leave that little hole open. It can be resolved in 3.4.x and I'll do that on merge to `master` once this PR is approved. 

All tests pass with `docker/build.sh -t -i`

VOTE +1