### PR TITLE
TINKERPOP-2455 Remove previously deprecated keep-alive in driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -79,6 +79,7 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Removed `Property.Exceptions.propertyValueCanNotBeNull` exception type as `null` now has meaning in Gremlin.
 * Removed the "experimental" support for multi/meta-properties in Neo4j.
 * Removed Gryo serialization configurations from Gremlin Server sample configurations and default configurations.
+* Removed previously deprecated custom keep-alive functionality in the Java driver.
 * Removed previously deprecated `BytecodeUtil`.
 * Removed previously deprecated `Cluster.maxWaitForSessionClose` configuration option.
 * Removed previously deprecated `TraversalStrategies.applyStrategies()`.

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -529,6 +529,8 @@ The following deprecated classes, methods or fields have been removed in this ve
 ** `org.apache.tinkerpop.gremlin.structure.util.star.StarGraph.Builder#create()`
 * `gremlin-driver`
 ** `org.apache.tinkerpop.gremlin.driver.Tokens#ARGS_SCRIPT_EVAL_TIMEOUT`
+** `org.apache.tinkerpop.gremlin.driver.Channelizer#createKeepAliveMessage()`
+** `org.apache.tinkerpop.gremlin.driver.Channelizer#supportsKeepAlive()`
 ** `org.apache.tinkerpop.gremlin.driver.Cluster.Builder#keyCertChainFile(String)`
 ** `org.apache.tinkerpop.gremlin.driver.Cluster.Builder#keyFile(String)`
 ** `org.apache.tinkerpop.gremlin.driver.Cluster.Builder#keyPassword(String)`
@@ -579,6 +581,7 @@ link:https://issues.apache.org/jira/browse/TINKERPOP-2233[TINKERPOP-2233],
 link:https://issues.apache.org/jira/browse/TINKERPOP-2239[TINKERPOP-2239],
 link:https://issues.apache.org/jira/browse/TINKERPOP-2269[TINKERPOP-2269],
 link:https://issues.apache.org/jira/browse/TINKERPOP-2273[TINKERPOP-2273],
+link:https://issues.apache.org/jira/browse/TINKERPOP-2455[TINKERPOP-2455],
 link:https://tinkerpop.apache.org/docs/3.5.0/upgrade/#_ssl_security[3.2.10 Upgrade Documentation for SSL]
 
 === Upgrading for Provider

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -70,29 +70,6 @@ public interface Channelizer extends ChannelHandler {
     public void close(final Channel channel);
 
     /**
-     * Create a message for the driver to use as a "keep-alive" for the connection. This method will only be used if
-     * {@link #supportsKeepAlive()} is {@code true}.
-     *
-     * @deprecated As of release 3.4.9, not directly replaced. Any keep-alive functionality should be implemented as
-     * a function of the configured channel and not as a component of the {@code Channelizer} itself.
-     */
-    @Deprecated
-    public default Object createKeepAliveMessage() {
-        return null;
-    }
-
-    /**
-     * Determines if the channelizer supports a method for keeping the connection to the server alive.
-     *
-     * @deprecated As of release 3.4.9, not directly replaced. Any keep-alive functionality should be implemented as
-     * a function of the configured channel and not as a component of the {@code Channelizer} itself.
-     */
-    @Deprecated
-    public default boolean supportsKeepAlive() {
-        return false;
-    }
-
-    /**
      * Called after the channel connects. The {@code Channelizer} may need to perform some functions, such as a
      * handshake.
      */
@@ -174,30 +151,6 @@ public interface Channelizer extends ChannelHandler {
         }
 
         /**
-         * Keep-alive is supported through the ping/pong websocket protocol.
-         *
-         * @see <a href=https://tools.ietf.org/html/rfc6455#section-5.5.2>IETF RFC 6455</a>
-         * @deprecated As of release 3.4.9, not directly replaced. The keep-alive functionality is delegated to Netty
-         * {@code IdleStateHandler} which is added to the pipeline in {@link Channelizer}.
-         */
-        @Deprecated
-        @Override
-        public boolean supportsKeepAlive() {
-            return true;
-        }
-
-        /**
-         * @deprecated As of release 3.4.9, not directly replaced. The keep-alive functionality is delegated to Netty
-         * {@code IdleStateHandler} which is added to the pipeline in {@link Channelizer}.
-         */
-        @Deprecated
-        @Override
-        public Object createKeepAliveMessage() {
-            throw new UnsupportedOperationException(
-                    "WebSocketChannelizer uses Netty's IdleStateHandler to send keep alive ping frames to the server.");
-        }
-
-        /**
          * Sends a {@code CloseWebSocketFrame} to the server for the specified channel.
          */
         @Override
@@ -231,7 +184,8 @@ public interface Channelizer extends ChannelHandler {
                             connection.getUri(), WebSocketVersion.V13, null, /*allow extensions*/ true,
                             EmptyHttpHeaders.INSTANCE, maxContentLength), cluster.getConnectionSetupTimeout());
 
-            final int keepAliveInterval = toIntExact(TimeUnit.SECONDS.convert(cluster.connectionPoolSettings().keepAliveInterval, TimeUnit.MILLISECONDS));
+            final int keepAliveInterval = toIntExact(TimeUnit.SECONDS.convert(
+                    cluster.connectionPoolSettings().keepAliveInterval, TimeUnit.MILLISECONDS));
 
             pipeline.addLast("http-codec", new HttpClientCodec());
             pipeline.addLast("aggregator", new HttpObjectAggregator(maxContentLength));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -671,9 +671,8 @@ public final class Cluster {
         }
 
         /**
-         * Length of time in milliseconds to wait on an idle connection before sending a keep-alive request. This
-         * setting is only relevant to {@link Channelizer} implementations that return {@code true} for
-         * {@link Channelizer#supportsKeepAlive()}.  Set to zero to disable this feature.
+         * Length of time in milliseconds to wait on an idle connection before sending a keep-alive request. Set to
+         * zero to disable this feature.
          */
         public Builder keepAliveInterval(final long keepAliveInterval) {
             this.keepAliveInterval = keepAliveInterval;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -321,9 +321,8 @@ final class Settings {
         public int maxSize = ConnectionPool.MAX_POOL_SIZE;
 
         /**
-         * Length of time in milliseconds to wait on an idle connection before sending a keep-alive request. This
-         * setting is only relevant to {@link Channelizer} implementations that return {@code true} for
-         * {@link Channelizer#supportsKeepAlive()}. Set to zero to disable this feature.
+         * Length of time in milliseconds to wait on an idle connection before sending a keep-alive request. Set to
+         * zero to disable this feature.
          */
         public long keepAliveInterval = Connection.KEEP_ALIVE_INTERVAL;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2455

We deprecated the custom keep-alive functionality in the java driver back in 3.4.9 as it now relies more directly on netty. Removed it wholly for 3.5.0. 

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1