### PR TITLE
Tinkerpop-1641 Kerberos authentication for gremlin-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - sudo apt install python3.6
   - sudo rm /usr/bin/python3
   - sudo ln -s python3.6 /usr/bin/python3
-  - sudo apt install gcc python3.6-dev libkrb5-dev
+  - sudo apt install libkrb5-dev
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - sudo apt install python3.6
   - sudo rm /usr/bin/python3
   - sudo ln -s python3.6 /usr/bin/python3
-  - sudo apt install libkrb5-dev
+  - sudo apt install gcc python3.6-dev libkrb5-dev
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
   - sudo apt install python3.6
   - sudo rm /usr/bin/python3
   - sudo ln -s python3.6 /usr/bin/python3
+  - sudo apt install libkrb5-dev
 
 jobs:
   include:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,9 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Bump to Neo4j 3.4.11.
 * Added a parameterized `TypeTranslator` for use with `GroovyTranslator` that should produce more cache hits.
 * Added support for `TextP` in Neo4j using its string search functions.
+* Added a kerberos KDC to the docker container for testing GLV's.
+* Added kerberos authentication to Gremlin-Python.
+* Added audit logging to bytecode-based traversals.
 * Changed `TraversalStrategy` application methodology to apply each strategy in turn to each level of the traversal hierarchy starting from root down to children.
 * Prevented more than one `Client` from connecting to the same Gremlin Server session.
 * Bumped to Jackson 2.10.x.

--- a/bin/gephi-mock.py
+++ b/bin/gephi-mock.py
@@ -28,7 +28,7 @@ class GephiHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Content-Type', 'text/plain')
         self.end_headers()
-        self.wfile.write("{}")
+        self.wfile.write("{}".encode('utf-8'))
 
     def do_GET(self):
         self.respond()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,9 @@ RUN apt-get install -y --force-yes dotnet-sdk-3.1 mono-devel
 # custom build and install 3.5.3 and upgrade pip along the way. this could be resolved by using bionic
 # but trying to keep all of our release branches on the same docker image and the older versions sorta
 # suit 3.3.x and 3.4.x
-RUN apt-get install -y --force-yes python python-dev python-pip build-essential checkinstall zlib1g-dev libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get install -y python python-dev python-pip build-essential checkinstall zlib1g-dev libreadline-gplv2-dev \
+    libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libkrb5-dev krb5-user
 RUN cd /opt && wget https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tgz && tar -xvf Python-3.5.3.tgz
 RUN cd /opt/Python-3.5.3 && ./configure && make && make install
 RUN ln -sf /usr/bin/python3.5.3 /usr/bin/python3

--- a/docker/gremlin-server.sh
+++ b/docker/gremlin-server.sh
@@ -57,7 +57,8 @@ echo "Using Gremlin Server $GREMLIN_SERVER_VERSION"
 sed -e "s/GREMLIN_SERVER_VERSION\$/${GREMLIN_SERVER_VERSION}/" docker/gremlin-server/Dockerfile.template > Dockerfile
 
 docker build -t tinkerpop:${BUILD_TAG} .
-docker run ${TINKERPOP_TEST_DOCKER_OPTS} ${REMOVE_CONTAINER} -ti -v "${HOME}"/.groovy:/root/.groovy -v "${HOME}"/.m2:/root/.m2 tinkerpop:${BUILD_TAG} ${@}
+docker run ${TINKERPOP_TEST_DOCKER_OPTS} ${REMOVE_CONTAINER} -h gremlin-server-test -v "${HOME}"/.groovy:/root/.groovy \
+    -v "${HOME}"/.m2:/root/.m2 -v ${PROJECT_HOME}gremlin-test/target:/opt/gremlin-test -ti tinkerpop:${BUILD_TAG} ${@}
 
 status=$?
 popd > /dev/null

--- a/docker/gremlin-server/Dockerfile.template
+++ b/docker/gremlin-server/Dockerfile.template
@@ -25,7 +25,7 @@ COPY docker/gremlin-server/docker-entrypoint.sh docker/gremlin-server/*.yaml /op
 RUN chmod 755 /opt/docker-entrypoint.sh
 ENV GREMLIN_SERVER_VERSION=GREMLIN_SERVER_VERSION
 
-EXPOSE 45940
+EXPOSE 45940-45942 4588
 
 ENTRYPOINT ["/opt/docker-entrypoint.sh"]
 CMD []

--- a/docker/gremlin-server/docker-entrypoint.sh
+++ b/docker/gremlin-server/docker-entrypoint.sh
@@ -19,18 +19,71 @@
 #
 
 TINKERPOP_HOME=/opt/gremlin-server
-
 cp /opt/test/scripts/* ${TINKERPOP_HOME}/scripts
 
 IP=$(hostname -i)
-echo "#######################"
+
+echo "#############################################################################"
 echo IP is $IP
-echo "#######################"
+echo
+echo Available Gremlin Server instances:
+echo "ws://${IP}:45940/gremlin with anonymous access"
+echo "ws://${IP}:45941/gremlin with basic authentication (stephen/password)"
+echo "ws://${IP}:45942/gremlin with kerberos authentication (stephen/password)"
+echo
+echo "See docker/gremlin-server/docker-entrypoints.sh for transcripts per GLV."
+echo "#############################################################################"
 
 cp *.yaml ${TINKERPOP_HOME}/conf/
 
 java -version
 
-/opt/gremlin-server/bin/gremlin-server.sh install org.apache.tinkerpop gremlin-python ${GREMLIN_SERVER_VERSION}
 /opt/gremlin-server/bin/gremlin-server.sh conf/gremlin-server-integration.yaml &
-exec /opt/gremlin-server/bin/gremlin-server.sh conf/gremlin-server-integration-secure.yaml
+
+/opt/gremlin-server/bin/gremlin-server.sh conf/gremlin-server-integration-secure.yaml &
+
+java -cp /opt/gremlin-test/gremlin-test-3.5.0-SNAPSHOT-jar-with-dependencies.jar \
+     -Dlog4j.configuration="file:/opt/gremlin-server/conf/log4j-server.properties" \
+     org.apache.tinkerpop.gremlin.server.KdcFixture /opt/gremlin-server &
+
+export JAVA_OPTIONS="-Xms512m -Xmx4096m -Djava.security.krb5.conf=/opt/gremlin-server/target/kdc/krb5.conf"
+exec /opt/gremlin-server/bin/gremlin-server.sh conf/gremlin-server-integration-krb5.yaml
+
+
+#######################################################################
+# Transcripts for connecting to gremlin-server-test using various GLV's
+#######################################################################
+#
+# cd ${APACHE_TINKERPOP}                              # first terminal: location of cloned gitrepo
+# docker/gremlin-server.sh
+
+# cd ${APACHE_TINKERPOP}                              # second terminal
+# export KRB5_CONFIG=`pwd`/docker/gremlin-server/krb5.conf
+# echo 'password' | kinit stephen
+# klist
+
+# Gremlin-Groovy
+# --------------
+# KRB5_OPTION="-Djava.security.krb5.conf=`pwd`/docker/gremlin-server/krb5.conf"
+# JAAS_OPTION="-Djava.security.auth.login.config=`pwd`/docker/gremlin-server/gremlin-console-jaas.conf"
+# export JAVA_OPTIONS="${KRB5_OPTION} ${JAAS_OPTION}"
+# cd gremlin-console/target/apache-tinkerpop-gremlin-console-3.x.y-SNAPSHOT-standalone
+# If necessary (versions 3.4.2-3.4.6): in bin/gremlin.sh replace JVM_OPTS+=( "${JAVA_OPTIONS}" ) by JVM_OPTS+=( ${JAVA_OPTIONS} )
+# bin/gremlin.sh
+# gremlin> cluster = Cluster.build("172.17.0.2").port(45940).create()
+# gremlin> cluster = Cluster.build("172.17.0.2").port(45941).credentials("stephen", "password").create()
+# gremlin> cluster = Cluster.build("172.17.0.2").port(45942).addContactPoint("gremlin-server-test").protocol("test-service").jaasEntry("GremlinConsole").create()
+# gremlin> g = traversal().withRemote(DriverRemoteConnection.using(cluster, "gmodern"))
+# gremlin> g.V()
+
+# Gremlin-Python
+# --------------
+# cd gremlin-python/target/python3
+# source env/bin/activate
+# python
+# >>> from gremlin_python.process.anonymous_traversal import traversal
+# >>> from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+# >>> g = traversal().withRemote(DriverRemoteConnection('ws://172.17.0.2:45940/gremlin','gmodern'))
+# >>> g = traversal().withRemote(DriverRemoteConnection('ws://172.17.0.2:45941/gremlin','gmodern', username='stephen', password='password'))
+# >>> g = traversal().withRemote(DriverRemoteConnection('ws://172.17.0.2:45942/gremlin','gmodern', kerberized_service='test-service@gremlin-server-test'))
+# >>> g.V().toList()

--- a/docker/gremlin-server/gremlin-console-jaas.conf
+++ b/docker/gremlin-server/gremlin-console-jaas.conf
@@ -17,24 +17,8 @@
  * under the License.
  */
 
-if (Boolean.parseBoolean(skipTests)) return
-
-log.info("Tests for native ${executionName} complete")
-
-def server = project.getContextValue("gremlin.server")
-log.info("Shutting down $server")
-server.stop().join()
-
-def serverSecure = project.getContextValue("gremlin.server.secure")
-log.info("Shutting down $serverSecure")
-serverSecure.stop().join()
-
-def kdcServer = project.getContextValue("gremlin.server.kdcserver")
-log.info("Shutting down $kdcServer")
-kdcServer.close()
-
-def serverKrb5 = project.getContextValue("gremlin.server.krb5")
-log.info("Shutting down $serverKrb5")
-serverKrb5.stop().join()
-
-log.info("All Gremlin Server instances are shutdown for ${executionName}")
+GremlinConsole {
+  com.sun.security.auth.module.Krb5LoginModule required
+  doNotPrompt=true
+  useTicketCache=true;
+};

--- a/docker/gremlin-server/gremlin-server-integration-krb5.yaml
+++ b/docker/gremlin-server/gremlin-server-integration-krb5.yaml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+host: 0.0.0.0
+port: 45942
+evaluationTimeout: 30000
+graphs: {
+  graph: conf/tinkergraph-empty.properties,
+  classic: conf/tinkergraph-empty.properties,
+  modern: conf/tinkergraph-empty.properties,
+  crew: conf/tinkergraph-empty.properties,
+  grateful: conf/tinkergraph-empty.properties,
+  sink: conf/tinkergraph-empty.properties}
+scriptEngines: {
+  gremlin-groovy: {
+    plugins: { org.apache.tinkerpop.gremlin.server.jsr223.GremlinServerGremlinPlugin: {},
+               org.apache.tinkerpop.gremlin.tinkergraph.jsr223.TinkerGraphGremlinPlugin: {},
+               org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPlugin: {expectedCompilationTime: 30000},
+               org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]},
+               org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/generate-all.groovy]}}}}
+serializers:
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV1d0], custom: [groovy.json.JsonBuilder;org.apache.tinkerpop.gremlin.driver.ser.JsonBuilderGryoSerializer]}}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0], custom: [groovy.json.JsonBuilder;org.apache.tinkerpop.gremlin.driver.ser.JsonBuilderGryoSerializer]}}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV1d0], custom: [groovy.json.JsonBuilder;org.apache.tinkerpop.gremlin.driver.ser.JsonBuilderGryoSerializer]}}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true}}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { serializeResultToString: true}}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0] }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV2d0] }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV1d0] }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1 }
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}
+processors:
+  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+  - { className: org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor, config: {}}
+metrics: {
+  slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
+idleConnectionTimeout: 0
+keepAliveInterval: 0
+maxInitialLineLength: 4096
+maxHeaderSize: 8192
+maxChunkSize: 8192
+maxContentLength: 1000000
+maxAccumulationBufferComponents: 1024
+resultIterationBatchSize: 64
+writeBufferLowWaterMark: 32768
+writeBufferHighWaterMark: 65536
+authentication: {
+  authenticator: org.apache.tinkerpop.gremlin.server.auth.Krb5Authenticator,
+  config: {
+    principal: test-service/gremlin-server-test@TEST.COM,
+    keytab: /opt/gremlin-server/target/kdc/test-service.keytab}}

--- a/docker/gremlin-server/krb5.conf
+++ b/docker/gremlin-server/krb5.conf
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[libdefaults]
+    kdc_realm = TEST.COM
+    default_realm = TEST.COM
+    udp_preference_limit = 4096
+    kdc_tcp_port = 4588
+    kdc_udp_port = 4588
+
+[realms]
+    TEST.COM = {
+        kdc = 172.17.0.2:4588
+    }

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1258,11 +1258,10 @@ authentication: {
     keytab: /etc/security/keytabs/gremlinserver.service.keytab}}
 
 `Krb5Authenticator` needs a Kerberos service principal and a keytab that holds the secret key for that principal. The keytab
-location and service name, e.g. gremlinserver, are free to be chosen. In addition, if the krb5.conf kerberos
-configuration file is not available from the
-https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default location], `Krb5Authenticator` needs the location
-of the krb5.conf configuration file, to be specified as a system property in the JAVA_OPTIONS environment variable
-of Gremlin Server:
+location and service name, e.g. gremlinserver, are free to be chosen. `Krb5Authenticator` finds the KDC's hostname and
+port from the krb5.conf file with Kerberos configurations. This file can reside at either the
+https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default location] or a location to be specified as a
+system property in the JAVA_OPTIONS environment variable of Gremlin Server:
 
 [source, bash]
 export JAVA_OPTIONS="${JAVA_OPTIONS} -Xms512m -Xmx4096m -Djava.security.krb5.conf=/etc/krb5.conf"
@@ -1287,7 +1286,7 @@ ticket cache that is normally refreshed when a user logs in to a host within the
 
 The Gremlin client needs the location of the JAAS configuration file to be passed as a system property to the JVM. For
 Gremlin-Console the easiest way to do this is to pass it to the run script via the JAVA_OPTIONS environment property.
-If the krb5.conf kerberos configuration file is not available from the
+If the krb5.conf Kerberos configuration file is not available from the
 https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default location] it has to be provided as a system
 property as well:
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1076,7 +1076,8 @@ Gremlin-Console |PLAIN SASL (username/password) |3.0.0-incubating
 |Pluggable SASL |3.0.0-incubating
 |GSSAPI SASL (Kerberos) |3.3.0
 |Gremlin.NET |PLAIN SASL |3.3.0
-|Gremlin-Python |PLAIN SASL |3.2.2
+1.2+v|Gremlin-Python |PLAIN SASL |3.2.2
+|GSSAPI SASL (Kerberos) |3.4.7
 |Gremlin.Net |PLAIN SASL |3.2.7
 |Gremlin-Javascript |PLAIN SASL |3.3.0
 |=========================================================
@@ -1256,14 +1257,22 @@ authentication: {
     principal: gremlinserver/hostname.your.org@YOUR.REALM,
     keytab: /etc/security/keytabs/gremlinserver.service.keytab}}
 
-Krb5Authenticator needs a Kerberos service principal and a keytab that holds the secret key for that principal. The keytab
-location and service name, e.g. gremlinserver, are free to be chosen, but Gremlin clients have to specify this service name
-as the `protocol`. For Gremlin-Console the `protocol` is an entry in the remote.yaml file, for Gremlin-java the client builder
-has a `protocol()` method.
+`Krb5Authenticator` needs a Kerberos service principal and a keytab that holds the secret key for that principal. The keytab
+location and service name, e.g. gremlinserver, are free to be chosen. In addition, if the krb5.conf kerberos
+configuration file is not available from the
+https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default location], `Krb5Authenticator` needs the location
+of the krb5.conf configuration file, to be specified as a system property in the JAVA_OPTIONS environment variable
+of Gremlin Server:
+
+[source, bash]
+export JAVA_OPTIONS="${JAVA_OPTIONS} -Xms512m -Xmx4096m -Djava.security.krb5.conf=/etc/krb5.conf"
+
+Gremlin clients have to specify the service name as the `protocol` connection parameter. For Gremlin-Console the
+`protocol` is an entry in the remote.yaml file, for Gremlin-java the client builder has a `protocol()` method.
 
 In addition to the `protocol`, the Gremlin client needs to specify a `jaasEntry`, an entry in the
-link:https://en.wikipedia.org/wiki/Java_Authentication_and_Authorization_Service[JAAS] configuration file. Gremlin-Console
-comes with a sample gremlin-jaas.conf file with a `GremlinConsole` jaasEntry:
+link:https://en.wikipedia.org/wiki/Java_Authentication_and_Authorization_Service[JAAS] configuration file. As a
+start one can define a conf/gremlin-jaas.conf file with a `GremlinConsole` jaasEntry:
 
 [source, jaas]
 GremlinConsole {
@@ -1272,15 +1281,20 @@ GremlinConsole {
   useTicketCache=true;
 };
 
-This configuration tells Gremlin-Console to pass authentication requests from gremlin-server to the Krb5LoginModule, which is
-part of the java standard library.  The Krb5LoginModule does not prompt the user for a username and password but uses the ticket cache that
-is normally refreshed when a user logs in to a host within the Kerberos realm.
+This configuration tells Gremlin Console to pass authentication requests from Gremlin Server to the Krb5LoginModule, which is
+part of the java standard library. The Krb5LoginModule does not prompt the user for a username and password but uses the
+ticket cache that is normally refreshed when a user logs in to a host within the Kerberos realm.
 
-Finally, the Gremlin client needs the location of the JAAS configuration file to be passed as a system property to the JVM. For
-Gremlin-Console the easiest way to do this is to pass it to the run script via the JAVA_OPTIONS environment property:
+The Gremlin client needs the location of the JAAS configuration file to be passed as a system property to the JVM. For
+Gremlin-Console the easiest way to do this is to pass it to the run script via the JAVA_OPTIONS environment property.
+If the krb5.conf kerberos configuration file is not available from the
+https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default location] it has to be provided as a system
+property as well:
 
 [source, bash]
-export JAVA_OPTIONS="$JAVA_OPTIONS -Djava.security.auth.login.config=conf/gremlin-jaas.conf"
+JAAS_OPTION="-Djava.security.auth.login.config=conf/gremlin-jaas.conf"
+KRB5_OPTION="-Djava.security.krb5.conf=/etc/krb5.conf"
+export JAVA_OPTIONS="${JAVA_OPTIONS} ${KRB5_OPTION} ${JAAS_OPTION}"
 
 [[script-execution]]
 ===== Protecting Script Execution

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -675,12 +675,12 @@ g = traversal().withRemote(DriverRemoteConnection(
 
 # Kerberos authentication
 g = traversal().withRemote(DriverRemoteConnection(
-    'ws://localhost:8182/gremlin', 'g', kerberized_service='gremlin'))
+    'ws://localhost:8182/gremlin', 'g', kerberized_service='gremlin@hostname.your.org'))
 ----
 
 The value specified for the kerberized_service should correspond to the first part of the principal name configured for
-the gremlin service. The Gremlin-Python client reads the kerberos configurations from your system.
-It finds the KDC's hostname and port from the krb5.conf file at the
+the gremlin service, but with the slash replaced by an _at_ sign. The Gremlin-Python client reads the kerberos
+configurations from your system. It finds the KDC's hostname and port from the krb5.conf file at the
 https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default location] or as indicated in the KRB5_CONFIG
 environment variable. It finds credentials from the credential cache or a keytab file at the
 https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default locations] or as indicated

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -642,6 +642,7 @@ To install Gremlin-Python, use Python's link:https://en.wikipedia.org/wiki/Pip_(
 [source,bash]
 ----
 pip install gremlinpython
+pip install gremlinpython[kerberos]     # Optional, not available on Microsoft Windows
 ----
 
 === Connecting
@@ -660,8 +661,35 @@ to the `DriverRemoteConnection` constructor.
 
 [source,python]
 ----
-g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g',headers={'Header':'Value'}))
+g = traversal().withRemote(DriverRemoteConnection(
+    'ws://localhost:8182/gremlin', 'g', headers={'Header':'Value'}))
 ----
+
+Gremlin-Python supports plain text and Kerberos SASL authentication, you can set it on the connection options.
+
+[source,python]
+----
+# Plain text authentication
+g = traversal().withRemote(DriverRemoteConnection(
+    'ws://localhost:8182/gremlin', 'g', username='stephen', password='password'))
+
+# Kerberos authentication
+g = traversal().withRemote(DriverRemoteConnection(
+    'ws://localhost:8182/gremlin', 'g', kerberized_service='gremlin'))
+----
+
+The value specified for the kerberized_service should correspond to the first part of the principal name configured for
+the gremlin service. The Gremlin-Python client reads the kerberos configurations from your system.
+It finds the KDC's hostname and port from the krb5.conf file at the
+https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default location] or as indicated in the KRB5_CONFIG
+environment variable. It finds credentials from the credential cache or a keytab file at the
+https://web.mit.edu/kerberos/krb5-devel/doc/mitK5defaults.html[default locations] or as indicated
+in the KRB5CCNAME or KRB5_KTNAME environment variables.
+
+If you authenticate to a remote <<connecting-gremlin-server,Gremlin Server>> or
+<<connecting-rgp,Remote Gremlin Provider>>, this server normally has SSL activated and the websockets url will start
+with 'wss://'. If Gremlin-Server uses a self-signed certificate for SSL, Gremlin-Python needs access to a local copy of
+the CA certificate file (in openssl .pem format), to be specified in the SSL_CERT_FILE environment variable.
 
 [[python-imports]]
 === Common Imports
@@ -737,6 +765,7 @@ can be passed to the `Client` or `DriverRemoteConnection` instance as keyword ar
 |message_serializer |The message serializer implementation.|`gremlin_python.driver.serializer.GraphSONMessageSerializer`
 |password |The password to submit on requests that require authentication. |""
 |username |The username to submit on requests that require authentication. |""
+|kerberized_service |the first part of the principal name configured for the gremlin service|"""
 |session | A unique string-based identifier (typically a UUID) to enable a <<sessions,session-based connection>>. This is not a valid configuration for `DriverRemoteConnection`. |None
 |=========================================================
 

--- a/gremlin-dotnet/pom.xml
+++ b/gremlin-dotnet/pom.xml
@@ -69,6 +69,11 @@ limitations under the License.
                         <version>${project.version}</version>
                     </dependency>
                     <dependency>
+                        <groupId>org.apache.tinkerpop</groupId>
+                        <artifactId>gremlin-test</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                         <version>${groovy.version}</version>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -49,6 +49,11 @@ limitations under the License.
                         <version>${project.version}</version>
                     </dependency>
                     <dependency>
+                        <groupId>org.apache.tinkerpop</groupId>
+                        <artifactId>gremlin-test</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                         <version>${log4j.version}</version>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -135,7 +135,7 @@ limitations under the License.
                                         </exec>
                                         <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
                                               failonerror="true">
-                                            <arg line="install wheel radish-bdd PyHamcrest aenum isodate kerberos six tornado"/>
+                                            <arg line="install wheel radish-bdd PyHamcrest aenum isodate kerberos six"/>
                                         </exec>
                                         <copy todir="${project.build.directory}/python-packaged">
                                             <fileset dir="src/main/python"/>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -135,7 +135,7 @@ limitations under the License.
                                         </exec>
                                         <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
                                               failonerror="true">
-                                            <arg line="install wheel radish-bdd PyHamcrest aenum isodate"/>
+                                            <arg line="install wheel radish-bdd PyHamcrest aenum isodate kerberos six tornado"/>
                                         </exec>
                                         <copy todir="${project.build.directory}/python-packaged">
                                             <fileset dir="src/main/python"/>
@@ -208,6 +208,8 @@ limitations under the License.
                                         <exec executable="env/bin/python" dir="${project.build.directory}/python3"
                                               failonerror="true">
                                             <env key="PYTHONPATH" value=""/>
+                                            <env key="KRB5_CONFIG" value="${project.build.directory}/kdc/krb5.conf"/>
+                                            <env key="KRB5CCNAME" value="${project.build.directory}/kdc/test-tkt.cc"/>
                                             <arg line="setup.py test"/>
                                         </exec>
                                         <!-- radish seems to like all dependencies in place -->
@@ -242,6 +244,11 @@ limitations under the License.
                             <dependency>
                                 <groupId>org.apache.tinkerpop</groupId>
                                 <artifactId>gremlin-server</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.tinkerpop</groupId>
+                                <artifactId>gremlin-test</artifactId>
                                 <version>${project.version}</version>
                             </dependency>
                             <dependency>

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -39,7 +39,7 @@ class Client:
     def __init__(self, url, traversal_source, protocol_factory=None,
                  transport_factory=None, pool_size=None, max_workers=None,
                  message_serializer=None, username="", password="",
-                 headers=None, session=""):
+                 kerberized_service="", headers=None, session=""):
         self._url = url
         self._headers = headers
         self._traversal_source = traversal_source
@@ -64,7 +64,8 @@ class Client:
             protocol_factory = lambda: protocol.GremlinServerWSProtocol(
                 self._message_serializer,
                 username=self._username,
-                password=self._password)
+                password=self._password,
+                kerberized_service=kerberized_service)
         self._protocol_factory = protocol_factory
         if self._sessionEnabled:
             if pool_size is None:

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -29,9 +29,9 @@ class DriverRemoteConnection(RemoteConnection):
 
     def __init__(self, url, traversal_source, protocol_factory=None,
                  transport_factory=None, pool_size=None, max_workers=None,
-                 username="", password="", message_serializer=None,
-                 graphson_reader=None, graphson_writer=None,
-                 headers=None):
+                 username="", password="", kerberized_service='',
+                 message_serializer=None, graphson_reader=None,
+                 graphson_writer=None, headers=None):
         if message_serializer is None:
             message_serializer = serializer.GraphSONMessageSerializer(
                 reader=graphson_reader,
@@ -44,6 +44,7 @@ class DriverRemoteConnection(RemoteConnection):
                                      message_serializer=message_serializer,
                                      username=username,
                                      password=password,
+                                     kerberized_service=kerberized_service,
                                      headers=headers)
         self._url = self._client._url
         self._traversal_source = self._client._traversal_source

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -88,8 +88,8 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
     def data_received(self, message, results_dict):
         # if Gremlin Server cuts off then we get a None for the message
         if message is None:
-            raise GremlinServerError({'code': 500, 'message': 'Server disconnected - please try to reconnect',
-                                      'attributes': {}})
+            raise GremlinServerError({'code': 500,
+                                      'message': 'Server disconnected - please try to reconnect', 'attributes': {}})
 
         message = self._message_serializer.deserialize_message(message)
         request_id = message['requestId']

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -88,9 +88,9 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
     def data_received(self, message, results_dict):
         # if Gremlin Server cuts off then we get a None for the message
         if message is None:
-            raise GremlinServerError(
-                {'code': 500, 'message': 'Server disconnected - please try to reconnect',
-                 'attributes': {}})
+            raise GremlinServerError({'code': 500, 'message': 'Server disconnected - please try to reconnect',
+                                      'attributes': {}})
+
         message = self._message_serializer.deserialize_message(message)
         request_id = message['requestId']
         result_set = results_dict[request_id] if request_id in results_dict else ResultSet(None, None)

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -18,7 +18,9 @@
 #
 import abc
 import base64
+import struct
 
+# import kerberos    Optional dependency imported in relevant codeblock
 import six
 
 try:
@@ -26,7 +28,7 @@ try:
 except ImportError:
     import json
 
-from gremlin_python.driver import serializer, request
+from gremlin_python.driver import request
 from gremlin_python.driver.resultset import ResultSet
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
@@ -34,13 +36,17 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 class GremlinServerError(Exception):
     def __init__(self, status):
-        super(GremlinServerError, self).__init__("{0}: {1}".format(status["code"], status["message"]))
-        self._status_attributes = status["attributes"]
-        self.status_code = status["code"]
+        super(GremlinServerError, self).__init__('{0}: {1}'.format(status['code'], status['message']))
+        self._status_attributes = status['attributes']
+        self.status_code = status['code']
 
     @property
     def status_attributes(self):
         return self._status_attributes
+
+
+class ConfigurationError(Exception):
+    pass
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -51,7 +57,7 @@ class AbstractBaseProtocol:
         self._transport = transport
 
     @abc.abstractmethod
-    def data_received(self, message):
+    def data_received(self, message, results_dict):
         pass
 
     @abc.abstractmethod
@@ -61,10 +67,15 @@ class AbstractBaseProtocol:
 
 class GremlinServerWSProtocol(AbstractBaseProtocol):
 
-    def __init__(self, message_serializer, username='', password=''):
+    MAX_CONTENT_LENGTH = 65536
+    QOP_AUTH_BIT = 1
+    _kerberos_context = None
+
+    def __init__(self, message_serializer, username='', password='', kerberized_service=''):
         self._message_serializer = message_serializer
         self._username = username
         self._password = password
+        self._kerberized_service = kerberized_service
 
     def connection_made(self, transport):
         super(GremlinServerWSProtocol, self).connection_made(transport)
@@ -77,9 +88,9 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
     def data_received(self, message, results_dict):
         # if Gremlin Server cuts off then we get a None for the message
         if message is None:
-            raise GremlinServerError({'code': 500, 
-                                      'message': 'Server disconnected - please try to reconnect', 'attributes': {}})
-
+            raise GremlinServerError(
+                {'code': 500, 'message': 'Server disconnected - please try to reconnect',
+                 'attributes': {}})
         message = self._message_serializer.deserialize_message(message)
         request_id = message['requestId']
         result_set = results_dict[request_id] if request_id in results_dict else ResultSet(None, None)
@@ -88,14 +99,22 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
         data = message['result']['data']
         result_set.aggregate_to = aggregate_to
         if status_code == 407:
-            auth = b''.join([b'\x00', self._username.encode('utf-8'),
-                             b'\x00', self._password.encode('utf-8')])
-            request_message = request.RequestMessage(
-                'traversal', 'authentication',
-                {'sasl': base64.b64encode(auth).decode()})
+            if self._username and self._password:
+                auth_bytes = b''.join([b'\x00', self._username.encode('utf-8'),
+                                       b'\x00', self._password.encode('utf-8')])
+                auth = base64.b64encode(auth_bytes)
+                request_message = request.RequestMessage(
+                    'traversal', 'authentication', {'sasl': auth.decode()})
+            elif self._kerberized_service:
+                request_message = self._kerberos_received(message)
+            else:
+                raise ConfigurationError(
+                    'Gremlin server requires authentication credentials in DriverRemoteConnection.'
+                    'For basic authentication provide username and password. '
+                    'For kerberos authentication provide the kerberized_service parameter.')
             self.write(request_id, request_message)
             data = self._transport.read()
-            # Allow recursive call for auth
+            # Allow for auth handshake with multiple steps
             return self.data_received(data, results_dict)
         elif status_code == 204:
             result_set.stream.put_nowait([])
@@ -109,4 +128,58 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
             return status_code
         else:
             del results_dict[request_id]
-            raise GremlinServerError(message["status"])
+            raise GremlinServerError(message['status'])
+
+    def _kerberos_received(self, message):
+        # Inspired by: https://github.com/thobbs/pure-sasl/blob/0.6.2/puresasl/mechanisms.py
+        #              https://github.com/thobbs/pure-sasl/blob/0.6.2/LICENSE
+        try:
+            import kerberos
+        except ImportError:
+            raise ImportError('Please install gremlinpython[kerberos].')
+
+        # First pass: get service granting ticket and return it to gremlin-server
+        if not self._kerberos_context:
+            try:
+                _, kerberos_context = kerberos.authGSSClientInit(
+                    self._kerberized_service, gssflags=kerberos.GSS_C_MUTUAL_FLAG)
+                kerberos.authGSSClientStep(kerberos_context, '')
+                auth = kerberos.authGSSClientResponse(kerberos_context)
+                self._kerberos_context = kerberos_context
+            except kerberos.KrbError as e:
+                raise ConfigurationError(
+                    'Kerberos authentication requires a valid service name in DriverRemoteConnection, '
+                    'as well as a valid tgt (export KRB5CCNAME) or keytab (export KRB5_KTNAME): ' + str(e))
+            return request.RequestMessage('', 'authentication', {'sasl': auth})
+
+        # Second pass: completion of authentication
+        sasl_response = message['status']['attributes']['sasl']
+        if not self._username:
+            result_code = kerberos.authGSSClientStep(self._kerberos_context, sasl_response)
+            if result_code == kerberos.AUTH_GSS_COMPLETE:
+                self._username = kerberos.authGSSClientUserName(self._kerberos_context)
+            return request.RequestMessage('', 'authentication', {'sasl': ''})
+
+        # Third pass: sasl quality of protection (qop) handshake
+
+        # Gremlin-server Krb5Authenticator only supports qop=QOP_AUTH; use ssl for confidentiality.
+        # Handshake content format:
+        # byte 0: the selected qop. 1==auth, 2==auth-int, 4==auth-conf
+        # byte 1-3: the max length for any buffer sent back and forth on this connection. (big endian)
+        # the rest of the buffer: the authorization user name in UTF-8 - not null terminated.
+        kerberos.authGSSClientUnwrap(self._kerberos_context, sasl_response)
+        data = kerberos.authGSSClientResponse(self._kerberos_context)
+        plaintext_data = base64.b64decode(data)
+        assert len(plaintext_data) == 4, "Unexpected response from gremlin server sasl handshake"
+        word, = struct.unpack('!I', plaintext_data)
+        qop_bits = word >> 24
+        assert self.QOP_AUTH_BIT & qop_bits, "Unexpected sasl qop level received from gremlin server"
+
+        name_length = len(self._username)
+        fmt = '!I' + str(name_length) + 's'
+        word = self.QOP_AUTH_BIT << 24 | self.MAX_CONTENT_LENGTH
+        out = struct.pack(fmt, word, self._username.encode("utf-8"),)
+        encoded = base64.b64encode(out).decode('ascii')
+        kerberos.authGSSClientWrap(self._kerberos_context, encoded)
+        auth = kerberos.authGSSClientResponse(self._kerberos_context)
+        return request.RequestMessage('', 'authentication', {'sasl': auth})

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -48,7 +48,7 @@ install_requires = [
     'aenum>=1.4.5,<3.0.0',
     'tornado>=4.4.1,<6.0',
     'six>=1.10.0,<2.0.0',
-    'isodate>=0.6.0,<1.0.0'
+    'isodate>=0.6.0,<1.0.0',
 ]
 
 if sys.version_info < (3, 2):
@@ -80,6 +80,9 @@ setup(
         'PyHamcrest>=1.9.0,<2.0.0'
     ],
     install_requires=install_requires,
+    extra_require={
+        'kerberos': 'kerberos>=1.3.0,<2.0.0'    # Does not install in Microsoft Windows
+    },
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -16,10 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import pytest
-
 import uuid
-from gremlin_python.driver.protocol import GremlinServerError
+
 from gremlin_python.driver.client import Client
 from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.driver.request import RequestMessage
@@ -231,11 +229,11 @@ def test_big_result_set(client):
     assert len(results) == 10000
 
 
-def test_big_result_set_secure(secure_client):
+def test_big_result_set_secure(authenticated_client):
     g = Graph().traversal()
     t = g.inject(1).repeat(__.addV('person').property('name', __.loops())).times(20000).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = secure_client.submit(message)
+    result_set = authenticated_client.submit(message)
     results = []
     for result in result_set:
         results += result
@@ -243,7 +241,7 @@ def test_big_result_set_secure(secure_client):
 
     t = g.V().limit(10)
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = secure_client.submit(message)
+    result_set = authenticated_client.submit(message)
     results = []
     for result in result_set:
         results += result
@@ -251,7 +249,7 @@ def test_big_result_set_secure(secure_client):
 
     t = g.V().limit(100)
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = secure_client.submit(message)
+    result_set = authenticated_client.submit(message)
     results = []
     for result in result_set:
         results += result
@@ -259,7 +257,7 @@ def test_big_result_set_secure(secure_client):
 
     t = g.V().limit(1000)
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = secure_client.submit(message)
+    result_set = authenticated_client.submit(message)
     results = []
     for result in result_set:
         results += result
@@ -267,7 +265,7 @@ def test_big_result_set_secure(secure_client):
 
     t = g.V().limit(10000)
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = secure_client.submit(message)
+    result_set = authenticated_client.submit(message)
     results = []
     for result in result_set:
         results += result

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -16,15 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import pytest
-
-from tornado import ioloop, gen
 
 from gremlin_python import statics
 from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.statics import long
-from gremlin_python.driver.driver_remote_connection import (
-    DriverRemoteConnection)
 from gremlin_python.process.traversal import Traverser
 from gremlin_python.process.traversal import TraversalStrategy
 from gremlin_python.process.traversal import Bindings
@@ -99,7 +94,6 @@ class TestDriverRemoteConnection(object):
         # test binding in P
         results = g.V().has('person', 'age', Bindings.of('x', lt(30))).count().next()
         assert 2 == results
-
 
     def test_lambda_traversals(self, remote_connection):
         statics.load_statics(globals())
@@ -201,3 +195,9 @@ class TestDriverRemoteConnection(object):
         assert 6 == t.next()
         assert 6 == t.clone().next()
         assert 6 == t.clone().next()
+
+    def test_authenticated(self, remote_connection_authenticated):
+        statics.load_statics(globals())
+        g = traversal().withRemote(remote_connection_authenticated)
+
+        assert long(6) == g.V().count().toList()[0]

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
@@ -476,8 +476,8 @@ class TestGraphSONWriter(object):
 class TestFunctionalGraphSONIO(object):
     """Functional IO tests"""
 
-    def test_timestamp(self, remote_connection_v2):
-        g = Graph().traversal().withRemote(remote_connection_v2)
+    def test_timestamp(self, remote_connection_graphsonV2):
+        g = Graph().traversal().withRemote(remote_connection_graphsonV2)
         ts = timestamp(1481750076295 / 1000)
         resp = g.addV('test_vertex').property('ts', ts)
         resp = resp.toList()
@@ -491,8 +491,8 @@ class TestFunctionalGraphSONIO(object):
         finally:
             g.V(vid).drop().iterate()
 
-    def test_datetime(self, remote_connection_v2):
-        g = Graph().traversal().withRemote(remote_connection_v2)
+    def test_datetime(self, remote_connection_graphsonV2):
+        g = Graph().traversal().withRemote(remote_connection_graphsonV2)
         dt = datetime.datetime.utcfromtimestamp(1481750076295 / 1000)
         resp = g.addV('test_vertex').property('dt', dt).toList()
         vid = resp[0].id
@@ -505,8 +505,8 @@ class TestFunctionalGraphSONIO(object):
         finally:
             g.V(vid).drop().iterate()
 
-    def test_uuid(self, remote_connection_v2):
-        g = Graph().traversal().withRemote(remote_connection_v2)
+    def test_uuid(self, remote_connection_graphsonV2):
+        g = Graph().traversal().withRemote(remote_connection_graphsonV2)
         uid = uuid.UUID("41d2e28a-20a4-4ab0-b379-d810dede3786")
         resp = g.addV('test_vertex').property('uuid', uid).toList()
         vid = resp[0].id

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -100,12 +100,6 @@ limitations under the License.
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.kerby</groupId>
-            <artifactId>kerb-simplekdc</artifactId>
-            <version>2.0.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>
@@ -156,7 +150,6 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/Krb5Authenticator.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/Krb5Authenticator.java
@@ -72,7 +72,7 @@ public class Krb5Authenticator implements Authenticator {
             principalName = (String) config.get(PRINCIPAL_KEY);
             subject = JaasKrbUtil.loginUsingKeytab(principalName, keytabFile);
         } catch (Exception e) {
-            logger.warn("Failed to login to kdc");
+            logger.warn("Failed to login to kdc:" + e.getMessage());
         }
         
         logger.debug("Done logging in to kdc");
@@ -110,7 +110,7 @@ public class Krb5Authenticator implements Authenticator {
                 //   https://docs.oracle.com/javase/8/docs/technotes/guides/security/sasl/sasl-refguide.html#SERVER
                 // Rely on GSSAPI defaults for Sasl.MAX_BUFFER and Sasl.QOP. Note, however, that gremlin-driver has
                 // Sasl.SERVER_AUTH fixed to true (mutual authentication) and one can configure SSL for enhanced confidentiality,
-                // Sasl policy properties for negotiating the authenticatin mechanism are not relevant here, because
+                // Sasl policy properties for negotiating the authentication mechanism are not relevant here, because
                 // GSSAPI is the only available mechanism for this authenticator
                 final Map props = new HashMap<String, Object>();
                 final String[] principalParts = principalName.split("/|@");

--- a/gremlin-test/pom.xml
+++ b/gremlin-test/pom.xml
@@ -52,6 +52,11 @@ limitations under the License.
             <artifactId>slf4j-log4j12</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerb-simplekdc</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>
@@ -76,6 +81,24 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <!--Needed for docker/gremlin-server.sh-->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
[x] mvn clean install -DskipTests && mvn clean install -Pglv-python
[x] mvn clean install -pl gremlin-server -DskipIntegrationTests=false
[x] docker/build.sh -t
[x] bin/process-docs.sh
[x] manual connection to ws://172.17.0.2:45940/gremlin on docker/gremlin-server.sh with Gremlin Console and Gremlin Python
[x] manual connection to ws://172.17.0.2:45941/gremlin on docker/gremlin-server.sh with Gremlin Console and Gremlin Python
[x] manual connection to ws://172.17.0.2:45942/gremlin on docker/gremlin-server.sh with Gremlin Console and Gremlin Python

This feature ([Kerberos for gremlin-python](https://issues.apache.org/jira/browse/TINKERPOP-1641)) turned out to have a pretty large footprint because of the need to make the KDC server available in both gremlin-test and the gremlin-server-test docker container. Three concerns regarding the review:      
1. I am not entirely sure whether the gremlin-test jar-with-dependencies is the cleanest way to make the KDC available in the Docker container.        
2. Because of the sheer complexity of Kerberos configs and error messages I thought it useful to document the transcripts of the manual connections made against the gremlin-server-test docker container. If reviewers feel the same, please state what is the best location for it (possibly not the current location docker/gremlin-server/docker-entrypoint.sh).     
3. This work originated from an earlier ticket [TINKERPOP-1566](https://issues.apache.org/jira/browse/TINKERPOP-1566). That one was also reviewed by Mike Adamson on request from Stephen Mallette. Although the current work does not change the java Kerberos part of the code, it might still be worthwhile to involve him.