### PR TITLE
TINKERPOP-2213 Deprecated scriptEvaluationTimeout for evaluationTimeout

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `ImmutableExplanation` for a `TraversalExplanation` that just contains data.
 * Fixed `TraversalExplanation` deserialization in GraphSON 2 and 3 which was not supported before in Java.
 * Added support for custom request headers in Python.
+* Deprecated `scriptEvaluationTimeout` in favor of the more generic `evaluationTimeout`.
+* Update jackson databind 2.9.9.3.
 * Bumped jackson databind 2.9.9.3.
 * Fixed Java driver authentication problems when calling the driver from multiple threads.
 * Modified Java driver to use IP address rather than hostname to create connections.

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -1036,7 +1036,7 @@ be aliased to different variable names for purposes of the current request.  The
 global variable and its key represents the new binding name as it will be referenced in the Gremlin query.  For
 example, if the Gremlin Server defines two `TraversalSource` instances named `g1` and `g2`, it would be possible
 to send an alias pair with key of "g" and value of "g2" and thus allow the script to refer to "g2" simply as "g".
-|scriptEvaluationTimeout |Long |An override for the server setting that determines the maximum time to wait for a script to execute on the server.
+|evaluationTimeout |Long |An override for the server setting that determines the maximum time to wait for a script to execute on the server.
 |=========================================================
 
 ==== Session OpProcessor
@@ -1079,7 +1079,7 @@ Gremlin Server are deployed, session state is not shared among them.
 |session |String | *Required* The session identifier for the current session - typically this value should be a UUID (the session will be created if it doesn't exist).
 |manageTransaction |Boolean |When set to `true` the transaction for the current request is auto-committed or rolled-back as are done with sessionless requests - defaulted to `false`.
 |bindings |Map |A map of key/value pairs to apply as variables in the context of the Gremlin script.
-|scriptEvaluationTimeout |Long |An override for the server setting that determines the maximum time to wait for a script to execute on the server.
+|evaluationTimeout |Long |An override for the server setting that determines the maximum time to wait for a script to execute on the server.
 |language |String |The flavor of Gremlin used (e.g. `gremlin-groovy`)
 |aliases |Map |A map of key/value pairs that allow globally bound `Graph` and `TraversalSource` objects to
 be aliased to different variable names for purposes of the current request.  The value represents the name the

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1250,7 +1250,7 @@ The following table describes the various YAML configuration options that Gremli
 |scriptEngines.<name>.staticImports |A comma separated list of "static" imports to make available to the `ScriptEngine`. |_none_
 |scriptEngines.<name>.scripts |A comma separated list of script files to execute on `ScriptEngine` initialization. `Graph` and `TraversalSource` instance references produced from scripts will be stored globally in Gremlin Server, therefore it is possible to use initialization scripts to add Traversal Strategies or create entirely new `Graph` instances all together. Instantiating a `LifeCycleHook` in a script provides a way to execute scripts when Gremlin Server starts and stops.|_none_
 |scriptEngines.<name>.config |A `Map` of configuration settings for the `ScriptEngine`.  These settings are dependent on the `ScriptEngine` implementation being used. |_none_
-|scriptEvaluationTimeout |The amount of time in milliseconds before a script evaluation and iteration of result times out. This feature can be turned off by setting the value to `0`. |30000
+|evaluationTimeout |The amount of time in milliseconds before a script evaluation and iteration of result times out. This feature can be turned off by setting the value to `0`. |30000
 |serializers |A `List` of `Map` settings, where each `Map` represents a `MessageSerializer` implementation to use along with its configuration. If this value is not set, then Gremlin Server will configure with GraphSON and Gryo but will not register any `ioRegistries` for configured graphs. |_empty_
 |serializers[X].className |The full class name of the `MessageSerializer` implementation. |_none_
 |serializers[X].config |A `Map` containing `MessageSerializer` specific configurations. |_none_
@@ -1603,7 +1603,7 @@ continuously:
 gremlin> :remote connect tinkerpop.server conf/remote.yaml
 ==>Configured localhost/127.0.0.1:8182
 gremlin> :> while(true) { }
-==>Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 30000 ms or evaluation was otherwise cancelled directly for request [while(true) {}]
+==>Evaluation exceeded the configured 'evaluationTimeout' threshold of 30000 ms or evaluation was otherwise cancelled directly for request [while(true) {}]
 
 The `GroovyCompilerGremlinPlugin` has a number of configuration options:
 
@@ -1920,10 +1920,10 @@ generally means being measured in the low hundreds of milliseconds and "slow" me
 evaluations are blocking operations that aren't always easily interrupted, so once a "slow" script is being evaluated in
 the context of a `ScriptEngine` it must finish its work.  Lots of "slow" scripts will eventually consume the
 `gremlinPool` preventing other scripts from getting processed from the queue.
-** To limit the impact of this problem, consider properly setting the `scriptEvaluationTimeout` to something "sane".
+** To limit the impact of this problem, consider properly setting the `evaluationTimeout` to something "sane".
 In other words, test the traversals being sent to Gremlin Server and determine the maximum time they take to evaluate
 and iterate over results, then set the timeout value accordingly.
-** Note that `scriptEvaluationTimeout` can only attempt to interrupt the evaluation on timeout.  It allows Gremlin
+** Note that `evaluationTimeout` can only attempt to interrupt the evaluation on timeout.  It allows Gremlin
 Server to "ignore" the result of that evaluation, which means the thread in the `gremlinPool` that did the evaluation
 may still be consumed after the timeout if interruption does not succeed on the thread.
 * Graph element serialization for `Vertex` and `Edge` can be expensive, as their data structures are complex given the

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -52,6 +52,20 @@ are configuration problems with authentication and SSL, preventing the connectio
 
 link:https://issues.apache.org/jira/browse/TINKERPOP-2132[TINKERPOP-2132]
 
+==== Deprecated scriptEvaluationTimeout
+
+The `scriptEvaluationTimeout` controls the length of time a request is processed by Gremlin Server (or at its core,
+the `GremlinExecutor`). Of course, with the introduction of bytecode-based requests many versions ago, this naming
+has failed to make complete sense in more recent times. Therefore, `scriptEvaluationTimeout` has been deprecated and
+replaced by `evaluationTimeout`. Both configurations are still respected, but it is advised that users switch to
+`evaluationTimeout` as `scriptEvaluationTimeout` will be removed in a later version.
+
+Note that when configuring Gremlin Server's `evaluationTimeout` that the `scriptEvaluationTimeout` should be set to
+`-1` (the default) or else it will use that value in its initialization of the server and ignore the
+`evaluationTimeout`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2213[TINKERPOP-2213]
+
 == TinkerPop 3.3.8
 
 *Release Date: August 5, 2019*

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/resources/gremlin-server.yaml
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/test/resources/gremlin-server.yaml
@@ -19,7 +19,7 @@ host: localhost
 port: 45940
 threadPoolWorker: 1
 gremlinPool: 8
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 serializedResponseTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/jsr223/gremlin-server-integration.yaml
+++ b/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/jsr223/gremlin-server-integration.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 45940
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 scriptEngines: {
   gremlin-groovy: {

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
@@ -114,10 +114,10 @@ namespace Gremlin.Net.Driver
         public static string ArgsLanguage = "language";
 
         /// <summary>
-        ///     Argument name that allows to override the server setting that determines the maximum time to wait for a script to
-        ///     execute on the server.
+        ///     Argument name that allows to override the server setting that determines the maximum time to wait for a
+        ///     request to execute on the server.
         /// </summary>
-        public static string ArgsEvalTimeout = "scriptEvaluationTimeout";
+        public static string ArgsEvalTimeout = "evaluationTimeout";
 
         /// <summary>
         ///     Argument name for the response to the server authentication challenge. This value is dependent on the SASL

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MessagesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MessagesTests.cs
@@ -96,7 +96,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         }
 
         [Fact]
-        public async Task ShouldUseSpecifiedScriptEvaluationTimeout()
+        public async Task ShouldUseSpecifiedEvaluationTimeout()
         {
             var gremlinServer = new GremlinServer(TestHost, TestPort);
             using (var gremlinClient = new GremlinClient(gremlinServer))

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
@@ -52,7 +52,13 @@ public final class Tokens {
     public static final String ARGS_FORCE = "force";
     public static final String ARGS_GREMLIN = "gremlin";
     public static final String ARGS_LANGUAGE = "language";
+
+    /**
+     * @deprecated As of release 3.3.9, replaced by {@link #ARGS_EVAL_TIMEOUT}.
+     */
+    @Deprecated
     public static final String ARGS_SCRIPT_EVAL_TIMEOUT = "scriptEvaluationTimeout";
+    public static final String ARGS_EVAL_TIMEOUT = "evaluationTimeout";
     public static final String ARGS_HOST = "host";
     public static final String ARGS_SESSION = "session";
     public static final String ARGS_MANAGE_TRANSACTION = "manageTransaction";

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
@@ -93,7 +93,7 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
         /**
          * Introduces timed checks to loops and other portions of a script to provide an interrupt for a long running
          * script. This configuration should not be used in conjunction with the Gremlin Server which has its own
-         * {@code scriptEvaluationTimeout} which performs a similar task but in a more complete way specific to the
+         * {@code evaluationTimeout} which performs a similar task but in a more complete way specific to the
          * server. Configuring both may lead to inconsistent timeout errors returning from the server. This
          * configuration should only be used if configuring a standalone instance fo the {@link GremlinGroovyScriptEngine}.
          */

--- a/gremlin-server/conf/gremlin-server-classic.yaml
+++ b/gremlin-server/conf/gremlin-server-classic.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 scriptEngines: {

--- a/gremlin-server/conf/gremlin-server-modern-py.yaml
+++ b/gremlin-server/conf/gremlin-server-modern-py.yaml
@@ -29,7 +29,7 @@ host: localhost
 port: 8182
 threadPoolWorker: 1
 gremlinPool: 8
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 scriptEngines: {

--- a/gremlin-server/conf/gremlin-server-modern-readonly.yaml
+++ b/gremlin-server/conf/gremlin-server-modern-readonly.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 scriptEngines: {

--- a/gremlin-server/conf/gremlin-server-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-modern.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 scriptEngines: {

--- a/gremlin-server/conf/gremlin-server-neo4j.yaml
+++ b/gremlin-server/conf/gremlin-server-neo4j.yaml
@@ -27,7 +27,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
   graph: conf/neo4j-empty.properties}

--- a/gremlin-server/conf/gremlin-server-rest-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-modern.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -25,7 +25,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -25,7 +25,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-spark.yaml
+++ b/gremlin-server/conf/gremlin-server-spark.yaml
@@ -40,7 +40,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
   graph: conf/hadoop-gryo.properties}

--- a/gremlin-server/conf/gremlin-server.yaml
+++ b/gremlin-server/conf/gremlin-server.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -30,7 +30,6 @@ import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
 import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
 import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.util.DefaultGraphManager;
-import info.ganglia.gmetric4j.gmetric.GMetric;
 import org.apache.tinkerpop.gremlin.server.util.LifeCycleHook;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.yaml.snakeyaml.TypeDescription;
@@ -102,15 +101,25 @@ public class Settings {
     public int threadPoolBoss = 1;
 
     /**
-     * Time in milliseconds to wait for a script to complete execution.  Defaults to 30000.
+     * Time in milliseconds to wait for a request (script or bytecode) to complete execution.  Defaults to -1 and
+     * thus defers to {@link #evaluationTimeout} for this configuration. When set to something greater than -1 then
+     * this configuration is used.
+     *
+     * @deprecated As of release 3.3.9, replaced by {@link #evaluationTimeout}.
      */
-    public long scriptEvaluationTimeout = 30000L;
+    @Deprecated
+    public long scriptEvaluationTimeout = -1L;
+
+    /**
+     * Time in milliseconds to wait for a request (script or bytecode) to complete execution. Defaults to 30000.
+     */
+    public long evaluationTimeout = 30000L;
 
     /**
      * Time in milliseconds to wait while an evaluated script serializes its results. This value represents the
      * total serialization time allowed for the request.  Defaults to 0 which disables this setting.
      *
-     * @deprecated As of release 3.2.1, replaced wholly by {@link #scriptEvaluationTimeout}.
+     * @deprecated As of release 3.2.1, replaced wholly by {@link #evaluationTimeout}.
      */
     @Deprecated
     public long serializedResponseTimeout = 0L;
@@ -252,6 +261,10 @@ public class Settings {
 
     public Optional<SslSettings> optionalSsl() {
         return Optional.ofNullable(ssl);
+    }
+
+    public long getEvaluationTimeout() {
+        return -1 == scriptEvaluationTimeout ? evaluationTimeout : scriptEvaluationTimeout;
     }
 
     /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
@@ -212,7 +212,7 @@ public class Session {
 
     private GremlinExecutor.Builder initializeGremlinExecutor() {
         final GremlinExecutor.Builder gremlinExecutorBuilder = GremlinExecutor.build()
-                .scriptEvaluationTimeout(settings.scriptEvaluationTimeout)
+                .evaluationTimeout(settings.getEvaluationTimeout())
                 .afterTimeout(b -> {
                     graphManager.rollbackAll();
                     this.bindings.clear();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -372,11 +372,14 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
         // earlier validation in selection of this op method should free us to cast this without worry
         final Map<String, String> aliases = (Map<String, String>) msg.optionalArgs(Tokens.ARGS_ALIASES).get();
 
-        // timeout override
-        final long seto = msg.getArgs().containsKey(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT)
-            // could be sent as an integer or long
-            ? ((Number) msg.getArgs().get(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT)).longValue()
-            : context.getSettings().scriptEvaluationTimeout;
+        // timeout override - handle both deprecated and newly named configuration. earlier logic should prevent
+        // both configurations from being submitted at the same time
+        final Map<String, Object> args = msg.getArgs();
+        final long seto = args.containsKey(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT) || args.containsKey(Tokens.ARGS_EVAL_TIMEOUT)
+                // could be sent as an integer or long
+                ? (args.containsKey(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT) ?
+                ((Number) args.get(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT)).longValue() : ((Number) args.get(Tokens.ARGS_EVAL_TIMEOUT)).longValue())
+                : context.getSettings().getEvaluationTimeout();
 
         final GraphManager graphManager = context.getGraphManager();
         final String traversalSourceName = aliases.entrySet().iterator().next().getValue();
@@ -414,7 +417,7 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                         t = t.getCause();
 
                     if (t instanceof InterruptedException || t instanceof TraversalInterruptedException) {
-                        final String errorMessage = String.format("A timeout occurred during traversal evaluation of [%s] - consider increasing the limit given to scriptEvaluationTimeout", msg);
+                        final String errorMessage = String.format("A timeout occurred during traversal evaluation of [%s] - consider increasing the limit given to evaluationTimeout", msg);
                         logger.warn(errorMessage);
                         context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR_TIMEOUT)
                                                              .statusMessage(errorMessage)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
@@ -108,7 +108,7 @@ public class ServerGremlinExecutor {
         logger.info("Initialized Gremlin thread pool.  Threads in pool named with pattern gremlin-*");
 
         final GremlinExecutor.Builder gremlinExecutorBuilder = GremlinExecutor.build()
-                .scriptEvaluationTimeout(settings.scriptEvaluationTimeout)
+                .evaluationTimeout(settings.getEvaluationTimeout())
                 .afterFailure((b, e) -> this.graphManager.rollbackAll())
                 .beforeEval(b -> this.graphManager.rollbackAll())
                 .afterTimeout(b -> this.graphManager.rollbackAll())
@@ -137,7 +137,7 @@ public class ServerGremlinExecutor {
             try {
                 // use no timeout on the engine initialization - perhaps this can be a configuration later
                 final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build().
-                        scriptEvaluationTimeoutOverride(0L).create();
+                        evaluationTimeoutOverride(0L).create();
                 gremlinExecutor.eval("1+1", engineName, new SimpleBindings(Collections.emptyMap()), lifeCycle).join();
                 registerMetrics(engineName);
                 logger.info("Initialized {} GremlinScriptEngine and registered metrics", engineName);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -65,14 +65,14 @@ public abstract class AbstractGremlinServerIntegrationTest {
     }
 
     /**
-     * This method may be called after {@link #startServer()} to (re-)set the script evaluation timeout in
+     * This method may be called after {@link #startServer()} to (re-)set the evaluation timeout in
      * the running server.
-     * @param timeoutInMillis new script evaluation timeout
+     * @param timeoutInMillis new evaluation timeout
      */
-    protected void overrideScriptEvaluationTimeout(final long timeoutInMillis) {
+    protected void overrideEvaluationTimeout(final long timeoutInMillis) {
         // Note: overriding settings in a running server is not guaranteed to work for all settings.
         // It works for the evaluation timeout, though, because GremlinExecutor is re-created for each evaluation.
-        overriddenSettings.scriptEvaluationTimeout = timeoutInMillis;
+        overriddenSettings.evaluationTimeout = timeoutInMillis;
     }
 
     public InputStream getSettingsInputStream() {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -172,12 +172,12 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
                 settings.graphs.put("graph", "conf/neo4j-empty.properties");
                 break;
             case "shouldProcessSessionRequestsInOrderAfterTimeout":
-                settings.scriptEvaluationTimeout = 250;
+                settings.evaluationTimeout = 250;
                 settings.threadPoolWorker = 1;
                 break;
             case "shouldProcessTraversalInterruption":
             case "shouldProcessEvalInterruption":
-                settings.scriptEvaluationTimeout = 1500;
+                settings.evaluationTimeout = 1500;
                 break;
         }
 
@@ -1601,7 +1601,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         {
             final Throwable root = ExceptionUtils.getRootCause(ex);
             assertThat(root, instanceOf(ResponseException.class));
-            assertThat(root.getMessage(), startsWith("Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 250 ms"));
+            assertThat(root.getMessage(), startsWith("Evaluation exceeded the configured 'evaluationTimeout' threshold of 250 ms"));
         }
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -180,7 +180,8 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
             final Throwable root = ExceptionUtils.getRootCause(ex);
 
             // depending on the configuration of the system environment you might get either of these
-            assertThat(root, anyOf(instanceOf(GSSException.class), instanceOf(ResponseException.class)));
+            assertThat(root, anyOf(instanceOf(GSSException.class), instanceOf(ResponseException.class),
+                    instanceOf(NoHostAvailableException.class)));
         } finally {
             cluster.close();
         }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -173,7 +173,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.writeBufferLowWaterMark = 32;
                 break;
             case "shouldReceiveFailureTimeOutOnScriptEval":
-                settings.scriptEvaluationTimeout = 1000;
+                settings.evaluationTimeout = 1000;
                 break;
             case "shouldReceiveFailureTimeOutOnTotalSerialization":
                 settings.serializedResponseTimeout = 1;
@@ -306,6 +306,9 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.processors.add(processorSettingsSmall);
                 break;
             case "shouldTimeOutRemoteTraversal":
+                settings.evaluationTimeout = 500;
+                break;
+            case "shouldTimeOutRemoteTraversalUsingDeprecatedConfiguration":
                 settings.scriptEvaluationTimeout = 500;
                 break;
             case "shouldPingChannelIfClientDies":
@@ -419,6 +422,34 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
+    public void shouldTimeOutRemoteTraversalUsingDeprecatedConfiguration() throws Exception {
+        final GraphTraversalSource g = traversal().withRemote(conf);
+
+        try {
+            // tests sleeping thread
+            g.inject(1).sideEffect(Lambda.consumer("Thread.sleep(10000)")).iterate();
+            fail("This traversal should have timed out");
+        } catch (Exception ex) {
+            final Throwable t = ex.getCause();
+            assertThat(t, instanceOf(ResponseException.class));
+            assertEquals(ResponseStatusCode.SERVER_ERROR_TIMEOUT, ((ResponseException) t).getResponseStatusCode());
+        }
+
+        // make a graph with a cycle in it to force a long run traversal
+        graphGetter.get().traversal().addV("person").as("p").addE("self").to("p").iterate();
+
+        try {
+            // tests an "unending" traversal
+            g.V().repeat(__.out()).until(__.outE().count().is(0)).iterate();
+            fail("This traversal should have timed out");
+        } catch (Exception ex) {
+            final Throwable t = ex.getCause();
+            assertThat(t, instanceOf(ResponseException.class));
+            assertEquals(ResponseStatusCode.SERVER_ERROR_TIMEOUT, ((ResponseException) t).getResponseStatusCode());
+        }
+    }
+
+    @Test
     public void shouldProduceProperExceptionOnTimeout() throws Exception {
         final Cluster cluster = TestClientFactory.open();
         final Client client = cluster.connect(name.getMethodName());
@@ -435,7 +466,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         // Note: this test may have a false negative result, but a failure  would indicate a real problem.
         for(int i = 0; i < 30; i++) {
             int timeout = 1 + i;
-            overrideScriptEvaluationTimeout(timeout);
+            overrideEvaluationTimeout(timeout);
 
             try {
                 client.submit("x = 1 + 1").all().get().get(0).getInt();
@@ -957,7 +988,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldReceiveFailureTimeOutOnScriptEval() throws Exception {
         try (SimpleClient client = TestClientFactory.createWebSocketClient()){
             final List<ResponseMessage> responses = client.submit("Thread.sleep(3000);'some-stuff-that-should not return'");
-            assertThat(responses.get(0).getStatus().getMessage(), startsWith("Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 1000 ms"));
+            assertThat(responses.get(0).getStatus().getMessage(), startsWith("Evaluation exceeded the configured 'evaluationTimeout' threshold of 1000 ms"));
 
             // validate that we can still send messages to the server
             assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());
@@ -973,7 +1004,23 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                     .addArg(Tokens.ARGS_GREMLIN, "Thread.sleep(3000);'some-stuff-that-should not return'")
                     .create();
             final List<ResponseMessage> responses = client.submit(msg);
-            assertThat(responses.get(0).getStatus().getMessage(), startsWith("Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 100 ms"));
+            assertThat(responses.get(0).getStatus().getMessage(), startsWith("Evaluation exceeded the configured 'evaluationTimeout' threshold of 100 ms"));
+
+            // validate that we can still send messages to the server
+            assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldReceiveFailureTimeOutOnEvalUsingOverride() throws Exception {
+        try (SimpleClient client = TestClientFactory.createWebSocketClient()) {
+            final RequestMessage msg = RequestMessage.build("eval")
+                    .addArg(Tokens.ARGS_EVAL_TIMEOUT, 100L)
+                    .addArg(Tokens.ARGS_GREMLIN, "Thread.sleep(3000);'some-stuff-that-should not return'")
+                    .create();
+            final List<ResponseMessage> responses = client.submit(msg);
+            assertThat(responses.get(0).getStatus().getMessage(), startsWith("Evaluation exceeded the configured 'evaluationTimeout' threshold of 100 ms"));
 
             // validate that we can still send messages to the server
             assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());
@@ -984,7 +1031,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldReceiveFailureTimeOutOnScriptEvalOfOutOfControlLoop() throws Exception {
         try (SimpleClient client = TestClientFactory.createWebSocketClient()){
             // timeout configured for 1 second so the timed interrupt should trigger prior to the
-            // scriptEvaluationTimeout which is at 30 seconds by default
+            // evaluationTimeout which is at 30 seconds by default
             final List<ResponseMessage> responses = client.submit("while(true){}");
             assertThat(responses.get(0).getStatus().getMessage(), startsWith("Timeout during script evaluation triggered by TimedInterruptCustomizerProvider"));
 
@@ -994,7 +1041,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     /**
-     * @deprecated As of release 3.2.1, replaced by tests covering {@link Settings#scriptEvaluationTimeout}.
+     * @deprecated As of release 3.2.1, replaced by tests covering {@link Settings#evaluationTimeout}.
      */
     @Test
     @SuppressWarnings("unchecked")

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
@@ -223,7 +223,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
             fail("The close of the session on client2 should have interrupted the script sent on client1");
         } catch (Exception ex) {
             final Throwable root = ExceptionUtils.getRootCause(ex);
-            assertThat(root.getMessage(), startsWith("Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of 30000 ms or evaluation was otherwise cancelled directly for request"));
+            assertThat(root.getMessage(), startsWith("Evaluation exceeded the configured 'evaluationTimeout' threshold of 30000 ms or evaluation was otherwise cancelled directly for request"));
         }
 
         client1.close();

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 45940
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties,
   classic: conf/tinkergraph-empty.properties,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2213

The `scriptEvaluationTimeout` still works from a configuration perspective from both a client and server perspective. Used -1 to "disable" `scriptEvaluationTimeout` in the server configuration to thus favor `evaluationTimeout`. Setting `scriptEvaluationTimeout` directly to something other -1 will force that value to be respected so there should be no breaking changes here.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1