### PR TITLE
TINKERPOP-2309 Bump to Tornado 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: java
 os:
   - linux
 jdk:
-  - oraclejdk8
+  - openjdk8
 sudo: required
-dist: trusty
+dist: xenial
 services:
   - docker
 cache:
@@ -20,12 +20,13 @@ install:
   - mvn -version
 
 before_install:
-  - sudo apt-get install -y dpkg # workaround for travis-ci/travis-ci#9361
-  - wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
+  - wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
   - sudo dpkg -i packages-microsoft-prod.deb
-  - sudo apt-get install apt-transport-https
-  - sudo apt-get update
-  - sudo apt-get install dotnet-sdk-2.2
+  - sudo add-apt-repository universe
+  - sudo apt update
+  - sudo apt install apt-transport-https
+  - sudo apt update
+  - sudo apt install dotnet-sdk-2.2
 
 jobs:
   include:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-10]]
 === TinkerPop 3.3.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Bump to Tornado 5.x for gremlin-python.
 * Deprecated `TraversalStrategies.applyStrategies()`.
 
 [[release-3-3-9]]

--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -46,7 +46,7 @@ version = __version__.version
 
 install_requires = [
     'aenum>=1.4.5',
-    'tornado>=4.4.1,<5.0',
+    'tornado>=4.4.1,<6.0',
     'six>=1.10.0',
     'isodate>=0.6.0'
 ]

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -295,18 +295,3 @@ class TestDriverRemoteConnection(object):
         assert results
         results = t.side_effects.close()
         assert not results
-
-
-def test_in_tornado_app(remote_connection):
-    # Make sure nothing weird with loops
-    @gen.coroutine
-    def go():
-        conn = DriverRemoteConnection(
-            'ws://localhost:45940/gremlin', 'gmodern', pool_size=4)
-        g = traversal().withRemote(conn)
-        yield gen.sleep(0)
-        assert len(g.V().toList()) == 6
-        conn.close()
-
-    io_loop = ioloop.IOLoop.current()
-    io_loop.run_sync(go)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2309

Removed a test that started failing after the version bump. I assume it no longer is necessary given that the error is "Cannot run the event loop while another loop is running" and I've taken to mean that since asyncio is automatically use when available the test is no longer relevant.

I'm not sure if other work should be done as a result of this upgrade. I came across this comment on ipython while researching the test error I was receiving:

https://github.com/jupyter/notebook/issues/3397#issuecomment-519283894

Not sure I know enough at this time about tornado/asyncio to know what should be done to improve our implementation. If anyone cares to comment or help by making a PR, it would be appreciated.

Builds with `mvn clean install -pl gremlin-python`.

VOTE +1