### PR TITLE
TINKERPOP-2212 Fixed detachement problem in Path

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Prevented client-side hangs if metadata generation fails on the server.
 * Fixed bug with `EventStrategy` in relation to `addE()` where detachment was not happening properly.
 * Ensured that `gremlin.sh` works when directories contain spaces.
+* Fixed bug in detachment of `Path` where embedded collection objects would prevent that process.
 * Enabled `ctrl+c` to interrupt long running processes in Gremlin Console.
 * Quieted "host unavailable" warnings for both the driver and Gremlin Console.
 * Fixed bug in `GremlinGroovyScriptEngine` interpreter mode around class definitions.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedPath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedPath.java
@@ -32,9 +32,7 @@ import java.util.function.Function;
  */
 public class DetachedPath extends MutablePath implements Attachable<Path> {
 
-    private DetachedPath() {
-
-    }
+    private DetachedPath() {}
 
     public Path get() {
         return this;
@@ -42,17 +40,11 @@ public class DetachedPath extends MutablePath implements Attachable<Path> {
 
     protected DetachedPath(final Path path, final boolean withProperties) {
         path.forEach((object, labels) -> {
-            if (object instanceof DetachedElement || object instanceof DetachedProperty || object instanceof DetachedPath) {
+            if (object instanceof DetachedElement || object instanceof DetachedProperty || object instanceof DetachedPath)
                 this.objects.add(object);
-            } else if (object instanceof Element) {
-                this.objects.add(DetachedFactory.detach((Element) object, withProperties));
-            } else if (object instanceof Property) {
-                this.objects.add(DetachedFactory.detach((Property) object));
-            } else if (object instanceof Path) {
-                this.objects.add(DetachedFactory.detach((Path) object, withProperties));
-            } else {
-                this.objects.add(object);
-            }
+            else
+                this.objects.add(DetachedFactory.detach(object, withProperties));
+
             //Make a copy of the labels as its an UnmodifiableSet which can not be serialized.
             this.labels.add(new LinkedHashSet<>(labels));
         });

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferencePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferencePath.java
@@ -32,9 +32,7 @@ import java.util.function.Function;
  */
 public class ReferencePath extends MutablePath implements Attachable<Path> {
 
-    private ReferencePath() {
-
-    }
+    private ReferencePath() {}
 
     public Path get() {
         return this;
@@ -42,22 +40,11 @@ public class ReferencePath extends MutablePath implements Attachable<Path> {
 
     protected ReferencePath(final Path path) {
         path.forEach((object, labels) -> {
-            if (object instanceof ReferenceElement || object instanceof ReferenceProperty || object instanceof ReferencePath) {
+            if (object instanceof ReferenceElement || object instanceof ReferenceProperty || object instanceof ReferencePath)
                 this.objects.add(object);
-                this.labels.add(new HashSet<>(labels));
-            } else if (object instanceof Element) {
-                this.objects.add(ReferenceFactory.detach((Element) object));
-                this.labels.add(new HashSet<>(labels));
-            } else if (object instanceof Property) {
-                this.objects.add(ReferenceFactory.detach((Property) object));
-                this.labels.add(new HashSet<>(labels));
-            } else if (object instanceof Path) {
-                this.objects.add(ReferenceFactory.detach((Path) object));
-                this.labels.add(new HashSet<>(labels));
-            } else {
-                this.objects.add(object);
-                this.labels.add(new HashSet<>(labels));
-            }
+            else
+                this.objects.add(ReferenceFactory.detach(object));
+            this.labels.add(new HashSet<>(labels));
         });
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactoryTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedFactoryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.structure.util.detached;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.MutablePath;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class DetachedFactoryTest {
+
+    @Test
+    public void shouldDetachPathToReferenceWithEmbeddedLists() {
+        final Path path = MutablePath.make();
+        path.extend(DetachedVertex.build().setId(1).setLabel("person").
+                addProperty(new DetachedVertexProperty<>(
+                        101, "name", "stephen", Collections.emptyMap())).create(), Collections.singleton("a"));
+        path.extend(Collections.singletonList(DetachedVertex.build().setId(2).setLabel("person").
+                addProperty(new DetachedVertexProperty<>(
+                        102, "name", "vadas", Collections.emptyMap())).create()), Collections.singleton("a"));
+        path.extend(Collections.singletonList(Collections.singletonList(DetachedVertex.build().setId(3).setLabel("person").
+                addProperty(new DetachedVertexProperty<>(
+                        103, "name", "josh", Collections.emptyMap())).create())), Collections.singleton("a"));
+
+        final Path detached = DetachedFactory.detach(path, true);
+        final Vertex v1  = detached.get(0);
+        assertThat(v1, instanceOf(DetachedVertex.class));
+        assertEquals("stephen", v1.values("name").next());
+        assertEquals(1, IteratorUtils.count(v1.properties()));
+
+        final Vertex v2  = (Vertex) ((List) detached.get(1)).get(0);
+        assertThat(v2, instanceOf(DetachedVertex.class));
+        assertEquals("vadas", v2.values("name").next());
+        assertEquals(1, IteratorUtils.count(v2.properties()));
+
+        final Vertex v3  = (Vertex) ((List) ((List) detached.get(2)).get(0)).get(0);
+        assertThat(v3, instanceOf(DetachedVertex.class));
+        assertEquals("josh", v3.values("name").next());
+        assertEquals(1, IteratorUtils.count(v3.properties()));
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactoryTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/reference/ReferenceFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.structure.util.reference;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.MutablePath;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class ReferenceFactoryTest {
+
+    @Test
+    public void shouldDetachPathToReferenceWithEmbeddedLists() {
+        final Path path = MutablePath.make();
+        path.extend(DetachedVertex.build().setId(1).setLabel("person").
+                addProperty(new DetachedVertexProperty<>(
+                        101, "name", "stephen", Collections.emptyMap())).create(), Collections.singleton("a"));
+        path.extend(Collections.singletonList(DetachedVertex.build().setId(2).setLabel("person").
+                addProperty(new DetachedVertexProperty<>(
+                        102, "name", "vadas", Collections.emptyMap())).create()), Collections.singleton("a"));
+        path.extend(Collections.singletonList(Collections.singletonList(DetachedVertex.build().setId(3).setLabel("person").
+                addProperty(new DetachedVertexProperty<>(
+                        103, "name", "josh", Collections.emptyMap())).create())), Collections.singleton("a"));
+
+        final Path detached = ReferenceFactory.detach(path);
+        final Vertex v1  = detached.get(0);
+        assertThat(v1, instanceOf(ReferenceVertex.class));
+        assertThat(v1.properties().hasNext(), is(false));
+
+        final Vertex v2  = (Vertex) ((List) detached.get(1)).get(0);
+        assertThat(v2, instanceOf(ReferenceVertex.class));
+        assertThat(v2.properties().hasNext(), is(false));
+
+        final Vertex v3  = (Vertex) ((List) ((List) detached.get(2)).get(0)).get(0);
+        assertThat(v3, instanceOf(ReferenceVertex.class));
+        assertThat(v3.properties().hasNext(), is(false));
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2212

If the Path contained a Collection it would not properly detach the objects within the collection.

All tests pass with `docker/build.sh -t -i`

VOTE +1