### PR TITLE
TINKERPOP-2356 Bump to Jackson 2.10

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,11 +42,12 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Refactored `Traversal` semantics to always expect `EmptyStep` as a parent if it is meant to be the root `Traversal`.
 * Configured GraphBinary as the default binary serialization format for the Java Driver.
 * Configured GraphSON 3.0 as the default text serialization format when no serializer can be determined.
-* Upgraded to Neo4j 3.4.11.
+* Bump to Neo4j 3.4.11.
 * Added a parameterized `TypeTranslator` for use with `GroovyTranslator` that should produce more cache hits.
 * Added support for `TextP` in Neo4j using its string search functions.
 * Changed `TraversalStrategy` application methodology to apply each strategy in turn to each level of the traversal hierarchy starting from root down to children.
 * Prevented more than one `Client` from connecting to the same Gremlin Server session.
+* Bumped to Jackson 2.10.x.
 * Removed internal functionality for the session close message in Gremlin Server - the message is accepted but ignored if sent.
 * Removed `Property.Exceptions.propertyValueCanNotBeNull` exception type as `null` now has meaning in Gremlin.
 * Removed the "experimental" support for multi/meta-properties in Neo4j.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONReader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONReader.java
@@ -177,7 +177,8 @@ public final class GraphSONReader implements GraphReader {
                              final Direction attachEdgesOfThisDirection) throws IOException {
         // graphson v3 has special handling for generic Map instances, by forcing to linkedhashmap (which is probably
         // what it should have been anyway) stargraph format can remain unchanged across all versions
-        final Map<String, Object> vertexData = mapper.readValue(inputStream, version == GraphSONVersion.V3_0 ? linkedHashMapTypeReference : mapTypeReference);
+        final Map<String, Object> vertexData = version == GraphSONVersion.V3_0 ?
+                mapper.readValue(inputStream, linkedHashMapTypeReference) : mapper.readValue(inputStream, mapTypeReference);
         final StarGraph starGraph = StarGraphGraphSONDeserializer.readStarGraphVertex(vertexData);
         if (vertexAttachMethod != null) vertexAttachMethod.apply(starGraph.getStarVertex());
 
@@ -315,9 +316,9 @@ public final class GraphSONReader implements GraphReader {
 
         /**
          * If the adjacency list is wrapped in a JSON object, as is done when writing a graph with
-         * {@link GraphSONWriter.Builder#wrapAdjacencyList} set to {@code true}, this setting needs to be set to
-         * {@code true} to properly read it.  By default, this value is {@code false} and the adjacency list is
-         * simply read as line delimited vertices.
+         * {@link GraphSONWriter.Builder#wrapAdjacencyList(boolean)} wrapAdjacencyList} set to {@code true}, this
+         * setting needs to be set to {@code true} to properly read it.  By default, this value is {@code false} and
+         * the adjacency list is simply read as line delimited vertices.
          * <p/>
          * By setting this value to {@code true}, the generated JSON is no longer "splittable" by line and thus not
          * suitable for OLAP processing.  Furthermore, reading this format of the JSON with

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeResolverBuilder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeResolverBuilder.java
@@ -21,7 +21,9 @@ package org.apache.tinkerpop.gremlin.structure.io.graphson;
 import org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig;
 import org.apache.tinkerpop.shaded.jackson.databind.JavaType;
 import org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig;
+import org.apache.tinkerpop.shaded.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType;
+import org.apache.tinkerpop.shaded.jackson.databind.jsontype.PolymorphicTypeValidator;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeDeserializer;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeIdResolver;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeSerializer;
@@ -41,6 +43,7 @@ public class GraphSONTypeResolverBuilder extends StdTypeResolverBuilder {
     private TypeInfo typeInfo;
     private String valuePropertyName;
     private final GraphSONVersion version;
+    private final PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder().build();
 
     public GraphSONTypeResolverBuilder(final GraphSONVersion version) {
         this.version = version;
@@ -49,7 +52,7 @@ public class GraphSONTypeResolverBuilder extends StdTypeResolverBuilder {
     @Override
     public TypeDeserializer buildTypeDeserializer(final DeserializationConfig config, final JavaType baseType,
                                                   final Collection<NamedType> subtypes) {
-        final TypeIdResolver idRes = this.idResolver(config, baseType, subtypes, false, true);
+        final TypeIdResolver idRes = this.idResolver(config, baseType, typeValidator, subtypes, false, true);
         return new GraphSONTypeDeserializer(baseType, idRes, this.getTypeProperty(), typeInfo, valuePropertyName);
     }
 
@@ -57,7 +60,7 @@ public class GraphSONTypeResolverBuilder extends StdTypeResolverBuilder {
     @Override
     public TypeSerializer buildTypeSerializer(final SerializationConfig config, final JavaType baseType,
                                               final Collection<NamedType> subtypes) {
-        final TypeIdResolver idRes = this.idResolver(config, baseType, subtypes, true, false);
+        final TypeIdResolver idRes = this.idResolver(config, baseType, typeValidator, subtypes, true, false);
         return version == GraphSONVersion.V2_0 ?
                 new GraphSONTypeSerializerV2d0(idRes, this.getTypeProperty(), typeInfo, valuePropertyName) :
                 new GraphSONTypeSerializerV3d0(idRes, this.getTypeProperty(), typeInfo, valuePropertyName);

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/util/DependencyGrabberIntegrateTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/util/DependencyGrabberIntegrateTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.fail;
  */
 public class DependencyGrabberIntegrateTest {
     private static final String GROUP_ID = "org.apache.tinkerpop";
-    private static final String VERSION = "3.3.7";
+    private static final String VERSION = "3.3.8";
 
     private static final GroovyClassLoader groovyClassLoader = new GroovyClassLoader();
     private static final File extTestDir = TestHelper.makeTestDataPath(DependencyGrabberIntegrateTest.class);

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -49,7 +49,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.3</version>
+            <version>2.10.3</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2356

This moves us off the CVE flooded 2.9.x. Changes were pretty minimal. I suppose we could backport if we really wanted to but this was mostly done to see what the impact would be as we look forward to hopefully going to Jackson 3.0 before TP 3.5.0 releases.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1