### PR TITLE
TINKERPOP-2445 Remove quiet time when shutting down Java client

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -67,6 +67,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Connections to the server in a connection pool are created in parallel instead of serially in Java Driver.
 * Connection pools for multiple endpoints are created in parallel instead of serially in Java Driver.
 * Introduced new HostNotAvailable exception to represent cases when no server with active connection is available. 
+* Don't wait for new requests during shutdown of event loop group in Java Driver.
 
 [[release-3-4-8]]
 === TinkerPop 3.4.8 (Release Date: August 3, 2020)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -64,6 +64,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1081,7 +1082,7 @@ public final class Cluster {
     }
 
     static class Factory {
-        private final EventLoopGroup group;
+        private final NioEventLoopGroup group;
 
         public Factory(final int nioPoolSize) {
             final BasicThreadFactory threadFactory = new BasicThreadFactory.Builder().namingPattern("gremlin-driver-loop-%d").build();
@@ -1095,7 +1096,9 @@ public final class Cluster {
         }
 
         void shutdown() {
-            group.shutdownGracefully().awaitUninterruptibly();
+            // Do not provide a quiet period (default is 2s) to accept more requests. Once we have decided to shutdown,
+            // no new requests should be accepted.
+            group.shutdownGracefully(/*quiet period*/0, /*timeout*/2, TimeUnit.SECONDS).awaitUninterruptibly();
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2445

**Problem**: Client init and shutdown takes ~2s with 100 connections even if we aren't sending any queries at all (against a locally running server w/o ssl).

**Reason**: 95% of the time is taken by shutdown. More specifically, [this line](https://github.com/apache/tinkerpop/blob/3.4-dev/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java) where we close Netty's event loop group. The default setting for closing the event loop group contains a "quiet time" of 2s, during which it will allow more requests to be handled by the executor. Thus, it will always wait at least 2s before shutting down. This 2s is configurable and we could change it instead of using the default.

**Change**: We are changing the quiet time to 0 because the event loop group is shutdown after executor (worker threads) are shutdown in a similar manner where we don't allow any more requests. 