### PR TITLE
TINKERPOP-2266 Start keep alive polling on Connection construction

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Made `Cluster` be able to open configuration file on resources directory.
 * Bump to Tornado 5.x for gremlin-python.
+* Started keep-alive polling on `Connection` construction to ensure that a `Connection` doesn't die in the pool.
 * Deprecated `TraversalStrategies.applyStrategies()`.
 * Deprecated Jython support in `gremlin-python`.
 * Reverted: Modified Java driver to use IP address rather than hostname to create connections.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -113,6 +113,8 @@ final class Connection {
             channelizer.connected();
 
             logger.info("Created new connection for {}", uri);
+
+            scheduleKeepAlive();
         } catch (Exception ie) {
             logger.debug("Error opening connection on {}", uri);
             throw new ConnectionException(uri, "Could not open connection", ie);
@@ -244,6 +246,13 @@ final class Connection {
                 });
         channel.writeAndFlush(requestMessage, requestPromise);
 
+        scheduleKeepAlive();
+
+        return requestPromise;
+    }
+
+    private void scheduleKeepAlive() {
+        final Connection thisConnection = this;
         // try to keep the connection alive if the channel allows such things - websockets will
         if (channelizer.supportsKeepAlive() && keepAliveInterval > 0) {
 
@@ -263,8 +272,6 @@ final class Connection {
             // through on the connection
             if (oldKeepAliveFuture != null) oldKeepAliveFuture.cancel(true);
         }
-
-        return requestPromise;
     }
 
     public void returnToPool() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2266

If nothing writes to the Connection then keep alive doesn't start which might let it die in the pool if it is not used at some point.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1