### PR TITLE
#TINKERPOP-2432 improve toString for the Bytecode and unit test

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/bytecode-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/bytecode-test.js
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+/**
+ * @author Serhiy Salo
+ */
+'use strict';
+
+const assert = require('assert');
+const graph = require('../../lib/structure/graph');
+const graphTraversalModule = require('../../lib/process/graph-traversal');
+const __ = graphTraversalModule.statics;
+
+describe('Bytecode', () => {
+
+    describe('#toString()', () => {
+        it('should produce valid string representation', () => {
+            const g = new graph.Graph().traversal();
+            const bytecode = g.V().hasLabel("airport").where(__.outE("route").hasId(7753));
+            assert.ok(bytecode);
+            assert.strictEqual(bytecode.toString(), '[[],[["V"],["hasLabel",["airport"]],["where",[["outE",["route"]],["hasId",[7753]]]]]]');
+        });
+    });
+});


### PR DESCRIPTION
according to the documentation the Bytecode to string should produce valid Bytecode encoding. 
[
 ["V", [1]],
 ["repeat", [[
   ["out", ["knows"]]
   ["hasLabel", ["person"]]]]]
 ["times", [2]]
 ["values", ["name"]]
]

#TINKERPOP-2432