### PR TITLE
TINKERPOP-2330 JavaScript GLV: Export GraphSON2 and 3 writers/readers

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/index.js
@@ -80,10 +80,7 @@ module.exports = {
     AnonymousTraversalSource
   },
   structure: {
-    io: {
-      GraphSONReader: gs.GraphSONReader,
-      GraphSONWriter: gs.GraphSONWriter
-    },
+    io: gs,
     Edge: graph.Edge,
     Graph: graph.Graph,
     Path: graph.Path,

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
@@ -36,7 +36,7 @@ describe('Client', function () {
       }
     };
 
-    const customClient = new Client('localhost:8182', {traversalSource: 'g'});
+    const customClient = new Client('ws://localhost:8182', {traversalSource: 'g'});
     customClient._connection = connectionMock;
     customClient.submit(query)
   });
@@ -51,7 +51,7 @@ describe('Client', function () {
       }
     };
 
-    const customClient = new Client('localhost:8182', {traversalSource: 'g', processor: customOpProcessor});
+    const customClient = new Client('ws://localhost:8182', {traversalSource: 'g', processor: customOpProcessor});
     customClient._connection = connectionMock;
     customClient.submit(query)
   });

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/exports-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/exports-test.js
@@ -59,6 +59,12 @@ describe('API', function () {
     assert.ok(glvModule.structure.io);
     assert.strictEqual(typeof glvModule.structure.io.GraphSONReader, 'function');
     assert.strictEqual(typeof glvModule.structure.io.GraphSONWriter, 'function');
+    validateConstructor(glvModule.structure.io, 'GraphSON2Reader');
+    validateConstructor(glvModule.structure.io, 'GraphSON2Writer');
+    validateConstructor(glvModule.structure.io, 'GraphSON3Reader');
+    validateConstructor(glvModule.structure.io, 'GraphSON3Writer');
+    assert.strictEqual(glvModule.structure.io.GraphSONReader, glvModule.structure.io.GraphSON3Reader);
+    assert.strictEqual(glvModule.structure.io.GraphSONWriter, glvModule.structure.io.GraphSON3Writer);
     assert.strictEqual(typeof glvModule.structure.Edge, 'function');
     assert.strictEqual(typeof glvModule.structure.Graph, 'function');
     assert.strictEqual(typeof glvModule.structure.Path, 'function');


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2330

Adds GraphSON2 and GraphSON3 writer/readers for backward compatibility, something that I've missed when introducing GraphSON3 support in #858.