### PR TITLE
TINKERPOP-2384 Added key traversal to local children

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-* Fix authorization bug when using `WsAndHttpChannelizerHandler` with keep-alive enabled.
+* Fixed authorization bug when using `WsAndHttpChannelizerHandler` with keep-alive enabled.
+* Fixed bug in `select(Traversal)` where side-effects were getting lost if accessed from the child traversal.
 
 [[release-3-4-7]]
 === TinkerPop 3.4.7 (Release Date: June 1, 2020)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalSelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalSelectStep.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequire
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -108,13 +109,24 @@ public final class TraversalSelectStep<S, E> extends MapStep<S, E> implements Tr
 
     @Override
     public List<Traversal.Admin<?, ?>> getLocalChildren() {
-        return null == this.selectTraversal ? Collections.emptyList() : Collections.singletonList(this.selectTraversal);
+        if (null == this.selectTraversal && null == this.keyTraversal)
+            return Collections.emptyList();
+
+        final List<Traversal.Admin<?, ?>> children = new ArrayList<>();
+        if (selectTraversal != null)
+            children.add(selectTraversal);
+        if (keyTraversal != null)
+            children.add(keyTraversal);
+
+        return children;
     }
 
     @Override
     public void removeLocalChild(final Traversal.Admin<?, ?> traversal) {
         if (this.selectTraversal == traversal)
             this.selectTraversal = null;
+        if (this.keyTraversal == traversal)
+            this.keyTraversal = null;
     }
 
     @Override
@@ -129,11 +141,6 @@ public final class TraversalSelectStep<S, E> extends MapStep<S, E> implements Tr
                 TraverserRequirement.SIDE_EFFECTS,
                 TraverserRequirement.PATH);
     }
-
-    //@Override
-    //public Set<String> getScopeKeys() {
-    //    return Collections.singleton(this.selectKey);
-    //}
 
     public Pop getPop() {
         return this.pop;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/GraphBinaryRemoteGraphComputerProvider.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/GraphBinaryRemoteGraphComputerProvider.java
@@ -32,10 +32,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "*",
         reason = "The addEdge() step is not supported by GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndTest",
-        method = "g_V_asXaX_outXknowsX_and_outXcreatedX_inXcreatedX_asXaX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX1X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
@@ -43,22 +39,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX2X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CoalesceTest",
-        method = "g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.ComplexTest",
-        method = "playlistPaths",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CountTest",
-        method = "g_V_whereXinXkknowsX_outXcreatedX_count_is_0XX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupTest",
-        method = "g_V_asXaX_both_asXbX_dedupXa_bX_byXlabelX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphTest",
         method = "g_V_hasLabelXpersonX_asXpX_VXsoftwareX_addInEXuses_pX",
@@ -76,14 +56,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_VX1X_V_valuesXnameX",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_groupXmX_byXnameX_byXinXknowsX_nameX_capXmX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_hasLabelXpersonX_asXpX_outXcreatedX_group_byXnameX_byXselectXpX_valuesXageX_sumX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_injectXg_VX4XX_out_name",
         reason = "The inject() step is not supported by GraphComputer")
@@ -91,62 +63,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_out_injectXv2X_name",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.LocalTest",
-        method = "g_V_localXmatchXproject__created_person__person_name_nameX_selectXname_projectX_by_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_and_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX2XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
         method = "g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX",
@@ -157,14 +73,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         reason = "The inject() step is not supported by GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_hasLabelXpersonX_optionalXoutXknowsX_optionalXoutXcreatedXXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_optionalXout_optionalXoutXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
         method = "g_VX1X_optionalXaddVXdogXX_label",
         reason = "The addV() step is not supported on GraphComputer")
 @Graph.OptOut(
@@ -172,137 +80,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_V_asXaX_out_asXbX_out_asXcX_simplePath_byXlabelX_fromXbX_toXcX_path_byXnameX",
         reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterComplexVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterEdgeCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterMixedCriteria",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterionAndKeepLabels",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldGetExcludedEdge",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_tree_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_treeXaX_byXnameX_both_both_capXaX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasIdX6XX_path_byXnameX_unfold",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
         method = "g_V_hasLabelXpersonX_V_hasLabelXsoftwareX_name",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXandXasXaX_outXknowsX_asXbX__orXasXbX_outXcreatedX_hasXname_rippleX__asXbX_inXknowsX_count_isXnotXeqX0XXXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXin_count_isXeqX3XX_or_whereXoutXcreatedX_and_hasXlabel_personXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_whereXandXasXbX_in__notXasXaX_outXcreatedX_hasXname_rippleXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_out_hasXageX_whereXgtXaXX_byXageX_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXasXbX_outXcreatedX_hasXname_rippleXX_valuesXage_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_asXaX_out_asXbX_out_asXcX_path_fromXbX_toXcX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_out_out_path_byXnameX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_repeatXoutX_timesX2X_path_byXitX_byXnameX_byXlangX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_VX1X_out_path_byXageX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXloop_name_loopX_repeatXinX_timesX5X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXname_markoX_repeatXoutE_inV_simplePathX_untilXhasXname_rippleXX_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
         method = "g_withBulkXfalseX_withSackX1_sumX_V_out_barrier_sack",
@@ -311,34 +91,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
         method = "g_withBulkXfalseX_withSackX1_sumX_VX1X_localXoutEXknowsX_barrierXnormSackX_inVX_inXknowsX_barrier_sack",
         reason = "One bulk is currently not supported on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX_byXmathX_plus_XX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_localXselectXa_bX_byXnameXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaX_in_asXbXX_selectXa_bX_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaXX_selectXaX_byXtailXlocalX_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest",
         method = "g_injectXg_VX1X_propertiesXnameX_nextX_value",
@@ -351,22 +103,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.WriteTest",
         method = "*",
         reason = "The io() step is not supported generally by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXout_repeatXoutX_timesX1XX_timesX1X_limitX1X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXoutXknowsXX_untilXrepeatXoutXcreatedXX_emitXhasXname_lopXXX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX3X_repeatXbothX_createdXX_untilXloops_is_40XXemit_repeatXin_knowsXX_emit_loopsXisX1Xdedup_values",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX6X_repeatXa_bothXcreatedX_simplePathX_emitXrepeatXb_bothXknowsXX_untilXloopsXbX_asXb_whereXloopsXaX_asXbX_hasXname_vadasXX_dedup_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
 @GraphProvider.Descriptor(computer = TinkerGraphComputer.class)
 public class GraphBinaryRemoteGraphComputerProvider extends AbstractRemoteGraphProvider {
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/GraphSONRemoteGraphComputerProvider.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/GraphSONRemoteGraphComputerProvider.java
@@ -32,10 +32,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "*",
         reason = "The addEdge() step is not supported by GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndTest",
-        method = "g_V_asXaX_outXknowsX_and_outXcreatedX_inXcreatedX_asXaX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX1X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
@@ -43,22 +39,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX2X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CoalesceTest",
-        method = "g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.ComplexTest",
-        method = "playlistPaths",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CountTest",
-        method = "g_V_whereXinXkknowsX_outXcreatedX_count_is_0XX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupTest",
-        method = "g_V_asXaX_both_asXbX_dedupXa_bX_byXlabelX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphTest",
         method = "g_V_hasLabelXpersonX_asXpX_VXsoftwareX_addInEXuses_pX",
@@ -76,14 +56,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_VX1X_V_valuesXnameX",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_groupXmX_byXnameX_byXinXknowsX_nameX_capXmX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_hasLabelXpersonX_asXpX_outXcreatedX_group_byXnameX_byXselectXpX_valuesXageX_sumX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_injectXg_VX4XX_out_name",
         reason = "The inject() step is not supported by GraphComputer")
@@ -91,62 +63,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_out_injectXv2X_name",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.LocalTest",
-        method = "g_V_localXmatchXproject__created_person__person_name_nameX_selectXname_projectX_by_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_and_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX2XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
         method = "g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX",
@@ -157,14 +73,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         reason = "The inject() step is not supported by GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_hasLabelXpersonX_optionalXoutXknowsX_optionalXoutXcreatedXXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_optionalXout_optionalXoutXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
         method = "g_VX1X_optionalXaddVXdogXX_label",
         reason = "The addV() step is not supported on GraphComputer")
 @Graph.OptOut(
@@ -172,137 +80,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_V_asXaX_out_asXbX_out_asXcX_simplePath_byXlabelX_fromXbX_toXcX_path_byXnameX",
         reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterComplexVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterEdgeCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterMixedCriteria",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterionAndKeepLabels",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldGetExcludedEdge",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_tree_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_treeXaX_byXnameX_both_both_capXaX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasIdX6XX_path_byXnameX_unfold",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
         method = "g_V_hasLabelXpersonX_V_hasLabelXsoftwareX_name",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXandXasXaX_outXknowsX_asXbX__orXasXbX_outXcreatedX_hasXname_rippleX__asXbX_inXknowsX_count_isXnotXeqX0XXXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXin_count_isXeqX3XX_or_whereXoutXcreatedX_and_hasXlabel_personXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_whereXandXasXbX_in__notXasXaX_outXcreatedX_hasXname_rippleXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_out_hasXageX_whereXgtXaXX_byXageX_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXasXbX_outXcreatedX_hasXname_rippleXX_valuesXage_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_asXaX_out_asXbX_out_asXcX_path_fromXbX_toXcX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_out_out_path_byXnameX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_repeatXoutX_timesX2X_path_byXitX_byXnameX_byXlangX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_VX1X_out_path_byXageX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXloop_name_loopX_repeatXinX_timesX5X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXname_markoX_repeatXoutE_inV_simplePathX_untilXhasXname_rippleXX_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
         method = "g_withBulkXfalseX_withSackX1_sumX_V_out_barrier_sack",
@@ -311,34 +91,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
         method = "g_withBulkXfalseX_withSackX1_sumX_VX1X_localXoutEXknowsX_barrierXnormSackX_inVX_inXknowsX_barrier_sack",
         reason = "One bulk is currently not supported on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX_byXmathX_plus_XX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_localXselectXa_bX_byXnameXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaX_in_asXbXX_selectXa_bX_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaXX_selectXaX_byXtailXlocalX_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest",
         method = "g_injectXg_VX1X_propertiesXnameX_nextX_value",
@@ -351,22 +103,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.WriteTest",
         method = "*",
         reason = "The io() step is not supported generally by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXout_repeatXoutX_timesX1XX_timesX1X_limitX1X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXoutXknowsXX_untilXrepeatXoutXcreatedXX_emitXhasXname_lopXXX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX3X_repeatXbothX_createdXX_untilXloops_is_40XXemit_repeatXin_knowsXX_emit_loopsXisX1Xdedup_values",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX6X_repeatXa_bothXcreatedX_simplePathX_emitXrepeatXb_bothXknowsXX_untilXloopsXbX_asXb_whereXloopsXaX_asXbX_hasXname_vadasXX_dedup_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
 @GraphProvider.Descriptor(computer = TinkerGraphComputer.class)
 public class GraphSONRemoteGraphComputerProvider extends AbstractRemoteGraphProvider {
     public GraphSONRemoteGraphComputerProvider() {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/GryoRemoteGraphComputerProvider.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/GryoRemoteGraphComputerProvider.java
@@ -33,10 +33,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "*",
         reason = "The addEdge() step is not supported by GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndTest",
-        method = "g_V_asXaX_outXknowsX_and_outXcreatedX_inXcreatedX_asXaX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX1X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
@@ -44,22 +40,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX2X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CoalesceTest",
-        method = "g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.ComplexTest",
-        method = "playlistPaths",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CountTest",
-        method = "g_V_whereXinXkknowsX_outXcreatedX_count_is_0XX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupTest",
-        method = "g_V_asXaX_both_asXbX_dedupXa_bX_byXlabelX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphTest",
         method = "g_V_hasLabelXpersonX_asXpX_VXsoftwareX_addInEXuses_pX",
@@ -77,14 +57,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_VX1X_V_valuesXnameX",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_groupXmX_byXnameX_byXinXknowsX_nameX_capXmX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_hasLabelXpersonX_asXpX_outXcreatedX_group_byXnameX_byXselectXpX_valuesXageX_sumX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_injectXg_VX4XX_out_name",
         reason = "The inject() step is not supported by GraphComputer")
@@ -92,62 +64,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_out_injectXv2X_name",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.LocalTest",
-        method = "g_V_localXmatchXproject__created_person__person_name_nameX_selectXname_projectX_by_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_and_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX2XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
         method = "g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX",
@@ -158,14 +74,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         reason = "The inject() step is not supported by GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_hasLabelXpersonX_optionalXoutXknowsX_optionalXoutXcreatedXXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_optionalXout_optionalXoutXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
         method = "g_VX1X_optionalXaddVXdogXX_label",
         reason = "The addV() step is not supported on GraphComputer")
 @Graph.OptOut(
@@ -173,137 +81,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_V_asXaX_out_asXbX_out_asXcX_simplePath_byXlabelX_fromXbX_toXcX_path_byXnameX",
         reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterComplexVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterEdgeCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterMixedCriteria",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterionAndKeepLabels",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldGetExcludedEdge",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_tree_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_treeXaX_byXnameX_both_both_capXaX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasIdX6XX_path_byXnameX_unfold",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
         method = "g_V_hasLabelXpersonX_V_hasLabelXsoftwareX_name",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXandXasXaX_outXknowsX_asXbX__orXasXbX_outXcreatedX_hasXname_rippleX__asXbX_inXknowsX_count_isXnotXeqX0XXXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXin_count_isXeqX3XX_or_whereXoutXcreatedX_and_hasXlabel_personXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_whereXandXasXbX_in__notXasXaX_outXcreatedX_hasXname_rippleXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_out_hasXageX_whereXgtXaXX_byXageX_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXasXbX_outXcreatedX_hasXname_rippleXX_valuesXage_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_asXaX_out_asXbX_out_asXcX_path_fromXbX_toXcX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_out_out_path_byXnameX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_repeatXoutX_timesX2X_path_byXitX_byXnameX_byXlangX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_VX1X_out_path_byXageX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXloop_name_loopX_repeatXinX_timesX5X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXname_markoX_repeatXoutE_inV_simplePathX_untilXhasXname_rippleXX_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
         method = "g_withBulkXfalseX_withSackX1_sumX_V_out_barrier_sack",
@@ -312,34 +92,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
         method = "g_withBulkXfalseX_withSackX1_sumX_VX1X_localXoutEXknowsX_barrierXnormSackX_inVX_inXknowsX_barrier_sack",
         reason = "One bulk is currently not supported on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX_byXmathX_plus_XX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_localXselectXa_bX_byXnameXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaX_in_asXbXX_selectXa_bX_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaXX_selectXaX_byXtailXlocalX_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest",
         method = "g_injectXg_VX1X_propertiesXnameX_nextX_value",
@@ -352,22 +104,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.WriteTest",
         method = "*",
         reason = "The io() step is not supported generally by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXout_repeatXoutX_timesX1XX_timesX1X_limitX1X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXoutXknowsXX_untilXrepeatXoutXcreatedXX_emitXhasXname_lopXXX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX3X_repeatXbothX_createdXX_untilXloops_is_40XXemit_repeatXin_knowsXX_emit_loopsXisX1Xdedup_values",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX6X_repeatXa_bothXcreatedX_simplePathX_emitXrepeatXb_bothXknowsXX_untilXloopsXbX_asXb_whereXloopsXaX_asXbX_hasXname_vadasXX_dedup_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
 @GraphProvider.Descriptor(computer = TinkerGraphComputer.class)
 public class GryoRemoteGraphComputerProvider extends AbstractRemoteGraphProvider {
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GryoRemoteGraphGroovyTranslatorComputerProvider.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GryoRemoteGraphGroovyTranslatorComputerProvider.java
@@ -35,10 +35,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "*",
         reason = "The addEdge() step is not supported by GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndTest",
-        method = "g_V_asXaX_outXknowsX_and_outXcreatedX_inXcreatedX_asXaX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX1X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
@@ -46,22 +42,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest",
         method = "g_injectX2X_chooseXisX1X__constantX10Xfold__foldX",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CoalesceTest",
-        method = "g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.ComplexTest",
-        method = "playlistPaths",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CountTest",
-        method = "g_V_whereXinXkknowsX_outXcreatedX_count_is_0XX_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupTest",
-        method = "g_V_asXaX_both_asXbX_dedupXa_bX_byXlabelX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphTest",
         method = "g_V_hasLabelXpersonX_asXpX_VXsoftwareX_addInEXuses_pX",
@@ -79,14 +59,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_VX1X_V_valuesXnameX",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_groupXmX_byXnameX_byXinXknowsX_nameX_capXmX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",
-        method = "g_V_hasLabelXpersonX_asXpX_outXcreatedX_group_byXnameX_byXselectXpX_valuesXageX_sumX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_injectXg_VX4XX_out_name",
         reason = "The inject() step is not supported by GraphComputer")
@@ -94,62 +66,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest",
         method = "g_VX1X_out_injectXv2X_name",
         reason = "The inject() step is not supported by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.LocalTest",
-        method = "g_V_localXmatchXproject__created_person__person_name_nameX_selectXname_projectX_by_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_and_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX2XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX3XX_hasXname_peterX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest",
-        method = "g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_mathXb_plus_aX_byXinXcreatedX_countX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.MathTest",
         method = "g_withSackX1X_injectX1X_repeatXsackXsumX_byXconstantX1XXX_timesX5X_emit_mathXsin__X_byXsackX",
@@ -160,14 +76,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         reason = "The inject() step is not supported by GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_hasLabelXpersonX_optionalXoutXknowsX_optionalXoutXcreatedXXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
-        method = "g_V_optionalXout_optionalXoutXX_path",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.OptionalTest",
         method = "g_VX1X_optionalXaddVXdogXX_label",
         reason = "The addV() step is not supported on GraphComputer")
 @Graph.OptOut(
@@ -175,137 +83,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_V_asXaX_out_asXbX_out_asXcX_simplePath_byXlabelX_fromXbX_toXcX_path_byXnameX",
         reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterComplexVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterEdgeCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterMixedCriteria",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterion",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldFilterVertexCriterionAndKeepLabels",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest",
-        method = "shouldGetExcludedEdge",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXlimitXlocal_0XX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_tailXlocalX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_tree_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest",
-        method = "g_VX1X_out_out_treeXaX_byXnameX_both_both_capXaX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest",
-        method = "g_VX1X_repeatXboth_simplePathX_untilXhasIdX6XX_path_byXnameX_unfold",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
         method = "g_V_hasLabelXpersonX_V_hasLabelXsoftwareX_name",
         reason = "Mid-traversal V()/E() is currently not supported on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXandXasXaX_outXknowsX_asXbX__orXasXbX_outXcreatedX_hasXname_rippleX__asXbX_inXknowsX_count_isXnotXeqX0XXXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_out_asXbX_whereXin_count_isXeqX3XX_or_whereXoutXcreatedX_and_hasXlabel_personXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_inXcreatedX_asXdX_whereXa_ltXbX_orXgtXcXX_andXneqXdXXX_byXageX_byXweightX_byXinXcreatedX_valuesXageX_minX_selectXa_c_dX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_asXbX_whereXandXasXbX_in__notXasXaX_outXcreatedX_hasXname_rippleXXX_selectXa_bX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_out_hasXageX_whereXgtXaXX_byXageX_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXasXbX_outXcreatedX_hasXname_rippleXX_valuesXage_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_asXaX_out_asXbX_out_asXcX_path_fromXbX_toXcX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_out_out_path_byXnameX_byXageX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_V_repeatXoutX_timesX2X_path_byXitX_byXnameX_byXlangX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest",
-        method = "g_VX1X_out_path_byXageX_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_1X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_in_asXaX_in_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_limitXlocal_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        method = "g_V_asXaX_out_asXaX_out_asXaX_selectXmixed_aX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXloop_name_loopX_repeatXinX_timesX5X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_hasXname_markoX_repeatXoutE_inV_simplePathX_untilXhasXname_rippleXX_path_byXnameX_byXlabelX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest",
         method = "g_withBulkXfalseX_withSackX1_sumX_V_out_barrier_sack",
@@ -315,33 +95,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         method = "g_withBulkXfalseX_withSackX1_sumX_VX1X_localXoutEXknowsX_barrierXnormSackX_inVX_inXknowsX_barrier_sack",
         reason = "One bulk is currently not supported on GraphComputer")
 @Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX_byXmathX_plus_XX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_asXaX_outXknowsX_asXbX_localXselectXa_bX_byXnameXX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaX_in_asXbXX_selectXa_bX_byXnameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_untilXout_outX_repeatXin_asXaXX_selectXaX_byXtailXlocalX_nameX",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest",
+        method = "g_injectXg_VX1X_propertiesXnameX_nextX_value",
+        reason = "Needs investigation")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ReadTest",
         method = "*",
@@ -350,22 +106,6 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComp
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.WriteTest",
         method = "*",
         reason = "The io() step is not supported generally by GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXout_repeatXoutX_timesX1XX_timesX1X_limitX1X_path_by_name",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_V_repeatXoutXknowsXX_untilXrepeatXoutXcreatedXX_emitXhasXname_lopXXX_path_byXnameX",
-        reason = "It is not possible to access more than a path element's id on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX3X_repeatXbothX_createdXX_untilXloops_is_40XXemit_repeatXin_knowsXX_emit_loopsXisX1Xdedup_values",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX6X_repeatXa_bothXcreatedX_simplePathX_emitXrepeatXb_bothXknowsXX_untilXloopsXbX_asXb_whereXloopsXaX_asXbX_hasXname_vadasXX_dedup_name",
-        reason = "Local traversals may not traverse past the local star-graph on GraphComputer")
 @GraphProvider.Descriptor(computer = TinkerGraphComputer.class)
 public class GryoRemoteGraphGroovyTranslatorComputerProvider extends GryoRemoteGraphGroovyTranslatorProvider {
     private final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/GremlinProcessRunner.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/GremlinProcessRunner.java
@@ -70,7 +70,11 @@ public class GremlinProcessRunner extends BlockJUnit4ClassRunner {
     private static boolean validateForGraphComputer(final Throwable e) {
         Throwable ex = e;
         while (ex != null) {
-            if (ex instanceof VerificationException)
+            // for remote tests ex will be a IllegalStateException holding a VerificationException or only have a
+            // string message to compare on
+            if (ex instanceof VerificationException || ex.getCause() instanceof VerificationException ||
+                ex.getMessage().contains("It is not possible to access more than a path element's id on GraphComputer") ||
+                ex.getMessage().contains("Local traversals may not traverse past the local star-graph on GraphComputer"))
                 return true;
             else if (ex instanceof NotSerializableException)
                 return true;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SideEffectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SideEffectTest.java
@@ -43,6 +43,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.valueMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -67,6 +69,8 @@ public abstract class SideEffectTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Integer> get_g_withSideEffectXa_0_sumX_V_out_sideEffectXsideEffectsXa_bulkXX_capXaX();
 
     public abstract Traversal<Vertex, Integer> get_g_withSideEffectXa_0X_V_out_sideEffectXsideEffectsXa_1XX_capXaX();
+
+    public abstract Traversal<Vertex, String> get_g_withSideEffectXk_nameX_V_order_byXvalueMap_selectXkX_unfoldX_name();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -191,6 +195,14 @@ public abstract class SideEffectTest extends AbstractGremlinProcessTest {
         checkSideEffects(traversal.asAdmin().getSideEffects(), "a", Integer.class);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_withSideEffectXk_nameX_V_order_byXvalueMap_selectXkX_unfoldX_name() {
+        final Traversal<Vertex, String> traversal = get_g_withSideEffectXk_nameX_V_order_byXvalueMap_selectXkX_unfoldX_name();
+        checkOrderedResults(Arrays.asList(
+                "josh", "lop", "marko", "peter", "ripple", "vadas"), traversal);
+    }
+
     public static class Traversals extends SideEffectTest {
 
         @Override
@@ -245,6 +257,11 @@ public abstract class SideEffectTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Integer> get_g_withSideEffectXa_0X_V_out_sideEffectXsideEffectsXa_1XX_capXaX() {
             return g.withSideEffect("a", 0).V().out().sideEffect(t -> t.sideEffects("a", 1)).cap("a");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_withSideEffectXk_nameX_V_order_byXvalueMap_selectXkX_unfoldX_name() {
+            return g.withSideEffect("key","name").V().order().by(valueMap().select(select("key")).unfold()).values("name");
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2384

Without this change side-effects don't propogate to the key traversal and they can't be accessed. Generalized VerificationException errors for remote tests so that the Ignore list didn't have to be so long for those tests.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1