### PR TITLE
TINKERPOP-2329 JavaScript GLV: upgrade ws dependency

### DIFF
--- a/gremlin-javascript/glv/PackageJson.template
+++ b/gremlin-javascript/glv/PackageJson.template
@@ -33,15 +33,15 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "ws": "^3.0.0"
+    "ws": "^6.2.1"
   },
   "devDependencies": {
-    "mocha": "~4.0.1",
-    "cucumber": "~3.1.0",
     "chai": "~4.1.2",
+    "cucumber": "~4.2.1",
     "grunt": "~1.0.2",
     "grunt-cli": "~1.2.0",
-    "grunt-jsdoc": "~2.3.0"
+    "grunt-jsdoc": "~2.3.0",
+    "mocha": "~4.0.1"
   },
   "repository": {
     "type": "git",
@@ -52,9 +52,9 @@
     "url": "https://issues.apache.org/jira/browse/TINKERPOP"
   },
   "scripts": {
-    "test": "mocha test/unit test/integration -t 5000",
+    "test": "./node_modules/mocha/bin/mocha test/unit test/integration -t 5000",
     "features": "cucumber.js --require test/cucumber ../../../../../gremlin-test/features/",
-    "unit-test": "mocha test/unit"
+    "unit-test": "./node_modules/mocha/bin/mocha test/unit"
   },
   "engines": {
     "node": ">=6"

--- a/gremlin-javascript/glv/PackageJson.template
+++ b/gremlin-javascript/glv/PackageJson.template
@@ -38,10 +38,10 @@
   "devDependencies": {
     "chai": "~4.1.2",
     "cucumber": "~4.2.1",
-    "grunt": "~1.0.2",
-    "grunt-cli": "~1.2.0",
-    "grunt-jsdoc": "~2.3.0",
-    "mocha": "~4.0.1"
+    "grunt": "~1.0.4",
+    "grunt-cli": "~1.3.2",
+    "grunt-jsdoc": "~2.3.1",
+    "mocha": "~5.2.0"
   },
   "repository": {
     "type": "git",
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha test/unit test/integration -t 5000",
-    "features": "cucumber.js --require test/cucumber ../../../../../gremlin-test/features/",
+    "features": "./node_modules/.bin/cucumber-js --require test/cucumber ../../../../../gremlin-test/features/",
     "unit-test": "./node_modules/mocha/bin/mocha test/unit"
   },
   "engines": {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
@@ -19,10 +19,10 @@
   "devDependencies": {
     "chai": "~4.1.2",
     "cucumber": "~4.2.1",
-    "grunt": "~1.0.2",
-    "grunt-cli": "~1.2.0",
-    "grunt-jsdoc": "~2.3.0",
-    "mocha": "~4.0.1"
+    "grunt": "~1.0.4",
+    "grunt-cli": "~1.3.2",
+    "grunt-jsdoc": "~2.3.1",
+    "mocha": "~5.2.0"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha test/unit test/integration -t 5000",
-    "features": "cucumber.js --require test/cucumber ../../../../../gremlin-test/features/",
+    "features": "./node_modules/.bin/cucumber-js --require test/cucumber ../../../../../gremlin-test/features/",
     "unit-test": "./node_modules/mocha/bin/mocha test/unit"
   },
   "engines": {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
@@ -14,15 +14,15 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "ws": "^3.0.0"
+    "ws": "^6.2.1"
   },
   "devDependencies": {
-    "mocha": "~4.0.1",
-    "cucumber": "~3.1.0",
     "chai": "~4.1.2",
+    "cucumber": "~4.2.1",
     "grunt": "~1.0.2",
     "grunt-cli": "~1.2.0",
-    "grunt-jsdoc": "~2.3.0"
+    "grunt-jsdoc": "~2.3.0",
+    "mocha": "~4.0.1"
   },
   "repository": {
     "type": "git",
@@ -33,9 +33,9 @@
     "url": "https://issues.apache.org/jira/browse/TINKERPOP"
   },
   "scripts": {
-    "test": "mocha test/unit test/integration -t 5000",
+    "test": "./node_modules/mocha/bin/mocha test/unit test/integration -t 5000",
     "features": "cucumber.js --require test/cucumber ../../../../../gremlin-test/features/",
-    "unit-test": "mocha test/unit"
+    "unit-test": "./node_modules/mocha/bin/mocha test/unit"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
Update dependencies as long as those work with Node.js 6+ runtime.

https://issues.apache.org/jira/browse/TINKERPOP-2329

VOTE +1