### PR TITLE
TINKERPOP-2347 Remove invalid service descriptors from gremlin-shaded

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,10 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `maxWaitForClose` configuration option to the Java driver.
 * Deprecated `maxWaitForSessionClose` in the Java driver.
 
+==== Bugs
+
+* TINKERPOP-2347 Remove invalid service descriptors from gremlin-shaded
+
 [[release-3-3-10]]
 === TinkerPop 3.3.10 (Release Date: February 3, 2020)
 

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -97,6 +97,16 @@ limitations under the License.
                                     <shadedPattern>org.apache.tinkerpop.shaded.jackson</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <filters>
+                                <!-- Exclude service descriptors because they still reference unshaded classes, this
+                                     causes an error if the JAR is used as an automatic module in a JPMS app. -->
+                                <filter>
+                                  <artifact>*</artifact>
+                                  <excludes>
+                                    <exclude>META-INF/services/**</exclude>
+                                  </excludes>
+                                </filter>
+                            </filters>
                             <!-- false below means the shade plugin overwrites the main project artifact (the one
                                  with no classifier). false does *not* actually detach the main artifact, despite what
                                  the option name suggests. -->


### PR DESCRIPTION
No automated test, but I published a small project to reproduce the issue [here](https://github.com/olim7t/dummy-jpms).

It's actually only a warning when run from the command line, but I get an error in IntelliJ IDEA.