### PR TITLE
Fix threaded transaction tests. 

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
@@ -598,6 +598,7 @@ public class TransactionTest extends AbstractGremlinTest {
         threadedG.tx().commit();
 
         // there should be one vertex for each thread
+        graph.tx().rollback();
         assertVertexEdgeCounts(graph, numberOfThreads, 0);
     }
 
@@ -638,6 +639,7 @@ public class TransactionTest extends AbstractGremlinTest {
         threadedG.tx().commit();
 
         // there should be one vertex for each thread
+        graph.tx().rollback();
         assertVertexEdgeCounts(graph, numberOfThreads, 0);
 
         try {


### PR DESCRIPTION
The graph thread should be refreshed to observe the result of the committed transaction (see the discussion here https://groups.google.com/forum/#!topic/gremlin-users/2JhAtXcCucE).