### PR TITLE
Handle closed connections gracefully instead of bubbling up exceptions

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -103,8 +103,17 @@ namespace Gremlin.Net.Driver
             {
                 try
                 {
-                    var received = await _webSocketConnection.ReceiveMessageAsync().ConfigureAwait(false);
-                    Parse(received);
+                    var receivedMessage = await _webSocketConnection.ReceiveMessageAsync().ConfigureAwait(false);
+
+                    if (!receivedMessage.ConnectionClosed)
+                    {
+                        Parse(receivedMessage.Data);
+                    }
+                    else
+                    {
+                        await CloseAsync().ConfigureAwait(false);
+                        return;
+                    }
                 }
                 catch (Exception e)
                 {
@@ -116,6 +125,11 @@ namespace Gremlin.Net.Driver
 
         private void Parse(byte[] received)
         {
+            if (received == null || received.Length == 0)
+            {
+                return;
+            }
+
             var receivedMsg = _messageSerializer.DeserializeMessage<ResponseMessage<JToken>>(received);
 
             try

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/RecievedResult.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/RecievedResult.cs
@@ -1,4 +1,27 @@
-﻿namespace Gremlin.Net.Driver
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+namespace Gremlin.Net.Driver
 {
     internal sealed class RecievedMessageResult
     {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/RecievedResult.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/RecievedResult.cs
@@ -1,0 +1,19 @@
+﻿namespace Gremlin.Net.Driver
+{
+    internal sealed class RecievedMessageResult
+    {
+        private RecievedMessageResult(byte[] data, bool connectionClosed)
+        {
+            Data = data;
+            ConnectionClosed = connectionClosed;
+        }
+
+        public static RecievedMessageResult Success(byte[] data) => new RecievedMessageResult(data, false);
+        public static RecievedMessageResult Failed() => new RecievedMessageResult(null, true);
+
+        public byte[] Data { get; }
+        public bool ConnectionClosed { get; }
+    }
+
+
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -73,8 +73,13 @@ namespace Gremlin.Net.Driver
                     .ConfigureAwait(false);
         }
 
-        public async Task<byte[]> ReceiveMessageAsync()
+        public async Task<RecievedMessageResult> ReceiveMessageAsync()
         {
+            if (_client.State != WebSocketState.Open)
+            {
+                return RecievedMessageResult.Failed();
+            }
+
             using (var ms = new MemoryStream())
             {
                 WebSocketReceiveResult received;
@@ -85,7 +90,7 @@ namespace Gremlin.Net.Driver
                     ms.Write(receiveBuffer.Array, receiveBuffer.Offset, received.Count);
                 } while (!received.EndOfMessage);
 
-                return ms.ToArray();
+                return RecievedMessageResult.Success(ms.ToArray());
             }
         }
 


### PR DESCRIPTION
A lot of `NullReferenceException`s were being thrown and internally handled which was causing some performance issues in our codebase. This PR handles attempts to receive data when the connection has been closed.