### PR TITLE
TINKERPOP-2302 add `ElementMapStep#isOnGraphComputer()` (master)

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ElementMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ElementMapStep.java
@@ -97,6 +97,9 @@ public class ElementMapStep<K,E> extends MapStep<Element, Map<K, E>> implements 
         this.onGraphComputer = true;
     }
 
+    public boolean isOnGraphComputer() {
+        return onGraphComputer;
+    }
 
     public String[] getPropertyKeys() {
         return propertyKeys;


### PR DESCRIPTION
Adds a getter for `onGraphComputer`.  This is intended to support strategies that replace this step but want to preserve this state across replacement.

https://issues.apache.org/jira/browse/TINKERPOP-2302