### PR TITLE
TINKERPOP-2280 Changed toString of T

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,8 +23,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-9]]
 === TinkerPop 3.3.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-* TINKERPOP-2260 Update jackson databind 2.9.9.3
-
+* Altered `T.toString()` to include the "T." prefix.
+* Update jackson databind 2.9.9.3
 
 [[release-3-3-8]]
 === TinkerPop 3.3.8 (Release Date: August 5, 2019)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/T.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/T.java
@@ -95,6 +95,11 @@ public enum T implements Function<Element, Object> {
     @Override
     public abstract Object apply(final Element element);
 
+    @Override
+    public String toString() {
+        return "T." + name();
+    }
+
     public static T fromString(final String accessor) {
         if (accessor.equals(LABEL))
             return label;

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
@@ -182,6 +183,8 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
             return "VertexProperty.Cardinality." + object.toString();
         else if (object instanceof TraversalOptionParent.Pick)
             return "TraversalOptionParent.Pick." + object.toString();
+        else if (object instanceof T)
+            return "T." + ((T) object).name();
         else if (object instanceof Enum)
             return ((Enum) object).getDeclaringClass().getSimpleName() + "." + object.toString();
         else if (object instanceof Element) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2280

Reduce confusion when `T` is in a `Map` and users overload property keys that match `T` instance names like "label" and "id". I think I'm still classifying this as a non-breaking change despite changing the form of the `toString()`. Folks probably shouldn't be relying on that in their code. I would think they would simply use `name()` as you typically would with an `enum` if you were working with the string representation. 

All tests pass with `docker/build.sh -t -n -i`

VOTE +1