### PR TITLE
TINKERPOP-2280 Add ReservedKeysVerificationStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,8 +28,11 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed `TraversalExplanation` deserialization in GraphSON 2 and 3 which was not supported before in Java.
 * Added support for custom request headers in Python.
 * Deprecated `scriptEvaluationTimeout` in favor of the more generic `evaluationTimeout`.
-* Update jackson databind 2.9.9.3.
 * Bumped jackson databind 2.9.9.3.
+* Added `ReservedKeysVerificationStrategy` to allow warnings or exceptions when certain keys are used for properties.
+* Added the `AbstractWarningVerificationStrategy` base class for "warning" style `VerificationStrategy` implementations.
+* Refactored `EdgeLabelVerificationStrategy` to use `AbstractWarningVerificationStrategy`.
+* Added `EdgeLabelVerificationStrategy` to Python.
 * Fixed Java driver authentication problems when calling the driver from multiple threads.
 * Modified Java driver to use IP address rather than hostname to create connections.
 * Fixed potential for `NullPointerException` with empty identifiers in `GraphStep`.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -29,6 +29,22 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.9/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== ReservedKeysVerificationStrategy
+
+`ReservedKeysVerificationStrategy` is a new `VerificationStrategy` that can be used to help prevent traversals from
+adding property keys that are protected. They may be protected as a result of the key being a reserved keyword of the
+underlying graph system or they key may simply violate some standard conventions.
+
+[source,text]
+----
+gremlin> g.withStrategies(ReservedKeysVerificationStrategy.build().throwException().create()).addV('person').property("id",123)
+The provided traversal contains a AddVertexStartStep that is setting a property key to a reserved word: id
+Type ':help' or ':h' for help.
+Display stack trace? [yN]
+----
+
+link:https://issues.apache.org/jira/browse/TINKERPOP-2280[TINKERPOP-2280]
+
 ==== Javascript ResponseError
 
 Gremlin Javascript now enables more robust error handling by way of a `ResponseError` which provides access to more

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/AbstractWarningVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/AbstractWarningVerificationStrategy.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.verification;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base {@link TraversalStrategy} class that is configurable to throw warnings or exceptions.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public abstract class AbstractWarningVerificationStrategy
+        extends AbstractTraversalStrategy<TraversalStrategy.VerificationStrategy>
+        implements TraversalStrategy.VerificationStrategy  {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractWarningVerificationStrategy.class);
+
+    protected static final String THROW_EXCEPTION = "throwException";
+    protected static final String LOG_WARNING = "logWarning";
+
+    protected final boolean throwException;
+    protected final boolean logWarning;
+
+    AbstractWarningVerificationStrategy(final Builder builder) {
+        this.throwException = builder.throwException;
+        this.logWarning = builder.logWarning;
+    }
+
+    /**
+     * Implementations should check the traversal and throw a standard {@link VerificationException} as it would if
+     * it had directly implemented {@link #apply(Traversal.Admin)}. The message provided to the exception will be
+     * used to log a warning and/or the same exception thrown if configured to do so.
+     */
+    abstract void verify(final Traversal.Admin<?, ?> traversal) throws VerificationException;
+
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        try {
+            verify(traversal);
+        } catch (VerificationException ve) {
+            if (logWarning)
+                LOGGER.warn(ve.getMessage());
+
+            if (throwException)
+                throw ve;
+        }
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        final Map<String, Object> m = new HashMap<>(2);
+        m.put(THROW_EXCEPTION, this.throwException);
+        m.put(LOG_WARNING, this.logWarning);
+        return new MapConfiguration(m);
+    }
+
+    public static abstract class Builder<T extends AbstractWarningVerificationStrategy, B extends Builder> {
+
+        protected boolean throwException;
+        protected boolean logWarning;
+
+        Builder() { }
+
+        public B throwException(final boolean throwException) {
+            this.throwException = throwException;
+            return (B) this;
+        }
+
+        public B throwException() {
+            return this.throwException(true);
+        }
+
+        public B logWarning(final boolean logWarning) {
+            this.logWarning = logWarning;
+            return (B) this;
+        }
+
+        public B logWarning() {
+            return this.logWarning(true);
+        }
+
+        public abstract T create();
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ReservedKeysVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ReservedKeysVerificationStrategy.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.verification;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.Parameterizing;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This verification strategy detects property keys that should not be used by the traversal. A term may be reserved
+ * by a particular graph implementation or as a convention given best practices.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ *  * @example <pre>
+ *  * __.addV("person").property("id", 123)           // throws an IllegalStateException
+ *  * __.addE("knows").property("label", "green")     // throws an IllegalStateException
+ *  * </pre>
+ */
+public class ReservedKeysVerificationStrategy extends AbstractWarningVerificationStrategy {
+
+    private static final String KEYS = "keys";
+    private static final Set<String> DEFAULT_RESERVED_KEYS = new HashSet<>(Arrays.asList("id", "label"));
+    private final Set<String> reservedKeys;
+
+    private ReservedKeysVerificationStrategy(final Builder builder) {
+        super(builder);
+        this.reservedKeys = builder.reservedKeys;
+    }
+
+    @Override
+    void verify(final Traversal.Admin<?, ?> traversal) throws VerificationException {
+        for (final Step<?, ?> step : traversal.getSteps()) {
+            if (step instanceof AddVertexStep || step instanceof AddVertexStartStep ||
+                step instanceof AddEdgeStartStep || step instanceof AddEdgeStep ||
+                step instanceof AddPropertyStep) {
+                final Parameterizing propertySettingStep = (Parameterizing) step;
+                final Parameters params = propertySettingStep.getParameters();
+                for (String key : reservedKeys) {
+                    if (params.contains(key)) {
+                        final String msg = String.format(
+                                "The provided traversal contains a %s that is setting a property key to a reserved" +
+                                        " word: %s", propertySettingStep.getClass().getSimpleName(), key);
+                        throw new VerificationException(msg, traversal);
+                    }
+                }
+            }
+        }
+    }
+
+    public static ReservedKeysVerificationStrategy create(final Configuration configuration) {
+        return build()
+                .reservedKeys(configuration.getList(KEYS, new ArrayList<>(DEFAULT_RESERVED_KEYS)).
+                        stream().map(Object::toString).collect(Collectors.toSet()))
+                .throwException(configuration.getBoolean(THROW_EXCEPTION, false))
+                .logWarning(configuration.getBoolean(LOG_WARNING, false)).create();
+    }
+
+    public static ReservedKeysVerificationStrategy.Builder build() {
+        return new ReservedKeysVerificationStrategy.Builder();
+    }
+
+    public final static class Builder extends AbstractWarningVerificationStrategy.Builder<ReservedKeysVerificationStrategy, Builder> {
+        private Set<String> reservedKeys = DEFAULT_RESERVED_KEYS;
+
+        private Builder() {}
+
+        public Builder reservedKeys(final Set<String> keys) {
+            reservedKeys = keys;
+            return this;
+        }
+
+        @Override
+        public ReservedKeysVerificationStrategy create() {
+            return new ReservedKeysVerificationStrategy(this);
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Verification/EdgeLabelVerificationStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Verification/EdgeLabelVerificationStrategy.cs
@@ -1,0 +1,49 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+namespace Gremlin.Net.Process.Traversal.Strategy.Verification
+{
+    /// <summary>
+    ///     Provides a way to prevent traversals that sub-optimally fail to include edge label specification .
+    /// </summary>
+    public class EdgeLabelVerificationStrategy : AbstractTraversalStrategy
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="EdgeLabelVerificationStrategy" /> class.
+        /// </summary>
+        public EdgeLabelVerificationStrategy()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="EdgeLabelVerificationStrategy" /> class.
+        /// </summary>
+        /// <param name="logWarning">Constrains vertices for the <see cref="ITraversal" />.</param>
+        /// <param name="throwException">Constrains edges for the <see cref="ITraversal" />.</param>
+        public EdgeLabelVerificationStrategy(bool logWarning = false, bool throwException = false)
+        {
+            Configuration["logWarning"] = logWarning;
+            Configuration["throwException"] = throwException;
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Verification/ReservedKeysVerificationStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Verification/ReservedKeysVerificationStrategy.cs
@@ -1,0 +1,55 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Collections.Generic;
+
+namespace Gremlin.Net.Process.Traversal.Strategy.Verification
+{
+    /// <summary>
+    ///     Provides a way to prevent traversal from using property keys that are reserved terms. By default, these
+    ///     are "id" and "label" - providers may have their own reserved terms as well.
+    /// </summary>
+    public class ReservedKeysVerificationStrategy : AbstractTraversalStrategy
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ReservedKeysVerificationStrategy" /> class.
+        /// </summary>
+        public ReservedKeysVerificationStrategy()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ReservedKeysVerificationStrategy" /> class
+        /// </summary>
+        /// <param name="logWarning">Write a warning to the configured log on the server if a reserved key is used.</param>
+        /// <param name="throwException">Throw an exception if a reserved key is used.</param>
+        /// <param name="keys">List of keys to define as reserved. If not set then the defaults are used.</param>
+        public ReservedKeysVerificationStrategy(bool logWarning = false, bool throwException = false, List<string> keys = null)
+        {
+            Configuration["logWarning"] = logWarning;
+            Configuration["throwException"] = throwException;
+            if (keys != null)
+                Configuration["keys"] = keys;
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
@@ -21,8 +21,10 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using Gremlin.Net.Process.Traversal;
+using Gremlin.Net.Process.Traversal.Strategy.Verification;
 using Xunit;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection

--- a/gremlin-python/src/main/jython/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/protocol.py
@@ -27,6 +27,7 @@ except ImportError:
     import json
 
 from gremlin_python.driver import serializer, request
+from gremlin_python.driver.resultset import ResultSet
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
@@ -75,7 +76,7 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
 
         message = self._message_serializer.deserialize_message(json.loads(message.decode('utf-8')))
         request_id = message['requestId']
-        result_set = results_dict[request_id]
+        result_set = results_dict[request_id] if request_id in results_dict else ResultSet(None, None)
         status_code = message['status']['code']
         aggregate_to = message['result']['meta'].get('aggregateTo', 'list')
         data = message['result']['data']

--- a/gremlin-python/src/main/jython/gremlin_python/process/strategies.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/strategies.py
@@ -168,6 +168,7 @@ class GraphFilterStrategy(TraversalStrategy):
     def __init__(self):
         TraversalStrategy.__init__(self)
 
+
 class EarlyLimitStrategy(TraversalStrategy):
     def __init__(self):
         TraversalStrategy.__init__(self)
@@ -175,6 +176,7 @@ class EarlyLimitStrategy(TraversalStrategy):
 ###########################
 # VERIFICATION STRATEGIES #
 ###########################
+
 
 class LambdaRestrictionStrategy(TraversalStrategy):
     def __init__(self):
@@ -184,3 +186,18 @@ class LambdaRestrictionStrategy(TraversalStrategy):
 class ReadOnlyStrategy(TraversalStrategy):
     def __init__(self):
         TraversalStrategy.__init__(self)
+
+
+class EdgeLabelVerificationStrategy(TraversalStrategy):
+    def __init__(self, log_warning=False, throw_exception=False):
+        TraversalStrategy.__init__(self)
+        self.configuration["logWarning"] = log_warning
+        self.configuration["throwException"] = throw_exception
+
+
+class ReservedKeysVerificationStrategy(TraversalStrategy):
+    def __init__(self, log_warning=False, throw_exception=False, keys=["id", "label"]):
+        TraversalStrategy.__init__(self)
+        self.configuration["logWarning"] = log_warning
+        self.configuration["throwException"] = throw_exception
+        self.configuration["keys"] = keys

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -21,6 +21,7 @@ import pytest
 from tornado import ioloop, gen
 
 from gremlin_python import statics
+from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.statics import long
 from gremlin_python.driver.driver_remote_connection import (
     DriverRemoteConnection)
@@ -30,7 +31,7 @@ from gremlin_python.process.traversal import P
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.structure.graph import Vertex
-from gremlin_python.process.strategies import SubgraphStrategy
+from gremlin_python.process.strategies import SubgraphStrategy, ReservedKeysVerificationStrategy
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
@@ -167,6 +168,16 @@ class TestDriverRemoteConnection(object):
         g = traversal().withRemote(remote_connection).withComputer()
         assert 6 == g.V().count().next()
         assert 6 == g.E().count().next()
+        #
+        g = traversal().withRemote(remote_connection). \
+            withStrategies(ReservedKeysVerificationStrategy(throw_exception=True))
+        try:
+            g.addV("person").property("id", "please-don't-use-id").iterate()
+            assert False
+        except KeyError as gse:
+            # gross we need to fix this: https://issues.apache.org/jira/browse/TINKERPOP-2297
+            # would prefer to assert a GremlinServerError status code
+            assert True
 
     def test_side_effects(self, remote_connection):
         statics.load_statics(globals())


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2280

Abstracted out a "warning" style verification strategy that ended up being used by this new strategy and EdgeLabelVerificationStrategy. If this ReservedKeysVerificationStrategy is added it will prevent the specified keys from being used in property keys. Providers can choose to implement this strategy if they have keywords they wish to prevent use of and users can of course use it as needed for their own conventions. By default, the strategy blocks use of "id" and "label" as a convention.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1

