### PR TITLE
TINKERPOP-2243 Add userAgent to RequestOptions.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,7 +29,7 @@ This release also includes changes from <<release-3-3-8, 3.3.8>>.
 * Modified `NumberHelper` to better ignore `Double.NaN` in `min()` and `max()` comparisons.
 * Bump to Netty 4.1.36.
 * Bump to Groovy 2.5.7.
-* TINKERPOP-2243 Added `userAgent` to RequestOptions. Gremlin Console sends `Gremlin Console` as the `userAgent`.
+* Added `userAgent` to RequestOptions. Gremlin Console sends `Gremlin Console/<version>` as the `userAgent`.
 
 [[release-3-4-2]]
 === TinkerPop 3.4.2 (Release Date: May 28, 2019)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ This release also includes changes from <<release-3-3-8, 3.3.8>>.
 * Modified `NumberHelper` to better ignore `Double.NaN` in `min()` and `max()` comparisons.
 * Bump to Netty 4.1.36.
 * Bump to Groovy 2.5.7.
+* TINKERPOP-2243 Added `userAgent` to RequestOptions. Gremlin Console sends `Gremlin Console` as the `userAgent`.
 
 [[release-3-4-2]]
 === TinkerPop 3.4.2 (Release Date: May 28, 2019)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ This release also includes changes from <<release-3-3-8, 3.3.8>>.
 * Bump to Netty 4.1.36.
 * Bump to Groovy 2.5.7.
 * Added `userAgent` to RequestOptions. Gremlin Console sends `Gremlin Console/<version>` as the `userAgent`.
+* Fixed DriverRemoteConnection ignoring `with` `Token` options when multiple were set.
 
 [[release-3-4-2]]
 === TinkerPop 3.4.2 (Release Date: May 28, 2019)

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -55,7 +55,7 @@ import java.util.stream.Stream;
  */
 public class DriverRemoteAcceptor implements RemoteAcceptor {
     public static final int NO_TIMEOUT = 0;
-    public static final String USER_AGENT_PREFIX = "Gremlin Console/";
+    public static final String USER_AGENT = "Gremlin Console/" + Gremlin.version();
 
     private Cluster currentCluster;
     private Client currentClient;
@@ -211,7 +211,7 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
             if (timeout > NO_TIMEOUT)
                 options.timeout(timeout);
 
-            options.userAgent(USER_AGENT_PREFIX + Gremlin.version());
+            options.userAgent(USER_AGENT);
 
             final ResultSet rs = this.currentClient.submit(gremlin, options.create());
             final List<Result> results = rs.all().get();

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.jsr223.console.GremlinShellEnvironment;
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteAcceptor;
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteException;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
+import org.apache.tinkerpop.gremlin.util.Gremlin;
 
 import javax.security.sasl.SaslException;
 import java.io.File;
@@ -54,7 +55,7 @@ import java.util.stream.Stream;
  */
 public class DriverRemoteAcceptor implements RemoteAcceptor {
     public static final int NO_TIMEOUT = 0;
-    public static final String USER_AGENT = "Gremlin Console";
+    public static final String USER_AGENT_PREFIX = "Gremlin Console/";
 
     private Cluster currentCluster;
     private Client currentClient;
@@ -210,7 +211,7 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
             if (timeout > NO_TIMEOUT)
                 options.timeout(timeout);
 
-            options.userAgent(USER_AGENT);
+            options.userAgent(USER_AGENT_PREFIX + Gremlin.version());
 
             final ResultSet rs = this.currentClient.submit(gremlin, options.create());
             final List<Result> results = rs.all().get();

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -54,6 +54,7 @@ import java.util.stream.Stream;
  */
 public class DriverRemoteAcceptor implements RemoteAcceptor {
     public static final int NO_TIMEOUT = 0;
+    public static final String USER_AGENT = "Gremlin Console";
 
     private Cluster currentCluster;
     private Client currentClient;
@@ -208,6 +209,8 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
             aliases.forEach(options::addAlias);
             if (timeout > NO_TIMEOUT)
                 options.timeout(timeout);
+
+            options.userAgent(USER_AGENT);
 
             final ResultSet rs = this.currentClient.submit(gremlin, options.create());
             final List<Result> results = rs.all().get();

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -344,6 +344,7 @@ public abstract class Client {
         options.getParameters().ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, params));
         options.getAliases().ifPresent(aliases -> request.addArg(Tokens.ARGS_ALIASES, aliases));
         options.getOverrideRequestId().ifPresent(request::overrideRequestId);
+        options.getUserAgent().ifPresent(userAgent -> request.addArg(Tokens.ARGS_USER_AGENT, userAgent));
 
         return submitAsync(request.create());
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
@@ -39,6 +39,7 @@ public final class RequestOptions {
     private final Integer batchSize;
     private final Long timeout;
     private final UUID overrideRequestId;
+    private final String userAgent;
 
     private RequestOptions(final Builder builder) {
         this.aliases = builder.aliases;
@@ -46,6 +47,7 @@ public final class RequestOptions {
         this.batchSize = builder.batchSize;
         this.timeout = builder.timeout;
         this.overrideRequestId = builder.overrideRequestId;
+        this.userAgent = builder.userAgent;
     }
 
     public Optional<UUID> getOverrideRequestId() {
@@ -68,6 +70,10 @@ public final class RequestOptions {
         return Optional.ofNullable(timeout);
     }
 
+    public Optional<String> getUserAgent() {
+        return Optional.ofNullable(userAgent);
+    }
+
     public static Builder build() {
         return new Builder();
     }
@@ -78,6 +84,7 @@ public final class RequestOptions {
         private Integer batchSize = null;
         private Long timeout = null;
         private UUID overrideRequestId = null;
+        private String userAgent = null;
 
         /**
          * The aliases to set on the request.
@@ -125,6 +132,14 @@ public final class RequestOptions {
          */
         public Builder timeout(final long timeout) {
             this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Sets the userAgent identifier to be sent on the request.
+         */
+        public Builder userAgent(final String userAgent) {
+            this.userAgent = userAgent;
             return this;
         }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
@@ -50,6 +50,7 @@ public final class Tokens {
     public static final String ARGS_SIDE_EFFECT = "sideEffect";
     public static final String ARGS_AGGREGATE_TO = "aggregateTo";
     public static final String ARGS_SIDE_EFFECT_KEY = "sideEffectKey";
+    public static final String ARGS_USER_AGENT = "userAgent";
 
     public static final String VAL_AGGREGATE_TO_BULKSET = "bulkset";
     public static final String VAL_AGGREGATE_TO_LIST = "list";

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -38,8 +38,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_BATCH_SIZE;
-import static org.apache.tinkerpop.gremlin.driver.Tokens.REQUEST_ID;
 import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_SCRIPT_EVAL_TIMEOUT;
+import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_USER_AGENT;
+import static org.apache.tinkerpop.gremlin.driver.Tokens.REQUEST_ID;
 
 /**
  * A {@link RemoteConnection} implementation for Gremlin Server. Each {@code DriverServerConnection} is bound to one
@@ -234,10 +235,12 @@ public class DriverRemoteConnection implements RemoteConnection {
             final Map<String,Object> options = optionsStrategy.getOptions();
             if (options.containsKey(ARGS_SCRIPT_EVAL_TIMEOUT))
                 builder.timeout((long) options.get(ARGS_SCRIPT_EVAL_TIMEOUT));
-            else if (options.containsKey(REQUEST_ID))
+            if (options.containsKey(REQUEST_ID))
                 builder.overrideRequestId((UUID) options.get(REQUEST_ID));
-            else if (options.containsKey(ARGS_BATCH_SIZE))
+            if (options.containsKey(ARGS_BATCH_SIZE))
                 builder.batchSize((int) options.get(ARGS_BATCH_SIZE));
+            if (options.containsKey(ARGS_USER_AGENT))
+                builder.userAgent((String) options.get(ARGS_USER_AGENT));
         }
         return builder.create();
     }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
@@ -43,9 +43,11 @@ public class DriverRemoteConnectionTest {
                         with(Tokens.ARGS_BATCH_SIZE, 1000).
                         with(Tokens.REQUEST_ID, requestId).
                         with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 100000L).
+                        with(Tokens.ARGS_USER_AGENT, "test").
                         V().asAdmin().getBytecode());
         assertEquals(requestId, options.getOverrideRequestId().get());
         assertEquals(1000, options.getBatchSize().get().intValue());
         assertEquals(100000L, options.getTimeout().get().longValue());
+        assertEquals("test", options.getUserAgent().get());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2243

This allows graph providers to tailor their error messages to the client.