### PR TITLE
TINKERPOP-2445 Remove unnecessary initialization of serializers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed all configuration keys on `AbstractWarningVerificationStrategy` implementations to `public`.
 * Deprecated `BytecodeUtil` and merged its functionality to the existing `BytecodeHelper`.
 * Added configuring implementation in HasStep
+* Remove static initialization for `GraphSONMessageSerializerV1d0` and `GraphSONMessageSerializerV1d0` in Java driver.
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/Serializers.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/Serializers.java
@@ -56,24 +56,6 @@ public enum Serializers {
 
     private String value;
 
-    /**
-     * Default serializer for results returned from Gremlin Server. This implementation must be of type
-     * {@link MessageTextSerializer} so that it can be compatible with text-based websocket messages.
-     *
-     * @deprecated As of release 3.3.5, not replaced, simply specify the exact version of the serializer to use.
-     */
-    @Deprecated
-    public static final MessageSerializer DEFAULT_RESULT_SERIALIZER = new GraphSONMessageSerializerV1d0();
-
-    /**
-     * Default serializer for requests received by Gremlin Server. This implementation must be of type
-     * {@link MessageTextSerializer} so that it can be compatible with text-based websocket messages.
-     *
-     * @deprecated As of release 3.3.5, not replaced, simply specify the exact version of the serializer to use.
-     */
-    @Deprecated
-    public static final MessageSerializer DEFAULT_REQUEST_SERIALIZER = new GraphSONMessageSerializerV1d0();
-
     Serializers(final String mimeType) {
         this.value = mimeType;
     }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/ServerSerializers.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/ServerSerializers.java
@@ -20,7 +20,6 @@ package org.apache.tinkerpop.gremlin.server.handler;
 
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0;
-import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -31,8 +30,7 @@ final class ServerSerializers {
 
     /**
      * Default serializer used by the server when the serializer requested does not match what is on the server.
-     * Using GraphSON 1.0 on 3.3.5 because that's what it has long been set to in previous versions on
-     * {@link Serializers#DEFAULT_RESULT_SERIALIZER} which is now deprecated.
+     * Using GraphSON 1.0 on 3.3.5 because that's what it has long been set to in previous versions.
      */
     static final MessageSerializer DEFAULT_SERIALIZER = new GraphSONMessageSerializerV1d0();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2445

## Change
Remove deprecated methods.

## Motivation
Initialization of GraphsonV1.0 is a major contributor (~28%) to initialize a client with a single connection.