### PR TITLE
Typo fix to tp33

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1717,7 +1717,7 @@ sandboxing implementations can be developed by using this white listing model an
 `AbstractSandboxExtension`.
 
 A final thought on the topic of `GroovyCompilerGremlinPlugin` implementation is that it is not just for
-"security" (though is is demonstrated in that capacity here).  It can be used for a variety of features that
+"security" (though it is demonstrated in that capacity here).  It can be used for a variety of features that
 can fine tune the Groovy compilation process.  Read more about compilation customization in the
 link:http://docs.groovy-lang.org/latest/html/documentation/#compilation-customizers[Groovy Documentation].
 


### PR DESCRIPTION
Did I target this fix to the correct branch?  A notification email I received containing a message from Stephen Mallette re my first pull request mentioned that 3.3.x is currently maintained on the tp33 branch, 3.4.x on tp34, and 3.5.0 (unreleased) on master, and said it'd be nice if I could target future PRs to the earliest branch to show the problem, so I checked the tp33 branch to see if the typo was there, and it was.  But I didn't check for anything earlier (tp32?) ... should I have?  Or is tp33 the earliest one to check?  Thanks!