### PR TITLE
fix unit test failure in non-English environment

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/OrderTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/OrderTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 public class OrderTest {
 
-    private static final SimpleDateFormat formatter = new SimpleDateFormat("dd-MMM-yyyy");
+    private static final SimpleDateFormat formatter = new SimpleDateFormat("dd-MMM-yyyy", Locale.ENGLISH);
 
     @Parameterized.Parameters(name = "{0}.test({1},{2})")
     public static Iterable<Object[]> data() throws ParseException {

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/GraphBinaryReaderWriterRoundTripTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/binary/GraphBinaryReaderWriterRoundTripTest.java
@@ -180,7 +180,7 @@ public class GraphBinaryReaderWriterRoundTripTest {
                 new Object[] {"BigDecimalNeg", new BigDecimal("-1234567890987654321.1232132"), null},
 
                 // date+time
-                new Object[] {"Date", DateFormat.getDateInstance(DateFormat.MEDIUM).parse("Jan 12, 1952"), null},
+                new Object[] {"Date", DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.ENGLISH).parse("Jan 12, 1952"), null},
                 new Object[] {"Timestamp", Timestamp.valueOf("2016-01-15 12:01:02"), null},
                 new Object[] {"Duration", Duration.ofSeconds(213123213, 400), null},
                 new Object[] {"Instant", Instant.ofEpochSecond(213123213, 400), null},


### PR DESCRIPTION
Hello everyone,
I am a gremlin user from China.
When I tried to build tinkerpop, I encountered a problem with the unit test failure. The error log looks like this:
`java.text.ParseException: Unparseable date: "1-Jan-2018"`
This is because my operating system default language is Chinese, the January in Chinese should be "一月".
This pull request can fix this problem.