### PR TITLE
[TINKERPOP-2416] MultiIterator should implement AutoCloseable

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.util.iterator;
 
 import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -28,7 +29,7 @@ import java.util.List;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class MultiIterator<T> implements Iterator<T>, Serializable {
+public final class MultiIterator<T> implements Iterator<T>, Serializable, AutoCloseable {
 
     private final List<Iterator<T>> iterators = new ArrayList<>();
     private int current = 0;
@@ -85,4 +86,14 @@ public final class MultiIterator<T> implements Iterator<T>, Serializable {
         this.current = 0;
     }
 
+    /**
+     * Close the underlying iterators if auto-closeable. Note that when Exception is thrown from any iterator
+     * in the for loop on closing, remaining iterators possibly left unclosed.
+     */
+    @Override
+    public void close() {
+        for (Iterator<T> iterator : this.iterators) {
+            CloseableIterator.closeIterator(iterator);
+        }
+    }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIteratorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIteratorTest.java
@@ -20,7 +20,6 @@ package org.apache.tinkerpop.gremlin.util.iterator;
 
 import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -29,6 +28,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -111,5 +111,48 @@ public class MultiIteratorTest {
         itty.clear();
 
         assertFalse(itty.hasNext());
+    }
+
+    @Test
+    public void shouldCloseIterators() {
+
+        final MultiIterator<String> itty = new MultiIterator<>();
+        final DummyAutoCloseableIterator<String> inner1 = new DummyAutoCloseableIterator<>();
+        final DummyAutoCloseableIterator<String> inner2 = new DummyAutoCloseableIterator<>();
+        itty.addIterator(inner1);
+        itty.addIterator(inner2);
+
+        itty.close();
+
+        assertTrue(inner1.isClosed());
+        assertTrue(inner2.isClosed());
+    }
+
+    // Dummy iterator to verify that its close method is called in the test.
+    private static class DummyAutoCloseableIterator<T> implements Iterator<T>, AutoCloseable {
+        private boolean closed;
+
+        public DummyAutoCloseableIterator() {
+            closed = false;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public T next() {
+            return null;
+        }
+
+        @Override
+        public void close() throws Exception {
+            closed = true;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
     }
 }


### PR DESCRIPTION
As described in the [JIRA](https://issues.apache.org/jira/browse/TINKERPOP-2416), currently `MultiIterator` does not implement `AutoCloseable`. This potentially introduces resource leak when we have multiple iterators that implement `AutoCloseable` and combine them using `IteratorUtils#concat`. The caller may expect all iterators to be closed automatically by calling `CloseableIterator#closeIterator` but right now `MultiIterator` doesn't implement AutoCloseable so even the underlying iterators are auto-closeable, they are never be closed.

This simple PR just adds AutoCloseable implementation to MultiIterator, close all inner iterators if they implement AutoCloseable.