### PR TITLE
Expose Connection Status to Client

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -82,7 +82,7 @@ namespace Gremlin.Net.Driver
         /// <inheritdoc />
         public int NrRequestsInFlight => _callbackByRequestId.Count;
         /// <summary>
-        /// Provides whether the first available connection snapshot is open
+        /// Provides whether the first available connection snapshot is open 
         /// </summary>
         public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -84,7 +84,7 @@ namespace Gremlin.Net.Driver
         /// <summary>
         /// Provides whether the first available connection snapshot is open
         /// </summary>
-        public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
+        internal bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
         /// <inheritdoc />
         public Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -41,9 +41,7 @@ namespace Gremlin.Net.Driver
         void Finalize(Dictionary<string, object> statusAttributes);
         void HandleFailure(Exception objException);
     }
-    /// <summary>
-    ///  Connection Class
-    /// </summary>
+
     public class Connection : IConnection
     {
         private readonly GraphSONReader _graphSONReader;
@@ -60,9 +58,7 @@ namespace Gremlin.Net.Driver
         private int _connectionState = 0;
         private int _writeInProgress = 0;
         private const int Closed = 1;
-        /// <summary>
-        ///   Constructor
-        /// </summary>
+
         public Connection(Uri uri, string username, string password, GraphSONReader graphSONReader,
             GraphSONWriter graphSONWriter, string mimeType, Action<ClientWebSocketOptions> webSocketConfiguration)
         {
@@ -74,25 +70,17 @@ namespace Gremlin.Net.Driver
             _messageSerializer = new JsonMessageSerializer(mimeType);
             _webSocketConnection = new WebSocketConnection(webSocketConfiguration);
         }
-        /// <summary>
-        ///   Constructor
-        /// </summary>
+
         public async Task ConnectAsync()
         {
             await _webSocketConnection.ConnectAsync(_uri).ConfigureAwait(false);
             BeginReceiving();
         }
-        /// <summary>
-        ///   NrRequestsInFlight
-        /// </summary>
+
         public int NrRequestsInFlight => _callbackByRequestId.Count;
-        /// <summary>
-        ///     Exposes Connection Status publicly
-        /// </summary>
+
         public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
-        /// <summary>
-        ///   Methos to Execute Query
-        /// </summary>
+
         public Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             var receiver = new ResponseHandlerForSingleRequestMessage<T>(_graphSONReader);
@@ -250,9 +238,7 @@ namespace Gremlin.Net.Driver
             var serializedMsg = _messageSerializer.SerializeMessage(graphsonMsg);
             await _webSocketConnection.SendMessageAsync(serializedMsg).ConfigureAwait(false);
         }
-        /// <summary>
-        ///  Close Method
-        /// </summary>
+
         public async Task CloseAsync()
         {
             Interlocked.Exchange(ref _connectionState, Closed);
@@ -263,17 +249,12 @@ namespace Gremlin.Net.Driver
 
         private bool _disposed;
 
-        /// <summary>
-        ///   Dispose
-        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-        /// <summary>
-        ///   Dispose Virtual
-        /// </summary>
+
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -41,8 +41,10 @@ namespace Gremlin.Net.Driver
         void Finalize(Dictionary<string, object> statusAttributes);
         void HandleFailure(Exception objException);
     }
-
-    internal class Connection : IConnection
+    /// <summary>
+    ///     Gets the number of open connections.
+    /// </summary>
+    public class Connection : IConnection
     {
         private readonly GraphSONReader _graphSONReader;
         private readonly GraphSONWriter _graphSONWriter;
@@ -58,7 +60,9 @@ namespace Gremlin.Net.Driver
         private int _connectionState = 0;
         private int _writeInProgress = 0;
         private const int Closed = 1;
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         public Connection(Uri uri, string username, string password, GraphSONReader graphSONReader,
             GraphSONWriter graphSONWriter, string mimeType, Action<ClientWebSocketOptions> webSocketConfiguration)
         {
@@ -70,17 +74,25 @@ namespace Gremlin.Net.Driver
             _messageSerializer = new JsonMessageSerializer(mimeType);
             _webSocketConnection = new WebSocketConnection(webSocketConfiguration);
         }
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         public async Task ConnectAsync()
         {
             await _webSocketConnection.ConnectAsync(_uri).ConfigureAwait(false);
             BeginReceiving();
         }
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         public int NrRequestsInFlight => _callbackByRequestId.Count;
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         public Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             var receiver = new ResponseHandlerForSingleRequestMessage<T>(_graphSONReader);
@@ -104,7 +116,17 @@ namespace Gremlin.Net.Driver
                 try
                 {
                     var received = await _webSocketConnection.ReceiveMessageAsync().ConfigureAwait(false);
+
                     Parse(received);
+
+                    //if (received.Length > 0)
+                    //{
+                    //    Parse(received);
+                    //}
+                    //else
+                    //{
+                    //    Console.WriteLine("---");
+                    //}
                 }
                 catch (Exception e)
                 {
@@ -117,7 +139,7 @@ namespace Gremlin.Net.Driver
         private void Parse(byte[] received)
         {
             var receivedMsg = _messageSerializer.DeserializeMessage<ResponseMessage<JToken>>(received);
-            
+
             try
             {
                 TryParseResponseMessage(receivedMsg);
@@ -133,6 +155,11 @@ namespace Gremlin.Net.Driver
 
         private void TryParseResponseMessage(ResponseMessage<JToken> receivedMsg)
         {
+            //to reduce trying to process nulls
+            if (receivedMsg == null)
+            {
+                return;
+            }
             var status = receivedMsg.Status;
             status.ThrowIfStatusIndicatesError();
 
@@ -216,7 +243,7 @@ namespace Gremlin.Net.Driver
             {
             }
         }
-        
+
         private void NotifyAboutConnectionFailure(Exception exception)
         {
             foreach (var cb in _callbackByRequestId.Values)
@@ -232,7 +259,9 @@ namespace Gremlin.Net.Driver
             var serializedMsg = _messageSerializer.SerializeMessage(graphsonMsg);
             await _webSocketConnection.SendMessageAsync(serializedMsg).ConfigureAwait(false);
         }
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         public async Task CloseAsync()
         {
             Interlocked.Exchange(ref _connectionState, Closed);
@@ -242,13 +271,17 @@ namespace Gremlin.Net.Driver
         #region IDisposable Support
 
         private bool _disposed;
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -41,9 +41,7 @@ namespace Gremlin.Net.Driver
         void Finalize(Dictionary<string, object> statusAttributes);
         void HandleFailure(Exception objException);
     }
-    /// <summary>
-    ///     Gets the number of open connections.
-    /// </summary>
+
     public class Connection : IConnection
     {
         private readonly GraphSONReader _graphSONReader;
@@ -60,9 +58,7 @@ namespace Gremlin.Net.Driver
         private int _connectionState = 0;
         private int _writeInProgress = 0;
         private const int Closed = 1;
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+
         public Connection(Uri uri, string username, string password, GraphSONReader graphSONReader,
             GraphSONWriter graphSONWriter, string mimeType, Action<ClientWebSocketOptions> webSocketConfiguration)
         {
@@ -82,17 +78,11 @@ namespace Gremlin.Net.Driver
             await _webSocketConnection.ConnectAsync(_uri).ConfigureAwait(false);
             BeginReceiving();
         }
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+    
         public int NrRequestsInFlight => _callbackByRequestId.Count;
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+ 
         public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+  
         public Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             var receiver = new ResponseHandlerForSingleRequestMessage<T>(_graphSONReader);
@@ -118,15 +108,6 @@ namespace Gremlin.Net.Driver
                     var received = await _webSocketConnection.ReceiveMessageAsync().ConfigureAwait(false);
 
                     Parse(received);
-
-                    //if (received.Length > 0)
-                    //{
-                    //    Parse(received);
-                    //}
-                    //else
-                    //{
-                    //    Console.WriteLine("---");
-                    //}
                 }
                 catch (Exception e)
                 {
@@ -271,17 +252,13 @@ namespace Gremlin.Net.Driver
         #region IDisposable Support
 
         private bool _disposed;
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -82,7 +82,7 @@ namespace Gremlin.Net.Driver
         /// <inheritdoc />
         public int NrRequestsInFlight => _callbackByRequestId.Count;
         /// <summary>
-        /// Provides whether the first available connection snapshot is open 
+        /// Provides whether the first available connection snapshot is open
         /// </summary>
         public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -70,9 +70,7 @@ namespace Gremlin.Net.Driver
             _messageSerializer = new JsonMessageSerializer(mimeType);
             _webSocketConnection = new WebSocketConnection(webSocketConfiguration);
         }
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+
         public async Task ConnectAsync()
         {
             await _webSocketConnection.ConnectAsync(_uri).ConfigureAwait(false);
@@ -240,9 +238,7 @@ namespace Gremlin.Net.Driver
             var serializedMsg = _messageSerializer.SerializeMessage(graphsonMsg);
             await _webSocketConnection.SendMessageAsync(serializedMsg).ConfigureAwait(false);
         }
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
+   
         public async Task CloseAsync()
         {
             Interlocked.Exchange(ref _connectionState, Closed);

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -41,7 +41,9 @@ namespace Gremlin.Net.Driver
         void Finalize(Dictionary<string, object> statusAttributes);
         void HandleFailure(Exception objException);
     }
-
+    /// <summary>
+    /// Connection
+    /// </summary>
     public class Connection : IConnection
     {
         private readonly GraphSONReader _graphSONReader;
@@ -59,6 +61,7 @@ namespace Gremlin.Net.Driver
         private int _writeInProgress = 0;
         private const int Closed = 1;
 
+        /// <inheritdoc />
         public Connection(Uri uri, string username, string password, GraphSONReader graphSONReader,
             GraphSONWriter graphSONWriter, string mimeType, Action<ClientWebSocketOptions> webSocketConfiguration)
         {
@@ -70,17 +73,19 @@ namespace Gremlin.Net.Driver
             _messageSerializer = new JsonMessageSerializer(mimeType);
             _webSocketConnection = new WebSocketConnection(webSocketConfiguration);
         }
-
+        /// <inheritdoc />
         public async Task ConnectAsync()
         {
             await _webSocketConnection.ConnectAsync(_uri).ConfigureAwait(false);
             BeginReceiving();
         }
-
+        /// <inheritdoc />
         public int NrRequestsInFlight => _callbackByRequestId.Count;
-
+        /// <summary>
+        /// Provides whether the first available connection snapshot is open
+        /// </summary>
         public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
-
+        /// <inheritdoc />
         public Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             var receiver = new ResponseHandlerForSingleRequestMessage<T>(_graphSONReader);
@@ -238,7 +243,7 @@ namespace Gremlin.Net.Driver
             var serializedMsg = _messageSerializer.SerializeMessage(graphsonMsg);
             await _webSocketConnection.SendMessageAsync(serializedMsg).ConfigureAwait(false);
         }
-
+        /// <inheritdoc />
         public async Task CloseAsync()
         {
             Interlocked.Exchange(ref _connectionState, Closed);
@@ -248,13 +253,13 @@ namespace Gremlin.Net.Driver
         #region IDisposable Support
 
         private bool _disposed;
-
+        /// <inheritdoc />
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-
+        /// <inheritdoc />
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -41,7 +41,9 @@ namespace Gremlin.Net.Driver
         void Finalize(Dictionary<string, object> statusAttributes);
         void HandleFailure(Exception objException);
     }
-
+    /// <summary>
+    ///  Connection Class
+    /// </summary>
     public class Connection : IConnection
     {
         private readonly GraphSONReader _graphSONReader;
@@ -58,7 +60,9 @@ namespace Gremlin.Net.Driver
         private int _connectionState = 0;
         private int _writeInProgress = 0;
         private const int Closed = 1;
-
+        /// <summary>
+        ///   Constructor
+        /// </summary>
         public Connection(Uri uri, string username, string password, GraphSONReader graphSONReader,
             GraphSONWriter graphSONWriter, string mimeType, Action<ClientWebSocketOptions> webSocketConfiguration)
         {
@@ -70,17 +74,25 @@ namespace Gremlin.Net.Driver
             _messageSerializer = new JsonMessageSerializer(mimeType);
             _webSocketConnection = new WebSocketConnection(webSocketConfiguration);
         }
-
+        /// <summary>
+        ///   Constructor
+        /// </summary>
         public async Task ConnectAsync()
         {
             await _webSocketConnection.ConnectAsync(_uri).ConfigureAwait(false);
             BeginReceiving();
         }
-    
+        /// <summary>
+        ///   NrRequestsInFlight
+        /// </summary>
         public int NrRequestsInFlight => _callbackByRequestId.Count;
- 
+        /// <summary>
+        ///     Exposes Connection Status publicly
+        /// </summary>
         public bool IsOpen => _webSocketConnection.IsOpen && Volatile.Read(ref _connectionState) != Closed;
-  
+        /// <summary>
+        ///   Methos to Execute Query
+        /// </summary>
         public Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
         {
             var receiver = new ResponseHandlerForSingleRequestMessage<T>(_graphSONReader);
@@ -238,7 +250,9 @@ namespace Gremlin.Net.Driver
             var serializedMsg = _messageSerializer.SerializeMessage(graphsonMsg);
             await _webSocketConnection.SendMessageAsync(serializedMsg).ConfigureAwait(false);
         }
-   
+        /// <summary>
+        ///  Close Method
+        /// </summary>
         public async Task CloseAsync()
         {
             Interlocked.Exchange(ref _connectionState, Closed);
@@ -249,12 +263,17 @@ namespace Gremlin.Net.Driver
 
         private bool _disposed;
 
+        /// <summary>
+        ///   Dispose
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-
+        /// <summary>
+        ///   Dispose Virtual
+        /// </summary>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -75,7 +75,7 @@ namespace Gremlin.Net.Driver
 
         private async Task EnsurePoolIsPopulatedAsync()
         {
-            // The pool could have been (partially) empty because of  connection problems. So, we need to populate it again.
+            // The pool could have been (partially) empty because of connection problems. So, we need to populate it again.
             if (_poolSize <= NrConnections) return;
             var poolState = Interlocked.CompareExchange(ref _poolState, PoolPopulationInProgress, PoolIdle);
             if (poolState == PoolPopulationInProgress) return;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -75,7 +75,7 @@ namespace Gremlin.Net.Driver
 
         private async Task EnsurePoolIsPopulatedAsync()
         {
-            // The pool could have been (partially) empty because of connection problems. So, we need to populate it again.
+            // The pool could have been (partially) empty because of  connection problems. So, we need to populate it again.
             if (_poolSize <= NrConnections) return;
             var poolState = Interlocked.CompareExchange(ref _poolState, PoolPopulationInProgress, PoolIdle);
             if (poolState == PoolPopulationInProgress) return;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -52,7 +52,7 @@ namespace Gremlin.Net.Driver
         }
 
         public int NrConnections => _connections.Count;
-        public Connection FirstConnection
+        internal Connection FirstConnection
         {
             get
             {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -52,7 +52,7 @@ namespace Gremlin.Net.Driver
         }
 
         public int NrConnections => _connections.Count;
-        internal Connection FirstConnection
+        internal Connection FirstConnectionSnapshot
         {
             get
             {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -71,13 +71,9 @@ namespace Gremlin.Net.Driver
             _connectionPool =
                 new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());
         }
-        /// <summary>
-        ///   Connection Count
-        /// </summary>
+
         public int NrConnections => _connectionPool.NrConnections;
-        /// <summary>
-        ///   Exposes the first available connection on the client
-        /// </summary>
+
         public Connection FirstAvailableConnection => _connectionPool.FirstConnection;
 
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -44,7 +44,7 @@ namespace Gremlin.Net.Driver
         /// The GraphSON2 mime type to use.
         /// </summary>
         public const string GraphSON2MimeType = "application/vnd.gremlin-v2.0+json";
-        
+
         private readonly ConnectionPool _connectionPool;
 
         /// <summary>
@@ -69,13 +69,19 @@ namespace Gremlin.Net.Driver
             var connectionFactory = new ConnectionFactory(gremlinServer, reader, writer, mimeType ?? DefaultMimeType,
                 webSocketConfiguration);
             _connectionPool =
-                new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());            
+                new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());
         }
 
         /// <summary>
         ///     Gets the number of open connections.
         /// </summary>
         public int NrConnections => _connectionPool.NrConnections;
+
+        /// <summary>
+        ///     Gets the number of open connections.
+        /// </summary>
+        public Connection FirstAvailableConnection => _connectionPool.FirstConnection;
+
 
         /// <inheritdoc />
         public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -71,9 +71,13 @@ namespace Gremlin.Net.Driver
             _connectionPool =
                 new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());
         }
-
+        /// <summary>
+        ///   Connection Count
+        /// </summary>
         public int NrConnections => _connectionPool.NrConnections;
-
+        /// <summary>
+        ///   Exposes the first available connection on the client
+        /// </summary>
         public Connection FirstAvailableConnection => _connectionPool.FirstConnection;
 
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -72,9 +72,15 @@ namespace Gremlin.Net.Driver
                 new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());
         }
 
+        /// <summary>
+        ///     Provides number of connections in pool.
+        /// </summary>
         public int NrConnections => _connectionPool.NrConnections;
 
-        public Connection FirstAvailableConnection => _connectionPool.FirstConnection;
+        /// <summary>
+        ///     Provides whether the first available connection snapshot in pool is still open.
+        /// </summary>
+        public bool IsConnectionOpen => _connectionPool.FirstConnectionSnapshot.IsOpen;
 
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -80,7 +80,7 @@ namespace Gremlin.Net.Driver
         /// <summary>
         ///     Provides whether the first available connection snapshot in pool is still open.
         /// </summary>
-        public bool IsConnectionOpen => _connectionPool.FirstConnectionSnapshot.IsOpen;
+        public bool IsConnectionOpen =>  _connectionPool.FirstConnectionSnapshot.IsOpen;
 
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -72,14 +72,8 @@ namespace Gremlin.Net.Driver
                 new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());
         }
 
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
         public int NrConnections => _connectionPool.NrConnections;
 
-        /// <summary>
-        ///     Gets the number of open connections.
-        /// </summary>
         public Connection FirstAvailableConnection => _connectionPool.FirstConnection;
 
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -80,7 +80,7 @@ namespace Gremlin.Net.Driver
         /// <summary>
         ///     Provides whether the first available connection snapshot in pool is still open.
         /// </summary>
-        public bool HasOpenConnection => (bool)_connectionPool.FirstConnectionSnapshot?.IsOpen;
+        public bool HasOpenConnection => (bool)_connectionPool?.FirstConnectionSnapshot?.IsOpen;
 
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -80,7 +80,7 @@ namespace Gremlin.Net.Driver
         /// <summary>
         ///     Provides whether the first available connection snapshot in pool is still open.
         /// </summary>
-        public bool IsConnectionOpen =>  _connectionPool.FirstConnectionSnapshot.IsOpen;
+        public bool IsConnectionOpen => _connectionPool.FirstConnectionSnapshot.IsOpen;
 
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -80,7 +80,7 @@ namespace Gremlin.Net.Driver
         /// <summary>
         ///     Provides whether the first available connection snapshot in pool is still open.
         /// </summary>
-        public bool IsConnectionOpen => (bool)_connectionPool.FirstConnectionSnapshot?.IsOpen;
+        public bool HasOpenConnection => (bool)_connectionPool.FirstConnectionSnapshot?.IsOpen;
 
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -80,7 +80,7 @@ namespace Gremlin.Net.Driver
         /// <summary>
         ///     Provides whether the first available connection snapshot in pool is still open.
         /// </summary>
-        public bool IsConnectionOpen => _connectionPool.FirstConnectionSnapshot.IsOpen;
+        public bool IsConnectionOpen => (bool)_connectionPool.FirstConnectionSnapshot?.IsOpen;
 
 
         /// <inheritdoc />


### PR DESCRIPTION
When a consumer of the Gremlin.Net client calls to execute a Gremlin query, i.e. "SubmitAsync," and the connection is not open, there will be a costly timeout error.  I have experienced 30 to 90 second timeouts. 

By exposing connection status, the client's consumer can check the client's connection status before making this call.  My responsiveness is excellent now, and I now use the Gremlin.Net client in PROD.

Modified code to add a non-breaking HasOpenConnection bool function on the Gremlin.Net GremlinClient object.  It can be used this way:

    if(gremlinClient.HasOpenConnection)
        await gremlinClient.SubmitAsync("g.V().range(0,1).property('hello','world')");

This property could also be negated by adding this functionality inside the SubmitAsync function.  The function's code could check each time before submit, and then reconnect before submit, or just check and return null with an error if no connection.  This would remove the decision making from the developer's code, limiting the client's flexibility.

I favor the the simpler approach of exposing the pool's status (as read-only) to the client, and while this changes the interface, for the sake of brevity, that's what I implemented.  

The ideal solution would be to allow the SubmitAsync call to fail immediately if there is a connection issue, and note that in the results.  That way the consumer can decide how to react to the results info, yet there is no wait, and no change of interface.
