### PR TITLE
Add trustStoreType such that keystore and truststore can be different type

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -191,6 +191,7 @@ public final class Cluster {
                 .keyStoreType(settings.connectionPool.keyStoreType)
                 .trustStore(settings.connectionPool.trustStore)
                 .trustStorePassword(settings.connectionPool.trustStorePassword)
+                .trustStoreType(settings.connectionPool.trustStoreType)
                 .sslCipherSuites(settings.connectionPool.sslCipherSuites)
                 .sslEnabledProtocols(settings.connectionPool.sslEnabledProtocols)
                 .sslSkipCertValidation(settings.connectionPool.sslSkipCertValidation)
@@ -525,9 +526,9 @@ public final class Cluster {
 
             // Load custom truststore
             if (null != connectionPoolSettings.trustStore) {
-                final String keystoreType = null == connectionPoolSettings.keyStoreType ? KeyStore.getDefaultType()
-                        : connectionPoolSettings.keyStoreType;
-                final KeyStore truststore = KeyStore.getInstance(keystoreType);
+                final String trustStoreType = null != connectionPoolSettings.trustStoreType ? connectionPoolSettings.trustStoreType
+                        : null != connectionPoolSettings.keyStoreType ? connectionPoolSettings.keyStoreType : KeyStore.getDefaultType();
+                final KeyStore truststore = KeyStore.getInstance(trustStoreType);
                 final char[] password = null == connectionPoolSettings.trustStorePassword ? null
                         : connectionPoolSettings.trustStorePassword.toCharArray();
                 try (final InputStream in = new FileInputStream(connectionPoolSettings.trustStore)) {
@@ -591,6 +592,7 @@ public final class Cluster {
         private String trustStore = null;
         private String trustStorePassword = null;
         private String keyStoreType = null;
+        private String trustStoreType = null;
         private String validationRequest = "''";
         private List<String> sslEnabledProtocols = new ArrayList<>();
         private List<String> sslCipherSuites = new ArrayList<>();
@@ -768,6 +770,14 @@ public final class Cluster {
          */
         public Builder keyStoreType(final String keyStoreType) {
             this.keyStoreType = keyStoreType;
+            return this;
+        }
+
+        /**
+         * The format of the {@link #trustStore}, either {@code JKS} or {@code PKCS12}
+         */
+        public Builder trustStoreType(final String trustStoreType) {
+            this.trustStoreType = trustStoreType;
             return this;
         }
 
@@ -1087,6 +1097,7 @@ public final class Cluster {
             connectionPoolSettings.trustStore = builder.trustStore;
             connectionPoolSettings.trustStorePassword = builder.trustStorePassword;
             connectionPoolSettings.keyStoreType = builder.keyStoreType;
+            connectionPoolSettings.trustStoreType = builder.trustStoreType;
             connectionPoolSettings.sslCipherSuites = builder.sslCipherSuites;
             connectionPoolSettings.sslEnabledProtocols = builder.sslEnabledProtocols;
             connectionPoolSettings.sslSkipCertValidation = builder.sslSkipCertValidation;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -201,6 +201,9 @@ final class Settings {
             if (connectionPoolConf.containsKey("trustStorePassword"))
                 cpSettings.trustStorePassword = connectionPoolConf.getString("trustStorePassword");
 
+            if (connectionPoolConf.containsKey("trustStoreType"))
+                cpSettings.trustStoreType = connectionPoolConf.getString("trustStoreType");
+
             if (connectionPoolConf.containsKey("sslEnabledProtocols"))
                 cpSettings.sslEnabledProtocols = connectionPoolConf.getList("sslEnabledProtocols").stream().map(Object::toString)
                         .collect(Collectors.toList());
@@ -317,6 +320,12 @@ final class Settings {
          * {@code javax.net.ssl.keyStoreType}.
          */
         public String keyStoreType;
+
+        /**
+         * JSSE truststore format. 'jks' or 'pkcs12'. Similar to setting JSSE property
+         * {@code javax.net.ssl.trustStoreType}.
+         */
+        public String trustStoreType;
 
         /**
          * @see <a href=

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -56,6 +56,7 @@ public class SettingsTest {
         conf.setProperty("connectionPool.keyStoreType", "pkcs12");
         conf.setProperty("connectionPool.trustStore", "trust.jks");
         conf.setProperty("connectionPool.trustStorePassword", "password3");
+        conf.setProperty("connectionPool.trustStoreType", "jks");
         conf.setProperty("connectionPool.sslEnabledProtocols", Arrays.asList("TLSv1.1","TLSv1.2"));
         conf.setProperty("connectionPool.sslCipherSuites", Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"));
         conf.setProperty("connectionPool.sslSkipCertValidation", true);
@@ -94,6 +95,7 @@ public class SettingsTest {
         assertEquals("pkcs12", settings.connectionPool.keyStoreType);
         assertEquals("trust.jks", settings.connectionPool.trustStore);
         assertEquals("password3", settings.connectionPool.trustStorePassword);
+        assertEquals("jks", settings.connectionPool.trustStoreType);
         assertEquals(Arrays.asList("TLSv1.1","TLSv1.2"), settings.connectionPool.sslEnabledProtocols);
         assertEquals(Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"), settings.connectionPool.sslCipherSuites);
         assertThat(settings.connectionPool.sslSkipCertValidation, is(true));

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -307,8 +307,10 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
 
                 // Load custom truststore for client auth certs
                 if (null != sslSettings.trustStore) {
-                    final String keystoreType = null == sslSettings.keyStoreType ? KeyStore.getDefaultType() : sslSettings.keyStoreType;
-                    final KeyStore truststore = KeyStore.getInstance(keystoreType);
+                    final String trustStoreType = null != sslSettings.trustStoreType ? sslSettings.trustStoreType
+                            : sslSettings.keyStoreType != null ? sslSettings.keyStoreType : KeyStore.getDefaultType();
+
+                    final KeyStore truststore = KeyStore.getInstance(trustStoreType);
                     final char[] password = null == sslSettings.trustStorePassword ? null : sslSettings.trustStorePassword.toCharArray();
                     try (final InputStream in = new FileInputStream(sslSettings.trustStore)) {
                         truststore.load(in, password);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -527,6 +527,11 @@ public class Settings {
         public String keyStoreType;
 
         /**
+         * The format of the {@link #trustStore}, either {@code JKS} or {@code PKCS12}
+         */
+        public String trustStoreType;
+
+        /**
          * A list of SSL protocols to enable. @see <a href=
          *      "https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSE_Protocols">JSSE
          *      Protocols</a>

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -50,6 +50,8 @@ public abstract class AbstractGremlinServerIntegrationTest {
     public static final String P12_CLIENT_TRUST = "src/test/resources/client-trust.p12";
     public static final String KEYSTORE_TYPE_JKS = "jks";
     public static final String KEYSTORE_TYPE_PKCS12 = "pkcs12";
+    public static final String TRUSTSTORE_TYPE_JKS = "jks";
+    public static final String TRUSTSTORE_TYPE_PKCS12 = "pkcs12";
 
     protected GremlinServer server;
     private Settings overriddenSettings;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -316,6 +316,21 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             case "shouldCloseChannelIfClientDoesntRespond":
                 settings.idleConnectionTimeout = 1000;
                 break;
+            case "shouldEnableSslAndClientCertificateAuthWithDifferentStoreType":
+            case "shouldEnableSslAndClientCertificateAuthAndFailWithIncorrectKeyStoreType":
+            case "shouldEnableSslAndClientCertificateAuthAndFailWithIncorrectTrustStoreType":
+                settings.ssl = new Settings.SslSettings();
+                settings.ssl.enabled = true;
+                settings.ssl.needClientAuth = ClientAuth.REQUIRE;
+                settings.ssl.keyStore = JKS_SERVER_KEY;
+                settings.ssl.keyStorePassword = KEY_PASS;
+                settings.ssl.keyStoreType = KEYSTORE_TYPE_JKS;
+                settings.ssl.trustStore = P12_SERVER_TRUST;
+                settings.ssl.trustStorePassword = KEY_PASS;
+                settings.ssl.trustStoreType = TRUSTSTORE_TYPE_PKCS12;
+                break;
+            default:
+                break;
         }
 
         return settings;
@@ -1500,6 +1515,71 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             fail("Should have tanked out because of number of parameters used and size of the compile script");
         } catch (Exception ex) {
             assertThat(ex.getMessage(), containsString("The Gremlin statement that was submitted exceed the maximum compilation size allowed by the JVM"));
+        }
+    }
+
+    @Test
+    public void shouldEnableSslAndClientCertificateAuthWithDifferentStoreType() {
+        final Cluster cluster = TestClientFactory.build().enableSsl(true)
+                .keyStore(JKS_CLIENT_KEY).keyStorePassword(KEY_PASS).keyStoreType(KEYSTORE_TYPE_JKS)
+                .trustStore(P12_CLIENT_TRUST).trustStorePassword(KEY_PASS).trustStoreType(TRUSTSTORE_TYPE_PKCS12)
+                .create();
+        final Client client = cluster.connect();
+
+        try {
+            assertEquals("test", client.submit("'test'").one().getString());
+        } finally {
+            cluster.close();
+        }
+
+        final Cluster cluster2 = TestClientFactory.build().enableSsl(true)
+                .keyStore(P12_CLIENT_KEY).keyStorePassword(KEY_PASS).keyStoreType(KEYSTORE_TYPE_PKCS12)
+                .trustStore(JKS_CLIENT_TRUST).trustStorePassword(KEY_PASS).trustStoreType(TRUSTSTORE_TYPE_JKS)
+                .create();
+        final Client client2 = cluster2.connect();
+
+        try {
+            assertEquals("test", client2.submit("'test'").one().getString());
+        } finally {
+            cluster2.close();
+        }
+    }
+
+    @Test
+    public void shouldEnableSslAndClientCertificateAuthAndFailWithIncorrectKeyStoreType() {
+        final Cluster cluster = TestClientFactory.build().enableSsl(true)
+                .keyStore(JKS_CLIENT_KEY).keyStorePassword(KEY_PASS).keyStoreType(KEYSTORE_TYPE_PKCS12)
+                .trustStore(P12_CLIENT_TRUST).trustStorePassword(KEY_PASS).trustStoreType(TRUSTSTORE_TYPE_PKCS12)
+                .create();
+        final Client client = cluster.connect();
+
+        try {
+            String res = client.submit("'test'").one().getString();
+            fail("Should throw exception because incorrect keyStoreType is specified");
+        } catch (Exception x) {
+            final Throwable root = ExceptionUtils.getRootCause(x);
+            assertThat(root, instanceOf(TimeoutException.class));
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void shouldEnableSslAndClientCertificateAuthAndFailWithIncorrectTrustStoreType() {
+        final Cluster cluster = TestClientFactory.build().enableSsl(true)
+                .keyStore(P12_CLIENT_KEY).keyStorePassword(KEY_PASS).keyStoreType(KEYSTORE_TYPE_PKCS12)
+                .trustStore(JKS_CLIENT_TRUST).trustStorePassword(KEY_PASS).trustStoreType(TRUSTSTORE_TYPE_PKCS12)
+                .create();
+        final Client client = cluster.connect();
+
+        try {
+            client.submit("'test'").one();
+            fail("Should throw exception because incorrect trustStoreType is specified");
+        } catch (Exception x) {
+            final Throwable root = ExceptionUtils.getRootCause(x);
+            assertThat(root, instanceOf(TimeoutException.class));
+        } finally {
+            cluster.close();
         }
     }
 }


### PR DESCRIPTION
This PR adds a little bit more flexibility to the usage of different store types between keystore and truststore. For example, `jks` in keystore and `pkcs12` in truststore.

It preserves the original behavior, such that if the user does not define the `trustStoreType`, it would use the `keyStoreType`.

----
- Ran `mvn clean install` successfully
- Ran `docker/build.sh -i -t` successfully
