### PR TITLE
TINKERPOP-2287: Typeserializer lookup by superclass

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistry.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistry.java
@@ -319,7 +319,7 @@ public class TypeSerializerRegistry {
         }
     }
 
-    public <DT> TypeSerializer<DT> getSerializer(final Class<DT> type) throws SerializationException {
+    public <DT> TypeSerializer<DT> findSerializer(final Class<DT> type) {
         TypeSerializer<?> serializer = serializers.get(type);
 
         if (null == serializer) {
@@ -349,6 +349,17 @@ public class TypeSerializerRegistry {
                 }
             }
         }
+
+        if (null == serializer && null != type.getSuperclass()) {
+            // Lookup by superclass
+            return (TypeSerializer<DT>) findSerializer(type.getSuperclass());
+        }
+
+        return (TypeSerializer<DT>) serializer;
+    }
+
+    public <DT> TypeSerializer<DT> getSerializer(final Class<DT> type) throws SerializationException {
+        TypeSerializer<?> serializer = findSerializer(type);
 
         if (null == serializer && fallbackResolver != null) {
             serializer = fallbackResolver.apply(type);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistry.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistry.java
@@ -52,8 +52,6 @@ import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.Inet4Address;
-import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
@@ -146,8 +144,6 @@ public class TypeSerializerRegistry {
             new RegistryEntry<>(Character.class, new CharSerializer()),
             new RegistryEntry<>(Duration.class, new DurationSerializer()),
             new RegistryEntry<>(InetAddress.class, new InetAddressSerializer()),
-            new RegistryEntry<>(Inet4Address.class, new InetAddressSerializer<>()),
-            new RegistryEntry<>(Inet6Address.class, new InetAddressSerializer<>()),
             new RegistryEntry<>(Instant.class, new InstantSerializer()),
             new RegistryEntry<>(LocalDate.class, new LocalDateSerializer()),
             new RegistryEntry<>(LocalTime.class, new LocalTimeSerializer()),

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
@@ -26,6 +26,9 @@ import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.junit.Test;
 
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.util.UUID;
 
 import static junit.framework.TestCase.assertEquals;
@@ -75,6 +78,23 @@ public class TypeSerializerRegistryTest {
         assertSame(expectedForProperty, registry.getSerializer(Property.class));
         assertSame(expectedForVertexProperty, registry.getSerializer(DataType.VERTEXPROPERTY));
         assertSame(expectedForProperty, registry.getSerializer(DataType.PROPERTY));
+    }
+
+    @Test
+    public void shouldResolveSerializerForSuperclass() throws SerializationException {
+        final TypeSerializer<InetAddress> expectedForInetAddress = new TestInetAddressSerializer();
+
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .add(InetAddress.class, expectedForInetAddress)
+                .create();
+
+        assertSame(expectedForInetAddress, registry.getSerializer(InetAddress.class));
+
+        // this should return the superclass serializer, which does not
+//        assertSame(expectedForInetAddress, registry.getSerializer(Inet4Address.class));
+
+        // this should return the superclass serializer, which does not
+//        assertSame(expectedForInetAddress, registry.getSerializer(Inet6Address.class));
     }
 
     @Test
@@ -133,6 +153,14 @@ public class TypeSerializerRegistryTest {
         @Override
         public DataType getDataType() {
             return DataType.UUID;
+        }
+    }
+
+    private static class TestInetAddressSerializer extends TestBaseTypeSerializer<InetAddress> {
+
+        @Override
+        public DataType getDataType() {
+            return DataType.INETADDRESS;
         }
     }
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/TypeSerializerRegistryTest.java
@@ -90,11 +90,30 @@ public class TypeSerializerRegistryTest {
 
         assertSame(expectedForInetAddress, registry.getSerializer(InetAddress.class));
 
-        // this should return the superclass serializer, which does not
-//        assertSame(expectedForInetAddress, registry.getSerializer(Inet4Address.class));
+        // this should return the superclass serializer
+        assertSame(expectedForInetAddress, registry.getSerializer(Inet4Address.class));
 
-        // this should return the superclass serializer, which does not
-//        assertSame(expectedForInetAddress, registry.getSerializer(Inet6Address.class));
+        // this should return the superclass serializer
+        assertSame(expectedForInetAddress, registry.getSerializer(Inet6Address.class));
+    }
+
+    @Test
+    public void shouldResolveSerializerForDirectMatchClassBeforeSuperclass() throws SerializationException {
+        final TypeSerializer<InetAddress> expectedForInetAddress = new TestInetAddressSerializer();
+        final TypeSerializer<Inet4Address> expectedForInet4Address = new TestInet4AddressSerializer();
+
+        final TypeSerializerRegistry registry = TypeSerializerRegistry.build()
+                .add(Inet4Address.class, expectedForInet4Address)
+                .add(InetAddress.class, expectedForInetAddress)
+                .create();
+
+        assertSame(expectedForInetAddress, registry.getSerializer(InetAddress.class));
+
+        // this should return the direct match class serializer
+        assertSame(expectedForInet4Address, registry.getSerializer(Inet4Address.class));
+
+        // this should return the superclass serializer
+        assertSame(expectedForInetAddress, registry.getSerializer(Inet6Address.class));
     }
 
     @Test
@@ -157,6 +176,14 @@ public class TypeSerializerRegistryTest {
     }
 
     private static class TestInetAddressSerializer extends TestBaseTypeSerializer<InetAddress> {
+
+        @Override
+        public DataType getDataType() {
+            return DataType.INETADDRESS;
+        }
+    }
+
+    private static class TestInet4AddressSerializer extends TestBaseTypeSerializer<Inet4Address> {
 
         @Override
         public DataType getDataType() {


### PR DESCRIPTION
**Discussion**

If I understand the code correctly, looks like the current code could not look up the superclass serializer correctly.

For example, `InetAddress` is the superclass of `Inet4Address`, `Inet6Address`. If we remove the registry entry of `Inet4Adress` and `Inet6Address`, it could not redirect and lookup the serializer registered by the superclass (i.e. `InetAddress`) when we try to get the serializer for `Inet4Address` and `Inet6Address`.

To resolve that, I would like to propose the changes in this PR:

If the serializer of the input class type is not found, try and see if there is a serializer registered with its superclass.
