### PR TITLE
Upgrade commons-compress to version 1.19 due to CVE-2018-11771

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Postponed the timing of transport creation to `connection.write` in Gremlin Python.
 * Made `EventStrategy` compatible with multi-valued properties.
 * Changed `TraversalOpProcessor` to throw a `SERVER_ERROR_SCRIPT_EVALUATION` (597) if lambdas don't compile.
+* Bumped `commons-compress` to 1.19 due to CVE-2018-11771.
 
 [[release-3-3-8]]
 === TinkerPop 3.3.8 (Release Date: August 5, 2019)

--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -95,6 +95,10 @@ limitations under the License.
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
             </exclusions>
             <!--<scope>provided</scope>-->
         </dependency>
@@ -136,6 +140,11 @@ limitations under the License.
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.19</version>
         </dependency>
         <!-- TEST -->
         <dependency>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -239,6 +239,11 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <!-- avro conflicts -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- consistent dependencies -->
@@ -287,6 +292,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
             <version>3.9.9.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.19</version>
         </dependency>
         <!-- TEST -->
         <dependency>


### PR DESCRIPTION
**CVE-2018-11771**

According to sourceclear:

https://www.sourceclear.com/vulnerability-database/security/denial-of-service-dos-/java/sid-7319

`commons-compress` is vulnerable to denial of service (DoS) attacks.

Although it looks like `hadoop-gremlin` does not use the library directly, but still may be worth upgrading it.

Run `docker/build.sh -t -i` on my local, and the Reactor Summary reports `BUILD SUCCESS`.
