### PR TITLE
TINKERPOP-2438 Introduce GremlinScriptChecker

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-10]]
 === TinkerPop 3.4.10 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-
+* Added `GremlinScriptChecker` to provide a way to extract properties of scripts before doing an actual `eval()`.
 
 [[release-3-4-9]]
 === TinkerPop 3.4.9 (Release Date: December 7, 2020)

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -437,6 +437,23 @@ RequestOptions options = RequestOptions.build().timeout(500).create();
 List<Result> result = client.submit("g.V().repeat(both()).times(100)", options).all().get();
 ----
 
+The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar with
+bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Gremlin Server will respect timeouts set this way
+in scripts as well. With scripts of course, it is possible to send multiple traversals at once in the same script.
+In such events, the timeout for the request is interpreted as a sum of all timeouts identified in the script.
+
+[source,java]
+----
+RequestOptions options = RequestOptions.build().timeout(500).create();
+List<Result> result = client.submit("g.with(EVALUATION_TIMEOUT, 500).addV().iterate();" +
+                                    "g.addV().iterate();
+                                    "g.with(EVALUATION_TIMEOUT, 500).addV();", options).all().get();
+----
+
+In the above example, `RequestOptions` defines a timeout of 500 milliseconds, but the script has three traversals with
+two internal settings for the timeout using `with()`. The request timeout used by the server will therefore be 1000
+milliseconds (overriding the 500 which itself was an override for whatever configuration was on the server).
+
 ==== Aliases
 
 Scripts submitted to Gremlin Server automatically have the globally configured `Graph` and `TraversalSource` instances
@@ -976,6 +993,22 @@ result_set = client.submit('g.V().repeat(both()).times(100)', result_options={'e
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent` and
 `evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated).
 
+IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
+with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple
+timeouts will be interpreted as a sum of all timeouts identified in the script for that request.
+
+[source,java]
+----
+RequestOptions options = RequestOptions.build().timeout(500).create();
+List<Result> result = client.submit("g.with(EVALUATION_TIMEOUT, 500).addV().iterate();" +
+                                    "g.addV().iterate();
+                                    "g.with(EVALUATION_TIMEOUT, 500).addV();", options).all().get();
+----
+
+In the above example, `RequestOptions` defines a timeout of 500 milliseconds, but the script has three traversals with
+two internal settings for the timeout using `with()`. The request timeout used by the server will therefore be 1000
+milliseconds (overriding the 500 which itself was an override for whatever configuration was on the server).
+
 [[gremlin-python-dsl]]
 === Domain Specific Languages
 
@@ -1281,6 +1314,10 @@ The following options are allowed on a per-request basis in this fashion: `batch
 `evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated). These options are
 available as constants on the `Gremlin.Net.Driver.Tokens` class.
 
+IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
+with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple
+timeouts will be interpreted as a sum of all timeouts identified in the script for that request.
+
 anchor:gremlin-net-dsl[]
 [[gremlin-dotnet-dsl]]
 === Domain Specific Languages
@@ -1564,6 +1601,10 @@ const result = await client.submit("g.V().repeat(both()).times(100)", null, { ev
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent` and
 `evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated).
+
+IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
+with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple
+timeouts will be interpreted as a sum of all timeouts identified in the script for that request.
 
 [[gremlin-javascript-dsl]]
 === Domain Specific Languages

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -21,7 +21,7 @@ package org.apache.tinkerpop.gremlin.groovy.engine;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
-import org.apache.tinkerpop.gremlin.groovy.jsr223.ast.GremlinASTChecker;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinScriptChecker;
 import org.apache.tinkerpop.gremlin.jsr223.CachedGremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.jsr223.ConcurrentBindings;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin;
@@ -258,7 +258,7 @@ public class GremlinExecutor implements AutoCloseable {
 
         // override the timeout if the lifecycle has a value assigned. if the script contains with(timeout)
         // options then allow that value to override what's provided on the lifecycle
-        final Optional<Long> timeoutDefinedInScript = GremlinASTChecker.parse(script).getTimeout();
+        final Optional<Long> timeoutDefinedInScript = GremlinScriptChecker.parse(script).getTimeout();
         final long scriptEvalTimeOut = timeoutDefinedInScript.orElse(
                 lifeCycle.getEvaluationTimeoutOverride().orElse(evaluationTimeout));
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinScriptChecker.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinScriptChecker.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Processes Gremlin strings using regex so as to try to detect certain properties from the script without actual
+ * having to execute a {@code eval()} on it.
+ */
+public class GremlinScriptChecker {
+
+    public static final Result EMPTY_RESULT = new Result(0);
+    private static final List<String> tokens = Arrays.asList("evaluationTimeout", "scriptEvaluationTimeout",
+                                                             "ARGS_EVAL_TIMEOUT", "ARGS_SCRIPT_EVAL_TIMEOUT");
+
+    /**
+     * Matches single line comments, multi-line comments and space characters.
+     * <pre>
+     * 	OR: match either of the followings
+     * Sequence: match all of the followings in order
+     * / /
+     * Repeat
+     * AnyCharacterExcept\n
+     * zero or more times
+     * EndOfLine
+     * Sequence: match all of the followings in order
+     * /
+     * *
+     * Repeat
+     * CapturingGroup
+     * GroupNumber:1
+     * OR: match either of the followings
+     * AnyCharacterExcept\n
+     * AnyCharIn[ CarriageReturn NewLine]
+     * zero or more times (ungreedy)
+     * *
+     * /
+     * WhiteSpaceCharacter
+     * </pre>
+     */
+    private static final Pattern patternClean = Pattern.compile("//.*$|/\\*(.|[\\r\\n])*?\\*/|\\s", Pattern.MULTILINE);
+
+    /**
+     * Regex fragment for the timeout tokens to look for. There are basically four:
+     * <ul>
+     *     <li>{@code evaluationTimeout} which is a string value and thus single or double quoted</li>
+     *     <li>{@code scriptEvaluationTimeout} which is a string value and thus single or double quoted</li>
+     *     <li>{@code ARGS_EVAL_TIMEOUT} which is a enum type of value which can be referenced with or without a {@code Tokens} qualifier</li>
+     *     <li>{@code ARGS_SCRIPT_EVAL_TIMEOUT} which is a enum type of value which can be referenced with or without a {@code Tokens} qualifier</li>
+     * </ul>
+     * <pre>
+     * 	OR: match either of the followings
+     * Sequence: match all of the followings in order
+     * AnyCharIn[ " ']
+     * e v a l u a t i o n T i m e o u t
+     * AnyCharIn[ " ']
+     * Sequence: match all of the followings in order
+     * AnyCharIn[ " ']
+     * s c r i p t E v a l u a t i o n T i m e o u t
+     * AnyCharIn[ " ']
+     * Sequence: match all of the followings in order
+     * Repeat
+     * CapturingGroup
+     * (NonCapturingGroup)
+     * Sequence: match all of the followings in order
+     * T o k e n s
+     * .
+     * optional
+     * A R G S _ E V A L _ T I M E O U T
+     * Sequence: match all of the followings in order
+     * Repeat
+     * CapturingGroup
+     * (NonCapturingGroup)
+     * Sequence: match all of the followings in order
+     * T o k e n s
+     * .
+     * optional
+     * A R G S _ S C R I P T _ E V A L _ T I M E O U T
+     * </pre>
+     */
+    private static final String timeoutTokens = "[\"']evaluationTimeout[\"']|[\"']scriptEvaluationTimeout[\"']|(?:Tokens\\.)?ARGS_EVAL_TIMEOUT|(?:Tokens\\.)?ARGS_SCRIPT_EVAL_TIMEOUT";
+
+    /**
+     * Matches {@code .with({timeout-token},{timeout})} with a matching group on the {@code timeout}.
+     *
+     * <pre>
+     * Sequence: match all of the followings in order
+     * .
+     * w i t h
+     * (
+     * CapturingGroup
+     * (NonCapturingGroup)
+     * OR: match either of the followings
+     * Sequence: match all of the followings in order
+     * AnyCharIn[ " ']
+     * e v a l u a t i o n T i m e o u t
+     * AnyCharIn[ " ']
+     * Sequence: match all of the followings in order
+     * AnyCharIn[ " ']
+     * s c r i p t E v a l u a t i o n T i m e o u t
+     * AnyCharIn[ " ']
+     * Sequence: match all of the followings in order
+     * Repeat
+     * CapturingGroup
+     * (NonCapturingGroup)
+     * Sequence: match all of the followings in order
+     * T o k e n s
+     * .
+     * optional
+     * A R G S _ E V A L _ T I M E O U T
+     * Sequence: match all of the followings in order
+     * Repeat
+     * CapturingGroup
+     * (NonCapturingGroup)
+     * Sequence: match all of the followings in order
+     * T o k e n s
+     * .
+     * optional
+     * A R G S _ S C R I P T _ E V A L _ T I M E O U T
+     * ,
+     * CapturingGroup
+     * GroupNumber:1
+     * Repeat
+     * Digit
+     * zero or more times
+     * Repeat
+     * CapturingGroup
+     * GroupNumber:2
+     * OR: match either of the followings
+     * Sequence: match all of the followings in order
+     * Repeat
+     * :
+     * optional
+     * L
+     * l
+     * optional
+     * )
+     * </pre>
+     */
+    private static final Pattern patternTimeout = Pattern.compile("\\.with\\((?:" + timeoutTokens + "),(\\d*)(:?L|l)?\\)");
+
+    /**
+     * Parses a Gremlin script and extracts a {@code Result} containing properties that are relevant to the checker.
+     */
+    public static Result parse(final String gremlin) {
+        if (gremlin.isEmpty()) return EMPTY_RESULT;
+
+        // do a cheap check for tokens we care about - no need to parse unless one of these tokens is present in
+        // the string.
+        if (tokens.stream().noneMatch(gremlin::contains)) return EMPTY_RESULT;
+
+        // kill out comments/whitespace. for whitespace, ignoring the need to keep string literals together as that
+        // isn't currently a requirement
+        final String cleanGremlin = patternClean.matcher(gremlin).replaceAll("");
+
+        final Matcher m = patternTimeout.matcher(cleanGremlin);
+        if (!m.find()) return EMPTY_RESULT;
+
+        long l = Long.parseLong(m.group(1));
+        while (m.find()) {
+            l += Long.parseLong(m.group(1));
+        }
+
+        return new Result(l);
+    }
+
+    public static class Result {
+        private final long timeout;
+
+        private Result(final long timeout) {
+            this.timeout = timeout;
+        }
+
+        /**
+         * Gets the value of the timeouts that were set using the {@code with()} source step. If there are multiple
+         * commands using this step, the timeouts are summed together.
+         */
+        public final Optional<Long> getTimeout() {
+            return timeout == 0 ? Optional.empty() : Optional.of(timeout);
+        }
+    }
+}

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinScriptCheckerTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinScriptCheckerTest.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinScriptChecker.EMPTY_RESULT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class GremlinScriptCheckerTest {
+
+    @Test
+    public void shouldNotFindTimeout() {
+        assertEquals(Optional.empty(), GremlinScriptChecker.parse("g.with(true).V().out('knows')").getTimeout());
+    }
+
+    @Test
+    public void shouldReturnEmpty() {
+        assertSame(EMPTY_RESULT, GremlinScriptChecker.parse(""));
+    }
+
+    @Test
+    public void shouldNotFindTimeoutCozWeCommentedItOut() {
+        assertEquals(Optional.empty(), GremlinScriptChecker.parse("g.\n" +
+                "                                                  // with('evaluationTimeout', 1000L).\n" +
+                "                                                  with(true).V().out('knows')").getTimeout());
+    }
+
+    @Test
+    public void shouldIdentifyTimeoutAsStringKeySingleQuoted() {
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('scriptEvaluationTimeout', 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldIdentifyTimeoutAsStringKeyDoubleQuoted() {
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(\"evaluationTimeout\", 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(\"scriptEvaluationTimeout\", 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldIdentifyTimeoutAsTokenKey() {
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldIdentifyTimeoutAsTokenKeyWithoutClassName() {
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldIdentifyMultipleTimeouts() {
+        assertEquals(6000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows');" +
+                "g.with('evaluationTimeout', 1000L).with(true).V().out('knows');\n" +
+                "                                                   //g.with('evaluationTimeout', 1000L).with(true).V().out('knows');\n" +
+                "                                                   /* g.with('evaluationTimeout', 1000L).with(true).V().out('knows');*/\n" +
+                "                                                   /* \n" +
+                "g.with('evaluationTimeout', 1000L).with(true).V().out('knows'); \n" +
+                "*/ \n" +
+                "                                                   g.with('evaluationTimeout', 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with('scriptEvaluationTimeout', 1000L).with(true).V().out('knows');").
+                getTimeout().get().longValue());
+    }
+
+    @Test
+    public void shouldParseLong() {
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).addV().property(id, 'blue').as('b').\n" +
+                "  addV().property(id, 'orange').as('o').\n" +
+                "  addV().property(id, 'red').as('r').\n" +
+                "  addV().property(id, 'green').as('g').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('b').\n" +
+                "  addE('bridge').from('g').to('o').\n" +
+                "  addE('bridge').from('g').to('r').\n" +
+                "  addE('bridge').from('g').to('r').\n" +
+                "  addE('bridge').from('o').to('b').\n" +
+                "  addE('bridge').from('o').to('b').\n" +
+                "  addE('bridge').from('o').to('r').\n" +
+                "  addE('bridge').from('o').to('r').iterate()").
+                getTimeout().get().longValue());
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2438

Even though TINKERPOP-2438 is already done this is a bit of a follow on to that change. The GremlinScriptChecker performs the same exact task as the GremlinAstChecker but it does so with regex parsing which should be faster than processing a full AST. I've left the GremlinASTChecker where it is because I wonder if there isn't yet some usage for more rigorous sort of checks we might come up with in the future or perhaps have checks that only work well with AST processing. It can be removed in the future if we like.

VOTE +1