### PR TITLE
TINKERPOP-2046 Gremlin-Python: Add support for custom request headers in WebSocket request

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -632,6 +632,12 @@ the "g" provided to the `DriverRemoteConnection` corresponds to the name of a `G
 [source,python]
 g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 
+If you need to send additional headers in the websockets connection, you can pass an optional `headers` parameter
+to the `DriverRemoteConnection` constructor.
+
+[source,python]
+g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g',headers={'Header':'Value'}))
+
 [[python-imports]]
 === Common Imports
 

--- a/gremlin-python/src/main/jython/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/client.py
@@ -38,8 +38,10 @@ class Client:
 
     def __init__(self, url, traversal_source, protocol_factory=None,
                  transport_factory=None, pool_size=None, max_workers=None,
-                 message_serializer=None, username="", password=""):
+                 message_serializer=None, username="", password="",
+                 headers=None):
         self._url = url
+        self._headers = headers
         self._traversal_source = traversal_source
         if message_serializer is None:
             message_serializer = serializer.GraphSONSerializersV3d0()
@@ -102,7 +104,8 @@ class Client:
         protocol = self._protocol_factory()
         return connection.Connection(
             self._url, self._traversal_source, protocol,
-            self._transport_factory, self._executor, self._pool)
+            self._transport_factory, self._executor, self._pool,
+            headers=self._headers)
 
     def submit(self, message, bindings=None):
         return self.submitAsync(message, bindings=bindings).result()

--- a/gremlin-python/src/main/jython/gremlin_python/driver/connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/connection.py
@@ -28,8 +28,9 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 class Connection:
 
     def __init__(self, url, traversal_source, protocol, transport_factory,
-                 executor, pool):
+                 executor, pool, headers=None):
         self._url = url
+        self._headers = headers
         self._traversal_source = traversal_source
         self._protocol = protocol
         self._transport_factory = transport_factory
@@ -43,7 +44,7 @@ class Connection:
         if self._transport:
             self._transport.close()
         self._transport = self._transport_factory()
-        self._transport.connect(self._url)
+        self._transport.connect(self._url, self._headers)
         self._protocol.connection_made(self._transport)
         self._inited = True
 

--- a/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
@@ -30,7 +30,8 @@ class DriverRemoteConnection(RemoteConnection):
     def __init__(self, url, traversal_source, protocol_factory=None,
                  transport_factory=None, pool_size=None, max_workers=None,
                  username="", password="", message_serializer=None,
-                 graphson_reader=None, graphson_writer=None):
+                 graphson_reader=None, graphson_writer=None,
+                 headers=None):
         if message_serializer is None:
             message_serializer = serializer.GraphSONMessageSerializer(
                 reader=graphson_reader,
@@ -42,7 +43,8 @@ class DriverRemoteConnection(RemoteConnection):
                                      max_workers=max_workers,
                                      message_serializer=message_serializer,
                                      username=username,
-                                     password=password)
+                                     password=password,
+                                     headers=headers)
         self._url = self._client._url
         self._traversal_source = self._client._traversal_source
 

--- a/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
@@ -17,6 +17,7 @@ specific language governing permissions and limitations
 under the License.
 """
 from tornado import ioloop, websocket
+from tornado import httpclient
 
 from gremlin_python.driver.transport import AbstractBaseTransport
 
@@ -28,7 +29,9 @@ class TornadoTransport(AbstractBaseTransport):
     def __init__(self):
         self._loop = ioloop.IOLoop(make_current=False)
 
-    def connect(self, url):
+    def connect(self, url, headers=None):
+        if headers:
+            url = httpclient.HTTPRequest(url, headers=headers)
         self._ws = self._loop.run_sync(
             lambda: websocket.websocket_connect(url))
 

--- a/gremlin-python/src/main/jython/gremlin_python/driver/transport.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/transport.py
@@ -26,7 +26,7 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 class AbstractBaseTransport:
 
     @abc.abstractmethod
-    def connect(self, url):
+    def connect(self, url, headers=None):
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
The actual headers implementation is in the `gremlin_python.driver.tornado.transport package`. Other files are just passing the `headers` parameter (added to last position to avoid any backward-compatibility problems).

Tested to work e.g. when connecting to AWS Neptune DB.