### PR TITLE
TINKERPOP-2410 Release server threads waiting on connection if the connection is dead. 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Avoid creating unnecessary detached objects in JVM.
 * Added support for `TraversalStrategy` usage in Javascript.
 * Added `Traversal.getTraverserSetSupplier()` to allow providers to supply their own `TraverserSet` instances.
+* Release server threads waiting on connection if the connection is dead.
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -134,6 +134,15 @@ public abstract class AbstractOpProcessor implements OpProcessor {
             // while waiting for the client to catch up
             if (aggregate.size() < resultIterationBatchSize && itty.hasNext() && !forceFlush) aggregate.add(itty.next());
 
+            // Don't keep executor busy if client has already given up; there is no way to catch up if the channel is
+            // not active, and hence we should break the loop.
+            if (!nettyContext.channel().isActive()) {
+                if (managedTransactionsForRequest) {
+                    attemptRollback(msg, context.getGraphManager(), settings.strictTransactionManagement);
+                }
+                break;
+            }
+
             // send back a page of results if batch size is met or if it's the end of the results being iterated.
             // also check writeability of the channel to prevent OOME for slow clients.
             //


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2410

Consider a situation where the server has sent some results back to the client and is waiting for Netty channel to be writable again before sending rest of the results. Let's assume that the client dies (or is closed) at this instant without consuming the entire set of results. In this case, the server threads will continue to wait for the channel to become writable (which it never will since client is dead) until the timeout is hit.

With this change, if the connection becomes inactive, the loop will break and free up the threads.

## Testing
We don't have any test mechanism to check the number of busy server threads. Hence, no tests are added to repro this case. Any suggestions on how to add tests for such scenarios are welcome!