### PR TITLE
TINKERPOP-2285 Added ResponseError in gremlin-javascript

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-9]]
 === TinkerPop 3.3.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Exposed response status attributes in a `ResponseError` in gremlin-javascript.
 * Added `ImmutableExplanation` for a `TraversalExplanation` that just contains data.
 * Fixed `TraversalExplanation` deserialization in GraphSON 2 and 3 which was not supported before in Java.
 * Added support for custom request headers in Python.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -29,6 +29,21 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.9/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Javascript ResponseError
+
+Gremlin Javascript now enables more robust error handling by way of a `ResponseError` which provides access to more
+information from the server. Specifically, it includes the `statusMessage` and `statusCode` which were formerly packed
+into the `Error.message` property, which meant that the error message string had to be parsed if there was a need to
+take a specific action based on that information. The `ResponseError` also includes the `statusAttributes` which
+is a `Map` object that will typically incorporate server `exceptions` and `stackTrace` keys, but could also include
+provider specific error information.
+
+The original error messaging has remained unchanged and therefore users who were message parsing should not expect
+changes in behavior, however, future versions will eliminate the "overuse" of the `Error.message` property, so it is
+advised that users update their code to take advantage of the `ResponseError` features.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2285[TINKERPOP-2285]
+
 ==== Java Driver NoHostAvailableException
 
 Expect a `NoHostAvailableException` rather than a more generic `TimeoutException` if the Java driver is unable to

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
@@ -32,6 +32,7 @@ const Bytecode = require('./lib/process/bytecode');
 const Translator = require('./lib/process/translator');
 const utils = require('./lib/utils');
 const DriverRemoteConnection = require('./lib/driver/driver-remote-connection');
+const ResponseError = require('./lib/driver/response-error');
 const Client = require('./lib/driver/client');
 const ResultSet = require('./lib/driver/result-set');
 const Authenticator = require('./lib/driver/auth/authenticator');
@@ -43,6 +44,7 @@ module.exports = {
     RemoteConnection: rc.RemoteConnection,
     RemoteStrategy: rc.RemoteStrategy,
     RemoteTraversal: rc.RemoteTraversal,
+    ResponseError,
     DriverRemoteConnection,
     Client,
     ResultSet,

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/response-error.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/response-error.js
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+'use strict';
+
+/**
+ * Represents an error obtained from the server.
+ */
+class ResponseError extends Error {
+  constructor(message, responseStatus) {
+    super(message);
+    this.name = "ResponseError";
+
+    /**
+     * Gets the server status code.
+     */
+    this.statusCode = responseStatus.code;
+
+    /**
+     * Gets the server status message.
+     */
+    this.statusMessage = responseStatus.message;
+
+    /**
+     * Gets the server status attributes as a Map (may contain provider specific status information).
+     */
+    this.statusAttributes = responseStatus.attributes || {};
+  }
+}
+
+module.exports = ResponseError;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/remote-connection-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/remote-connection-tests.js
@@ -53,6 +53,11 @@ describe('DriverRemoteConnection', function () {
         .catch(function (err) {
           assert.ok(err);
           assert.ok(err.message.indexOf('599') > 0);
+          assert.ok(err.statusCode === 599);
+          assert.ok(err.statusMessage === 'Could not locate method: GraphTraversalSource.SYNTAX_ERROR()');
+          assert.ok(err.statusAttributes);
+          assert.ok(err.statusAttributes.has('exceptions'));
+          assert.ok(err.statusAttributes.has('stackTrace'));
         });
     });
   });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2285

`ResponseError` in javascript is akin to `ResponseException` in java. It includes more direct access to protocol lever server error information such as the status code and status attributes which means we don't need to pack that information into the error message itself at all. Kept that old style to the error messages just in case users were parsing those in prior versions - didn't want to break that.

Builds with `mvn clean install -pl gremlin-javascript`

VOTE +1