### PR TITLE
TINKERPOP-2315 Implement clone() for all GLVs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Improved error messaging for a `Cluster` with a bad `Channelizer` configuration in the Java driver.
 * Made `Cluster` be able to open configuration file on resources directory.
+* Implemented `Traversal.clone()` operations for all language variants.
 * Bump to Tornado 5.x for gremlin-python.
 * Deprecated `TraversalStrategies.applyStrategies()`.
 * Deprecated Jython support in `gremlin-python`.

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -29,6 +29,36 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.3.10/CHANGELOG.as
 
 === Upgrading for Users
 
+==== Traversal Clone
+
+Once a traversal has been executed (i.e. iterated) it's internal state is such that it cannot be re-used:
+
+[source,text]
+----
+gremlin> t = g.V().count()
+==>6
+gremlin> t
+gremlin>
+----
+
+To re-use a traversal it must be copied with `clone()` as follows:
+
+[source,text]
+----
+gremlin> t = g.V().count()
+==>6
+gremlin> t.clone()
+==>6
+gremlin> t.clone()
+==>6
+----
+
+The ability to `clone()` has been exclusive to Java and was a missing component of other supported languages like
+Python, Javascript and .NET. This feature has now been added for all the language variants making the ability to
+re-use traversals consistent in all ecosystems.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2315[TINKERPOP-2315]
+
 ==== Deprecated Jython Support
 
 Jython support in `gremlin-python` has been deprecated to focus on native Python 3.x support for 3.5.0 where Jython

--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -80,5 +80,13 @@ namespace Gremlin.Net.Process.Traversal
             return Wrap<$method.t1, $method.t2>(this);
         }
 <% } %>
+
+        /// <summary>
+        /// Make a copy of a traversal that is reset for iteration.
+        /// </summary>
+        public GraphTraversal<S, E> Clone()
+        {
+            return new GraphTraversal<S, E>(this.TraversalStrategies, this.Bytecode);
+        }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -1677,5 +1677,13 @@ namespace Gremlin.Net.Process.Traversal
             return Wrap<S, E>(this);
         }
 
+
+        /// <summary>
+        /// Make a copy of a traversal that is reset for iteration.
+        /// </summary>
+        public GraphTraversal<S, E> Clone()
+        {
+            return new GraphTraversal<S, E>(this.TraversalStrategies, this.Bytecode);
+        }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -46,6 +46,19 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         }
 
         [Fact]
+        public void g_V_Count_Clone()
+        {
+            var connection = _connectionFactory.CreateRemoteConnection();
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var t = g.V().Count();
+
+            Assert.Equal(6, t.Next());
+            Assert.Equal(6, t.Clone().Next());
+            Assert.Equal(6, t.Clone().Next());
+        }
+
+        [Fact]
         public void g_VX1X_Next()
         {
             var connection = _connectionFactory.CreateRemoteConnection();

--- a/gremlin-javascript/glv/GraphTraversalSource.template
+++ b/gremlin-javascript/glv/GraphTraversalSource.template
@@ -113,6 +113,14 @@ class GraphTraversal extends Traversal {
   constructor(graph, traversalStrategies, bytecode) {
     super(graph, traversalStrategies, bytecode);
   }
+
+  /**
+   * Copy a traversal so as to reset and re-use it.
+   */
+  clone() {
+    return new GraphTraversal(this.graph, this.traversalStrategies, this.getBytecode());
+  }
+
   <% graphStepMethods.each{ method -> %>
   /**
    * Graph traversal <%= method %> method.

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
@@ -201,6 +201,14 @@ class GraphTraversal extends Traversal {
   constructor(graph, traversalStrategies, bytecode) {
     super(graph, traversalStrategies, bytecode);
   }
+
+  /**
+   * Copy a traversal so as to reset and re-use it.
+   */
+  clone() {
+    return new GraphTraversal(this.graph, this.traversalStrategies, this.getBytecode());
+  }
+
   
   /**
    * Graph traversal V method.

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
@@ -79,6 +79,20 @@ describe('Traversal', function () {
       });
     });
   });
+  describe('#clone()', function () {
+    it('should reset a traversal when cloned', function () {
+      var g = traversal().withRemote(connection);
+      var t = g.V().count();
+      return t.next().then(function (item1) {
+            assert.ok(item1);
+            assert.strictEqual(item1.value, 6);
+            t.clone().next().then(function (item2) {
+              assert.ok(item2);
+              assert.strictEqual(item2.value, 6);
+            });
+      });
+    });
+  });
   describe('#next()', function () {
     it('should submit the traversal and return an iterator', function () {
       var g = traversal().withRemote(connection);

--- a/gremlin-python/glv/GraphTraversalSource.template
+++ b/gremlin-python/glv/GraphTraversalSource.template
@@ -85,6 +85,9 @@ class GraphTraversal(Traversal):
 
     def __getattr__(self, key):
         return self.values(key)
+
+    def clone(self):
+        return GraphTraversal(self.graph, self.traversal_strategies, self.bytecode)
 <% graphStepMethods.each { method -> %>
     def <%= method %>(self, *args):
         self.bytecode.add_step("<%= toJava.call(method) %>", *args)

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -131,6 +131,9 @@ class GraphTraversal(Traversal):
     def __getattr__(self, key):
         return self.values(key)
 
+    def clone(self):
+        return GraphTraversal(self.graph, self.traversal_strategies, self.bytecode)
+
     def V(self, *args):
         self.bytecode.add_step("V", *args)
         return self

--- a/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_driver_remote_connection.py
@@ -295,3 +295,11 @@ class TestDriverRemoteConnection(object):
         assert results
         results = t.side_effects.close()
         assert not results
+
+    def test_clone(self, remote_connection):
+        g = traversal().withRemote(remote_connection)
+        t = g.V().count()
+        assert 6 == t.next()
+        assert 6 == t.clone().next()
+        assert 6 == t.clone().next()
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2315

Hard to believe we didn't have `clone()` in place across the board. There might have been some more idiomatic ways to implements this per language but I decided to stick with `clone()` as it is in Java for all languages. Just felt like it should be consistent. Happy to hear other opinions on that matter, but besides that:

Builds with `mvn clean install`

VOTE +1