### PR TITLE
TINKERPOP-2427 Simplify Netty reference counting

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
@@ -80,13 +80,13 @@ public final class WebSocketClientHandler extends SimpleChannelInboundHandler<Ob
         // a close frame doesn't mean much here.  errors raised from closed channels will mark the host as dead
         final WebSocketFrame frame = (WebSocketFrame) msg;
         if (frame instanceof TextWebSocketFrame) {
-            ctx.fireChannelRead(frame.retain(2));
+            ctx.fireChannelRead(frame.retain());
         } else if (frame instanceof PingWebSocketFrame) {
             ctx.writeAndFlush(new PongWebSocketFrame());
         }else if (frame instanceof PongWebSocketFrame) {
             logger.debug("Received response from keep-alive request");
         } else if (frame instanceof BinaryWebSocketFrame) {
-            ctx.fireChannelRead(frame.retain(2));
+            ctx.fireChannelRead(frame.retain());
         } else if (frame instanceof CloseWebSocketFrame)
             ch.close();
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketGremlinResponseDecoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketGremlinResponseDecoder.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.driver.handler;
 
-import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
 import io.netty.channel.ChannelHandler;
@@ -27,7 +26,6 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
-import io.netty.util.ReferenceCountUtil;
 
 import java.util.List;
 
@@ -44,19 +42,15 @@ public final class WebSocketGremlinResponseDecoder extends MessageToMessageDecod
 
     @Override
     protected void decode(final ChannelHandlerContext channelHandlerContext, final WebSocketFrame webSocketFrame, final List<Object> objects) throws Exception {
-        try {
-            if (webSocketFrame instanceof BinaryWebSocketFrame) {
-                final BinaryWebSocketFrame tf = (BinaryWebSocketFrame) webSocketFrame;
-                objects.add(serializer.deserializeResponse(tf.content()));
-            } else if (webSocketFrame instanceof TextWebSocketFrame){
-                final TextWebSocketFrame tf = (TextWebSocketFrame) webSocketFrame;
-                final MessageTextSerializer textSerializer = (MessageTextSerializer) serializer;
-                objects.add(textSerializer.deserializeResponse(tf.text()));
-            } else {
-                throw new RuntimeException(String.format("WebSocket channel does not handle this type of message: %s", webSocketFrame.getClass().getName()));
-            }
-        } finally {
-            ReferenceCountUtil.release(webSocketFrame);
+        if (webSocketFrame instanceof BinaryWebSocketFrame) {
+            final BinaryWebSocketFrame tf = (BinaryWebSocketFrame) webSocketFrame;
+            objects.add(serializer.deserializeResponse(tf.content()));
+        } else if (webSocketFrame instanceof TextWebSocketFrame) {
+            final TextWebSocketFrame tf = (TextWebSocketFrame) webSocketFrame;
+            final MessageTextSerializer textSerializer = (MessageTextSerializer) serializer;
+            objects.add(textSerializer.deserializeResponse(tf.text()));
+        } else {
+            throw new RuntimeException(String.format("WebSocket channel does not handle this type of message: %s", webSocketFrame.getClass().getName()));
         }
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/AbstractClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/AbstractClient.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.ReferenceCountUtil;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
@@ -84,11 +83,7 @@ public abstract class AbstractClient implements SimpleClient {
 
         @Override
         protected void channelRead0(final ChannelHandlerContext channelHandlerContext, final ResponseMessage response) throws Exception {
-            try {
-                callback.accept(response);
-            } finally {
-                ReferenceCountUtil.release(response);
-            }
+            callback.accept(response);
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2427

### Motivation
We have some incorrect configuration in the code such as:
1. https://github.com/apache/tinkerpop/blob/3.4-dev/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketGremlinResponseDecoder.java#L59 (MessageToMessageDecoder automatically decreases the reference count).

1. https://github.com/apache/tinkerpop/blob/3.4-dev/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java#L270 (SimpleChannelInboundHandler automatically decreases the reference count).

which are fixed by hardcoding values such as:
* https://github.com/apache/tinkerpop/blob/3.4-dev/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java#L89

### Changes
* Do not release reference count in SimpleChannelInboundHandler and MessageToMessageDecoder since they already do that automatically.
* Retain references when we want to pass the message to the next handler.

### Testing
gremlin-driver `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`
gremlin-server `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`