### PR TITLE
TINKERPOP-2438 Improved performance of GremlinASTChecker

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug in `:bytecode` command preventing translations with whitespace from working properly.
 * Added `reset` and `config` options to the `:bytecode` command to allow for greater customization options.
 * Added GraphSON extension module and the `TinkerIoRegistry` to the default `GraphSONMapper` configuration used by the `:bytecode` command.
+* Added `GremlinASTChecker` to provide a way to extract properties of scripts before doing an actual `eval()`.
 * Avoided creating unnecessary detached objects in JVM.
 * Added support for `TraversalStrategy` usage in Javascript.
 * Added `Traversal.getTraverserSetSupplier()` to allow providers to supply their own `TraverserSet` instances.

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -256,8 +256,11 @@ public class GremlinExecutor implements AutoCloseable {
         bindings.putAll(globalBindings);
         bindings.putAll(boundVars);
 
-        // override the timeout if the lifecycle has a value assigned.
-        final long scriptEvalTimeOut = lifeCycle.getEvaluationTimeoutOverride().orElse(evaluationTimeout);
+        // override the timeout if the lifecycle has a value assigned. if the script contains with(timeout)
+        // options then allow that value to override what's provided on the lifecycle
+        final Optional<Long> timeoutDefinedInScript = GremlinASTChecker.parse(script).getTimeout();
+        final long scriptEvalTimeOut = timeoutDefinedInScript.orElse(
+                lifeCycle.getEvaluationTimeoutOverride().orElse(evaluationTimeout));
 
         final CompletableFuture<Object> evaluationFuture = new CompletableFuture<>();
         final FutureTask<Void> evalFuture = new FutureTask<>(() -> {

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorOverGraphTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorOverGraphTest.java
@@ -47,7 +47,6 @@ import static org.junit.Assert.fail;
 public class GremlinExecutorOverGraphTest {
     private final BasicThreadFactory testingThreadFactory = new BasicThreadFactory.Builder().namingPattern("test-gremlin-executor-%d").build();
 
-    @Ignore("GremlinASTChecker introduced some performance isssue on low latency traversals - resolve then re-enable this test")
     @Test
     public void shouldOverrideTimeoutWithinScript() throws Exception {
         final TinkerGraph graph = TinkerFactory.createModern();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2438

Used CompileStatic annotation and introduced a lightweight check to validate that there was reason to accept the expense of parsing. It's a bit of a hack in a sense but after some analysis it seems that there are no easy fixes. Everything ends in fairly advanced refactoring and extension of GremlinGroovyScriptEngine and GremlinGroovyClassLoader (with possible pull requests to Groovy). That seems like a fair bit of effort for what this feature is and I'm not sure it's worth it. The typical use case for timeout setting should not encounter the performance problem that would ensue from parsing to the Groovy AST.

