### PR TITLE
TINKERPOP-1733 Support g.E().properties().hasKey('xx') & hasValue('xx')

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
@@ -84,17 +84,12 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
         if (this.key.equals(T.label.getAccessor()))
             return testLabel(element);
 
-        if (element instanceof Vertex) {
-            final Iterator<? extends Property> itty = element.properties(this.key);
-            while (itty.hasNext()) {
-                if (testValue(itty.next()))
-                    return true;
-            }
-            return false;
-        } else {
-            final Property property = element.property(this.key);
-            return property.isPresent() && testValue(property);
+        final Iterator<? extends Property> itty = element.properties(this.key);
+        while (itty.hasNext()) {
+            if (testValue(itty.next()))
+                return true;
         }
+        return false;
     }
 
     public final boolean test(final Property property) {
@@ -128,7 +123,6 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
     protected boolean testKey(Property property) {
         return this.predicate.test(property.key());
     }
-
 
     public final String toString() {
         return this.key + '.' + this.predicate;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -46,6 +46,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -838,7 +839,7 @@ public final class StarGraph implements Graph, Serializable {
     public final class StarOutEdge extends StarEdge {
 
         private StarOutEdge(final Object id, final String label, final Object otherId) {
-            super(id, label, otherId);
+            super(new StarEdgeId(id, otherId), label, otherId);
         }
 
         @Override
@@ -855,7 +856,7 @@ public final class StarGraph implements Graph, Serializable {
     public final class StarInEdge extends StarEdge {
 
         private StarInEdge(final Object id, final String label, final Object otherId) {
-            super(id, label, otherId);
+            super(new StarEdgeId(otherId, id), label, otherId);
         }
 
         @Override
@@ -866,6 +867,32 @@ public final class StarGraph implements Graph, Serializable {
         @Override
         public Vertex inVertex() {
             return starVertex;
+        }
+    }
+
+    public final class StarEdgeId {
+
+        private final Object outVertexId;
+        private final Object inVertexId;
+
+        public StarEdgeId(Object outVertexId, Object inVertexId) {
+            this.outVertexId = outVertexId;
+            this.inVertexId = inVertexId;
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (!(other instanceof StarEdgeId)) {
+                return false;
+            }
+            StarEdgeId otherId = (StarEdgeId) other;
+            return Objects.equals(this.outVertexId, otherId.outVertexId) &&
+                   Objects.equals(this.inVertexId, otherId.inVertexId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.outVertexId, this.inVertexId);
         }
     }
 

--- a/gremlin-test/features/filter/Has.feature
+++ b/gremlin-test/features/filter/Has.feature
@@ -408,19 +408,6 @@ Feature: Step - has()
       | v[josh] |
       | v[peter] |
 
-  Scenario: g_V_both_dedup_properties_hasKeyXageX_value
-    Given the modern graph
-    And the traversal of
-    """
-    g.V().both().properties().dedup().hasKey("age").value()
-    """
-    When iterated to list
-    Then the result should be unordered
-      | result |
-      | d[29].i |
-      | d[27].i |
-      | d[32].i |
-      | d[35].i |
   Scenario: g_V_hasXage_withinX27X_count
     Given the modern graph
     And the traversal of
@@ -465,6 +452,19 @@ Feature: Step - has()
       | result |
       | d[2].l |
 
+  Scenario: g_V_both_dedup_properties_hasKeyXageX_value
+    Given the modern graph
+    And the traversal of
+    """
+    g.V().both().properties().dedup().hasKey("age").value()
+    """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[29].i |
+      | d[27].i |
+      | d[32].i |
+      | d[35].i |
 
   Scenario: g_V_both_dedup_properties_hasKeyXageX_hasValueXgtX30XX_value
     Given the modern graph
@@ -478,6 +478,34 @@ Feature: Step - has()
       | result |
       | d[32].i |
       | d[35].i |
+
+  Scenario: g_V_bothE_properties_dedup_hasKeyXweightX_value
+    Given the modern graph
+    And the traversal of
+    """
+    g.V().bothE().properties().dedup().hasKey("weight").value()
+    """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[0.5].d |
+      | d[0.4].d |
+      | d[1.0].d |
+      | d[0.2].d |
+      | d[0.4].d |
+      | d[1.0].d |
+
+  Scenario: g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value
+    Given the modern graph
+    And using the parameter d0d3 defined as "d[0.3].d"
+    And the traversal of
+    """
+    g.V().bothE().properties().dedup().hasKey("weight").hasValue(P.lt(0.3)).value()
+    """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[0.2].d |
 
   Scenario: g_V_hasNotXageX_name
     Given the modern graph

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
@@ -105,6 +105,10 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Integer> get_g_V_both_properties_dedup_hasKeyXageX_hasValueXgtX30XX_value();
 
+    public abstract Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_value();
+
+    public abstract Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value();
+
     public abstract Traversal<Vertex, String> get_g_V_hasNotXageX_name();
 
     public abstract Traversal<Vertex, Vertex> get_g_V_hasIdX1X_hasIdX2X(final Object v1Id, final Object v2Id);
@@ -478,6 +482,22 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
     }
 
     @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_bothE_properties_dedup_hasKeyXweightX_value() {
+        final Traversal<Vertex, Double> traversal = get_g_V_bothE_properties_dedup_hasKeyXweightX_value();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(0.5, 0.4, 1.0, 0.2, 0.4, 1.0), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value() {
+        final Traversal<Vertex, Double> traversal = get_g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(0.2), traversal);
+    }
+
+    @Test
     @LoadGraphWith
     public void g_V_hasNotXageX_name() {
         final Traversal<Vertex, String> traversal = get_g_V_hasNotXageX_name();
@@ -781,6 +801,16 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Integer> get_g_V_both_properties_dedup_hasKeyXageX_hasValueXgtX30XX_value() {
             return g.V().both().properties().dedup().hasKey("age").hasValue(P.gt(30)).value();
+        }
+
+        @Override
+        public Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_value() {
+            return g.V().bothE().properties().dedup().hasKey("weight").value();
+        }
+
+        @Override
+        public Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value() {
+            return g.V().bothE().properties().dedup().hasKey("weight").hasValue(P.lt(0.3)).value();
         }
 
         @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2313
https://issues.apache.org/jira/browse/TINKERPOP-1733

Currently, an exception will be thrown for this query: `XxProperty cannot be cast to Element`