### PR TITLE
TINKERPOP-2199 Fixed P.within()/without() behavior in gremlin-python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Quieted "host unavailable" warnings for both the driver and Gremlin Console.
 * Fixed bug in `GremlinGroovyScriptEngine` interpreter mode around class definitions.
 * Implemented `EdgeLabelVerificationStrategy`.
+* Fixed behavior of `P` for `within()` and `without()` in gremlin-python to be consistent with Java when using varargs.
 * Added parameter to configure the `processor` in the gremlin-javascript `client` constructor.
 
 [[release-3-3-6]]

--- a/gremlin-python/glv/TraversalSource.template
+++ b/gremlin-python/glv/TraversalSource.template
@@ -131,11 +131,25 @@ class P(object):
         self.operator = operator
         self.value = value
         self.other = other
-<% pmethods.each { method -> %>
+<% pmethods.findAll{!(it in ["within","without"])}.each { method -> %>
     @staticmethod
     def <%= method %>(*args):
         return P("<%= toJava.call(method) %>", *args)
 <% } %>
+    @staticmethod
+    def within(*args):
+        if len(args) == 1 and type(args[0]) == list:
+            return P("within", args[0])
+        else:
+            return P("within", list(args))
+        
+    @staticmethod
+    def without(*args):
+        if len(args) == 1 and type(args[0]) == list:
+            return P("without", args[0])
+        else:
+            return P("without", list(args))
+
     def and_(self, arg):
         return P("and", self, arg)
 

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -252,11 +252,17 @@ class P(object):
 
     @staticmethod
     def within(*args):
-        return P("within", *args)
-
+        if len(args) == 1 and type(args[0]) == list:
+            return P("within", args[0])
+        else:
+            return P("within", list(args))
+        
     @staticmethod
     def without(*args):
-        return P("without", *args)
+        if len(args) == 1 and type(args[0]) == list:
+            return P("without", args[0])
+        else:
+            return P("without", list(args))
 
     def and_(self, arg):
         return P("and", self, arg)

--- a/gremlin-python/src/main/jython/tests/process/test_dsl.py
+++ b/gremlin-python/src/main/jython/tests/process/test_dsl.py
@@ -65,7 +65,7 @@ class SocialTraversalSource(GraphTraversalSource):
         traversal = self.get_graph_traversal().V().hasLabel("person")
 
         if len(args) > 0:
-            traversal = traversal.has("name", P.within(args))
+            traversal = traversal.has("name", P.within(*args))
 
         return traversal
 

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV2d0.py
@@ -342,7 +342,12 @@ class TestGraphSONWriter(object):
             self.graphson_writer.writeObject(P.lt("b").or_(P.gt("c")).and_(P.neq("d"))))
 
         result = {'@type': 'g:P', '@value': {'predicate':'within','value': [{"@type": "g:Int32", "@value": 1},{"@type": "g:Int32", "@value": 2}]}}
-        assert result == json.loads(self.graphson_writer.writeObject(P.within([1,2])))
+        assert result == json.loads(self.graphson_writer.writeObject(P.within([1, 2])))
+        assert result == json.loads(self.graphson_writer.writeObject(P.within(1, 2)))
+
+        result = {'@type': 'g:P', '@value': {'predicate':'within','value': [{"@type": "g:Int32", "@value": 1}]}}
+        assert result == json.loads(self.graphson_writer.writeObject(P.within([1])))
+        assert result == json.loads(self.graphson_writer.writeObject(P.within(1)))
 
     def test_strategies(self):
         # we have a proxy model for now given that we don't want to have to have g:XXX all registered on the Gremlin traversal machine (yet)

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -395,6 +395,12 @@ class TestGraphSONWriter(object):
         result = {'@type': 'g:P', '@value': {'predicate': 'within', 'value': {'@type': 'g:List', '@value': [
             {"@type": "g:Int32", "@value": 1}, {"@type": "g:Int32", "@value": 2}]}}}
         assert result == json.loads(self.graphson_writer.writeObject(P.within([1, 2])))
+        assert result == json.loads(self.graphson_writer.writeObject(P.within(1, 2)))
+
+        result = {'@type': 'g:P', '@value': {'predicate': 'within', 'value': {'@type': 'g:List', '@value': [
+            {"@type": "g:Int32", "@value": 1}]}}}
+        assert result == json.loads(self.graphson_writer.writeObject(P.within([1])))
+        assert result == json.loads(self.graphson_writer.writeObject(P.within(1)))
 
     def test_strategies(self):
         # we have a proxy model for now given that we don't want to have to have g:XXX all registered on the Gremlin traversal machine (yet)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2199

Made behavior for varags usage consistent with what Java does. Was never really sure what to do with this, but after reviewing the Java implementation it prefers a Collection as a single argument and basically converts the varargs to Collection, so basically just doing the same thing here.

builds with `mvn clean install`

VOTE +1