### PR TITLE
Use a List of strategies instead of Set

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -24,18 +24,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.optimiza
 import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.optimization.MessagePassingReductionStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.AdjacentToIncidentStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.CountStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.EarlyLimitStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.FilterRankingStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.InlineFilterStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.MatchPredicateStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.OrderLimitStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathRetractionStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.RepeatUnrollStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.*;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.StandardVerificationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
@@ -44,16 +33,7 @@ import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.tools.MultiMap;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -125,7 +105,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
      *
      * @param strategies the traversal strategies to sort
      */
-    public static Set<TraversalStrategy<?>> sortStrategies(final Set<TraversalStrategy<?>> strategies) {
+    public static List<TraversalStrategy<?>> sortStrategies(final List<TraversalStrategy<?>> strategies) {
         final Map<Class<? extends TraversalStrategy>, Set<Class<? extends TraversalStrategy>>> dependencyMap = new HashMap<>();
         final Map<Class<? extends TraversalStrategy>, Set<Class<? extends TraversalStrategy>>> strategiesByCategory = new HashMap<>();
         final Set<Class<? extends TraversalStrategy>> strategyClasses = new HashSet<>(strategies.size());
@@ -168,7 +148,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
             visit(dependencyMap, sortedStrategyClasses, seenStrategyClasses, unprocessedStrategyClasses, strategy);
         }
 
-        final Set<TraversalStrategy<?>> sortedStrategies = new LinkedHashSet<>();
+        final List<TraversalStrategy<?>> sortedStrategies = new ArrayList<>();
         //We now have a linked set of sorted strategy classes
         for (Class<? extends TraversalStrategy> strategyClass : sortedStrategyClasses) {
             for (TraversalStrategy strategy : strategies) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalStrategies.java
@@ -25,17 +25,15 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class DefaultTraversalStrategies implements TraversalStrategies {
 
-    protected Set<TraversalStrategy<?>> traversalStrategies = new LinkedHashSet<>();
+    protected List<TraversalStrategy<?>> traversalStrategies = new ArrayList<>();
 
     @Override
     @SuppressWarnings({"unchecked", "varargs"})
@@ -93,7 +91,7 @@ public class DefaultTraversalStrategies implements TraversalStrategies {
     public DefaultTraversalStrategies clone() {
         try {
             final DefaultTraversalStrategies clone = (DefaultTraversalStrategies) super.clone();
-            clone.traversalStrategies = new LinkedHashSet<>(this.traversalStrategies.size());
+            clone.traversalStrategies = new ArrayList<>(this.traversalStrategies.size());
             clone.traversalStrategies.addAll(this.traversalStrategies);
             return clone;
         } catch (final CloneNotSupportedException e) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
@@ -34,23 +34,13 @@ import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -227,7 +217,7 @@ public class TraversalStrategiesTest {
     }
 
     /**
-     * Tests that {@link org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies#sortStrategies(java.util.Set)}
+     * Tests that {@link org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies#sortStrategies(java.util.List)}
      * works as advertised. This class defines a bunch of dummy strategies which define an order. It is verified
      * that the right order is being returned.
      */
@@ -245,10 +235,10 @@ public class TraversalStrategiesTest {
                 n = new StrategyN(),
                 o = new StrategyO();
 
-        Set<TraversalStrategy<?>> s;
+        List<TraversalStrategy<?>> s;
 
         //Dependency well defined
-        s = new LinkedHashSet<>((Collection) Arrays.asList(b, a));
+        s = new ArrayList<>((Collection) Arrays.asList(b, a));
         s = TraversalStrategies.sortStrategies(s);
         Iterator<TraversalStrategy<?>> it = s.iterator();
         assertEquals(2, s.size());
@@ -256,12 +246,12 @@ public class TraversalStrategiesTest {
         assertEquals(b, it.next());
 
         //No dependency
-        s = new LinkedHashSet<>((Collection) Arrays.asList(c, a));
+        s = new ArrayList<>((Collection) Arrays.asList(c, a));
         s = TraversalStrategies.sortStrategies(s);
         assertEquals(2, s.size());
 
         //Dependency well defined
-        s = new LinkedHashSet<>((Collection)Arrays.asList(c, a, b));
+        s = new ArrayList<>((Collection)Arrays.asList(c, a, b));
         s = TraversalStrategies.sortStrategies(s);
         assertEquals(3, s.size());
         it = s.iterator();
@@ -270,7 +260,7 @@ public class TraversalStrategiesTest {
         assertEquals(c, it.next());
 
         //Circular dependency => throws exception
-        s = new LinkedHashSet<>((Collection)Arrays.asList(c, k, a, b));
+        s = new ArrayList<>((Collection)Arrays.asList(c, k, a, b));
         try {
             TraversalStrategies.sortStrategies(s);
             fail();
@@ -279,7 +269,7 @@ public class TraversalStrategiesTest {
         }
 
         //Dependency well defined
-        s = new LinkedHashSet<>((Collection) Arrays.asList(d, c, a, e, b));
+        s = new ArrayList<>((Collection) Arrays.asList(d, c, a, e, b));
         s = TraversalStrategies.sortStrategies(s);
         assertEquals(5, s.size());
         it = s.iterator();
@@ -290,7 +280,7 @@ public class TraversalStrategiesTest {
         assertEquals(e, it.next());
 
         //Circular dependency => throws exception
-        s = new LinkedHashSet<>((Collection) Arrays.asList(d, c, k, a, e, b));
+        s = new ArrayList<>((Collection) Arrays.asList(d, c, k, a, e, b));
         try {
             TraversalStrategies.sortStrategies(s);
             fail();
@@ -299,13 +289,13 @@ public class TraversalStrategiesTest {
         }
 
         //Lots of strategies
-        s = new LinkedHashSet<>((Collection) Arrays.asList(b, l, m, n, o, a));
+        s = new ArrayList<>((Collection) Arrays.asList(b, l, m, n, o, a));
         s = TraversalStrategies.sortStrategies(s);
         List<TraversalStrategy<?>> list = new ArrayList<>(s);
         assertTrue(list.indexOf(a) < list.indexOf(b));
 
         // sort and then add more
-        s = new LinkedHashSet<>(new LinkedHashSet<>((Collection) Arrays.asList(b, a, c)));
+        s = new ArrayList<>(new LinkedHashSet<>((Collection) Arrays.asList(b, a, c)));
         s = TraversalStrategies.sortStrategies(s);
         assertEquals(3, s.size());
         it = s.iterator();
@@ -437,10 +427,10 @@ public class TraversalStrategiesTest {
                 e = new StrategyEFinalization(),
                 k = new StrategyKVerification();
 
-        Set<TraversalStrategy<?>> s;
+        List<TraversalStrategy<?>> s;
 
         //in category sorting
-        s = new LinkedHashSet<>((Collection) Arrays.asList(b, a));
+        s = new ArrayList<>((Collection) Arrays.asList(b, a));
         s = TraversalStrategies.sortStrategies(s);
         assertEquals(2, s.size());
         Iterator<TraversalStrategy<?>> it = s.iterator();
@@ -448,7 +438,7 @@ public class TraversalStrategiesTest {
         assertEquals(b, it.next());
 
         //mixed category sorting
-        s = new LinkedHashSet<>((Collection) Arrays.asList(a, e, b, d));
+        s = new ArrayList<>((Collection) Arrays.asList(a, e, b, d));
         s = TraversalStrategies.sortStrategies(s);
         assertEquals(4, s.size());
         it = s.iterator();
@@ -458,7 +448,7 @@ public class TraversalStrategiesTest {
         assertEquals(e, it.next());
 
         //full reverse sorting
-        s = new LinkedHashSet<>((Collection) Arrays.asList(k, e, d, c, b, a));
+        s = new ArrayList<>((Collection) Arrays.asList(k, e, d, c, b, a));
         s = TraversalStrategies.sortStrategies(s);
         assertEquals(6, s.size());
         it = s.iterator();


### PR DESCRIPTION
### Issue

If we configure 2 strategies with same class, only one is used.
Consider this gremlin query:

```
gremlin> graph.traversal().withStrategies(PartitionStrategy.build().partitionKey("_partition").writePartition("a").readPartitions("a").create(), PartitionStrategy.build().partitionKey("_partition").writePartition("b").readPartitions("b").create()).strategies
==>strategies[ConnectiveStrategy, PartitionStrategy, MatchPredicateStrategy, FilterRankingStrategy, InlineFilterStrategy, IncidentToAdjacentStrategy, AdjacentToIncidentStrategy, RepeatUnrollStrategy, PathRetractionStrategy, CountStrategy, EarlyLimitStrategy, LazyBarrierStrategy, BitsyTraversalStrategy, ProfileStrategy, StandardVerificationStrategy]
```

this is the desired result (2 PartitionStrategy in the list): 

```
gremlin> graph.traversal().withStrategies(PartitionStrategy.build().partitionKey("_partition").writePartition("a").readPartitions("a").create(), PartitionStrategy.build().partitionKey("_partition").writePartition("b").readPartitions("b").create()).strategies
==>strategies[ConnectiveStrategy, PartitionStrategy, PartitionStrategy, MatchPredicateStrategy, FilterRankingStrategy, InlineFilterStrategy, IncidentToAdjacentStrategy, AdjacentToIncidentStrategy, RepeatUnrollStrategy, PathRetractionStrategy, CountStrategy, EarlyLimitStrategy, LazyBarrierStrategy, BitsyTraversalStrategy, ProfileStrategy, StandardVerificationStrategy]
```

### Solution

Substitute `Set<TraversalStrategy<?>>` with `List<TraversalStrategy<?>>` in class `org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies` 
