### PR TITLE
TINKERPOP-2335 Set node.js support at 10 for 3.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 __version__.py
 .glv
 settings.xml
+package-lock.json
 tools/
 [Dd]ebug/
 [Rr]elease/

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -29,10 +29,21 @@ limitations under the License.
         <maven.test.skip>false</maven.test.skip>
         <skipTests>${maven.test.skip}</skipTests>
         <gremlin.server.dir>${project.parent.basedir}/gremlin-server</gremlin.server.dir>
+        <npm.version>6.14.6</npm.version>
+        <node.version>v10.22.0</node.version>
     </properties>
     <build>
         <directory>${basedir}/target</directory>
         <finalName>${project.artifactId}-${project.version}</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>1.10.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <!--
@@ -152,7 +163,6 @@ file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\"
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.7.6</version>
                 <executions>
                     <execution>
                         <id>install node and npm</id>
@@ -208,7 +218,8 @@ file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\"
                 </executions>
                 <configuration>
                     <workingDirectory>src/main/javascript/gremlin-javascript</workingDirectory>
-                    <nodeVersion>v6.12.3</nodeVersion>
+                    <nodeVersion>${node.version}</nodeVersion>
+                    <npmVersion>${npm.version}</npmVersion>
                 </configuration>
             </plugin>
             <!--
@@ -264,7 +275,6 @@ file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\"
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.4</version>
                         <executions>
                             <execution>
                                 <id>npm publish</id>
@@ -285,7 +295,8 @@ file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\"
                             -->
                             <skip>false</skip>
                             <workingDirectory>src/main/javascript/gremlin-javascript</workingDirectory>
-                            <nodeVersion>v6.12.3</nodeVersion>
+                            <nodeVersion>${node.version}</nodeVersion>
+                            <npmVersion>${npm.version}</npmVersion>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
@@ -19,9 +19,9 @@
   "devDependencies": {
     "chai": "~4.1.2",
     "cucumber": "~4.2.1",
-    "grunt": "~1.0.4",
+    "grunt": "~1.2.0",
     "grunt-cli": "~1.3.2",
-    "grunt-jsdoc": "~2.3.1",
+    "grunt-jsdoc": "~2.4.1",
     "mocha": "~5.2.0"
   },
   "repository": {
@@ -38,6 +38,6 @@
     "unit-test": "./node_modules/mocha/bin/mocha test/unit"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -409,8 +409,7 @@ limitations under the License.
                         <exclude>**/*.nuspec</exclude>
                         <exclude>**/gremlin-javascript/node_modules/**</exclude>
                         <exclude>**/gremlin-javascript/doc/**</exclude>
-                        <exclude>**/node/node_modules/**</exclude>
-                        <exclude>**/node/node</exclude>
+                        <exclude>**/node/**</exclude>
                         <exclude>**/npm-debug.log</exclude>
                         <exclude>**/_site/**</exclude>
                         <exclude>**/.pytest_cache/**</exclude>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2335

Upgraded frontend plugin and centralized configuration a bit. 

Builds with `mvn clean install`

VOTE +1