### PR TITLE
TINKERPOP-2438 Added AST preprocessing for scripts

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,7 +35,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug in Javascript `Translator` that wasn't handling child traversals well.
 * Implemented `AutoCloseable` on `MultiIterator`.
 * Fixed an iterator leak in `HasContainer`.
-* Avoid creating unnecessary detached objects in JVM.
+* Added `GremlinASTChecker` to provide a way to extract properties of scripts before doing an actual `eval()`.
+* Avoided creating unnecessary detached objects in JVM.
 * Added support for `TraversalStrategy` usage in Javascript.
 * Added `Traversal.getTraverserSetSupplier()` to allow providers to supply their own `TraverserSet` instances.
 

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTChecker.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTChecker.groovy
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223.ast
+
+import org.codehaus.groovy.ast.CodeVisitorSupport
+import org.codehaus.groovy.ast.builder.AstBuilder
+import org.codehaus.groovy.ast.expr.ArgumentListExpression
+import org.codehaus.groovy.ast.expr.ConstantExpression
+import org.codehaus.groovy.ast.expr.Expression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.PropertyExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codehaus.groovy.control.CompilePhase
+
+/**
+ * Processes Gremlin strings as an AST so as to try to detect certain properties from the script without actual
+ * having to execute a {@code eval()} on it.
+ */
+final class GremlinASTChecker {
+
+    private static final astBuilder = new AstBuilder()
+    public static final EMPTY_RESULT = new Result(0);
+
+    /**
+     * Parses a Gremlin script and extracts a {@code Result} containing properties that are relevant to the checker.
+     */
+    static Result parse(String gremlin) {
+        if (gremlin.empty) return EMPTY_RESULT
+
+        def ast = astBuilder.buildFromString(CompilePhase.CONVERSION, false, gremlin)
+        def tocheck = new TimeoutCheck()
+        ast[0].visit(tocheck)
+        return new Result(tocheck.total)
+    }
+
+    static class Result {
+        private final long timeout
+
+        Result(long timeout) {
+            this.timeout = timeout
+        }
+
+        /**
+         * Gets the value of the timeouts that were set using the {@code with()} source step. If there are multiple
+         * commands using this step, the timeouts are summed together.
+         */
+        Optional<Long> getTimeout() {
+            timeout == 0 ? Optional.empty() : Optional.of(timeout)
+        }
+    }
+
+    static class TimeoutCheck extends CodeVisitorSupport {
+
+        def total = 0L
+
+        @Override
+        void visitMethodCallExpression(MethodCallExpression call) {
+            if (call.methodAsString == "with")
+                call.getArguments().visit(this)
+
+            call.getObjectExpression().visit(this);
+        }
+
+        @Override
+        void visitArgumentlistExpression(ArgumentListExpression ale) {
+            def argumentExpressions = ale.asList()
+            if (argumentExpressions.size() == 2) {
+                def key = getArgument(argumentExpressions[0])
+                def value = getArgument(argumentExpressions[1])
+
+                if (isTimeoutKey(key) && value instanceof Number) {
+                    total += value
+                }
+            }
+        }
+
+        private static isTimeoutKey(def k) {
+            // can't use Tokens object from here as it's in gremlin-driver. would rather not put a
+            // groovy build in gremlin-driver so we're just stuck with strings for now.
+            return k == "evaluationTimeout" ||
+                    k == "scriptEvaluationTimeout" ||
+                    k == "ARGS_EVAL_TIMEOUT" ||
+                    k == "ARGS_SCRIPT_EVAL_TIMEOUT"
+        }
+
+        private static getArgument(Expression expr) {
+            // ConstantExpression for a direct String usage,
+            // PropertyExpression for Token.*
+            // VariableExpression for static import of the Token field
+            if (expr instanceof ConstantExpression)
+                return ((ConstantExpression) expr).value
+            else if (expr instanceof PropertyExpression)
+                return ((PropertyExpression) expr).propertyAsString
+            else if (expr instanceof VariableExpression)
+                return ((VariableExpression) expr).text
+        }
+    }
+}
+
+//import org.apache.tinkerpop.gremlin.groovy.jsr223.ast.GremlinASTChecker
+//import java.util.concurrent.TimeUnit
+//import org.apache.commons.lang.RandomStringUtils
+//rand = new java.util.Random()
+//engine = new groovy.text.SimpleTemplateEngine()
+//baseScript = 'g.with("evaluationTimeout",1).V().out("$a").in().where(outE().has("weight",$b).count().is($c)).order().by("name",desc).limit($d).project("x","y").by("name").by(outE().fold());'
+//[1,10,50,100,500,1000,5000,10000].collect {
+//    def binding = [a: RandomStringUtils.random(30), b: rand.nextDouble(), c: rand.nextInt(), d: rand.nextInt()]
+//    def longScript = (0..<it).collect{engine.createTemplate(baseScript).make(binding)}.join()
+//    def start = System.nanoTime()
+//    GremlinASTChecker.parse(longScript).getTimeout().get()
+//    [it, TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS)]
+//}

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.groovy.engine;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.ast.GremlinASTChecker;
 import org.apache.tinkerpop.gremlin.jsr223.CachedGremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.jsr223.ConcurrentBindings;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin;
@@ -255,8 +256,11 @@ public class GremlinExecutor implements AutoCloseable {
         bindings.putAll(globalBindings);
         bindings.putAll(boundVars);
 
-        // override the timeout if the lifecycle has a value assigned
-        final long scriptEvalTimeOut = lifeCycle.getEvaluationTimeoutOverride().orElse(evaluationTimeout);
+        // override the timeout if the lifecycle has a value assigned. if the script contains with(timeout)
+        // options then allow that value to override what's provided on the lifecycle
+        final Optional<Long> timeoutDefinedInScript = GremlinASTChecker.parse(script).getTimeout();
+        final long scriptEvalTimeOut = timeoutDefinedInScript.orElse(
+                lifeCycle.getEvaluationTimeoutOverride().orElse(evaluationTimeout));
 
         final CompletableFuture<Object> evaluationFuture = new CompletableFuture<>();
         final FutureTask<Void> evalFuture = new FutureTask<>(() -> {

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTCheckerTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTCheckerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223.ast;
+
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.ast.GremlinASTChecker.EMPTY_RESULT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class GremlinASTCheckerTest {
+
+    @Test
+    public void shouldNotFindTimeout() {
+        assertEquals(Optional.empty(), GremlinASTChecker.parse("g.with(true).V().out('knows')").getTimeout());
+    }
+
+    @Test
+    public void shouldReturnEmpty() {
+        assertSame(EMPTY_RESULT, GremlinASTChecker.parse(""));
+    }
+
+    @Test(expected = MultipleCompilationErrorsException.class)
+    public void shouldNotParse() {
+        GremlinASTChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows'))");
+    }
+
+    @Test
+    public void shouldNotFindTimeoutCozWeCommentedItOut() {
+        assertEquals(Optional.empty(), GremlinASTChecker.parse("g.\n" +
+                "                                                  // with('evaluationTimeout', 1000L).\n" +
+                "                                                  with(true).V().out('knows')").getTimeout());
+    }
+
+    @Test
+    public void shouldIdentifyTimeoutAsStringKey() {
+        assertEquals(1000, GremlinASTChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldIdentifyTimeoutAsTokenKey() {
+        assertEquals(1000, GremlinASTChecker.parse("g.with(Tokens.ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldIdentifyTimeoutAsTokenKeyWithoutClassName() {
+        assertEquals(1000, GremlinASTChecker.parse("g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldIdentifyMultipleTimeouts() {
+        assertEquals(6000, GremlinASTChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows');" +
+                "g.with('evaluationTimeout', 1000L).with(true).V().out('knows')\n" +
+                "                                                   //g.with('evaluationTimeout', 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with('evaluationTimeout', 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with('scriptEvaluationTimeout', 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -42,6 +42,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.server.channel.NioChannelizer;
+import org.apache.tinkerpop.gremlin.server.handler.OpExecutorHandler;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.Storage;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
@@ -121,6 +122,10 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             final org.apache.log4j.Logger webSocketClientHandlerLogger = org.apache.log4j.Logger.getLogger(WebSocketClientHandler.class);
             previousLogLevel = webSocketClientHandlerLogger.getLevel();
             webSocketClientHandlerLogger.setLevel(Level.DEBUG);
+        } else if (name.getMethodName().equals("shouldEventuallySucceedAfterMuchFailure")) {
+            final org.apache.log4j.Logger opExecutorHandlerLogger = org.apache.log4j.Logger.getLogger(OpExecutorHandler.class);
+            previousLogLevel = opExecutorHandlerLogger.getLevel();
+            opExecutorHandlerLogger.setLevel(Level.ERROR);
         }
 
         rootLogger.addAppender(recordingAppender);
@@ -133,6 +138,9 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         if (name.getMethodName().equals("shouldKeepAliveForWebSockets")) {
             final org.apache.log4j.Logger webSocketClientHandlerLogger = org.apache.log4j.Logger.getLogger(WebSocketClientHandler.class);
             webSocketClientHandlerLogger.setLevel(previousLogLevel);
+        } else if (name.getMethodName().equals("shouldEventuallySucceedAfterMuchFailure")) {
+            final org.apache.log4j.Logger opExecutorHandlerLogger = org.apache.log4j.Logger.getLogger(OpExecutorHandler.class);
+            opExecutorHandlerLogger.setLevel(previousLogLevel);
         }
 
         rootLogger.removeAppender(recordingAppender);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2438

There are sometimes things you want to know about what a script is doing before it goes to `eval()`. The immediate purpose is to extract timeouts passed using `with()` so that they can be applied to a request as an override to the server timeout. In this way, users who make the mistake of using this method (meant for remote bytecode requests initially) with script submission accidentally aren't left wondering why it didn't work as expected.

Performance doesn't appear to suffer too much from this added processing. I wrote this little benchmark:

```text
gremlin> baseScript = 'g.with("evaluationTimeout",1).V().out("$a").in().where(outE().has("weight",$b).count().is($c)).order().by("name",desc).limit($d).project("x","y").by("name").by(outE().fold());'
==>g.with("evaluationTimeout",1).V().out("$a").in().where(outE().has("weight",$b).count().is($c)).order().by("name",desc).limit($d).project("x","y").by("name").by(outE().fold());
gremlin> [1,10,50,100,500,1000,5000,10000].collect {
......1>   def binding = [a: RandomStringUtils.random(30), b: rand.nextDouble(), c: rand.nextInt(), d: rand.nextInt()]
......2>   def longScript = (0..<it).collect{engine.createTemplate(baseScript).make(binding)}.join()
......3>   def start = System.nanoTime()
......4>   GremlinASTChecker.parse(longScript).getTimeout().get()
......5>   [it, TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS)]
......6> }
==>[1,1]
==>[10,2]
==>[50,8]
==>[100,13]
==>[500,59]
==>[1000,107]
==>[5000,514]
==>[10000,976]
```

I test on a fairly long sort of traversal - the `baseScript` - to see how long it takes to do the timeout extraction with different length scripts denoted by `longScript` which basically is just the `baseScript` concatenated together by the number of lines we want to test. I random generated some data in each script line to just be sure that no caching was at play (as we see in the `GremlinGroovyScriptEngine`). 

The output seems favorable in my mind. Parsing a single "good-sized" line of Gremlin is basically instantaneous and even if someone went crazy and sent a 10000 line script (which will likely create bigger problems) it parses in under 1 second. Not feeling inclined to do much additional optimization based on these numbers right now. If reviewing, please let me know if I'm making any bad assumptions here in what that little microbenchmark is doing.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1