### PR TITLE
TINKERPOP-2435 Ignored python magic methods in Gremlin sugar

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated `withGraph()` in favor of `withEmbedded()` on `AnonymousTraversalSource`.
 * Added support for per-request level configurations, like timeouts, in .NET, Python and Javascript.
 * Fixed bug in Javascript `Translator` that wasn't handling child traversals well.
+* Prevented Gremlin Python sugar from being confused by Python magic methods.
 * Implemented `AutoCloseable` on `MultiIterator`.
 * Fixed an iterator leak in `HasContainer`.
 * Avoid creating unnecessary detached objects in JVM.

--- a/gremlin-python/glv/GraphTraversalSource.template
+++ b/gremlin-python/glv/GraphTraversalSource.template
@@ -99,6 +99,9 @@ class GraphTraversal(Traversal):
             raise TypeError("Index must be int or slice")
 
     def __getattr__(self, key):
+        if key.startswith('__'):
+            raise AttributeError(
+                'Python magic methods or keys starting with double underscore cannot be used for Gremlin sugar - prefer values(' + key + ')')
         return self.values(key)
 
     def clone(self):

--- a/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/graph_traversal.py
@@ -149,6 +149,9 @@ class GraphTraversal(Traversal):
             raise TypeError("Index must be int or slice")
 
     def __getattr__(self, key):
+        if key.startswith('__'):
+            raise AttributeError(
+                'Python magic methods or keys starting with double underscore cannot be used for Gremlin sugar - prefer values(' + key + ')')
         return self.values(key)
 
     def clone(self):

--- a/gremlin-python/src/main/jython/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/jython/tests/process/test_traversal.py
@@ -19,6 +19,8 @@
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
+from pytest import fail
+
 from gremlin_python.structure.graph import Graph
 from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.process.traversal import P
@@ -103,5 +105,21 @@ class TestTraversal(object):
         assert 3 == len(original.bytecode.step_instructions)
         assert 5 == len(clone.bytecode.step_instructions)
         assert 4 == len(cloneClone.bytecode.step_instructions)
+
+    def test_no_sugar_for_magic_methods(self):
+        g = traversal().withGraph(Graph())
+
+        t = g.V().age
+        assert 2 == len(t.bytecode.step_instructions)
+
+        try:
+            t = g.V().__len__
+            fail("can't do sugar with magic")
+        except AttributeError as err:
+            assert str(err) == 'Python magic methods or keys starting with double underscore cannot be used for Gremlin sugar - prefer values(__len__)'
+
+
+
+
 
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2435

Seems like less of a problem in practice as most Python users wouldn't improperly do g.V().__len__ but debugging tools might do such things on code introspection as PyCharm does with its debugger. That of course would build unexpected Gremlin and will typically return no values (as any traversal ending with values() and a key that doesnt exist will just filter out).

All tests pass with `mvn clean install -pl gremlin-python`

VOTE +1