### PR TITLE
TINKERPOP-2203 Added console remote timeout to each request

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ This release also includes changes from <<release-3-3-7, 3.3.7>>.
 * Allow a `Traversal` to know what `TraversalSource` it spawned from.
 * Changed definition of generic in signature of `from(Traversal)` and `to(Traversal)` steps to use a wildcard rather than `Vertex`.
 * Fixed problem with connection pool sizing and retry.
+* Changed `:>` in Gremlin Console to submit the client-side timeout on each request.
 
 [[release-3-4-1]]
 === TinkerPop 3.4.1 (Release Date: March 18, 2019)

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -35,6 +35,19 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.4.1/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Gremlin Console Timeout
+
+The Gremlin Console timeout that is set by `:remote config timeout x` was client-side only in prior versions, which
+meant that if the console timeout was less than the server timeout the client would timeout but the server might still
+be processing the request. Similarly, a longer timeout on the console would not change the server and the timeout
+would occur sooner than expected. These discrepancies often led to confusion.
+
+As of 3.4.0, the Java Driver API allowed for timeout settings to be more easily passed per request, so the console
+was modified for this current version to pass the console timeout for each remote submission thus yielding more
+consistent and intuitive behavior.
+
+link:https://issues.apache.org/jira/browse/TINKERPOP-2203[TINKERPOP-2203]
+
 ==== Mix SPARQL and Gremlin
 
 In the initial release of `sparql-gremlin` it was only possible to execute a SPARQL query and have it translate to


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2203

Passes the console timeout to the server on each `:submit`:

```text
gremlin> :remote config timeout 50
==>Set remote timeout to 50ms
gremlin> :> Thread.sleep(1000);"back"
Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 50 ms or evaluation was otherwise cancelled directly for request [Thread.sleep(1000);"back"]
Type ':help' or ':h' for help.
Display stack trace? [yN]y
java.util.concurrent.TimeoutException: Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 50 ms or evaluation was otherwise cancelled directly for request [Thread.sleep(1000);"back"]
	at org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor.lambda$eval$1(GremlinExecutor.java:315)
	at io.netty.util.concurrent.PromiseTask$RunnableAdapter.call(PromiseTask.java:38)
	at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:125)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:465)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884)
	at java.lang.Thread.run(Thread.java:748)
```

All good with `mvn clean install && mvn verify -pl gremlin-console -DskipIntegrationTests=false`.

VOTE +1
