### PR TITLE
TINKERPOP-2350 Fixed bug in Traversal.clone() in Gremlin.NET

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,7 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated `maxWaitForSessionClose` in the Java driver.
 * Bumped to Jackson 2.9.10.3.
 * Remove invalid service descriptors from gremlin-shaded.
-* Fixed bug in Python traversal `clone()` where deep copies of bytecode were not occurring.
+* Fixed bug in Python and .NET traversal `clone()` where deep copies of bytecode were not occurring.
 
 [[release-3-3-10]]
 === TinkerPop 3.3.10 (Release Date: February 3, 2020)

--- a/gremlin-dotnet/glv/GraphTraversal.template
+++ b/gremlin-dotnet/glv/GraphTraversal.template
@@ -86,7 +86,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal<S, E> Clone()
         {
-            return new GraphTraversal<S, E>(this.TraversalStrategies, this.Bytecode);
+            return new GraphTraversal<S, E>(TraversalStrategies, new Bytecode(Bytecode));
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -1683,7 +1683,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public GraphTraversal<S, E> Clone()
         {
-            return new GraphTraversal<S, E>(this.TraversalStrategies, this.Bytecode);
+            return new GraphTraversal<S, E>(TraversalStrategies, new Bytecode(Bytecode));
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
@@ -63,5 +63,25 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
             Assert.Equal(0, gLocal.TraversalStrategies.Count);
             Assert.Equal(1, gRemote.TraversalStrategies.Count);
         }
+
+        [Fact]
+        public void CloneShouldCreateIndependentGraphTraversalModifiyingBytecode()
+        {
+            var g = AnonymousTraversalSource.Traversal();
+            var original = g.V().Out("created");
+            var clone = original.Clone().Out("knows");
+            var cloneClone = clone.Clone().Out("created");
+            
+            Assert.Equal(2, original.Bytecode.StepInstructions.Count);
+            Assert.Equal(3, clone.Bytecode.StepInstructions.Count);
+            Assert.Equal(4, cloneClone.Bytecode.StepInstructions.Count);
+
+            original.Has("person", "name", "marko");
+            clone.V().Out();
+            
+            Assert.Equal(3, original.Bytecode.StepInstructions.Count);
+            Assert.Equal(5, clone.Bytecode.StepInstructions.Count);
+            Assert.Equal(4, cloneClone.Bytecode.StepInstructions.Count);
+        }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2350

This is basically the same fix for .NET as #1268 for Python. This also includes the commit from #1268 so I'll rebase this once that PR is merged.

VOTE +1