### PR TITLE
Reuse a byte buffer instead of re-allocating it on every loop.

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -78,9 +78,11 @@ namespace Gremlin.Net.Driver
             using (var ms = new MemoryStream())
             {
                 WebSocketReceiveResult received;
+                var buffer = new byte[ReceiveBufferSize];
+
                 do
                 {
-                    var receiveBuffer = new ArraySegment<byte>(new byte[ReceiveBufferSize]);
+                    var receiveBuffer = new ArraySegment<byte>(buffer);
                     received = await _client.ReceiveAsync(receiveBuffer, CancellationToken.None).ConfigureAwait(false);
                     ms.Write(receiveBuffer.Array, receiveBuffer.Offset, received.Count);
                 } while (!received.EndOfMessage);


### PR DESCRIPTION
For large result sets, this will release a little bit of GC pressure. 