### PR TITLE
TINKERPOP-2481 Consistent match() output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,8 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Added `Grouping` step interface.
 * Added `TraversalParent.replaceTraversal()` which can replace a direct child traversal.
 * Added `ByModulatorOptimizationStrategy` which replaces certain standard traversals w/ optimized traversals (e.g. `TokenTraversal`).
+* Improved `IdentityRemovalStrategy` by accounting for `EndStep` situations.
+* Added `IdentityRemovalStrategy` to the standard list of `TraversalStrategies`.
 * Refactored `MapStep` to move its logic to `ScalarMapStep` so that the old behavior could be preserved while allow other implementations to have more flexibility.
 * Modified TinkerGraph to support `null` property values and can be configured to disable that feature.
 * Modified `null` handling in mutations to be consistent for a new `Vertex` as well as update to an existing one.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Added `ByModulatorOptimizationStrategy` which replaces certain standard traversals w/ optimized traversals (e.g. `TokenTraversal`).
 * Improved `IdentityRemovalStrategy` by accounting for `EndStep` situations.
 * Added `IdentityRemovalStrategy` to the standard list of `TraversalStrategies`.
+* Modified `PathRetractionStrategy` to leave labels more often with `match()` cases to return more consistent results.
 * Refactored `MapStep` to move its logic to `ScalarMapStep` so that the old behavior could be preserved while allow other implementations to have more flexibility.
 * Modified TinkerGraph to support `null` property values and can be configured to disable that feature.
 * Modified `null` handling in mutations to be consistent for a new `Vertex` as well as update to an existing one.

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -435,6 +435,68 @@ configuration options may have changed.
 * Experimental support for multi/meta-properties in Neo4j which were previously deprecated have now been permanently
 removed.
 
+==== match() Consistency
+
+The `match()` step behavior might have seemed inconsistent those first using it. While there are a number of examples
+that might demonstrate this issue, the easiest one to consume would be:
+
+[source,text]
+----
+gremlin> g.V().match(__.as("a").out("knows").as("b"))
+==>[a:v[1],b:v[2]]
+==>[a:v[1],b:v[4]]
+gremlin> g.V().match(__.as("a").out("knows").as("b")).unfold()
+gremlin> g.V().match(__.as("a").out("knows").as("b")).identity()
+==>[]
+==>[]
+----
+
+The output is unexpected if there isn't awareness of some underlying optimizations at play, where `match()` as the
+final step in the traversal implies that the user wants all of the labels as part of the output. With the addition
+of the extra steps, `unfold()` and `identity()` in the above case, the implication is that the traversal must be
+explicit in the labels to preserve from match, thus:
+
+[source,text]
+----
+gremlin> g.V().match(__.as("a").out("knows").as("b")).select('a','b').unfold()
+==>a=v[1]
+==>b=v[2]
+==>a=v[1]
+==>b=v[4]
+gremlin> g.V().match(__.as("a").out("knows").as("b")).select('a','b').identity()
+==>[a:v[1],b:v[2]]
+==>[a:v[1],b:v[4]]
+----
+
+Being explicit, as is the preference in writing Gremlin to good form, helps restrict the path history required to
+execute the traversal and therefore preserves memory. Of course, making `match()` a special form of end step is a
+confusing approach as the behavior of the step changes simply because another step is in play. Furthermore, correct
+execution of the traversal, relies on the execution of traversal strategies when the same traversal should produce
+the same results irrespective of the strategies applied to it.
+
+In 3.5.0, we look to better adhere to that guiding design principle and ensure a more consistent output for these types
+of traversals. While the preferred method is to specify the labels to preserve from `match()` with a following
+`select()` step as shown above, `match()` will now consistently return all labels when they are not specified
+explicitly.
+
+[source,text]
+----
+gremlin> g.V().match(__.as("a").out("knows").as("b"))
+==>[a:v[1],b:v[2]]
+==>[a:v[1],b:v[4]]
+gremlin> g.V().match(__.as("a").out("knows").as("b")).identity()
+==>[a:v[1],b:v[2]]
+==>[a:v[1],b:v[4]]
+gremlin> g.V().match(__.as("a").out("knows").as("b")).unfold()
+==>a=v[1]
+==>b=v[2]
+==>a=v[1]
+==>b=v[4]
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2481[TINKERPOP-2481],
+link:https://issues.apache.org/jira/browse/TINKERPOP-2499[TINKERPOP-2499]
+
 ==== Deprecation Removal
 
 The following deprecated classes, methods or fields have been removed in this version:

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Step.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Step.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal;
 
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 
 import java.io.Serializable;
@@ -52,6 +53,14 @@ public interface Step<S, E> extends Iterator<Traverser.Admin<E>>, Serializable, 
      * @param start The traverser to add
      */
     public void addStart(final Traverser.Admin<S> start);
+
+    /**
+     * Determines if starts objects are present without iterating forward. This function has special applicability
+     * around {@link ReducingBarrierStep} implementations where they always return {@code true} for calls to
+     * {@link #hasNext()}. Using this function gives insight to what the step itself is holding in its iterator without
+     * performing any sort of processing on the step itself.
+     */
+    public boolean hasStarts();
 
     /**
      * Set the step that is previous to the current step.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.Coun
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.EarlyLimitStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.ByModulatorOptimizationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.FilterRankingStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IdentityRemovalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.InlineFilterStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
@@ -217,6 +218,7 @@ public interface TraversalStrategies extends Serializable, Cloneable, Iterable<T
         static {
             final TraversalStrategies graphStrategies = new DefaultTraversalStrategies();
             graphStrategies.addStrategies(
+                    IdentityRemovalStrategy.instance(),
                     ConnectiveStrategy.instance(),
                     EarlyLimitStrategy.instance(),
                     InlineFilterStrategy.instance(),

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/AbstractStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/AbstractStep.java
@@ -98,6 +98,11 @@ public abstract class AbstractStep<S, E> implements Step<S, E> {
     }
 
     @Override
+    public boolean hasStarts() {
+        return this.starts.hasNext();
+    }
+
+    @Override
     public void setPreviousStep(final Step<?, S> step) {
         this.previousStep = step;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/EmptyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/EmptyStep.java
@@ -50,6 +50,11 @@ public final class EmptyStep<S, E> implements Step<S, E>, TraversalParent {
     }
 
     @Override
+    public boolean hasStarts() {
+        return false;
+    }
+
+    @Override
     public void addStart(final Traverser.Admin<S> start) {
 
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PathUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PathUtil.java
@@ -58,7 +58,6 @@ public class PathUtil {
                 }
             }
             referencedLabels.addAll(labels);
-
         }
 
         return referencedLabels;

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalTest.java
@@ -179,6 +179,11 @@ public class TraversalTest {
         }
 
         @Override
+        public boolean hasStarts() {
+            return false;
+        }
+
+        @Override
         public void setPreviousStep(final Step step) {
 
         }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/gremlin.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/gremlin.js
@@ -391,6 +391,7 @@ const gremlins = {
     g_V_matchXa_followedBy_count_isXgtX10XX_b__a_0followedBy_count_isXgtX10XX_bX_count: [function({g}) { return g.V().match(__.as("a").out("followedBy").count().is(P.gt(10)).as("b"),__.as("a").in_("followedBy").count().is(P.gt(10)).as("b")).count() }], 
     g_V_matchXa_0sungBy_b__a_0writtenBy_c__b_writtenBy_dX_whereXc_sungBy_dX_whereXd_hasXname_GarciaXX: [function({g}) { return g.V().match(__.as("a").in_("sungBy").as("b"),__.as("a").in_("writtenBy").as("c"),__.as("b").out("writtenBy").as("d")).where(__.as("c").out("sungBy").as("d")).where(__.as("d").has("name","Garcia")) }], 
     g_V_matchXa_hasXname_GarciaX__a_0writtenBy_b__b_followedBy_c__c_writtenBy_d__whereXd_neqXaXXX: [function({g}) { return g.V().match(__.as("a").has("name","Garcia"),__.as("a").in_("writtenBy").as("b"),__.as("b").out("followedBy").as("c"),__.as("c").out("writtenBy").as("d"),__.where("d",P.neq("a"))) }], 
+    g_V_matchXa_outXknowsX_name_bX_identity: [function({g}) { return g.V().match(__.as("a").out("knows").values("name").as("b")).identity() }], 
     g_V_outE_mathX0_minus_itX_byXweightX: [function({g}) { return g.V().outE().math("0-_").by("weight") }], 
     g_V_hasXageX_valueMap_mathXit_plus_itXbyXselectXageX_unfoldXX: [function({g}) { return g.V().has("age").valueMap().math("_+_").by(__.select("age").unfold()) }], 
     g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX: [function({g}) { return g.V().as("a").out("knows").as("b").math("a + b").by("age") }], 

--- a/gremlin-python/src/main/python/radish/gremlin.py
+++ b/gremlin-python/src/main/python/radish/gremlin.py
@@ -376,6 +376,7 @@ world.gremlins = {
     'g_V_matchXa_followedBy_count_isXgtX10XX_b__a_0followedBy_count_isXgtX10XX_bX_count': [(lambda g:g.V().match(__.as_('a').out('followedBy').count().is_(P.gt(10)).as_('b'),__.as_('a').in_('followedBy').count().is_(P.gt(10)).as_('b')).count())], 
     'g_V_matchXa_0sungBy_b__a_0writtenBy_c__b_writtenBy_dX_whereXc_sungBy_dX_whereXd_hasXname_GarciaXX': [(lambda g:g.V().match(__.as_('a').in_('sungBy').as_('b'),__.as_('a').in_('writtenBy').as_('c'),__.as_('b').out('writtenBy').as_('d')).where(__.as_('c').out('sungBy').as_('d')).where(__.as_('d').has('name','Garcia')))], 
     'g_V_matchXa_hasXname_GarciaX__a_0writtenBy_b__b_followedBy_c__c_writtenBy_d__whereXd_neqXaXXX': [(lambda g:g.V().match(__.as_('a').has('name','Garcia'),__.as_('a').in_('writtenBy').as_('b'),__.as_('b').out('followedBy').as_('c'),__.as_('c').out('writtenBy').as_('d'),__.where('d',P.neq('a'))))], 
+    'g_V_matchXa_outXknowsX_name_bX_identity': [(lambda g:g.V().match(__.as_('a').out('knows').name.as_('b')).identity())], 
     'g_V_outE_mathX0_minus_itX_byXweightX': [(lambda g:g.V().outE().math('0-_').by('weight'))], 
     'g_V_hasXageX_valueMap_mathXit_plus_itXbyXselectXageX_unfoldXX': [(lambda g:g.V().has('age').valueMap().math('_+_').by(__.select('age').unfold()))], 
     'g_V_asXaX_outXknowsX_asXbX_mathXa_plus_bX_byXageX': [(lambda g:g.V().as_('a').out('knows').as_('b').math('a + b').by('age'))], 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
@@ -71,7 +71,7 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
     public void shouldCloseConnectionDeadDueToUnRecoverableError() throws Exception {
         // Set a low value of maxContentLength to intentionally trigger CorruptedFrameException
         final Cluster cluster = TestClientFactory.build()
-                                                 .serializer(Serializers.GRYO_V3D0)
+                                                 .serializer(Serializers.GRAPHBINARY_V1D0)
                                                  .maxContentLength(64)
                                                  .minConnectionPoolSize(1)
                                                  .maxConnectionPoolSize(2)
@@ -88,6 +88,8 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
             } catch (Exception re) {
                 assertThat(re.getCause() instanceof CorruptedFrameException, is(true));
             }
+
+            Thread.sleep(3000);
 
             // Assert that the host has not been marked unavailable
             assertEquals(1, cluster.availableHosts().size());

--- a/gremlin-test/features/map/Match.feature
+++ b/gremlin-test/features/map/Match.feature
@@ -540,3 +540,14 @@ Feature: Step - match()
       | m[{"a":"v[Garcia]","b":"v[CRYPTICAL ENVELOPMENT]","c":"v[THE OTHER ONE]","d":"v[Weir]"}] |
       | m[{"a":"v[Garcia]","b":"v[CRYPTICAL ENVELOPMENT]","c":"v[WHARF RAT]","d":"v[Hunter]"}] |
 
+  Scenario: g_V_matchXa_outXknowsX_name_bX_identity
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().match(__.as("a").out("knows").values("name").as("b")).identity()
+      """
+    When iterated to list
+    Then the result should be unordered
+      | result |
+      | m[{"a":"v[marko]","b":"vadas"}] |
+      | m[{"a":"v[marko]","b":"josh"}] |

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchTest.java
@@ -69,6 +69,8 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, Object>> get_g_V_valueMap_matchXa_selectXnameX_bX();
 
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_matchXa_outXknowsX_name_bX_identity();
+
     // very basic query
     public abstract Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_out_bX();
 
@@ -608,6 +610,16 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
                 "a", "josh", "b", "ripple"), traversal);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_matchXa_outXknowsX_name_bX_identity() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_matchXa_outXknowsX_name_bX_identity();
+        printTraversalForm(traversal);
+        checkResults(makeMapList(2,
+                "a", convertToVertex(graph, "marko"), "b", "vadas",
+                "a", convertToVertex(graph, "marko"), "b", "josh"), traversal);
+    }
+
     public static class GreedyMatchTraversals extends Traversals {
         @Before
         public void setupTest() {
@@ -624,6 +636,11 @@ public abstract class MatchTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_valueMap_matchXa_selectXnameX_bX() {
             return g.V().valueMap().match(as("a").select("name").as("b"));
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_matchXa_outXknowsX_name_bX_identity() {
+            return g.V().match(__.as("a").out("knows").values("name").as("b")).identity();
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/EarlyLimitStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/EarlyLimitStrategyProcessTest.java
@@ -35,8 +35,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.GRATEFUL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -92,10 +93,10 @@ public class EarlyLimitStrategyProcessTest extends AbstractGremlinProcessTest {
 
         if (t.asAdmin().getStrategies().getStrategy(EarlyLimitStrategy.class).isPresent()) {
             assertEquals(10, metrics.getMetrics().size());
-            assertTrue(metrics.getMetrics(5).getName().endsWith("@[d]"));
+            assertThat(metrics.getMetrics(5).getName().endsWith("@[d]"), is(true));
             assertEquals("RangeGlobalStep(0,1)", metrics.getMetrics(6).getName());
             assertEquals("PathStep@[e]", metrics.getMetrics(7).getName());
-            assertTrue(metrics.getMetrics(7).getCounts().values().stream().allMatch(x -> x == 1L));
+            assertThat(metrics.getMetrics(7).getCounts().values().stream().allMatch(x -> x == 1L), is(true));
         } else {
             assertEquals(11, metrics.getMetrics().size());
             assertEquals("RangeGlobalStep(0,5)@[d]", metrics.getMetrics(6).getName());
@@ -105,7 +106,7 @@ public class EarlyLimitStrategyProcessTest extends AbstractGremlinProcessTest {
             // forward pulling an extra traverser, so pretty sure the correct assertion is to match what happens with
             // EarlyLimitStrategy above. i'm not even sure there is a point to asserting this anymore as the original
             // intent does not appear clear to me, but i will leave it for now.
-            assertTrue(metrics.getMetrics(7).getCounts().values().stream().allMatch(x -> x == 1L));
+            assertThat(metrics.getMetrics(7).getCounts().values().stream().allMatch(x -> x == 1L), is(true));
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2481
https://issues.apache.org/jira/browse/TINKERPOP-2499

Before:

```text
gremlin> g.V().match(__.as("a").out("knows").as("b"))
==>[a:v[1],b:v[2]]
==>[a:v[1],b:v[4]]
gremlin> g.V().match(__.as("a").out("knows").as("b")).unfold()
gremlin> g.V().match(__.as("a").out("knows").as("b")).identity()
==>[]
==>[]
```

After:

```text
gremlin> g.V().match(__.as("a").out("knows").as("b"))
==>[a:v[1],b:v[2]]
==>[a:v[1],b:v[4]]
gremlin> g.V().match(__.as("a").out("knows").as("b")).identity()
==>[a:v[1],b:v[2]]
==>[a:v[1],b:v[4]]
gremlin> g.V().match(__.as("a").out("knows").as("b")).unfold()
==>a=v[1]
==>b=v[2]
==>a=v[1]
==>b=v[4]
```

This change goes for consistency of output over optimization avoiding a situation where the addition of a step alters its behavior in some unexpected way. This is effectively a breaking change as it modifies the output of traversal output.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1