### PR TITLE
add getter method for GraphSONMessageSerializer

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0.java
@@ -154,6 +154,10 @@ public abstract class AbstractGraphSONMessageSerializerV1d0 extends AbstractMess
                 .version(GraphSONVersion.V1_0);
     }
 
+    public ObjectMapper getMapper() {
+        return this.mapper;
+    }
+
     public final static class GremlinServerModule extends SimpleModule {
         public GremlinServerModule() {
             super("graphson-gremlin-server");

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
@@ -146,6 +146,10 @@ public abstract class AbstractGraphSONMessageSerializerV2d0 extends AbstractMess
                 .version(GraphSONVersion.V2_0);
     }
 
+    public ObjectMapper getMapper() {
+        return this.mapper;
+    }
+
     public final static class GremlinServerModule extends SimpleModule {
         public GremlinServerModule() {
             super("graphson-gremlin-server");


### PR DESCRIPTION
Very simple changes. I just want a way to retrieve GraphSONMapper from these Serializer.

Background:

Our implementation is heavily inspired by [HttpGremlinEndpointHandler.java](https://github.com/apache/tinkerpop/blob/6c7be04be215f7877cca12b2d681d8cd81b7fb2f/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java) and we can retrieve MessageTextSerializer there, but this can only serialize / deserialize the whole response message.

I want to have capability to serialize / deserialize any element (e.g. some Vertex or Edge only) in the graph in HttpHandler and right now I define the same GraphSONMapper separately. But if I can just grab the GraphSONMapper I already setup for MessageTextSerializer, it would be good.

This mapper object can't be modified so it should also be safe. Please let me know if this addition is OK, if yes I will add tests + change log.

Thanks !