### PR TITLE
TINKERPOP-2473 Prevented assignment of more than one strategy of the same type.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Allowed the possibility for the propagation of `null` as a `Traverser` in Gremlin.
 * Fixed a bug where spark-gremlin was not re-attaching properties when using `dedup()`.
 * Ensured better consistency of the use of `null` as arguments to mutation steps.
+* Prevented `TraversalStrategy` instances from being added more than once, where the new instance replaces the old.
 * Allowed `property(T.label,Object)` to be used if no value was supplied to `addV(String)`.
 * Allowed additional arguments to `Client.submit()` in Javascript driver to enable setting of parameters like `scriptEvaluationTimeout`.
 * Gremlin.Net driver no longer supports skipping deserialization by default. Users can however create their own `IMessageSerializer` if they need this functionality.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3816,12 +3816,11 @@ Therefore, one should keep the following in mind when modifying the list of `Tra
 `conf/gremlin-server-modern-readonly.yaml` file from the Gremlin Server distribution, which applies the `ReadOnlyStrategy`
 to the `GraphTraversalSource` that remote clients can connect to. However, a remote client can remove it on its turn
 by applying the `withoutStrategies()` step with the `ReadOnlyStrategy`.
-* The traversal strategies assume that they are only applied once: no exception is raised or warning is logged when you
-try it nevertheless. As a result, the behavior in case of multiple application of the same traversal strategy is
-unspecified. For some, like the <<partitionstrategy, PartitionStrategy>> the first instance prevails. For others, like
-the <<subgraphstrategy, SubgraphStrategy>>, the last instance prevails. The `OptionStrategy`, which is applied
-implicitly as a result of a `with()` step, is an exception in that it actually merges the parameters of multiple
-`with()` steps.
+* When a `TraversalStrategy` of a particular type is added, it replaces any instances of its type that exist prior to
+it. Multiple instances of a `TraversalStrategy` can therefore not be registered and their functionality is no way
+merged automatically. Therefore, if there is a particular strategy registered whose functionality needs to be changed
+it is important to either find and modify the existing instance or construct a new one copying the options to keep
+from the old to the new instance.
 
 === Definition
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
@@ -367,7 +367,7 @@ public interface TraversalSource extends Cloneable, AutoCloseable {
         return clone;
     }
 
-    public default Optional<Class> getAnonymousTraversalClass() {
+    public default Optional<Class<?>> getAnonymousTraversalClass() {
         return Optional.empty();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -97,8 +97,9 @@ public interface TraversalStrategies extends Serializable, Cloneable, Iterable<T
     }
 
     /**
-     * Add all the provided {@link TraversalStrategy} instances to the current collection.
-     * When all the provided strategies have been added, the collection is resorted.
+     * Add all the provided {@link TraversalStrategy} instances to the current collection. When all the provided
+     * strategies have been added, the collection is resorted. If a strategy class is found to already be defined, it
+     * is removed and replaced by the newly added one.
      *
      * @param strategies the traversal strategies to add
      * @return the newly updated/sorted traversal strategies collection
@@ -135,7 +136,6 @@ public interface TraversalStrategies extends Serializable, Cloneable, Iterable<T
             strategyClasses.add(s.getClass());
             MultiMap.put(strategiesByCategory, s.getTraversalCategory(), s.getClass());
         });
-
 
         //Initialize all the dependencies
         strategies.forEach(strategy -> {
@@ -191,7 +191,6 @@ public interface TraversalStrategies extends Serializable, Cloneable, Iterable<T
                     + seenStrategyClases + ']');
         }
 
-
         if (unprocessedStrategyClasses.contains(strategyClass)) {
             seenStrategyClases.add(strategyClass);
             for (Class<? extends TraversalStrategy> dependency : MultiMap.get(dependencyMap, strategyClass)) {
@@ -209,7 +208,7 @@ public interface TraversalStrategies extends Serializable, Cloneable, Iterable<T
          * Keeps track of {@link GraphComputer} and/or {@link Graph} classes that have been initialized to the
          * classloader so that they do not have to be reflected again.
          */
-        private static Set<Class> LOADED = ConcurrentHashMap.newKeySet();
+        private static final Set<Class<?>> LOADED = ConcurrentHashMap.newKeySet();
 
         private static final Map<Class<? extends Graph>, TraversalStrategies> GRAPH_CACHE = new HashMap<>();
         private static final Map<Class<? extends GraphComputer>, TraversalStrategies> GRAPH_COMPUTER_CACHE = new HashMap<>();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java
@@ -27,6 +27,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+import com.squareup.javapoet.WildcardTypeName;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
@@ -57,10 +58,10 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.NoType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
@@ -355,7 +356,8 @@ public class GremlinDslProcessor extends AbstractProcessor {
                     .addModifiers(Modifier.PUBLIC)
                     .addAnnotation(Override.class)
                     .addStatement("return Optional.of(__.class)")
-                    .returns(ParameterizedTypeName.get(Optional.class, Class.class))
+                    .returns(ParameterizedTypeName.get(ClassName.get(Optional.class),
+                             ParameterizedTypeName.get(ClassName.get(Class.class), WildcardTypeName.subtypeOf(Object.class))))
                     .build());
         }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -75,11 +75,6 @@ public class GraphTraversalSource implements TraversalSource {
 
     ////////////////
 
-    @Override
-    public Optional<Class> getAnonymousTraversalClass() {
-        return Optional.of(__.class);
-    }
-
     public GraphTraversalSource(final Graph graph, final TraversalStrategies traversalStrategies) {
         this.graph = graph;
         this.strategies = traversalStrategies;
@@ -93,6 +88,11 @@ public class GraphTraversalSource implements TraversalSource {
         this(EmptyGraph.instance(), TraversalStrategies.GlobalCache.getStrategies(EmptyGraph.class).clone());
         this.connection = connection;
         this.strategies.addStrategies(new RemoteStrategy(connection));
+    }
+
+    @Override
+    public Optional<Class<?>> getAnonymousTraversalClass() {
+        return Optional.of(__.class);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategies.java
@@ -41,7 +41,8 @@ public class DefaultTraversalStrategies implements TraversalStrategies {
     @SuppressWarnings({"unchecked", "varargs"})
     public TraversalStrategies addStrategies(final TraversalStrategy<?>... strategies) {
         for (final TraversalStrategy<?> addStrategy : strategies) {
-            this.traversalStrategies.remove(addStrategy);
+            // search by class to prevent strategies from being added more than once
+            getStrategy(addStrategy.getClass()).ifPresent(s -> this.traversalStrategies.remove(s));
         }
         Collections.addAll(this.traversalStrategies, strategies);
         this.traversalStrategies = TraversalStrategies.sortStrategies(this.traversalStrategies);

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategiesTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategiesTest.java
@@ -26,7 +26,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SideEf
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -48,9 +49,20 @@ public class DefaultTraversalStrategiesTest {
             o = new TraversalStrategiesTest.StrategyO();
 
     @Test
+    public void testNoRepeatStrategies() {
+        final TraversalStrategies s = new DefaultTraversalStrategies();
+        s.addStrategies(b, a, d, b, a, a, d, d);
+        s.addStrategies(new TraversalStrategiesTest.StrategyD(), new TraversalStrategiesTest.StrategyB());
+        assertEquals(3, s.toList().size());
+        assertEquals(a, s.toList().get(0));
+        assertEquals(b, s.toList().get(1));
+        assertEquals(d, s.toList().get(2));
+    }
+
+    @Test
     public void testWellDefinedDependency() {
         //Dependency well defined
-        TraversalStrategies s = new DefaultTraversalStrategies();
+        final TraversalStrategies s = new DefaultTraversalStrategies();
         s.addStrategies(b, a);
         assertEquals(2, s.toList().size());
         assertEquals(a, s.toList().get(0));
@@ -60,7 +72,7 @@ public class DefaultTraversalStrategiesTest {
     @Test
     public void testNoDependency() {
         //No dependency
-        TraversalStrategies s = new DefaultTraversalStrategies();
+        final TraversalStrategies s = new DefaultTraversalStrategies();
         s.addStrategies(c, a);
         assertEquals(2, s.toList().size());
     }
@@ -84,7 +96,7 @@ public class DefaultTraversalStrategiesTest {
     @Test
     public void testCircularDependency() {
         //Circular dependency => throws exception
-        TraversalStrategies s = new DefaultTraversalStrategies();
+        final TraversalStrategies s = new DefaultTraversalStrategies();
         try {
             s.addStrategies(c, k, a, b);
             fail();
@@ -116,7 +128,7 @@ public class DefaultTraversalStrategiesTest {
     @Test
     public void testCircularDependency2() {
         //Circular dependency => throws exception
-        TraversalStrategies s = new DefaultTraversalStrategies();
+        final TraversalStrategies s = new DefaultTraversalStrategies();
         try {
             s.addStrategies(d, c, k, a, e, b);
             fail();
@@ -199,10 +211,10 @@ public class DefaultTraversalStrategiesTest {
         assertEquals(1, fifthTraversal.getSideEffects().keys().size());
         assertEquals(2, fifthTraversal.getSideEffects().<Integer>get("a").intValue());
 
-        assertTrue(firstTraversal.getStrategies() == secondTraversal.getStrategies());
-        assertTrue(firstTraversal.getStrategies() != thirdTraversal.getStrategies());
-        assertTrue(forthTraversal.getStrategies() == thirdTraversal.getStrategies());
-        assertTrue(fifthTraversal.getStrategies() == firstTraversal.getStrategies());
+        assertSame(firstTraversal.getStrategies(), secondTraversal.getStrategies());
+        assertNotSame(firstTraversal.getStrategies(), thirdTraversal.getStrategies());
+        assertSame(forthTraversal.getStrategies(), thirdTraversal.getStrategies());
+        assertSame(fifthTraversal.getStrategies(), firstTraversal.getStrategies());
     }
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2473

Don't think that this is a major change in the sense that it's unlikely that anyone was relying on the old behavior. The code now just better enforces what was expected to happen.

VOTE +1