### PR TITLE
Add support to provide extra arguments to the Client.submit()

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -69,17 +69,18 @@ class Client {
    * Send a request to the Gremlin Server, can send a script or bytecode steps.
    * @param {Bytecode|string} message The bytecode or script to send
    * @param {Object} [bindings] The script bindings, if any.
+   * @param {Object} [extraArgs] The extra arguments, if any.
    * @returns {Promise}
    */
-  submit(message, bindings) {
+  submit(message, bindings, extraArgs) {
     if (typeof message === 'string') {
-      const args = {
+      const args = Object.assign({}, extraArgs, {
         'gremlin': message,
         'bindings': bindings,
         'language': 'gremlin-groovy',
         'accept': this._connection.mimeType,
         'aliases': { 'g': this._options.traversalSource || 'g' }
-      };
+      });
       if (this._options.session && this._options.processor === 'session') {
         args['session'] = this._options.session;
       }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
@@ -55,4 +55,20 @@ describe('Client', function () {
     customClient._connection = connectionMock;
     customClient.submit(query)
   });
+
+  it('should allow to submit extra arguments', function () {
+    const connectionMock = {
+      submit: function (bytecode, op, args, requestId, processor) {
+        assert.strictEqual(args.gremlin, query);
+        assert.strictEqual(args.scriptEvaluationTimeout, 123);
+        assert.strictEqual(processor, customOpProcessor);
+
+        return Promise.resolve();
+      }
+    };
+
+    const customClient = new Client('ws://localhost:9321', {traversalSource: 'g', processor: customOpProcessor});
+    customClient._connection = connectionMock;
+    customClient.submit(query, null, {"scriptEvaluationTimeout": 123})
+  });
 });


### PR DESCRIPTION
The goal of this PR is to provide a capability to specify arguments on query submission via JS Client. In our use case we would like to be able to specify `scriptEvaluationTimeout` argument for certain queries (which we expect to be slow and we want to prevent accidental timeouts). 

I am by no means a JS expert, hence probably adding extraArgs as an argument to the `submit` function is not ideal, but with this change we can write something like this to increase the timeout:

```js
const gremlin = require('gremlin');

const traversal = gremlin.process.AnonymousTraversalSource.traversal;
const p = gremlin.process.P;
const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;

const Client = gremlin.driver.Client;

const client = new Client('<endpoint>','gmodern')
client.open();
message = `<very-long-query>`

client.submit(message, null, {"scriptEvaluationTimeout": 60000}).catch(function(error) {
  console.log("BOOOM ERROR!");
  console.log(error);
}).then(function (result) {
  console.log(result);
});

client.close();
```

Also, just to clarify - we can't use Java Client (where specifying arguments seems to be supported) as this is used in AWS JS Lambda -> AWS Neptune interaction. 