### PR TITLE
TINKERPOP-2482 Rename wsConnectionTimeout to connectionSetupTimeout

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -275,7 +275,7 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.trustStore |File location for a SSL Certificate Chain to use when SSL is enabled. If this value is not provided and SSL is enabled, the default `TrustManager` will be used. |_none_
 |connectionPool.trustStorePassword |The password of the `trustStore` if it is password-protected |_none_
 |connectionPool.validationRequest |A script that is used to test server connectivity. A good script to use is one that evaluates quickly and returns no data. The default simply returns an empty string, but if a graph is required by a particular provider, a good traversal might be `g.inject()`. |_''_
-|connectionPool.wsHandshakeTimeoutMillis |Duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. |15000
+|connectionPool.connectionSetupTimeoutMillis | Duration of time in milliseconds provided for connection setup to complete which includes WebSocket protocol handshake and SSL handshake. |15000
 |hosts |The list of hosts that the driver will connect to. |localhost
 |jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -232,7 +232,7 @@ public interface Channelizer extends ChannelHandler {
             handler = new WebSocketClientHandler(
                     WebSocketClientHandshakerFactory.newHandshaker(
                             connection.getUri(), WebSocketVersion.V13, null, /*allow extensions*/ true,
-                            EmptyHttpHeaders.INSTANCE, maxContentLength), cluster.getWsHandshakeTimeout());
+                            EmptyHttpHeaders.INSTANCE, maxContentLength), cluster.getConnectionSetupTimeout());
 
             final int keepAliveInterval = toIntExact(TimeUnit.SECONDS.convert(cluster.connectionPoolSettings().keepAliveInterval, TimeUnit.MILLISECONDS));
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -208,7 +208,7 @@ public final class Cluster {
                 .minSimultaneousUsagePerConnection(settings.connectionPool.minSimultaneousUsagePerConnection)
                 .maxConnectionPoolSize(settings.connectionPool.maxSize)
                 .minConnectionPoolSize(settings.connectionPool.minSize)
-                .wsHandshakeTimeoutMillis(settings.connectionPool.wsHandshakeTimeoutMillis)
+                .connectionSetupTimeoutMillis(settings.connectionPool.connectionSetupTimeoutMillis)
                 .validationRequest(settings.connectionPool.validationRequest);
 
         if (settings.username != null && settings.password != null)
@@ -445,11 +445,12 @@ public final class Cluster {
     }
 
     /**
-     * Gets time duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. Beyond this
-     * duration an exception would be thrown if the handshake is not complete by then.
+     * Gets time duration of time in milliseconds provided for connection setup to complete which includes WebSocket
+     * handshake and SSL handshake. Beyond this duration an exception would be thrown if the handshake is not complete
+     * by then.
      */
-    public long getWsHandshakeTimeout() {
-        return manager.connectionPoolSettings.wsHandshakeTimeoutMillis;
+    public long getConnectionSetupTimeout() {
+        return manager.connectionPoolSettings.connectionSetupTimeoutMillis;
     }
 
     /**
@@ -620,7 +621,7 @@ public final class Cluster {
         private SslContext sslContext = null;
         private LoadBalancingStrategy loadBalancingStrategy = new LoadBalancingStrategy.RoundRobin();
         private AuthProperties authProps = new AuthProperties();
-        private long wsHandshakeTimeoutMillis = Connection.WS_HANDSHAKE_TIMEOUT_MILLIS;
+        private long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
 
         private Builder() {
             // empty to prevent direct instantiation
@@ -1058,14 +1059,14 @@ public final class Cluster {
         }
 
         /**
-         * Sets the duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. Beyond this
-         * duration an exception would be thrown.
+         * Sets the duration of time in milliseconds provided for connection setup to complete which includes WebSocket
+         * handshake and SSL handshake. Beyond this duration an exception would be thrown.
          *
          * Note that this value should be greater that SSL handshake timeout defined in
          * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake.
          */
-        public Builder wsHandshakeTimeoutMillis(final long wsHandshakeTimeoutMillis) {
-            this.wsHandshakeTimeoutMillis = wsHandshakeTimeoutMillis;
+        public Builder connectionSetupTimeoutMillis(final long connectionSetupTimeoutMillis) {
+            this.connectionSetupTimeoutMillis = connectionSetupTimeoutMillis;
             return this;
         }
 
@@ -1159,7 +1160,7 @@ public final class Cluster {
             connectionPoolSettings.keepAliveInterval = builder.keepAliveInterval;
             connectionPoolSettings.channelizer = builder.channelizer;
             connectionPoolSettings.validationRequest = builder.validationRequest;
-            connectionPoolSettings.wsHandshakeTimeoutMillis = builder.wsHandshakeTimeoutMillis;
+            connectionPoolSettings.connectionSetupTimeoutMillis = builder.connectionSetupTimeoutMillis;
 
             sslContextOptional = Optional.ofNullable(builder.sslContext);
 
@@ -1230,8 +1231,8 @@ public final class Cluster {
             if (builder.workerPoolSize < 1)
                 throw new IllegalArgumentException("workerPoolSize must be greater than zero");
 
-            if (builder.wsHandshakeTimeoutMillis < 1)
-                throw new IllegalArgumentException("wsHandshakeTimeoutMillis must be greater than zero");
+            if (builder.connectionSetupTimeoutMillis < 1)
+                throw new IllegalArgumentException("connectionSetupTimeoutMillis must be greater than zero");
 
             try {
                 Class.forName(builder.channelizer);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -69,7 +69,7 @@ final class Connection {
     public static final int RECONNECT_INTERVAL = 1000;
     public static final int RESULT_ITERATION_BATCH_SIZE = 64;
     public static final long KEEP_ALIVE_INTERVAL = 180000;
-    public final static long WS_HANDSHAKE_TIMEOUT_MILLIS = 15000;
+    public final static long CONNECTION_SETUP_TIMEOUT_MILLIS = 15000;
 
     /**
      * When a {@code Connection} is borrowed from the pool, this number is incremented to indicate the number of

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -257,8 +257,8 @@ final class Settings {
             if (connectionPoolConf.containsKey("validationRequest"))
                 cpSettings.validationRequest = connectionPoolConf.getString("validationRequest");
 
-            if (connectionPoolConf.containsKey("wsHandshakeTimeoutMillis"))
-                cpSettings.wsHandshakeTimeoutMillis = connectionPoolConf.getLong("wsHandshakeTimeoutMillis");
+            if (connectionPoolConf.containsKey("connectionSetupTimeoutMillis"))
+                cpSettings.connectionSetupTimeoutMillis = connectionPoolConf.getLong("connectionSetupTimeoutMillis");
 
             settings.connectionPool = cpSettings;
         }
@@ -451,13 +451,15 @@ final class Settings {
         public String validationRequest = "''";
 
         /**
-         * Duration of time in milliseconds provided for WebSocket protocol to complete it's handshake. Beyond this
-         * duration an exception would be thrown if the handshake is not complete by then.
+         *
+         * Duration of time in milliseconds provided for connection setup to complete which includes WebSocket
+         * handshake and SSL handshake. Beyond this duration an exception would be thrown if the handshake is not
+         * complete by then.
          *
          * Note that this value should be greater that SSL handshake timeout defined in
          * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake.
          */
-        public long wsHandshakeTimeoutMillis = Connection.WS_HANDSHAKE_TIMEOUT_MILLIS;
+        public long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
     }
 
     public static class SerializerSettings {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/WebSocketClientHandler.java
@@ -37,12 +37,12 @@ import org.slf4j.LoggerFactory;
 public final class WebSocketClientHandler extends WebSocketClientProtocolHandler {
     private static final Logger logger = LoggerFactory.getLogger(WebSocketClientHandler.class);
 
-    private final long handshakeTimeoutMillis;
+    private final long connectionSetupTimeoutMillis;
     private ChannelPromise handshakeFuture;
 
     public WebSocketClientHandler(final WebSocketClientHandshaker handshaker, final long timeoutMillis) {
         super(handshaker, /*handleCloseFrames*/true, /*dropPongFrames*/true, timeoutMillis);
-        this.handshakeTimeoutMillis = timeoutMillis;
+        this.connectionSetupTimeoutMillis = timeoutMillis;
     }
 
     public ChannelFuture handshakeFuture() {
@@ -97,7 +97,7 @@ public final class WebSocketClientHandler extends WebSocketClientProtocolHandler
             if (!handshakeFuture.isDone()) {
                 handshakeFuture.setFailure(
                         new TimeoutException(String.format("handshake not completed in stipulated time=[%s]ms",
-                                handshakeTimeoutMillis)));
+                                connectionSetupTimeoutMillis)));
             }
         } else {
             super.userEventTriggered(ctx, event);

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
@@ -62,7 +62,7 @@ public class ClusterBuilderTest {
                 {"resultIterationBatchSizeNeg1", Cluster.build().resultIterationBatchSize(-1), "resultIterationBatchSize must be greater than zero"},
                 {"nioPoolSize0", Cluster.build().nioPoolSize(0), "nioPoolSize must be greater than zero"},
                 {"nioPoolSizeNeg1", Cluster.build().nioPoolSize(-1), "nioPoolSize must be greater than zero"},
-                {"wsHandshakeTimeoutMillis0", Cluster.build().wsHandshakeTimeoutMillis(0), "wsHandshakeTimeoutMillis must be greater than zero"},
+                {"connectionSetupTimeoutMillis0", Cluster.build().connectionSetupTimeoutMillis(0), "connectionSetupTimeoutMillis must be greater than zero"},
                 {"workerPoolSize0", Cluster.build().workerPoolSize(0), "workerPoolSize must be greater than zero"},
                 {"workerPoolSizeNeg1", Cluster.build().workerPoolSize(-1), "workerPoolSize must be greater than zero"},
                 {"channelizer", Cluster.build().channelizer("MissingChannelizer"), "The channelizer specified [MissingChannelizer] could not be instantiated - it should be the fully qualified classname of a Channelizer implementation available on the classpath"}});

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -72,7 +72,7 @@ public class SettingsTest {
         conf.setProperty("connectionPool.resultIterationBatchSize", 1100);
         conf.setProperty("connectionPool.channelizer", "channelizer0");
         conf.setProperty("connectionPool.validationRequest", "g.inject()");
-        conf.setProperty("connectionPool.wsHandshakeTimeoutMillis", 15000);
+        conf.setProperty("connectionPool.connectionSetupTimeoutMillis", 15000);
 
         final Settings settings = Settings.from(conf);
 
@@ -109,7 +109,7 @@ public class SettingsTest {
         assertEquals(700, settings.connectionPool.maxWaitForConnection);
         assertEquals(800, settings.connectionPool.maxContentLength);
         assertEquals(900, settings.connectionPool.reconnectInterval);
-        assertEquals(15000, settings.connectionPool.wsHandshakeTimeoutMillis);
+        assertEquals(15000, settings.connectionPool.connectionSetupTimeoutMillis);
         assertEquals(1100, settings.connectionPool.resultIterationBatchSize);
         assertEquals("channelizer0", settings.connectionPool.channelizer);
         assertEquals("g.inject()", settings.connectionPool.validationRequest);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2482

Rename wsConnectionTimeout to connectionSetupTimeout. This is a newly introduced parameter in https://github.com/apache/tinkerpop/pull/1335 which is not released yet (scheduled to be released in 3.4.9). 

The new name represents the functionality of the parameter better which includes both ssl and websocket handshake duration.