### PR TITLE
TINKERPOP-2453 Enable websocket compression for python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,7 +49,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated driver `Channelizer` keep-alive related methods.
 * Delegate handling of WebSocket handshake to Netty instead of custom code in Java Driver.
 * Delegate detection of idle connection to Netty instead of custom keep alive logic for `WebSocketChannelizer`.
-* Added support for WebSocket frame compression extension ( [RFC7692](https://tools.ietf.org/html/rfc7692) ) for `WebSocketChannelizer` in Java driver.
+* Added support for WebSocket frame compression extension ( [RFC7692](https://tools.ietf.org/html/rfc7692) ) for `WebSocketChannelizer` in Java/Python driver.
 * Added server support for WebSocket compression extension ( [RFC7692](https://tools.ietf.org/html/rfc7692) ).
 * Fixed bug with Bytecode serialization when `Bytecode.toString()` is used in Javascript.
 * Fixed "toString" for P and TextP to produce valid script representation from bytecode glv steps containing a string predicate in Javascript.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -770,13 +770,21 @@ can be passed to the `Client` or `DriverRemoteConnection` instance as keyword ar
 |=========================================================
 
 Note that the `transport_factory` can allow for additional configuration of the `TornadoTransport`, which exposes
-options to manage `ioloop` timeouts:
+options to manage `ioloop` timeouts and compression settings:
 
-```python
+[source,python]
+----
 g = traversal().withRemote(
   DriverRemoteConnection('ws://localhost:8182/gremlin','g',
-                         transport_factory=lambda: TornadoTransport(read_timeout=10, write_timeout=10)))
-```
+                         transport_factory=lambda: TornadoTransport(read_timeout=10,
+                                                                    write_timeout=10,
+                                                                    compression_options={'compression_level':5,'mem_level':5})))
+----
+
+Compression configuration options are described in the
+link:https://docs.python.org/3.6/library/zlib.html#zlib.compressobj[zlib documentation]. By default, compression
+settings are configured as shown in the above example.
+
 [[gremlin-python-strategies]]
 === Traversal Strategies
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -80,6 +80,17 @@ const sg = g.withStrategies(
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2054[TINKERPOP-2054]
 
+==== WebSocket Compression
+
+Gremlin Server now supports standard WebSocket compression (per link:https://tools.ietf.org/html/rfc7692[RFC 7692]).
+Both the Java and Python drivers support this functionality from the client's perspective. Compression is enabled by
+default and should be backward compatible, thus allowing older versions of the driver to connect to newer versions of
+the server and vice versa. Using the compression-enabled drivers with a server that also supports that functionality
+will greatly reduce network IO requirements.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2441[TINKERPOP-2441],
+link:https://issues.apache.org/jira/browse/TINKERPOP-2453[TINKERPOP-2453]
+
 ==== Per Request Options
 
 With Java it has been possible to pass per-request settings for both scripts and bytecode. While Javascript, Python,

--- a/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
@@ -26,16 +26,19 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 class TornadoTransport(AbstractBaseTransport):
 
-    def __init__(self, read_timeout=30, write_timeout=30):
+    def __init__(self, read_timeout=30, write_timeout=30,
+                 compression_options={'compression_level': 5, 'mem_level': 5}):
         self._loop = ioloop.IOLoop(make_current=False)
+        self._ws = None
         self._read_timeout = read_timeout
         self._write_timeout = write_timeout
+        self._compression_options = compression_options
 
     def connect(self, url, headers=None):
         if headers:
             url = httpclient.HTTPRequest(url, headers=headers)
         self._ws = self._loop.run_sync(
-            lambda: websocket.websocket_connect(url))
+            lambda: websocket.websocket_connect(url, compression_options=self._compression_options))
 
     def write(self, message):
         self._loop.run_sync(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2453

Compression tests show similar results to what we saw on #1344 when we did this for Java

### Compression Disabled

![compression-disabled](https://user-images.githubusercontent.com/384249/98989047-8b25d800-24f6-11eb-9aeb-694a5fbb80d5.png)

### Compression Enabled

![compression-enabled](https://user-images.githubusercontent.com/384249/98989065-90832280-24f6-11eb-949a-e840958d7227.png)

Builds with `mvn clean install`

VOTE +1








