### PR TITLE
TINKERPOP-2193 Allow a Traversal to know what TraversalSource it spawned from

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-3-7, 3.3.7>>.
 
+* Allow a `Traversal` to know what `TraversalSource` it spawned from.
 
 [[release-3-4-1]]
 === TinkerPop 3.4.1 (Release Date: March 18, 2019)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
@@ -491,7 +491,19 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
          */
         public boolean isLocked();
 
+        /**
+         * Gets the {@link Graph} instance associated to this {@link Traversal}.
+         */
         public Optional<Graph> getGraph();
+
+        /**
+         * Gets the {@link TraversalSource} that spawned the {@link Traversal} instance initially if present. This
+         * {@link TraversalSource} should have spawned from the associated {@link Graph} returned from
+         * {@link #getGraph()}.
+         */
+        public default Optional<TraversalSource> getTraversalSource() {
+            return Optional.empty();
+        }
 
         public void setGraph(final Graph graph);
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -53,6 +53,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     private Step<?, E> finalEndStep = EmptyStep.instance();
     private final StepPosition stepPosition = new StepPosition();
     protected transient Graph graph;
+    protected transient TraversalSource g;
     protected List<Step> steps = new ArrayList<>();
     // steps will be repeatedly retrieved from this traversal so wrap them once in an immutable list that can be reused
     protected List<Step> unmodifiableSteps = Collections.unmodifiableList(steps);
@@ -69,6 +70,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
         this.graph = graph;
         this.strategies = traversalStrategies;
         this.bytecode = bytecode;
+        this.g = null;
     }
 
     public DefaultTraversal(final Graph graph) {
@@ -77,10 +79,12 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
 
     public DefaultTraversal(final TraversalSource traversalSource) {
         this(traversalSource.getGraph(), traversalSource.getStrategies(), traversalSource.getBytecode());
+        this.g = traversalSource;
     }
 
     public DefaultTraversal(final TraversalSource traversalSource, final DefaultTraversal.Admin<S,E> traversal) {
         this(traversalSource.getGraph(), traversalSource.getStrategies(), traversal.getBytecode());
+        this.g = traversalSource;
         steps.addAll(traversal.getSteps());
     }
 
@@ -329,6 +333,11 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     @Override
     public Optional<Graph> getGraph() {
         return Optional.ofNullable(this.graph);
+    }
+
+    @Override
+    public Optional<TraversalSource> getTraversalSource() {
+        return Optional.ofNullable(this.g);
     }
 
     @Override

--- a/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/SparqlToGremlinCompiler.java
+++ b/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/SparqlToGremlinCompiler.java
@@ -98,15 +98,11 @@ public class SparqlToGremlinCompiler {
         int traversalIndex = 0;
         final int numberOfTraversal = traversalList.size();
         final int numberOfOptionalTraversal = optionalTraversals.size();
-        Traversal arrayOfAllTraversals[] = null;
+        final Traversal[] arrayOfAllTraversals = (numberOfOptionalTraversal > 0) ?
+            new Traversal[numberOfTraversal - numberOfOptionalTraversal + 1] :
+            new Traversal[numberOfTraversal - numberOfOptionalTraversal];
 
-        if (numberOfOptionalTraversal > 0) {
-            arrayOfAllTraversals = new Traversal[numberOfTraversal - numberOfOptionalTraversal +1];
-        } else {
-            arrayOfAllTraversals = new Traversal[numberOfTraversal - numberOfOptionalTraversal];
-        }
-        
-        Traversal arrayOfOptionalTraversals[] = new Traversal[numberOfOptionalTraversal];
+        final Traversal[] arrayOfOptionalTraversals = new Traversal[numberOfOptionalTraversal];
 
         for (Traversal tempTrav : traversalList) {
             arrayOfAllTraversals[traversalIndex++] = tempTrav;

--- a/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/strategy/SparqlStrategy.java
+++ b/sparql-gremlin/src/main/java/org/apache/tinkerpop/gremlin/sparql/process/traversal/strategy/SparqlStrategy.java
@@ -21,12 +21,14 @@ package org.apache.tinkerpop.gremlin.sparql.process.traversal.strategy;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.strategy.decoration.RemoteStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.sparql.SparqlToGremlinCompiler;
 import org.apache.tinkerpop.gremlin.sparql.process.traversal.dsl.sparql.SparqlTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Collections;
@@ -74,8 +76,11 @@ public class SparqlStrategy extends AbstractTraversalStrategy<TraversalStrategy.
             // further assumes that there is just one argument to that injection which is a string (i.e. sparql query)
             if (injections.length == 1 && injections[0] instanceof String) {
                 final String sparql = (String) injections[0];
+
+                // try to grab the TraversalSource from the Traversal, but if it's not there then try to the Graph
+                // instance and spawn one off from there.
                 final Traversal<Vertex, ?> sparqlTraversal = SparqlToGremlinCompiler.compile(
-                        traversal.getGraph().get(), sparql);
+                        (GraphTraversalSource) traversal.getTraversalSource().orElseGet(() -> traversal.getGraph().map(Graph::traversal).get()), sparql);
                 TraversalHelper.insertTraversal(stepWithSparql, sparqlTraversal.asAdmin(), traversal);
                 traversal.removeStep(stepWithSparql);
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2193

Unclear why this wasn't done originally. As noted in the JIRA we already had the `TraversalSource` passed to the created `Traversal` only to pick and choose bits/pieces we wanted to keep rather than the `TraversalSource` itself.  

All tests pass with `docker/build.sh -t -n -i`

VOTE +1