### PR TITLE
TINKERPOP-2295 Removed scriptEvaluationTimeout configurations

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Added support for `TextP` in Neo4j using its string search functions.
 * Removed the "experimental" support for multi/meta-properties in Neo4j.
 * Removed Gryo serialization configurations from Gremlin Server sample configurations and default configurations.
+* Removed previously deprecated `scriptEvaluationTimeout`.
 * Removed previously deprecated remote traversal side-effects.
 * Removed previously deprecated `Serializers.DEFAULT_RESULT_SERIALIZER` and `Serializers.DEFAULT_REQUEST_SERIALIZER`.
 * Removed previously deprecated `decr` and `incr` from `Order`.

--- a/docker/gremlin-server/gremlin-server-integration-secure.yaml
+++ b/docker/gremlin-server/gremlin-server-integration-secure.yaml
@@ -17,7 +17,7 @@
 
 host: 0.0.0.0
 port: 45941
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties,
   classic: conf/tinkergraph-empty.properties,

--- a/docker/gremlin-server/gremlin-server-integration.yaml
+++ b/docker/gremlin-server/gremlin-server-integration.yaml
@@ -17,7 +17,7 @@
 
 host: 0.0.0.0
 port: 45940
-scriptEvaluationTimeout: 30000
+evaluationTimeout: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties,
   classic: conf/tinkergraph-empty.properties,

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -407,7 +407,7 @@ which will boost performance and reduce resources required on the server.
 
 There are a number of overloads to `Client.submit()` that accept a `RequestOptions` object. The `RequestOptions`
 provide a way to include options that are specific to the request made with the call to `submit()`. A good use-case for
-this feature is to set a per-request override to the `scriptEvaluationTimeout` so that it only applies to the current
+this feature is to set a per-request override to the `evaluationTimeout` so that it only applies to the current
 request.
 
 [source,java]

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -145,6 +145,7 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.structure.util.star.StarGraph#builder()`
 ** `org.apache.tinkerpop.gremlin.structure.util.star.StarGraph.Builder#create()`
 * `gremlin-driver`
+** `org.apache.tinkerpop.gremlin.driver.Tokens#ARGS_SCRIPT_EVAL_TIMEOUT`
 ** `org.apache.tinkerpop.gremlin.driver.Cluster.Builder#keyCertChainFile(String)`
 ** `org.apache.tinkerpop.gremlin.driver.Cluster.Builder#keyFile(String)`
 ** `org.apache.tinkerpop.gremlin.driver.Cluster.Builder#keyPassword(String)`
@@ -152,6 +153,7 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteTraversalSideEffects`
 ** `org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteTraversal#getSideEffects()`
 * `gremlin-server`
+** `org.apache.tinkerpop.gremlin.server.Settings.scriptEvaluationTimeout`
 ** `org.apache.tinkerpop.gremlin.server.Settings.SslSettings.keyCertChainFile`
 ** `org.apache.tinkerpop.gremlin.server.Settings.SslSettings.keyFile`
 ** `org.apache.tinkerpop.gremlin.server.Settings.SslSettings.keyPassword`

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -341,7 +341,7 @@ public abstract class Client {
                 .add(Tokens.ARGS_BATCH_SIZE, batchSize);
 
         // apply settings if they were made available
-        options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, timeout));
+        options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_EVAL_TIMEOUT, timeout));
         options.getParameters().ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, params));
         options.getAliases().ifPresent(aliases -> request.addArg(Tokens.ARGS_ALIASES, aliases));
         options.getOverrideRequestId().ifPresent(request::overrideRequestId);
@@ -565,7 +565,7 @@ public abstract class Client {
 
                 // apply settings if they were made available
                 options.getBatchSize().ifPresent(batchSize -> request.add(Tokens.ARGS_BATCH_SIZE, batchSize));
-                options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, timeout));
+                options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_EVAL_TIMEOUT, timeout));
 
                 return submitAsync(request.create());
             } catch (Exception ex) {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
@@ -127,7 +127,7 @@ public final class RequestOptions {
         }
 
         /**
-         * The per client request override in milliseconds for the server configured {@code scriptEvaluationTimeout}.
+         * The per client request override in milliseconds for the server configured {@code evaluationTimeout}.
          * If this value is not set, then the configuration for the server is used.
          */
         public Builder timeout(final long timeout) {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Tokens.java
@@ -40,12 +40,6 @@ public final class Tokens {
     public static final String ARGS_FORCE = "force";
     public static final String ARGS_GREMLIN = "gremlin";
     public static final String ARGS_LANGUAGE = "language";
-
-    /**
-     * @deprecated As of release 3.3.9, replaced by {@link #ARGS_EVAL_TIMEOUT}.
-     */
-    @Deprecated
-    public static final String ARGS_SCRIPT_EVAL_TIMEOUT = "scriptEvaluationTimeout";
     public static final String ARGS_EVAL_TIMEOUT = "evaluationTimeout";
     public static final String ARGS_HOST = "host";
     public static final String ARGS_SESSION = "session";

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -38,7 +38,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_BATCH_SIZE;
-import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_SCRIPT_EVAL_TIMEOUT;
 import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_EVAL_TIMEOUT;
 import static org.apache.tinkerpop.gremlin.driver.Tokens.ARGS_USER_AGENT;
 import static org.apache.tinkerpop.gremlin.driver.Tokens.REQUEST_ID;
@@ -236,8 +235,6 @@ public class DriverRemoteConnection implements RemoteConnection {
             final Map<String,Object> options = optionsStrategy.getOptions();
             if (options.containsKey(ARGS_EVAL_TIMEOUT))
                 builder.timeout((long) options.get(ARGS_EVAL_TIMEOUT));
-            if (options.containsKey(ARGS_SCRIPT_EVAL_TIMEOUT))
-                builder.timeout((long) options.get(ARGS_SCRIPT_EVAL_TIMEOUT));
             if (options.containsKey(REQUEST_ID))
                 builder.overrideRequestId((UUID) options.get(REQUEST_ID));
             if (options.containsKey(ARGS_BATCH_SIZE))

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
@@ -42,7 +42,7 @@ public class DriverRemoteConnectionTest {
                         with("y", 100).
                         with(Tokens.ARGS_BATCH_SIZE, 1000).
                         with(Tokens.REQUEST_ID, requestId).
-                        with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 100000L).
+                        with(Tokens.ARGS_EVAL_TIMEOUT, 100000L).
                         with(Tokens.ARGS_USER_AGENT, "test").
                         V().asAdmin().getBytecode());
         assertEquals(requestId, options.getOverrideRequestId().get());

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -504,21 +504,6 @@ public class GremlinExecutor implements AutoCloseable {
         }
 
         /**
-         * Amount of time a script has before it times out. Note that the time required covers both script evaluation
-         * as well as any time needed for a post result transformation (if the transformation function is supplied
-         * to the {@link GremlinExecutor#eval}).
-         *
-         * @param scriptEvaluationTimeout Time in milliseconds that an evaluation is allowed to run and its
-         *                                results potentially transformed. Set to zero to have no timeout set.
-         * @deprecated As of release 3.3.9, replaced by {@link #evaluationTimeout}.
-         */
-        @Deprecated
-        public Builder scriptEvaluationTimeout(final long scriptEvaluationTimeout) {
-            this.evaluationTimeout = scriptEvaluationTimeout;
-            return this;
-        }
-
-        /**
          * Amount of time an evaluation has before it times out. Note that the time required covers both evaluation
          * as well as any time needed for a post result transformation (if the transformation function is supplied
          * to the {@link GremlinExecutor#eval}).
@@ -635,14 +620,6 @@ public class GremlinExecutor implements AutoCloseable {
             evaluationTimeoutOverride = Optional.ofNullable(builder.evaluationTimeoutOverride);
         }
 
-        /**
-         * @deprecated As of release 3.3.9, replaced by {@link #getEvaluationTimeoutOverride()}.
-         */
-        @Deprecated
-        public Optional<Long> getScriptEvaluationTimeoutOverride() {
-            return evaluationTimeoutOverride;
-        }
-
         public Optional<Long> getEvaluationTimeoutOverride() {
             return evaluationTimeoutOverride;
         }
@@ -736,18 +713,6 @@ public class GremlinExecutor implements AutoCloseable {
              */
             public Builder afterFailure(final BiConsumer<Bindings, Throwable> afterFailure) {
                 this.afterFailure = afterFailure;
-                return this;
-            }
-
-            /**
-             * An override to the global {@code evaluationTimeout} setting on the script engine. If this value
-             * is set to {@code null} (the default) it will use the global setting.
-             *
-             * @deprecated As of release 3.3.9, replaced by {@link #evaluationTimeoutOverride}
-             */
-            @Deprecated
-            public Builder scriptEvaluationTimeoutOverride(final Long scriptEvaluationTimeoutOverride) {
-                this.evaluationTimeoutOverride = scriptEvaluationTimeoutOverride;
                 return this;
             }
 

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
@@ -265,7 +265,7 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .scriptEvaluationTimeout(250)
+                .evaluationTimeout(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
@@ -319,13 +319,13 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .scriptEvaluationTimeout(10000)
+                .evaluationTimeout(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
-                    .scriptEvaluationTimeoutOverride(250L).create();
+                    .evaluationTimeoutOverride(250L).create();
             gremlinExecutor.eval("Thread.sleep(1000);10", "gremlin-groovy", new SimpleBindings(), lifeCycle).get();
             fail("This script should have timed out with an exception");
         } catch (Exception ex) {
@@ -458,15 +458,15 @@ public class GremlinExecutorTest {
 
     @Test
     public void shouldCancelTimeoutOnSuccessfulScript() throws Exception {
-        final long scriptEvaluationTimeout = 5_000;
+        final long evaluationTimeout = 5_000;
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .scriptEvaluationTimeout(scriptEvaluationTimeout)
+                .evaluationTimeout(evaluationTimeout)
                 .create();
 
         final long now = System.currentTimeMillis();
         assertEquals(2, gremlinExecutor.eval("1+1").get());
         gremlinExecutor.close();
-        assertTrue(System.currentTimeMillis() - now < scriptEvaluationTimeout);
+        assertTrue(System.currentTimeMillis() - now < evaluationTimeout);
     }
 
     @Test

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -101,16 +101,6 @@ public class Settings {
     public int threadPoolBoss = 1;
 
     /**
-     * Time in milliseconds to wait for a request (script or bytecode) to complete execution.  Defaults to -1 and
-     * thus defers to {@link #evaluationTimeout} for this configuration. When set to something greater than -1 then
-     * this configuration is used.
-     *
-     * @deprecated As of release 3.3.9, replaced by {@link #evaluationTimeout}.
-     */
-    @Deprecated
-    public long scriptEvaluationTimeout = -1L;
-
-    /**
      * Time in milliseconds to wait for a request (script or bytecode) to complete execution. Defaults to 30000.
      */
     public long evaluationTimeout = 30000L;
@@ -255,7 +245,7 @@ public class Settings {
     }
 
     public long getEvaluationTimeout() {
-        return -1 == scriptEvaluationTimeout ? evaluationTimeout : scriptEvaluationTimeout;
+        return evaluationTimeout;
     }
 
     /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -221,11 +221,8 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
 
         // timeout override - handle both deprecated and newly named configuration. earlier logic should prevent
         // both configurations from being submitted at the same time
-        final long seto = args.containsKey(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT) || args.containsKey(Tokens.ARGS_EVAL_TIMEOUT)
-            // could be sent as an integer or long
-            ? (args.containsKey(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT) ?
-                ((Number) args.get(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT)).longValue() : ((Number) args.get(Tokens.ARGS_EVAL_TIMEOUT)).longValue())
-            : settings.getEvaluationTimeout();
+        final long seto = args.containsKey(Tokens.ARGS_EVAL_TIMEOUT) ?
+                ((Number) args.get(Tokens.ARGS_EVAL_TIMEOUT)).longValue() : settings.getEvaluationTimeout();
 
         final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
                 .evaluationTimeoutOverride(seto)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -162,11 +162,8 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
         // timeout override - handle both deprecated and newly named configuration. earlier logic should prevent
         // both configurations from being submitted at the same time
         final Map<String, Object> args = msg.getArgs();
-        final long seto = args.containsKey(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT) || args.containsKey(Tokens.ARGS_EVAL_TIMEOUT)
-                // could be sent as an integer or long
-                ? (args.containsKey(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT) ?
-                ((Number) args.get(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT)).longValue() : ((Number) args.get(Tokens.ARGS_EVAL_TIMEOUT)).longValue())
-                : context.getSettings().getEvaluationTimeout();
+        final long seto = args.containsKey(Tokens.ARGS_EVAL_TIMEOUT) ?
+                ((Number) args.get(Tokens.ARGS_EVAL_TIMEOUT)).longValue() : context.getSettings().getEvaluationTimeout();
 
         final GraphManager graphManager = context.getGraphManager();
         final String traversalSourceName = aliases.entrySet().iterator().next().getValue();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -191,9 +191,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             case "shouldProcessEvalInterruption":
                 settings.evaluationTimeout = 1500;
                 break;
-            case "shouldProcessEvalTimeoutOverride":
-                settings.scriptEvaluationTimeout = 15000;
-                break;
         }
 
         return settings;
@@ -219,23 +216,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         // should not die completely just because we had a bad serialization error.  that kind of stuff happens
         // from time to time, especially in the console if you're just exploring.
         assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
-
-        cluster.close();
-    }
-
-    @Test
-    public void shouldProcessEvalTimeoutOverride() throws Exception {
-        final Cluster cluster = TestClientFactory.open();
-        final Client client = cluster.connect();
-        final RequestOptions options = RequestOptions.build().timeout(500).create();
-
-        try {
-            client.submit("Thread.sleep(5000);'done'", options).all().get();
-            fail("Should have timed out");
-        } catch (Exception ex) {
-            final ResponseException re = (ResponseException) ex.getCause();
-            assertEquals(ResponseStatusCode.SERVER_ERROR_TIMEOUT, re.getResponseStatusCode());
-        }
 
         cluster.close();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2295

This setting was previously deprecated in 3.3.9 and is no longer needed.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1