### PR TITLE
TINKERPOP-2256 TINKERPOP-2256 processAllStarts of AggregateStep should only be called when barrier is empty

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateStep.java
@@ -106,7 +106,9 @@ public final class AggregateStep<S> extends AbstractStep<S, S> implements SideEf
 
     @Override
     protected Traverser.Admin<S> processNextStart() {
-        this.processAllStarts();
+        if (this.barrier.isEmpty()) {
+            this.processAllStarts();
+        }
         return this.barrier.remove();
     }
 
@@ -126,13 +128,17 @@ public final class AggregateStep<S> extends AbstractStep<S, S> implements SideEf
 
     @Override
     public boolean hasNextBarrier() {
-        this.processAllStarts();
+        if (this.barrier.isEmpty()) {
+            this.processAllStarts();
+        }
         return !this.barrier.isEmpty();
     }
 
     @Override
     public TraverserSet<S> nextBarrier() throws NoSuchElementException {
-        this.processAllStarts();
+        if (this.barrier.isEmpty()) {
+            this.processAllStarts();
+        }
         if (this.barrier.isEmpty())
             throw FastNoSuchElementException.instance();
         else {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2256

I follow the usage of hasProcessedOnce in ReducingBarrierStep and i think AggregateStep doesn't need the done() function.