### PR TITLE
TINKERPOP-2351 Fixed bug in Order when enum is a key in Map

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `trustStoreType` such that keystore and truststore can be of different types in the Java driver.
 * Added session support to gremlin-javascript.
 * Modified Gremlin Server to close the session when the channel itself is closed.
+* Fixed bug in `Order` where comparisons of `enum` types wouldn't compare with `String` values.
 * Added `maxWaitForClose` configuration option to the Java driver.
 * Deprecated `maxWaitForSessionClose` in the Java driver.
 * Remove invalid service descriptors from gremlin-shaded

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Order.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Order.java
@@ -41,9 +41,7 @@ public enum Order implements Comparator<Object> {
     incr {
         @Override
         public int compare(final Object first, final Object second) {
-            return first instanceof Number && second instanceof Number
-                    ? NumberHelper.compare((Number) first, (Number) second)
-                    : Comparator.<Comparable>naturalOrder().compare((Comparable) first, (Comparable) second);
+            return asc.compare(first, second);
         }
 
         @Override
@@ -62,9 +60,7 @@ public enum Order implements Comparator<Object> {
     decr {
         @Override
         public int compare(final Object first, final Object second) {
-            return first instanceof Number && second instanceof Number
-                    ? NumberHelper.compare((Number) second, (Number) first)
-                    : Comparator.<Comparable>reverseOrder().compare((Comparable) first, (Comparable) second);
+            return desc.compare(first, second);
         }
 
         @Override
@@ -98,9 +94,13 @@ public enum Order implements Comparator<Object> {
     asc {
         @Override
         public int compare(final Object first, final Object second) {
-            return first instanceof Number && second instanceof Number
-                    ? NumberHelper.compare((Number) first, (Number) second)
-                    : Comparator.<Comparable>naturalOrder().compare((Comparable) first, (Comparable) second);
+            // need to convert enum to string representations for comparison or else you can get cast exceptions.
+            // this typically happens when sorting local on the keys of maps that contain T
+            final Object f = first instanceof Enum<?> ? ((Enum<?>) first).name() : first;
+            final Object s = second instanceof Enum<?> ? ((Enum<?>) second).name() : second;
+            return f instanceof Number && s instanceof Number
+                    ? NumberHelper.compare((Number) f, (Number) s)
+                    : Comparator.<Comparable>naturalOrder().compare((Comparable) f, (Comparable) s);
         }
 
         @Override
@@ -117,9 +117,13 @@ public enum Order implements Comparator<Object> {
     desc {
         @Override
         public int compare(final Object first, final Object second) {
-            return first instanceof Number && second instanceof Number
-                    ? NumberHelper.compare((Number) second, (Number) first)
-                    : Comparator.<Comparable>reverseOrder().compare((Comparable) first, (Comparable) second);
+            // need to convert enum to string representations for comparison or else you can get cast exceptions.
+            // this typically happens when sorting local on the keys of maps that contain T
+            final Object f = first instanceof Enum<?> ? ((Enum<?>) first).name() : first;
+            final Object s = second instanceof Enum<?> ? ((Enum<?>) second).name() : second;
+            return f instanceof Number && s instanceof Number
+                    ? NumberHelper.compare((Number) s, (Number) f)
+                    : Comparator.<Comparable>reverseOrder().compare((Comparable) f, (Comparable) s);
         }
 
         @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/OrderTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/OrderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -58,6 +59,8 @@ public class OrderTest {
                 {Order.desc, Arrays.asList(100L, 1L, -1L, 0L), Arrays.asList(100L, 1L, 0L, -1L)},
                 {Order.asc, Arrays.asList(100, 1, -1, 0), Arrays.asList(-1, 0, 1, 100)},
                 {Order.desc, Arrays.asList(100, 1, -1, 0), Arrays.asList(100, 1, 0, -1)},
+                {Order.asc, Arrays.asList("b", "a", T.id, "c", "d"), Arrays.asList("a", "b", "c", "d", T.id)},
+                {Order.desc, Arrays.asList("b", "a", T.id, "c", "d"), Arrays.asList(T.id, "d", "c", "b", "a")},
                 {Order.incr, Arrays.asList("b", "a", "c", "d"), Arrays.asList("a", "b", "c", "d")},
                 {Order.decr, Arrays.asList("b", "a", "c", "d"), Arrays.asList("d", "c", "b", "a")},
                 {Order.incr, Arrays.asList(formatter.parse("1-Jan-2018"), formatter.parse("1-Jan-2020"), formatter.parse("1-Jan-2008")),

--- a/gremlin-test/features/map/Order.feature
+++ b/gremlin-test/features/map/Order.feature
@@ -368,3 +368,18 @@ Feature: Step - order()
       """
       TODO
       """
+
+  Scenario: g_VX1X_valueMapXtrueX_orderXlocalX_byXkeys_descXunfold
+    Given the modern graph
+    And using the parameter v1Id defined as "v[marko].id"
+    And the traversal of
+      """
+      g.V(v1Id).valueMap(true).order(Scope.local).by(Column.keys, Order.desc).unfold()
+      """
+    When iterated to list
+    Then the result should be ordered
+      | result |
+      | m[{"name":["marko"]}] |
+      | m[{"t[label]":"person"}] |
+      | m[{"t[id]":"v[marko].id"}] |
+      | m[{"age":[29]}] |


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2351

This seemed like an easy fix. Can't think of any bad side-effects. Not sure if there are other special cases we should consider, but at least this common case is solved.

```text
gremlin> g.V().valueMap(true).order(local).by(keys,desc)
==>[name:[marko],label:person,id:1,age:[29]]
==>[name:[vadas],label:person,id:2,age:[27]]
==>[name:[lop],lang:[java],label:software,id:3]
==>[name:[josh],label:person,id:4,age:[32]]
==>[name:[ripple],lang:[java],label:software,id:5]
==>[name:[peter],label:person,id:6,age:[35]]
gremlin> g.V(1).valueMap(true).order(local).by(keys,desc).next()[T.id]
==>1
gremlin> g.V(1).valueMap(true).order(local).by(keys,desc).next()[T.label]
==>person
```

When this merges forward to `3.4-dev` I will modify the test to use `elementMap()` rather than `valueMap(true)` since that method is deprecated.

All tests pass with `docker/build.sh -t -i`

VOTE +1