### PR TITLE
Fix Bytecode.addSource  arguments is null bug

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bytecode.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Bytecode.java
@@ -62,13 +62,17 @@ public final class Bytecode implements Cloneable, Serializable {
      */
     public void addSource(final String sourceName, final Object... arguments) {
         if (sourceName.equals(TraversalSource.Symbols.withoutStrategies)) {
-            final Class<TraversalStrategy>[] classes = new Class[arguments.length];
-            for (int i = 0; i < arguments.length; i++) {
-                classes[i] = arguments[i] instanceof TraversalStrategyProxy ?
-                        ((TraversalStrategyProxy) arguments[i]).getStrategyClass() :
-                        (Class) arguments[i];
+            if (arguments == null)
+                this.sourceInstructions.add(new Instruction(sourceName, null));
+            else {
+                final Class<TraversalStrategy>[] classes = new Class[arguments.length];
+                for (int i = 0; i < arguments.length; i++) {
+                    classes[i] = arguments[i] instanceof TraversalStrategyProxy ?
+                            ((TraversalStrategyProxy) arguments[i]).getStrategyClass() :
+                            (Class) arguments[i];
+                }
+                this.sourceInstructions.add(new Instruction(sourceName, classes));
             }
-            this.sourceInstructions.add(new Instruction(sourceName, classes));
         } else
             this.sourceInstructions.add(new Instruction(sourceName, flattenArguments(arguments)));
         Bindings.clear();
@@ -262,7 +266,7 @@ public final class Bytecode implements Cloneable, Serializable {
     /////
 
     private final Object[] flattenArguments(final Object... arguments) {
-        if (arguments.length == 0)
+        if (arguments == null || arguments.length == 0)
             return EMPTY_ARRAY;
         final List<Object> flatArguments = new ArrayList<>(arguments.length);
         for (final Object object : arguments) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/BytecodeTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/BytecodeTest.java
@@ -176,4 +176,15 @@ public class BytecodeTest {
         assertEquals(1, b.getStepInstructions().size());
         assertEquals(2, b.getStepInstructions().get(0).getArguments().length);
     }
+
+    @Test
+    public void shouldAvoidArgumentsNpe() {
+        final Bytecode first = new Bytecode();
+        try {
+            first.addSource("3", null);
+            first.addSource(TraversalSource.Symbols.withoutStrategies, null);
+        } catch (Exception e) {
+            e.getCause().printStackTrace(System.err);
+        }
+    }
 }


### PR DESCRIPTION
I think it is a simple bug and and could  recurrent easily,
I both fix two position and add one test case.

old jira here:
https://issues.apache.org/jira/browse/TINKERPOP-2298?jql=reporter%20in%20(currentUser())