### PR TITLE
TINKERPOP-2475 Barrier step touches one more element of next loop

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
@@ -64,7 +64,7 @@ public final class NoOpBarrierStep<S> extends AbstractStep<S, S> implements Loca
 
     @Override
     public void processAllStarts() {
-        while (this.starts.hasNext() && (this.maxBarrierSize == Integer.MAX_VALUE || this.barrier.size() < this.maxBarrierSize)) {
+        while ((this.maxBarrierSize == Integer.MAX_VALUE || this.barrier.size() < this.maxBarrierSize) && this.starts.hasNext()) {
             final Traverser.Admin<S> traverser = this.starts.next();
             traverser.setStepId(this.getNextStep().getId()); // when barrier is reloaded, the traversers should be at the next step
             this.barrier.add(traverser);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2475

Fixed a bug which will preload one more element in barrier action. 

For example, if we have 4 vertices, and we have a barrier(2) step, we expect to get the first 2 in a barrier then the last 2 in another barrier loop. But when we get the first 2 vertices, the third one has already been loaded:

Vertices need to be load:
`v1`, `v2`, `v3`, `v4`

After the fisrt loop of the barrier(2) 
before fix:
`v1 loaded`, `v2 loaded`, `v3 loaded but not return`, `v4 not loaded`
after fix:
`v1 loaded`, `v2 loaded`, `v3 not loaded`, `v4 not loaded`