### PR TITLE
TINKERPOP-2441 Add support for WebSocket compression

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Java driver now delegates handling of WebSocket handshake to Netty instead of custom code.
 * Fixed bug with Bytecode serialization when `Bytecode.toString()` is used in Javascript.
 * Fixed "toString" for P and TextP to produce valid script representation from bytecode glv steps containing a string predicate in Javascript.
+* Add support for WebSocket compression extension.
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -37,6 +37,7 @@ import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.ssl.SslContext;
 import org.apache.tinkerpop.gremlin.driver.simple.WebSocketClient;
 import org.slf4j.Logger;
@@ -215,6 +216,8 @@ public interface Channelizer extends ChannelHandler {
 
             pipeline.addLast("http-codec", new HttpClientCodec());
             pipeline.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
+            // Add compression extension for WebSocket defined in https://tools.ietf.org/html/rfc7692
+            pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
             pipeline.addLast("ws-handler", handler);
             pipeline.addLast("gremlin-encoder", webSocketGremlinRequestEncoder);
             pipeline.addLast("gremlin-decoder", webSocketGremlinResponseDecoder);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -211,8 +211,8 @@ public interface Channelizer extends ChannelHandler {
             final int maxContentLength = cluster.connectionPoolSettings().maxContentLength;
             handler = new WebSocketClientHandler(
                     WebSocketClientHandshakerFactory.newHandshaker(
-                            connection.getUri(), WebSocketVersion.V13, null, false, EmptyHttpHeaders.INSTANCE, maxContentLength),
-                    cluster.getWsHandshakeTimeout());
+                            connection.getUri(), WebSocketVersion.V13, null, /*allow extensions*/ true,
+                            EmptyHttpHeaders.INSTANCE, maxContentLength), cluster.getWsHandshakeTimeout());
 
             pipeline.addLast("http-codec", new HttpClientCodec());
             pipeline.addLast("aggregator", new HttpObjectAggregator(maxContentLength));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/WebSocketClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/WebSocketClient.java
@@ -64,7 +64,7 @@ public class WebSocketClient extends AbstractClient {
 
         try {
             final WebSocketClientHandler wsHandler = new WebSocketClientHandler(WebSocketClientHandshakerFactory.newHandshaker(
-                    uri, WebSocketVersion.V13, null, false, EmptyHttpHeaders.INSTANCE, 65536), 10000);
+                    uri, WebSocketVersion.V13, null, true, EmptyHttpHeaders.INSTANCE, 65536), 10000);
             final MessageSerializer serializer = new GryoMessageSerializerV3d0();
             b.channel(NioSocketChannel.class)
                     .handler(new ChannelInitializer<SocketChannel>() {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -103,6 +103,7 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
     public static final String PIPELINE_AUTHENTICATOR = "authenticator";
     public static final String PIPELINE_REQUEST_HANDLER = "request-handler";
     public static final String PIPELINE_HTTP_RESPONSE_ENCODER = "http-response-encoder";
+    public static final String PIPELINE_WEBSOCKET_SERVER_COMPRESSION = "web-socket-server-compression-handler";
 
     protected static final String PIPELINE_SSL = "ssl";
     protected static final String PIPELINE_OP_SELECTOR = "op-selector";

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
@@ -102,7 +102,7 @@ public class WebSocketChannelizer extends AbstractChannelizer {
         // setting closeOnProtocolViolation to false prevents causing all the other requests using the same channel
         // to fail when a single request causes a protocol violation.
         final WebSocketDecoderConfig wsDecoderConfig = WebSocketDecoderConfig.newBuilder().
-                closeOnProtocolViolation(false).allowExtensions(false).maxFramePayloadLength(settings.maxContentLength).build();
+                closeOnProtocolViolation(false).allowExtensions(true).maxFramePayloadLength(settings.maxContentLength).build();
         pipeline.addLast(PIPELINE_REQUEST_HANDLER, new WebSocketServerProtocolHandler(GREMLIN_ENDPOINT,
                 null, false, false, 10000L, wsDecoderConfig));
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
@@ -36,6 +36,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
@@ -95,6 +96,8 @@ public class WebSocketChannelizer extends AbstractChannelizer {
             pipeline.addLast(new LoggingHandler("log-aggregator-encoder", LogLevel.DEBUG));
 
         pipeline.addLast(PIPELINE_HTTP_RESPONSE_ENCODER, new HttpResponseEncoder());
+        // Add compression extension for WebSocket defined in https://tools.ietf.org/html/rfc7692
+        pipeline.addLast(PIPELINE_WEBSOCKET_SERVER_COMPRESSION, new WebSocketServerCompressionHandler());
 
         // setting closeOnProtocolViolation to false prevents causing all the other requests using the same channel
         // to fail when a single request causes a protocol violation.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
@@ -78,7 +78,7 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
 
         try {
             // Add the test data so that the g.V() response could exceed maxContentLength
-            client.submit("g.inject(1).repeat(__.addV()).times(10).count()").all().get();
+            client.submit("g.inject(1).repeat(__.addV()).times(20).count()").all().get();
             try {
                 client.submit("g.V().fold()").all().get();
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -290,7 +290,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldEventuallySucceedAfterChannelLevelError() throws Exception {
         final Cluster cluster = TestClientFactory.build()
                 .reconnectInterval(500)
-                .maxContentLength(1024).create();
+                .maxContentLength(64).create();
         final Client client = cluster.connect();
 
         try {
@@ -299,7 +299,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
                 fail("Request should have failed because it exceeded the max content length allowed");
             } catch (Exception ex) {
                 final Throwable root = ExceptionUtils.getRootCause(ex);
-                assertThat(root.getMessage(), containsString("Max frame length of 1024 has been exceeded."));
+                assertThat(root.getMessage(), containsString("Max frame length of 64 has been exceeded."));
             }
 
             assertEquals(2, client.submit("1+1").all().join().get(0).getInt());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2441

Support WebSocket compression extension on server and clients. The compression was standardized in https://tools.ietf.org/html/rfc7692 and Netty provides out of the box implementation for it. Note that the compression goes through a negotiation (via HTTP headers) and in cases when the server supports it but the client doesn't, it would fall back. Vice versa is also true and hence, it is a backward compatible functionality.  

