### PR TITLE
TINKERPOP-2415 Avoid unnecessary detached objects if not required

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Improved initialization time of Java Driver if the default serializer is replaced.
 * Fixed bug in Javascript `Translator` that wasn't handling child traversals well.
 * Fixed an iterator leak in `HasContainer`.
+* Avoid creating unnecessary detached objects in JVM 
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DropStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DropStep.java
@@ -50,7 +50,7 @@ public class DropStep<S> extends FilterStep<S> implements Mutating<Event> {
         final S s = traverser.get();
         if (s instanceof Element) {
             final Element toRemove = (Element) s;
-            if (callbackRegistry != null) {
+            if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
                 final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
                 final Event removeEvent;
                 if (s instanceof Vertex)
@@ -68,7 +68,7 @@ public class DropStep<S> extends FilterStep<S> implements Mutating<Event> {
             toRemove.remove();
         } else if (s instanceof Property) {
             final Property toRemove = (Property) s;
-            if (callbackRegistry != null) {
+            if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
                 final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
                 final Event.ElementPropertyEvent removeEvent;
                 if (toRemove.element() instanceof Edge)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
@@ -116,7 +116,7 @@ public class AddEdgeStartStep extends AbstractStep<Edge, Edge>
                         .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
             final String edgeLabel = (String) this.parameters.get(traverser, T.label, () -> Edge.DEFAULT_LABEL).get(0);
             final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));
-            if (callbackRegistry != null) {
+            if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
                 final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
                 final Event.EdgeAddedEvent vae = new Event.EdgeAddedEvent(eventStrategy.detach(edge));
                 callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -107,7 +107,7 @@ public class AddEdgeStep<S> extends MapStep<S, Edge>
         final String edgeLabel = this.parameters.get(traverser, T.label, () -> Edge.DEFAULT_LABEL).get(0);
 
         final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));
-        if (callbackRegistry != null) {
+        if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
             final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
             final Event.EdgeAddedEvent vae = new Event.EdgeAddedEvent(eventStrategy.detach(edge));
             callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
@@ -87,7 +87,7 @@ public class AddVertexStartStep extends AbstractStep<Vertex, Vertex>
             this.first = false;
             final TraverserGenerator generator = this.getTraversal().getTraverserGenerator();
             final Vertex vertex = this.getTraversal().getGraph().get().addVertex(this.parameters.getKeyValues(generator.generate(false, (Step) this, 1L)));
-            if (this.callbackRegistry != null) {
+            if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
                 final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
                 final Event.VertexAddedEvent vae = new Event.VertexAddedEvent(eventStrategy.detach(vertex));
                 this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
@@ -79,7 +79,7 @@ public class AddVertexStep<S> extends MapStep<S, Vertex>
     @Override
     protected Vertex map(final Traverser.Admin<S> traverser) {
         final Vertex vertex = this.getTraversal().getGraph().get().addVertex(this.parameters.getKeyValues(traverser));
-        if (this.callbackRegistry != null) {
+        if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
             final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
             final Event.VertexAddedEvent vae = new Event.VertexAddedEvent(eventStrategy.detach(vertex));
             this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
@@ -92,7 +92,7 @@ public class AddPropertyStep<S extends Element> extends SideEffectStep<S>
 
         final Element element = traverser.get();
 
-        if (this.callbackRegistry != null) {
+        if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
             getTraversal().getStrategies().getStrategy(EventStrategy.class)
                     .ifPresent(eventStrategy -> {
                         Event.ElementPropertyChangedEvent evt = null;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2415

This change adds some defensive checks to avoid creating additional detached objects when not required.