### PR TITLE
TINKERPOP-2271 Add warnings=true|false console preference (tp34)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ This release also includes changes from <<release-3-3-8, 3.3.8>>.
 * Bump to Groovy 2.5.7.
 * Added `userAgent` to RequestOptions. Gremlin Console sends `Gremlin Console/<version>` as the `userAgent`.
 * Fixed DriverRemoteConnection ignoring `with` `Token` options when multiple were set.
+* Added `:set warnings <true|false>` to Gremlin Console.
 
 [[release-3-4-2]]
 === TinkerPop 3.4.2 (Release Date: May 28, 2019)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -216,6 +216,7 @@ Preferences are set with `:set name value`.  Values can contain spaces when quot
 |Preference |Type |Description
 |max-iteration | int | Controls the maximum number of results that the Console will display. Default: 100 results.
 |colors | bool | Enable ANSI color rendering. Default: true
+|warnings | bool | Enable display of remote execution warnings. Default: true
 |gremlin.color | colors | Color of the ASCII art gremlin on startup.
 |info.color | colors | Color of "info" type messages.
 |error.color | colors | Color of "error" type messages.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/PluggedIn.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/PluggedIn.groovy
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.console
 
+import org.apache.tinkerpop.gremlin.console.Preferences;
 import org.apache.tinkerpop.gremlin.jsr223.BindingsCustomizer
 import org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin
 import org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer
@@ -101,6 +102,9 @@ class PluggedIn {
 
         @Override
         void errPrintln(final String line) {
+            if (!Preferences.warnings) {
+                return;
+            }
             io.err.println("[warn] " + line);
         }
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Preferences.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Preferences.groovy
@@ -89,6 +89,10 @@ public class Preferences {
     public static final Boolean PREF_COLORS_DEFAULT = true;
     public static boolean colors = PREF_COLORS_DEFAULT
 
+    public static final String PREF_WARNINGS = "warnings"
+    public static final Boolean PREF_WARNINGS_DEFAULT = true
+    public static boolean warnings = PREF_WARNINGS_DEFAULT
+
     public static void expandoMagic() {
 
         // Override all GroovySH Preference methods
@@ -236,7 +240,14 @@ public class Preferences {
                             } else {
                                 colors = Boolean.valueOf(evt.newValue)
                             }
+                        }  else if (evt.key == PREF_WARNINGS) {
+                            if (null == evt.newValue) {
+                                warnings = Boolean.valueOf(STORE.get(PREF_WARNINGS, PREF_WARNINGS_DEFAULT.toString()))
+                            } else {
+                                warnings = Boolean.valueOf(evt.newValue)
+                            }
                         }
+
                     }
                 })
 
@@ -292,5 +303,7 @@ public class Preferences {
         resultPrompt =  STORE.get(PREF_RESULT_PROMPT, PREF_RESULT_PROMPT_DEFAULT)
 
         colors =  Boolean.valueOf(STORE.get(PREF_COLORS, PREF_COLORS_DEFAULT.toString()))
+
+        warnings =  Boolean.valueOf(STORE.get(PREF_WARNINGS, PREF_WARNINGS_DEFAULT.toString()))
     }
 }


### PR DESCRIPTION
This PR adds a new gremlin-console preference controlling the display of server-originated warnings:

```
:set warnings true // the default; all warnings displayed

:set warnings false // all warnings suppressed
```

https://issues.apache.org/jira/browse/TINKERPOP-2271