### PR TITLE
Upgrade to Netty 4.1.52.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ limitations under the License.
         <jcabi.version>1.1</jcabi.version>
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
-        <netty.version>4.1.49.Final</netty.version>
+        <netty.version>4.1.52.Final</netty.version>
         <slf4j.version>1.7.25</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <spark.version>3.0.0</spark.version>


### PR DESCRIPTION
- Update Netty to 4.1.52.Final which includes both security fixes and AArch64 performance improvements
- Refer release notes for detail:
  - https://netty.io/news/2020/05/13/4-1-50-Final.html
  - https://netty.io/news/2020/09/08/4-1-52-Final.html