### PR TITLE
TINKERPOP-2206 Fixed g:List serialization

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Ensured that `gremlin.sh` works when directories contain spaces.
 * Enabled `ctrl+c` to interrupt long running processes in Gremlin Console.
 * Quieted "host unavailable" warnings for both the driver and Gremlin Console.
+* Fixed construction of `g:List` from arrays in gremlin-javascript.
 * Fixed bug in `GremlinGroovyScriptEngine` interpreter mode around class definitions.
 * Implemented `EdgeLabelVerificationStrategy`.
 * Added parameter to configure the `processor` in the gremlin-javascript `client` constructor.

--- a/gremlin-javascript/glv/TraversalSource.template
+++ b/gremlin-javascript/glv/TraversalSource.template
@@ -159,7 +159,7 @@ class P {
   }
 
   static without(...args) {
-    if (args.length == 1 && Array.isArray(args[0])) {
+    if (args.length === 1 && Array.isArray(args[0])) {
       return new P("without", args[0], null);
     } else {
       return new P("without", args, null);

--- a/gremlin-javascript/glv/TraversalSource.template
+++ b/gremlin-javascript/glv/TraversalSource.template
@@ -149,7 +149,24 @@ class P {
   or(arg) {
     return new P('or', this, arg);
   }
-<% pmethods.each{ method -> %>
+
+  static within(...args) {
+    if (args.length === 1 && Array.isArray(args[0])) {
+      return new P("within", args[0], null);
+    } else {
+      return new P("within", args, null);
+    }
+  }
+
+  static without(...args) {
+    if (args.length == 1 && Array.isArray(args[0])) {
+      return new P("without", args[0], null);
+    } else {
+      return new P("without", args, null);
+    }
+  }
+
+<% pmethods.findAll{!(it in ["within","without"])}.each{ method -> %>
   /** @param {...Object} args */
   static <%= toJs.call(method) %>(...args) {
     return createP('<%= method %>', args);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -159,7 +159,7 @@ class P {
   }
 
   static without(...args) {
-    if (args.length == 1 && Array.isArray(args[0])) {
+    if (args.length === 1 && Array.isArray(args[0])) {
       return new P("without", args[0], null);
     } else {
       return new P("without", args, null);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -150,6 +150,23 @@ class P {
     return new P('or', this, arg);
   }
 
+  static within(...args) {
+    if (args.length === 1 && Array.isArray(args[0])) {
+      return new P("within", args[0], null);
+    } else {
+      return new P("within", args, null);
+    }
+  }
+
+  static without(...args) {
+    if (args.length == 1 && Array.isArray(args[0])) {
+      return new P("without", args[0], null);
+    } else {
+      return new P("without", args, null);
+    }
+  }
+
+
   /** @param {...Object} args */
   static between(...args) {
     return createP('between', args);
@@ -203,16 +220,6 @@ class P {
   /** @param {...Object} args */
   static test(...args) {
     return createP('test', args);
-  }
-
-  /** @param {...Object} args */
-  static within(...args) {
-    return createP('within', args);
-  }
-
-  /** @param {...Object} args */
-  static without(...args) {
-    return createP('without', args);
   }
 
 }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/graph-serializer.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/graph-serializer.js
@@ -50,27 +50,29 @@ class GraphSONWriter {
       }
       s.writer = this;
       // Insert custom serializers first
-      this._serializers.unshift(s);
+      th
+      is._serializers.unshift(s);
     });
   }
 
   adaptObject(value) {
     let s;
-    if (Array.isArray(value)) {
-      return value.map(item => this.adaptObject(item));
-    }
+    let o = value;
     for (let i = 0; i < this._serializers.length; i++) {
       const currentSerializer = this._serializers[i];
-      if (currentSerializer.canBeUsedFor && currentSerializer.canBeUsedFor(value)) {
+      if (currentSerializer.canBeUsedFor && currentSerializer.canBeUsedFor(o)) {
         s = currentSerializer;
         break;
       }
     }
     if (s) {
-      return s.serialize(value);
+      return s.serialize(o);
+    }
+    if (Array.isArray(value)) {
+      o = value.map(item => this.adaptObject(item));
     }
     // Default (strings / objects / ...)
-    return value;
+    return o;
   }
 
   /**

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/graph-serializer.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/graph-serializer.js
@@ -50,29 +50,33 @@ class GraphSONWriter {
       }
       s.writer = this;
       // Insert custom serializers first
-      th
-      is._serializers.unshift(s);
+      this._serializers.unshift(s);
     });
   }
 
   adaptObject(value) {
     let s;
-    let o = value;
+
     for (let i = 0; i < this._serializers.length; i++) {
       const currentSerializer = this._serializers[i];
-      if (currentSerializer.canBeUsedFor && currentSerializer.canBeUsedFor(o)) {
+      if (currentSerializer.canBeUsedFor && currentSerializer.canBeUsedFor(value)) {
         s = currentSerializer;
         break;
       }
     }
+
     if (s) {
-      return s.serialize(o);
+      return s.serialize(value);
     }
+
     if (Array.isArray(value)) {
-      o = value.map(item => this.adaptObject(item));
+      // We need to handle arrays when there is no serializer
+      // for older versions of GraphSON
+      return value.map(item => this.adaptObject(item));
     }
+
     // Default (strings / objects / ...)
-    return o;
+    return value;
   }
 
   /**

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/type-serializers.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/type-serializers.js
@@ -144,7 +144,7 @@ class BytecodeSerializer extends TypeSerializer {
     const result = new Array(instructions.length);
     result[0] = instructions[0];
     for (let i = 0; i < instructions.length; i++) {
-      result[i] = this.writer.adaptObject(instructions[i]);
+      result[i] = instructions[i].map(item => this.writer.adaptObject(item));
     }
     return result;
   }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
@@ -26,6 +26,7 @@ const assert = require('assert');
 const graph = require('../../lib/structure/graph');
 const t = require('../../lib/process/traversal.js');
 const gs = require('../../lib/structure/io/graph-serializer.js');
+const utils = require('../../lib/utils');
 const GraphSONReader = gs.GraphSONReader;
 const GraphSONWriter = gs.GraphSONWriter;
 const P = t.P;
@@ -151,6 +152,11 @@ describe('GraphSONWriter', function () {
     assert.strictEqual(writer.write(true), 'true');
     assert.strictEqual(writer.write(false), 'false');
   });
+  it('should write list values', function () {
+    const writer = new GraphSONWriter();
+    const expected = JSON.stringify({"@type": "g:List", "@value": ["marko"]});
+    assert.strictEqual(writer.write(["marko"]), expected);
+  });
   it('should write enum values', function () {
     const writer = new GraphSONWriter();
     assert.strictEqual(writer.write(t.cardinality.set), '{"@type":"g:Cardinality","@value":"set"}');
@@ -162,5 +168,17 @@ describe('GraphSONWriter', function () {
         {"@type":"g:P","@value":{"predicate":"gt","value":"c"}}]}},
       {"@type":"g:P","@value":{"predicate":"neq","value":"d"}}]}});
     assert.strictEqual(writer.write(P.lt("b").or(P.gt("c")).and(P.neq("d"))), expected);
+  });
+  it('should write P.within single', function () {
+    const writer = new GraphSONWriter();
+    const expected = JSON.stringify({"@type": "g:P", "@value": {"predicate": "within", "value": {"@type": "g:List", "@value": [ "marko" ]}}});
+    assert.strictEqual(writer.write(P.within(["marko"])), expected);
+    assert.strictEqual(writer.write(P.within("marko")), expected);
+  });
+  it('should write P.within multiple', function () {
+    const writer = new GraphSONWriter();
+    const expected = JSON.stringify({"@type": "g:P", "@value": {"predicate": "within", "value": {"@type": "g:List", "@value": [ "marko", "josh"]}}});
+    assert.strictEqual(writer.write(P.within(["marko","josh"])), expected);
+    assert.strictEqual(writer.write(P.within("marko","josh")), expected);
   });
 });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2206

Seems like javascript arrays were being serialized as naked JSON objects rather than g:List. Java serialization seemed to forgive that for some reason, but prevented certain operations to really work right in the process like P.within() logic from TINKERPOP-2199 which was also fixed in this change.

There may be nicer ways to correct these issues from a javascript programming perspective - I just kinda hammered something in there. Happy to hear better ways to do things.

Builds with `mvn clean install`:

VOTE +1