### PR TITLE
TINKERPOP-2487 add stdev and percentile steps

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1919,6 +1919,42 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#min-org.apache.tinkerpop.gremlin.process.traversal.Scope-++[`min(Scope)`],
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/Scope.html++[`Scope`]
 
+[[stdev-step]]
+=== Stdev Step
+
+The `stdev()`-step (*map*) operates on a stream of numbers and calculates the standard deviation of those numbers.
+
+[gremlin-groovy,modern]
+----
+g.V().values('ages')
+g.V().values('ages').stdev()
+----
+
+*Additional References*
+
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#stdev--++[`stdev()`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#stdev-org.apache.tinkerpop.gremlin.process.traversal.Scope-++[`stdev(Scope)`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/Scope.html++[`Scope`]
+
+[[percentile-step]]
+=== Percentile Step
+
+The `percentile()`-step (*map*) operates on a stream of numbers and determine the n-th percentile values.
+It accepts one or more integer values within range [0..100]. If there is only one percentile input, the step result would be a single number value.
+If multiple percentile inputs are provided, the step result would be a `Map<Integer, Number>`.
+
+[gremlin-groovy,modern]
+----
+g.V().values('ages')
+g.V().values('ages').percentile(50) <1>
+g.V().values('ages').percentile(50, 90) <2>
+----
+
+<1> Calculate the 50-th percentile / median value of all persons' ages. The result is a single value.
+
+<2> Calculate the 50-th and 90-th percentile value of persons' ages. The result is a map.
+
+
 [[none-step]]
 === None Step
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -104,6 +104,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PercentileGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PercentileLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProjectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertyKeyStep;
@@ -114,6 +116,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.SackStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SampleLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectOneStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.StdevGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.StdevLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.TailLocalStep;
@@ -984,6 +988,52 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     public default <E2 extends Number> GraphTraversal<S, E2> mean(final Scope scope) {
         this.asAdmin().getBytecode().addStep(Symbols.mean, scope);
         return this.asAdmin().addStep(scope.equals(Scope.global) ? new MeanGlobalStep(this.asAdmin()) : new MeanLocalStep(this.asAdmin()));
+    }
+
+    /**
+     * Calculate the standard deviation value in the stream.
+     *
+     * @return the traversal with an appended {@link StdevGlobalStep}.
+     * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#stdev-step" target="_blank">Reference Documentation - Stdev Step</a>
+     */
+    public default <E2 extends Number> GraphTraversal<S, E2> stdev() {
+        this.asAdmin().getBytecode().addStep(Symbols.stdev);
+        return this.asAdmin().addStep(new StdevGlobalStep<>(this.asAdmin()));
+    }
+
+    /**
+     * Calculate the standard deviation value in the stream given the {@link Scope}.
+     *
+     * @return the traversal with an appended {@link StdevGlobalStep} or {@link StdevLocalStep} depending on the {@link Scope}.
+     * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#stdev-step" target="_blank">Reference Documentation - Stdev Step</a>
+     */
+    public default <E2 extends Number> GraphTraversal<S, E2> stdev(final Scope scope) {
+        this.asAdmin().getBytecode().addStep(Symbols.stdev, scope);
+        return this.asAdmin().addStep(scope.equals(Scope.global) ? new StdevGlobalStep(this.asAdmin()) : new StdevLocalStep(this.asAdmin()));
+    }
+
+    /**
+     * Calculate required percentile value.
+     *
+     * @param n the quantile value must be an integer between 0 and 100, or an IllegalArgumentException will be thrown.
+     * @return the traversal with an appended {@link PercentileGlobalStep}.
+     * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#percentile-step" target="_blank">Reference Documentation - Percentile Step</a>
+     */
+    public default GraphTraversal<S, Object> percentile(final int... n) {
+        this.asAdmin().getBytecode().addStep(Symbols.percentile);
+        return this.asAdmin().addStep(new PercentileGlobalStep(this.asAdmin(), n));
+    }
+
+    /**
+     * Calculate required percentile value.
+     *
+     * @param n the quantile value must be an integer between 0 and 100, or an IllegalArgumentException will be thrown.
+     * @return the traversal with an appended {@link PercentileGlobalStep} or {@link PercentileLocalStep} depending on the {@link Scope}.
+     * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#percentile-step" target="_blank">Reference Documentation - Percentile Step</a>
+     */
+    public default GraphTraversal<S, Object> percentile(final Scope scope, final int... n) {
+        this.asAdmin().getBytecode().addStep(Symbols.percentile);
+        return this.asAdmin().addStep(scope.equals(Scope.global) ? new PercentileGlobalStep(this.asAdmin(), n) : new PercentileLocalStep(this.asAdmin(), n));
     }
 
     /**
@@ -2994,6 +3044,8 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         public static final String max = "max";
         public static final String min = "min";
         public static final String mean = "mean";
+        public static final String stdev = "stdev";
+        public static final String percentile = "percentile";
         public static final String group = "group";
         public static final String groupCount = "groupCount";
         public static final String tree = "tree";

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -474,6 +474,34 @@ public class __ {
     }
 
     /**
+     * @see GraphTraversal#stdev()
+     */
+    public static <A> GraphTraversal<A, Double> stdev() {
+        return __.<A>start().stdev();
+    }
+
+    /**
+     * @see GraphTraversal#stdev(Scope)
+     */
+    public static <A> GraphTraversal<A, Double> stdev(final Scope scope) {
+        return __.<A>start().stdev(scope);
+    }
+
+    /**
+     * @see GraphTraversal#percentile(int...)
+     */
+    public static <A> GraphTraversal<A, Object> percentile(final int... n) {
+        return __.<A>start().percentile(n);
+    }
+
+    /**
+     * @see GraphTraversal#percentile(Scope, int...)
+     */
+    public static <A> GraphTraversal<A, Object> percentile(final Scope scope, final int... n) {
+        return __.<A>start().percentile(scope, n);
+    }
+
+    /**
      * @see GraphTraversal#group()
      */
     public static <A, K, V> GraphTraversal<A, Map<K, V>> group() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileGlobalStep.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.util.NumberHelper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * @author Junshi Guo
+ */
+public class PercentileGlobalStep<S extends Number> extends ReducingBarrierStep<S, Object> {
+
+    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.OBJECT, TraverserRequirement.BULK);
+    List<S> buffer;
+    private final int[] percentiles;
+
+    public PercentileGlobalStep(final Traversal.Admin traversal, final int... percentiles) {
+        super(traversal);
+        this.buffer = new ArrayList<>();
+        this.percentiles = percentiles;
+        this.setSeedSupplier(() -> Collections.emptyMap());
+        this.setReducingBiOperator((x, y) -> Collections.emptyMap());
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.buffer.clear();
+    }
+
+    @Override
+    public void done() {
+        super.done();
+        this.buffer.clear();
+    }
+
+    @Override
+    public Object projectTraverser(final Traverser.Admin<S> traverser) {
+        Stream.iterate(0, n -> n+1).limit(traverser.bulk()).forEach(n -> this.buffer.add(traverser.get()));
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return REQUIREMENTS;
+    }
+
+    @Override
+    public Object generateFinalResult(final Object percentileNumber) {
+        if (this.percentiles.length > 1) {
+            return NumberHelper.percentiles(this.buffer, percentiles);
+        } else if (this.percentiles.length == 1) {
+            return NumberHelper.percentile(this.buffer, percentiles[0]);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        PercentileGlobalStep<?> that = (PercentileGlobalStep<?>) o;
+        return Arrays.equals(percentiles, that.percentiles);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(percentiles);
+        return result;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileLocalStep.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.percentile;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.percentiles;
+
+/**
+ * @author Junshi Guo
+ */
+public class PercentileLocalStep<E extends Number, S extends Iterable<E>> extends MapStep<S, Object> {
+
+    private final int[] percentiles;
+
+    public PercentileLocalStep(final Traversal.Admin traversal, final int... percentiles) {
+        super(traversal);
+        this.percentiles = percentiles;
+        if (percentiles == null || percentiles.length == 0) {
+            throw new IllegalArgumentException("Percentile step should be provided at least one argument.");
+        }
+    }
+
+    @Override
+    protected Object map(final Traverser.Admin<S> traverser) {
+        final Iterator<E> iterator = traverser.get().iterator();
+        if (!iterator.hasNext()) {
+            throw FastNoSuchElementException.instance();
+        }
+        List<E> buffer = new ArrayList<>();
+        iterator.forEachRemaining(result -> buffer.add(result));
+        if (percentiles.length == 1) {
+            return percentile(buffer, percentiles[0]);
+        } else {
+            return percentiles(buffer, percentiles);
+        }
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        PercentileLocalStep<?, ?> that = (PercentileLocalStep<?, ?>) o;
+        return Arrays.equals(percentiles, that.percentiles);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(percentiles);
+        return result;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevGlobalStep.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.util.NumberHelper;
+import org.apache.tinkerpop.gremlin.util.function.StdevNumberSupplier;
+
+import java.io.Serializable;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.BinaryOperator;
+import java.util.function.Supplier;
+
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.div;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.mul;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.sub;
+
+/**
+ * @author Junshi Guo
+ */
+public class StdevGlobalStep<S extends Number, E extends Number> extends ReducingBarrierStep<S, E> {
+
+    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.OBJECT, TraverserRequirement.BULK);
+
+    public StdevGlobalStep(final Traversal.Admin traversal) {
+        super(traversal);
+        this.setSeedSupplier((Supplier) StdevNumberSupplier.instance());
+        this.setReducingBiOperator(StdevGlobalBiOperator.INSTANCE);
+    }
+
+    @Override
+    public E projectTraverser(final Traverser.Admin<S> traverser) {
+        return (E) new StdevNumber(traverser.get(), traverser.bulk());
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return REQUIREMENTS;
+    }
+
+    @Override
+    public E generateFinalResult(final E stdevNumber) {
+        return (E) ((StdevNumber) stdevNumber).getFinal();
+    }
+
+    ////////
+
+    private static final class StdevGlobalBiOperator<S extends Number> implements BinaryOperator<S>, Serializable {
+
+        private static final StdevGlobalBiOperator INSTANCE = new StdevGlobalBiOperator<>();
+
+        @Override
+        public S apply(final S mutatingSeed, final S number) {
+            if (mutatingSeed instanceof StdevNumber) {
+                return number instanceof StdevNumber ?
+                        (S) ((StdevNumber) mutatingSeed).add((StdevNumber) number) :
+                        (S) ((StdevNumber) mutatingSeed).add(number, 1l);
+            } else {
+                return number instanceof StdevNumber ?
+                        (S) ((StdevNumber) number).add(mutatingSeed, 1l) :
+                        (S) new StdevNumber(number, 1l).add(mutatingSeed, 1l);
+            }
+        }
+    }
+
+    public static final class StdevNumber extends Number implements Comparable<Number> {
+
+        private Number sum;
+        private Number squareSum;
+        private long count;
+
+        public StdevNumber() {
+            this(0, 0);
+        }
+
+        public StdevNumber(final Number value, final long count) {
+            this.count = count;
+            this.sum = mul(value, count);
+            this.squareSum = mul(mul(value, value), count);
+        }
+
+        public StdevNumber add(final Number value, final long count) {
+            this.count += count;
+            this.sum = NumberHelper.add(sum, mul(value, count));
+            this.squareSum = NumberHelper.add(squareSum, mul(mul(value, value), count));
+            return this;
+        }
+
+        public StdevNumber add(final StdevNumber other) {
+            this.count += other.count;
+            this.sum = NumberHelper.add(sum, other.sum);
+            this.squareSum = NumberHelper.add(squareSum, other.squareSum);
+            return this;
+        }
+
+        @Override
+        public int intValue() {
+            return getFinal().intValue();
+        }
+
+        @Override
+        public long longValue() {
+            return getFinal().longValue();
+        }
+
+        @Override
+        public float floatValue() {
+            return getFinal().floatValue();
+        }
+
+        @Override
+        public double doubleValue() {
+            return getFinal().doubleValue();
+        }
+
+        @Override
+        public String toString() {
+            return getFinal().toString();
+        }
+
+        @Override
+        public int compareTo(final Number number) {
+            return Double.compare(this.doubleValue(), number.doubleValue());
+        }
+
+        @Override
+        public boolean equals(final Object object) {
+            return object instanceof Number && Double.valueOf(this.doubleValue()).equals(((Number) object).doubleValue());
+        }
+
+        @Override
+        public int hashCode() {
+            return Double.valueOf(this.doubleValue()).hashCode();
+        }
+
+        public Number getFinal() {
+            Number mean = div(sum, count, true);
+            Number variation = sub(div(squareSum, count, true), mul(mean, mean));
+            return Math.sqrt(variation.doubleValue());
+        }
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevLocalStep.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser.Admin;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.div;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.mul;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.add;
+import static org.apache.tinkerpop.gremlin.util.NumberHelper.sub;
+
+/**
+ * @author Junshi Guo
+ */
+public class StdevLocalStep<E extends Number, S extends Iterable<E>> extends MapStep<S, Number> {
+
+    public StdevLocalStep(Traversal.Admin traversal) {
+        super(traversal);
+    }
+
+    @Override
+    protected Number map(final Admin<S> traverser) {
+        final Iterator<E> iterator = traverser.get().iterator();
+        if (!iterator.hasNext()) {
+            throw FastNoSuchElementException.instance();
+        }
+
+        Number sum = null;
+        Number squareSum = null;
+        int count = 0;
+        while (iterator.hasNext()) {
+            E value = iterator.next();
+            if (sum == null) {
+                sum = value;
+                squareSum = mul(value, value);
+            } else {
+                sum = add(sum, value);
+                squareSum = add(squareSum, mul(value, value));
+            }
+            count++;
+        }
+        Number mean = div(sum, count, true);
+        Number variation = sub(div(squareSum, count, true), mul(mean, mean));
+        return Math.sqrt(variation.doubleValue());
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
@@ -21,6 +21,10 @@ package org.apache.tinkerpop.gremlin.util;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 
 /**
@@ -370,6 +374,37 @@ public final class NumberHelper {
         return isNonValue(a) ? b :
                 isNonValue(b) ? a :
                         a.compareTo(b) > 0 ? a : b;
+    }
+
+    public static <S extends Number> S percentile(final List<S> nums, final int quantile) {
+        nums.sort(NumberHelper::compare);
+        return percentileHelper(nums, quantile);
+    }
+
+    public static <S extends Number> Map<Integer, S> percentiles(final List<S> nums, final int... quantiles) {
+        nums.sort(NumberHelper::compare);
+        Map<Integer, S> percentileMap = new HashMap<>(quantiles.length);
+        for (int quantile : quantiles) {
+            percentileMap.putIfAbsent(quantile, percentileHelper(nums, quantile));
+        }
+        return percentileMap;
+    }
+
+    /**
+     * The nearest-rank method described in https://en.wikipedia.org/wiki/Percentile is used to calculate percentile of input.
+     */
+    private static <S extends Number> S percentileHelper(List<S> nums, int quantiles) {
+        if (quantiles < 0 || quantiles > 100) {
+            throw new IllegalArgumentException("percentile value must between 0 and 100");
+        }
+        if (nums == null || nums.isEmpty()) {
+            return null;
+        }
+        int index = (int)Math.ceil((quantiles / 100.0) * nums.size());
+        if (index < 1) {
+            index = 1;
+        }
+        return nums.get(index - 1);
     }
 
     public static Integer compare(final Number a, final Number b) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/StdevNumberSupplier.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/StdevNumberSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.util.function;
+
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.StdevGlobalStep;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+/**
+ * @author Junshi Guo
+ */
+public final class StdevNumberSupplier implements Supplier<StdevGlobalStep.StdevNumber>, Serializable {
+
+    private static final StdevNumberSupplier INSTANCE = new StdevNumberSupplier();
+
+    private StdevNumberSupplier() {}
+
+    @Override
+    public StdevGlobalStep.StdevNumber get() {
+        return new StdevGlobalStep.StdevNumber();
+    }
+
+    public static StdevNumberSupplier instance() {
+        return INSTANCE;
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileGlobalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileGlobalStepTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Junshi Guo
+ */
+public class PercentileGlobalStepTest extends StepTest {
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Arrays.asList(
+                __.percentile(50),
+                __.percentile(50, 100),
+                __.percentile(Scope.global, 30),
+                __.percentile(Scope.global, 30, 60)
+        );
+    }
+
+    @Test
+    public void testReturnTypes() {
+        final List<Integer> list = new ArrayList<>();
+        for (int i = 1; i < 101; i++) {
+            list.add(i);
+        }
+        assertEquals(50, __.inject(list).unfold().percentile(Scope.global, 50).next());
+        Object multiPercentile = __.inject(list).unfold().percentile(50, 100).next();
+        assertTrue(multiPercentile instanceof Map);
+        Map mapResult = (Map) multiPercentile;
+        assertEquals(2, mapResult.size());
+        assertEquals(50, mapResult.get(50));
+        assertEquals(100, mapResult.get(100));
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PercentileLocalStepTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Junshi Guo
+ */
+public class PercentileLocalStepTest extends StepTest {
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Arrays.asList(
+                __.percentile(Scope.local, 50),
+                __.percentile(Scope.local, 50, 100)
+        );
+    }
+
+    @Test
+    public void testReturnTypes() {
+        final List<Integer> list = new ArrayList<>();
+        for (int i = 1; i < 101; i++) {
+            list.add(i);
+        }
+        assertEquals(50, __.inject(list).percentile(Scope.local, 50).next());
+        Object multiPercentile = __.inject(list).percentile(Scope.local, 50, 100).next();
+        assertTrue(multiPercentile instanceof Map);
+        Map mapResult = (Map) multiPercentile;
+        assertEquals(2, mapResult.size());
+        assertEquals(50, mapResult.get(50));
+        assertEquals(100, mapResult.get(100));
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevGlobalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevGlobalStepTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Junshi Guo
+ */
+public class StdevGlobalStepTest extends StepTest {
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Collections.singletonList(__.stdev());
+    }
+
+    @Test
+    public void testReturnTypes() {
+        assertEquals(0d, __.__(2, 2, 2).stdev().next());
+        assertEquals(Math.sqrt(1.25d), (Double) __.__(1, 2, 3, 4).stdev().next(), 1e-6);
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/StdevLocalStepTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Junshi Guo
+ */
+public class StdevLocalStepTest extends StepTest {
+
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Collections.singletonList(__.stdev(Scope.local));
+    }
+
+    @Test
+    public void testReturnType() {
+        assertEquals(0d, __.__(2, 2, 2).fold().stdev(Scope.local).next());
+        assertEquals(0d, __.__(2d, 2d, 2d).fold().stdev(Scope.local).next());
+        assertEquals(Math.sqrt(1.25d), (Double) __.__(1d, 2, 3, 4).fold().stdev(Scope.local).next(), 1e-6);
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -1195,6 +1195,28 @@ namespace Gremlin.Net.Process.Traversal
         }
 
         /// <summary>
+        ///     Adds the percentile step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal<S, object> Percentile (Scope scope, params int[] n)
+        {
+            var args = new List<object>(1 + n.Length) {scope};
+            args.AddRange(n);
+            Bytecode.AddStep("percentile", args.ToArray());
+            return Wrap<S, object>(this);
+        }
+
+        /// <summary>
+        ///     Adds the percentile step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal<S, object> Percentile (params int[] n)
+        {
+            var args = new List<object>(0 + n.Length) {};
+            args.AddRange(n);
+            Bytecode.AddStep("percentile", args.ToArray());
+            return Wrap<S, object>(this);
+        }
+
+        /// <summary>
         ///     Adds the profile step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
         public GraphTraversal<S, E2> Profile<E2> ()
@@ -1475,6 +1497,24 @@ namespace Gremlin.Net.Process.Traversal
         public GraphTraversal<S, E2> Skip<E2> (long skip)
         {
             Bytecode.AddStep("skip", skip);
+            return Wrap<S, E2>(this);
+        }
+
+        /// <summary>
+        ///     Adds the stdev step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal<S, E2> Stdev<E2> ()
+        {
+            Bytecode.AddStep("stdev");
+            return Wrap<S, E2>(this);
+        }
+
+        /// <summary>
+        ///     Adds the stdev step to this <see cref="GraphTraversal{SType, EType}" />.
+        /// </summary>
+        public GraphTraversal<S, E2> Stdev<E2> (Scope scope)
+        {
+            Bytecode.AddStep("stdev", scope);
             return Wrap<S, E2>(this);
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
@@ -899,6 +899,26 @@ namespace Gremlin.Net.Process.Traversal
         }
 
         /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the percentile step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Percentile(Scope scope, params int[] n)
+        {
+            return n.Length == 0
+                ? new GraphTraversal<object, object>().Percentile(scope)
+                : new GraphTraversal<object, object>().Percentile(scope, n);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the percentile step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, object> Percentile(params int[] n)
+        {
+            return n.Length == 0
+                ? new GraphTraversal<object, object>().Percentile()
+                : new GraphTraversal<object, object>().Percentile(n);            
+        }
+
+        /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the project step to that traversal.
         /// </summary>
         public static GraphTraversal<object, IDictionary<string, E2>> Project<E2>(string projectKey, params string[] projectKeys)
@@ -1110,6 +1130,22 @@ namespace Gremlin.Net.Process.Traversal
         public static GraphTraversal<object, E2> Skip<E2>(long skip)
         {
             return new GraphTraversal<object, E2>().Skip<E2>(skip);            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the stdev step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, double> Stdev()
+        {
+            return new GraphTraversal<object, double>().Stdev();            
+        }
+
+        /// <summary>
+        ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the stdev step to that traversal.
+        /// </summary>
+        public static GraphTraversal<object, double> Stdev(Scope scope)
+        {
+            return new GraphTraversal<object, double>().Stdev(scope);            
         }
 
         /// <summary>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
@@ -913,6 +913,16 @@ class GraphTraversal extends Traversal {
   }
   
   /**
+   * Graph traversal percentile method.
+   * @param {...Object} args
+   * @returns {GraphTraversal}
+   */
+  percentile(...args) {
+    this.bytecode.addStep('percentile', args);
+    return this;
+  }
+  
+  /**
    * Graph traversal profile method.
    * @param {...Object} args
    * @returns {GraphTraversal}
@@ -1069,6 +1079,16 @@ class GraphTraversal extends Traversal {
    */
   skip(...args) {
     this.bytecode.addStep('skip', args);
+    return this;
+  }
+  
+  /**
+   * Graph traversal stdev method.
+   * @param {...Object} args
+   * @returns {GraphTraversal}
+   */
+  stdev(...args) {
+    this.bytecode.addStep('stdev', args);
     return this;
   }
   
@@ -1335,6 +1355,7 @@ const statics = {
   outE: (...args) => callOnEmptyTraversal('outE', args),
   outV: (...args) => callOnEmptyTraversal('outV', args),
   path: (...args) => callOnEmptyTraversal('path', args),
+  percentile: (...args) => callOnEmptyTraversal('percentile', args),
   project: (...args) => callOnEmptyTraversal('project', args),
   properties: (...args) => callOnEmptyTraversal('properties', args),
   property: (...args) => callOnEmptyTraversal('property', args),
@@ -1347,6 +1368,7 @@ const statics = {
   sideEffect: (...args) => callOnEmptyTraversal('sideEffect', args),
   simplePath: (...args) => callOnEmptyTraversal('simplePath', args),
   skip: (...args) => callOnEmptyTraversal('skip', args),
+  stdev: (...args) => callOnEmptyTraversal('stdev', args),
   store: (...args) => callOnEmptyTraversal('store', args),
   subgraph: (...args) => callOnEmptyTraversal('subgraph', args),
   sum: (...args) => callOnEmptyTraversal('sum', args),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2487

Added two frequently used analytical steps for calculation of standard deviation and percentile value. The example usage is 

```
gremlin> g.V().values('ages')
==>1
==>2
==>3
gremlin> g.V().values('ages').stdev()
==>0.816
gremlin> g.V().values('ages').fold().stdev(Scope.local)
==>0.816

gremlin> g.V().values('ages').percentile(50)
==>2
// one percentile, return single value
gremlin> g.V().values('ages').percentile(0, 100)
==>[0: 1, 100: 3]
// multiple percentiles, return a map
```
