### PR TITLE
TINKERPOP-2291 Added GraphSON support for deserialization of TraversalExplanation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,8 +23,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-9]]
 === TinkerPop 3.3.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-* Update jackson databind 2.9.9.3.
-* Postpone the timing of transport creation to `connection.write` in Gremlin Python.
+* Added `ImmutableExplanation` for a `TraversalExplanation` that just contains data.
+* Fixed `TraversalExplanation` deserialization in GraphSON 2 and 3 which was not supported before in Java.
+* Updated jackson databind 2.9.9.3.
+* Postponed the timing of transport creation to `connection.write` in Gremlin Python.
 
 [[release-3-3-8]]
 === TinkerPop 3.3.8 (Release Date: August 5, 2019)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/AbstractExplanation.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/AbstractExplanation.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.util;
+
+import org.javatuples.Triplet;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Base class for "TraversalExplanation" instances and centralizes the key functionality which is the job of doing
+ * {@link #prettyPrint()}.
+ * 
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public abstract class AbstractExplanation {
+
+    protected abstract Stream<String> getStrategyTraversalsAsString();
+
+    protected Stream<String> getTraversalStepsAsString() {
+        return Stream.concat(Stream.of(this.getOriginalTraversalAsString()), getIntermediates().map(Triplet::getValue2));
+    }
+
+    protected abstract String getOriginalTraversalAsString();
+
+    /**
+     * First string is the traversal strategy, the second is the category and the third is the traversal
+     * representation at that point.
+     */
+    protected abstract Stream<Triplet<String,String,String>> getIntermediates();
+
+    @Override
+    public String toString() {
+        return this.prettyPrint(Integer.MAX_VALUE);
+    }
+
+    public String prettyPrint() {
+        return this.prettyPrint(100);
+    }
+
+    /**
+     * A pretty-print representation of the traversal explanation.
+     *
+     * @return a {@link String} representation of the traversal explanation
+     */
+    public String prettyPrint(final int maxLineLength) {
+        final String originalTraversal = "Original Traversal";
+        final String finalTraversal = "Final Traversal";
+        final int maxStrategyColumnLength = getStrategyTraversalsAsString()
+                .map(String::length)
+                .max(Comparator.naturalOrder())
+                .orElse(15);
+        final int newLineIndent = maxStrategyColumnLength + 10;
+        final int maxTraversalColumn = maxLineLength - newLineIndent;
+        if (maxTraversalColumn < 1)
+            throw new IllegalArgumentException("The maximum line length is too small to present the " + TraversalExplanation.class.getSimpleName() + ": " + maxLineLength);
+        int largestTraversalColumn = getTraversalStepsAsString()
+                .map(s -> wordWrap(s, maxTraversalColumn, newLineIndent))
+                .flatMap(s -> Stream.of(s.split("\n")))
+                .map(String::trim)
+                .map(s -> s.trim().startsWith("[") ? s : "   " + s) // 3 indent on new lines
+                .map(String::length)
+                .max(Comparator.naturalOrder())
+                .get();
+
+        final StringBuilder builder = new StringBuilder("Traversal Explanation\n");
+        for (int i = 0; i < (maxStrategyColumnLength + 7 + largestTraversalColumn); i++) {
+            builder.append("=");
+        }
+
+        spacing(originalTraversal, maxStrategyColumnLength, builder);
+
+        builder.append(wordWrap(getOriginalTraversalAsString(), maxTraversalColumn, newLineIndent));
+        builder.append("\n\n");
+
+        final List<Triplet<String,String,String>> intermediates = this.getIntermediates().collect(Collectors.toList());
+        for (Triplet<String,String,String> t : intermediates) {
+            builder.append(t.getValue0());
+            int spacesToAdd = maxStrategyColumnLength - t.getValue0().length() + 1;
+            for (int i = 0; i < spacesToAdd; i++) {
+                builder.append(" ");
+            }
+            builder.append("[").append(t.getValue1().substring(0, 1)).append("]");
+            for (int i = 0; i < 3; i++) {
+                builder.append(" ");
+            }
+            builder.append(wordWrap(t.getValue2(), maxTraversalColumn, newLineIndent)).append("\n");
+        }
+
+        spacing(finalTraversal, maxStrategyColumnLength, builder);
+
+        builder.append(wordWrap((intermediates.size() > 0 ?
+                intermediates.get(intermediates.size() - 1).getValue2() :
+                getOriginalTraversalAsString()), maxTraversalColumn, newLineIndent));
+        return builder.toString();
+    }
+
+    public static void spacing(String finalTraversal, int maxStrategyColumnLength, StringBuilder builder) {
+        builder.append("\n");
+        builder.append(finalTraversal);
+        for (int i = 0; i < maxStrategyColumnLength - finalTraversal.length() + 7; i++) {
+            builder.append(" ");
+        }
+    }
+
+    private String wordWrap(final String longString, final int maxLengthPerLine, final int newLineIndent) {
+        if (longString.length() <= maxLengthPerLine)
+            return longString;
+
+        StringBuilder builder = new StringBuilder();
+        int counter = 0;
+        for (int i = 0; i < longString.length(); i++) {
+            if (0 == counter) {
+                builder.append(longString.charAt(i));
+            } else if (counter < maxLengthPerLine) {
+                builder.append(longString.charAt(i));
+            } else {
+                builder.append("\n");
+                for (int j = 0; j < newLineIndent; j++) {
+                    builder.append(" ");
+                }
+                builder.append(longString.charAt(i));
+                counter = 0;
+            }
+            counter++;
+        }
+
+        return builder.toString();
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ImmutableExplanation.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ImmutableExplanation.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.util;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.javatuples.Pair;
+import org.javatuples.Triplet;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * A data-only representation of a {@link TraversalExplanation} which doesn't re-calculate the "explanation" from
+ * the raw traversal data each time the explanation is displayed.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class ImmutableExplanation extends TraversalExplanation {
+
+    private final String originalTraversal;
+    private final List<Triplet<String, String, String>> intermediates;
+
+    public ImmutableExplanation(final String originalTraversal,
+                                final List<Triplet<String, String, String>> intermediates) {
+        this.originalTraversal = originalTraversal;
+        this.intermediates = intermediates;
+    }
+
+    @Override
+    public List<Pair<TraversalStrategy, Traversal.Admin<?, ?>>> getStrategyTraversals() {
+        throw new UnsupportedOperationException("This instance is immutable");
+    }
+
+    @Override
+    public Traversal.Admin<?, ?> getOriginalTraversal() {
+        throw new UnsupportedOperationException("This instance is immutable");
+    }
+
+    @Override
+    public ImmutableExplanation asImmutable() {
+        return this;
+    }
+
+    @Override
+    protected Stream<String> getStrategyTraversalsAsString() {
+        return getIntermediates().map(Triplet::getValue0);
+    }
+
+    @Override
+    protected Stream<String> getTraversalStepsAsString() {
+        return Stream.concat(Stream.of(this.originalTraversal), getIntermediates().map(Triplet::getValue2));
+    }
+
+    @Override
+    protected String getOriginalTraversalAsString() {
+        return this.originalTraversal;
+    }
+
+    @Override
+    protected Stream<Triplet<String, String, String>> getIntermediates() {
+        return intermediates.stream();
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
@@ -247,6 +247,7 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
             addDeserializer(Edge.class, new GraphSONSerializersV3d0.EdgeJacksonDeserializer());
             addDeserializer(Property.class, new GraphSONSerializersV3d0.PropertyJacksonDeserializer());
             addDeserializer(Path.class, new GraphSONSerializersV3d0.PathJacksonDeserializer());
+            addDeserializer(TraversalExplanation.class, new GraphSONSerializersV3d0.TraversalExplanationJacksonDeserializer());
             addDeserializer(VertexProperty.class, new GraphSONSerializersV3d0.VertexPropertyJacksonDeserializer());
             addDeserializer(Metrics.class, new GraphSONSerializersV3d0.MetricsJacksonDeserializer());
             addDeserializer(TraversalMetrics.class, new GraphSONSerializersV3d0.TraversalMetricsJacksonDeserializer());
@@ -464,6 +465,7 @@ abstract class GraphSONModule extends TinkerPopJacksonModule {
             addDeserializer(Property.class, new GraphSONSerializersV2d0.PropertyJacksonDeserializer());
             addDeserializer(Path.class, new GraphSONSerializersV2d0.PathJacksonDeserializer());
             addDeserializer(VertexProperty.class, new GraphSONSerializersV2d0.VertexPropertyJacksonDeserializer());
+            addDeserializer(TraversalExplanation.class, new GraphSONSerializersV2d0.TraversalExplanationJacksonDeserializer());
             addDeserializer(Metrics.class, new GraphSONSerializersV2d0.MetricsJacksonDeserializer());
             addDeserializer(TraversalMetrics.class, new GraphSONSerializersV2d0.TraversalMetricsJacksonDeserializer());
             addDeserializer(Tree.class, new GraphSONSerializersV2d0.TreeJacksonDeserializer());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV3d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV3d0.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.MutablePath;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalMetrics;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ImmutableExplanation;
 import org.apache.tinkerpop.gremlin.process.traversal.util.Metrics;
 import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation;
@@ -55,6 +56,7 @@ import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdScalarSerializer;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdSerializer;
 import org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory;
 import org.javatuples.Pair;
+import org.javatuples.Triplet;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -605,6 +607,32 @@ class GraphSONSerializersV3d0 {
             }
 
             return vp.create();
+        }
+
+        @Override
+        public boolean isCachable() {
+            return true;
+        }
+    }
+
+    static class TraversalExplanationJacksonDeserializer extends StdDeserializer<TraversalExplanation> {
+        public TraversalExplanationJacksonDeserializer() {
+            super(TraversalExplanation.class);
+        }
+
+        @Override
+        public TraversalExplanation deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+            final Map<String, Object> explainData = deserializationContext.readValue(jsonParser, Map.class);
+            final String originalTraversal = explainData.get(GraphSONTokens.ORIGINAL).toString();
+            final List<Triplet<String, String, String>> intermediates = new ArrayList<>();
+            final List<Map<String,Object>> listMap = (List<Map<String,Object>>) explainData.get(GraphSONTokens.INTERMEDIATE);
+            for (Map<String,Object> m : listMap) {
+                intermediates.add(Triplet.with(m.get(GraphSONTokens.STRATEGY).toString(),
+                        m.get(GraphSONTokens.CATEGORY).toString(),
+                        m.get(GraphSONTokens.TRAVERSAL).toString()));
+            }
+
+            return new ImmutableExplanation(originalTraversal, intermediates);
         }
 
         @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanationTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanationTest.java
@@ -39,6 +39,14 @@ import static org.junit.Assert.assertTrue;
 public class TraversalExplanationTest {
 
     @Test
+    public void shouldMakeImmutable() {
+        final TraversalExplanation explanation = __.V().out().out().explain();
+        final ImmutableExplanation immutable = explanation.asImmutable();
+        assertEquals(explanation.prettyPrint(), immutable.prettyPrint());
+        assertEquals(explanation.toString(), immutable.toString());
+    }
+
+    @Test
     public void shouldSupportAnonymousTraversals() {
         final String toString = __.out("knows").in("created").explain().toString();
         assertTrue(toString.contains("Traversal Explanation"));

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraver
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 import org.junit.Test;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.__;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringStartsWith.startsWith;
@@ -82,6 +84,15 @@ public class GraphSONMapperEmbeddedTypeTest extends AbstractGraphSONTest {
 
     @Parameterized.Parameter(0)
     public String version;
+
+    @Test
+    public void shouldHandleTraversalExplanation() throws Exception {
+        assumeThat(version, not(startsWith("v1")));
+        
+        final TraversalExplanation o = __().out().outV().outE().explain();
+        final TraversalExplanation deser = serializeDeserialize(mapper, o, TraversalExplanation.class);
+        assertEquals(o.prettyPrint(), deser.prettyPrint());
+    }
 
     @Test
     public void shouldHandleNumberConstants() throws Exception {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2291

Added the notion of `ImmutableExplanation` which allows the deserialization to occur. As an immutable object the recalculation of the `TraversalExplanation` does not need to occur from the raw data. In fact, if it did it would be "wrong" as it would recalculate on the client rather than the server and server side strategies may not be applied. That said, the design choices here in the class hierarchy are a bit odd in that `ImmutableExplanatio`n should really extend `AbstractExplanation`, but to avoid breaking changes in derser in gryo/graphson it seemed best to go with the slightly less optimal approach. Perhaps a future release branch were breaking changes are allowed can rectify this.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1