### PR TITLE
TINKERPOP-2440 Simplify driver by delegating keepAlive logic to Netty

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,9 +43,11 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Release server threads waiting on connection if the connection is dead.
 * Fixed bug where server closes HTTP connection on request error even if keep alive is set to true.
 * Java driver now delegates handling of WebSocket handshake to Netty instead of custom code.
+* Java driver now delegates sending keepAlive messages to Netty for `WebSocketChannelizer`.
+* Java driver now uses WebSocket compression extension ([RFC7692](https://tools.ietf.org/html/rfc7692)) for `WebSocketChannelizer`.
+* Server now supports WebSocket compression extension ([RFC7692](https://tools.ietf.org/html/rfc7692)).
 * Fixed bug with Bytecode serialization when `Bytecode.toString()` is used in Javascript.
 * Fixed "toString" for P and TextP to produce valid script representation from bytecode glv steps containing a string predicate in Javascript.
-* Add support for WebSocket compression extension.
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -176,6 +176,10 @@ public interface Channelizer extends ChannelHandler {
             return true;
         }
 
+        /**
+         * @deprecated As of release 3.5.0, not directly replaced. The keep-alive functionality is delegated to Netty
+         * {@link io.netty.handler.timeout.IdleStateHandler} which is added to the pipeline in {@link Channelizer}.
+         */
         @Override
         public Object createKeepAliveMessage() {
             throw new UnsupportedOperationException(

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -281,6 +281,10 @@ final class Connection {
         return requestPromise;
     }
 
+    /**
+     * @deprecated As of release 3.5.0, not directly replaced. The keep-alive functionality is delegated to Netty
+     * {@link io.netty.handler.timeout.IdleStateHandler} which is added to the pipeline in {@link Channelizer}.
+     */
     private void scheduleKeepAlive() {
         final Connection thisConnection = this;
         // try to keep the connection alive if the channel allows such things - websockets will

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -143,7 +143,10 @@ final class Connection {
 
             logger.info("Created new connection for {}", uri);
 
-            scheduleKeepAlive();
+            // Default WebSocketChannelizer uses Netty's IdleStateHandler
+            if (!(channelizer instanceof Channelizer.WebSocketChannelizer)) {
+                scheduleKeepAlive();
+            }
         } catch (Exception ie) {
             logger.debug("Error opening connection on {}", uri);
             throw new ConnectionException(uri, "Could not open connection", ie);
@@ -270,7 +273,10 @@ final class Connection {
                 });
         channel.writeAndFlush(requestMessage, requestPromise);
 
-        scheduleKeepAlive();
+        // Default WebSocketChannelizer uses Netty's IdleStateHandler
+        if (!(channelizer instanceof Channelizer.WebSocketChannelizer)) {
+            scheduleKeepAlive();
+        }
 
         return requestPromise;
     }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -118,7 +118,8 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         recordingAppender = new Log4jRecordingAppender();
         final org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
 
-        if (name.getMethodName().equals("shouldKeepAliveForWebSockets")) {
+        if (name.getMethodName().equals("shouldKeepAliveForWebSockets") ||
+                name.getMethodName().equals("shouldKeepAliveForWebSocketsWithNoInFlightRequests")) {
             final org.apache.log4j.Logger webSocketClientHandlerLogger = org.apache.log4j.Logger.getLogger(WebSocketClientHandler.class);
             previousLogLevel = webSocketClientHandlerLogger.getLevel();
             webSocketClientHandlerLogger.setLevel(Level.DEBUG);
@@ -135,7 +136,8 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void teardownForEachTest() {
         final org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
 
-        if (name.getMethodName().equals("shouldKeepAliveForWebSockets")) {
+        if (name.getMethodName().equals("shouldKeepAliveForWebSockets") ||
+                name.getMethodName().equals("shouldKeepAliveForWebSocketsWithNoInFlightRequests")) {
             final org.apache.log4j.Logger webSocketClientHandlerLogger = org.apache.log4j.Logger.getLogger(WebSocketClientHandler.class);
             webSocketClientHandlerLogger.setLevel(previousLogLevel);
         } else if (name.getMethodName().equals("shouldEventuallySucceedAfterMuchFailure")) {
@@ -287,6 +289,74 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
+<<<<<<< HEAD
+=======
+    public void shouldKeepAliveForWebSockets() throws Exception {
+        // keep the connection pool size at 1 to remove the possibility of lots of connections trying to ping which will
+        // complicate the assertion logic
+        final Cluster cluster = TestClientFactory.build().
+                minConnectionPoolSize(1).
+                maxConnectionPoolSize(1).
+                keepAliveInterval(1002).create();
+        try {
+            final Client client = cluster.connect();
+
+            // fire up lots of requests so as to schedule/deschedule lots of ping jobs
+            for (int ix = 0; ix < 500; ix++) {
+                assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
+            }
+
+            // don't send any messages for a bit so that the driver pings in the background
+            Thread.sleep(3000);
+
+            // make sure no bonus messages sorta fire off once we get back to sending requests
+            for (int ix = 0; ix < 500; ix++) {
+                assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
+            }
+
+            // there really shouldn't be more than 3 of these sent. should definitely be at least one though
+            // this assertion is based on number of pongs received
+            final long messages = recordingAppender.getMessages().stream().filter(m -> m.contains("Sending ping frame to the server")).count();
+            assertThat(messages, allOf(greaterThan(0L), lessThanOrEqualTo(3L)));
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void shouldKeepAliveForWebSocketsWithNoInFlightRequests() throws Exception {
+        // keep the connection pool size at 1 to remove the possibility of lots of connections trying to ping which will
+        // complicate the assertion logic
+        final Cluster cluster = TestClientFactory.build().
+                minConnectionPoolSize(1).
+                maxConnectionPoolSize(1).
+                keepAliveInterval(1002).create();
+        try {
+            final Client client = cluster.connect();
+
+            // forcefully initialize the client to mimic a scenario when client has some active connection with no
+            // in flight requests on them.
+            client.init();
+
+            // don't send any messages for a bit so that the driver pings in the background
+            Thread.sleep(3000);
+
+            // make sure no bonus messages sorta fire off once we get back to sending requests
+            for (int ix = 0; ix < 500; ix++) {
+                assertEquals(2, client.submit("1+1").all().get().get(0).getInt());
+            }
+
+            // there really shouldn't be more than 3 of these sent. should definitely be at least one though
+            // this assertion is based on number of pongs received
+            final long messages = recordingAppender.getMessages().stream().filter(m -> m.contains("Sending ping frame to the server")).count();
+            assertThat(messages, allOf(greaterThan(0L), lessThanOrEqualTo(3L)));
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
+>>>>>>> Simplify driver by delegating keepAlive logic to Netty
     public void shouldEventuallySucceedAfterChannelLevelError() throws Exception {
         final Cluster cluster = TestClientFactory.build()
                 .reconnectInterval(500)

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -289,8 +289,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
-<<<<<<< HEAD
-=======
     public void shouldKeepAliveForWebSockets() throws Exception {
         // keep the connection pool size at 1 to remove the possibility of lots of connections trying to ping which will
         // complicate the assertion logic
@@ -315,7 +313,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             }
 
             // there really shouldn't be more than 3 of these sent. should definitely be at least one though
-            // this assertion is based on number of pongs received
             final long messages = recordingAppender.getMessages().stream().filter(m -> m.contains("Sending ping frame to the server")).count();
             assertThat(messages, allOf(greaterThan(0L), lessThanOrEqualTo(3L)));
         } finally {
@@ -347,7 +344,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             }
 
             // there really shouldn't be more than 3 of these sent. should definitely be at least one though
-            // this assertion is based on number of pongs received
             final long messages = recordingAppender.getMessages().stream().filter(m -> m.contains("Sending ping frame to the server")).count();
             assertThat(messages, allOf(greaterThan(0L), lessThanOrEqualTo(3L)));
         } finally {
@@ -356,7 +352,6 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
->>>>>>> Simplify driver by delegating keepAlive logic to Netty
     public void shouldEventuallySucceedAfterChannelLevelError() throws Exception {
         final Cluster cluster = TestClientFactory.build()
                 .reconnectInterval(500)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2440

Java driver can be simplified by delegating the keepAlive logic to Netty's IdleStateHandler instead of maintaining and writing our own custom code. 

Note that this implementation is backward compatible for 3.4.x series as the existing keepAlive logic should still continue to work for Channelizers other than `WebSocketChannelizer` (notice the if statement in the code that checks for channelizer class before scheduling keepAlive). For `WebSocketChannelizer`, the number of Ping frames sent to the server is still the same except that it is now handled by Netty.

### Testing
1. Added a new unit test
2. gremlin-server `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`
3. gremlin-driver `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`

