### PR TITLE
TINKERPOP-2270 Deprecate Neo4j multi/metaproperty support

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bump to Groovy 2.4.17.
 * Bump to Jackson Databind 2.9.9.1.
 * Improved error messaging when an attempt is made to serialize multi-properties to GraphML.
+* Deprecated multi/meta-property support in `Neo4jGraph`.
 * Improved exception and messaging for gt/gte/lt/lte when one of the object isn't a `Comparable`.
 * Added test infrastructure to check for storage iterator leak.
 * Fixed multiple iterator leaks in query processor.

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -114,43 +114,6 @@ graph.close()
 <5> Find all vertices whose name is Garcia which requires a linear scan of all the data in the graph.
 <6> Drop the created index.
 
-=== Multi/Meta-Properties
-
-`Neo4jGraph` supports both multi- and meta-properties (see <<vertex-properties,vertex properties>>). These features
-are not native to Neo4j and are implemented using "hidden" Neo4j nodes. For example, when a vertex has multiple
-"name" properties, each property is a new node (multi-properties) which can have properties attached to it
-(meta-properties). As such, the native, underlying representation may become difficult to query directly using
-another graph language such as <<_cypher,Cypher>>. The default setting is to disable multi- and meta-properties.
-However, if this feature is desired, then it can be activated via `gremlin.neo4j.metaProperties` and
-`gremlin.neo4j.multiProperties` configurations being set to `true`. Once the configuration is set, it can not be
-changed for the lifetime of the graph.
-
-[gremlin-groovy]
-----
-conf = new BaseConfiguration()
-conf.setProperty('gremlin.neo4j.directory','/tmp/neo4j')
-conf.setProperty('gremlin.neo4j.multiProperties',true)
-conf.setProperty('gremlin.neo4j.metaProperties',true)
-graph = Neo4jGraph.open(conf)
-g = graph.traversal()
-g.addV().property('name','michael').property('name','michael hunger').property('name','mhunger')
-g.V().properties('name').property('acl', 'public')
-g.V(0).valueMap()
-g.V(0).properties()
-g.V(0).properties().valueMap()
-graph.close()
-----
-
-WARNING: `Neo4jGraph` without multi- and meta-properties is in 1-to-1 correspondence with the native, underlying Neo4j
-representation. It is recommended that if the user does not require multi/meta-properties, then they should not
-enable them. Without multi- and meta-properties enabled, Neo4j can be interacted with with other tools and technologies
-that do not leverage TinkerPop.
-
-IMPORTANT: When using a multi-property enabled `Neo4jGraph`, vertices may represent their properties on "hidden
-nodes" adjacent to the vertex. If a vertex property key/value is required for indexing, then two indices are
-required -- e.g. `CREATE INDEX ON :person(name)` and `CREATE INDEX ON :vertexProperty(name)`
-(see <<_indices,Neo4j indices>>).
-
 === Cypher
 
 image::gremlin-loves-cypher.png[width=400]

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
@@ -85,7 +85,17 @@ public final class Neo4jGraph implements Graph, WrappedGraph<Neo4jGraphAPI> {
 
     public static final String CONFIG_DIRECTORY = "gremlin.neo4j.directory";
     public static final String CONFIG_CONF = "gremlin.neo4j.conf";
+
+    /**
+     * @deprecated As of release 3.3.8, not replaced.
+     */
+    @Deprecated
     public static final String CONFIG_META_PROPERTIES = "gremlin.neo4j.metaProperties";
+
+    /**
+     * @deprecated As of release 3.3.8, not replaced.
+     */
+    @Deprecated
     public static final String CONFIG_MULTI_PROPERTIES = "gremlin.neo4j.multiProperties";
 
     private final Neo4jTransaction neo4jTransaction = new Neo4jTransaction();
@@ -110,7 +120,7 @@ public final class Neo4jGraph implements Graph, WrappedGraph<Neo4jGraphAPI> {
             this.neo4jGraphVariables.set(Graph.Hidden.hide(CONFIG_META_PROPERTIES), supportsMetaProperties);
         this.trait = supportsMultiProperties ? MultiMetaNeo4jTrait.instance() : NoMultiNoMetaNeo4jTrait.instance();
         if (supportsMultiProperties)
-            LOGGER.warn(this.getClass().getSimpleName() + " multi/meta-properties feature is considered experimental and should not be used in a production setting until this warning is removed");
+            LOGGER.warn(this.getClass().getSimpleName() + " multi/meta-properties feature has always been considered experimental and not production ready - it is now deprecated as of 3.3.8");
         this.tx().commit();
     }
 
@@ -234,6 +244,11 @@ public final class Neo4jGraph implements Graph, WrappedGraph<Neo4jGraphAPI> {
         }
     }
 
+
+    /**
+     * @deprecated As of release 3.3.8, not replaced.
+     */
+    @Deprecated
     public Neo4jTrait getTrait() {
         return this.trait;
     }

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/MultiMetaNeo4jTrait.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/MultiMetaNeo4jTrait.java
@@ -49,7 +49,9 @@ import java.util.stream.Stream;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated As of release 3.3.8, not replaced.
  */
+@Deprecated
 public final class MultiMetaNeo4jTrait implements Neo4jTrait {
 
     private static final MultiMetaNeo4jTrait INSTANCE = new MultiMetaNeo4jTrait();

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/Neo4jTrait.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/Neo4jTrait.java
@@ -34,7 +34,9 @@ import java.util.function.Predicate;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated As of release 3.3.8, not replaced.
  */
+@Deprecated
 public interface Neo4jTrait {
 
     public Predicate<Neo4jNode> getNodePredicate();

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/NoMultiNoMetaNeo4jTrait.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/trait/NoMultiNoMetaNeo4jTrait.java
@@ -42,7 +42,9 @@ import java.util.function.Predicate;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated As of release 3.3.8, not replaced.
  */
+@Deprecated
 public final class NoMultiNoMetaNeo4jTrait implements Neo4jTrait {
 
     private static final NoMultiNoMetaNeo4jTrait INSTANCE = new NoMultiNoMetaNeo4jTrait();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2270

Purposely didn't add any upgrade notes. Just didn't seem necessary for the deprecation of a feature that was never really production ready.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1