### PR TITLE
Update client.js to handle default options

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -44,7 +44,7 @@ class Client {
    * @param {String} [options.session] The sessionId of Client in session mode. Defaults to null means session-less Client.
    * @constructor
    */
-  constructor(url, options) {
+  constructor(url, options = {}) {
     this._options = options;
     if (this._options.processor === 'session') {
       // compatibility with old 'session' processor setting


### PR DESCRIPTION
Following the docs present in [here](https://github.com/apache/tinkerpop/blob/master/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md), getting started with Gremlin throws the following error:

```bash
/home/node/node_modules/gremlin/lib/driver/client.js:49
if (this._options.processor === 'session') {
  TypeError: Cannot read property 'processor' of undefined
  at new Client (/home/node/node_modules/gremlin/lib/driver/client.js:49:23)
  at new DriverRemoteConnection (/home/node/node_modules/gremlin/lib/driver/driver-remote-connection.js:53:20)
```

So, I suggest that we can pass a default empty object to the client constructor, what do you think?

Default docs reference:
```js
const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
```