### PR TITLE
update requestId and userAgent in RequestMessage with RequestOptions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ This release also includes changes from <<release-3-3-10, 3.3.10>>.
 * Introduced internal `Buffer` API as a way to wrap Netty's Buffer API and moved `GraphBinaryReader`, `GraphBinaryWriter` and `TypeSerializer<T>` to `gremlin-core`.
 * Unified the behavior of property comparison: only compare key&value.
 * Supported `hasKey()` and `hasValue()` step for edge property and meta property, like `g.E().properties().hasKey('xx')`.
+* Client sends overrideRequestId and userAgent to Server when they are present in requestOptions with a bytecode query request.
 
 [[release-3-4-4]]
 === TinkerPop 3.4.4 (Release Date: October 14, 2019)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -565,6 +565,8 @@ public abstract class Client {
                 // apply settings if they were made available
                 options.getBatchSize().ifPresent(batchSize -> request.add(Tokens.ARGS_BATCH_SIZE, batchSize));
                 options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, timeout));
+                options.getOverrideRequestId().ifPresent(request::overrideRequestId);
+                options.getUserAgent().ifPresent(userAgent -> request.add(Tokens.ARGS_USER_AGENT, userAgent));
 
                 return submitAsync(request.create());
             } catch (Exception ex) {


### PR DESCRIPTION
a new PR for https://github.com/apache/tinkerpop/pull/1226

We miss to put requestId and userAgent in bytecode query submission while they are available in requestOptions. This commits fix the issue.

I ran the tests locally and it worked fine. Please let me know if the change any issue. Thanks.
