### PR TITLE
TINKERPOP-2350 Fixed bug in Traversal.clone() in gremlin-python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,7 +30,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `maxWaitForClose` configuration option to the Java driver.
 * Deprecated `maxWaitForSessionClose` in the Java driver.
 * Bumped to Jackson 2.9.10.3.
-* Remove invalid service descriptors from gremlin-shaded
+* Remove invalid service descriptors from gremlin-shaded.
+* Fixed bug in Python traversal `clone()` where deep copies of bytecode were not occurring.
 
 [[release-3-3-10]]
 === TinkerPop 3.3.10 (Release Date: February 3, 2020)

--- a/gremlin-python/glv/GraphTraversalSource.template
+++ b/gremlin-python/glv/GraphTraversalSource.template
@@ -18,6 +18,7 @@
 #
 
 import sys
+import copy
 from .traversal import Traversal
 from .traversal import TraversalStrategies
 from .strategies import VertexProgramStrategy
@@ -87,7 +88,7 @@ class GraphTraversal(Traversal):
         return self.values(key)
 
     def clone(self):
-        return GraphTraversal(self.graph, self.traversal_strategies, self.bytecode)
+        return GraphTraversal(self.graph, self.traversal_strategies, copy.deepcopy(self.bytecode))
 <% graphStepMethods.each { method -> %>
     def <%= method %>(self, *args):
         self.bytecode.add_step("<%= toJava.call(method) %>", *args)

--- a/gremlin-python/glv/TraversalSource.template
+++ b/gremlin-python/glv/TraversalSource.template
@@ -17,10 +17,10 @@
 # under the License.
 #
 
+import copy
 from aenum import Enum
 from .. import statics
 from ..statics import long
-
 
 class Traversal(object):
     def __init__(self, graph, traversal_strategies, bytecode):
@@ -314,6 +314,20 @@ class Bytecode(object):
             return self.source_instructions == other.source_instructions and self.step_instructions == other.step_instructions
         else:
             return False
+
+    def __copy__(self):
+        bb = Bytecode()
+        bb.source_instructions = self.source_instructions
+        bb.step_instructions = self.step_instructions
+        bb.bindings = self.bindings
+        return bb
+
+    def __deepcopy__(self, memo={}):
+        bb = Bytecode()
+        bb.source_instructions = copy.deepcopy(self.source_instructions, memo)
+        bb.step_instructions = copy.deepcopy(self.step_instructions, memo)
+        bb.bindings = copy.deepcopy(self.bindings, memo)
+        return bb
 
     def __convertArgument(self,arg):
         if isinstance(arg, Traversal):

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -18,6 +18,7 @@
 #
 
 import sys
+import copy
 from .traversal import Traversal
 from .traversal import TraversalStrategies
 from .strategies import VertexProgramStrategy
@@ -132,7 +133,7 @@ class GraphTraversal(Traversal):
         return self.values(key)
 
     def clone(self):
-        return GraphTraversal(self.graph, self.traversal_strategies, self.bytecode)
+        return GraphTraversal(self.graph, self.traversal_strategies, copy.deepcopy(self.bytecode))
 
     def V(self, *args):
         self.bytecode.add_step("V", *args)

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -17,10 +17,10 @@
 # under the License.
 #
 
+import copy
 from aenum import Enum
 from .. import statics
 from ..statics import long
-
 
 class Traversal(object):
     def __init__(self, graph, traversal_strategies, bytecode):
@@ -478,6 +478,20 @@ class Bytecode(object):
             return self.source_instructions == other.source_instructions and self.step_instructions == other.step_instructions
         else:
             return False
+
+    def __copy__(self):
+        bb = Bytecode()
+        bb.source_instructions = self.source_instructions
+        bb.step_instructions = self.step_instructions
+        bb.bindings = self.bindings
+        return bb
+
+    def __deepcopy__(self, memo={}):
+        bb = Bytecode()
+        bb.source_instructions = copy.deepcopy(self.source_instructions, memo)
+        bb.step_instructions = copy.deepcopy(self.step_instructions, memo)
+        bb.bindings = copy.deepcopy(self.bindings, memo)
+        return bb
 
     def __convertArgument(self,arg):
         if isinstance(arg, Traversal):

--- a/gremlin-python/src/main/jython/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/jython/tests/process/test_traversal.py
@@ -20,6 +20,7 @@
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
 from gremlin_python.structure.graph import Graph
+from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.process.traversal import P
 from gremlin_python.process.traversal import Binding
 from gremlin_python.process.graph_traversal import __
@@ -27,7 +28,7 @@ from gremlin_python.process.graph_traversal import __
 
 class TestTraversal(object):
     def test_bytecode(self):
-        g = Graph().traversal()
+        g = traversal().withGraph(Graph())
         bytecode = g.V().out("created").bytecode
         assert 0 == len(bytecode.bindings.keys())
         assert 0 == len(bytecode.source_instructions)
@@ -82,3 +83,22 @@ class TestTraversal(object):
         assert 0 == len(bytecode.bindings.keys())
         assert 0 == len(bytecode.source_instructions)
         assert 0 == len(bytecode.step_instructions)
+
+    def test_clone_traversal(self):
+        g = traversal().withGraph(Graph())
+        original = g.V().out("created")
+        clone = original.clone().out("knows")
+        cloneClone = clone.clone().out("created")
+
+        assert 2 == len(original.bytecode.step_instructions)
+        assert 3 == len(clone.bytecode.step_instructions)
+        assert 4 == len(cloneClone.bytecode.step_instructions)
+
+        original.has("person", "name", "marko")
+        clone.V().out()
+
+        assert 3 == len(original.bytecode.step_instructions)
+        assert 5 == len(clone.bytecode.step_instructions)
+        assert 4 == len(cloneClone.bytecode.step_instructions)
+
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2350

We weren't deep copying bytecode before. Added a test to verify things are working as expected and manually tested the failing example in the JIRA:

```text
>>> g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
>>> t0 = g.V().hasLabel('x')
>>> t0
[['V'], ['hasLabel', 'x']]
>>> t1 = t0.clone()
>>> t1
[['V'], ['hasLabel', 'x']]
>>> t1.has('name','y')
[['V'], ['hasLabel', 'x'], ['has', 'name', 'y']]
>>> t0
[['V'], ['hasLabel', 'x']]
>>> 

VOTE +1