### PR TITLE
TINKERPOP-1733 Support g.E().properties().hasKey('xx') & hasValue('xx')

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ This release also includes changes from <<release-3-3-10, 3.3.10>>.
 * Improved error messaging for `by(String)` so that it is more clear as to what the problem is
 * Bump to Netty 4.1.42
 * GraphBinary: Introduced our own `Buffer` API as a way to wrap Netty's Buffer API. Moved `GraphBinaryReader`, `GraphBinaryWriter` and `TypeSerializer<T>` to gremlin-core.
+* TINKERPOP-2318 Unify the behavior of property comparison: only compare key&value.
+* TINKERPOP-1733 Support hasKey() and hasValue() step for edge property and meta property, like `g.E().properties().hasKey('xx')`.
 
 [[release-3-4-4]]
 === TinkerPop 3.4.4 (Release Date: October 14, 2019)

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -94,6 +94,176 @@ Display stack trace? [yN]n
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2314[TINKERPOP-2314]
 
+==== hasKey() Step and hasValue() Step
+
+Previously, hasKey() Step and hasValue() Step is only supported applying to vertex property. In order to support more general scenarios, these two steps are currently allowed to be applied to edge property and meta property.
+
+Old behavior of hasKey() / hasValue() with edge property and meta property:
+
+[source,groovy]
+----
+gremlin> graph = TinkerFactory.createTheCrew()
+==>tinkergraph[vertices:6 edges:14]
+gremlin> g = graph.traversal()
+==>graphtraversalsource[tinkergraph[vertices:6 edges:14], standard]
+
+gremlin> g.E().properties().hasKey('since')
+TinkerProperty cannot be cast to Element
+
+gremlin> g.V().properties("location").properties().hasKey("startTime")
+TinkerProperty cannot be cast to Element
+
+gremlin> g.E().properties().hasValue(2010)
+TinkerProperty cannot be cast to Element
+
+gremlin> g.V().properties("location").properties().hasValue(2005)
+TinkerProperty cannot be cast to Element
+----
+
+New behavior of hasKey() with edge property:
+
+[source,groovy]
+----
+gremlin> g.E().properties().hasKey('since')
+==>p[since->2009]
+==>p[since->2010]
+==>p[since->2010]
+==>p[since->2011]
+==>p[since->2012]
+----
+
+New behavior of hasKey() with meta property:
+
+[source,groovy]
+----
+gremlin> g.V().properties().hasKey('location').properties().hasKey('startTime')
+==>p[startTime->1997]
+==>p[startTime->2001]
+==>p[startTime->2004]
+==>p[startTime->2004]
+==>p[startTime->2005]
+==>p[startTime->2005]
+==>p[startTime->1990]
+==>p[startTime->2000]
+==>p[startTime->2006]
+==>p[startTime->2007]
+==>p[startTime->2011]
+==>p[startTime->2014]
+==>p[startTime->1982]
+==>p[startTime->2009]
+----
+
+New behavior of hasValue() with edge property:
+
+[source,groovy]
+----
+gremlin> g.E().properties().hasValue(2010)
+==>p[since->2010]
+==>p[since->2010]
+----
+
+New behavior of hasValue() with meta property:
+
+[source,groovy]
+----
+gremlin> g.V().properties().hasKey('location').properties().hasValue(2005)
+==>p[endTime->2005]
+==>p[endTime->2005]
+==>p[startTime->2005]
+==>p[startTime->2005]
+----
+
+link:https://issues.apache.org/jira/browse/TINKERPOP-1733[TINKERPOP-1733]
+
+==== Properties comparison regardless of parent elements
+
+Unify the behavior of property comparison: two properties are equal only if their key&value are equal, even if their parent elements are not equal. It makes sense when comparing properties regardless of parent elements, just focus on the property itself, it would be more uniform and concise.
+The benefit of this change is that the behavior of property comparison and `dedup()`-step are predictable, and it will not affect the result whether a property detaches the parent element.
+Note: The "property" here refer to edge property and meta property, excluding vertex property.
+
+Old behavior:
+
+[source,groovy]
+----
+gremlin> graph = TinkerFactory.createTheCrew()
+==>tinkergraph[vertices:6 edges:14]
+gremlin> g = graph.traversal()
+==>graphtraversalsource[tinkergraph[vertices:6 edges:14], standard]
+
+gremlin> g.E().properties().count()
+==>13
+
+gremlin> g.E().properties()
+==>p[since->2009]
+==>p[since->2010]
+==>p[skill->4]
+==>p[skill->5]
+==>p[since->2010]
+==>p[since->2011]
+==>p[skill->5]
+==>p[skill->4]
+==>p[since->2012]
+==>p[skill->3]
+==>p[skill->3]
+==>p[skill->5]
+==>p[skill->3]
+
+gremlin> g.E().properties().dedup().count()
+==>13
+
+gremlin> g.E().dedup().properties()
+==>p[since->2009]
+==>p[since->2010]
+==>p[skill->4]
+==>p[skill->5]
+==>p[since->2010]
+==>p[since->2011]
+==>p[skill->5]
+==>p[skill->4]
+==>p[since->2012]
+==>p[skill->3]
+==>p[skill->3]
+==>p[skill->5]
+==>p[skill->3]
+----
+
+New behavior:
+
+[source,groovy]
+----
+gremlin> g.E().properties().count()
+==>13
+
+gremlin> g.E().properties()
+==>p[since->2009]
+==>p[since->2010]
+==>p[skill->4]
+==>p[skill->5]
+==>p[since->2010]
+==>p[since->2011]
+==>p[skill->5]
+==>p[skill->4]
+==>p[since->2012]
+==>p[skill->3]
+==>p[skill->3]
+==>p[skill->5]
+==>p[skill->3]
+
+gremlin> g.E().properties().dedup().count()
+==>7
+
+gremlin> g.E().properties().dedup()
+==>p[since->2009]
+==>p[since->2010]
+==>p[skill->4]
+==>p[skill->5]
+==>p[since->2011]
+==>p[since->2012]
+==>p[skill->3]
+----
+
+link:https://issues.apache.org/jira/browse/TINKERPOP-2318[TINKERPOP-2318]
+
 === Upgrading for Providers
 
 ==== Graph Driver Providers

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
@@ -84,17 +84,12 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
         if (this.key.equals(T.label.getAccessor()))
             return testLabel(element);
 
-        if (element instanceof Vertex) {
-            final Iterator<? extends Property> itty = element.properties(this.key);
-            while (itty.hasNext()) {
-                if (testValue(itty.next()))
-                    return true;
-            }
-            return false;
-        } else {
-            final Property property = element.property(this.key);
-            return property.isPresent() && testValue(property);
+        final Iterator<? extends Property> itty = element.properties(this.key);
+        while (itty.hasNext()) {
+            if (testValue(itty.next()))
+                return true;
         }
+        return false;
     }
 
     public final boolean test(final Property property) {
@@ -126,7 +121,6 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
     protected boolean testKey(Property property) {
         return this.predicate.test(property.key());
     }
-
 
     public final String toString() {
         return this.key + '.' + this.predicate;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
@@ -81,25 +81,30 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
         // if the predicate value is a String.  this allows stuff like: g.V().has(id,lt(10)) to work properly
         if (this.key.equals(T.id.getAccessor()))
             return testingIdString ? testIdAsString(element) : testId(element);
-        else if (this.key.equals(T.label.getAccessor()))
+        if (this.key.equals(T.label.getAccessor()))
             return testLabel(element);
-        else if (element instanceof VertexProperty && this.key.equals(T.value.getAccessor()))
-            return testValue((VertexProperty) element);
-        else if (element instanceof VertexProperty && this.key.equals(T.key.getAccessor()))
-            return testKey((VertexProperty) element);
-        else {
-            if (element instanceof Vertex) {
-                final Iterator<? extends Property> itty = element.properties(this.key);
-                while (itty.hasNext()) {
-                    if (testValue(itty.next()))
-                        return true;
-                }
-                return false;
-            } else {
-                final Property property = element.property(this.key);
-                return property.isPresent() && testValue(property);
+
+        if (element instanceof Vertex) {
+            final Iterator<? extends Property> itty = element.properties(this.key);
+            while (itty.hasNext()) {
+                if (testValue(itty.next()))
+                    return true;
             }
+            return false;
+        } else {
+            final Property property = element.property(this.key);
+            return property.isPresent() && testValue(property);
         }
+    }
+
+    public final boolean test(final Property property) {
+        if (this.key.equals(T.value.getAccessor()))
+            return testValue(property);
+        if (this.key.equals(T.key.getAccessor()))
+            return testKey(property);
+        if (property instanceof Element)
+            return test((Element) property);
+        return false;
     }
 
     protected boolean testId(Element element) {
@@ -175,10 +180,16 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
         }
     }
 
-    public static boolean testAll(final Element element, final List<HasContainer> hasContainers) {
+    public static <S> boolean testAll(final S element, final List<HasContainer> hasContainers) {
+        boolean isProperty = element instanceof Property;
         for (final HasContainer hasContainer : hasContainers) {
-            if (!hasContainer.test(element))
-                return false;
+            if (isProperty) {
+                if (!hasContainer.test((Property) element))
+                    return false;
+            } else {
+                if (!hasContainer.test((Element) element))
+                    return false;
+            }
         }
         return true;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelper.java
@@ -394,11 +394,10 @@ public final class ElementHelper {
      * @return true if elements and equal and false otherwise
      */
     public static boolean areEqual(final Element a, final Object b) {
-        if (null == b || null == a)
-            return false;
-
         if (a == b)
             return true;
+        if (null == b || null == a)
+            return false;
         if (!((a instanceof Vertex && b instanceof Vertex) ||
                 (a instanceof Edge && b instanceof Edge) ||
                 (a instanceof VertexProperty && b instanceof VertexProperty)))
@@ -471,18 +470,17 @@ public final class ElementHelper {
      * @return true if equal and false otherwise
      */
     public static boolean areEqual(final Property a, final Object b) {
-        if (null == b || null == a)
-            return false;
-
         if (a == b)
             return true;
+        if (null == b || null == a)
+            return false;
         if (!(b instanceof Property))
             return false;
         if (!a.isPresent() && !((Property) b).isPresent())
             return true;
         if (!a.isPresent() && ((Property) b).isPresent() || a.isPresent() && !((Property) b).isPresent())
             return false;
-        return a.key().equals(((Property) b).key()) && a.value().equals(((Property) b).value()) && areEqual(a.element(), ((Property) b).element());
+        return a.key().equals(((Property) b).key()) && a.value().equals(((Property) b).value());
 
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelperTest.java
@@ -277,8 +277,8 @@ public class ElementHelperTest {
     }
 
     @Test
-    public void shouldDetermineElementsAreNotEqualWhenBothNull() {
-        assertFalse(ElementHelper.areEqual((Element) null, null));
+    public void shouldDetermineElementsAreEqualWhenBothNull() {
+        assertTrue(ElementHelper.areEqual((Element) null, null));
     }
 
     @Test
@@ -312,8 +312,8 @@ public class ElementHelperTest {
     }
 
     @Test
-    public void shouldDeterminePropertiesAreNotEqualBecauseBothAreNull() {
-        assertFalse(ElementHelper.areEqual((Property) null, null));
+    public void shouldDeterminePropertiesAreEqualBecauseBothAreNull() {
+        assertTrue(ElementHelper.areEqual((Property) null, null));
     }
 
     @Test
@@ -384,7 +384,7 @@ public class ElementHelperTest {
     }
 
     @Test
-    public void shouldDeterminePropertiesAreNotEqualWhenElementsAreDifferent() {
+    public void shouldDeterminePropertiesAreEqualWhenElementsAreDifferent() {
         final Property mockPropertyA = mock(Property.class);
         final Property mockPropertyB = mock(Property.class);
         final Element mockElement = mock(Element.class);
@@ -398,7 +398,7 @@ public class ElementHelperTest {
         when(mockPropertyA.value()).thenReturn("v");
         when(mockPropertyB.value()).thenReturn("v");
 
-        assertFalse(ElementHelper.areEqual(mockPropertyA, mockPropertyB));
+        assertTrue(ElementHelper.areEqual(mockPropertyA, mockPropertyB));
     }
 
     @Test

--- a/gremlin-test/features/filter/Has.feature
+++ b/gremlin-test/features/filter/Has.feature
@@ -408,19 +408,6 @@ Feature: Step - has()
       | v[josh] |
       | v[peter] |
 
-  Scenario: g_V_both_dedup_properties_hasKeyXageX_value
-    Given the modern graph
-    And the traversal of
-    """
-    g.V().both().properties().dedup().hasKey("age").value()
-    """
-    When iterated to list
-    Then the result should be unordered
-      | result |
-      | d[29].i |
-      | d[27].i |
-      | d[32].i |
-      | d[35].i |
   Scenario: g_V_hasXage_withinX27X_count
     Given the modern graph
     And the traversal of
@@ -465,6 +452,19 @@ Feature: Step - has()
       | result |
       | d[2].l |
 
+  Scenario: g_V_both_dedup_properties_hasKeyXageX_value
+    Given the modern graph
+    And the traversal of
+    """
+    g.V().both().properties().dedup().hasKey("age").value()
+    """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[29].i |
+      | d[27].i |
+      | d[32].i |
+      | d[35].i |
 
   Scenario: g_V_both_dedup_properties_hasKeyXageX_hasValueXgtX30XX_value
     Given the modern graph
@@ -478,6 +478,32 @@ Feature: Step - has()
       | result |
       | d[32].i |
       | d[35].i |
+
+  Scenario: g_V_bothE_properties_dedup_hasKeyXweightX_value
+    Given the modern graph
+    And the traversal of
+    """
+    g.V().bothE().properties().dedup().hasKey("weight").value()
+    """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[0.5].d |
+      | d[1.0].d |
+      | d[0.4].d |
+      | d[0.2].d |
+
+  Scenario: g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value
+    Given the modern graph
+    And using the parameter d0d3 defined as "d[0.3].d"
+    And the traversal of
+    """
+    g.V().bothE().properties().dedup().hasKey("weight").hasValue(P.lt(0.3)).value()
+    """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[0.2].d |
 
   Scenario: g_V_hasNotXageX_name
     Given the modern graph

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
@@ -105,6 +105,10 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Integer> get_g_V_both_properties_dedup_hasKeyXageX_hasValueXgtX30XX_value();
 
+    public abstract Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_value();
+
+    public abstract Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value();
+
     public abstract Traversal<Vertex, String> get_g_V_hasNotXageX_name();
 
     public abstract Traversal<Vertex, Vertex> get_g_V_hasIdX1X_hasIdX2X(final Object v1Id, final Object v2Id);
@@ -478,6 +482,22 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
     }
 
     @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_bothE_properties_dedup_hasKeyXweightX_value() {
+        final Traversal<Vertex, Double> traversal = get_g_V_bothE_properties_dedup_hasKeyXweightX_value();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(0.5, 1.0, 0.4, 0.2), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value() {
+        final Traversal<Vertex, Double> traversal = get_g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(0.2), traversal);
+    }
+
+    @Test
     @LoadGraphWith
     public void g_V_hasNotXageX_name() {
         final Traversal<Vertex, String> traversal = get_g_V_hasNotXageX_name();
@@ -781,6 +801,16 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Integer> get_g_V_both_properties_dedup_hasKeyXageX_hasValueXgtX30XX_value() {
             return g.V().both().properties().dedup().hasKey("age").hasValue(P.gt(30)).value();
+        }
+
+        @Override
+        public Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_value() {
+            return g.V().bothE().properties().dedup().hasKey("weight").value();
+        }
+
+        @Override
+        public Traversal<Vertex, Double> get_g_V_bothE_properties_dedup_hasKeyXweightX_hasValueXltX0d3XX_value() {
+            return g.V().bothE().properties().dedup().hasKey("weight").hasValue(P.lt(0.3)).value();
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedPropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedPropertyTest.java
@@ -95,8 +95,14 @@ public class DetachedPropertyTest extends AbstractGremlinTest {
 
     @Test
     @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
-    public void shouldNotBeEqualPropertiesAsThereIsDifferentId() {
-        assertFalse(DetachedFactory.detach(g.E(convertToEdgeId("marko", "created", "lop")).next().property("weight")).equals(DetachedFactory.detach(g.E(convertToEdgeId("josh", "created", "lop")).next().property("weight"))));
+    public void shouldBeEqualPropertiesWithSameKeyValueAndDifferentElement() {
+        assertTrue(DetachedFactory.detach(g.E(convertToEdgeId("marko", "created", "lop")).next().property("weight")).equals(DetachedFactory.detach(g.E(convertToEdgeId("josh", "created", "lop")).next().property("weight"))));
+    }
+
+    @Test
+    @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+    public void shouldNotBeEqualPropertiesAsThereIsDifferentValue() {
+        assertFalse(DetachedFactory.detach(g.E(convertToEdgeId("marko", "created", "lop")).next().property("weight")).equals(DetachedFactory.detach(g.E(convertToEdgeId("peter", "created", "lop")).next().property("weight"))));
     }
 
     @Test
@@ -105,7 +111,7 @@ public class DetachedPropertyTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.EdgePropertyFeatures.class, feature = Graph.Features.EdgePropertyFeatures.FEATURE_DOUBLE_VALUES)
     public void shouldNotBeEqualPropertiesAsThereIsDifferentKey() {
         final Object joshCreatedLopEdgeId = convertToEdgeId("josh", "created", "lop");
-        final Edge e = g.V(convertToVertexId("josh")).next().addEdge("created", g.V(convertToVertexId("lop")).next(), "weight", 0.4d);
-        assertFalse(DetachedFactory.detach(e.property("weight")).equals(DetachedFactory.detach(g.E(joshCreatedLopEdgeId).next().property("weight"))));
+        final Edge e = g.V(convertToVertexId("josh")).next().addEdge("created", g.V(convertToVertexId("lop")).next(), "double", 0.4d);
+        assertFalse(DetachedFactory.detach(e.property("double")).equals(DetachedFactory.detach(g.E(joshCreatedLopEdgeId).next().property("weight"))));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2313
https://issues.apache.org/jira/browse/TINKERPOP-1733
https://issues.apache.org/jira/browse/TINKERPOP-2318

Currently, an exception will be thrown for this query: `XxProperty cannot be cast to Element`