### PR TITLE
TINKERPOP-2408 Fix iterator leak in HasContainer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Delegated handling of erroneous response to the worker thread pool instead of event loop thread pool in Java Driver.
 * Removed `Connection` from `Connection Pool` when server closes a connection with no pending requests in Java Driver.
 * Fixed bug in Javascript `Translator` that wasn't handling child traversals well.
+* Fix an interator leak in HasContainer. 
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
@@ -82,9 +82,19 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
             return testLabel(element);
 
         final Iterator<? extends Property> itty = element.properties(this.key);
-        while (itty.hasNext()) {
-            if (testValue(itty.next()))
-                return true;
+        try {
+            while (itty.hasNext()) {
+                if (testValue(itty.next()))
+                    return true;
+            }
+        } finally {
+            if (itty instanceof AutoCloseable) {
+                try {
+                    ((AutoCloseable)itty).close();
+                } catch (Exception ex) {
+                    throw ex instanceof RuntimeException ? (RuntimeException) ex : new RuntimeException(ex);
+                }
+            }
         }
         return false;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/HasContainer.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.io.Serializable;
@@ -88,13 +89,7 @@ public class HasContainer implements Serializable, Cloneable, Predicate<Element>
                     return true;
             }
         } finally {
-            if (itty instanceof AutoCloseable) {
-                try {
-                    ((AutoCloseable)itty).close();
-                } catch (Exception ex) {
-                    throw ex instanceof RuntimeException ? (RuntimeException) ex : new RuntimeException(ex);
-                }
-            }
+            CloseableIterator.closeIterator(itty);
         }
         return false;
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2408

**Change**
Close the iterator to release resources. If the iterator is not closed, due to short circuit return, it could lead to iterator leaks in the underlying storage.

**Deployment**
Added ChangeLog