### PR TITLE
Throw error from DriverRemoteConnection on connection error

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -52,6 +52,9 @@ class DriverRemoteConnection extends RemoteConnection {
   constructor(url, options) {
     super(url);
     this._client = new Client(url, options);
+    this.addListener('socketError',  (err) => {
+        throw err;
+    });
   }
 
   /** @override */


### PR DESCRIPTION
Adds a listener that throws an error from a DriverRemoteConnection if an error occurs setting up a Websocket connection. Prior to this change, Gremlin requests submitted via a failed connection would succeed, but return a null result.