### PR TITLE
TINKERPOP-2262 Prevented channel close by server on protocol error

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ This release also includes changes from <<release-3-3-10, 3.3.10>>.
 * Expanded the use of `by(String)` modulator so that it can work on `Map` as well as `Element`.
 * Improved error messaging for `by(String)` so that it is more clear as to what the problem is
 * Bump to Netty 4.1.42
+* Improved Gremlin Server websocket handling preventing automatic server close of the channel for protocol errors.
 * Introduced internal `Buffer` API as a way to wrap Netty's Buffer API and moved `GraphBinaryReader`, `GraphBinaryWriter` and `TypeSerializer<T>` to `gremlin-core`.
 * Unified the behavior of property comparison: only compare key&value.
 * Supported `hasKey()` and `hasValue()` step for edge property and meta property, like `g.E().properties().hasKey('xx')`.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -276,17 +276,8 @@ final class Connection {
         }
     }
 
-    /*
-     * In the event of an IOException (typically means that the Connection might have been closed from the server side
-     * - this is typical in situations like when a request is sent that exceeds maxContentLength and the server closes
-     * the channel on its side) or other exceptions that indicate a non-recoverable state for the Connection object
-     * (a netty CorruptedFrameException is a good example of that), the Connection cannot simply be returned to the
-     * pool as future uses will end with refusal from the server and make it appear as a dead host as the write will
-     * not succeed. Instead, the Connection needs to be replaced in these scenarios which destroys the dead channel
-     * on the client and allows a new one to be reconstructed.
-     */
     private void handleConnectionCleanupOnError(final Connection thisConnection, final Throwable t) {
-        if (thisConnection.isDead() || t instanceof IOException || t instanceof CodecException) {
+        if (thisConnection.isDead()) {
             if (pool != null) pool.replaceConnection(thisConnection);
         } else {
             thisConnection.returnToPool();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -870,10 +870,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             // it seems ok to pass in this case.
         } catch (Exception re) {
             final Throwable root = ExceptionUtils.getRootCause(re);
-            // Netty closes the channel to the server on a non-recoverable error such as CorruptedFrameException
-            // and the connection is subsequently destroyed. Each of the pending requests are given an error with
-            // the following error message.
-            //
+
             // went with two possible error messages here as i think that there is some either non-deterministic
             // behavior around the error message or it's environmentally dependent (e.g. different jdk, versions, etc)
             assertThat(root.getMessage(), Matchers.anyOf(is("Connection to server is no longer active"), is("Connection reset by peer")));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2262

Allows the channel on the driver to be reused rather than replaced. Interestingly no additional error handling seemed to be needed as all tests passed.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1