### PR TITLE
TINKERPOP-2192 Null checks added to Connection.Parse

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -124,9 +124,9 @@ namespace Gremlin.Net.Driver
             }
             catch (Exception e)
             {
-                if (_callbackByRequestId.TryRemove(receivedMsg.RequestId, out var responseHandler))
+                if (receivedMsg != null && _callbackByRequestId.TryRemove(receivedMsg.RequestId, out var responseHandler))
                 {
-                    responseHandler.HandleFailure(e);
+                    responseHandler?.HandleFailure(e);
                 }
             }
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2192

Added null check to Gremlin.Net.Driver.Connection.Parse method for receivedMsg variable and responseHandler. My first pull request to public repo, hope I did it correctly