### PR TITLE
TINKERPOP-2293 Improved landing pages for all GLVs

### DIFF
--- a/gremlin-dotnet/glv/Gremlin.Net.csproj.template
+++ b/gremlin-dotnet/glv/Gremlin.Net.csproj.template
@@ -36,8 +36,15 @@ Apache TinkerPop™ is a graph computing framework for both graph databases (OLT
 
 Gremlin.Net implements Gremlin within .NET. C# syntax has the same constructs as Java including "dot notation" for function chaining (a.b.c), round bracket function arguments (a(b,c)), and support for global namespaces (a(b()) vs a(__.b())). As such, anyone familiar with Gremlin-Java will immediately be able to work with Gremlin.Net. Moreover, there are a few added constructs to Gremlin.Net that make traversals a bit more succinct.
 
-Please see the reference documentation of Apache TinkerPop for more information on usage and use our Google Group gremlin-users if you have any questions:
-https://groups.google.com/forum/#!forum/gremlin-users
+Gremlin.Net is designed to connect to a "server" that is hosting a TinkerPop-enabled graph system. That "server" could be Gremlin Server
+
+http://tinkerpop.apache.org/docs/current/reference/#gremlin-server
+
+or a remote graph provider that exposes protocols by which Gremlin.Net can connect.
+
+Please see the reference documentation of Apache TinkerPop for more information on usage: https://s.apache.org/pgbwu
+
+and use our Google Group gremlin-users if there are any questions: https://s.apache.org/c8hru
 
 NOTE that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and thus for early testing purposes only.</Description>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -36,8 +36,15 @@ Apache TinkerPop™ is a graph computing framework for both graph databases (OLT
 
 Gremlin.Net implements Gremlin within .NET. C# syntax has the same constructs as Java including "dot notation" for function chaining (a.b.c), round bracket function arguments (a(b,c)), and support for global namespaces (a(b()) vs a(__.b())). As such, anyone familiar with Gremlin-Java will immediately be able to work with Gremlin.Net. Moreover, there are a few added constructs to Gremlin.Net that make traversals a bit more succinct.
 
-Please see the reference documentation of Apache TinkerPop for more information on usage and use our Google Group gremlin-users if you have any questions:
-https://groups.google.com/forum/#!forum/gremlin-users
+Gremlin.Net is designed to connect to a "server" that is hosting a TinkerPop-enabled graph system. That "server" could be Gremlin Server
+
+http://tinkerpop.apache.org/docs/current/reference/#gremlin-server
+
+or a remote graph provider that exposes protocols by which Gremlin.Net can connect.
+
+Please see the reference documentation of Apache TinkerPop for more information on usage: https://s.apache.org/pgbwu
+
+and use our Google Group gremlin-users if there are any questions: https://s.apache.org/c8hru
 
 NOTE that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and thus for early testing purposes only.</Description>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
@@ -32,6 +32,32 @@ Gremlin-Javascript implements Gremlin within the JavaScript language and can be 
 npm install gremlin
 ```
 
+Gremlin-Javascript is designed to connect to a "server" that is hosting a TinkerPop-enabled graph system. That "server" 
+could be [Gremlin Server][gs] or a [remote Gremlin provider][rgp] that exposes protocols by which Gremlin-Javascript 
+can connect.
+
+A typical connection to a server running on "localhost" that supports the Gremlin Server protocol using websockets 
+looks like this:
+
+```javascript
+const gremlin = require('gremlin');
+const traversal = gremlin.process.AnonymousTraversalSource.traversal;
+const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
+
+const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
+```
+
+Once "g" has been established as a connection, it is then possible to start writing Gremlin traversals to query the 
+remote graph:
+
+```javascript
+g.V().hasLabel('person').values('name').toList()
+  .then(names => console.log(names));
+
+const names = await g.V().hasLabel('person').values('name').toList();
+console.log(names);
+```
+
 Please see the [reference documentation][docs] at Apache TinkerPop for more information.
 
 NOTE that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and 
@@ -40,3 +66,5 @@ thus for early testing purposes only.
 [tk]: http://tinkerpop.apache.org
 [gremlin]: http://tinkerpop.apache.org/gremlin.html
 [docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript
+[gs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-server
+[rgp]: http://tinkerpop.apache.org/docs/current/reference/#connecting-rgp

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
@@ -47,7 +47,7 @@ const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
 ```
 
-Once "g" has been established as a connection, it is then possible to start writing Gremlin traversals to query the 
+Once "g" has been created using a connection, it is then possible to start writing Gremlin traversals to query the 
 remote graph:
 
 ```javascript

--- a/gremlin-python/src/main/jython/README
+++ b/gremlin-python/src/main/jython/README
@@ -32,6 +32,21 @@ chaining ``(a.b.c)``, round bracket function arguments ``(a(b,c))```, and suppor
 ``(a(b()) vs a(__.b()))```. As such, anyone familiar with Gremlin-Java will immediately be able to work with
 Gremlin-Python. Moreover, there are a few added constructs to Gremlin-Python that make traversals a bit more succinct.
 
+Gremlin-Python is designed to connect to a "server" that is hosting a TinkerPop-enabled graph system. That "server"
+could be `Gremlin Server <http://tinkerpop.apache.org/docs/current/reference/#gremlin-server>`_ or a
+`remote Gremlin provider` <http://tinkerpop.apache.org/docs/current/reference/#connecting-rgp>`_ that exposes
+protocols by which Gremlin-Python can connect.
+
+A typical connection to a server running on "localhost" that supports the Gremlin Server protocol using websockets
+from the Python shell looks like this:
+
+    >>> from gremlin_python.process.anonymous_traversal import traversal
+    >>> from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+    >>> g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
+
+Once "g" has been established as a connection, it is then possible to start writing Gremlin traversals to query the
+remote graph:
+
     >>> g.V().both()[1:3].toList()
     [v[2], v[4]]
     >>> g.V().both()[1].toList()

--- a/gremlin-python/src/main/jython/README
+++ b/gremlin-python/src/main/jython/README
@@ -44,7 +44,7 @@ from the Python shell looks like this:
     >>> from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
     >>> g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 
-Once "g" has been established as a connection, it is then possible to start writing Gremlin traversals to query the
+Once "g" has been created using a connection, it is then possible to start writing Gremlin traversals to query the
 remote graph:
 
     >>> g.V().both()[1:3].toList()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2293

Landing pages are what are published for each languages package manager (e.g. pypi). Made it clear that Gremlin Server or a Remote Gremlin Provider was required for these GLVs to work properly. Added enough information to explain how to create "g" in case folks aren't at all familiar with any aspect of Gremlin and wonder what that variable is. Added some more links as I didn't want to repeat information that can be found in the reference docs and ultimately we need users to head over there to get familiar with them anyway. I would have liked to have done more with .NET so that it was more like js and python but nuget isn't to robust in displaying project descriptions so there isn't much flexibility there. To my surprise, a sparse/rough project descriptions seems "normal" for nuget when I looked at other top packages.

@FlorianHockmann  and @jorgebay any additional tweaks we should make as we start approaching next release? nuget is a real pain - i finally fixed that broken gremlin-users link but had to do it by way of an Apache short link. I looked around for other examples of displaying links and even the microsoft packages just paste big fat links in their descriptions - weird.

VOTE +1