### PR TITLE
make Cluster be able to open file in classpath resource dir

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-3-10]]
 === TinkerPop 3.3.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Made `Cluster` be able to open configuration file on resources directory.
 * Bump to Tornado 5.x for gremlin-python.
 * Deprecated `TraversalStrategies.applyStrategies()`.
 * Deprecated Jython support in `gremlin-python`.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -1605,4 +1605,10 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             assertThat(root.getMessage(), startsWith("Evaluation exceeded the configured 'evaluationTimeout' threshold of 250 ms"));
         }
     }
+
+    @Test
+    public void shouldClusterReadFileFromResources() throws Exception {
+        final Cluster cluster = Cluster.open(TestClientFactory.RESOURCE_PATH);
+        assertTrue(cluster != null);
+    }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
@@ -33,6 +33,7 @@ public final class TestClientFactory {
     public static final URI WEBSOCKET_URI = URI.create("ws://localhost:" + PORT + "/gremlin");
     public static final URI NIO_URI = URI.create("gs://localhost:" + PORT);
     public static final String HTTP = "http://localhost:" + PORT;
+    public static final String RESOURCE_PATH = "conf/remote-objects.yaml";
 
     public static Cluster.Builder build() {
         return Cluster.build("localhost").port(45940);

--- a/gremlin-server/src/test/resources/conf/remote-objects.yaml
+++ b/gremlin-server/src/test/resources/conf/remote-objects.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+###############################################################################
+# IMPORTANT
+###############################################################################
+# Changes to this file need to be appropriately replicated to
+#
+# - docker/gremlin-server/conf/remote-objects.yaml
+#
+# Without such changes, the test docker server can't be started for independent
+# testing with Gremlin Language Variants. Note this file's relation to
+# gremlin-server/src/test/resources/scripts/test-server-start.groovy
+###############################################################################
+
+hosts: [localhost]
+port: 45940
+serializer: {  className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0 }


### PR DESCRIPTION
i found Cluster.open() method can not load the yaml file that stored in project‘s resource dir,
therefore i want to submit this code to make this happen for  those who stored yaml file in there classpath based dir 