### PR TITLE
TINKERPOP-2335 Update to .NET Core 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - sudo apt update
   - sudo apt install apt-transport-https
   - sudo apt update
-  - sudo apt install dotnet-sdk-2.2
+  - sudo apt install dotnet-sdk-3.1
   - sudo apt install python3.6
   - sudo rm /usr/bin/python3
   - sudo ln -s python3.6 /usr/bin/python3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update
 # include both java 8/11 so that we can use the same docker image for future builds on that version of the jdk as we do
 # for the older release branches. the java version to use is just controlled by JAVA_HOME hardcoded below
 RUN apt-get install -y openjdk-8-jdk openjdk-11-jdk gawk git maven openssh-server subversion zip
-RUN apt-get install -y --force-yes dotnet-sdk-2.2 mono-devel
+RUN apt-get install -y --force-yes dotnet-sdk-3.1 mono-devel
 
 # python3 on xenial install 3.5.2 which is insufficient for newer versions of python/typing#259 so
 # custom build and install 3.5.3 and upgrade pip along the way. this could be resolved by using bionic

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -160,7 +160,7 @@ See the <<release-environment,Release Environment>> section for more information
 [[dotnet-environment]]
 === DotNet Environment
 
-The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=2.1.300) to work with the
+The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=3.1) to work with the
 `gremlin-dotnet` module. If .NET Core SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
 

--- a/gremlin-dotnet/glv/Gremlin.Net.Template.csproj.template
+++ b/gremlin-dotnet/glv/Gremlin.Net.Template.csproj.template
@@ -20,8 +20,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
@@ -20,8 +20,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <DebugType>portable</DebugType>
-    <AssemblyName>Gremlin.Net.IntegrationTest</AssemblyName>
-    <PackageId>Gremlin.Net.IntegrationTest</PackageId>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <DebugType>portable</DebugType>
-    <AssemblyName>Gremlin.Net.UnitTest</AssemblyName>
-    <PackageId>Gremlin.Net.UnitTest</PackageId>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2335

This updates `3.3-dev` (and subsequently the other release branches) to .NET Core 3.1 so that we only need to have **one .NET Core SDK version installed which will be 3.1** after this PR is merged. 3.1 is the newest version right now and it is also an LTS version.

As already said on #1260, this basically only affects our build process / environment, but not users:

> This has no effect on users of Gremlin.Net as that targets .NET Standard which doesn't need to be changed at all. The only change affecting users is the update in Gremlin.Net.Template, but that is a good thing in my opinion as the template is only used to create a completely new project and then using the latest LTS version sounds like the best approach to me.

After this is merged I can rebase #1260 which will then only remove support for .NET Standard 1.3 on `master`.

`dotnet/build.sh -t` succeeds.

VOTE +1