### PR TITLE
TINKERPOP-2413 withEmbedded()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,8 +26,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Delegated handling of erroneous response to the worker thread pool instead of event loop thread pool in Java Driver.
 * Removed `Connection` from `Connection Pool` when server closes a connection with no pending requests in Java Driver.
 * Improved initialization time of Java Driver if the default serializer is replaced.
+* Deprecated `withGraph()` in favor of `withEmbedded()` on `AnonymousTraversalSource`.
 * Fixed bug in Javascript `Translator` that wasn't handling child traversals well.
-* Fix an interator leak in HasContainer. 
+* Fixed an iterator leak in `HasContainer`.
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/docs/site/home/gremlin.html
+++ b/docs/site/home/gremlin.html
@@ -293,7 +293,7 @@ g.V().hasLabel("person").
   public void run(String name, String property) {
 
     Graph graph = GraphFactory.open(...);
-    GraphTraversalSource g = graph.traversal();
+    GraphTraversalSource g = traversal().withEmbedded(graph);
 
     double avg = g.V().has("name",name).
                    out("knows").out("created").
@@ -337,9 +337,9 @@ g.V().hasLabel("person").
        <div class="col-md-12">
           <pre style="padding:10px;"><code class="language-gremlin">Graph graph = GraphFactory.open(...);
 GraphTraversalSource g;
-g = graph.traversal();                                                         // local OLTP
-g = traversal().withRemote(DriverRemoteConnection.using("localhost", 8182))    // remote
-g = graph.traversal().withComputer(SparkGraphComputer.class);                 // distributed OLAP</code>
+g = traversal().withEmbedded(graph);                                            // local OLTP
+g = traversal().withRemote(DriverRemoteConnection.using("localhost", 8182))     // remote
+g = traversal().withEmbedded(graph).withComputer(SparkGraphComputer.class);     // distributed OLAP</code>
 </pre>
        </div>
        <br/>

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -871,7 +871,7 @@ A `RequestMessage` to evaluate a script with variable bindings looks like this i
 { "requestId":"1d6d02bd-8e56-421d-9438-3bd6d0079ff1",
   "op":"eval",
   "processor":"",
-  "args":{"gremlin":"g.traversal().V(x).out()",
+  "args":{"gremlin":"g.V(x).out()",
           "bindings":{"x":1},
           "language":"gremlin-groovy"}}
 ----
@@ -896,7 +896,7 @@ NOTE: Gremlin Server will only accept masked packets as it pertains to a WebSock
 
 When Gremlin Server receives that request, it will decode it given the "mime type", pass it to the requested
 `OpProcessor` which will execute the `op` defined in the message.  In this case, it will evaluate the script
-`g.traversal().V(x).out()` using the `bindings` supplied in the `args` and stream back the results in a series of
+`g.V(x).out()` using the `bindings` supplied in the `args` and stream back the results in a series of
 `ResponseMessages`.  A `ResponseMessage` looks like this:
 
 [width="100%",cols="3,10",options="header"]
@@ -1094,7 +1094,7 @@ To demonstrate consider this example:
 cluster = Cluster.open()
 client = cluster.connect()
 aliased = client.alias("g")
-g = org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph.instance().traversal()     <1>
+g = traversal().withEmbedded(org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph.instance())     <1>
 rs = aliased.submit(g.V().both().barrier().both().barrier()).all().get()                    <2>
 aliased.submit(g.V().both().barrier().both().barrier().count()).all().get().get(0).getInt() <3>
 rs.collect{[value: it.getObject().get(), bulk: it.getObject().bulk()]}                      <4>

--- a/docs/src/recipes/centrality.asciidoc
+++ b/docs/src/recipes/centrality.asciidoc
@@ -115,7 +115,6 @@ other reachable vertices in the graph. The following examples use the modern toy
 
 [gremlin-groovy,modern]
 ----
-g = TinkerFactory.createModern().traversal()
 g.withSack(1f).V().as("v").                                                     <1>
   repeat(both().simplePath().as("v")).emit().                                   <2>
   filter(project("x","y","z").by(select(first, "v")).                           <3>
@@ -185,6 +184,6 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#pagerank-step[pageRank()
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().pageRank().by('pageRank').values('pageRank')
 ----

--- a/docs/src/recipes/olap-spark-yarn.asciidoc
+++ b/docs/src/recipes/olap-spark-yarn.asciidoc
@@ -105,7 +105,7 @@ conf.setProperty('spark.executor.extraLibraryPath', "$hadoop/lib/native:$hadoop/
 conf.setProperty('gremlin.spark.persistContext', 'true')
 hdfs.copyFromLocal('data/tinkerpop-modern.kryo', 'tinkerpop-modern.kryo')
 graph = GraphFactory.open(conf)
-g = graph.traversal().withComputer(SparkGraphComputer)
+g = traversal().withEmbedded(graph).withComputer(SparkGraphComputer)
 g.V().group().by(values('name')).by(both().count())
 ----
 

--- a/docs/src/reference/compilers.asciidoc
+++ b/docs/src/reference/compilers.asciidoc
@@ -67,7 +67,7 @@ may be used as follows:
 [gremlin-groovy,modern]
 ----
 graph = TinkerFactory.createModern()
-g = graph.traversal(SparqlTraversalSource)                                                             <1>
+g = traversal(SparqlTraversalSource).withEmbedded(graph)                                               <1>
 g.sparql("""SELECT ?name ?age
             WHERE { ?person v:name ?name . ?person v:age ?age }
             ORDER BY ASC(?age)""")                                                                     <2>
@@ -388,7 +388,7 @@ graph.
 
 [gremlin-groovy,theCrew]
 ----
-g = graph.traversal(SparqlTraversalSource)
+g = traversal(SparqlTraversalSource).withEmbedded(graph)
 g.sparql("""SELECT ?name ?startTime
 WHERE {
   ?person v:name "daniel" .
@@ -422,7 +422,7 @@ steps as shown below:
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal(SparqlTraversalSource)
+g = traversal(SparqlTraversalSource).withEmbedded(graph)
 g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }")
 g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }").select("name")
 g.sparql("SELECT * WHERE { }").out("knows").values("name")

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -109,7 +109,7 @@ The "toy" graph provides a way to get started with Gremlin quickly.
 
 [gremlin-groovy]
 ----
-g = TinkerFactory.createModern().traversal()
+g = traversal().withEmbedded(TinkerFactory.createModern())
 g.V()
 g.V().values('name')
 g.V().has('name','marko').out('knows').values('name')
@@ -296,7 +296,7 @@ from the command line.  Consider the following file named `gremlin.groovy`:
 [source,groovy]
 ----
 graph = TinkerFactory.createModern()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.V().each { println it }
 ----
 
@@ -322,7 +322,7 @@ to system out:
 [source,groovy]
 ----
 graph = TinkerFactory.createModern()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.V().has('name',args[0]).each { println it }
 ----
 
@@ -362,7 +362,7 @@ graph might create a script called `init.groovy` like:
 [source,groovy]
 ----
 graph = TinkerFactory.createModern()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 ----
 
 and then start Gremlin Console as follows:
@@ -1239,7 +1239,7 @@ Please see the example usage as follows:
 ----
 graph = TinkerGraph.open()
 graph.createIndex("username",Vertex.class)
-credentials = graph.traversal(CredentialTraversalSource.class)
+credentials = traversal(CredentialTraversalSource.class).withEmbedded(graph)
 credentials.user("stephen","password")
 credentials.user("daniel","better-password")
 credentials.user("marko","rainbow-dash")
@@ -1845,7 +1845,7 @@ like this:
 
 [source,groovy]
 ----
-globals << [g : graph.traversal().withStrategies(ReferenceElementStrategy.instance())]
+globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy.instance())]
 ----
 
 This configuration is global to Gremlin Server and therefore all methods of connection will always return elements

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -108,7 +108,7 @@ to creating a `GraphTraversalSource`. For <<connecting-embedded,embedded>> mode,
 [source,java]
 ----
 Graph graph = ...;
-GraphTraversalSource g = graph.traversal();
+GraphTraversalSource g = traversal().withEmbedded(graph);
 ----
 
 Using "g" it is then possible to start writing Gremlin. The "g" allows for the setting of many configuration options
@@ -521,7 +521,7 @@ Using the DSL then just involves telling the `Graph` to use it:
 
 [source,java]
 ----
-SocialTraversalSource social = graph.traversal(SocialTraversalSource.class);
+SocialTraversalSource social = traversal(SocialTraversalSource.class).withEmbedded(graph);
 social.V().has("name","marko").knows("josh");
 ----
 
@@ -573,7 +573,7 @@ It is then possible to use the `persons()` method to start traversals:
 
 [source,java]
 ----
-SocialTraversalSource social = graph.traversal(SocialTraversalSource.class);
+SocialTraversalSource social = traversal(SocialTraversalSource.class).withEmbedded(graph);
 social.persons("marko").knows("josh");
 ----
 
@@ -982,7 +982,7 @@ be used:
 
 [source,python]
 ----
-social = Graph().traversal(SocialTraversalSource).withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
+social = traversal(SocialTraversalSource).withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 social.persons("marko").knows("josh")
 social.persons("marko").youngestFriendsAge()
 social.persons().filter(__.createdAtLeast(2)).count()
@@ -1062,6 +1062,7 @@ the remote end.
 include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=connecting]
 ----
 
+[[dotnet-imports]]
 === Common Imports
 
 There are a number of classes, functions and tokens that are typically used with Gremlin. The following imports
@@ -1291,6 +1292,7 @@ const names = await g.V().hasLabel('person').values('name').toList();
 console.log(names);
 ----
 
+[[javascript-imports]]
 === Common Imports
 
 There are a number of classes, functions and tokens that are typically used with Gremlin. The following imports

--- a/docs/src/reference/implementations-hadoop-start.asciidoc
+++ b/docs/src/reference/implementations-hadoop-start.asciidoc
@@ -148,7 +148,7 @@ which is the OLAP Gremlin machine.
 hdfs.copyFromLocal('data/tinkerpop-modern.kryo', 'tinkerpop-modern.kryo')
 hdfs.ls()
 graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.V().count()
 g.V().out().out().values('name')
 g.V().group().by{it.value('name')[1]}.by('name').next()

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -76,7 +76,7 @@ The Gremlin-Console session below demonstrates Neo4j indices. For more informati
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 graph.cypher("CREATE INDEX ON :person(name)")
 graph.tx().commit()  <1>
 g.addV('person').property('name','marko')
@@ -93,7 +93,7 @@ labels), a linear scan of the vertex-label partition is still faster than a line
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.tx().commit()
 clock(1000) {g.V().hasLabel('artist').has('name','Garcia').iterate()}  <1>
@@ -124,7 +124,7 @@ It is possible to leverage Cypher from within Gremlin by using the `Neo4jGraph.c
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io('data/tinkerpop-modern.kryo').read().iterate()
 graph.cypher('MATCH (a {name:"marko"}) RETURN a')
 graph.cypher('MATCH (a {name:"marko"}) RETURN a').select('a').out('knows').values('name')
@@ -155,7 +155,7 @@ An example use case is presented below.
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 vertex = (Neo4jVertex) g.addV('human::animal').next() <1>
 vertex.label() <2>
 vertex.labels() <3>
@@ -215,7 +215,7 @@ which can then be used as follows:
 ----
 gremlin> graph = GraphFactory.open('neo4j.properties')
 ==>neo4jgraph[community single [/tmp/neo4j]]
-gremlin> g = graph.traversal()
+gremlin> g = traversal().withEmbedded(graph)
 ==>graphtraversalsource[neo4jgraph[community single [/tmp/neo4j]], standard]
 ----
 

--- a/docs/src/reference/implementations-spark.asciidoc
+++ b/docs/src/reference/implementations-spark.asciidoc
@@ -44,7 +44,7 @@ Once the `lib/` directory is distributed, `SparkGraphComputer` can be used as fo
 [gremlin-groovy]
 ----
 graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
-g = graph.traversal().withComputer(SparkGraphComputer)
+g = traversal().withEmbedded(graph).withComputer(SparkGraphComputer)
 g.V().count()
 g.V().out().out().values('name')
 ----
@@ -54,7 +54,7 @@ For using lambdas in Gremlin-Groovy, simply provide `:remote connect` a `Travers
 [gremlin-groovy]
 ----
 graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
-g = graph.traversal().withComputer(SparkGraphComputer)
+g = traversal().withEmbedded(graph).withComputer(SparkGraphComputer)
 :remote connect tinkerpop.hadoop graph g
 :> g.V().group().by{it.value('name')[1]}.by('name')
 ----

--- a/docs/src/reference/implementations-tinkergraph.asciidoc
+++ b/docs/src/reference/implementations-tinkergraph.asciidoc
@@ -44,7 +44,7 @@ Constructing a simple graph using TinkerGraph in Java8 is presented below:
 [source,java]
 ----
 Graph graph = TinkerGraph.open();
-GraphTraversalSource g = graph.traversal();
+GraphTraversalSource g = traversal().withEmbedded(graph);
 Vertex marko = g.addV("person").property("name","marko").property("age",29).next();
 Vertex lop = g.addV("software").property("name","lop").property("lang","java").next();
 g.addE("created").from(marko).to(lop).property("weight",0.6d).iterate();
@@ -89,11 +89,11 @@ TinkerGraph over the Grateful Dead graph.
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 clock(1000) {g.V().has('name','Garcia').iterate()} <1>
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 graph.createIndex('name',Vertex.class)
 g.io('data/grateful-dead.xml').read().iterate()
 clock(1000){g.V().has('name','Garcia').iterate()} <2>
@@ -158,13 +158,13 @@ cardinality to `list` or else the data will import as `single`.  Consider the fo
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io("data/tinkerpop-crew.kryo").read().iterate()
 g.V().properties()
 conf = new BaseConfiguration()
 conf.setProperty("gremlin.tinkergraph.defaultVertexPropertyCardinality","list")
 graph = TinkerGraph.open(conf)
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io("data/tinkerpop-crew.kryo").read().iterate()
 g.V().properties()
 ----

--- a/docs/src/reference/intro.asciidoc
+++ b/docs/src/reference/intro.asciidoc
@@ -222,7 +222,7 @@ $ bin/gremlin.sh
 -----oOOo-(3)-oOOo-----
 gremlin> graph = TinkerFactory.createModern() // <1>
 ==>tinkergraph[vertices:6 edges:6]
-gremlin> g = graph.traversal()        // <2>
+gremlin> g = traversal().withEmbedded(graph)        // <2>
 ==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
 gremlin> g.V().has('name','marko').out('knows').values('name') // <3>
 ==>vadas
@@ -325,11 +325,12 @@ that are JVM-based (or have a JVM-based connector) and directly implement Tinker
 [source,java]
 Graph graph = TinkerGraph.open();
 
-The "graph" then spawns a `GraphTraversalSource` as follows and typically, by convention, this variable is named "g":
+The "graph" is then used to spawn a `GraphTraversalSource` as follows and typically, by convention, this variable is
+named "g":
 
 [source,java]
 ----
-GraphTraversalSource g = graph.traversal();
+GraphTraversalSource g = traversal().withEmbedded(graph);
 List<Vertex> vertices = g.V().toList()
 ----
 

--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -33,7 +33,7 @@ spawn `GraphTraversalSource` instances so as to write Gremlin:
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.addV('person')
 ----
 
@@ -117,7 +117,7 @@ A running example using vertex properties is provided below to demonstrate and e
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 v = g.addV().property('name','marko').property('name','marko a. rodriguez').next()
 g.V(v).properties('name').count() <1>
 v.property(list, 'name', 'm. a. rodriguez') <2>
@@ -290,7 +290,7 @@ not support transactions.
 ----
 gremlin> graph = Neo4jGraph.open('/tmp/neo4j')
 ==>neo4jgraph[EmbeddedGraphDatabase [/tmp/neo4j]]
-gremlin> g = graph.traversal()
+gremlin> g = traversal().withEmbedded(graph)
 ==>graphtraversalsource[neo4jgraph[community single [/tmp/neo4j]], standard]
 gremlin> graph.features()
 ==>FEATURES
@@ -340,7 +340,7 @@ is bound to the current thread of execution. Consider the following example to d
 
 [source,java]
 ----
-GraphTraversalSource g = graph.traversal();
+GraphTraversalSource g = traversal().withEmbedded(graph);
 g.addV("person").("name","stephen").iterate();
 
 Thread t1 = new Thread(() -> {
@@ -374,7 +374,7 @@ different threads operating within the same transaction, the above code could be
 [source,java]
 ----
 Graph threaded = graph.tx().createThreadedTx();
-GraphTraversalSource g = graph.traversal();
+GraphTraversalSource g = traversal().withEmbedded(graph);
 g.addV("person").("name","stephen").iterate();
 
 Thread t1 = new Thread(() -> {

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -80,7 +80,7 @@ memory manipulations).
 ----
 result = graph.compute().program(PageRankVertexProgram.build().create()).submit().get()
 result.memory().runtime
-g = result.graph().traversal()
+g = traversal().withEmbedded(result.graph())
 g.V().elementMap()
 ----
 
@@ -137,7 +137,7 @@ that the property is "hidden" unless it is directly accessed via name.
 graph = TinkerFactory.createModern()
 result = graph.compute().program(PeerPressureVertexProgram.build().create()).mapReduce(ClusterPopulationMapReduce.build().create()).submit().get()
 result.memory().get('clusterPopulation')
-g = result.graph().traversal()
+g = traversal().withEmbedded(result.graph())
 g.V().values(PeerPressureVertexProgram.CLUSTER).groupCount().next()
 g.V().elementMap()
 ----
@@ -367,7 +367,7 @@ The above `PageRankVertexProgram` is used as follows.
 ----
 result = graph.compute().program(PageRankVertexProgram.build().create()).submit().get()
 result.memory().runtime
-g = result.graph().traversal()
+g = traversal().withEmbedded(result.graph())
 g.V().elementMap()
 ----
 
@@ -375,7 +375,7 @@ Note that `GraphTraversal` provides a <<pagerank-step,`pageRank()`>>-step.
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().pageRank().elementMap()
 g.V().pageRank().by('pageRank').times(5).order().by('pageRank').elementMap()
 ----
@@ -398,7 +398,7 @@ Note that `GraphTraversal` provides a <<peerpressure-step,`peerPressure()`>>-ste
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().peerPressure().by('cluster').elementMap()
 g.V().peerPressure().by(outE('knows')).by('cluster').elementMap()
 ----
@@ -495,9 +495,9 @@ link:http://markorodriguez.com/2011/04/19/local-and-distributed-traversal-engine
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.V().both().hasLabel('person').values('age').groupCount().next() // OLTP
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().both().hasLabel('person').values('age').groupCount().next() // OLAP
 ----
 

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -475,9 +475,9 @@ made more salient on a larger graph. Therefore, the example below leverages the 
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io('data/grateful-dead.xml').read().iterate()
-g = graph.traversal().withoutStrategies(LazyBarrierStrategy) <1>
+g = traversal().withEmbedded(graph).withoutStrategies(LazyBarrierStrategy) <1>
 clockWithResult(1){g.V().both().both().both().count().next()} <2>
 clockWithResult(1){g.V().repeat(both()).times(3).count().next()} <3>
 clockWithResult(1){g.V().both().barrier().both().barrier().both().barrier().count().next()} <4>
@@ -498,7 +498,7 @@ optimization scenario with the added benefit of reducing the risk of an out-of-m
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()  <1>
+g = traversal().withEmbedded(graph)  <1>
 g.io('data/grateful-dead.xml').read().iterate()
 clockWithResult(1){g.V().both().both().both().count().next()}
 g.V().both().both().both().count().iterate().toString()  <2>
@@ -696,7 +696,7 @@ that supports `GraphComputer` (OLAP).
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().
   connectedComponent().
     with(ConnectedComponent.propertyName, 'component').
@@ -1644,7 +1644,7 @@ songs which Jerry Garcia has both sung and written (using the Grateful Dead grap
 
 [gremlin-groovy]
 ----
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.V().match(
         __.as('a').has('name', 'Garcia'),
@@ -2114,7 +2114,7 @@ IMPORTANT: The `pageRank()`-step is a `VertexComputing`-step and as such, can on
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().pageRank().by('pageRank').values('pageRank')
 g.V().hasLabel('person').
   pageRank().
@@ -2131,7 +2131,7 @@ The <<explain-step,`explain()`>>-step can be used to understand how the traversa
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().hasLabel('person').
   pageRank().
     with(PageRank.edges, __.outE('knows')).
@@ -2249,7 +2249,7 @@ IMPORTANT: The `peerPressure()`-step is a `VertexComputing`-step and as such, ca
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().peerPressure().by('cluster').values('cluster')
 g.V().hasLabel('person').
   peerPressure().
@@ -2420,7 +2420,7 @@ Finally, an example is provided using `PageRankVertexProgram` which doesn't use 
 
 [gremlin-groovy,modern]
 ----
-g = graph.traversal().withComputer()
+g = traversal().withEmbedded(graph).withComputer()
 g.V().hasLabel('person').
   program(PageRankVertexProgram.build().property('rank').create(graph)).
     order().by('rank', asc).
@@ -2797,7 +2797,7 @@ ranking.
 
 [gremlin-groovy]
 ----
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.V().hasLabel('song').out('followedBy').groupCount().by('name').
       order(local).by(values,desc).limit(local, 5)
@@ -2811,7 +2811,7 @@ Similarly, for extracting the values from a path or map.
 
 [gremlin-groovy]
 ----
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.V().hasLabel('song').out('sungBy').groupCount().by('name') <1>
 g.V().hasLabel('song').out('sungBy').groupCount().by('name').select(values) <2>
@@ -3050,7 +3050,7 @@ The following example demonstrates how to produce the "knows" subgraph:
 [gremlin-groovy,modern]
 ----
 subGraph = g.E().hasLabel('knows').subgraph('subGraph').cap('subGraph').next() <1>
-sg = subGraph.traversal()
+sg = traversal().withEmbedded(subGraph)
 sg.E() <2>
 ----
 
@@ -3062,7 +3062,7 @@ A more common subgraphing use case is to get all of the graph structure surround
 [gremlin-groovy,modern]
 ----
 subGraph = g.V(3).repeat(__.inE().subgraph('subGraph').outV()).times(3).cap('subGraph').next()  <1>
-sg = subGraph.traversal()
+sg = traversal().withEmbedded(subGraph)
 sg.E()
 ----
 
@@ -3075,8 +3075,8 @@ There can be multiple `subgraph()` calls within the same traversal. Each operati
 ----
 t = g.V().outE('knows').subgraph('knowsG').inV().outE('created').subgraph('createdG').
           inV().inE('created').subgraph('createdG').iterate()
-t.sideEffects.get('knowsG').traversal().E()
-t.sideEffects.get('createdG').traversal().E()
+traversal().withEmbedded(t.sideEffects.get('knowsG')).E()
+traversal().withEmbedded(t.sideEffects.get('createdG')).E()
 ----
 
 TinkerGraph is the ideal (and default) `Graph` into which a subgraph is extracted as it's fast, in-memory, and supports
@@ -3938,7 +3938,7 @@ allow specification of custom identifiers when creating elements:
 
 [gremlin-groovy]
 ----
-g = TinkerGraph.open().traversal()
+g = traversal().withEmbedded(TinkerGraph.open())
 v = g.addV().property(id,'42a').next()
 g.V('42a')
 ----
@@ -3951,7 +3951,7 @@ under the hood.
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
 strategy = ElementIdStrategy.build().create()
-g = graph.traversal().withStrategies(strategy)
+g = traversal().withEmbedded(graph).withStrategies(strategy)
 g.addV().property(id, '42a').id()
 ----
 
@@ -3986,7 +3986,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.*
 graph = TinkerFactory.createModern()
 l = new ConsoleMutationListener(graph)
 strategy = EventStrategy.build().addListener(l).create()
-g = graph.traversal().withStrategies(strategy)
+g = traversal().withEmbedded(graph).withStrategies(strategy)
 g.addV().property('name','stephen')
 g.V().has('name','stephen').
   property(list, 'location', 'centreville', 'startTime', 1990, 'endTime', 2000).
@@ -4041,9 +4041,9 @@ The best way to understand `PartitionStrategy` is via example.
 graph = TinkerFactory.createModern()
 strategyA = PartitionStrategy.build().partitionKey("_partition").writePartition("a").readPartitions("a").create()
 strategyB = PartitionStrategy.build().partitionKey("_partition").writePartition("b").readPartitions("b").create()
-gA = graph.traversal().withStrategies(strategyA)
+gA = traversal().withEmbedded(graph).withStrategies(strategyA)
 gA.addV() // this vertex has a property of {_partition:"a"}
-gB = graph.traversal().withStrategies(strategyB)
+gB = traversal().withEmbedded(graph).withStrategies(strategyB)
 gB.addV() // this vertex has a property of {_partition:"b"}
 gA.V()
 gB.V()
@@ -4083,7 +4083,7 @@ Display stack trace? [yN]
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createTheCrew()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 g.V().as('a').values('location').as('b').  <1>
   select('a','b').by('name').by()
 g = g.withStrategies(SubgraphStrategy.build().vertexProperties(hasNot('endTime')).create()) <2>
@@ -4106,7 +4106,7 @@ edges must be labeled "develops," and vertex properties must be the persons curr
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createTheCrew()
-g = graph.traversal().withStrategies(SubgraphStrategy.build().
+g = traversal().withEmbedded(graph).withStrategies(SubgraphStrategy.build().
   vertices(or(hasNot('location'),properties('location').count().is(gt(3)))).
   edges(hasLabel('develops')).
   vertexProperties(or(hasLabel(neq('location')),hasNot('endTime'))).create())

--- a/docs/src/tutorials/getting-started/index.asciidoc
+++ b/docs/src/tutorials/getting-started/index.asciidoc
@@ -116,7 +116,7 @@ It can be instantiated in the console this way:
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createModern()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 ----
 
 The first command creates a `Graph` instance named `graph`, which thus provides a reference to the data you want
@@ -131,6 +131,13 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-embedded[embe
 restricted to languages using the Java Virtual Machine (JVM). Other methods are similar in form, but are not the focus of
 this tutorial. See the Reference Documentation for more information on the different ways of
 link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-gremlin[connecting with Gremlin].
+
+NOTE: The `traversal()` method is statically imported from the `AnonymousTraversalSource` class so that it can be used
+in a more fluent fashion. There are common imports for all languages that support Gremlin to make it easier to read
+and to write (link:https://tinkerpop.apache.org/docs/x.y.z/reference/#java-imports[Java],
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#python-imports[Python],
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#dotnet-imports[.NET],
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#javascript-imports[Javascript]).
 
 With your `TraversalSource` `g` available it is now possible to ask Gremlin to traverse the `Graph`:
 
@@ -210,7 +217,7 @@ as an example. First, you need to create this graph:
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 v1 = g.addV("person").property(id, 1).property("name", "marko").property("age", 29).next()
 v2 = g.addV("software").property(id, 3).property("name", "lop").property("lang", "java").next()
 g.addE("created").from(v1).to(v2).property(id, 9).property("weight", 0.4)
@@ -226,7 +233,7 @@ that static importing you would instead have to write:
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 v1 = g.addV("person").property(T.id, 1).property("name", "marko").property("age", 29).next()
 v2 = g.addV("software").property(T.id, 3).property("name", "lop").property("lang", "java").next()
 g.addE("created").from(v1).to(v2).property(T.id, 9).property("weight", 0.4)
@@ -273,7 +280,7 @@ g.V().has('name','marko')
 ----
 
 NOTE: The variable `g` is the `TraversalSource`, which was introduced in the "The First Five Minutes". The
-`TraversalSource` is created with `graph.traversal()` and is the object used to spawn new traversals.
+`TraversalSource` is created with `traversal().withEmbedded(graph)` and is the object used to spawn new traversals.
 
 This bit of Gremlin can be improved and made more
 link:https://tinkerpop.apache.org/docs/x.y.z/recipes/#unspecified-label-in-global-vertex-lookup[idiomatically pleasing]
@@ -353,7 +360,7 @@ the "First Five Minutes" section. Recall that you can create this `Graph` and es
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createModern()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 ----
 
 Earlier we'd used the `has()`-step to tell Gremlin how to find the "marko" vertex. Let's look at some other ways to
@@ -525,7 +532,7 @@ TinkerGraph:
 graph = TinkerGraph.open()
 graph.createIndex('userId', Vertex.class) <1>
 
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 
 getOrCreate = { id ->
   g.V().has('user','userId', id).

--- a/docs/src/tutorials/gremlin-language-variants/index.asciidoc
+++ b/docs/src/tutorials/gremlin-language-variants/index.asciidoc
@@ -44,7 +44,7 @@ public class MyApplication {
 
     // assumes args[0] is a configuration file location
     Graph graph = GraphFactory.open(args[0]);
-    GraphTraversalSource g = graph.traversal();
+    GraphTraversalSource g = traversal().withEmbedded(graph);
 
     // assumes that args[1] and args[2] are range boundaries
     Iterator<Map<String,Double>> result =
@@ -160,7 +160,7 @@ TinkerPop-enabled graph system.
 Every language variant, regardless of the implementation details, will have to account for the four core concepts below:
 
 1. `Graph` (**data**): The source of the graph data to be traversed and the interface which enables the creation of a
-`GraphTraversalSource` (via `graph.traversal()`).
+`GraphTraversalSource` (via `traversal().withEmbedded(graph)`).
 
 2. `GraphTraversalSource` (**compiler**): This is the typical `g` reference. A `GraphTraversalSource` maintains the
 `withXXX()`-strategy methods as well as the "traversal spawn"-methods such as `V()`, `E()`, `addV()`, etc.

--- a/docs/src/tutorials/the-gremlin-console/index.asciidoc
+++ b/docs/src/tutorials/the-gremlin-console/index.asciidoc
@@ -74,8 +74,8 @@ create an empty TinkerGraph as follows:
 
 [gremlin-groovy]
 ----
-graph = TinkerGraph.open()   <1>
-g = graph.traversal()        <2>
+graph = TinkerGraph.open()                 <1>
+g = traversal().withEmbedded(graph)        <2>
 ----
 
 <1> Creates the `Graph` instance that is the API to the
@@ -86,6 +86,13 @@ link:https://tinkerpop.apache.org/docs/x.y.z/tutorials/getting-started/#_graph_t
 that `Graph`.
 
 IMPORTANT: TinkerPop recommends creating the `TraversalSource` once and re-using it as necessary in your application.
+
+NOTE: The `traversal()` method is statically imported from the `AnonymousTraversalSource` class so that it can be used
+in a more fluent fashion. There are common imports for all languages that support Gremlin to make it easier to read
+and to write (link:https://tinkerpop.apache.org/docs/x.y.z/reference/#java-imports[Java],
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#python-imports[Python],
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#dotnet-imports[.NET],
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#javascript-imports[Javascript]).
 
 [[toy-graphs]]
 Now that you have an empty TinkerGraph instance, you could load a sample of your data and get started with some
@@ -105,7 +112,7 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#vertex-properties[vertex
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createModern()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 ----
 
 image:grateful-gremlin.png[float=right,width=110] As you might have noticed from the diagrams of these graphs or from
@@ -118,7 +125,7 @@ However, if you find that a larger graph might be helpful, there is another opti
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createGratefulDead()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 ----
 
 The Grateful Dead graph ships with the Gremlin Console and the data can be found in several formats (along with the
@@ -399,7 +406,7 @@ the data of the "person" vertices in the graph:
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createTheCrew()
-g = graph.traversal()
+g = traversal().withEmbedded(graph)
 
 g.V().hasLabel('person').valueMap()
 ----

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -21,14 +21,43 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *Avant-Gremlin Construction #3 for Theremin and Flowers*
 
-== TinkerPop 3.4.8
+== TinkerPop 3.4.9
 
 *Release Date: NOT OFFICIALLY RELEASED YET*
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.4.9/CHANGELOG.asciidoc#release-3-4-9[changelog] for a
 complete list of all the modifications that are part of this release.
 
+=== withEmbedded()
 
+The `AnonymousTraversalSource` was introduced in 3.3.5 and is most typically used for constructing remote
+`TraversalSource` instances, but it also provides a way to construct a `TraversalSource` from an embedded `Graph`
+instance:
+
+[source,text]
+----
+gremlin> g = traversal().withGraph(TinkerFactory.createModern())
+==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
+gremlin> g = traversal().withRemote(DriverRemoteConnection.using('localhost',8182))
+==>graphtraversalsource[emptygraph[empty], standard]
+----
+
+The `withGraph(Graph)` method is now deprecated in favor the new `withEmbedded(Graph)` method that is more explicit
+about its intent:
+
+[source,text]
+----
+gremlin> g = traversal().withEmbedded(TinkerFactory.createModern())
+==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
+----
+
+This change is mostly applicable to JVM languages where embedded `Graph` instances are available. For Gremlin Language
+Variants not on the JVM, the `withGraph(Graph)` method has simply been deprecated and not replaced (with the preference
+to use `withRemote()` variants).
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2413[TINKERPOP-2413]
+
+== TinkerPop 3.4.8
 
 *Release Date: August 3, 2020*
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/AnonymousTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/AnonymousTraversalSource.java
@@ -24,10 +24,6 @@ import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
-import java.lang.reflect.Constructor;
-
-import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE_CONNECTION_CLASS;
-
 /**
  * Provides a unified way to construct a {@link TraversalSource} from the perspective of the traversal. In this syntax
  * the user is creating the source and binding it to a reference which is either an existing {@link Graph} instance
@@ -60,24 +56,28 @@ public class AnonymousTraversalSource<T extends TraversalSource> {
     }
 
     /**
-     * Creates the specified {@link TraversalSource} binding a {@link RemoteConnection} as its reference such that
-     * traversals spawned from it will execute over that reference.
+     * Creates a {@link TraversalSource} binding a {@link RemoteConnection} to a remote {@link Graph} instances as its
+     * reference so that traversals spawned from it will execute over that reference.
+     *
+     * @param configFile a path to a file that would normally be provided to configure a {@link RemoteConnection}
      */
     public T withRemote(final String configFile) throws Exception {
         return withRemote(new PropertiesConfiguration(configFile));
     }
 
     /**
-     * Creates the specified {@link TraversalSource} binding a {@link RemoteConnection} as its reference such that
-     * traversals spawned from it will execute over that reference.
+     * Creates a {@link TraversalSource} binding a {@link RemoteConnection} to a remote {@link Graph} instances as its
+     * reference so that traversals spawned from it will execute over that reference.
+     *
+     * @param conf a {@code Configuration} object that would normally be provided to configure a {@link RemoteConnection}
      */
     public T withRemote(final Configuration conf) {
         return withRemote(RemoteConnection.from(conf));
     }
 
     /**
-     * Creates the specified {@link TraversalSource} binding a {@link RemoteConnection} as its reference such that
-     * traversals spawned from it will execute over that reference.
+     * Creates a {@link TraversalSource} binding a {@link RemoteConnection} to a remote {@link Graph} instances as its
+     * reference so that traversals spawned from it will execute over that reference.
      */
     public T withRemote(final RemoteConnection remoteConnection) {
         try {
@@ -88,10 +88,20 @@ public class AnonymousTraversalSource<T extends TraversalSource> {
     }
 
     /**
-     * Creates the specified {@link TraversalSource} binding a {@link Graph} as its reference such that traversals
-     * spawned from it will execute over that reference.
+     * Creates the specified {@link TraversalSource} binding an embedded {@link Graph} as its reference such that
+     * traversals spawned from it will execute over that reference.
+     *
+     * @deprecated As of release 3.4.9, replaced by {@link #withEmbedded(Graph)}
      */
     public T withGraph(final Graph graph) {
+        return withEmbedded(graph);
+    }
+
+    /**
+     * Creates the specified {@link TraversalSource} binding an embedded {@link Graph} as its reference such that
+     * traversals spawned from it will execute over that reference.
+     */
+    public T withEmbedded(final Graph graph) {
         try {
             return traversalSourceClass.getConstructor(Graph.class).newInstance(graph);
         } catch (final Exception e) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/anonymous-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/anonymous-traversal.js
@@ -32,7 +32,7 @@ const Graph = require('../structure/graph').Graph;
 class AnonymousTraversalSource {
 
   /**
-   * Creates a new instance of {@link AnonymousTraversalSource}.
+   * Creates a new instance of {@code AnonymousTraversalSource}.
    * @param {Function} [traversalSourceClass] Optional {@code GraphTraversalSource} constructor.
    */
   constructor(traversalSourceClass) {
@@ -50,8 +50,8 @@ class AnonymousTraversalSource {
   }
 
   /**
-   * Creates the specified {@link GraphTraversalSource{ binding a {@link RemoteConnection} as its reference such that
-   * traversals spawned from it will execute over that reference.
+   * Creates a {@link GraphTraversalSource} binding a {@link RemoteConnection} to a remote {@link Graph} instances as its
+   * reference so that traversals spawned from it will execute over that reference.
    * @param {GraphTraversalSource} remoteConnection
    * @return {GraphTraversalSource}
    */
@@ -60,10 +60,15 @@ class AnonymousTraversalSource {
   }
 
   /**
-   * Creates the specified {@link GraphTraversalSource} binding a {@link Graph} as its reference such that traversals
-   * spawned from it will execute over that reference.
+   * Creates the specified {@link GraphTraversalSource} binding an embedded {@link Graph} as its reference such that
+   * traversals spawned from it will execute over that reference. As there are no "embedded Graph" instances in
+   * gremlin-javascript as there on the JVM, the {@link GraphTraversalSource} can only ever be constructed as "empty"
+   * with a {@link Graph} instance (which is only a reference to a graph and is not capable of holding data). As a
+   * result, the {@link GraphTraversalSource} will do nothing unless a "remote" is then assigned to it later.
    * @param {Graph} graph
    * @return {GraphTraversalSource}
+   * @deprecated As of release 3.4.9, prefer {@link withRemote} until some form of "embedded graph" becomes available
+   * at which point there will be support for {@code withEmbedded} which is part of the canonical Java API.
    */
   withGraph(graph) {
     return new this.traversalSourceClass(graph, new TraversalStrategies());

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
@@ -25,6 +25,9 @@
 const gt = require('../process/graph-traversal');
 const { TraversalStrategies } = require('../process/traversal-strategy');
 
+/**
+ * An "empty" graph object to server only as a reference.
+ */
 class Graph {
   /**
    * Returns the graph traversal source.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2413

Deprecated `withGraph()` on `AnonymousTraversalSource` in favor of `withEmbedded()`. Didn't really alter tests so as to keep testing running through the old deprecated method which basically just proxies to `withEmbedded()`. GLVs didn't need much change since there really is no "embedded" option there. For python and .NET, i changed nothing since there is no embedded version. For javascript I explicitly deprecated `withGraph()` and fixed up jsdoc a bit. Modified documentation to better promote `withEmbedded()` - not sure why we didn't do that for `withGraph()` long ago (perhaps the idea was to wait for 3.5.0, but in a way I'm sorta glad we didn't as we've now deprecated.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1