### PR TITLE
TINKERPOP-2369 Replace Connection on server initiated Channel close

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,10 @@ limitations under the License.
 
 image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/avant-gremlin.png[width=185]
 
+[[release-3-4-9]]
+=== TinkerPop 3.4.9
+* Replace `Connection` on server initiated `Channel` close for connections with no pending requests.
+
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
@@ -219,6 +219,11 @@ final class Handler {
             try {
                 final ResponseStatusCode statusCode = response.getStatus().getCode();
                 final ResultQueue queue = pending.get(response.getRequestId());
+                if (queue == null) {
+                    // client is not expecting any results from the server for this requestID. Ignore it.
+                    logger.warn("Server sent a message for unrecognized requestID={}. Ignoring the server message.", response.getRequestId());
+                    return;
+                }
                 if (statusCode == ResponseStatusCode.SUCCESS || statusCode == ResponseStatusCode.PARTIAL_CONTENT) {
                     final Object data = response.getResult().getData();
                     final Map<String,Object> meta = response.getResult().getMeta();

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SimpleWebSocketServer.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SimpleWebSocketServer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+/**
+ * Simple Netty Server
+ */
+public class SimpleWebSocketServer {
+    public static final int PORT = 45940;
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+
+    public Channel start(TestWebSocketServerInitializer channelInitializer) throws InterruptedException {
+        bossGroup = new NioEventLoopGroup(1);
+        workerGroup = new NioEventLoopGroup();
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .handler(new LoggingHandler(LogLevel.INFO))
+                .childHandler(channelInitializer);
+        return b.bind(PORT).sync().channel();
+    }
+
+    public void stop() {
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWSGremlinInitializer.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWSGremlinInitializer.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0;
+import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+
+import java.util.List;
+import java.util.UUID;
+
+
+/**
+ * Initializer which partially mimics the Gremlin Server. This initializer injects a handler in the
+ * server pipeline that can be modified to send the desired response for a test case.
+ */
+public class TestWSGremlinInitializer extends TestWebSocketServerInitializer {
+    private static final Logger logger = LoggerFactory.getLogger(TestWSGremlinInitializer.class);
+    /**
+     * If a request with this ID comes to the server, the server responds back with a single vertex picked from Modern
+     * graph.
+     */
+    public static final UUID SINGLE_VERTEX_REQUEST_ID =
+            UUID.fromString("6457272A-4018-4538-B9AE-08DD5DDC0AA1");
+
+    /**
+     * If a request with this ID comes to the server, the server responds back with a single vertex picked from Modern
+     * graph. After some delay, server sends a Close WebSocket frame on the same connection.
+     */
+    public static final UUID SINGLE_VERTEX_DELAYED_CLOSE_CONNECTION_REQUEST_ID =
+            UUID.fromString("3cb39c94-9454-4398-8430-03485d08bdae");
+
+    public static final UUID FAILED_AFTER_DELAY_REQUEST_ID =
+            UUID.fromString("edf79c8b-1d32-4102-a5d2-a5feeca40864");
+    public static final UUID CLOSE_CONNECTION_REQUEST_ID =
+            UUID.fromString("0150143b-00f9-48a7-a268-28142d902e18");
+    public static final UUID CLOSE_CONNECTION_REQUEST_ID_2 =
+            UUID.fromString("3c4cf18a-c7f2-4dad-b9bf-5c701eb33000");
+
+    /**
+     * Gremlin serializer used for serializing/deserializing the request/response. This should be same as client.
+     */
+    private static final GraphSONMessageSerializerV2d0 SERIALIZER = new GraphSONMessageSerializerV2d0();
+
+    @Override
+    public void postInit(ChannelPipeline pipeline) {
+        pipeline.addLast(new ClientTestConfigurableHandler());
+    }
+
+    /**
+     * Handler introduced in the server pipeline to configure expected response for test cases.
+     */
+    private static class ClientTestConfigurableHandler extends MessageToMessageDecoder<BinaryWebSocketFrame> {
+        @Override
+        protected void decode(final ChannelHandlerContext ctx, final BinaryWebSocketFrame frame, final List<Object> objects)
+                throws Exception {
+            final ByteBuf messageBytes = frame.content();
+            final byte len = messageBytes.readByte();
+            if (len <= 0) {
+                objects.add(RequestMessage.INVALID);
+                return;
+            }
+
+            final ByteBuf contentTypeBytes = ctx.alloc().buffer(len);
+            try {
+                messageBytes.readBytes(contentTypeBytes);
+            } finally {
+                contentTypeBytes.release();
+            }
+            final RequestMessage msg = SERIALIZER.deserializeRequest(messageBytes.discardReadBytes());
+
+            if (msg.getRequestId().equals(SINGLE_VERTEX_DELAYED_CLOSE_CONNECTION_REQUEST_ID)) {
+                logger.info("sending vertex result frame");
+                ctx.channel().writeAndFlush(new TextWebSocketFrame(returnSingleVertexResponse(
+                        SINGLE_VERTEX_DELAYED_CLOSE_CONNECTION_REQUEST_ID)));
+                logger.info("waiting for 2 sec");
+                Thread.sleep(2000);
+                logger.info("sending close frame");
+                ctx.channel().writeAndFlush(new CloseWebSocketFrame());
+            } else if (msg.getRequestId().equals(SINGLE_VERTEX_REQUEST_ID)) {
+                logger.info("sending vertex result frame");
+                ctx.channel().writeAndFlush(new TextWebSocketFrame(returnSingleVertexResponse(SINGLE_VERTEX_REQUEST_ID)));
+            } else if (msg.getRequestId().equals(FAILED_AFTER_DELAY_REQUEST_ID)) {
+                logger.info("waiting for 2 sec");
+                Thread.sleep(1000);
+                ResponseMessage responseMessage = ResponseMessage.build(msg)
+                        .code(ResponseStatusCode.SERVER_ERROR)
+                        .statusAttributeException(new RuntimeException()).create();
+                ctx.channel().writeAndFlush(new TextWebSocketFrame(SERIALIZER.serializeResponseAsString(responseMessage)));
+            } else if (msg.getRequestId().equals(CLOSE_CONNECTION_REQUEST_ID)) {
+                Thread.sleep(1000);
+                ctx.channel().writeAndFlush(new CloseWebSocketFrame());
+            }
+        }
+
+        private String returnSingleVertexResponse(UUID requestID) throws SerializationException {
+            final TinkerGraph graph = TinkerFactory.createClassic();
+            final GraphTraversalSource g = graph.traversal();
+            final Vertex t = g.V().limit(1).next();
+
+            return SERIALIZER.serializeResponseAsString(ResponseMessage.build(requestID).result(t).create());
+        }
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWebSocketServerInitializer.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWebSocketServerInitializer.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
+
+/**
+ * A vanilla WebSocket server Initializer implementation using Netty. This initializer would configure the server for
+ * WebSocket handshake and decoding incoming WebSocket frames.
+ */
+public abstract class TestWebSocketServerInitializer extends ChannelInitializer<SocketChannel> {
+    private static final String WEBSOCKET_PATH = "/gremlin";
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ChannelPipeline pipeline = ch.pipeline();
+        pipeline.addLast(new HttpServerCodec());
+        pipeline.addLast(new HttpObjectAggregator(65536));
+        pipeline.addLast(new WebSocketServerCompressionHandler());
+        pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
+        this.postInit(ch.pipeline());
+    }
+
+    public abstract void postInit(ChannelPipeline ch);
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.log4j.Level;
+import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class WebSocketClientBehaviorIntegrateTest {
+    @Rule
+    public TestName name = new TestName();
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketClientBehaviorIntegrateTest.class);
+    private Log4jRecordingAppender recordingAppender = null;
+    private Level previousLogLevel;
+    private SimpleWebSocketServer server;
+
+    @Before
+    public void setUp() throws InterruptedException {
+        recordingAppender = new Log4jRecordingAppender();
+        final org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+        if (name.getMethodName().equals("TestClosedConnectionIsRecycledForConnectionWithPendingRequests")) {
+            final org.apache.log4j.Logger connectionLogger = org.apache.log4j.Logger.getLogger(ConnectionPool.class);
+            previousLogLevel = connectionLogger.getLevel();
+            connectionLogger.setLevel(Level.DEBUG);
+        }
+
+        rootLogger.addAppender(recordingAppender);
+
+        server = new SimpleWebSocketServer();
+        server.start(new TestWSGremlinInitializer());
+    }
+
+    @After
+    public void shutdown() {
+        server.stop();
+
+        // reset logger
+        final org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+
+        if (name.getMethodName().equals("TestClosedConnectionIsRecycledForConnectionWithPendingRequests")) {
+            final org.apache.log4j.Logger connectionLogger = org.apache.log4j.Logger.getLogger(Connection.class);
+            connectionLogger.setLevel(previousLogLevel);
+        }
+
+        rootLogger.removeAppender(recordingAppender);
+    }
+
+    /**
+     * Test a scenario when server closes a connection which does not have any active requests. Such connection
+     * should be recycled and replaced by another connection.
+     */
+    @Test
+    public void TestClosedConnectionIsRecycledForConnectionWithNoRequests() throws InterruptedException {
+        final Cluster cluster = Cluster.build("localhost").port(SimpleWebSocketServer.PORT)
+                .minConnectionPoolSize(1)
+                .maxConnectionPoolSize(1)
+                .serializer(Serializers.GRAPHSON_V2D0)
+                .create();
+        final Client.ClusteredClient client = cluster.connect();
+
+        // Initialize the client preemptively
+        client.init();
+
+        // assert number of connections opened
+        ConnectionPool channelPool = client.hostConnectionPools.values().stream().findFirst().get();
+        Assert.assertEquals(1, channelPool.getConnectionIDs().size());
+
+        final String originalConnectionID = channelPool.getConnectionIDs().iterator().next();
+        logger.info("On client init ConnectionIDs: " + channelPool.getConnectionIDs());
+
+        // trigger the testing server to send a WS close frame
+        Vertex v = client.submit("1", RequestOptions.build()
+                .overrideRequestId(TestWSGremlinInitializer.SINGLE_VERTEX_DELAYED_CLOSE_CONNECTION_REQUEST_ID).create())
+                .one().getVertex();
+
+        Assert.assertNotNull(v);
+
+        // assert connection is not closed yet
+        Assert.assertEquals(1, channelPool.getConnectionIDs().size());
+
+        // wait for server to send the close WS frame
+        Thread.sleep(6000);
+
+        // assert that original connection is not part of the connection pool any more
+        Assert.assertFalse("The original connection should have been closed by the server.",
+                channelPool.getConnectionIDs().contains(originalConnectionID));
+
+        // assert sanity after connection replacement
+        v = client.submit("1",
+                RequestOptions.build().overrideRequestId(TestWSGremlinInitializer.SINGLE_VERTEX_REQUEST_ID).create())
+                .one().getVertex();
+        Assert.assertNotNull(v);
+    }
+
+    /**
+     * Tests a scenario when the connection a faulty connection replaced by a new connection.
+     * Ensures that the creation of a new replacement channel only happens once.
+     */
+    @Test
+    public void TestClosedConnectionIsRecycledForConnectionWithPendingRequests() throws InterruptedException, ExecutionException {
+        final Cluster cluster = Cluster.build("localhost").port(SimpleWebSocketServer.PORT)
+                .minConnectionPoolSize(1)
+                .maxConnectionPoolSize(1)
+                .serializer(Serializers.GRAPHSON_V2D0)
+                .create();
+
+        final Client.ClusteredClient client = cluster.connect();
+
+        // Initialize the client preemptively
+        client.init();
+
+        // assert number of connections opened
+        ConnectionPool channelPool = client.hostConnectionPools.values().stream().findFirst().get();
+        Assert.assertEquals(1, channelPool.getConnectionIDs().size());
+
+        // Send two requests in flight. Both should error out.
+        CompletableFuture<ResultSet> req1 = client.submitAsync("1", RequestOptions.build()
+                .overrideRequestId(TestWSGremlinInitializer.CLOSE_CONNECTION_REQUEST_ID).create());
+        CompletableFuture<ResultSet> req2 = client.submitAsync("1", RequestOptions.build()
+                .overrideRequestId(TestWSGremlinInitializer.CLOSE_CONNECTION_REQUEST_ID_2).create());
+
+
+        // assert both are sent on same connection
+        Assert.assertEquals(1, channelPool.getConnectionIDs().size());
+
+        // trigger write for both requests
+        req1.get();
+        req2.get();
+
+        // wait for close message to arrive from server
+        Thread.sleep(2000);
+
+        // Assert that we should consider creating a connection only once, since only one connection is being closed.
+        Assert.assertEquals(1, recordingAppender.getMessages().stream().filter(str -> str.contains("Considering new connection on")).count());
+
+        // assert sanity after connection replacement
+        Vertex v = client.submit("1",
+                RequestOptions.build().overrideRequestId(TestWSGremlinInitializer.SINGLE_VERTEX_REQUEST_ID).create())
+                .one().getVertex();
+        Assert.assertNotNull(v);
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/util/Log4jRecordingAppender.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/util/Log4jRecordingAppender.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.util;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Provides a way to gather logging events for purpose of testing log output.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class Log4jRecordingAppender extends AppenderSkeleton {
+    private final List<String> messages = new ArrayList<>();
+    private final List<LoggingEvent> events = new ArrayList<>();
+
+    public Log4jRecordingAppender() {
+        super();
+        setLayout(new PatternLayout("%p - %m%n")); // note the EOLN char(s) appended
+    }
+
+    @Override
+    protected void append(final LoggingEvent event) {
+        messages.add(layout.format(event));
+        events.add(event);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return true;
+    }
+
+    public List<String> getMessages() { return messages; }
+
+    public List<LoggingEvent> getEvents() { return events; }
+
+    public void clear() {
+        messages.clear();
+    }
+
+    /**
+     * @param regex not null
+     * @return true if there is a substring of a message matching the regular expression, where:
+     *         . matches also the EOLN char(s) defined in the layout.
+     *         $ matches the end of the string
+     */
+    public boolean logContainsAny(final String regex) {
+        Pattern pattern;
+
+        pattern = Pattern.compile( regex, Pattern.DOTALL );
+
+        return messages.stream().anyMatch(m -> pattern.matcher( m ).find());
+    }
+
+    public boolean logContainsAny(final String loggerName, final Level level, final String fragment) {
+        return events.stream().anyMatch(m -> m.getLoggerName().equals(loggerName) &&
+                m.getLevel().equals(level) && m.getMessage().toString().contains(fragment));
+    }
+    public boolean logMatchesAny(final String loggerName, final Level level, final String regex) {
+        return events.stream().anyMatch(m -> m.getLoggerName().equals(loggerName) &&
+                m.getLevel().equals(level) && m.getMessage().toString().matches(regex));
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/util/Log4jRecordingAppenderTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/util/Log4jRecordingAppenderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.util;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class Log4jRecordingAppenderTest {
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Log4jRecordingAppenderTest.class);
+    private Log4jRecordingAppender recordingAppender = null;
+    private static final String lineSeparator = System.getProperty("line.separator");
+
+    private Level originalConfiguredLevel = null;
+
+    @Before
+    public void setupForEachTest() {
+        recordingAppender = new Log4jRecordingAppender();
+        final Logger rootLogger = Logger.getRootLogger();
+        if (null == originalConfiguredLevel) originalConfiguredLevel = rootLogger.getLevel();
+        rootLogger.addAppender(recordingAppender);
+        rootLogger.setLevel(Level.ALL);
+
+        logger.error("ERROR");
+        logger.warn("WARN");
+        logger.info("INFO");
+    }
+
+    @After
+    public void teardownForEachTest() {
+        final Logger rootLogger = Logger.getRootLogger();
+        rootLogger.removeAppender(recordingAppender);
+        rootLogger.setLevel(originalConfiguredLevel);
+    }
+
+    @Test
+    public void shouldRecordMessages() {
+        assertEquals(3, recordingAppender.getMessages().size());
+        assertEquals("ERROR - ERROR" + lineSeparator, recordingAppender.getMessages().get(0));
+        assertEquals("WARN - WARN"  + lineSeparator, recordingAppender.getMessages().get(1));
+        assertEquals("INFO - INFO" + lineSeparator, recordingAppender.getMessages().get(2));
+    }
+
+    @Test
+    public void shouldMatchAnyMessages() {
+        assertTrue(recordingAppender.logContainsAny("ERROR.*"));
+    }
+
+    @Test
+    public void shouldMatchNoMessages() {
+        assertFalse(recordingAppender.logContainsAny("this is not here"));
+    }
+
+    @Test
+    public void shouldClearMessages() {
+        assertEquals(3, recordingAppender.getMessages().size());
+        recordingAppender.clear();
+        assertEquals(0, recordingAppender.getMessages().size());
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
@@ -25,7 +25,6 @@ import org.apache.tinkerpop.gremlin.server.AbstractGremlinServerIntegrationTest;
 import org.apache.tinkerpop.gremlin.server.TestClientFactory;
 import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2369

With this change, the following behaviour are modified:
1. If server closes a `Channel`, the client would detect it and replace the `Connection`. 
    Prior to this change, the client would do nothing on server initiated `Channel` close (applicable for cases when there were 
    no active requests on the channel). This would cause the load balancer to allocate requests to an already closed 
    Connection.
2. Do not throw a NPE when server sends a response for a request which is not registered with the client. Ignore it silently.
3. Ensure that replacement of a `Connection` is done only once. Prior to this change, for each failure of request using the 
    `Connection`, a new connection was being created.


**Testing**
Added tests which fail before the fixes and then succeed after the changes.