### PR TITLE
TINKERPOP-2406 Delegate processing from event loop to worker threads

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-9]]
 === TinkerPop 3.4.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-
+* (Java driver) Delegate handling of erroneous response to the worker thread pool instead of event loop thread pool. 
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -243,7 +243,7 @@ final class Connection {
                                 // so this isn't going to be like a potentially dead host situation which is handled above on a failed
                                 // write operation.
                                 logger.debug("Error while processing request on the server {}.", this, t);
-                                handleConnectionCleanupOnError(thisConnection, t);
+                                handleConnectionCleanupOnError(thisConnection);
                             } else {
                                 // the callback for when the read was successful, meaning that ResultQueue.markComplete()
                                 // was called


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2406

**Motivation**
Netty client has two thread pools. Event loop thread pool which is responsible for handling socket events and another is a worker thread pool which is used to delegate busy work from event loop threads so that they can continue handling socket events. When programming in Netty, ideally, the event loop should never be blocked and must be kept free to respond to events.

In case of exceptional completion of readComplete which could be triggered by a server sending an error code in the response, the event loop thread is used to perform the clean up logic which could involve an expensive replaceConnection. This blocks the event loop.

**Change**
Delegate handling of erroneous response from the server (which might involve connection replacement) to the worker thread pool. After this change the event loop will have lesser pressure and event handling will become faster.
