### PR TITLE
Upgrade jackson due to CVE issues

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,8 +29,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed `TraversalExplanation` deserialization in GraphSON 2 and 3 which was not supported before in Java.
 * Added support for custom request headers in Python.
 * Deprecated `scriptEvaluationTimeout` in favor of the more generic `evaluationTimeout`.
-* Update jackson databind 2.9.9.3.
-* Bumped jackson databind 2.9.9.3.
+* Bumped jackson-databind to 2.9.10 due to CVE-2019-14379, CVE-2019-14540, CVE-2019-16335.
+* Bumped jackson-annotations to 2.9.10 to align the version of jackson-databind.
+* Bumped jackson-module-scala_2.11 to 2.9.10 to align the version of jackson-databind.
+* Bumped scala-library and scala-reflect to 2.11.12 due to the upgrade of jackson-module-scala_2.11.
 * Fixed Java driver authentication problems when calling the driver from multiple threads.
 * Modified Java driver to use IP address rather than hostname to create connections.
 * Fixed potential for `NullPointerException` with empty identifiers in `GraphStep`.

--- a/giraph-gremlin/pom.xml
+++ b/giraph-gremlin/pom.xml
@@ -132,7 +132,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.5</version>
+            <version>2.9.10</version>
         </dependency>
         <!-- TEST -->
         <dependency>

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -49,7 +49,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.3</version>
+            <version>2.9.10</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -153,13 +153,13 @@ limitations under the License.
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
-                    <version>2.11.8</version>
+                    <version>2.11.12</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-reflect</artifactId>
-                    <version>2.11.8</version>
+                    <version>2.11.12</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -239,13 +239,18 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <!-- jackson-core conflicts -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-scala_2.11</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- consistent dependencies -->
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.8</version>
+            <version>2.11.12</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
@@ -261,7 +266,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.5</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -271,7 +276,7 @@
         <dependency>
             <groupId>com.thoughtworks.paranamer</groupId>
             <artifactId>paranamer</artifactId>
-            <version>2.6</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.xerial.snappy</groupId>
@@ -287,6 +292,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
             <version>3.9.9.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_2.11</artifactId>
+            <version>2.9.10</version>
         </dependency>
         <!-- TEST -->
         <dependency>


### PR DESCRIPTION
**CVE-2019-14379, CVE-2019-14540, CVE-2019-16335**

According to sourceclear, `jackson-databind` has the following CVE issues:

CVE-2019-14379
https://www.sourceclear.com/vulnerability-database/security/remote-code-execution-rce-/java/sid-20928

CVE-2019-14540
https://www.sourceclear.com/vulnerability-database/security/deserialization-of-untrusted-data/java/sid-21522

CVE-2019-16335
https://www.sourceclear.com/vulnerability-database/security/deserialization-of-untrusted-data/java/sid-21523

* Upgraded `jackson-databind` to 2.9.10 due to CVE-2019-14379, CVE-2019-14540, CVE-2019-16335.
* Adjusted Dependency convergence errors due to the upgrade of `jackson-databind` with the following changes:
  - Aligned `jackson-annotations` to 2.9.10.
  - Aligned `jackson-module-scala_2.11` to 2.9.10.
  - Bumped `scala-library` and `scala-reflect` to 2.11.12 due to the upgrade of `jackson-module-scala_2.11`.
  - Bumped `paranamer` to 2.8.

Run `docker/build.sh -t -i -n` and the Reactor Summary reported BUILD SUCCESS.