### PR TITLE
TINKERPOP-2345 Improved error message for bad value for math()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-3-11, 3.3.11>>.
 
 * Gremlin.NET driver: Fixed a `NullReferenceException` and throw clear exception if received message is empty.
+* Improved error message for `math()` when the selected key in a `Map` is `null` or not a `Number`.
 
 [[release-3-4-6]]
 === TinkerPop 3.4.6 (Release Date: February 20, 2020)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/Scoping.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/Scoping.java
@@ -110,32 +110,24 @@ public interface Scoping {
     public enum Variable {START, END}
 
     public default <S> S getScopeValue(final Pop pop, final String key, final Traverser.Admin<?> traverser) throws IllegalArgumentException {
-        final Object object = traverser.get();
-        if (object instanceof Map && ((Map<String, S>) object).containsKey(key))
-            return ((Map<String, S>) object).get(key);
-        ///
-        if (traverser.getSideEffects().exists(key))
-            return traverser.getSideEffects().get(key);
-        ///
-        final Path path = traverser.path();
-        if (path.hasLabel(key))
-            return path.get(pop, key);
-        ///
-        throw new IllegalArgumentException("Neither the sideEffects, map, nor path has a " + key + "-key: " + this);
+        final S o = getNullableScopeValue(pop, key, traverser);
+        if (null == o)
+            throw new IllegalArgumentException("Neither the sideEffects, map, nor path has a " + key + "-key: " + this);
+        return o;
     }
 
     public default <S> S getNullableScopeValue(final Pop pop, final String key, final Traverser.Admin<?> traverser) {
         final Object object = traverser.get();
         if (object instanceof Map && ((Map<String, S>) object).containsKey(key))
             return ((Map<String, S>) object).get(key);
-        ///
+
         if (traverser.getSideEffects().exists(key))
             return traverser.getSideEffects().get(key);
-        ///
+
         final Path path = traverser.path();
         if (path.hasLabel(key))
             return path.get(pop, key);
-        ///
+
         return null;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2345

This problem really only applies to 3.4.x since by() didn't modulate Map traversers in 3.3.x. This change does also however fix the error message for non-Number objects trying to be passed into a math() expression, but the error is at least more understandable than the NullPointerException - on 3.3.x we get "java.lang.String cannot be cast to java.lang.Number" which while not perfect is probably good enough for that older version. It didn't seem like a big enough problem to add the enhancement there.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1