### PR TITLE
TINKERPOP-2272 Renamed steps/tokens conflicting with global function names

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,7 +40,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed the `reverse()` of `desc` and `asc` on `Order` to not use the deprecated `decr` and `incr`.
 * Fixed bug in `MatchStep` where the correct was not properly determined.
 * Fixed bug where client/server exception mismatch when server throw StackOverflowError
-* Prevent exception when closing a session that doesn't exist
+* Added underscore suffixed steps and tokens in Gremlin-Python that conflict with global function names.
+* Prevent exception when closing a session that doesn't exist.
 * Allow predicates and traversals to be used as options in `BranchStep`.
 * Improved performance of `aggregate()` by avoiding excessive calls to `hasNext()` when the barrier is empty.
 

--- a/gremlin-python/glv/GraphTraversalSource.template
+++ b/gremlin-python/glv/GraphTraversalSource.template
@@ -90,6 +90,32 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("<%= toJava.call(method) %>", *args)
         return self
 <% } %>
+    # Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+    def filter(self, *args):
+        self.bytecode.add_step("filter", *args)
+        return self
+
+    def id(self, *args):
+        self.bytecode.add_step("id", *args)
+        return self
+
+    def max(self, *args):
+        self.bytecode.add_step("max", *args)
+        return self
+
+    def min(self, *args):
+        self.bytecode.add_step("min", *args)
+        return self
+
+    def range(self, *args):
+        self.bytecode.add_step("range", *args)
+        return self
+
+    def sum(self, *args):
+        self.bytecode.add_step("sum", *args)
+        return self
+
 
 class __(object):
     graph_traversal = GraphTraversal
@@ -106,11 +132,71 @@ class __(object):
     def <%= method %>(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).<%= method %>(*args)
 <% } %>
+    # Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+    @classmethod
+    def filter(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).filter_(*args)
+
+    @classmethod
+    def id(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).id_(*args)
+
+    @classmethod
+    def max(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).max_(*args)
+
+    @classmethod
+    def min(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).min_(*args)
+
+    @classmethod
+    def range(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).range_(*args)
+
+    @classmethod
+    def sum(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).sum_(*args)
+
 <% anonStepMethods.each{ method -> %>
 def <%= method %>(*args):
     return __.<%= method %>(*args)
 
 <% } %>
+# Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+def filter(*args):
+    return __.filter_(*args)
+
+
+def id(*args):
+    return __.id_(*args)
+
+
+def max(*args):
+    return __.max_(*args)
+
+
+def min(*args):
+    return __.min_(*args)
+
+
+def range(*args):
+    return __.range_(*args)
+
+
+def sum(*args):
+    return __.sum_(*args)
+
+
 <% anonStepMethods.each{ method -> %>statics.add_static('<%= method %>', <%= method %>)
 
 <% } %>
+# Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+statics.add_static('filter', filter)
+statics.add_static('id', id)
+statics.add_static('max', max)
+statics.add_static('min', min)
+statics.add_static('range', range)
+statics.add_static('sum', sum)

--- a/gremlin-python/glv/TraversalSource.template
+++ b/gremlin-python/glv/TraversalSource.template
@@ -127,6 +127,32 @@ class Traversal(object):
 statics.add_static('<%= toPython.call(v.name()) %>', <%= v.getDeclaringClass().getSimpleName() %>.<%= toPython.call(v.name()) %>)<% } %>
 <% } %>
 
+T = Enum('T', ' id id_ key label value')
+
+statics.add_static('id', T.id)
+statics.add_static('label', T.label)
+statics.add_static('id_', T.id_)
+statics.add_static('key', T.key)
+statics.add_static('value', T.value)
+
+
+Operator = Enum('Operator', ' addAll and_ assign div max max_ min min_ minus mult or_ sum sum_ sumLong')
+
+statics.add_static('sum_', Operator.sum_)
+statics.add_static('sum', Operator.sum_)
+statics.add_static('minus', Operator.minus)
+statics.add_static('mult', Operator.mult)
+statics.add_static('div', Operator.div)
+statics.add_static('min', Operator.min_)
+statics.add_static('min_', Operator.min_)
+statics.add_static('max_', Operator.max_)
+statics.add_static('assign', Operator.assign)
+statics.add_static('and_', Operator.and_)
+statics.add_static('or_', Operator.or_)
+statics.add_static('addAll', Operator.addAll)
+statics.add_static('sumLong', Operator.sumLong)
+
+
 class P(object):
     def __init__(self, operator, value, other=None):
         self.operator = operator

--- a/gremlin-python/glv/generate.groovy
+++ b/gremlin-python/glv/generate.groovy
@@ -22,26 +22,38 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
 import org.apache.tinkerpop.gremlin.process.traversal.P
+import org.apache.tinkerpop.gremlin.process.traversal.Operator
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
+import org.apache.tinkerpop.gremlin.structure.T
 import java.lang.reflect.Modifier
 // this is a bit of a copy of what's in SymbolHelper - no way around it because this code generation task occurs
 // before the SymbolHelper is available to the plugin.
-def toPythonMap = ["global": "global_",
+def toPythonMap = ["and": "and_",
+                   "all": "all_",
                    "as": "as_",
-                   "in": "in_",
-                   "and": "and_",
-                   "or": "or_",
-                   "is": "is_",
-                   "not": "not_",
+                   "filter": "filter_",
                    "from": "from_",
+                   "global": "global_",
+                   "id": "id_",
+                   "in": "in_",
+                   "is": "is_",
                    "list": "list_",
+                   "max": "max_",
+                   "min": "min_",
+                   "not": "not_",
+                   "range": "range_",
+                   "or": "or_",
                    "set": "set_",
-                   "all": "all_"]
+                   "sum": "sum_"]
+
 def toJavaMap = toPythonMap.collectEntries{k,v -> [(v):k]}
 def toPython = { symbol -> toPythonMap.getOrDefault(symbol, symbol) }
 def toJava = { symbol -> toJavaMap.getOrDefault(symbol, symbol) }
+
+// for enums we ignore T and handle it manually because of conflict with T.id which is trickier to deal with
+// in the templating language
 def binding = ["enums": CoreImports.getClassImports()
-        .findAll { Enum.class.isAssignableFrom(it) }
+        .findAll { Enum.class.isAssignableFrom(it) && !(it in [T, Operator]) }
         .sort { a, b -> a.getSimpleName() <=> b.getSimpleName() },
                "pmethods": P.class.getMethods().
                        findAll { Modifier.isStatic(it.getModifiers()) }.

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -219,7 +219,7 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("emit", *args)
         return self
 
-    def filter(self, *args):
+    def filter_(self, *args):
         self.bytecode.add_step("filter", *args)
         return self
 
@@ -267,7 +267,7 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("hasValue", *args)
         return self
 
-    def id(self, *args):
+    def id_(self, *args):
         self.bytecode.add_step("id", *args)
         return self
 
@@ -327,7 +327,7 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("math", *args)
         return self
 
-    def max(self, *args):
+    def max_(self, *args):
         self.bytecode.add_step("max", *args)
         return self
 
@@ -335,7 +335,7 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("mean", *args)
         return self
 
-    def min(self, *args):
+    def min_(self, *args):
         self.bytecode.add_step("min", *args)
         return self
 
@@ -411,7 +411,7 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("propertyMap", *args)
         return self
 
-    def range(self, *args):
+    def range_(self, *args):
         self.bytecode.add_step("range", *args)
         return self
 
@@ -451,7 +451,7 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("subgraph", *args)
         return self
 
-    def sum(self, *args):
+    def sum_(self, *args):
         self.bytecode.add_step("sum", *args)
         return self
 
@@ -509,6 +509,32 @@ class GraphTraversal(Traversal):
 
     def where(self, *args):
         self.bytecode.add_step("where", *args)
+        return self
+
+    # Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+    def filter(self, *args):
+        self.bytecode.add_step("filter", *args)
+        return self
+
+    def id(self, *args):
+        self.bytecode.add_step("id", *args)
+        return self
+
+    def max(self, *args):
+        self.bytecode.add_step("max", *args)
+        return self
+
+    def min(self, *args):
+        self.bytecode.add_step("min", *args)
+        return self
+
+    def range(self, *args):
+        self.bytecode.add_step("range", *args)
+        return self
+
+    def sum(self, *args):
+        self.bytecode.add_step("sum", *args)
         return self
 
 
@@ -608,8 +634,8 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).emit(*args)
 
     @classmethod
-    def filter(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).filter(*args)
+    def filter_(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).filter_(*args)
 
     @classmethod
     def flatMap(cls, *args):
@@ -652,8 +678,8 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).hasValue(*args)
 
     @classmethod
-    def id(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).id(*args)
+    def id_(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).id_(*args)
 
     @classmethod
     def identity(cls, *args):
@@ -712,16 +738,16 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).math(*args)
 
     @classmethod
-    def max(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).max(*args)
+    def max_(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).max_(*args)
 
     @classmethod
     def mean(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).mean(*args)
 
     @classmethod
-    def min(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).min(*args)
+    def min_(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).min_(*args)
 
     @classmethod
     def not_(cls, *args):
@@ -776,8 +802,8 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).propertyMap(*args)
 
     @classmethod
-    def range(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).range(*args)
+    def range_(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).range_(*args)
 
     @classmethod
     def repeat(cls, *args):
@@ -816,8 +842,8 @@ class __(object):
         return cls.graph_traversal(None, None, Bytecode()).subgraph(*args)
 
     @classmethod
-    def sum(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).sum(*args)
+    def sum_(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).sum_(*args)
 
     @classmethod
     def tail(cls, *args):
@@ -874,6 +900,32 @@ class __(object):
     @classmethod
     def where(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).where(*args)
+
+    # Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+    @classmethod
+    def filter(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).filter_(*args)
+
+    @classmethod
+    def id(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).id_(*args)
+
+    @classmethod
+    def max(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).max_(*args)
+
+    @classmethod
+    def min(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).min_(*args)
+
+    @classmethod
+    def range(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).range_(*args)
+
+    @classmethod
+    def sum(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).sum_(*args)
 
 
 def V(*args):
@@ -960,8 +1012,8 @@ def emit(*args):
     return __.emit(*args)
 
 
-def filter(*args):
-    return __.filter(*args)
+def filter_(*args):
+    return __.filter_(*args)
 
 
 def flatMap(*args):
@@ -1004,8 +1056,8 @@ def hasValue(*args):
     return __.hasValue(*args)
 
 
-def id(*args):
-    return __.id(*args)
+def id_(*args):
+    return __.id_(*args)
 
 
 def identity(*args):
@@ -1064,16 +1116,16 @@ def math(*args):
     return __.math(*args)
 
 
-def max(*args):
-    return __.max(*args)
+def max_(*args):
+    return __.max_(*args)
 
 
 def mean(*args):
     return __.mean(*args)
 
 
-def min(*args):
-    return __.min(*args)
+def min_(*args):
+    return __.min_(*args)
 
 
 def not_(*args):
@@ -1128,8 +1180,8 @@ def propertyMap(*args):
     return __.propertyMap(*args)
 
 
-def range(*args):
-    return __.range(*args)
+def range_(*args):
+    return __.range_(*args)
 
 
 def repeat(*args):
@@ -1168,8 +1220,8 @@ def subgraph(*args):
     return __.subgraph(*args)
 
 
-def sum(*args):
-    return __.sum(*args)
+def sum_(*args):
+    return __.sum_(*args)
 
 
 def tail(*args):
@@ -1228,6 +1280,32 @@ def where(*args):
     return __.where(*args)
 
 
+# Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+def filter(*args):
+    return __.filter_(*args)
+
+
+def id(*args):
+    return __.id_(*args)
+
+
+def max(*args):
+    return __.max_(*args)
+
+
+def min(*args):
+    return __.min_(*args)
+
+
+def range(*args):
+    return __.range_(*args)
+
+
+def sum(*args):
+    return __.sum_(*args)
+
+
 statics.add_static('V', V)
 
 statics.add_static('addE', addE)
@@ -1270,7 +1348,7 @@ statics.add_static('drop', drop)
 
 statics.add_static('emit', emit)
 
-statics.add_static('filter', filter)
+statics.add_static('filter_', filter_)
 
 statics.add_static('flatMap', flatMap)
 
@@ -1292,7 +1370,7 @@ statics.add_static('hasNot', hasNot)
 
 statics.add_static('hasValue', hasValue)
 
-statics.add_static('id', id)
+statics.add_static('id_', id_)
 
 statics.add_static('identity', identity)
 
@@ -1322,11 +1400,11 @@ statics.add_static('match', match)
 
 statics.add_static('math', math)
 
-statics.add_static('max', max)
+statics.add_static('max_', max_)
 
 statics.add_static('mean', mean)
 
-statics.add_static('min', min)
+statics.add_static('min_', min_)
 
 statics.add_static('not_', not_)
 
@@ -1354,7 +1432,7 @@ statics.add_static('property', property)
 
 statics.add_static('propertyMap', propertyMap)
 
-statics.add_static('range', range)
+statics.add_static('range_', range_)
 
 statics.add_static('repeat', repeat)
 
@@ -1374,7 +1452,7 @@ statics.add_static('store', store)
 
 statics.add_static('subgraph', subgraph)
 
-statics.add_static('sum', sum)
+statics.add_static('sum_', sum_)
 
 statics.add_static('tail', tail)
 
@@ -1404,3 +1482,12 @@ statics.add_static('values', values)
 
 statics.add_static('where', where)
 
+
+# Deprecated - prefer the underscore suffixed versions e.g filter_()
+
+statics.add_static('filter', filter)
+statics.add_static('id', id)
+statics.add_static('max', max)
+statics.add_static('min', min)
+statics.add_static('range', range)
+statics.add_static('sum', sum)

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -154,20 +154,6 @@ GryoVersion = Enum('GryoVersion', ' V1_0 V3_0')
 statics.add_static('V1_0', GryoVersion.V1_0)
 statics.add_static('V3_0', GryoVersion.V3_0)
 
-Operator = Enum('Operator', ' addAll and_ assign div max min minus mult or_ sum sumLong')
-
-statics.add_static('sum', Operator.sum)
-statics.add_static('minus', Operator.minus)
-statics.add_static('mult', Operator.mult)
-statics.add_static('div', Operator.div)
-statics.add_static('min', Operator.min)
-statics.add_static('max', Operator.max)
-statics.add_static('assign', Operator.assign)
-statics.add_static('and_', Operator.and_)
-statics.add_static('or_', Operator.or_)
-statics.add_static('addAll', Operator.addAll)
-statics.add_static('sumLong', Operator.sumLong)
-
 Order = Enum('Order', ' asc decr desc incr shuffle')
 
 statics.add_static('incr', Order.incr)
@@ -193,12 +179,31 @@ Scope = Enum('Scope', ' global_ local')
 statics.add_static('global_', Scope.global_)
 statics.add_static('local', Scope.local)
 
-T = Enum('T', ' id key label value')
 
-statics.add_static('label', T.label)
+T = Enum('T', ' id id_ key label value')
+
 statics.add_static('id', T.id)
+statics.add_static('label', T.label)
+statics.add_static('id_', T.id_)
 statics.add_static('key', T.key)
 statics.add_static('value', T.value)
+
+
+Operator = Enum('Operator', ' addAll and_ assign div max max_ min min_ minus mult or_ sum sum_ sumLong')
+
+statics.add_static('sum_', Operator.sum_)
+statics.add_static('sum', Operator.sum_)
+statics.add_static('minus', Operator.minus)
+statics.add_static('mult', Operator.mult)
+statics.add_static('div', Operator.div)
+statics.add_static('min', Operator.min_)
+statics.add_static('min_', Operator.min_)
+statics.add_static('max_', Operator.max_)
+statics.add_static('assign', Operator.assign)
+statics.add_static('and_', Operator.and_)
+statics.add_static('or_', Operator.or_)
+statics.add_static('addAll', Operator.addAll)
+statics.add_static('sumLong', Operator.sumLong)
 
 
 class P(object):

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV2d0.py
@@ -140,8 +140,9 @@ class _GraphSONTypeIO(object):
 
     symbolMap = {"global_": "global", "as_": "as", "in_": "in", "and_": "and",
                  "or_": "or", "is_": "is", "not_": "not", "from_": "from",
-                 "set_": "set", "list_": "list", "all_": "all"}
-
+                 "set_": "set", "list_": "list", "all_": "all",
+                 "filter_": "filter", "id_": "id", "max_": "max", "min_": "min", "sum_": "sum"}
+    
     @classmethod
     def unmangleKeyword(cls, symbol):
         return cls.symbolMap.get(symbol, symbol)

--- a/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/gremlin_python/structure/io/graphsonV3d0.py
@@ -145,7 +145,8 @@ class _GraphSONTypeIO(object):
 
     symbolMap = {"global_": "global", "as_": "as", "in_": "in", "and_": "and",
                  "or_": "or", "is_": "is", "not_": "not", "from_": "from",
-                 "set_": "set", "list_": "list", "all_": "all"}
+                 "set_": "set", "list_": "list", "all_": "all",
+                 "filter_": "filter", "id_": "id", "max_": "max", "min_": "min", "sum_": "sum"}
 
     @classmethod
     def unmangleKeyword(cls, symbol):

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -85,6 +85,12 @@ class TestDriverRemoteConnection(object):
         assert 2 == len(results)
         assert 'marko' in results
         assert 'vadas' in results
+        # #
+        # this test just validates that the underscored versions of steps conflicting with Gremlin work
+        # properly and can be removed when the old steps are removed - TINKERPOP-2272
+        results = g.V().filter_(__.values('age').sum_().and_(
+            __.max_().is_(gt(0)), __.min_().is_(gt(0)))).range_(0, 1).id_().next()
+        assert 1 == results
 
     def test_iteration(self, remote_connection):
         statics.load_statics(globals())


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2272

Used the standard underscore suffix on these problems. Didn't document a bunch purposely because the intention is to retain the old conflicting steps/tokens for the time being (both are currently present in the library so as to be backward compatible in 3.3.x and 3.4.x). In 3.5.0 all tests will be modified, documentation updated and the old conflicting names completely removed. So, for now at least the new methods are present for use and we don't have a breaking change to be concerned about.

Builds with `mvn clean install -pl gremlin-python`

VOTE +1