### PR TITLE
TINKERPOP-2401 Backported bump of jackson to 2.11.x to 3.4.x

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-9]]
 === TinkerPop 3.4.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Bumped to Jackson 2.11.x.
 * Established a default read and write timeout for the `TornadoTransport` in Python, allowing it to be configurable.
 * Delegated handling of erroneous response to the worker thread pool instead of event loop thread pool in Java Driver.
 * Removed `Connection` from `Connection Pool` when server closes a connection with no pending requests in Java Driver.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONReader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONReader.java
@@ -177,7 +177,8 @@ public final class GraphSONReader implements GraphReader {
                              final Direction attachEdgesOfThisDirection) throws IOException {
         // graphson v3 has special handling for generic Map instances, by forcing to linkedhashmap (which is probably
         // what it should have been anyway) stargraph format can remain unchanged across all versions
-        final Map<String, Object> vertexData = mapper.readValue(inputStream, version == GraphSONVersion.V3_0 ? linkedHashMapTypeReference : mapTypeReference);
+        final Map<String, Object> vertexData = version == GraphSONVersion.V3_0 ?
+                mapper.readValue(inputStream, linkedHashMapTypeReference) : mapper.readValue(inputStream, mapTypeReference);
         final StarGraph starGraph = StarGraphGraphSONDeserializer.readStarGraphVertex(vertexData);
         if (vertexAttachMethod != null) vertexAttachMethod.apply(starGraph.getStarVertex());
 
@@ -315,9 +316,9 @@ public final class GraphSONReader implements GraphReader {
 
         /**
          * If the adjacency list is wrapped in a JSON object, as is done when writing a graph with
-         * {@link GraphSONWriter.Builder#wrapAdjacencyList} set to {@code true}, this setting needs to be set to
-         * {@code true} to properly read it.  By default, this value is {@code false} and the adjacency list is
-         * simply read as line delimited vertices.
+         * {@link GraphSONWriter.Builder#wrapAdjacencyList(boolean)} wrapAdjacencyList} set to {@code true}, this
+         * setting needs to be set to {@code true} to properly read it.  By default, this value is {@code false} and
+         * the adjacency list is simply read as line delimited vertices.
          * <p/>
          * By setting this value to {@code true}, the generated JSON is no longer "splittable" by line and thus not
          * suitable for OLAP processing.  Furthermore, reading this format of the JSON with

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeResolverBuilder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeResolverBuilder.java
@@ -21,7 +21,9 @@ package org.apache.tinkerpop.gremlin.structure.io.graphson;
 import org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig;
 import org.apache.tinkerpop.shaded.jackson.databind.JavaType;
 import org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig;
+import org.apache.tinkerpop.shaded.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType;
+import org.apache.tinkerpop.shaded.jackson.databind.jsontype.PolymorphicTypeValidator;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeDeserializer;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeIdResolver;
 import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeSerializer;
@@ -41,6 +43,7 @@ public class GraphSONTypeResolverBuilder extends StdTypeResolverBuilder {
     private TypeInfo typeInfo;
     private String valuePropertyName;
     private final GraphSONVersion version;
+    private final PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder().build();
 
     public GraphSONTypeResolverBuilder(final GraphSONVersion version) {
         this.version = version;
@@ -49,7 +52,7 @@ public class GraphSONTypeResolverBuilder extends StdTypeResolverBuilder {
     @Override
     public TypeDeserializer buildTypeDeserializer(final DeserializationConfig config, final JavaType baseType,
                                                   final Collection<NamedType> subtypes) {
-        final TypeIdResolver idRes = this.idResolver(config, baseType, subtypes, false, true);
+        final TypeIdResolver idRes = this.idResolver(config, baseType, typeValidator, subtypes, false, true);
         return new GraphSONTypeDeserializer(baseType, idRes, this.getTypeProperty(), typeInfo, valuePropertyName);
     }
 
@@ -57,7 +60,7 @@ public class GraphSONTypeResolverBuilder extends StdTypeResolverBuilder {
     @Override
     public TypeSerializer buildTypeSerializer(final SerializationConfig config, final JavaType baseType,
                                               final Collection<NamedType> subtypes) {
-        final TypeIdResolver idRes = this.idResolver(config, baseType, subtypes, true, false);
+        final TypeIdResolver idRes = this.idResolver(config, baseType, typeValidator, subtypes, true, false);
         return version == GraphSONVersion.V2_0 ?
                 new GraphSONTypeSerializerV2d0(idRes, this.getTypeProperty(), typeInfo, valuePropertyName) :
                 new GraphSONTypeSerializerV3d0(idRes, this.getTypeProperty(), typeInfo, valuePropertyName);

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -49,7 +49,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.6</version>
+            <version>2.11.2</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2401

On merge, there may need to be some polish up of CHANGELOG and JIRAs so that things dont look confusing as to when they occurred. Other than that, I couldn't find any real breaking changes here so decided to bring 3.4-dev all the way up to 2.11.x.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1