### PR TITLE
TINKERPOP-2196 Fixed PartitionStrategy when setting vertex label

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Improved folding of `property()` step into related mutating steps.
 * Removed `gperfutils` dependencies from Gremlin Console.
+* Fixed `PartitionStrategy` when setting vertex label and having `includeMetaProperties` configured to `true`.
+* Ensure `gremlin.sh` works when directories contain spaces
 * Ensured that `gremlin.sh` works when directories contain spaces.
 * Enabled `ctrl+c` to interrupt long running processes in Gremlin Console.
 * Quieted "host unavailable" warnings for both the driver and Gremlin Console.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
@@ -214,20 +214,24 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
                     final Parameters parameters = ((Parameterizing) step).getParameters();
                     final Map<Object, List<Object>> params = parameters.getRaw();
                     params.forEach((k, v) -> {
-                        final List<Step> addPropertyStepsToAppend = new ArrayList<>(v.size());
-                        final VertexProperty.Cardinality cardinality = vertexFeatures.getCardinality((String) k);
-                        v.forEach(o -> {
-                            final AddPropertyStep addPropertyStep = new AddPropertyStep(traversal, cardinality, k, o);
-                            addPropertyStep.addPropertyMutations(partitionKey, writePartition);
-                            addPropertyStepsToAppend.add(addPropertyStep);
 
-                            // need to remove the parameter from the AddVertex/StartStep because it's now being added
-                            // via the AddPropertyStep
-                            parameters.remove(k);
-                        });
+                        // need to filter out T based keys
+                        if (k instanceof String) {
+                            final List<Step> addPropertyStepsToAppend = new ArrayList<>(v.size());
+                            final VertexProperty.Cardinality cardinality = vertexFeatures.getCardinality((String) k);
+                            v.forEach(o -> {
+                                final AddPropertyStep addPropertyStep = new AddPropertyStep(traversal, cardinality, k, o);
+                                addPropertyStep.addPropertyMutations(partitionKey, writePartition);
+                                addPropertyStepsToAppend.add(addPropertyStep);
 
-                        Collections.reverse(addPropertyStepsToAppend);
-                        addPropertyStepsToAppend.forEach(s -> TraversalHelper.insertAfterStep(s, step, traversal));
+                                // need to remove the parameter from the AddVertex/StartStep because it's now being added
+                                // via the AddPropertyStep
+                                parameters.remove(k);
+                            });
+
+                            Collections.reverse(addPropertyStepsToAppend);
+                            addPropertyStepsToAppend.forEach(s -> TraversalHelper.insertAfterStep(s, step, traversal));
+                        }
                     });
                 }
             }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategyProcessTest.java
@@ -128,13 +128,23 @@ public class PartitionStrategyProcessTest extends AbstractGremlinProcessTest {
                 .partitionKey(partition).writePartition("B").addReadPartition("B").addReadPartition("A").create());
 
         final Vertex v = gOverA.addV().property("any", "thing").property("some", "thing").next();
+        final Vertex labelledV = gOverA.addV("person").property("name", "thing").property("that", "thing").next();
 
         assertNotNull(v);
         assertEquals("thing", g.V(v).values("any").next());
+        assertEquals(Vertex.DEFAULT_LABEL, g.V(v).label().next());
         assertEquals("A", g.V(v).values(partition).next());
         assertEquals("A", g.V(v).properties("any").values(partition).next());
         assertEquals("thing", g.V(v).values("some").next());
         assertEquals("A", g.V(v).properties("some").values(partition).next());
+
+        assertNotNull(labelledV);
+        assertEquals("thing", g.V(labelledV).values("name").next());
+        assertEquals("person", g.V(labelledV).label().next());
+        assertEquals("A", g.V(labelledV).values(partition).next());
+        assertEquals("A", g.V(labelledV).properties("name").values(partition).next());
+        assertEquals("thing", g.V(labelledV).values("that").next());
+        assertEquals("A", g.V(labelledV).properties("that").values(partition).next());
 
         gOverAB.V(v).property("that", "thing").iterate();
         assertEquals("thing", g.V(v).values("that").next());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2196

If includeMetaProperties is enabled and vertex label set then an error would follow because T.label was not being properly accounted for. You can't check cardinality for T.

Built with `mvn clean install -DincludeNeo4j`

VOTE +1