### PR TITLE
Removing '_' from `from` GraphTraversal Method

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
@@ -497,7 +497,7 @@ class GraphTraversal extends Traversal {
    * @param {...Object} args
    * @returns {GraphTraversal}
    */
-  from_(...args) {
+  from(...args) {
     this.bytecode.addStep('from', args);
     return this;
   }


### PR DESCRIPTION
Removing '_' from `from` GraphTraversal Method method to match documentation (http://tinkerpop.apache.org/docs/current/reference/#addedge-step - please notice step "7" api example.) 

- Would require Major version bump due to breakages in backwards compatibility.
- Could be a patch if we left `from_` unaltered, and added `from` which proxied the same thing.

This is largely just to start a conversation so that code can be referenced in a issue.