### PR TITLE
TINKERPOP-2339 Bump System.Net.WebSockets.Client dependency

### DIFF
--- a/gremlin-dotnet/glv/Gremlin.Net.csproj.template
+++ b/gremlin-dotnet/glv/Gremlin.Net.csproj.template
@@ -67,7 +67,7 @@ NOTE that versions suffixed with "-rc" are considered release candidates (i.e. p
 
   <ItemGroup Condition="'\$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.0" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -67,7 +67,7 @@ NOTE that versions suffixed with "-rc" are considered release candidates (i.e. p
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.0" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bump `System.Net.WebSockets.Client` dependency to `4.3.2` in Gremlin.Net.

https://issues.apache.org/jira/browse/TINKERPOP-2339

VOTE +1