### PR TITLE
TINKERPOP-2336 Added getMaxWaitForClose java driver setting.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Added `trustStoreType` such that keystore and truststore can be of different types in the Java driver.
 * Added session support to gremlin-javascript.
+* Modified Gremlin Server to close the session when the channel itself is closed.
+* Added `maxWaitForClose` configuration option to the Java driver.
+* Deprecated `maxWaitForSessionClose` in the Java driver.
 
 [[release-3-3-10]]
 === TinkerPop 3.3.10 (Release Date: February 3, 2020)

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -1061,6 +1061,12 @@ Gremlin Server are deployed, session state is not shared among them.
 !`close` !Close the specified session. Will return a `NO CONTENT` message as confirmation of the close being completed.
 |=========================================================
 
+NOTE: The "close" message is deprecated as of 3.3.11 as servers at this version are required to automatically interrupt
+running processes on the close of the connection and release resources such as sessions. Servers wishing to be
+compatible with older versions of the driver need only send back a `NO_CONTENT` for this message. Drivers wishing to
+be compatible with servers prior to 3.3.11 may continue to send the message on calls to `close()` otherwise such code
+can be removed.
+
 **`authentication` operation arguments**
 
 [width="100%",cols="2,2,9",options="header"]

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -37,6 +37,37 @@ ensuring a consistent implementation for all programming languages.
 
 [source,javascript]
 const client = new gremlin.driver.Client('ws://localhost:8182/gremlin', { traversalSource: 'g', 'processor': 'session' });
+==== Deprecate maxWaitForSessionClose
+
+The `maxWaitForSessionClose` setting for the Java driver has been deprecated and in some sense replaced by the
+`maxWaitForClose` setting. The two settings perform different functions, but expect `maxWaitForSessionClose` to be
+removed in future versions. The `maxWaitForClose` performs a more useful function than `maxWaitForSessionClose` in
+the sense that it tells the driver how long it should wait for pending messages from the server before closing the
+connection. The `maxWaitForSessionClose` on the other hand is how long the driver should wait for the server to
+respond to a session close message (i.e. an actual response from the server). Waiting for that specific response to the
+session close message could result in the driver hanging on calls to `Client.close()` if there is a long run query
+running on the server and close message is stacked behind that in queue.
+
+Future versions will remove support for that particular message and simply close the session when the connection is
+closed. As a result that setting will no longer be useful. The old setting is really only useful for connecting to
+older versions of the server prior to 3.3.11 that do not have the session shutdown hook bound to the close of the
+connection.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2336[TINKERPOP-2336]
+
+=== Upgrading for Providers
+
+==== Gremlin Driver Providers
+
+===== Session Close
+
+The "close" message for the `SessionOpProcessor` is deprecated, however the functionality to accept the message remains
+in Gremlin Server and the functionality to send the message remains in the Java driver. The expectation is that
+support for the message will be removed from the driver in a future release, likely at 3.5.0. Server implementations
+starting at 3.3.11 should look to use the close of a connection to trigger the close of a session and its release of
+resources.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2336[TINKERPOP-2336]
 
 == TinkerPop 3.3.10
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -236,6 +236,12 @@ final class Settings {
             if (connectionPoolConf.containsKey("maxWaitForConnection"))
                 cpSettings.maxWaitForConnection = connectionPoolConf.getInt("maxWaitForConnection");
 
+            if (connectionPoolConf.containsKey("maxWaitForSessionClose"))
+                cpSettings.maxWaitForSessionClose = connectionPoolConf.getInt("maxWaitForSessionClose");
+
+            if (connectionPoolConf.containsKey("maxWaitForClose"))
+                cpSettings.maxWaitForClose = connectionPoolConf.getInt("maxWaitForClose");
+
             if (connectionPoolConf.containsKey("maxContentLength"))
                 cpSettings.maxContentLength = connectionPoolConf.getInt("maxContentLength");
 
@@ -398,8 +404,18 @@ final class Settings {
          * If the connection is using a "session" this setting represents the amount of time in milliseconds to wait
          * for that session to close before timing out where the default value is 3000. Note that the server will
          * eventually clean up dead sessions itself on expiration of the session or during shutdown.
+         *
+         * @deprecated As of release 3.3.11, replaced in essence by {@link #maxWaitForClose}.
          */
+        @Deprecated
         public int maxWaitForSessionClose = Connection.MAX_WAIT_FOR_SESSION_CLOSE;
+
+        /**
+         * The amount of time in milliseconds to wait the connection to close before timing out where the default
+         * value is 3000. This timeout allows for a delay to occur in waiting for remaining messages that may still
+         * be returning from the server while a {@link Client#close()} is called.
+         */
+        public int maxWaitForClose = Connection.MAX_WAIT_FOR_CLOSE;
 
         /**
          * The maximum length in bytes that a message can be sent to the server. This number can be no greater than

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -124,10 +124,13 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
     /**
      * Session based requests accept a "close" operator in addition to "eval". A close will trigger the session to be
      * killed and any uncommitted transaction to be rolled-back.
-     * @return
      */
     @Override
     public Optional<ThrowingConsumer<Context>> selectOther(final RequestMessage requestMessage) throws OpProcessorException {
+        // deprecated the "close" message at 3.3.11 - should probably leave this check for the "close" token so that
+        // if older versions of the driver connect they won't get an error. can basically just write back a NO_CONTENT
+        // for the immediate term in 3.5.0 and then for some future version remove support for the message completely
+        // and thus disallow older driver versions from connecting at all.
         if (requestMessage.getOp().equals(Tokens.OPS_CLOSE)) {
             // this must be an in-session request
             if (!requestMessage.optionalArgs(Tokens.ARGS_SESSION).isPresent()) {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
@@ -168,6 +168,12 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
         // basically, we need one to submit the long run job and one to do the close operation that will cancel the
         // long run job. it is probably possible to do this with some low-level message manipulation but that's
         // probably not necessary
+        //
+        // this test wont work so well once we remove the sending of the session close message from the driver which
+        // got deprecated at 3.3.11 and lock a session to the connection that created it. in that case, two Client
+        // instances won't be able to connect to the same session which is what is happening below. not sure what
+        // form this test should take then especially since transactions will force close when the channel closes.
+        // perhaps it should just be removed.
         final Cluster cluster1 = TestClientFactory.open();
         final Client client1 = cluster1.connect(name.getMethodName());
         client1.submit("graph.addVertex()").all().join();
@@ -201,6 +207,12 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
         // basically, we need one to submit the long run job and one to do the close operation that will cancel the
         // long run job. it is probably possible to do this with some low-level message manipulation but that's
         // probably not necessary
+        //
+        // this test wont work so well once we remove the sending of the session close message from the driver which
+        // got deprecated at 3.3.11 and lock a session to the connection that created it. in that case, two Client
+        // instances won't be able to connect to the same session which is what is happening below. not sure what
+        // form this test should take then especially since transactions will force close when the channel closes.
+        // perhaps it should just be removed.
         final Cluster cluster1 = TestClientFactory.open();
         final Client client1 = cluster1.connect(name.getMethodName());
         client1.submit("graph.addVertex()").all().join();
@@ -320,7 +332,7 @@ public class GremlinServerSessionIntegrateTest  extends AbstractGremlinServerInt
             cluster.close();
         }
 
-        // there will be on for the timeout and a second for closing the cluster
+        // there will be one for the timeout and a second for closing the cluster
         assertEquals(2, recordingAppender.getMessages().stream()
                 .filter(msg -> msg.equals("INFO - Session shouldHaveTheSessionTimeout closed\n")).count());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2336

This one has been basically done for a while now - just got delayed a bit because of 3.4.6. Made a few minor tweaks to docs after reviewing the last day or so, but other than that it's unchanged.

Deprecated the "close" message for sessions along with its driver setting. The driver should stay compatible with older server versions, but the server now closes sessions with the close of the connection and there no longer is a block while all messages return from the server after a `Client.close()`.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1