### PR TITLE
TINKERPOP-2392 Improved GLV starting docs

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1047,9 +1047,9 @@ anchor:gremlin-DotNet[]
 image:gremlin-dotnet-logo.png[width=371,float=right] Apache TinkerPop's Gremlin.Net implements Gremlin within the C#
 language. It targets .NET Standard and can therefore be used on different operating systems and with different .NET
 frameworks, such as .NET Framework and link:https://www.microsoft.com/net/core[.NET Core]. Since the C# syntax is very
-similar to that of Java, it should be very easy to switch between Gremlin-Java and Gremlin.Net. The only major
-syntactical difference is that all method names in Gremlin.Net use PascalCase as opposed to camelCase in Gremlin-Java
-in order to comply with .NET conventions.
+similar to that of Java, it should be easy to switch between Gremlin-Java and Gremlin.Net. The only major syntactical
+difference is that all method names in Gremlin.Net use PascalCase as opposed to camelCase in Gremlin-Java in order
+to comply with .NET conventions.
 
 [source,powershell]
 nuget install Gremlin.Net
@@ -1223,9 +1223,9 @@ include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference
 === Differences
 
 The biggest difference between Gremlin in .NET and the canonical version in Java is the casing of steps. Canonical
-Gremlin utilizes `camelCase` as is typical in Java for function names, but C# utilizes `PascalCase` as it more typical
-in that language. Therefore, when viewing a typical Gremlin example written in Gremlin Console, the conversion to
-C# usually just requires capitalization of the first letter in the step name, thus the following example in Groovy:
+Gremlin utilizes `camelCase` as is typical in Java for function names, but C# utilizes `PascalCase` as it is more
+typical in that language. Therefore, when viewing a typical Gremlin example written in Gremlin Console, the conversion
+to C# usually just requires capitalization of the first letter in the step name, thus the following example in Groovy:
 
 [source,groovy]
 ----

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1012,6 +1012,7 @@ bits of conflicting Gremlin get an underscore appended as a suffix:
 
 *Tokens* - <<a-note-on-scopes,Scope.global_>>
 
+[[gremlin-python-limitations]]
 === Limitations
 
 * Traversals that return a `Set` *might* be coerced to a `List` in Python. In the case of Python, number equality
@@ -1021,6 +1022,9 @@ results within a collection across different languages. If a `Set` is needed the
 to `Set` manually.
 * Gremlin is capable of returning `Dictionary` results that use non-hashable keys (e.g. Dictionary as a key) and Python
 does not support that at a language level. Gremlin that returns such results will need to be re-written to avoid that.
+* The `subgraph()`-step is not supported by any variant that is not running on the Java Virtual Machine as there is
+no `Graph` instance to deserialize a result into on the client-side. A workaround is to replace the step with `store()`
+and then convert those results to something the client can use locally.
 
 === Application Examples
 
@@ -1215,6 +1219,57 @@ and then it can be called from the application as follows:
 include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDslTests.cs[tags=dslExamples]
 ----
 
+[[gremlin-net-differences]]
+=== Differences
+
+The biggest difference between Gremlin in .NET and the canonical version in Java is the casing of steps. Canonical
+Gremlin utilizes `camelCase` as is typical in Java for function names, but C# utilizes `PascalCase` as it more typical
+in that language. Therefore, when viewing a typical Gremlin example written in Gremlin Console, the conversion to
+C# usually just requires capitalization of the first letter in the step name, thus the following example in Groovy:
+
+[source,groovy]
+----
+g.V().has('person','name','marko').
+  out('knows').
+  elementMap().toList()
+----
+
+would become the following in C#:
+
+[source,csharp]
+----
+g.V().Has("Person","name","marko").
+  Out("knows").
+  ElementMap().ToList();
+----
+
+In addition to the uppercase change, also note the conversion of the single quotes to double quotes as is expected for
+declaring string values in C# and the addition of the semi-colon at the end of the line. In short, don't forget to
+apply the common syntax expectations for C# when trying to convert an example of Gremlin from a different language.
+
+Another common conversion issues lies in having to explicitly define generics, which can make canonical Gremlin appear
+much more complex in C# where type erasure is not a feature of the language. For example, the following example in
+Groovy:
+
+[source,groovy]
+----
+g.V().repeat(__.out()).times(2).values('name')
+----
+
+must be written as:
+
+[source,csharp]
+----
+g.V().Repeat(__.Out()).Times(2).Values<string>("name");
+----
+
+[[gremlin-net-limitations]]
+=== Limitations
+
+* The `subgraph()`-step is not supported by any variant that is not running on the Java Virtual Machine as there is
+no `Graph` instance to deserialize a result into on the client-side. A workaround is to replace the step with `store()`
+and then convert those results to something the client can use locally.
+
 anchor:gremlin-dotnet-template[]
 [[dotnet-application-examples]]
 === Application Examples
@@ -1313,6 +1368,16 @@ const scope = gremlin.process.scope
 const t = gremlin.process.t
 ----
 
+By defining these imports it becomes possible to write Gremlin in the more shorthand, canonical style that is
+demonstrated in most examples found here in the documentation:
+
+[source,javascript]
+----
+const { P: { gt } } = gremlin.process;
+const { order: { desc } } = gremlin.process;
+g.V().hasLabel('person').has('age',gt(30)).order().by('age',desc).toList()
+----
+
 === Submitting Scripts
 
 WARNING: TinkerPop does not recommend submitting script-based requests and generally continues to support this feature
@@ -1406,6 +1471,7 @@ g.person('marko').aged(29).values('name').toList().
   then(names => console.log(names));
 ----
 
+[[javascript-differences]]
 [[gremlin-javascript-differences]]
 === Differences
 
@@ -1413,3 +1479,10 @@ In situations where Javascript reserved words and global functions overlap with 
 bits of conflicting Gremlin get an underscore appended as a suffix:
 
 *Steps* - <<from-step,from_()>>, <<in-step,in_()>>, <<with-step,with_()>>
+
+[[gremlin-javascript-limitations]]
+=== Limitations
+
+* The `subgraph()`-step is not supported by any variant that is not running on the Java Virtual Machine as there is
+no `Graph` instance to deserialize a result into on the client-side. A workaround is to replace the step with `store()`
+and then convert those results to something the client can use locally.

--- a/gremlin-dotnet/README.md
+++ b/gremlin-dotnet/README.md
@@ -46,9 +46,9 @@ Gremlin variant for that language.
 **NOTE** that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and thus 
 for early testing purposes only.
 
-[tk]: http://tinkerpop.apache.org
-[gremlin]: http://tinkerpop.apache.org/gremlin.html
-[docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-dotnet
+[tk]: https://tinkerpop.apache.org
+[gremlin]: https://tinkerpop.apache.org/gremlin.html
+[docs]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-dotnet
 [console]: https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/
 [steps]: https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps
 [differences]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript-differences

--- a/gremlin-dotnet/README.md
+++ b/gremlin-dotnet/README.md
@@ -33,8 +33,22 @@ operating systems and with different .NET frameworks, such as .NET Framework and
 nuget install Gremlin.Net
 ```
 
-Please see the [reference documentation][docs] at Apache TinkerPop for more information.
+The Gremlin language allows users to write highly expressive graph traversals and has a broad list of functions that 
+cover a wide body of features. The [Reference Documentation][steps] describes these functions and other aspects of the 
+TinkerPop ecosystem including some specifics on [Gremlin in .NET][docs] itself. Most of the examples found in the 
+documentation use Groovy language syntax in the [Gremlin Console][console]. For the most part, these examples
+should generally translate to C# with [some logical modification][differences]. Given the strong correspondence 
+between canonical Gremlin in Java and its variants like C#, there is a limited amount of C#-specific 
+documentation and examples. This strong correspondence among variants ensures that the general Gremlin reference 
+documentation is applicable to all variants and that users moving between development languages can easily adopt the 
+Gremlin variant for that language.
+
+**NOTE** that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and thus 
+for early testing purposes only.
 
 [tk]: http://tinkerpop.apache.org
 [gremlin]: http://tinkerpop.apache.org/gremlin.html
-[docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-DotNet
+[docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-dotnet
+[console]: https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/
+[steps]: https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps
+[differences]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript-differences

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -42,9 +42,19 @@ http://tinkerpop.apache.org/docs/current/reference/#gremlin-server
 
 or a remote graph provider that exposes protocols by which Gremlin.Net can connect.
 
-Please see the reference documentation of Apache TinkerPop for more information on usage: https://s.apache.org/pgbwu
+Please see the Reference Documentation of Apache TinkerPop for more information on usage: http://tinkerpop.apache.org/docs/current/reference
 
 and use our Google Group gremlin-users if there are any questions: https://s.apache.org/c8hru
+
+The Gremlin language allows users to write highly expressive graph traversals and has a broad list of functions that cover a wide body of features. The Reference Documentation describes these functions and other aspects of the TinkerPop ecosystem including some specifics on Gremlin in .NET itself:
+
+https://s.apache.org/pgbwu
+
+Most of the examples found in the documentation use Groovy language syntax in the Gremlin Console. For the most part, these examples should generally translate to C# with some logical modification:
+
+https://s.apache.org/10v91
+
+Given the strong correspondence between canonical Gremlin in Java and its variants like C#, there is a limited amount of C#-specific documentation and examples. This strong correspondence among variants ensures that the general Gremlin reference documentation is applicable to all variants and that users moving between development languages can easily adopt the Gremlin variant for that language.
 
 NOTE that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and thus for early testing purposes only.</Description>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -38,11 +38,11 @@ Gremlin.Net implements Gremlin within .NET. C# syntax has the same constructs as
 
 Gremlin.Net is designed to connect to a "server" that is hosting a TinkerPop-enabled graph system. That "server" could be Gremlin Server
 
-http://tinkerpop.apache.org/docs/current/reference/#gremlin-server
+https://tinkerpop.apache.org/docs/current/reference/#gremlin-server
 
 or a remote graph provider that exposes protocols by which Gremlin.Net can connect.
 
-Please see the Reference Documentation of Apache TinkerPop for more information on usage: http://tinkerpop.apache.org/docs/current/reference
+Please see the Reference Documentation of Apache TinkerPop for more information on usage: https://tinkerpop.apache.org/docs/current/reference
 
 and use our Google Group gremlin-users if there are any questions: https://s.apache.org/c8hru
 
@@ -61,10 +61,10 @@ NOTE that versions suffixed with "-rc" are considered release candidates (i.e. p
     <SignAssembly>true</SignAssembly>
     <PackageId>Gremlin.Net</PackageId>
     <PackageTags>gremlin;tinkerpop;apache</PackageTags>
-    <PackageProjectUrl>http://tinkerpop.apache.org</PackageProjectUrl>
+    <PackageProjectUrl>https://tinkerpop.apache.org</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>gremlin-dotnet-logo_256x256.png</PackageIcon>
-    <PackageIconUrl>http://tinkerpop.apache.org/docs/current/images/gremlin-dotnet-logo_256x256.png</PackageIconUrl>
+    <PackageIconUrl>https://tinkerpop.apache.org/docs/current/images/gremlin-dotnet-logo_256x256.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/apache/tinkerpop</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>    
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/gremlin-dotnet/src/index.md
+++ b/gremlin-dotnet/src/index.md
@@ -46,9 +46,9 @@ Gremlin variant for that language.
 **NOTE** that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and thus 
 for early testing purposes only.
 
-[tk]: http://tinkerpop.apache.org
-[gremlin]: http://tinkerpop.apache.org/gremlin.html
-[docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-dotnet
+[tk]: https://tinkerpop.apache.org
+[gremlin]: https://tinkerpop.apache.org/gremlin.html
+[docs]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-dotnet
 [console]: https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/
 [steps]: https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps
 [differences]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript-differences

--- a/gremlin-dotnet/src/index.md
+++ b/gremlin-dotnet/src/index.md
@@ -33,8 +33,22 @@ operating systems and with different .NET frameworks, such as .NET Framework and
 nuget install Gremlin.Net
 ```
 
-Please see the [reference documentation][docs] at Apache TinkerPop for more information.
+The Gremlin language allows users to write highly expressive graph traversals and has a broad list of functions that 
+cover a wide body of features. The [Reference Documentation][steps] describes these functions and other aspects of the 
+TinkerPop ecosystem including some specifics on [Gremlin in .NET][docs] itself. Most of the examples found in the 
+documentation use Groovy language syntax in the [Gremlin Console][console]. For the most part, these examples
+should generally translate to C# with [some logical modification][differences]. Given the strong correspondence 
+between canonical Gremlin in Java and its variants like C#, there is a limited amount of C#-specific 
+documentation and examples. This strong correspondence among variants ensures that the general Gremlin reference 
+documentation is applicable to all variants and that users moving between development languages can easily adopt the 
+Gremlin variant for that language.
+
+**NOTE** that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and thus 
+for early testing purposes only.
 
 [tk]: http://tinkerpop.apache.org
 [gremlin]: http://tinkerpop.apache.org/gremlin.html
-[docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-DotNet
+[docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-dotnet
+[console]: https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/
+[steps]: https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps
+[differences]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript-differences

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
@@ -58,7 +58,17 @@ const names = await g.V().hasLabel('person').values('name').toList();
 console.log(names);
 ```
 
-# Main Operations
+# Sample Traversals
+
+The Gremlin language allows users to write highly expressive graph traversals and has a broad list of functions that 
+cover a wide body of features. The [Reference Documentation][steps] describes these functions and other aspects of the 
+TinkerPop ecosystem including some specifics on [Gremlin in Javascript][docs] itself. Most of the examples found in the 
+documentation use Groovy language syntax in the [Gremlin Console][console]. For the most part, these examples
+should generally translate to Javascript with [little modification][differences]. Given the strong correspondence 
+between canonical Gremlin in Java and its variants like Javascript, there is a limited amount of Javascript-specific 
+documentation and examples. This strong correspondence among variants ensures that the general Gremlin reference 
+documentation is applicable to all variants and that users moving between development languages can easily adopt the 
+Gremlin variant for that language.
 
 ## Create Vertex
 
@@ -68,36 +78,23 @@ const { t: { id } } = gremlin.process;
 const { cardinality: { single } } = gremlin.process;
 
 /**
- * create a new vertex with Id, Label and properties
- * @param {String,Number} vertexId Vertex Id
- * @param {String} label Vertex Label
+ * Create a new vertex with Id, Label and properties
+ * @param {String,Number} vertexId Vertex Id (assuming the graph database allows id assignment)
+ * @param {String} vlabel Vertex Label
  */
-const createVertex = async (vertexId, label) => {
-  const vertex = await g.addV(label)
+const createVertex = async (vertexId, vlabel) => {
+  const vertex = await g.addV(vlabel)
     .property(id, vertexId)
     .property(single, 'name', 'Apache')
-    .property(single, 'lastname', 'Tinkerpop')
+    .property('lastname', 'Tinkerpop') // default database cardinality
     .next();
 
   return vertex.value;
 };
 ```
 
-## Find Vertex
+## Find Vertices
 
-```javascript
-/**
- * find unique vertex with id and label
- * @param {String,Number} vertexId
- * @param {String} label
- */
-const findVertex = async (vertexId, label) => {
-  const vertex = await g.V(vertexId).hasLabel(label).elementMap().next();
-  return vertex.value;
-};
-```
-
-## Listing Vertexes
 ```javascript
 /**
  * List all vertexes in db
@@ -105,6 +102,22 @@ const findVertex = async (vertexId, label) => {
  */
 const listAll = async (limit = 500) => {
   return g.V().limit(limit).elementMap().toList();
+};
+/**
+ * Find unique vertex with id
+ * @param {Object} vertexId Vertex Id
+ */
+const findVertex = async (vertexId) => {
+  const vertex = await g.V(vertexId).elementMap().next();
+  return vertex.value;
+};
+/**
+ * Find vertices by label and 'name' property
+ * @param {String} vlabel Vertex label
+ * @param {String} name value of 'name' property
+ */
+const listByLabelAndName = async (vlabel, name) => {
+  return g.V().has(vlabel, 'name', name).elementMap().toList();
 };
 ```
 
@@ -115,7 +128,6 @@ const { cardinality: { single } } = gremlin.process;
 /**
  * Update Vertex Properties
  * @param {String,Number} vertexId Vertex Id
- * @param {String} label Vertex Label
  * @param {String} name Vertex Name Property
  */
 const updateVertex = async (vertexId, label, name) => {
@@ -123,8 +135,6 @@ const updateVertex = async (vertexId, label, name) => {
   return vertex.value;
 };
 ```
-
-Please see the [reference documentation][docs] at Apache TinkerPop for more information.
 
 NOTE that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and 
 thus for early testing purposes only.
@@ -134,3 +144,6 @@ thus for early testing purposes only.
 [docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript
 [gs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-server
 [rgp]: http://tinkerpop.apache.org/docs/current/reference/#connecting-rgp
+[console]: https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/
+[steps]: https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps
+[differences]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript-differences

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
@@ -139,11 +139,11 @@ const updateVertex = async (vertexId, label, name) => {
 NOTE that versions suffixed with "-rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and 
 thus for early testing purposes only.
 
-[tk]: http://tinkerpop.apache.org
-[gremlin]: http://tinkerpop.apache.org/gremlin.html
-[docs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript
-[gs]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-server
-[rgp]: http://tinkerpop.apache.org/docs/current/reference/#connecting-rgp
+[tk]: https://tinkerpop.apache.org
+[gremlin]: https://tinkerpop.apache.org/gremlin.html
+[docs]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript
+[gs]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-server
+[rgp]: https://tinkerpop.apache.org/docs/current/reference/#connecting-rgp
 [console]: https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/
 [steps]: https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps
 [differences]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-javascript-differences

--- a/gremlin-python/src/main/jython/README.rst
+++ b/gremlin-python/src/main/jython/README.rst
@@ -19,9 +19,9 @@
 Apache TinkerPop - Gremlin Python
 =================================
 
-`Apache TinkerPop™ <http://tinkerpop.apache.org>`_
+`Apache TinkerPop™ <https://tinkerpop.apache.org>`_
 is a graph computing framework for both graph databases (OLTP) and
-graph analytic systems (OLAP). `Gremlin <http://tinkerpop.apache.org/gremlin.html>`_
+graph analytic systems (OLAP). `Gremlin <https://tinkerpop.apache.org/gremlin.html>`_
 is the graph traversal language of
 TinkerPop. It can be described as a functional, data-flow language that enables users to succinctly express complex
 traversals on (or queries of) their application's property graph.
@@ -33,8 +33,8 @@ chaining ``(a.b.c)``, round bracket function arguments ``(a(b,c))``, and support
 Gremlin-Python. Moreover, there are a few added constructs to Gremlin-Python that make traversals a bit more succinct.
 
 Gremlin-Python is designed to connect to a "server" that is hosting a TinkerPop-enabled graph system. That "server"
-could be `Gremlin Server <http://tinkerpop.apache.org/docs/current/reference/#gremlin-server>`_ or a
-`remote Gremlin provider <http://tinkerpop.apache.org/docs/current/reference/#connecting-rgp>`_ that exposes
+could be `Gremlin Server <https://tinkerpop.apache.org/docs/current/reference/#gremlin-server>`_ or a
+`remote Gremlin provider <https://tinkerpop.apache.org/docs/current/reference/#connecting-rgp>`_ that exposes
 protocols by which Gremlin-Python can connect.
 
 A typical connection to a server running on "localhost" that supports the Gremlin Server protocol using websockets
@@ -61,7 +61,7 @@ Sample Traversals
 The Gremlin language allows users to write highly expressive graph traversals and has a broad list of functions that
 cover a wide body of features. The `Reference Documentation <https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps>`_
 describes these functions and other aspects of the TinkerPop ecosystem including some specifics on
-`Gremlin in Python <http://tinkerpop.apache.org/docs/current/reference/#gremlin-python>`_ itself. Most of the
+`Gremlin in Python <https://tinkerpop.apache.org/docs/current/reference/#gremlin-python>`_ itself. Most of the
 examples found in the documentation use Groovy language syntax in the
 `Gremlin Console <https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/>`_.
 For the most part, these examples should generally translate to Python with

--- a/gremlin-python/src/main/jython/README.rst
+++ b/gremlin-python/src/main/jython/README.rst
@@ -54,8 +54,66 @@ remote graph:
     >>> g.V().both().name.toList()
     [lop, vadas, josh, marko, marko, josh, peter, ripple, lop, marko, josh, lop]
 
-Please see the `reference documentation <http://tinkerpop.apache.org/docs/current/reference/#gremlin-python>`_
-at Apache TinkerPop for more information on usage.
+-----------------
+Sample Traversals
+-----------------
+
+The Gremlin language allows users to write highly expressive graph traversals and has a broad list of functions that
+cover a wide body of features. The `Reference Documentation <https://tinkerpop.apache.org/docs/current/reference/#graph-traversal-steps>`_
+describes these functions and other aspects of the TinkerPop ecosystem including some specifics on
+`Gremlin in Python <http://tinkerpop.apache.org/docs/current/reference/#gremlin-python>`_ itself. Most of the
+examples found in the documentation use Groovy language syntax in the
+`Gremlin Console <https://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/>`_.
+For the most part, these examples should generally translate to Python with
+`some modification <https://tinkerpop.apache.org/docs/current/reference/#gremlin-python-differences>`_. Given the
+strong correspondence between canonical Gremlin in Java and its variants like Python, there is a limited amount of
+Python-specific documentation and examples. This strong correspondence among variants ensures that the general
+Gremlin reference documentation is applicable to all variants and that users moving between development languages can
+easily adopt the Gremlin variant for that language.
+
+Create Vertex
+^^^^^^^^^^^^^
+
+.. code:: python
+
+    from gremlin_python.process.traversal import T
+    from gremlin_python.process.traversal import Cardinality
+
+    id = T.id
+    single = Cardinality.single
+
+    def create_vertex(self, vid, vlabel):
+        # default database cardinality is used when Cardinality argument is not specified
+        g.addV(vlabel).property(id, vid). \
+          property(single, 'name', 'Apache'). \
+          property('lastname', 'Tinkerpop'). \
+          next()
+
+Find Vertices
+^^^^^^^^^^^^^
+
+.. code:: python
+
+    def list_all(self, limit=500):
+        g.V().limit(limit).elementMap().toList()
+
+    def find_vertex(self, vid):
+        g.V(vid).elementMap().next()
+
+    def list_by_label_name(self, vlabel, name):
+        g.V().has(vlabel, 'name', name).elementMap().toList()
+
+Update Vertex
+^^^^^^^^^^^^^
+
+.. code:: python
+
+    from gremlin_python.process.traversal import Cardinality
+
+    single = Cardinality.single
+
+    def update_vertex(self, vid, name):
+        g.V(vid).property(single, 'name', name).next()
 
 NOTE that versions suffixed with "rc" are considered release candidates (i.e. pre-alpha, alpha, beta, etc.) and
 thus for early testing purposes only.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2392

This issue was about javascript but really might have applied to all GLVs. With the recent change of ae95dbe9c33b380555ee32716e56ec12b56c3f6c it seemed to make sense to expand this change to all GLVs and to improve upon it. I could have probably just CTR'd this in but thought it would be better to get some review on sample variety and syntax (as these changes will affect artifact repositories descriptions...nuget, pypi, npm...and I'm not sure there is a nice way to validate links/changes without a release deployment.

VOTE +1