### PR TITLE
TINKERPOP-2465 Fixed TestSupport file handling to work on windows.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/TestSupport.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/TestSupport.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,7 +40,8 @@ public class TestSupport {
 
     public static final String TEST_DATA_RELATIVE_DIR = "test-case-data";
 
-    protected TestSupport() {}
+    protected TestSupport() {
+    }
 
     /**
      * Creates a {@link File} reference that points to a directory relative to the supplied class in the
@@ -48,7 +50,7 @@ public class TestSupport {
      * {@code childPath} arguments would yield a relative directory like: {@code test-case-data/clazz/a/b/c}. It is
      * a good idea to use the test class for the {@code clazz} argument so that it's easy to find the data if
      * necessary after test execution.
-     *
+     * <p>
      * Avoid using makeTestDataPath(...).getAbsolutePath() and makeTestDataPath(...).toString() that produces
      * platform-dependent paths, that are incompatible with regular expressions and escape characters.
      * Instead use {@link Storage#toPath(File)}
@@ -61,7 +63,8 @@ public class TestSupport {
         cleanedPaths.add(0, cleanPathSegment(clazz.getSimpleName()));
 
         final File f = new File(new File(root, TEST_DATA_RELATIVE_DIR), String.join(Storage.FILE_SEPARATOR, cleanedPaths));
-        if (!f.exists()) f.mkdirs();
+        if (!f.exists())
+            f.mkdirs();
         return f;
     }
 
@@ -86,7 +89,7 @@ public class TestSupport {
      * supplied class in the {@code /target} directory.
      */
     public static String makeTestDataFile(final Class clazz, final String fileName) {
-      return Storage.toPath(new File(makeTestDataPath(clazz), fileName));
+        return Storage.toPath(new File(makeTestDataPath(clazz), fileName));
     }
 
     /**
@@ -97,7 +100,7 @@ public class TestSupport {
      * supplied class in the {@code /target} directory.
      */
     public static String makeTestDataFile(final Class clazz, final String subdir, final String fileName) {
-      return Storage.toPath(new File(makeTestDataPath(clazz, subdir), fileName));
+        return Storage.toPath(new File(makeTestDataPath(clazz, subdir), fileName));
     }
 
 
@@ -115,7 +118,7 @@ public class TestSupport {
         // as it likes to find that path in the .m2 directory and other weird places......
         final String buildDirectory = System.getProperty("build.dir");
 
-        if ( null == buildDirectory ) {
+        if (null == buildDirectory) {
             final String clsUri = clazz.getName().replace(".", "/") + ".class";
             final URL url = clazz.getClassLoader().getResource(clsUri);
             final String clsPath = url.getPath();
@@ -125,7 +128,8 @@ public class TestSupport {
         } else {
             root = new File(buildDirectory);
         }
-        if (!root.exists()) root.mkdirs();
+        if (!root.exists())
+            root.mkdirs();
         return root;
     }
 
@@ -135,7 +139,8 @@ public class TestSupport {
      */
     public static File generateTempFile(final Class clazz, final String fileName, final String fileNameSuffix) throws IOException {
         final File path = makeTestDataPath(clazz, "temp");
-        if (!path.exists()) path.mkdirs();
+        if (!path.exists())
+            path.mkdirs();
         return File.createTempFile(fileName, fileNameSuffix, path);
     }
 
@@ -163,13 +168,23 @@ public class TestSupport {
                                                     final String resourceName, final String extension, final boolean overwrite) throws IOException {
         final File temp = makeTestDataPath(graphClass, "resources");
         final File tempFile = new File(temp, resourceName + extension);
-        if (!tempFile.exists() || overwrite) {
-            try (final FileOutputStream outputStream = new FileOutputStream(tempFile)) {
-                int data;
-                try (final InputStream inputStream = resourceClass.getResourceAsStream(resourceName)) {
-                    while ((data = inputStream.read()) != -1) {
-                        outputStream.write(data);
-                    }
+        if(tempFile.exists() && !overwrite){
+            // overwrite is disabled and file already exists -> reuse as-is
+            return tempFile;
+        }
+        if(!tempFile.getParentFile().exists()){
+            Files.createDirectories(tempFile.getParentFile().toPath());
+        }
+        // either the file does not exist or needs to be overwritten, drop it
+        Files.deleteIfExists(tempFile.toPath());
+        // create the new file
+        Files.createFile(tempFile.toPath());
+        // fill it with the desired contents
+        try (final FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+            int data;
+            try (final InputStream inputStream = resourceClass.getResourceAsStream(resourceName)) {
+                while ((data = inputStream.read()) != -1) {
+                    outputStream.write(data);
                 }
             }
         }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGraphProvider.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGraphProvider.java
@@ -92,7 +92,7 @@ public abstract class AbstractGraphProvider implements GraphProvider {
             // created in an ad-hoc manner for the tests - just don't try to read any data into it.
             if (loadGraphWith != null) readIntoGraph(graph, loadGraphWith.value().location());
         } catch (IOException ioe) {
-            throw new RuntimeException("Graph could not be loaded with data for test: " + ioe.getMessage());
+            throw new RuntimeException("Graph could not be loaded with data for test: " + ioe.getMessage(), ioe);
         }
     }
 


### PR DESCRIPTION
This makes the TinkerGraph test suite pass on windows (it failed previously due to file handling issues).

This fixes:
https://issues.apache.org/jira/browse/TINKERPOP-2465?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel