### PR TITLE
Fix bug where client/server exception mismatch when server throw StackOverflowError

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added test infrastructure to check for storage iterator leak.
 * Fixed multiple iterator leaks in query processor.
 * Fixed bug in `MatchStep` where the correct was not properly determined.
+* Fixed bug where client/server exception mismatch when server throw StackOverflowError
 
 [[release-3-3-7]]
 === TinkerPop 3.3.7 (Release Date: May 28, 2019)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -318,9 +318,10 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
                                 .statusMessage(errorMessage)
                                 .statusAttributeException(t).create());
                     } else {
+                        final String errorMessage =  (t.getMessage() == null) ? t.toString() : t.getMessage();
                         logger.warn(String.format("Exception processing a script on request [%s].", msg), t);
                         rhc.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR_SCRIPT_EVALUATION)
-                                .statusMessage(t.getMessage())
+                                .statusMessage(errorMessage)
                                 .statusAttributeException(t).create());
                     }
                 }


### PR DESCRIPTION
old discussion and suggestion here:  https://github.com/apache/tinkerpop/pull/1127
issue here: https://issues.apache.org/jira/browse/TINKERPOP-2241