### PR TITLE
Tinkerpop-2437 Do not leave statusAttributes future dangling

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,13 +47,13 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Release server threads waiting on connection if the connection is dead.
 * Fixed bug where server closes HTTP connection on request error even if keep alive is set to true.
 * Deprecated driver `Channelizer` keep-alive related methods.
-* Java driver now delegates handling of WebSocket handshake to Netty instead of custom code.
-* Java driver now delegates sending keepAlive messages to Netty for `WebSocketChannelizer`.
-* Java driver now uses WebSocket compression extension ([RFC7692](https://tools.ietf.org/html/rfc7692)) for `WebSocketChannelizer`.
-* Server now supports WebSocket compression extension ([RFC7692](https://tools.ietf.org/html/rfc7692)).
+* Delegate handling of WebSocket handshake to Netty instead of custom code in Java Driver.
+* Delegate detection of idle connection to Netty instead of custom keep alive logic for `WebSocketChannelizer`.
+* Added support for WebSocket frame compression extension ( [RFC7692](https://tools.ietf.org/html/rfc7692) ) for `WebSocketChannelizer` in Java driver.
+* Added server support for WebSocket compression extension ( [RFC7692](https://tools.ietf.org/html/rfc7692) ).
 * Fixed bug with Bytecode serialization when `Bytecode.toString()` is used in Javascript.
 * Fixed "toString" for P and TextP to produce valid script representation from bytecode glv steps containing a string predicate in Javascript.
-* Fix bug which could cause Java driver to hang when using `ResultSet.statusAttributes()`
+* Fixed a bug which could cause Java driver to hang when using `ResultSet.statusAttributes()`
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Server now supports WebSocket compression extension ([RFC7692](https://tools.ietf.org/html/rfc7692)).
 * Fixed bug with Bytecode serialization when `Bytecode.toString()` is used in Javascript.
 * Fixed "toString" for P and TextP to produce valid script representation from bytecode glv steps containing a string predicate in Javascript.
+* Fix bug which could cause Java driver to hang when using `ResultSet.statusAttributes()`
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.driver;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+
 import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
 import org.apache.tinkerpop.gremlin.driver.handler.NioGremlinRequestEncoder;
 import org.apache.tinkerpop.gremlin.driver.handler.NioGremlinResponseDecoder;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -272,7 +272,7 @@ public final class Cluster {
     }
 
     public CompletableFuture<Void> closeAsync() {
-        return manager.close();
+        return manager.close().thenRun(() -> logger.info("Closed Cluster for hosts [{}]", this));
     }
 
     /**

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -20,10 +20,8 @@ package org.apache.tinkerpop.gremlin.driver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
-import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
@@ -121,7 +121,7 @@ final class Handler {
                 }
                 channelHandlerContext.writeAndFlush(messageBuilder.create());
             } else {
-                // SimpleChannelInboundHandler will release the frame if we don't retain it explicitely.
+                // SimpleChannelInboundHandler will release the frame if we don't retain it explicitly.
                 ReferenceCountUtil.retain(response);
                 channelHandlerContext.fireChannelRead(response);
             }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/AbstractResultQueueTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/AbstractResultQueueTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
+import org.junit.After;
 import org.junit.Before;
 
 import java.util.Collections;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public abstract class AbstractResultQueueTest {
-    protected final ExecutorService pool = Executors.newCachedThreadPool();
+    protected ExecutorService pool;
     protected ResultQueue resultQueue;
     protected CompletableFuture<Void> readCompleted;
 
@@ -41,6 +42,14 @@ public abstract class AbstractResultQueueTest {
         final LinkedBlockingQueue<Result> resultLinkedBlockingQueue = new LinkedBlockingQueue<>();
         readCompleted = new CompletableFuture<>();
         resultQueue = new ResultQueue(resultLinkedBlockingQueue, readCompleted);
+        pool =  Executors.newCachedThreadPool();
+    }
+
+    @After
+    public void closePool() {
+        if (!pool.isShutdown()) {
+            pool.shutdown();
+        }
     }
 
     protected Thread addToQueue(final int numberOfItemsToAdd, final long pauseBetweenItemsInMillis,

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultSetTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultSetTest.java
@@ -62,17 +62,51 @@ public class ResultSetTest extends AbstractResultQueueTest {
     }
 
     @Test
-    public void shouldHaveAllItemsAvailableAsynchronouslyOnReadComplete() {
+    public void shouldHaveAllItemsAvailableAsynchronouslyOnReadComplete() throws InterruptedException {
         final CompletableFuture<Void> all = resultSet.allItemsAvailableAsync();
         assertThat(all.isDone(), is(false));
         readCompleted.complete(null);
+        // flush all tasks in pool
+        pool.awaitTermination(2, TimeUnit.SECONDS);
         assertThat(all.isDone(), is(true));
     }
 
     @Test
-    public void shouldHaveAllItemsAvailableOnReadComplete() {
+    public void shouldHaveAllItemsAvailableAsynchronouslyOnReadCompleteExceptionally() throws InterruptedException {
+        final CompletableFuture<Void> all = resultSet.allItemsAvailableAsync();
+        assertThat(all.isDone(), is(false));
+        readCompleted.completeExceptionally(new RuntimeException());
+        // flush all tasks in pool
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+        assertThat(all.isDone(), is(true));
+        assertThat(all.isCompletedExceptionally(), is(true));
+    }
+
+    @Test
+    public void shouldHaveStatusAttributesCompleteOnReadComplete() throws InterruptedException {
+        final CompletableFuture<Map<String,Object>> attrbFut = resultSet.statusAttributes();
+        readCompleted.complete(null);
+        // flush all tasks in pool
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+        assertThat(attrbFut.isDone(), is(true));
+    }
+
+    @Test
+    public void shouldHaveStatusAttributesCompleteOnReadCompleteExceptionally() throws InterruptedException {
+        final CompletableFuture<Map<String,Object>> attrbFut = resultSet.statusAttributes();
+        readCompleted.completeExceptionally(new RuntimeException());
+        // flush all tasks in pool
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+        assertThat(attrbFut.isDone(), is(true));
+        assertThat(attrbFut.isCompletedExceptionally(), is(true));
+    }
+
+    @Test
+    public void shouldHaveAllItemsAvailableOnReadComplete() throws InterruptedException {
         assertThat(resultSet.allItemsAvailable(), is(false));
         readCompleted.complete(null);
+        // flush all tasks in pool
+        pool.awaitTermination(2, TimeUnit.SECONDS);
         assertThat(resultSet.allItemsAvailable(), is(true));
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2437

##Motivation
We do not complete the statusAttribute future if the underlying `readCompleted` is completed exceptionally.

##Testing
grenlin-server `mvn clean install -DskipIntegrationTests=false -DincludeNeo4j`