### PR TITLE
TINKERPOP-2357 Added :cls command to clear console screen

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ This release also includes changes from <<release-3-3-11, 3.3.11>>.
 
 * Gremlin.NET driver: Fixed a `NullReferenceException` and throw clear exception if received message is empty.
 * Improved error message for `math()` when the selected key in a `Map` is `null` or not a `Number`.
+* Added `:cls` command to Gremlin Console to clear the screen.
 
 [[release-3-4-6]]
 === TinkerPop 3.4.6 (Release Date: February 20, 2020)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -128,6 +128,7 @@ some other useful operations.  The following table outlines the most commonly us
 |:help |:? |Displays list of commands and descriptions.  When followed by a command name, it will display more specific help on that particular item.
 |:exit |:x |Ends the Console session.
 |import |:i |Import a class into the Console session.
+|:cls |:C |Clear the screen of the Console.
 |:clear |:c |Sometimes the Console can get into a state where the command buffer no longer understands input (e.g. a misplaced `(` or `}`).  Use this command to clear that buffer.
 |:load |:l |Load a file or URL into the command buffer for execution.
 |:install |:+ |Imports a Maven library and its dependencies into the Console.

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -30,7 +30,12 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
+==== Clear Screen Command
 
+Gremlin Console now has the `:cls` command to clear the screen. This feature acts as an alternative to platform
+specific clear operations and provides a common way to perform that function.
+
+link:https://issues.apache.org/jira/browse/TINKERPOP-2357[TINKERPOP-2357]
 
 == TinkerPop 3.4.6
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.console.commands.GremlinSetCommand
 import org.apache.tinkerpop.gremlin.console.commands.InstallCommand
 import org.apache.tinkerpop.gremlin.console.commands.PluginCommand
 import org.apache.tinkerpop.gremlin.console.commands.RemoteCommand
+import org.apache.tinkerpop.gremlin.console.commands.ClsCommand
 import org.apache.tinkerpop.gremlin.console.commands.SubmitCommand
 import org.apache.tinkerpop.gremlin.console.commands.UninstallCommand
 import org.apache.tinkerpop.gremlin.groovy.loaders.GremlinLoader
@@ -107,6 +108,7 @@ class Console {
         groovy.register(new RemoteCommand(groovy, mediator))
         groovy.register(new SubmitCommand(groovy, mediator))
         groovy.register(new BytecodeCommand(groovy, mediator))
+        groovy.register(new ClsCommand(groovy, mediator))
 
         // hide output temporarily while imports execute
         showShellEvaluationOutput(false)
@@ -288,6 +290,13 @@ class Console {
                 }
             }
         }
+    }
+
+    /**
+     * Clears the console screen.
+     */
+    def clear() {
+        io.out.println("\033[H\033[2J")
     }
 
     def printResult(def object) {

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/ClsCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/ClsCommand.groovy
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.console.commands
+
+import org.apache.tinkerpop.gremlin.console.Mediator
+import org.codehaus.groovy.tools.shell.CommandSupport
+import org.codehaus.groovy.tools.shell.Groovysh
+
+/**
+ * Clear the console.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+class ClsCommand extends CommandSupport {
+
+    private final Mediator mediator
+
+    public ClsCommand(final Groovysh shell, final Mediator mediator) {
+        super(shell, ":cls", ":C")
+        this.mediator = mediator
+    }
+
+    @Override
+    def Object execute(final List<String> arguments) {
+        mediator.console.clear();
+    }
+}

--- a/gremlin-console/src/main/resources/org/apache/tinkerpop/gremlin/console/commands/ClsCommand.properties
+++ b/gremlin-console/src/main/resources/org/apache/tinkerpop/gremlin/console/commands/ClsCommand.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+command.description=Clear the screen.
+command.usage=
+command.help=Clear the screen.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2357

This change was implemented a while ago but I didn't issue the PR immediately as I requested on the ML that folks test it on different platforms to make sure it works. The confirmations came in fast and then I accidentally forgot to get this into review.

I purposely didn't target `3.3-dev` here as it's a new feature and I didn't want to make any more mistakes related to putting anything other than bug fixes there. 

All tests pass with `docker/build.sh -t -i`

VOTE +1