### PR TITLE
Switch docker build to openjdk

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,27 +19,26 @@ FROM ubuntu:trusty
 
 LABEL maintainer="Daniel Kuppitz <me@gremlin.guru>"
 
-RUN apt-get update \
-    && apt-get -y install software-properties-common python-software-properties apt-transport-https curl dpkg \
-    && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
-    && add-apt-repository -y ppa:webupd8team/java \
-    && sh -c 'curl -s https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb' \
-    && sh -c 'dpkg -i packages-microsoft-prod.deb' \
-    && sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list' \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && apt-get update \
-    && apt-get install -y oracle-java8-installer gawk git maven openssh-server subversion zip \
-    && apt-get install -y --force-yes dotnet-sdk-2.2 python python-dev python3-dev python-pip build-essential mono-devel \
-    && pip install virtualenv virtualenvwrapper \
-    && pip install --upgrade pip \
-    && rm -rf /var/lib/apt/lists/* /var/cache/oracle-jdk8-installer
+RUN apt-get update
+RUN apt-get -y install software-properties-common python-software-properties apt-transport-https curl dpkg
+RUN add-apt-repository ppa:openjdk-r/ppa
+RUN sh -c 'curl -s https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb'
+RUN sh -c 'dpkg -i packages-microsoft-prod.deb'
+RUN sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list'
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN apt-get update
+RUN apt-get install -y openjdk-8-jdk gawk git maven openssh-server subversion zip
+RUN apt-get install -y --force-yes dotnet-sdk-2.2 python python-dev python3-dev python-pip build-essential mono-devel
+RUN pip install virtualenv virtualenvwrapper
+RUN pip install --upgrade pip
+RUN rm -rf /var/lib/apt/lists/* /var/cache/openjdk-8-jdk
 
 RUN sed -i 's@PermitRootLogin without-password@PermitRootLogin yes@' /etc/ssh/sshd_config
 RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuuid.so@g' /etc/pam.d/sshd
 RUN ssh-keygen -t rsa -f ~/.ssh/id_rsa -N '' \
     && cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 RUN sed -i 's/.*"$PS1".*/# \0/' ~/.bashrc
 RUN echo "export JAVA_HOME=${JAVA_HOME}" >> ~/.bashrc


### PR DESCRIPTION
Oracle jdk ppa has been discontinued in recent weeks leading to failed docker builds. This is basically a CTR fix, but creating a PR to trigger the Travis PR builder to make sure this change works. If testing this locally yourself, I guess you'll need to kill your local docker images.