### PR TITLE
TINKERPOP-2175 Better manage the executor thread on close.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated Jython support in `gremlin-python`.
 * Deprecated `NioChannelizer` and related classes in `gremlin-driver` and `gremlin-server`.
 * Fixed a bug in the `ClassCacheRequestCount` metric for `GremlinGroovyScriptEngine` which wasn't including the cache hit count, only the misses.
+* Improved Gremlin Server executor thread handling on client close requests.
 * Reverted: Modified Java driver to use IP address rather than hostname to create connections.
 
 [[release-3-3-9]]

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -561,7 +561,13 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
 
             // send back a page of results if batch size is met or if it's the end of the results being iterated.
             // also check writeability of the channel to prevent OOME for slow clients.
-            if (nettyContext.channel().isWritable()) {
+            //
+            // clients might decide to close the Netty channel to the server with a CloseWebsocketFrame after errors
+            // like CorruptedFrameException. On the server, although the channel gets closed, there might be some
+            // executor threads waiting for watermark to clear which will not clear in these cases since client has
+            // already given up on these requests. This leads to these executors waiting for the client to consume
+            // results till the timeout. checking for isActive() should help prevent that.
+            if (nettyContext.channel().isActive() && nettyContext.channel().isWritable()) {
                 if (forceFlush || aggregate.size() == resultIterationBatchSize || !itty.hasNext()) {
                     final ResponseStatusCode code = itty.hasNext() ? ResponseStatusCode.PARTIAL_CONTENT : ResponseStatusCode.SUCCESS;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2175

Pretty much implemented as described in the JIRA - make sense to me to check for an active channel in addition to writeability.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1