### PR TITLE
Tinkerpop-2426 Delegate WS internal handling to Netty

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `Traversal.getTraverserSetSupplier()` to allow providers to supply their own `TraverserSet` instances.
 * Release server threads waiting on connection if the connection is dead.
 * Fixed bug where server closes HTTP connection on request error even if keep alive is set to true.
+* Java driver now delegates handling of WebSocket handshake to Netty instead of custom code. 
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -275,6 +275,7 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.trustStore |File location for a SSL Certificate Chain to use when SSL is enabled. If this value is not provided and SSL is enabled, the default `TrustManager` will be used. |_none_
 |connectionPool.trustStorePassword |The password of the `trustStore` if it is password-protected |_none_
 |connectionPool.validationRequest |A script that is used to test server connectivity. A good script to use is one that evaluates quickly and returns no data. The default simply returns an empty string, but if a graph is required by a particular provider, a good traversal might be `g.inject()`. |_''_
+|connectionPool.wsHandshakeTimeoutMillis |Duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. |15000
 |hosts |The list of hosts that the driver will connect to. |localhost
 |jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -22,6 +22,7 @@ import io.netty.channel.Channel;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
 import org.apache.tinkerpop.gremlin.driver.handler.NioGremlinRequestEncoder;
 import org.apache.tinkerpop.gremlin.driver.handler.NioGremlinResponseDecoder;
@@ -44,7 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Client-side channel initializer interface.  It is responsible for constructing the Netty {@code ChannelPipeline}
@@ -209,7 +210,8 @@ public interface Channelizer extends ChannelHandler {
             final int maxContentLength = cluster.connectionPoolSettings().maxContentLength;
             handler = new WebSocketClientHandler(
                     WebSocketClientHandshakerFactory.newHandshaker(
-                            connection.getUri(), WebSocketVersion.V13, null, false, EmptyHttpHeaders.INSTANCE, maxContentLength));
+                            connection.getUri(), WebSocketVersion.V13, null, false, EmptyHttpHeaders.INSTANCE, maxContentLength),
+                    cluster.getWsHandshakeTimeout());
 
             pipeline.addLast("http-codec", new HttpClientCodec());
             pipeline.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
@@ -221,10 +223,12 @@ public interface Channelizer extends ChannelHandler {
         @Override
         public void connected() {
             try {
-                // block for a few seconds - if the handshake takes longer than there's gotta be issues with that
-                // server. more than likely, SSL is enabled on the server, but the client forgot to enable it or
-                // perhaps the server is not configured for websockets.
-                handler.handshakeFuture().get(15000, TimeUnit.MILLISECONDS);
+                // Block until the handshake is complete either successfully or with an error. The handshake future
+                // will complete with a timeout exception after some time so it is guaranteed that this future will
+                // complete.
+                // If future completed with an exception more than likely, SSL is enabled on the server, but the client
+                // forgot to enable it or perhaps the server is not configured for websockets.
+                handler.handshakeFuture().sync();
             } catch (Exception ex) {
                 throw new RuntimeException(new ConnectionException(connection.getUri(),
                         "Could not complete websocket handshake - ensure that client protocol matches server", ex));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -208,6 +208,7 @@ public final class Cluster {
                 .minSimultaneousUsagePerConnection(settings.connectionPool.minSimultaneousUsagePerConnection)
                 .maxConnectionPoolSize(settings.connectionPool.maxSize)
                 .minConnectionPoolSize(settings.connectionPool.minSize)
+                .wsHandshakeTimeoutMillis(settings.connectionPool.wsHandshakeTimeoutMillis)
                 .validationRequest(settings.connectionPool.validationRequest);
 
         if (settings.username != null && settings.password != null)
@@ -444,6 +445,14 @@ public final class Cluster {
     }
 
     /**
+     * Gets time duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. Beyond this
+     * duration an exception would be thrown if the handshake is not complete by then.
+     */
+    public long getWsHandshakeTimeout() {
+        return manager.connectionPoolSettings.wsHandshakeTimeoutMillis;
+    }
+
+    /**
      * Specifies the load balancing strategy to use on the client side.
      */
     public Class<? extends LoadBalancingStrategy> getLoadBalancingStrategy() {
@@ -611,6 +620,7 @@ public final class Cluster {
         private SslContext sslContext = null;
         private LoadBalancingStrategy loadBalancingStrategy = new LoadBalancingStrategy.RoundRobin();
         private AuthProperties authProps = new AuthProperties();
+        private long wsHandshakeTimeoutMillis = Connection.WS_HANDSHAKE_TIMEOUT_MILLIS;
 
         private Builder() {
             // empty to prevent direct instantiation
@@ -1047,6 +1057,18 @@ public final class Cluster {
             return this;
         }
 
+        /**
+         * Sets the duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. Beyond this
+         * duration an exception would be thrown.
+         *
+         * Note that this value should be greater that SSL handshake timeout defined in
+         * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake.
+         */
+        public Builder wsHandshakeTimeoutMillis(final long wsHandshakeTimeoutMillis) {
+            this.wsHandshakeTimeoutMillis = wsHandshakeTimeoutMillis;
+            return this;
+        }
+
         List<InetSocketAddress> getContactPoints() {
             return addresses.stream().map(addy -> new InetSocketAddress(addy, port)).collect(Collectors.toList());
         }
@@ -1137,6 +1159,7 @@ public final class Cluster {
             connectionPoolSettings.keepAliveInterval = builder.keepAliveInterval;
             connectionPoolSettings.channelizer = builder.channelizer;
             connectionPoolSettings.validationRequest = builder.validationRequest;
+            connectionPoolSettings.wsHandshakeTimeoutMillis = builder.wsHandshakeTimeoutMillis;
 
             sslContextOptional = Optional.ofNullable(builder.sslContext);
 
@@ -1206,6 +1229,9 @@ public final class Cluster {
 
             if (builder.workerPoolSize < 1)
                 throw new IllegalArgumentException("workerPoolSize must be greater than zero");
+
+            if (builder.wsHandshakeTimeoutMillis < 1)
+                throw new IllegalArgumentException("wsHandshakeTimeoutMillis must be greater than zero");
 
             try {
                 Class.forName(builder.channelizer);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.driver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
@@ -70,6 +71,7 @@ final class Connection {
     public static final int RECONNECT_INTERVAL = 1000;
     public static final int RESULT_ITERATION_BATCH_SIZE = 64;
     public static final long KEEP_ALIVE_INTERVAL = 180000;
+    public final static long WS_HANDSHAKE_TIMEOUT_MILLIS = 15000;
 
     /**
      * When a {@code Connection} is borrowed from the pool, this number is incremented to indicate the number of

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -257,6 +257,9 @@ final class Settings {
             if (connectionPoolConf.containsKey("validationRequest"))
                 cpSettings.validationRequest = connectionPoolConf.getString("validationRequest");
 
+            if (connectionPoolConf.containsKey("wsHandshakeTimeoutMillis"))
+                cpSettings.wsHandshakeTimeoutMillis = connectionPoolConf.getLong("wsHandshakeTimeoutMillis");
+
             settings.connectionPool = cpSettings;
         }
 
@@ -446,6 +449,15 @@ final class Settings {
          * A valid Gremlin script that can be used to test remote operations.
          */
         public String validationRequest = "''";
+
+        /**
+         * Duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. Beyond this
+         * duration an exception would be thrown if the handshake is not complete by then.
+         *
+         * Note that this value should be greater that SSL handshake timeout defined in
+         * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake.
+         */
+        public long wsHandshakeTimeoutMillis = Connection.WS_HANDSHAKE_TIMEOUT_MILLIS;
     }
 
     public static class SerializerSettings {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
@@ -35,7 +35,7 @@ public final class WebSocketClientHandler extends WebSocketClientProtocolHandler
     private ChannelPromise handshakeFuture;
 
     public WebSocketClientHandler(final WebSocketClientHandshaker handshaker, final long timeoutMillis) {
-        super(handshaker, true, true, timeoutMillis);
+        super(handshaker, /*handleCloseFrames*/true, /*dropPongFrames*/true, timeoutMillis);
         this.handshakeTimeoutMillis = timeoutMillis;
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/WebSocketClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/WebSocketClient.java
@@ -21,7 +21,6 @@ package org.apache.tinkerpop.gremlin.driver.simple;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
-import io.netty.handler.codec.http.HttpHeaders;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.handler.WebSocketClientHandler;
 import org.apache.tinkerpop.gremlin.driver.handler.WebSocketGremlinRequestEncoder;
@@ -41,7 +40,6 @@ import org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A simple, non-thread safe Gremlin Server client using websockets.  Typical use is for testing and demonstration.
@@ -65,10 +63,8 @@ public class WebSocketClient extends AbstractClient {
             throw new IllegalArgumentException("Unsupported protocol: " + protocol);
 
         try {
-            final WebSocketClientHandler wsHandler =
-                    new WebSocketClientHandler(
-                            WebSocketClientHandshakerFactory.newHandshaker(
-                                    uri, WebSocketVersion.V13, null, false, EmptyHttpHeaders.INSTANCE, 65536));
+            final WebSocketClientHandler wsHandler = new WebSocketClientHandler(WebSocketClientHandshakerFactory.newHandshaker(
+                    uri, WebSocketVersion.V13, null, false, EmptyHttpHeaders.INSTANCE, 65536), 10000);
             final MessageSerializer serializer = new GryoMessageSerializerV3d0();
             b.channel(NioSocketChannel.class)
                     .handler(new ChannelInitializer<SocketChannel>() {
@@ -86,7 +82,7 @@ public class WebSocketClient extends AbstractClient {
                     });
 
             channel = b.connect(uri.getHost(), uri.getPort()).sync().channel();
-            wsHandler.handshakeFuture().get(10000, TimeUnit.MILLISECONDS);
+            wsHandler.handshakeFuture().get();
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
@@ -62,6 +62,7 @@ public class ClusterBuilderTest {
                 {"resultIterationBatchSizeNeg1", Cluster.build().resultIterationBatchSize(-1), "resultIterationBatchSize must be greater than zero"},
                 {"nioPoolSize0", Cluster.build().nioPoolSize(0), "nioPoolSize must be greater than zero"},
                 {"nioPoolSizeNeg1", Cluster.build().nioPoolSize(-1), "nioPoolSize must be greater than zero"},
+                {"wsHandshakeTimeoutMillis0", Cluster.build().wsHandshakeTimeoutMillis(0), "wsHandshakeTimeoutMillis must be greater than zero"},
                 {"workerPoolSize0", Cluster.build().workerPoolSize(0), "workerPoolSize must be greater than zero"},
                 {"workerPoolSizeNeg1", Cluster.build().workerPoolSize(-1), "workerPoolSize must be greater than zero"},
                 {"channelizer", Cluster.build().channelizer("MissingChannelizer"), "The channelizer specified [MissingChannelizer] could not be instantiated - it should be the fully qualified classname of a Channelizer implementation available on the classpath"}});

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -72,6 +72,7 @@ public class SettingsTest {
         conf.setProperty("connectionPool.resultIterationBatchSize", 1100);
         conf.setProperty("connectionPool.channelizer", "channelizer0");
         conf.setProperty("connectionPool.validationRequest", "g.inject()");
+        conf.setProperty("connectionPool.wsHandshakeTimeoutMillis", 15000);
 
         final Settings settings = Settings.from(conf);
 
@@ -108,6 +109,7 @@ public class SettingsTest {
         assertEquals(700, settings.connectionPool.maxWaitForConnection);
         assertEquals(800, settings.connectionPool.maxContentLength);
         assertEquals(900, settings.connectionPool.reconnectInterval);
+        assertEquals(15000, settings.connectionPool.wsHandshakeTimeoutMillis);
         assertEquals(1100, settings.connectionPool.resultIterationBatchSize);
         assertEquals("channelizer0", settings.connectionPool.channelizer);
         assertEquals("g.inject()", settings.connectionPool.validationRequest);

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SimpleSocketServer.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SimpleSocketServer.java
@@ -20,8 +20,10 @@ package org.apache.tinkerpop.gremlin.driver;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -29,12 +31,12 @@ import io.netty.handler.logging.LoggingHandler;
 /**
  * Simple Netty Server
  */
-public class SimpleWebSocketServer {
+public class SimpleSocketServer {
     public static final int PORT = 45940;
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
 
-    public Channel start(final TestWebSocketServerInitializer channelInitializer) throws InterruptedException {
+    public Channel start(ChannelInitializer<SocketChannel>  channelInitializer) throws InterruptedException {
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
         final ServerBootstrap b = new ServerBootstrap();

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -45,7 +45,7 @@ public class WebSocketClientBehaviorIntegrateTest {
     private static final Logger logger = LoggerFactory.getLogger(WebSocketClientBehaviorIntegrateTest.class);
     private Log4jRecordingAppender recordingAppender = null;
     private Level previousLogLevel;
-    private SimpleWebSocketServer server;
+    private SimpleSocketServer server;
 
     @Before
     public void setUp() throws InterruptedException {
@@ -62,7 +62,7 @@ public class WebSocketClientBehaviorIntegrateTest {
 
         rootLogger.addAppender(recordingAppender);
 
-        server = new SimpleWebSocketServer();
+        server = new SimpleSocketServer();
         server.start(new TestWSGremlinInitializer());
     }
 
@@ -90,7 +90,7 @@ public class WebSocketClientBehaviorIntegrateTest {
      */
     @Test
     public void shouldRemoveConnectionFromPoolWhenServerClose_WithNoPendingRequests() throws InterruptedException {
-        final Cluster cluster = Cluster.build("localhost").port(SimpleWebSocketServer.PORT)
+        final Cluster cluster = Cluster.build("localhost").port(SimpleSocketServer.PORT)
                 .minConnectionPoolSize(1)
                 .maxConnectionPoolSize(1)
                 .serializer(Serializers.GRAPHSON_V2D0)
@@ -137,7 +137,7 @@ public class WebSocketClientBehaviorIntegrateTest {
      */
     @Test
     public void shouldRemoveConnectionFromPoolWhenServerClose_WithPendingRequests() throws InterruptedException, ExecutionException {
-        final Cluster cluster = Cluster.build("localhost").port(SimpleWebSocketServer.PORT)
+        final Cluster cluster = Cluster.build("localhost").port(SimpleSocketServer.PORT)
                 .minConnectionPoolSize(1)
                 .maxConnectionPoolSize(1)
                 .serializer(Serializers.GRAPHSON_V2D0)
@@ -185,7 +185,7 @@ public class WebSocketClientBehaviorIntegrateTest {
      */
     @Test
     public void shouldNotCreateReplacementConnectionWhenClientClosesConnection() throws ExecutionException, InterruptedException {
-        final Cluster cluster = Cluster.build("localhost").port(SimpleWebSocketServer.PORT)
+        final Cluster cluster = Cluster.build("localhost").port(SimpleSocketServer.PORT)
                 .minConnectionPoolSize(1)
                 .maxConnectionPoolSize(1)
                 .serializer(Serializers.GRAPHSON_V2D0)

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -279,38 +279,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
-    public void shouldKeepAliveForWebSockets() throws Exception {
-        // keep the connection pool size at 1 to remove the possibility of lots of connections trying to ping which will
-        // complicate the assertion logic
-        final Cluster cluster = TestClientFactory.build().
-                minConnectionPoolSize(1).
-                maxConnectionPoolSize(1).
-                keepAliveInterval(1000).create();
-        final Client client = cluster.connect();
-        try {
-
-            // fire up lots of requests so as to schedule/deschedule lots of ping jobs
-            for (int ix = 0; ix < 500; ix++) {
-                assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
-            }
-
-            // don't send any messages for a bit so that the driver pings in the background
-            Thread.sleep(3000);
-
-            // make sure no bonus messages sorta fire off once we get back to sending requests
-            for (int ix = 0; ix < 500; ix++) {
-                assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
-            }
-
-            // there really shouldn't be more than 3 of these sent. should definitely be at least one though
-            final long messages = recordingAppender.getMessages().stream().filter(m -> m.contains("Received response from keep-alive request")).count();
-            assertThat(messages, allOf(greaterThan(0L), lessThanOrEqualTo(3L)));
-        } finally {
-            cluster.close();
-        }
-    }
-
-    @Test
     public void shouldEventuallySucceedAfterChannelLevelError() throws Exception {
         final Cluster cluster = TestClientFactory.build()
                 .reconnectInterval(500)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2426

### Motivation
Let Netty perform the underlying WebSocket related stuff such as handshake, handling ping/pong etc. instead of writing the code ourselves.

### Changes
1. Use Netty's `WebSocketClientProtocolHandler` instead of writing a custom implementation at `WebSocketClientHandler`.
1. Introduce `WsHandshakeTimeout` as a configurable parameter. Set default to 15s.
1. Rename `SimpleWebSocketServer` to more appropriately reflect its functionality in tests.

**Note**: There is no significant functionality change other than increasing handshake time from 10s to 15s. This is increased because Netty's default value for SslHandshake itself is 10s, hence WsHandshake should be larger than that. 

### Testing
gremlin-driver `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`
gremlin-server `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`