### PR TITLE
TINKERPOP-2383 Fixed bug in has(T,Traversal)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-
+* Fixed bug in `has(T,Traversal)` where results were not being returned.
 
 [[release-3-4-7]]
 === TinkerPop 3.4.7 (Release Date: June 1, 2020)

--- a/gremlin-test/features/filter/Has.feature
+++ b/gremlin-test/features/filter/Has.feature
@@ -117,6 +117,18 @@ Feature: Step - has()
       | v[josh] |
       | v[peter] |
 
+  Scenario: g_V_hasXlabel_isXsoftwareXX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().has(T.label, __.is('software'))
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | v[lop] |
+      | v[ripple] |
+
   Scenario: g_VX1X_hasXage_gt_30X
     Given the modern graph
     And using the parameter v1Id defined as "v[marko].id"

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
@@ -81,6 +81,8 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_hasXage_isXgt_30XX();
 
+    public abstract Traversal<Vertex, Vertex> get_g_V_hasXlabel_isXsoftwareXX();
+
     public abstract Traversal<Edge, Edge> get_g_EX7X_hasLabelXknowsX(final Object e7Id);
 
     public abstract Traversal<Edge, Edge> get_g_E_hasLabelXknowsX();
@@ -229,6 +231,18 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         assertEquals(2, list.size());
         for (final Element v : list) {
             assertTrue(v.<Integer>value("age") > 30);
+        }
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasXlabel_isXsoftwareXX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_hasXlabel_isXsoftwareXX();
+        printTraversalForm(traversal);
+        final List<Vertex> list = traversal.toList();
+        assertEquals(2, list.size());
+        for (final Element v : list) {
+            assertEquals("software", v.label());
         }
     }
 
@@ -756,6 +770,11 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXage_isXgt_30XX() {
             return g.V().has("age", __.is(P.gt(30)));
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasXlabel_isXsoftwareXX() {
+            return g.V().has(T.label, __.is("software"));
         }
 
         @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2383

That has() was using PropertiesStep, but properties() doesn't process T values.

```text
gremlin> g.V().has(label, is('software'))
==>v[3]
==>v[5]
gremlin> g.V().has(id, is(6))
==>v[6]
```

All tests pass with `docker/build.sh -t -n -i`

VOTE +1