### PR TITLE
TINKERPOP-2310 and TINKERPOP-2311 Folllow up refactoring after TraversalStrategy changes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Renamed `AggregateStep` to `AggregateGlobalStep`.
 * Renamed `SERVER_ERROR_SCRIPT_EVALUATION` to `SERVER_ERROR_EVALUATION` given that this response code applies to remote traversals as well as scripts.
 * Refactored `TraversalStrategies` to implement `Iterable`.
+* Refactored `Traversal` semantics to always expect `EmptyStep` as a parent if it is meant to be the root `Traversal`.
 * Configured GraphBinary as the default binary serialization format for the Java Driver.
 * Configured GraphSON 3.0 as the default text serialization format when no serializer can be determined.
 * Upgraded to Neo4j 3.4.11.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Renamed `StoreStep` to `AggregateLocalStep`.
 * Renamed `AggregateStep` to `AggregateGlobalStep`.
 * Renamed `SERVER_ERROR_SCRIPT_EVALUATION` to `SERVER_ERROR_EVALUATION` given that this response code applies to remote traversals as well as scripts.
+* Refactored `TraversalStrategies` to implement `Iterable`.
 * Configured GraphBinary as the default binary serialization format for the Java Driver.
 * Configured GraphSON 3.0 as the default text serialization format when no serializer can be determined.
 * Upgraded to Neo4j 3.4.11.

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -240,7 +240,18 @@ relied on the old ordering of application. It may also present an opportunity to
 written to gain some processing benefit to the new order. Please be sure to review any custom strategies carefully
 when upgrading to this version.
 
-See: link:https://issues.apache.org/jira/browse/TINKERPOP-1568[TINKERPOP-1568]
+As part of this change, there have been some adjustments to the `Traversal` and `Traversal.Admin` interfaces which have
+helped to clarify coding intent. There is now an `isRoot()` method which determines whether or not the traversal has a
+parent or not. Under revised semantics for 3.5.0, a traversal's parent must be an `EmptyStep` instance and should not
+be `null`. With this change, provider `TraversalStrategy` implementations should be reviewed to evaluate if `isRoot()`
+semantics cause any breaks in logic to existing code.
+
+In addition, `TraversalStrategies` now implements `Iterable` and exposes an `iterator()` method which may be preferred
+over the old `toList()` style construction for getting the list of configured strategies.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1568[TINKERPOP-1568],
+link:https://issues.apache.org/jira/browse/TINKERPOP-2310[TINKERPOP-2310],
+link:https://issues.apache.org/jira/browse/TINKERPOP-2311[TINKERPOP-2311]
 
 ===== AbstractOpProcessor API Change
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -178,7 +178,7 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
                                 this.traversal.get().getParent().asStep().getNextStep().getNextStep() instanceof ComputerResultStep));
 
         // determine how to store halted traversers
-        final Iterator<?> itty = IteratorUtils.filter(this.traversal.get().getStrategies().toList(), strategy -> strategy instanceof HaltedTraverserStrategy).iterator();
+        final Iterator<?> itty = IteratorUtils.filter(this.traversal.get().getStrategies(), strategy -> strategy instanceof HaltedTraverserStrategy).iterator();
         this.haltedTraverserStrategy = itty.hasNext() ? (HaltedTraverserStrategy) itty.next() : HaltedTraverserStrategy.reference();
 
         // register traversal side-effects in memory

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -74,7 +74,7 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
         final Traversal.Admin<?, ?> computerSpecificTraversal = this.computerTraversal.getPure();
         final TraversalStrategies computerSpecificStrategies = this.getTraversal().getStrategies().clone();
 
-        IteratorUtils.filter(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()).toList(),
+        IteratorUtils.filter(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()),
                 s -> s instanceof TraversalStrategy.ProviderOptimizationStrategy).forEach(computerSpecificStrategies::addStrategies);
 
         computerSpecificTraversal.setStrategies(computerSpecificStrategies);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/decoration/VertexProgramStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/strategy/decoration/VertexProgramStrategy.java
@@ -162,8 +162,8 @@ public final class VertexProgramStrategy extends AbstractTraversalStrategy<Trave
     }
 
     public static Optional<Computer> getComputer(final TraversalStrategies strategies) {
-        final Optional<TraversalStrategy<?>> optional = strategies.toList().stream().filter(strategy -> strategy instanceof VertexProgramStrategy).findAny();
-        return optional.isPresent() ? Optional.of(((VertexProgramStrategy) optional.get()).computer) : Optional.empty();
+        final Optional<VertexProgramStrategy> optional = strategies.getStrategy(VertexProgramStrategy.class);
+        return optional.isPresent() ? Optional.of(optional.get().computer) : Optional.empty();
     }
 
     public void addGraphComputerStrategies(final TraversalSource traversalSource) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
@@ -480,18 +480,17 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
         /**
          * Set the {@link org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent} {@link Step} that is
          * the parent of this traversal. Traversals can be nested and this is the means by which the traversal tree is
-         * connected.
+         * connected. If there is no parent, then it should be a {@link EmptyStep}.
          *
-         * @param step the traversal holder parent step
+         * @param step the traversal holder parent step or {@link EmptyStep} if it has no parent
          */
         public void setParent(final TraversalParent step);
 
         /**
-         * Get the {@link org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent} {@link Step} that is
-         * the parent of this traversal. Traversals can be nested and this is the means by which the traversal tree is
-         * walked.
+         * Get the {@link TraversalParent} {@link Step} that is the parent of this traversal. Traversals can be nested
+         * and this is the means by which the traversal tree is walked.
          *
-         * @return the traversal holder parent step
+         * @return the traversal holder parent step or {@link EmptyStep} if it has no parent.
          */
         public TraversalParent getParent();
 
@@ -499,7 +498,7 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
          * Determines if the traversal is at the root level.
          */
         public default boolean isRoot() {
-            return null == getParent() || getParent() instanceof EmptyStep;
+            return getParent() instanceof EmptyStep;
         }
 
         /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -41,6 +41,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.Stan
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.apache.tinkerpop.gremlin.util.tools.MultiMap;
 
 import java.io.Serializable;
@@ -65,19 +66,22 @@ import java.util.stream.Collectors;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public interface TraversalStrategies extends Serializable, Cloneable {
+public interface TraversalStrategies extends Serializable, Cloneable, Iterable<TraversalStrategy<?>> {
 
     static List<Class<? extends TraversalStrategy>> STRATEGY_CATEGORIES = Collections.unmodifiableList(Arrays.asList(TraversalStrategy.DecorationStrategy.class, TraversalStrategy.OptimizationStrategy.class, TraversalStrategy.ProviderOptimizationStrategy.class, TraversalStrategy.FinalizationStrategy.class, TraversalStrategy.VerificationStrategy.class));
 
     /**
-     * Return all the {@link TraversalStrategy} instances associated with this {@link TraversalStrategies}.
+     * Return an immutable list of the {@link TraversalStrategy} instances.
      */
-    public List<TraversalStrategy<?>> toList();
+    public default List<TraversalStrategy<?>> toList() {
+        return Collections.unmodifiableList(IteratorUtils.list(iterator()));
+    }
 
     /**
-     * Return all the {@link TraversalStrategy} instances associated with this {@link TraversalStrategies}.
+     * Return an {@code Iterator} of the {@link TraversalStrategy} instances.
      */
-    public Iterator<TraversalStrategy<?>> toIterator();
+    @Override
+    public Iterator<TraversalStrategy<?>> iterator();
 
     /**
      * Return the {@link TraversalStrategy} instance associated with the provided class.
@@ -87,7 +91,8 @@ public interface TraversalStrategies extends Serializable, Cloneable {
      * @return an optional containing the strategy instance or not
      */
     public default <T extends TraversalStrategy> Optional<T> getStrategy(final Class<T> traversalStrategyClass) {
-        return (Optional) toList().stream().filter(s -> traversalStrategyClass.isAssignableFrom(s.getClass())).findAny();
+        return (Optional<T>) IteratorUtils.stream(iterator()).
+                filter(s -> traversalStrategyClass.isAssignableFrom(s.getClass())).findAny();
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/RequirementsStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/RequirementsStrategy.java
@@ -49,7 +49,7 @@ public final class RequirementsStrategy extends AbstractTraversalStrategy<Traver
     }
 
     public static void addRequirements(final TraversalStrategies traversalStrategies, final TraverserRequirement... requirements) {
-        RequirementsStrategy strategy = (RequirementsStrategy) traversalStrategies.toList().stream().filter(s -> s instanceof RequirementsStrategy).findAny().orElse(null);
+        RequirementsStrategy strategy = (RequirementsStrategy) traversalStrategies.getStrategy(RequirementsStrategy.class).orElse(null);
         if (null == strategy) {
             strategy = new RequirementsStrategy();
             traversalStrategies.addStrategies(strategy);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SideEffectStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SideEffectStrategy.java
@@ -50,7 +50,7 @@ public final class SideEffectStrategy extends AbstractTraversalStrategy<Traversa
     }
 
     public static <A> void addSideEffect(final TraversalStrategies traversalStrategies, final String key, final A value, final BinaryOperator<A> reducer) {
-        SideEffectStrategy strategy = (SideEffectStrategy) traversalStrategies.toList().stream().filter(s -> s instanceof SideEffectStrategy).findAny().orElse(null);
+        SideEffectStrategy strategy = traversalStrategies.getStrategy(SideEffectStrategy.class).orElse(null);
         if (null == strategy) {
             strategy = new SideEffectStrategy();
             traversalStrategies.addStrategies(strategy);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/StandardVerificationStrategy.java
@@ -51,8 +51,8 @@ public final class StandardVerificationStrategy extends AbstractTraversalStrateg
 
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
-        if (!traversal.getStrategies().toList().contains(ComputerFinalizationStrategy.instance()) &&
-                !traversal.getStrategies().toList().contains(ComputerVerificationStrategy.instance())) {
+        if (!traversal.getStrategies().getStrategy(ComputerFinalizationStrategy.class).isPresent() &&
+                !traversal.getStrategies().getStrategy(ComputerVerificationStrategy.class).isPresent()) {
             if (!TraversalHelper.getStepsOfAssignableClass(VertexComputing.class, traversal).isEmpty())
                 throw new VerificationException("VertexComputing steps must be executed with a GraphComputer: " + TraversalHelper.getStepsOfAssignableClass(VertexComputing.class, traversal), traversal);
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -207,7 +207,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
                 return this.finalEndStep.next();
             }
         } catch (final FastNoSuchElementException e) {
-            throw this.parent instanceof EmptyStep ? new NoSuchElementException() : e;
+            throw this.isRoot() ? new NoSuchElementException() : e;
         }
     }
 
@@ -230,7 +230,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
             // and release the resources.
             CloseableIterator.closeIterator(this);
 
-            throw this.parent instanceof EmptyStep ? new NoSuchElementException() : e;
+            throw this.isRoot() ? new NoSuchElementException() : e;
         }
     }
 
@@ -347,7 +347,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
 
     @Override
     public void setParent(final TraversalParent step) {
-        this.parent = step;
+        this.parent = null == step ? EmptyStep.instance() : step;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -138,7 +138,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
             // moving side-effect setting after actual recursive strategy application we save a loop and by
             // consequence also fix a problem where strategies might reset something in sideeffects which seems to
             // happen in TranslationStrategy.
-            final Iterator<TraversalStrategy<?>> strategyIterator = this.strategies.toIterator();
+            final Iterator<TraversalStrategy<?>> strategyIterator = this.strategies.iterator();
             while (strategyIterator.hasNext()) {
                 final TraversalStrategy<?> strategy = strategyIterator.next();
                 TraversalHelper.applyTraversalRecursively(strategy::apply, this);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategies.java
@@ -70,7 +70,7 @@ public class DefaultTraversalStrategies implements TraversalStrategies {
     }
 
     @Override
-    public Iterator<TraversalStrategy<?>> toIterator() {
+    public Iterator<TraversalStrategy<?>> iterator() {
         return this.traversalStrategies.iterator();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/EmptyTraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/EmptyTraversalStrategies.java
@@ -42,7 +42,7 @@ public final class EmptyTraversalStrategies implements TraversalStrategies {
 
 
     @Override
-    public Iterator<TraversalStrategy<?>> toIterator() {
+    public Iterator<TraversalStrategy<?>> iterator() {
         return toList().iterator();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanation.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanation.java
@@ -52,7 +52,7 @@ public class TraversalExplanation extends AbstractExplanation implements Seriali
     public TraversalExplanation(final Traversal.Admin<?, ?> traversal) {
         this.traversal = traversal.clone();
         final TraversalStrategies mutatingStrategies = new DefaultTraversalStrategies();
-        for (final TraversalStrategy strategy : this.traversal.getStrategies().toList()) {
+        for (final TraversalStrategy strategy : this.traversal.getStrategies()) {
             final Traversal.Admin<?, ?> mutatingTraversal = this.traversal.clone();
             mutatingStrategies.addStrategies(strategy);
             mutatingTraversal.setStrategies(mutatingStrategies);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -687,7 +687,7 @@ public final class TraversalHelper {
         childTraversal.setStrategies(parentTraversal.getStrategies());
         childTraversal.setSideEffects(parentTraversal.getSideEffects());
         parentTraversal.getGraph().ifPresent(childTraversal::setGraph);
-        for (final TraversalStrategy<?> strategy : parentTraversal.getStrategies().toList()) {
+        for (final TraversalStrategy<?> strategy : parentTraversal.getStrategies()) {
             strategy.apply(childTraversal);
             if (null != stopAfterStrategy && stopAfterStrategy.isInstance(strategy))
                 break;

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
@@ -66,10 +66,11 @@ public class TraversalStrategiesTest {
         TestGraph graph = new TestGraph();
         TraversalStrategies strategies = graph.traversal().getStrategies();
         assertFalse(TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList().isEmpty());
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()) {
+        assertTrue(TraversalStrategies.GlobalCache.getStrategies(Graph.class).iterator().hasNext());
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(Graph.class)) {
             assertTrue(strategies.getStrategy(strategy.getClass()).isPresent());
         }
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraphComputer.class).toList()) {
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraphComputer.class)) {
             assertFalse(strategies.getStrategy(strategy.getClass()).isPresent());
         }
         assertTrue(strategies.getStrategy(StrategyA.class).isPresent());
@@ -83,10 +84,10 @@ public class TraversalStrategiesTest {
         ///
         graph = new TestGraph();
         strategies = graph.traversal().getStrategies();
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()) {
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(Graph.class)) {
             assertTrue(strategies.getStrategy(strategy.getClass()).isPresent());
         }
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraphComputer.class).toList()) {
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraphComputer.class)) {
             assertFalse(strategies.getStrategy(strategy.getClass()).isPresent());
         }
         assertFalse(strategies.getStrategy(StrategyA.class).isPresent());
@@ -98,10 +99,10 @@ public class TraversalStrategiesTest {
         //////////////////////
         strategies = TraversalStrategies.GlobalCache.getStrategies(TestGraphComputer.class);
         assertFalse(TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class).toList().isEmpty());
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class).toList()) {
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class)) {
             assertTrue(strategies.getStrategy(strategy.getClass()).isPresent());
         }
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraph.class).toList()) {
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraph.class)) {
             assertFalse(strategies.getStrategy(strategy.getClass()).isPresent());
         }
         assertFalse(strategies.getStrategy(StrategyA.class).isPresent());
@@ -112,10 +113,10 @@ public class TraversalStrategiesTest {
         //
         strategies = TraversalStrategies.GlobalCache.getStrategies(TestGraphComputer.class);
         assertFalse(TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class).toList().isEmpty());
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class).toList()) {
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class)) {
             assertTrue(strategies.getStrategy(strategy.getClass()).isPresent());
         }
-        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraph.class).toList()) {
+        for (final TraversalStrategy strategy : TraversalStrategies.GlobalCache.getStrategies(TestGraph.class)) {
             assertFalse(strategies.getStrategy(strategy.getClass()).isPresent());
         }
         assertFalse(strategies.getStrategy(StrategyA.class).isPresent());

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProfileTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProfileTest.java
@@ -55,7 +55,6 @@ import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.GRATEFUL;
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -258,8 +257,8 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
 
         final TraversalMetrics traversalMetrics = traversal.next();
         validate_g_V_repeat_both_modern_profile(traversalMetrics,
-                traversal.asAdmin().getStrategies().toList().contains(RepeatUnrollStrategy.instance()) &&
-                        !traversal.asAdmin().getStrategies().toList().contains(ComputerVerificationStrategy.instance()));
+                traversal.asAdmin().getStrategies().getStrategy(RepeatUnrollStrategy.class).isPresent() &&
+                        !traversal.asAdmin().getStrategies().getStrategy(ComputerVerificationStrategy.class).isPresent());
     }
 
     @Test
@@ -270,8 +269,8 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
         traversal.iterate();
         final TraversalMetrics traversalMetrics = traversal.asAdmin().getSideEffects().get(METRICS_KEY);
         validate_g_V_repeat_both_modern_profile(traversalMetrics,
-                traversal.asAdmin().getStrategies().toList().contains(RepeatUnrollStrategy.instance()) &&
-                        !traversal.asAdmin().getStrategies().toList().contains(ComputerVerificationStrategy.instance()));
+                traversal.asAdmin().getStrategies().getStrategy(RepeatUnrollStrategy.class).isPresent() &&
+                        !traversal.asAdmin().getStrategies().getStrategy(ComputerVerificationStrategy.class).isPresent());
     }
 
     private void validate_g_V_repeat_both_modern_profile(final TraversalMetrics traversalMetrics, final boolean withRepeatUnrollStrategy) {
@@ -326,7 +325,7 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
         assertEquals(1, metrics.getCount(TraversalMetrics.TRAVERSER_COUNT_ID).longValue());
         assertEquals(1, metrics.getCount(TraversalMetrics.ELEMENT_COUNT_ID).longValue());
 
-        if (traversal.asAdmin().getStrategies().toList().stream().anyMatch(s -> s instanceof CountStrategy)) {
+        if (traversal.asAdmin().getStrategies().getStrategy(CountStrategy.class).isPresent()) {
             assertEquals("Metrics 1 should have 4 nested metrics.", 4, metrics.getNested().size());
         } else {
             assertEquals("Metrics 1 should have 3 nested metrics.", 3, metrics.getNested().size());

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/EarlyLimitStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/EarlyLimitStrategyProcessTest.java
@@ -90,7 +90,7 @@ public class EarlyLimitStrategyProcessTest extends AbstractGremlinProcessTest {
         assumeTrue("The following assertions apply to TinkerGraph only as provider strategies can alter the " +
                         "steps to not comply with expectations", graph.getClass().getSimpleName().equals("TinkerGraph"));
 
-        if (t.asAdmin().getStrategies().toList().stream().anyMatch(s -> s instanceof EarlyLimitStrategy)) {
+        if (t.asAdmin().getStrategies().getStrategy(EarlyLimitStrategy.class).isPresent()) {
             assertEquals(10, metrics.getMetrics().size());
             assertTrue(metrics.getMetrics(5).getName().endsWith("@[d]"));
             assertEquals("RangeGlobalStep(0,1)", metrics.getMetrics(6).getName());

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/interceptor/SparkStarBarrierInterceptor.java
@@ -163,7 +163,7 @@ public final class SparkStarBarrierInterceptor implements SparkVertexProgramInte
         final Step<?, ?> startStep = traversal.getStartStep();
         final Step<?, ?> endStep = traversal.getEndStep();
         // right now this is not supported because of how the SparkStarBarrierInterceptor mutates the traversal prior to local evaluation
-        if (traversal.getStrategies().toList().stream().filter(strategy -> strategy instanceof SubgraphStrategy).findAny().isPresent())
+        if (traversal.getStrategies().getStrategy(SubgraphStrategy.class).isPresent())
             return false;
         if (!startStep.getClass().equals(GraphStep.class) || ((GraphStep) startStep).returnsEdge())
             return false;

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkInterceptorStrategyTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkInterceptorStrategyTest.java
@@ -69,9 +69,9 @@ public class SparkInterceptorStrategyTest extends AbstractSparkTest {
         ///
         Graph graph = GraphFactory.open(configuration);
         GraphTraversalSource g = graph.traversal().withComputer().withoutStrategies(SparkSingleIterationStrategy.class);
-        assertFalse(g.getStrategies().toList().contains(SparkSingleIterationStrategy.instance()));
+        assertFalse(g.getStrategies().getStrategy(SparkSingleIterationStrategy.class).isPresent());
         assertFalse(g.V().count().explain().toString().contains(SparkSingleIterationStrategy.class.getSimpleName()));
-        assertTrue(g.getStrategies().toList().contains(SparkInterceptorStrategy.instance()));
+        assertTrue(g.getStrategies().getStrategy(SparkInterceptorStrategy.class).isPresent());
         assertTrue(g.V().count().explain().toString().contains(SparkInterceptorStrategy.class.getSimpleName()));
         /// groupCount(m)-test
         Traversal.Admin<Vertex, Long> traversal = g.V().groupCount("m").by(T.label).count().asAdmin();
@@ -97,9 +97,9 @@ public class SparkInterceptorStrategyTest extends AbstractSparkTest {
         ///
         Graph graph = GraphFactory.open(configuration);
         GraphTraversalSource g = graph.traversal().withComputer().withoutStrategies(SparkSingleIterationStrategy.class);
-        assertFalse(g.getStrategies().toList().contains(SparkSingleIterationStrategy.instance()));
+        assertFalse(g.getStrategies().getStrategy(SparkSingleIterationStrategy.class).isPresent());
         assertFalse(g.V().count().explain().toString().contains(SparkSingleIterationStrategy.class.getSimpleName()));
-        assertTrue(g.getStrategies().toList().contains(SparkInterceptorStrategy.instance()));
+        assertTrue(g.getStrategies().getStrategy(SparkInterceptorStrategy.class).isPresent());
         assertTrue(g.V().count().explain().toString().contains(SparkInterceptorStrategy.class.getSimpleName()));
         /// SparkCountInterceptor matches
         test(SparkStarBarrierInterceptor.class, 6l, g.V().count());

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkSingleIterationStrategyTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/traversal/strategy/optimization/SparkSingleIterationStrategyTest.java
@@ -88,11 +88,11 @@ public class SparkSingleIterationStrategyTest extends AbstractSparkTest {
 
         Graph graph = GraphFactory.open(configuration);
         GraphTraversalSource g = graph.traversal().withComputer().withoutStrategies(SparkInterceptorStrategy.class, MessagePassingReductionStrategy.class);
-        assertFalse(g.getStrategies().toList().contains(SparkInterceptorStrategy.instance()));
+        assertFalse(g.getStrategies().getStrategy(SparkInterceptorStrategy.class).isPresent());
         assertFalse(g.V().count().explain().getStrategyTraversals().stream().filter(pair -> pair.getValue0() instanceof SparkInterceptorStrategy).findAny().isPresent());
-        assertFalse(g.getStrategies().toList().contains(MessagePassingReductionStrategy.instance()));
+        assertFalse(g.getStrategies().getStrategy(MessagePassingReductionStrategy.class).isPresent());
         assertFalse(g.V().count().explain().getStrategyTraversals().stream().filter(pair -> pair.getValue0() instanceof MessagePassingReductionStrategy).findAny().isPresent());
-        assertTrue(g.getStrategies().toList().contains(SparkSingleIterationStrategy.instance()));
+        assertTrue(g.getStrategies().getStrategy(SparkSingleIterationStrategy.class).isPresent());
         assertTrue(g.V().count().explain().getStrategyTraversals().stream().filter(pair -> pair.getValue0() instanceof SparkSingleIterationStrategy).findAny().isPresent());
 
         test(true, g.V().limit(10));
@@ -116,11 +116,11 @@ public class SparkSingleIterationStrategyTest extends AbstractSparkTest {
 
         graph = GraphFactory.open(configuration);
         g = graph.traversal().withComputer().withoutStrategies(SparkInterceptorStrategy.class).withStrategies(MessagePassingReductionStrategy.instance());
-        assertFalse(g.getStrategies().toList().contains(SparkInterceptorStrategy.instance()));
+        assertFalse(g.getStrategies().getStrategy(SparkInterceptorStrategy.class).isPresent());
         assertFalse(g.V().count().explain().getStrategyTraversals().stream().filter(pair -> pair.getValue0() instanceof SparkInterceptorStrategy).findAny().isPresent());
-        assertTrue(g.getStrategies().toList().contains(MessagePassingReductionStrategy.instance()));
+        assertTrue(g.getStrategies().getStrategy(MessagePassingReductionStrategy.class).isPresent());
         assertTrue(g.V().count().explain().getStrategyTraversals().stream().filter(pair -> pair.getValue0() instanceof MessagePassingReductionStrategy).findAny().isPresent());
-        assertTrue(g.getStrategies().toList().contains(SparkSingleIterationStrategy.instance()));
+        assertTrue(g.getStrategies().getStrategy(SparkSingleIterationStrategy.class).isPresent());
         assertTrue(g.V().count().explain().getStrategyTraversals().stream().filter(pair -> pair.getValue0() instanceof SparkSingleIterationStrategy).findAny().isPresent());
 
         test(true, g.V().limit(10));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2310
https://issues.apache.org/jira/browse/TINKERPOP-2311

A few added refactoring opportunities were noticed as a result of TINKERPOP-1568. Basically, `TraversalStrategies` now implements `Iterable` and the semantics of `Traversal.isRoot()` have been narrowed to only check for `EmptyStep` rather than also checking for `null`.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1