### PR TITLE
TINKERPOP-2216 add status attribute for warnings

### DIFF
--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/PluggedIn.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/PluggedIn.groovy
@@ -100,6 +100,11 @@ class PluggedIn {
         }
 
         @Override
+        void errPrintln(final String line) {
+            io.err.println("[warn] " + line);
+        }
+
+        @Override
         def <T> T execute(final String line) {
             return (T) shell.execute(line)
         }

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/MockGroovyGremlinShellEnvironment.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/MockGroovyGremlinShellEnvironment.java
@@ -58,6 +58,14 @@ public class MockGroovyGremlinShellEnvironment implements GremlinShellEnvironmen
     }
 
     @Override
+    public void errPrintln(final String line) {
+        if (null == io)
+            groovysh.getIo().err.println("[warn]" + line);
+        else
+            io.err.println("[warn]" + line);
+    }
+
+    @Override
     public <T> T execute(final String line) {
         return (T) groovysh.execute(line);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/console/GremlinShellEnvironment.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/console/GremlinShellEnvironment.java
@@ -33,5 +33,9 @@ public interface GremlinShellEnvironment {
 
     public void println(final String line);
 
+    public default void errPrintln(final String line) {
+        println(line);
+    }
+
     public <T> T execute(final String line);
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
@@ -60,4 +60,19 @@ public final class Tokens {
 
     public static final String STATUS_ATTRIBUTE_EXCEPTIONS = "exceptions";
     public static final String STATUS_ATTRIBUTE_STACK_TRACE = "stackTrace";
+    /**
+     * A {@link ResultSet#statusAttributes()} key for user-facing warnings.
+     * <p>
+     * Implementations that set this key should consider using one of
+     * these two recommended value types:
+     * <ul>
+     *     <li>A {@link java.util.List} implementation containing
+     *     references for which {@link String#valueOf(Object)} produces
+     *     a meaningful return value.  For example, a list of strings.</li>
+     *     <li>Otherwise, any single non-list object for which
+     *     {@link String#valueOf(Object)} produces a meaningful return value.
+     *     For example, a string.</li>
+     * </ul>
+     */
+    public static final String STATUS_ATTRIBUTE_WARNINGS = "warnings";
 }


### PR DESCRIPTION
JIRA link: https://issues.apache.org/jira/browse/TINKERPOP-2216

There are a lot of alternative ways to approach this.  I'm just opening this PR, with this specific approach, because it illustrates the suggested feature a bit more clearly than the prose in the JIRA issue description.

This adds a new `Tokens` string literal with the value `"warnings"`.  The console's `DriverRemoteAcceptor` checks for this status attribute every time it receives a remote resultset, printing the value above the results (to `err` when available).  If the value is a list, each element gets passed through `String#valueOf` and printed on a separate line.  Otherwise, it's just passed through `String#valueOf` and printed once.

Testing this in isolation seems a bit tricky.  I've been testing this coupled with a remote graph running in Gremlin-Server. If anyone has suggestions about reusable test harness bits underneath `gremlin-console/src/test` that I should reuse for this, I'd be interested.
