### PR TITLE
TINKERPOP-2224 Detect and fix iterator leaks

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bump to Groovy 2.4.17.
 * Bump to Jackson 2.9.9.
 * Improved error messaging when an attempt is made to serialize multi-properties to GraphML.
+* Add test infrastructure to check for storage iterator leak
+* Fix multiple iterator leaks in query processor
 
 [[release-3-3-7]]
 === TinkerPop 3.3.7 (Release Date: May 28, 2019)

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -806,11 +806,11 @@ creating temporary files. The value is typically set to the project build direct
 SureFire Plugin, this is done via the configuration argLine with `-Dbuild.dir=${project.build.directory}`.
 
 ==== Checking resource leak
-Tinkerpop query engine retrieves data by interfacing with the provider using iterators. These iterators (depending
+TinkerPop query engine retrieves data by interfacing with the provider using iterators. These iterators (depending
 on the provider) may hold up resources in the underlying storage layer and hence, it is critical to close them after
 the query is finished.
 
-Tinkerpop provides you with the ability to test for such resource leaks by checking for leaks when you run the
+TinkerPop provides you with the ability to test for such resource leaks by checking for leaks when you run the
 Gremlin-Test suites against your implementation. To enable this leak detection, providers should increment the
 `StoreIteratorCounter` whenever a reource is opened and decrement it when it is closed. A reference implementation
 is provided with TinkerGraph as `TinkerGraphIterator.java`.

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -805,6 +805,16 @@ environment variable, depending on your project layout. Some tests require this 
 creating temporary files. The value is typically set to the project build directory. For example using the Maven
 SureFire Plugin, this is done via the configuration argLine with `-Dbuild.dir=${project.build.directory}`.
 
+==== Checking resource leak
+Tinkerpop query engine retrieves data by interfacing with the provider using iterators. These iterators (depending
+on the provider) may hold up resources in the underlying storage layer and hence, it is critical to close them after
+the query is finished.
+
+Tinkerpop provides you with the ability to test for such resource leaks by checking for leaks when you run the
+Gremlin-Test suites against your implementation. To enable this leak detection, providers should increment the
+`StoreIteratorCounter` whenever a reource is opened and decrement it when it is closed. A reference implementation
+is provided with TinkerGraph as `TinkerGraphIterator.java`.
+
 === Accessibility via GremlinPlugin
 
 image:gremlin-plugin.png[width=100,float=left] The applications distributed with TinkerPop3 do not distribute with

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
@@ -50,6 +50,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 
 /**
  * A {@link Traversal} represents a directed walk over a {@link Graph}.
@@ -180,6 +181,8 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
                 TraversalHelper.addToCollection(collection, traverser.get(), traverser.bulk());
             }
         } catch (final NoSuchElementException ignored) {
+        } finally {
+            CloseableIterator.closeIterator(this);
         }
         return collection;
     }
@@ -203,6 +206,8 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
                 endStep.next();
             }
         } catch (final NoSuchElementException ignored) {
+        } finally {
+            CloseableIterator.closeIterator(this);
         }
         return (Traversal<A, B>) this;
     }
@@ -255,6 +260,8 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
             }
         } catch (final NoSuchElementException ignore) {
 
+        }  finally {
+            CloseableIterator.closeIterator(this);
         }
     }
 
@@ -266,6 +273,8 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
             }
         } catch (final NoSuchElementException ignore) {
 
+        }  finally {
+            CloseableIterator.closeIterator(this);
         }
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStep.java
@@ -32,7 +32,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class NotStep<S> extends FilterStep<S> implements TraversalParent {
+public final class NotStep<S> extends FilterStep<S> implements TraversalParent{
 
     private Traversal.Admin<S, ?> notTraversal;
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Ranging;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
 import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
@@ -62,6 +63,9 @@ public final class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, 
         if (this.bypass) return true;
 
         if (this.high != -1 && this.counter.get() >= this.high) {
+            // This is a global step and this place would be the end of the traversal.
+            // Close the traversal to free up resources.
+            CloseableIterator.closeIterator(traversal);
             throw FastNoSuchElementException.instance();
         }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -18,6 +18,14 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -32,17 +40,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequire
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.DefaultTraverserGeneratorFactory;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.EmptyTraverser;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -201,6 +201,10 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
             this.lastTraverser.setBulk(this.lastTraverser.bulk() - 1L);
             return this.lastTraverser.get();
         } catch (final FastNoSuchElementException e) {
+            // No more elements will be produced by this traversal. Close this traversal
+            // and release the resources.
+            CloseableIterator.closeIterator(this);
+
             throw this.parent instanceof EmptyStep ? new NoSuchElementException() : e;
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -18,14 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Set;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -43,6 +35,15 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
@@ -18,12 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
@@ -18,12 +18,12 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
-
-import java.util.Iterator;
-import java.util.NoSuchElementException;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -43,6 +43,9 @@ public final class TraversalUtil {
             return traversal.next(); // map
         } catch (final NoSuchElementException e) {
             throw new IllegalArgumentException("The provided traverser does not map to a value: " + split + "->" + traversal);
+        } finally {
+            //Close the traversal to release any underlying resources.
+            CloseableIterator.closeIterator(traversal);
         }
     }
 
@@ -64,11 +67,19 @@ public final class TraversalUtil {
         traversal.reset();
         traversal.addStart(split);
         final Step<?, E> endStep = traversal.getEndStep();
+        boolean result = false;
         while (traversal.hasNext()) {
-            if (endStep.next().get().equals(end))
-                return true;
+            if (endStep.next().get().equals(end)) {
+                result = true;
+                break;
+            }
         }
-        return false;
+
+        // The traversal might not have been fully consumed in the loop above. Close the traversal to release any underlying
+        // resources.
+        CloseableIterator.closeIterator(traversal);
+
+        return result;
     }
 
     public static final <S, E> E applyNullable(final Traverser.Admin<S> traverser, final Traversal.Admin<S, E> traversal) {
@@ -81,7 +92,12 @@ public final class TraversalUtil {
         split.setBulk(1l);
         traversal.reset();
         traversal.addStart(split);
-        return traversal.hasNext(); // filter
+        boolean val =  traversal.hasNext(); // filter
+
+        //Close the traversal to release any underlying resources.
+        CloseableIterator.closeIterator(traversal);
+
+        return val;
     }
 
     ///////
@@ -93,6 +109,9 @@ public final class TraversalUtil {
             return traversal.next(); // map
         } catch (final NoSuchElementException e) {
             throw new IllegalArgumentException("The provided start does not map to a value: " + start + "->" + traversal);
+        } finally {
+            //Close the traversal to release any underlying resources.
+            CloseableIterator.closeIterator(traversal);
         }
     }
 
@@ -108,11 +127,19 @@ public final class TraversalUtil {
         traversal.reset();
         traversal.addStart(traversal.getTraverserGenerator().generate(start, traversal.getStartStep(), 1l));
         final Step<?, E> endStep = traversal.getEndStep();
+
+        boolean result = false;
         while (traversal.hasNext()) {
-            if (endStep.next().get().equals(end))
-                return true;
+            if (endStep.next().get().equals(end)) {
+                result = true;
+                break;
+            }
         }
-        return false;
+
+        //Close the traversal to release any underlying resources.
+        CloseableIterator.closeIterator(traversal);
+
+        return result;
     }
 
     public static final <S, E> E applyNullable(final S start, final Traversal.Admin<S, E> traversal) {
@@ -122,6 +149,11 @@ public final class TraversalUtil {
     public static final <S, E> boolean test(final S start, final Traversal.Admin<S, E> traversal) {
         traversal.reset();
         traversal.addStart(traversal.getTraverserGenerator().generate(start, traversal.getStartStep(), 1l));
-        return traversal.hasNext(); // filter
+        boolean result = traversal.hasNext(); // filter
+
+        //Close the traversal to release any underlying resources.
+        CloseableIterator.closeIterator(traversal);
+
+        return result;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/StoreIteratorCounter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/StoreIteratorCounter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.util.iterator;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+
+/**
+ * Utility class which can be used by providers to keep a count of the number of
+ * open iterators to the underlying storage. Please note that, by default, this does
+ * not maintain the count unless explicitly plugged-in by the provider implementation.
+ * <p>
+ * As an example on how to plugin-in the counter in the provider implementation
+ * check TinkerGraphIterator.
+ *
+ * @see Traversal#close()
+ */
+public class StoreIteratorCounter {
+    public static final StoreIteratorCounter INSTANCE = new StoreIteratorCounter();
+
+    private AtomicLong openIteratorCount = new AtomicLong(0);
+
+    public void reset() {
+        openIteratorCount.set(0);
+    }
+
+    public long getOpenIteratorCount() {
+        return openIteratorCount.get();
+    }
+
+    public void increment() {
+        openIteratorCount.incrementAndGet();
+    }
+
+    public void decrement() {
+        openIteratorCount.decrementAndGet();
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/StoreIteratorCounter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/StoreIteratorCounter.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.util.iterator;
 
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Utility class which can be used by providers to keep a count of the number of

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStepTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
-import java.util.Arrays;
-import java.util.List;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStepTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+
+public class NotStepTest extends StepTest {
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Arrays.asList(
+                __.not(V().out()),
+                __.not(as("test").in("my-edge"))
+        );
+    }
+}

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -18,16 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -47,6 +37,17 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -189,7 +189,7 @@ public abstract class AbstractGremlinTest {
 
     public Vertex convertToVertex(final Graph graph, final String vertexName) {
         // all test graphs have "name" as a unique id which makes it easy to hardcode this...works for now
-        return graphProvider.traversal(graph).V().has("name", vertexName).toList().get(0);
+        return graph.traversal().V().has("name", vertexName).toList().get(0);
     }
 
     public GraphTraversal<Vertex, Object> convertToVertexPropertyId(final String vertexName, final String vertexPropertyKey) {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -18,6 +18,16 @@
  */
 package org.apache.tinkerpop.gremlin;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -29,21 +39,14 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.apache.tinkerpop.gremlin.util.iterator.StoreIteratorCounter;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -63,6 +66,7 @@ public abstract class AbstractGremlinTest {
     protected GraphTraversalSource g;
     protected Configuration config;
     protected GraphProvider graphProvider;
+    protected boolean shouldTestIteratorLeak;
 
     @Rule
     public TestName name = new TestName();
@@ -74,8 +78,14 @@ public abstract class AbstractGremlinTest {
         final LoadGraphWith loadGraphWith = loadGraphWiths.length == 0 ? null : loadGraphWiths[0];
         final LoadGraphWith.GraphData loadGraphWithData = null == loadGraphWith ? null : loadGraphWith.value();
 
+        this.shouldTestIteratorLeak =  !this.getClass().isAnnotationPresent(IgnoreIteratorLeak.class);
+
         graphProvider = GraphManager.getGraphProvider();
         graphProvider.getTestListener().ifPresent(l -> l.onTestStart(this.getClass(), name.getMethodName()));
+
+        // Reset the counter for open iterators by this test
+        StoreIteratorCounter.INSTANCE.reset();
+
         config = graphProvider.standardGraphConfiguration(this.getClass(), name.getMethodName(), loadGraphWithData);
 
         // this should clear state from a previously unfinished test. since the graph does not yet exist,
@@ -130,6 +140,11 @@ public abstract class AbstractGremlinTest {
     @After
     public void tearDown() throws Exception {
         if (null != graphProvider) {
+            if (shouldTestIteratorLeak) {
+                long openItrCount = StoreIteratorCounter.INSTANCE.getOpenIteratorCount();
+                Assert.assertEquals("Iterator leak detected. Open iterator count=" + openItrCount, 0, openItrCount);
+            }
+
             graphProvider.getTestListener().ifPresent(l -> l.onTestEnd(this.getClass(), name.getMethodName()));
 
             // GraphProvider that has implemented the clear method must check null for graph and config.
@@ -173,7 +188,7 @@ public abstract class AbstractGremlinTest {
 
     public Vertex convertToVertex(final Graph graph, final String vertexName) {
         // all test graphs have "name" as a unique id which makes it easy to hardcode this...works for now
-        return graph.traversal().V().has("name", vertexName).next();
+        return graphProvider.traversal(graph).V().has("name", vertexName).toList().get(0);
     }
 
     public GraphTraversal<Vertex, Object> convertToVertexPropertyId(final String vertexName, final String vertexPropertyKey) {
@@ -194,7 +209,7 @@ public abstract class AbstractGremlinTest {
     }
 
     public Object convertToEdgeId(final Graph graph, final String outVertexName, String edgeLabel, final String inVertexName) {
-        return graph.traversal().V().has("name", outVertexName).outE(edgeLabel).as("e").inV().has("name", inVertexName).<Edge>select("e").next().id();
+        return graphProvider.traversal(graph).V().has("name", outVertexName).outE(edgeLabel).as("e").inV().has("name", inVertexName).<Edge>select("e").toList().get(0).id();
     }
 
     /**
@@ -260,7 +275,7 @@ public abstract class AbstractGremlinTest {
         assertThat(actual, instanceOf(expected.getClass()));
     }
 
-    public static void verifyUniqueStepIds(final Traversal.Admin<?, ?> traversal) {
+    private static void verifyUniqueStepIds(final Traversal.Admin<?, ?> traversal) {
         AbstractGremlinTest.verifyUniqueStepIds(traversal, 0, new HashSet<>());
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/IgnoreIteratorLeak.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/IgnoreIteratorLeak.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Any test class annotated with this annotation does not test for graceful close
+ * of any underlying storage iterators (aka iterator leak).
+ *
+ * This annotation has been temporarily added to allow for iterative fixing of all the
+ * iterator leaks in the code base.
+ *
+ * TODO: This annotation should be deleted after all the code places with an iterator
+ *       leak are fixed.
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface IgnoreIteratorLeak {
+}

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/CommunityGeneratorTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/CommunityGeneratorTest.java
@@ -22,6 +22,8 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
+import org.apache.tinkerpop.gremlin.IgnoreIteratorLeak;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
@@ -45,10 +47,12 @@ import static org.junit.Assert.*;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 @RunWith(Enclosed.class)
+@IgnoreIteratorLeak
 public class CommunityGeneratorTest {
     private static final Logger logger = LoggerFactory.getLogger(CommunityGeneratorTest.class);
 
     @RunWith(Parameterized.class)
+    @IgnoreIteratorLeak
     public static class DifferentDistributionsTest extends AbstractGeneratorTest {
 
         @Parameterized.Parameters(name = "test({0},{1},{2})")
@@ -96,10 +100,13 @@ public class CommunityGeneratorTest {
                 afterLoadGraphWith(graph1);
                 communityGeneratorTest(graph1, () -> 987654321l);
 
-                assertTrue(IteratorUtils.count(graph.edges()) > 0);
-                assertTrue(IteratorUtils.count(graph.vertices()) > 0);
-                assertTrue(IteratorUtils.count(graph1.edges()) > 0);
-                assertTrue(IteratorUtils.count(graph1.vertices()) > 0);
+                final GraphTraversalSource g = graph.traversal();
+                final GraphTraversalSource g1 = graph1.traversal();
+
+                assertTrue(g.E().count().next() > 0);
+                assertTrue(g.V().count().next() > 0);
+                assertTrue(g1.E().count().next() > 0);
+                assertTrue(g1.V().count().next() > 0);
 
                 // don't assert counts of edges...those may be the same, just ensure that not every vertex has the
                 // same number of edges between graphs.  that should make it harder for the test to fail.
@@ -126,11 +133,14 @@ public class CommunityGeneratorTest {
                 afterLoadGraphWith(graph1);
                 communityGeneratorTest(graph1, () -> 123456789l);
 
-                assertTrue(IteratorUtils.count(graph.edges()) > 0);
-                assertTrue(IteratorUtils.count(graph.vertices()) > 0);
-                assertTrue(IteratorUtils.count(graph1.edges()) > 0);
-                assertTrue(IteratorUtils.count(graph1.vertices()) > 0);
-                assertEquals(IteratorUtils.count(graph.edges()), IteratorUtils.count(graph1.edges()));
+                final GraphTraversalSource g = graph.traversal();
+                final GraphTraversalSource g1 = graph1.traversal();
+
+                assertTrue(g.E().count().next() > 0);
+                assertTrue(g.V().count().next() > 0);
+                assertTrue(g1.E().count().next() > 0);
+                assertTrue(g1.V().count().next() > 0);
+                assertEquals(g.E().count().next(), g.E().count().next());
 
                 // ensure that every vertex has the same number of edges between graphs.
                 assertTrue(same(graph, graph1));
@@ -160,6 +170,7 @@ public class CommunityGeneratorTest {
         private void communityGeneratorTest(final Graph graph, final Supplier<Long> seedGenerator) throws Exception {
             boolean generated = false;
             double localCrossPcent = crossPcent;
+            GraphTraversalSource g = graph.traversal();
             while (!generated) {
                 try {
                     final CommunityGenerator generator = CommunityGenerator.build(graph)
@@ -174,13 +185,13 @@ public class CommunityGeneratorTest {
                             .create();
                     final int numEdges = generator.generate();
                     assertTrue(numEdges > 0);
-                    tryCommit(graph, g -> assertEquals(new Long(numEdges), new Long(IteratorUtils.count(g.edges()))));
+                    tryCommit(graph, graphVar -> assertEquals(new Long(numEdges), graphVar.traversal().E().count().next()));
                     generated = true;
                 } catch (IllegalArgumentException iae) {
                     localCrossPcent = localCrossPcent - 0.005d;
                     generated = localCrossPcent < 0d;
 
-                    graph.vertices().forEachRemaining(Vertex::remove);
+                    g.V().drop().iterate();
                     tryCommit(graph);
                     afterLoadGraphWith(graph);
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/DistributionGeneratorTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/DistributionGeneratorTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
+import org.apache.tinkerpop.gremlin.IgnoreIteratorLeak;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -41,9 +42,11 @@ import static org.junit.Assert.assertTrue;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 @RunWith(Enclosed.class)
+@IgnoreIteratorLeak
 public class DistributionGeneratorTest {
 
     @RunWith(Parameterized.class)
+    @IgnoreIteratorLeak
     public static class DifferentDistributionsTest extends AbstractGeneratorTest {
 
         @Parameterized.Parameters(name = "test({0},{1})")
@@ -143,7 +146,7 @@ public class DistributionGeneratorTest {
         }
 
         protected Iterable<Vertex> verticesByOid(final Graph graph) {
-            List<Vertex> vertices = IteratorUtils.list(graph.vertices());
+            List<Vertex> vertices = graph.traversal().V().toList();
             Collections.sort(vertices,
                     (v1, v2) -> ((Integer) v1.value("oid")).compareTo((Integer) v2.value("oid")));
             return vertices;
@@ -152,7 +155,7 @@ public class DistributionGeneratorTest {
         private void distributionGeneratorTest(final Graph graph, final DistributionGenerator generator) {
             final int numEdges = generator.generate();
             assertTrue(numEdges > 0);
-            tryCommit(graph, g -> assertEquals(numEdges, IteratorUtils.count(g.edges())));
+            tryCommit(graph, g -> assertEquals(Long.valueOf(numEdges), g.traversal().E().count().next()));
         }
     }
 
@@ -174,7 +177,7 @@ public class DistributionGeneratorTest {
             assertTrue(edgesGenerated > 0);
             tryCommit(graph, g -> {
                 assertEquals(new Long(edgesGenerated), new Long(IteratorUtils.count(g.edges())));
-                assertTrue(IteratorUtils.count(g.vertices()) > 0);
+                assertTrue(g.traversal().V().count().next() > 0);
                 assertTrue(IteratorUtils.stream(g.edges()).allMatch(e -> e.value("data").equals("test")));
             });
         }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -23,6 +23,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.tinkerpop.gremlin.ExceptionCoverage;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.IgnoreIteratorLeak;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.computer.clustering.peerpressure.PeerPressureVertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
@@ -110,6 +111,7 @@ import static org.junit.Assume.assumeNoException;
         "graphDoesNotSupportProvidedGraphComputer"
 })
 @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+@IgnoreIteratorLeak
 public class GraphComputerTest extends AbstractGremlinProcessTest {
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgramTest.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.computer.bulkloading;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.IgnoreIteratorLeak;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.IgnoreEngine;
@@ -51,6 +52,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
+@IgnoreIteratorLeak
 public class BulkLoaderVertexProgramTest extends AbstractGremlinProcessTest {
 
     final static String TINKERGRAPH_LOCATION = TestHelper.makeTestDataDirectory(BulkLoaderVertexProgramTest.class) + "tinkertest.kryo";

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalInterruptionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalInterruptionTest.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal;
 
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.IgnoreIteratorLeak;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -42,6 +43,7 @@ import static org.junit.Assert.assertThat;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 @RunWith(Parameterized.class)
+@IgnoreIteratorLeak
 public class TraversalInterruptionTest extends AbstractGremlinProcessTest {
 
     @Parameterized.Parameters(name = "expectInterruption({0})")

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/FilterTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/FilterTest.java
@@ -18,21 +18,21 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -115,6 +115,7 @@ public abstract class FilterTest extends AbstractGremlinProcessTest {
         printTraversalForm(traversal);
         assertTrue(traversal.hasNext());
         assertEquals(Integer.valueOf(32), traversal.next().<Integer>value("age"));
+        assertFalse(traversal.hasNext());
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
@@ -222,6 +222,7 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         final Traversal<Vertex, Vertex> traversalJosh = get_g_VX1X_hasXage_gt_30X(convertToVertexId("josh"));
         printTraversalForm(traversalJosh);
         assertTrue(traversalJosh.hasNext());
+        traversalJosh.iterate();
     }
 
     @Test
@@ -238,6 +239,7 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         final Traversal<Vertex, Vertex> traversalJosh = get_g_VXv1X_hasXage_gt_30X(convertToVertex(graph,"josh"));
         printTraversalForm(traversalJosh);
         assertTrue(traversalJosh.hasNext());
+        traversalJosh.iterate();
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTest.java
@@ -273,7 +273,7 @@ public abstract class WhereTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_withSideEffectXa_g_VX2XX_VX1X_out_whereXneqXaXX() {
-        final Traversal<Vertex, Vertex> traversal = get_g_withSideEffectXa_graph_verticesX2XX_VX1X_out_whereXneqXaXX(convertToVertexId("marko"), convertToVertex("vadas"));
+        final Traversal<Vertex, Vertex> traversal = get_g_withSideEffectXa_graph_verticesX2XX_VX1X_out_whereXneqXaXX(convertToVertexId("marko"), convertToVertex(graph,"vadas"));
         printTraversalForm(traversal);
         int counter = 0;
         final Set<Vertex> vertices = new HashSet<>();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTest.java
@@ -273,7 +273,7 @@ public abstract class WhereTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_withSideEffectXa_g_VX2XX_VX1X_out_whereXneqXaXX() {
-        final Traversal<Vertex, Vertex> traversal = get_g_withSideEffectXa_graph_verticesX2XX_VX1X_out_whereXneqXaXX(convertToVertexId("marko"), g.V(convertToVertexId("vadas")).next());
+        final Traversal<Vertex, Vertex> traversal = get_g_withSideEffectXa_graph_verticesX2XX_VX1X_out_whereXneqXaXX(convertToVertexId("marko"), convertToVertex("vadas"));
         printTraversalForm(traversal);
         int counter = 0;
         final Set<Vertex> vertices = new HashSet<>();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.IgnoreIteratorLeak;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -47,6 +48,7 @@ import static org.junit.Assert.fail;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 @RunWith(GremlinProcessRunner.class)
+@IgnoreIteratorLeak
 public abstract class SubgraphTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Graph> get_g_V_withSideEffectXsgX_outEXknowsX_subgraphXsgX_name_capXsgX(final Object v1Id, final Graph subgraph);
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategyProcessTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
 
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.IgnoreIteratorLeak;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteGraph;
@@ -61,6 +62,7 @@ import static org.junit.Assume.assumeThat;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 @RunWith(GremlinProcessRunner.class)
+@IgnoreIteratorLeak
 public class SubgraphStrategyProcessTest extends AbstractGremlinProcessTest {
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
@@ -19,10 +19,7 @@
 package org.apache.tinkerpop.gremlin.structure.io;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
-import org.apache.tinkerpop.gremlin.FeatureRequirement;
-import org.apache.tinkerpop.gremlin.LoadGraphWith;
-import org.apache.tinkerpop.gremlin.TestHelper;
+import org.apache.tinkerpop.gremlin.*;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -106,9 +103,11 @@ import static org.junit.Assume.assumeThat;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 @RunWith(Enclosed.class)
+@IgnoreIteratorLeak
 public class IoTest {
     private static final Logger logger = LoggerFactory.getLogger(IoTest.class);
 
+    @IgnoreIteratorLeak
     public static class GraphMLTest extends AbstractGremlinTest {
         @Test
         @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -18,13 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.step.sideEffect;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
@@ -40,6 +33,14 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraphIterator;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerHelper;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -18,6 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.step.sideEffect;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
@@ -27,26 +34,24 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraphIterator;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerHelper;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Pieter Martin
  */
-public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder {
+public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder, AutoCloseable {
 
     private final List<HasContainer> hasContainers = new ArrayList<>();
+    /**
+     * List of iterators opened by this step.
+     */
+    private final List<Iterator> iterators = new ArrayList<>();
 
     public TinkerGraphStep(final GraphStep<S, E> originalGraphStep) {
         super(originalGraphStep.getTraversal(), originalGraphStep.getReturnClass(), originalGraphStep.isStartStep(), originalGraphStep.getIds());
@@ -62,32 +67,43 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
     private Iterator<? extends Edge> edges() {
         final TinkerGraph graph = (TinkerGraph) this.getTraversal().getGraph().get();
         final HasContainer indexedContainer = getIndexKey(Edge.class);
+        Iterator<Edge> iterator;
         // ids are present, filter on them first
         if (null == this.ids)
-            return Collections.emptyIterator();
+            iterator = Collections.emptyIterator();
         else if (this.ids.length > 0)
-            return this.iteratorList(graph.edges(this.ids));
+            iterator = this.iteratorList(graph.edges(this.ids));
         else
-            return null == indexedContainer ?
+            iterator = null == indexedContainer ?
                     this.iteratorList(graph.edges()) :
                     TinkerHelper.queryEdgeIndex(graph, indexedContainer.getKey(), indexedContainer.getPredicate().getValue()).stream()
-                            .filter(edge -> HasContainer.testAll(edge, this.hasContainers))
-                            .collect(Collectors.<Edge>toList()).iterator();
+                                .filter(edge -> HasContainer.testAll(edge, this.hasContainers))
+                                .collect(Collectors.<Edge>toList()).iterator();
+
+
+        iterators.add(iterator);
+
+        return iterator;
     }
 
     private Iterator<? extends Vertex> vertices() {
         final TinkerGraph graph = (TinkerGraph) this.getTraversal().getGraph().get();
         final HasContainer indexedContainer = getIndexKey(Vertex.class);
+        Iterator<? extends Vertex> iterator;
         // ids are present, filter on them first
         if (null == this.ids)
-            return Collections.emptyIterator();
+            iterator = Collections.emptyIterator();
         else if (this.ids.length > 0)
-            return this.iteratorList(graph.vertices(this.ids));
+            iterator = this.iteratorList(graph.vertices(this.ids));
         else
-            return null == indexedContainer ?
+            iterator = (null == indexedContainer ?
                     this.iteratorList(graph.vertices()) :
                     IteratorUtils.filter(TinkerHelper.queryVertexIndex(graph, indexedContainer.getKey(), indexedContainer.getPredicate().getValue()).iterator(),
-                            vertex -> HasContainer.testAll(vertex, this.hasContainers));
+                                         vertex -> HasContainer.testAll(vertex, this.hasContainers)));
+
+        iterators.add(iterator);
+
+        return iterator;
     }
 
     private HasContainer getIndexKey(final Class<? extends Element> indexedClass) {
@@ -116,7 +132,12 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
             if (HasContainer.testAll(e, this.hasContainers))
                 list.add(e);
         }
-        return list.iterator();
+
+        // close the old iterator to release resources since we are returning a new iterator (over list)
+        // out of this function.
+        CloseableIterator.closeIterator(iterator);
+
+        return new TinkerGraphIterator<>(list.iterator());
     }
 
     @Override
@@ -137,5 +158,10 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
     @Override
     public int hashCode() {
         return super.hashCode() ^ this.hasContainers.hashCode();
+    }
+
+    @Override
+    public void close() {
+        iterators.forEach(CloseableIterator::closeIterator);
     }
 }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -302,7 +302,7 @@ public final class TinkerGraph implements Graph {
                                                                   final Object... ids) {
         final Iterator<T> iterator;
         if (0 == ids.length) {
-            iterator = elements.values().iterator();
+            iterator = new TinkerGraphIterator<T>(elements.values().iterator());
         } else {
             final List<Object> idList = Arrays.asList(ids);
             validateHomogenousIds(idList);
@@ -312,8 +312,8 @@ public final class TinkerGraph implements Graph {
             // stuff - doesn't seem likely someone would detach a Titan vertex then try to expect that
             // vertex to be findable in OrientDB
             return clazz.isAssignableFrom(ids[0].getClass()) ?
-                    IteratorUtils.filter(IteratorUtils.map(idList, id -> elements.get(clazz.cast(id).id())).iterator(), Objects::nonNull)
-                    : IteratorUtils.filter(IteratorUtils.map(idList, id -> elements.get(idManager.convert(id))).iterator(), Objects::nonNull);
+                    new TinkerGraphIterator<T>(IteratorUtils.filter(IteratorUtils.map(idList, id -> elements.get(clazz.cast(id).id())).iterator(), Objects::nonNull))
+                    : new TinkerGraphIterator<T>(IteratorUtils.filter(IteratorUtils.map(idList, id -> elements.get(idManager.convert(id))).iterator(), Objects::nonNull));
         }
         return TinkerHelper.inComputerMode(this) ?
                 (Iterator<T>) (clazz.equals(Vertex.class) ?

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIterator.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIterator.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
+import org.apache.tinkerpop.gremlin.util.iterator.StoreIteratorCounter;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import org.apache.tinkerpop.gremlin.util.iterator.StoreIteratorCounter;
 
 /**
  * Wrapper on top of Iterator representing a closable resource to the underlying storage.

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIterator.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIterator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.structure;
+
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import org.apache.tinkerpop.gremlin.util.iterator.StoreIteratorCounter;
+
+/**
+ * Wrapper on top of Iterator representing a closable resource to the underlying storage.
+ *
+ * This class also serves as a reference on how the providers can maintain a counter of the
+ * underlying storage resources in their implementation. This counter in coordination with
+ * gremlin-test suite can be used to detect cases when the query processor does not gracefully
+ * release the underlying resources.
+ */
+public class TinkerGraphIterator<E> implements Iterator<E>, AutoCloseable {
+    /**
+     * Original iterator which is wrapped by this class
+     */
+    private Iterator<E> orig;
+    private E next;
+    /**
+     * Represents if the iterator has been fully consumed
+     */
+    private boolean finished;
+
+    @Override
+    public boolean hasNext() {
+        if (next != null) return true;
+        if (finished) return false;
+
+        return tryComputeNext();
+    }
+
+    @Override
+    public E next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        final E ret = next;
+
+        // pre-fetch the next value. It is important to do this
+        // so that the underlying resource can be closed after reading the
+        // last value of the iterator.
+        tryComputeNext();
+
+        return ret;
+    }
+
+    private boolean tryComputeNext() {
+        try {
+            next = orig.next();
+            return true;
+        } catch (NoSuchElementException ex) {
+            close();
+            next = null;
+            return false;
+        }
+    }
+
+    public TinkerGraphIterator(final Iterator<E> orig) {
+        this.orig = orig;
+        StoreIteratorCounter.INSTANCE.increment();
+        finished = false;
+    }
+
+    @Override
+    public void close() {
+        if (!finished) {
+            StoreIteratorCounter.INSTANCE.decrement();
+        }
+        finished = true;
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2224

## Motivation
During the execution of the query the underlying provider layer might open some resources such as cursors or iterators which should be closed on completion of execution of the query. This is largely done by calling Traversal.close() method at the end of the traversal.
However, there are bugs in the query processor which lead to a leak of these resources. 

As an example, consider the following query:

`g.V().not(__.V().out()).fold().unfold()`

The implementation of not() step creates a child traversal which would open an iterator(aka resource) at the storage layer but due to a bug in TraversalUtil.java, it will never close this traversal (even on calling Traversal.close() on the global Traversal). This leads to open resources on the storage layer.

The purpose of this task is to add a framework for detecting an iterator leak and consequently fixing the bugs unearthed by the new framework.

## Changes
1. Add a framework to the existing test suite which would detect iterator leak during execution of every query in the test suite.
2. Fix the bugs causing iterator leak at multiple places
3. Provide an annotation to skip check for iterator leak which require fixing. To be taken up as a separate task.

## Testing
- After adding the new assertion, the existing test cases fail and after fixing the bugs, they pass.
- gremlin-core: mvn clean install -DskipIntegrationTests=fals
- gremlin-test: mvn clean install -DskipIntegrationTests=fals
- tinkergraph-gremlin: mvn clean install -DskipIntegrationTests=fals
