### PR TITLE
Upgrade commons-compress to version 1.19 due to CVE-2018-11881

### DIFF
--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -119,7 +119,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.8.1</version>
+            <version>1.19</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -239,6 +239,11 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <!-- avro conflicts -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- consistent dependencies -->
@@ -287,6 +292,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
             <version>3.9.9.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.19</version>
         </dependency>
         <!-- TEST -->
         <dependency>


### PR DESCRIPTION
According to sourceclear:

https://www.sourceclear.com/vulnerability-database/security/denial-of-service-dos-/java/sid-7319

`commons-compress` is vulnerable to denial of service (DoS) attacks.

Although it looks like `hadoop-gremlin` does not use the library directly, but still may be worth upgrading.

Run `docker/build.sh -t -i` on my local, and the Reactor Summary reports `BUILD SUCCESS`.
