### PR TITLE
TINKERPOP-2211 Add API which allows per-request option for bytecode

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ This release also includes changes from <<release-3-3-7, 3.3.7>>.
 * Changed definition of generic in signature of `from(Traversal)` and `to(Traversal)` steps to use a wildcard rather than `Vertex`.
 * Fixed problem with connection pool sizing and retry.
 * Changed `:>` in Gremlin Console to submit the client-side timeout on each request.
+* Added option to set per-request settings on a `Traversal` submitted via `Bytecode`.
+* Fixed the Gryo registration for `OptionsStrategy` as it was not serializing state properly.
 
 [[release-3-4-1]]
 === TinkerPop 3.4.1 (Release Date: March 18, 2019)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ This release also includes changes from <<release-3-3-7, 3.3.7>>.
 * Changed definition of generic in signature of `from(Traversal)` and `to(Traversal)` steps to use a wildcard rather than `Vertex`.
 * Fixed problem with connection pool sizing and retry.
 * Changed `:>` in Gremlin Console to submit the client-side timeout on each request.
+* Provided method to override the request identifier with `RequestOptions`.
 * Added option to set per-request settings on a `Traversal` submitted via `Bytecode`.
 * Fixed the Gryo registration for `OptionsStrategy` as it was not serializing state properly.
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -27,13 +27,22 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.4.2/CHANGELOG.asciidoc#release-3-4-2[changelog] for a complete list of all the modifications that are part of this release.
 
-== TinkerPop 3.4.1
-
-*Release Date: March 18, 2019*
-
-Please see the link:https://github.com/apache/tinkerpop/blob/3.4.1/CHANGELOG.asciidoc#release-3-4-1[changelog] for a complete list of all the modifications that are part of this release.
-
 === Upgrading for Users
+
+==== Per Request Options
+
+In 3.4.0, the notion of `RequestOptions` were added so that users could have an easier way to configure settings on
+individual requests made through the Java driver. While that change provided a way to set those configurations for
+script based requests, it didn't include options to make those settings in a `Traversal` submitted via `Bytecode`. In
+this release those settings become available via `with()` step on the `TraversalSource` as follows:
+
+[source,java]
+----
+GraphTraversalSource g = traversal().withRemote(conf);
+List<Vertex> vertices = g.with(RemoteConnection.PER_REQUEST_TIMEOUT, 500).V().out("knows").toList()
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2211[TINKERPOP-2211]
 
 ==== Gremlin Console Timeout
 
@@ -46,14 +55,35 @@ As of 3.4.0, the Java Driver API allowed for timeout settings to be more easily 
 was modified for this current version to pass the console timeout for each remote submission thus yielding more
 consistent and intuitive behavior.
 
-link:https://issues.apache.org/jira/browse/TINKERPOP-2203[TINKERPOP-2203]
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2203[TINKERPOP-2203]
+
+=== Upgrading for Providers
+
+==== Graph Driver Providers
+
+===== Per Request Options
+
+In GraphBinary serialization, Java `write()` and `writeValue()` from `TypeSerializer<T>` interface now take a Netty's
+`ByteBuf` instance instead of an `ByteBufAllocator`, that way the same buffer instance gets reused during the write
+of a message. Additionally, we took the opportunity to remove the unused parameter from `ResponseMessageSerializer`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2161[TINKERPOP-2161]
+
+== TinkerPop 3.4.1
+
+*Release Date: March 18, 2019*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.4.1/CHANGELOG.asciidoc#release-3-4-1[changelog] for a complete list of all the modifications that are part of this release.
+
+=== Upgrading for Users
 
 ==== Mix SPARQL and Gremlin
 
 In the initial release of `sparql-gremlin` it was only possible to execute a SPARQL query and have it translate to
 Gremlin. Therefore, it was only possible to write a query like this:
 
-```text
+[source,text]
+----
 gremlin> g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }")
 ==>[name:marko,age:29]
 ==>[name:vadas,age:27]
@@ -66,11 +96,12 @@ gremlin> g.sparql("SELECT * WHERE { }")
 ==>v[4]
 ==>v[5]
 ==>v[6]
-```
+----
 
 In this release, however, it is now possible to further process that result with Gremlin steps:
 
-```text
+[source,text]
+----
 gremlin> g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }").select("name")
 ==>marko
 ==>vadas
@@ -79,7 +110,7 @@ gremlin> g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:ag
 gremlin> g.sparql("SELECT * WHERE { }").out("knows").values("name")
 ==>vadas
 ==>josh
-```
+----
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2171[TINKERPOP-2171],
 link:http://tinkerpop.apache.org/docs/3.4.1/reference/#sparql-with-gremlin[Reference Documentation]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteConnection.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteConnection.java
@@ -41,16 +41,6 @@ public interface RemoteConnection extends AutoCloseable {
     public static final String GREMLIN_REMOTE_CONNECTION_CLASS = GREMLIN_REMOTE + "remoteConnectionClass";
 
     /**
-     * Key for configuring a per-request timeout option for a {@code RemoteConnection} .
-     */
-    public static final String PER_REQUEST_TIMEOUT = GREMLIN_REMOTE + "timeout";
-
-    /**
-     * Key for configuring a the batch size option for a {@code RemoteConnection} .
-     */
-    public static final String PER_REQUEST_BATCH_SIZE = GREMLIN_REMOTE + "batchSize";
-
-    /**
      * Submits {@link Traversal} {@link Bytecode} to a server and returns a promise of a {@link RemoteTraversal}.
      * The {@link RemoteTraversal} is an abstraction over two types of results that can be returned as part of the
      * response from the server: the results of the {@link Traversal} itself and the side-effects that it produced.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteConnection.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteConnection.java
@@ -41,6 +41,16 @@ public interface RemoteConnection extends AutoCloseable {
     public static final String GREMLIN_REMOTE_CONNECTION_CLASS = GREMLIN_REMOTE + "remoteConnectionClass";
 
     /**
+     * Key for configuring a per-request timeout option for a {@code RemoteConnection} .
+     */
+    public static final String PER_REQUEST_TIMEOUT = GREMLIN_REMOTE + "timeout";
+
+    /**
+     * Key for configuring a the batch size option for a {@code RemoteConnection} .
+     */
+    public static final String PER_REQUEST_BATCH_SIZE = GREMLIN_REMOTE + "batchSize";
+
+    /**
      * Submits {@link Traversal} {@link Bytecode} to a server and returns a promise of a {@link RemoteTraversal}.
      * The {@link RemoteTraversal} is an abstraction over two types of results that can be returned as part of the
      * response from the server: the results of the {@link Traversal} itself and the side-effects that it produced.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/BytecodeUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/BytecodeUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.util;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+
+import java.util.Iterator;
+
+/**
+ * Utility class for parsing {@link Bytecode}.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public final class BytecodeUtil {
+
+    private BytecodeUtil() {}
+
+    /**
+     * Parses {@link Bytecode} to find {@link TraversalStrategy} objects in the source instructions.
+     */
+    public static <A extends TraversalStrategy> Iterator<A> findStrategies(final Bytecode bytecode, final Class<A> clazz) {
+        return IteratorUtils.map(
+                IteratorUtils.filter(bytecode.getSourceInstructions().iterator(),
+                        s -> s.getOperator().equals(TraversalSource.Symbols.withStrategies) && clazz.isAssignableFrom(s.getArguments()[0].getClass())),
+                os -> (A) os.getArguments()[0]);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoVersion.java
@@ -343,7 +343,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(LazyBarrierStrategy.class, 150));
             add(GryoTypeReg.of(MatchPredicateStrategy.class, 151));
             add(GryoTypeReg.of(OrderLimitStrategy.class, 152));
-            add(GryoTypeReg.of(OptionsStrategy.class, 187));
+            add(GryoTypeReg.of(OptionsStrategy.class, 187, new JavaSerializer()));
             add(GryoTypeReg.of(PathProcessorStrategy.class, 153));
             add(GryoTypeReg.of(PathRetractionStrategy.class, 154));
             add(GryoTypeReg.of(CountStrategy.class, 155));
@@ -579,7 +579,7 @@ public enum GryoVersion {
             add(GryoTypeReg.of(LazyBarrierStrategy.class, 150));
             add(GryoTypeReg.of(MatchPredicateStrategy.class, 151));
             add(GryoTypeReg.of(OrderLimitStrategy.class, 152));
-            add(GryoTypeReg.of(OptionsStrategy.class, 187));
+            add(GryoTypeReg.of(OptionsStrategy.class, 187, new JavaSerializer()));
             add(GryoTypeReg.of(PathProcessorStrategy.class, 153));
             add(GryoTypeReg.of(PathRetractionStrategy.class, 154));
             add(GryoTypeReg.of(CountStrategy.class, 155));

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/BytecodeUtilTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/BytecodeUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.util;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class BytecodeUtilTest {
+    private static final GraphTraversalSource g = EmptyGraph.instance().traversal();
+    
+    @Test
+    public void shouldFindStrategy() {
+        final Iterator<OptionsStrategy> itty = BytecodeUtil.findStrategies(g.with("x").with("y", 100).V().asAdmin().getBytecode(), OptionsStrategy.class);
+        int counter = 0;
+        while(itty.hasNext()) {
+            final OptionsStrategy strategy = itty.next();
+            if (strategy.getOptions().keySet().contains("x")) {
+                assertThat(strategy.getOptions().get("x"), is(true));
+                counter++;
+            } else if (strategy.getOptions().keySet().contains("y")) {
+                assertEquals(100, strategy.getOptions().get("y"));
+                counter++;
+            }
+        }
+
+        assertEquals(2, counter);
+    }
+
+    @Test
+    public void shouldNotFindStrategy() {
+        final Iterator<ReadOnlyStrategy> itty = BytecodeUtil.findStrategies(g.with("x").with("y", 100).V().asAdmin().getBytecode(), ReadOnlyStrategy.class);
+        assertThat(itty.hasNext(), is(false));
+    }
+}

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -343,6 +343,7 @@ public abstract class Client {
         options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, timeout));
         options.getParameters().ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, params));
         options.getAliases().ifPresent(aliases -> request.addArg(Tokens.ARGS_ALIASES, aliases));
+        options.getOverrideRequestId().ifPresent(request::overrideRequestId);
 
         return submitAsync(request.create());
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Options that can be supplied on a per request basis.
@@ -37,12 +38,18 @@ public final class RequestOptions {
     private final Map<String, Object> parameters;
     private final Integer batchSize;
     private final Long timeout;
+    private final UUID overrideRequestId;
 
     private RequestOptions(final Builder builder) {
         this.aliases = builder.aliases;
         this.parameters = builder.parameters;
         this.batchSize = builder.batchSize;
         this.timeout = builder.timeout;
+        this.overrideRequestId = builder.overrideRequestId;
+    }
+
+    public Optional<UUID> getOverrideRequestId() {
+        return Optional.ofNullable(overrideRequestId);
     }
 
     public Optional<Map<String, String>> getAliases() {
@@ -70,6 +77,7 @@ public final class RequestOptions {
         private Map<String, Object> parameters = null;
         private Integer batchSize = null;
         private Long timeout = null;
+        private UUID overrideRequestId = null;
 
         /**
          * The aliases to set on the request.
@@ -90,6 +98,14 @@ public final class RequestOptions {
                 parameters = new HashMap<>();
 
             parameters.put(name, value);
+            return this;
+        }
+
+        /**
+         * Overrides the identifier to be sent on the request.
+         */
+        public Builder overrideRequestId(final UUID overrideRequestId) {
+            this.overrideRequestId = overrideRequestId;
             return this;
         }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
@@ -34,6 +34,7 @@ public final class Tokens {
     public static final String OPS_KEYS = "keys";
     public static final String OPS_CLOSE = "close";
 
+    public static final String ARGS_OVERRIDE_REQUEST_ID = "overrideRequestId";
     public static final String ARGS_BATCH_SIZE = "batchSize";
     public static final String ARGS_BINDINGS = "bindings";
     public static final String ARGS_ALIASES = "aliases";

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
@@ -34,7 +34,7 @@ public final class Tokens {
     public static final String OPS_KEYS = "keys";
     public static final String OPS_CLOSE = "close";
 
-    public static final String ARGS_OVERRIDE_REQUEST_ID = "overrideRequestId";
+    public static final String REQUEST_ID = "requestId";
     public static final String ARGS_BATCH_SIZE = "batchSize";
     public static final String ARGS_BINDINGS = "bindings";
     public static final String ARGS_ALIASES = "aliases";

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -26,14 +26,20 @@ import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnectionException;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.RemoteTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.BytecodeUtil;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+
+import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_BATCH_SIZE;
+import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_OVERRIDE_REQUEST_ID;
+import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_SCRIPT_EVAL_TIMEOUT;
 
 /**
  * A {@link RemoteConnection} implementation for Gremlin Server. Each {@code DriverServerConnection} is bound to one
@@ -214,23 +220,26 @@ public class DriverRemoteConnection implements RemoteConnection {
     @Override
     public <E> CompletableFuture<RemoteTraversal<?, E>> submitAsync(final Bytecode bytecode) throws RemoteConnectionException {
         try {
-            final Iterator<OptionsStrategy> itty = IteratorUtils.map(
-                    IteratorUtils.filter(bytecode.getSourceInstructions().iterator(),
-                    s -> s.getOperator().equals(TraversalSource.Symbols.withStrategies) && s.getArguments()[0] instanceof OptionsStrategy),
-                    os -> (OptionsStrategy) os.getArguments()[0]);
-            final RequestOptions.Builder builder = RequestOptions.build();
-            while (itty.hasNext()) {
-                final OptionsStrategy optionsStrategy = itty.next();
-                if (optionsStrategy.getOptions().containsKey(PER_REQUEST_TIMEOUT))
-                    builder.timeout((long) optionsStrategy.getOptions().get(PER_REQUEST_TIMEOUT));
-                else if (optionsStrategy.getOptions().containsKey(PER_REQUEST_BATCH_SIZE))
-                    builder.batchSize((int) optionsStrategy.getOptions().get(PER_REQUEST_BATCH_SIZE));
-            }
-
-            return client.submitAsync(bytecode, builder.create()).thenApply(rs -> new DriverRemoteTraversal<>(rs, client, attachElements, conf));
+            return client.submitAsync(bytecode, getRequestOptions(bytecode)).thenApply(rs -> new DriverRemoteTraversal<>(rs, client, attachElements, conf));
         } catch (Exception ex) {
             throw new RemoteConnectionException(ex);
         }
+    }
+
+    protected static RequestOptions getRequestOptions(final Bytecode bytecode) {
+        final Iterator<OptionsStrategy> itty = BytecodeUtil.findStrategies(bytecode, OptionsStrategy.class);
+        final RequestOptions.Builder builder = RequestOptions.build();
+        while (itty.hasNext()) {
+            final OptionsStrategy optionsStrategy = itty.next();
+            final Map<String,Object> options = optionsStrategy.getOptions();
+            if (options.containsKey(ARGS_SCRIPT_EVAL_TIMEOUT))
+                builder.timeout((long) options.get(ARGS_SCRIPT_EVAL_TIMEOUT));
+            else if (options.containsKey(ARGS_OVERRIDE_REQUEST_ID))
+                builder.overrideRequestId((UUID) options.get(ARGS_OVERRIDE_REQUEST_ID));
+            else if (options.containsKey(ARGS_BATCH_SIZE))
+                builder.batchSize((int) options.get(ARGS_BATCH_SIZE));
+        }
+        return builder.create();
     }
 
     @Override

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -38,7 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_BATCH_SIZE;
-import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_OVERRIDE_REQUEST_ID;
+import static org.apache.tinkerpop.gremlin.driver.Tokens.REQUEST_ID;
 import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_SCRIPT_EVAL_TIMEOUT;
 
 /**
@@ -234,8 +234,8 @@ public class DriverRemoteConnection implements RemoteConnection {
             final Map<String,Object> options = optionsStrategy.getOptions();
             if (options.containsKey(ARGS_SCRIPT_EVAL_TIMEOUT))
                 builder.timeout((long) options.get(ARGS_SCRIPT_EVAL_TIMEOUT));
-            else if (options.containsKey(ARGS_OVERRIDE_REQUEST_ID))
-                builder.overrideRequestId((UUID) options.get(ARGS_OVERRIDE_REQUEST_ID));
+            else if (options.containsKey(REQUEST_ID))
+                builder.overrideRequestId((UUID) options.get(REQUEST_ID));
             else if (options.containsKey(ARGS_BATCH_SIZE))
                 builder.batchSize((int) options.get(ARGS_BATCH_SIZE));
         }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.remote;
+
+import org.apache.tinkerpop.gremlin.driver.RequestOptions;
+import org.apache.tinkerpop.gremlin.driver.Tokens;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class DriverRemoteConnectionTest {
+    private static final GraphTraversalSource g = EmptyGraph.instance().traversal();
+
+    @Test
+    public void shouldBuildRequestOptions() {
+        final UUID requestId = UUID.fromString("34a9f45f-8854-4d33-8b40-92a8171ee495");
+        final RequestOptions options = DriverRemoteConnection.getRequestOptions(
+                g.with("x").
+                        with("y", 100).
+                        with(Tokens.ARGS_BATCH_SIZE, 1000).
+                        with(Tokens.ARGS_OVERRIDE_REQUEST_ID, requestId).
+                        with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 100000L).
+                        V().asAdmin().getBytecode());
+        assertEquals(requestId, options.getOverrideRequestId().get());
+        assertEquals(1000, options.getBatchSize().get().intValue());
+        assertEquals(100000L, options.getTimeout().get().longValue());
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
@@ -41,7 +41,7 @@ public class DriverRemoteConnectionTest {
                 g.with("x").
                         with("y", 100).
                         with(Tokens.ARGS_BATCH_SIZE, 1000).
-                        with(Tokens.ARGS_OVERRIDE_REQUEST_ID, requestId).
+                        with(Tokens.REQUEST_ID, requestId).
                         with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 100000L).
                         V().asAdmin().getBytecode());
         assertEquals(requestId, options.getOverrideRequestId().get());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2211

Support `RequestOptions` with the Java driver using `TraversalSource.with()`. This PR replaces #1109

```text
g = traversal().withRemote(...);
g.with(ARGS_SCRIPT_EVAL_TIMEOUT, 500L).V().has(...).out().....
```

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1