### PR TITLE
TINKERPOP-2405 Provide method to configure tornado timeouts

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-9]]
 === TinkerPop 3.4.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Established a default read and write timeout for the `TornadoTransport` in Python, allowing it to be configurable.
 * Delegated handling of erroneous response to the worker thread pool instead of event loop thread pool in Java Driver.
 * Removed `Connection` from `Connection Pool` when server closes a connection with no pending requests in Java Driver.
 * Fixed bug in Javascript `Translator` that wasn't handling child traversals well.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -732,15 +732,25 @@ can be passed to the `Client` or `DriverRemoteConnection` instance as keyword ar
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Key |Description |Default
-|protocol_factory |A callable that returns an instance of `AbstractBaseProtocol`. |`gremlin_python.driver.protocol.GremlinServerWSProtocol`
-|transport_factory |A callable that returns an instance of `AbstractBaseTransport`. |`gremlin_python.driver.tornado.transport.TornadoTransport`
-|pool_size |The number of connections used by the pool. |4
+|headers |Additional headers that will be added to each request message. |`None`
 |max_workers |Maximum number of worker threads. |Number of CPUs * 5
 |message_serializer |The message serializer implementation.|`gremlin_python.driver.serializer.GraphSONMessageSerializer`
 |password |The password to submit on requests that require authentication. |""
+|pool_size |The number of connections used by the pool. |4
+|protocol_factory |A callable that returns an instance of `AbstractBaseProtocol`. |`gremlin_python.driver.protocol.GremlinServerWSProtocol`
+|transport_factory |A callable that returns an instance of `AbstractBaseTransport`. |`gremlin_python.driver.tornado.transport.TornadoTransport`
 |username |The username to submit on requests that require authentication. |""
 |session | A unique string-based identifier (typically a UUID) to enable a <<sessions,session-based connection>>. This is not a valid configuration for `DriverRemoteConnection`. |None
 |=========================================================
+
+Note that the `transport_factory` can allow for additional configuration of the `TornadoTransport`, which exposes
+options to manage `ioloop` timeouts:
+
+```python
+g = traversal().withRemote(
+  DriverRemoteConnection('ws://localhost:8182/gremlin','g',
+                         transport_factory=lambda: TornadoTransport(read_timeout=10, write_timeout=10)))
+```
 
 === Traversal Strategies
 

--- a/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
@@ -26,8 +26,10 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 class TornadoTransport(AbstractBaseTransport):
 
-    def __init__(self):
+    def __init__(self, read_timeout=30, write_timeout=30):
         self._loop = ioloop.IOLoop(make_current=False)
+        self._read_timeout = read_timeout
+        self._write_timeout = write_timeout
 
     def connect(self, url, headers=None):
         if headers:
@@ -37,10 +39,10 @@ class TornadoTransport(AbstractBaseTransport):
 
     def write(self, message):
         self._loop.run_sync(
-            lambda: self._ws.write_message(message, binary=True))
+            lambda: self._ws.write_message(message, binary=True), timeout=self._write_timeout)
 
     def read(self):
-        return self._loop.run_sync(lambda: self._ws.read_message())
+        return self._loop.run_sync(lambda: self._ws.read_message(), timeout=self._read_timeout)
 
     def close(self):
         self._ws.close()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2405

Set some defaults for the tornado timeouts and given existing methods for supplying a custom `TransportFactory` it's then possible for users to easily set custom values for those timeouts.

```python
g = traversal().withRemote(
  DriverRemoteConnection('ws://localhost:8182/gremlin','g',
                         transport_factory=lambda: TornadoTransport(read_timeout=10, write_timeout=10)))
```

All tests pass with `mvn clean install -pl gremlin=python`

VOTE +1