### PR TITLE
TINKERPOP-2107 Fixed property re-attachment

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-4-3, 3.4.3>>.
 
 * Allowed the possibility for the propagation of `null` as a `Traverser` in Gremlin.
+* Fixed a bug where spark-gremlin was not re-attaching properties when using `dedup()`.
 * Ensured better consistency of the use of `null` as arguments to mutation steps.
 * Allowed `property(T.label,Object)` to be used if no value was supplied to `addV(String)`.
 * Added a `Graph.Feature` for `supportsNullPropertyValues`.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -779,9 +779,12 @@ traverser's bulk is greater than 1, then it is set to 1 before being emitted.
 g.V().values('lang')
 g.V().values('lang').dedup()
 g.V(1).repeat(bothE('created').dedup().otherV()).emit().path() <1>
+g.V().bothE().properties().dedup() <2>
 ----
 
 <1> Traverse all `created` edges, but don't touch any edge twice.
+<2> Note that `Property` instances will compare on key and value, whereas a `VertexProperty` will also include its
+element as it is a first-class citizen.
 
 If a by-step modulation is provided to `dedup()`, then the object is processed accordingly prior to determining if it
 has been seen or not.

--- a/gremlin-test/features/filter/Dedup.feature
+++ b/gremlin-test/features/filter/Dedup.feature
@@ -244,4 +244,26 @@ Feature: Step - dedup()
     When iterated to list
     Then the result should be unordered
       | result |
-      | d[6].l |
+      | d[4].l |
+
+  Scenario: g_V_both_properties_dedup_count
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().both().properties().dedup().count()
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[12].l |
+
+  Scenario: g_V_both_properties_properties_dedup_count
+    Given the crew graph
+    And the traversal of
+      """
+      g.V().both().properties().properties().dedup().count()
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[21].l |

--- a/gremlin-test/features/filter/Dedup.feature
+++ b/gremlin-test/features/filter/Dedup.feature
@@ -235,3 +235,13 @@ Feature: Step - dedup()
       | result |
       | d[0].l |
 
+  Scenario: g_V_bothE_properties_dedup_count
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().bothE().properties().dedup().count()
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | d[6].l |

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
@@ -91,6 +91,8 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Long> get_g_V_repeatXdedupX_timesX2X_count();
 
+    public abstract Traversal<Vertex, Long> get_g_V_bothE_properties_dedup_count();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_out_in_valuesXnameX_fold_dedupXlocalX_unfold() {
@@ -312,6 +314,14 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
         assertFalse(traversal.hasNext());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_bothE_properties_dedup_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_bothE_properties_dedup_count();
+        printTraversalForm(traversal);
+        assertEquals(6L, traversal.next().longValue());
+        assertFalse(traversal.hasNext());
+    }
 
     public static class Traversals extends DedupTest {
         @Override
@@ -392,6 +402,11 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Long> get_g_V_repeatXdedupX_timesX2X_count() {
             return g.V().repeat(dedup()).times(2).count();
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_bothE_properties_dedup_count() {
+            return g.V().bothE().properties().dedup().count();
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
@@ -92,6 +93,10 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Long> get_g_V_repeatXdedupX_timesX2X_count();
 
     public abstract Traversal<Vertex, Long> get_g_V_bothE_properties_dedup_count();
+
+    public abstract Traversal<Vertex, Long> get_g_V_both_properties_dedup_count();
+
+    public abstract Traversal<Vertex, Long> get_g_V_both_properties_properties_dedup_count();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -319,7 +324,26 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
     public void g_V_bothE_properties_dedup_count() {
         final Traversal<Vertex, Long> traversal = get_g_V_bothE_properties_dedup_count();
         printTraversalForm(traversal);
-        assertEquals(6L, traversal.next().longValue());
+        assertEquals(4L, traversal.next().longValue());
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_both_properties_dedup_count() {
+        // vertex properties behave like Element with their dedup() so 12 is the right number there
+        final Traversal<Vertex, Long> traversal = get_g_V_both_properties_dedup_count();
+        printTraversalForm(traversal);
+        assertEquals(12L, traversal.next().longValue());
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(CREW)
+    public void g_V_both_properties_properties_dedup_count() {
+        final Traversal<Vertex, Long> traversal = get_g_V_both_properties_properties_dedup_count();
+        printTraversalForm(traversal);
+        assertEquals(21L, traversal.next().longValue());
         assertFalse(traversal.hasNext());
     }
 
@@ -407,6 +431,16 @@ public abstract class DedupTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Long> get_g_V_bothE_properties_dedup_count() {
             return g.V().bothE().properties().dedup().count();
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_both_properties_dedup_count() {
+            return g.V().both().properties().dedup().count();
+        }
+
+        @Override
+        public Traversal<Vertex, Long> get_g_V_both_properties_properties_dedup_count() {
+            return g.V().both().properties().properties().dedup().count();
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2107

This is a bit of a workaround that really only resolved itself properly as a result of TINKERPOP-2318 which only went to `master` and 3.5.0. 

All tests pass with `docker/build.sh -t -n -i`

VOTE +1