### PR TITLE
TINKERPOP-2182 Removed gperfutils dependencies in Console

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-7]]
 === TinkerPop 3.3.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Removed `gperfutils` dependencies from Gremlin Console.
 * Ensure `gremlin.sh` works when directories contain spaces
 * Enabled `ctrl+c` to interrupt long running processes in Gremlin Console.
 * Implemented `EdgeLabelVerificationStrategy`

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -2563,42 +2563,26 @@ g.V.map{it.name}  // sugar
 [[utilities-plugin]]
 === Utilities Plugin
 
-The Utilities Plugin provides various functions, helper methods and imports of external classes that are useful in the console.
+The Utilities Plugin provides various functions, helper methods and imports of external classes that are useful in
+the console.
 
 NOTE: The Utilities Plugin is enabled in the Gremlin Console by default.
-
-[[benchmarking-and-profiling]]
-==== Benchmarking and Profiling
-
-The link:https://code.google.com/p/gperfutils/[GPerfUtils] library provides a number of performance utilities for
-Groovy.  Specifically, these tools cover benchmarking and profiling.
-
-Benchmarking allows execution time comparisons of different pieces of code. While such a feature is generally useful,
-in the context of Gremlin, benchmarking can help compare traversal performance times to determine the optimal
-approach.  Profiling helps determine the parts of a program which are taking the most execution time, yielding
-low-level insight into the code being examined.
-
-[gremlin-groovy,modern]
-----
-:plugin use tinkerpop.sugar // Activate sugar plugin for use in benchmark
-benchmark{
- 'sugar' {g.V(1).name.next()}
- 'nosugar' {g.V(1).values('name').next()}
-}.prettyPrint()
-profile { g.V().iterate() }.prettyPrint()
-----
 
 [[describe-graph]]
 ==== Describe Graph
 
-A good implementation of the Gremlin APIs will validate their features against the link:../dev/provider/#validating-with-gremlin-test[Gremlin test suite].
-To learn more about a specific implementation's compliance with the test suite, use the `describeGraph` function.
-The following shows the output for `HadoopGraph`:
+A good implementation of the Gremlin APIs will validate their features against the
+link:../dev/provider/#validating-with-gremlin-test[Gremlin test suite]. To learn more about a specific
+implementation's compliance with the test suite, use the `describeGraph` function. The following shows the output
+for `HadoopGraph`:
 
 [gremlin-groovy,modern]
 ----
 describeGraph(HadoopGraph)
 ----
+
+NOTE: This command will only work for local `Graph` instances in the Gremlin Console. The command cannot be issued
+to remote graphs as scripts.
 
 [[application-templates]]
 == Application Templates

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -44,6 +44,37 @@ In earlier versions, the only option was to kill the Gremlin Console (typically 
 
 See link:https://issues.apache.org/jira/browse/TINKERPOP-2181[TINKERPOP-2181]
 
+==== Removed gperfutils Dependency
+
+Gremlin Console included references to:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.gperfutils</groupId>
+    <artifactId>gbench</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.gperfutils</groupId>
+    <artifactId>gprof</artifactId>
+</dependency
+----
+
+to provide some benchmarking and profiling tools for the Utilities Plugin. Neither project is well maintained at this
+point and given that TinkerPop has moved past the versions of Groovy that are supported by these tools it doesn't
+make sense to retain the dependencies. Users who wish to continue to use these tools can obviously do so still by
+manually adding the dependencies to the Gremlin Console or with the following command:
+
+[source,text]
+----
+gremlin> :install org.gperfutils gbench <version>
+gremlin> :install org.gperfutils gprof <version>
+----
+
+and then import the appropriate classes and methods to use.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2182[TINKERPOP-2182]
+
 === Upgrading for Providers
 
 ==== Detection of Anti-Patterns

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -56,16 +56,6 @@ limitations under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.gperfutils</groupId>
-            <artifactId>gbench</artifactId>
-            <version>0.4.3-groovy-2.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.gperfutils</groupId>
-            <artifactId>gprof</artifactId>
-            <version>0.3.1-groovy-2.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <optional>true</optional>

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/UtilitiesGremlinPlugin.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/UtilitiesGremlinPlugin.java
@@ -18,11 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.console.jsr223;
 
-import groovyx.gprof.ProfileStaticExtension;
 import org.apache.tinkerpop.gremlin.jsr223.AbstractGremlinPlugin;
-import org.apache.tinkerpop.gremlin.jsr223.DefaultImportCustomizer;
 import org.apache.tinkerpop.gremlin.jsr223.DefaultScriptCustomizer;
-import org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer;
 import org.apache.tinkerpop.gremlin.jsr223.ScriptCustomizer;
 
 import java.io.BufferedReader;
@@ -30,8 +27,6 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -40,49 +35,10 @@ public class UtilitiesGremlinPlugin extends AbstractGremlinPlugin {
 
     private static final String NAME = "tinkerpop.utilities";
 
-    private static final ImportCustomizer imports;
-
     private static final ScriptCustomizer scripts;
 
     static {
         try {
-            imports = DefaultImportCustomizer.build()
-                    .addClassImports(groovyx.gbench.Benchmark.class,
-                            groovyx.gbench.BenchmarkBuilder.class,
-                            groovyx.gbench.BenchmarkConstants.class,
-                            groovyx.gbench.BenchmarkContext.class,
-                            groovyx.gbench.Benchmarker.class,
-                            groovyx.gbench.BenchmarkList.class,
-                            groovyx.gbench.BenchmarkLogger.class,
-                            groovyx.gbench.BenchmarkMath.class,
-                            groovyx.gbench.BenchmarkMeasure.class,
-                            groovyx.gbench.BenchmarkStaticExtension.class,
-                            groovyx.gbench.BenchmarkSystem.class,
-                            groovyx.gbench.BenchmarkTime.class,
-                            groovyx.gbench.BenchmarkWarmUp.class,
-                            groovyx.gprof.Profiler.class,
-                            groovyx.gprof.ProfileStaticExtension.class,
-                            groovyx.gprof.CallFilter.class,
-                            groovyx.gprof.CallInfo.class,
-                            groovyx.gprof.CallInterceptor.class,
-                            groovyx.gprof.CallMatcher.class,
-                            groovyx.gprof.CallTree.class,
-                            groovyx.gprof.MethodCallFilter.class,
-                            groovyx.gprof.MethodCallInfo.class,
-                            groovyx.gprof.MethodInfo.class,
-                            groovyx.gprof.ProfileMetaClass.class,
-                            groovyx.gprof.ProxyReport.class,
-                            groovyx.gprof.Report.class,
-                            groovyx.gprof.ReportElement.class,
-                            groovyx.gprof.ReportNormalizer.class,
-                            groovyx.gprof.ReportPrinter.class,
-                            groovyx.gprof.ThreadInfo.class,
-                            groovyx.gprof.ThreadRunFilter.class,
-                            groovyx.gprof.Utils.class)
-                    .addMethodImports(
-                            ProfileStaticExtension.class.getMethod("profile", Object.class, Callable.class),
-                            ProfileStaticExtension.class.getMethod("profile", Object.class, Map.class, Callable.class)).create();
-
             final BufferedReader reader = new BufferedReader(new InputStreamReader(UtilitiesGremlinPlugin.class.getResourceAsStream("UtilitiesGremlinPluginScript.groovy")));
             final List<String> lines = new ArrayList<>();
             String line;
@@ -98,6 +54,6 @@ public class UtilitiesGremlinPlugin extends AbstractGremlinPlugin {
     }
 
     public UtilitiesGremlinPlugin() {
-        super(NAME, imports, scripts);
+        super(NAME, scripts);
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2182

Pretty straightforward. Made sure that the upgrade docs explained how to continue to use this feature if that is needed. 

All tests pass with `docker/build.sh -t -i`

VOTE +1