### PR TITLE
TINKERPOP-2320 allow to pass custom XmlInputFactory when instantiating GraphMLReader

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated `TraversalStrategies.applyStrategies()`.
 * Deprecated Jython support in `gremlin-python`.
 * Reverted: Modified Java driver to use IP address rather than hostname to create connections.
+* Allow custom XMLInputFactory to be used with GraphMLReader.
 
 [[release-3-3-9]]
 === TinkerPop 3.3.9 (Release Date: October 14, 2019)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLReader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLReader.java
@@ -56,18 +56,19 @@ import java.util.stream.Stream;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public final class GraphMLReader implements GraphReader {
-    private final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
 
     private final String edgeLabelKey;
     private final String vertexLabelKey;
     private final long batchSize;
     private final boolean strict;
+    private final XMLInputFactory inputFactory;
 
     private GraphMLReader(final Builder builder) {
         this.edgeLabelKey = builder.edgeLabelKey;
         this.batchSize = builder.batchSize;
         this.vertexLabelKey = builder.vertexLabelKey;
         this.strict = builder.strict;
+        this.inputFactory = builder.inputFactory;
     }
 
     @Override
@@ -343,6 +344,7 @@ public final class GraphMLReader implements GraphReader {
         private String vertexLabelKey = GraphMLTokens.LABEL_V;
         private boolean strict = true;
         private long batchSize = 10000;
+        private XMLInputFactory inputFactory;
 
         private Builder() {
         }
@@ -381,7 +383,18 @@ public final class GraphMLReader implements GraphReader {
             return this;
         }
 
+        /**
+         * the key to use as the inputFactory when a caller wants to pass XMLInputFactory with its own configuration.
+         */
+        public Builder xmlInputFactory(final XMLInputFactory inputFactory) {
+            this.inputFactory = inputFactory;
+            return this;
+        }
+
         public GraphMLReader create() {
+            if (this.inputFactory == null) {
+                this.inputFactory = XMLInputFactory.newInstance();
+            }
             return new GraphMLReader(this);
         }
     }


### PR DESCRIPTION
This pull request is a revised one from https://github.com/apache/tinkerpop/pull/1230.

Some provider wants to use XMLInputFactory with more secure configurations. This change makes it possible to pass XMLInputFactory when instantiating GraphMLReader.

I don't add any tests right now, I want to first confirm if this direction is OK. If yes, please suggest any tests that I need to add. Thanks !