### PR TITLE
Postpone the timing of transport creation to `connection.write`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,7 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.3.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * TINKERPOP-2260 Update jackson databind 2.9.9.3
-
+* TINKERPOP-2277 Postpone the timing of transport creation to `connection.write` in Gremlin Python SDK
 
 [[release-3-3-8]]
 === TinkerPop 3.3.8 (Release Date: August 5, 2019)

--- a/gremlin-python/src/main/jython/gremlin_python/driver/connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/connection.py
@@ -37,7 +37,7 @@ class Connection:
         self._transport = None
         self._pool = pool
         self._results = {}
-        self.connect()
+        self._inited = False
 
     def connect(self):
         if self._transport:
@@ -45,11 +45,15 @@ class Connection:
         self._transport = self._transport_factory()
         self._transport.connect(self._url)
         self._protocol.connection_made(self._transport)
+        self._inited = True
 
     def close(self):
-        self._transport.close()
+        if self._inited:
+            self._transport.close()
 
     def write(self, request_message):
+        if not self._inited:
+            self.connect()
         request_id = str(uuid.uuid4())
         result_set = resultset.ResultSet(queue.Queue(), request_id)
         self._results[request_id] = result_set


### PR DESCRIPTION
Make `gremlinpython` more friendly to scenarios which use multiple processes model like `Celery`.