### PR TITLE
TINKERPOP-2364 Hide  injected profile() steps in metrics output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-9]]
 === TinkerPop 3.4.9 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Modified the text of `profile()` output to hide step instances injected for purpose of collecting metrics.
 * Bumped to Jackson 2.11.x.
 * Bumped Netty 4.1.52.
 * Established a default read and write timeout for the `TornadoTransport` in Python, allowing it to be configurable.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
@@ -34,6 +34,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalSideEffects;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileSideEffectStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -242,7 +244,14 @@ public final class StringFactory {
     }
 
     public static String traversalString(final Traversal.Admin<?, ?> traversal) {
-        return traversal.getSteps().toString();
+        // generally speaking the need to show the profile steps in a toString() is limited to TinkerPop developers.
+        // most users would be confused by the output to profile as these steps are proliferated about the traversal
+        // and are internal collectors of data not the actual steps the user specified. the traversal profile output
+        // looks cleaner without this cruft and hopefully the lack of it's existence should not confuse TinkerPop
+        // developers trying to debug things. when You, yes, you future Stephen, find this comment....sorry?
+        return traversal.getSteps().stream().filter(
+                    s -> !(s instanceof ProfileStep) && !(s instanceof ProfileSideEffectStep)).
+                collect(Collectors.toList()).toString();
     }
 
     public static String storageString(final String internalString) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2364

Didn't really add any tests here as it was a small change and we don't really test the `toString()` outputs all that much. Would have pushed this change through as CTR but wanted to see if there were any concerns about changing the output by any graph providers. I can't quite imagine why this would mess anyone up but I'll leave this out here for the next few days to see if anyone has concerns. 

For comparison, here is the old output:

```text
gremlin> g.V().local(out().fold()).profile()
==>Traversal Metrics
Step                                                               Count  Traversers       Time (ms)    % Dur
=============================================================================================================
TinkerGraphStep(vertex,[])                                             1           1           0.092    68.58
LocalStep([VertexStep(OUT,vertex), ProfileStep,...                     1           1           0.042    31.42
  VertexStep(OUT,vertex)                                               1           1           0.013
  FoldStep                                                             1           1           0.011
                                            >TOTAL                     -           -           0.134        -
```

here is the new:

```text
gremlin> g.V().local(out().fold()).profile()
==>Traversal Metrics
Step                                                               Count  Traversers       Time (ms)    % Dur
=============================================================================================================
TinkerGraphStep(vertex,[])                                             6           6           2.377    72.51
LocalStep([VertexStep(OUT,vertex), FoldStep])                          6           6           0.901    27.49
  VertexStep(OUT,vertex)                                               6           6           0.444
  FoldStep                                                             6           6           0.133
                                            >TOTAL                     -           -           3.278        -
```

VOTE +1