### PR TITLE
Allow to configure processor in Gremlin-JavaScript

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Ensure `gremlin.sh` works when directories contain spaces
 * Enabled `ctrl+c` to interrupt long running processes in Gremlin Console.
 * Implemented `EdgeLabelVerificationStrategy`
+* Gremlin-JavaScript: added parameter to configure processor in client constructor
 
 [[release-3-3-6]]
 === TinkerPop 3.3.6 (Release Date: March 18, 2019)

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -39,6 +39,7 @@ class Client {
    * @param {String} [options.traversalSource] The traversal source. Defaults to: 'g'.
    * @param {GraphSONWriter} [options.writer] The writer to use.
    * @param {Authenticator} [options.authenticator] The authentication handler to use.
+   * @param {String} [options.processor] The name of the opProcessor to use
    * @constructor
    */
   constructor(url, options) {
@@ -70,7 +71,7 @@ class Client {
         'aliases': { 'g': this._options.traversalSource || 'g' }
       };
 
-      return this._connection.submit(null, 'eval', args, null, '');
+      return this._connection.submit(null, 'eval', args, null, this._options.processor || '');
     }
 
     if (message instanceof Bytecode) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const Client = require('../../lib/driver/client');
+
+describe('Client', function () {
+  const customOpProcessor = 'customOpProcessor';
+  const query = 'customQuery';
+
+  it('should use default opProcessor', function () {
+    const connectionMock = {
+      submit: function (bytecode, op, args, requestId, processor) {
+        assert.strictEqual(args.gremlin, query);
+        assert.strictEqual(processor, '');
+
+        return Promise.resolve();
+      }
+    };
+
+    const customClient = new Client('localhost:8182', {traversalSource: 'g'});
+    customClient._connection = connectionMock;
+    customClient.submit(query)
+  });
+
+  it('should allow to configure opProcessor', function () {
+    const connectionMock = {
+      submit: function (bytecode, op, args, requestId, processor) {
+        assert.strictEqual(args.gremlin, query);
+        assert.strictEqual(processor, customOpProcessor);
+
+        return Promise.resolve();
+      }
+    };
+
+    const customClient = new Client('localhost:8182', {traversalSource: 'g', processor: customOpProcessor});
+    customClient._connection = connectionMock;
+    customClient.submit(query)
+  });
+});


### PR DESCRIPTION
* It is currently possible to configure [opProcessor](https://tinkerpop.apache.org/docs/current/reference/#opprocessor-configurations) by creating custom `RequestMessage` in Gremlin-Java/Groovy, Gremlin.Net and Gremlin-Python
* It [was possible](https://github.com/jbmusso/gremlin-javascript/blob/master/gremlin-client/README.md#usage) to configure opProcessor in Gremlin-JavaScript 2.7.0 before API change
* For consistency, this PR adds an option to configure [opProcessor](https://tinkerpop.apache.org/docs/current/reference/#opprocessor-configurations) in new Gremlin Javascript API
* This is useful, for example, to connect to [Gremlin Server Cypher Plugin](https://github.com/opencypher/cypher-for-gremlin/tree/master/tinkerpop/cypher-gremlin-server-plugin#usage)