### PR TITLE
Upgrade to neo4j-tinkerpop-api-impl `0.9-3.4.0`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Removed previously deprecated `TraversalSource.withRemote()`.
 * Removed previously deprecated SSL settings: `keyCertChainFile`, `keyFile`, `keyPassword` and `trustCertChainFile` and related infrastructure.
 * Removed previously deprecated `BulkDumperVertexProgram` and `BulkLoaderVertexProgram`.
+* Upgrade to Neo4j 3.4.11
 
 == TinkerPop 3.4.0 (Avant-Gremlin Construction #3 for Theremin and Flowers)
 

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -28,7 +28,7 @@ limitations under the License.
 <dependency>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-  <version>0.7-3.2.3</version>
+  <version>0.9-3.4.0</version>
 </dependency>
 ----
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -15,6 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ////
 
+== TinkerPop 3.5.0
+
+=== Upgrading for Users
+
+==== Upgrade Neo4j
+
+Refer to Neo4j link:https://neo4j.com/guides/upgrade-archive/[3.4 Upgrade FAQ] for guide on how to upgrade from the previous 3.2.3 version.
+For example, configuration setting `dbms.allow_format_migration` is now `dbms.allow_upgrade`.
+
 = TinkerPop 3.4.0
 
 image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/avant-gremlin.png[width=225]

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -206,28 +206,84 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.3-2.3.3</version>
+                    <version>0.9-3.4.0</version>
                     <scope>test</scope>
                     <exclusions>
+                        <exclusion>
+                            <groupId>org.neo4j</groupId>
+                            <artifactId>neo4j-kernel</artifactId>
+                        </exclusion>
                         <exclusion>
                             <groupId>org.apache.commons</groupId>
                             <artifactId>commons-lang3</artifactId>
                         </exclusion>
                         <exclusion>
-                            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                            <artifactId>concurrentlinkedhashmap-lru</artifactId>
+                            <groupId>com.github.ben-manes.caffeine</groupId>
+                            <artifactId>caffeine</artifactId>
                         </exclusion>
                         <exclusion>
                             <groupId>org.scala-lang</groupId>
                             <artifactId>scala-library</artifactId>
                         </exclusion>
                         <exclusion>
+                            <groupId>org.scala-lang</groupId>
+                            <artifactId>scala-reflect</artifactId>
+                        </exclusion>
+                        <exclusion>
                             <groupId>org.slf4j</groupId>
                             <artifactId>slf4j-api</artifactId>
                         </exclusion>
                         <exclusion>
-                            <groupId>info.ganglia.gmetric4j</groupId>
-                            <artifactId>gmetric4j</artifactId>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-nop</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.lucene</groupId>
+                            <artifactId>lucene-core</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.dropwizard.metrics</groupId>
+                            <artifactId>metrics-core</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-all</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                    <version>2.11.8</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-reflect</artifactId>
+                    <version>2.11.8</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-core</artifactId>
+                    <version>5.5.0</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                    <version>4.0.2</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j-kernel</artifactId>
+                    <version>3.4.11</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-all</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>
@@ -340,7 +396,7 @@ limitations under the License.
                             <repository>tinkerpop/gremlin-server</repository>
                         </configuration>
                     </plugin>
-                </plugins>                
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-tinkerpop-api</artifactId>
-            <version>0.1</version>
+            <version>0.1.1</version>
         </dependency>
         <!-- TESTING -->
         <dependency>
@@ -89,7 +89,7 @@ limitations under the License.
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.7-3.2.3
+                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.9-3.4.0
                             </Gremlin-Plugin-Dependencies>
                         </manifestEntries>
                     </archive>
@@ -117,7 +117,7 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.7-3.2.3</version>
+                    <version>0.9-3.4.0</version>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>
@@ -148,6 +148,14 @@ limitations under the License.
                             <groupId>org.slf4j</groupId>
                             <artifactId>slf4j-nop</artifactId>
                         </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.lucene</groupId>
+                            <artifactId>lucene-core</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.dropwizard.metrics</groupId>
+                            <artifactId>metrics-core</artifactId>
+                        </exclusion>
                     </exclusions>
                 </dependency>
                 <dependency>
@@ -168,11 +176,22 @@ limitations under the License.
                     <version>2.3.1</version>
                     <scope>test</scope>
                 </dependency>
-                <!-- self-conflict with neo4j-graph-matching -->
+                <dependency>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-core</artifactId>
+                    <version>5.5.0</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                    <version>4.0.2</version>
+                    <scope>test</scope>
+                </dependency>
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-kernel</artifactId>
-                    <version>3.2.3</version>
+                    <version>3.4.11</version>
                     <scope>test</scope>
                 </dependency>
                 <!-- *** WARNING *** -->


### PR DESCRIPTION
* I think I've got dependency conflicts figured out. At least basic queries are executed ok and `mvn clean install -DincludeNeo4j` passes. Please clarify if I'm missing something.
* Upgrade to Neo4j  `3.4` (not `3.5`), because this is the latest available version in  `neo4j-tinkerpop-api-impl`. Migration to `3.5` will require some efforts.
* Upgrade Neo4j `3.2.3` → `3.4.11` should be straightforward. Added release notes anyway.
* Looks like #1042 could be merged after this