### PR TITLE
TINKERPOP-2168 Optimized P GraphSON deserialization

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-11]]
 === TinkerPop 3.4.11 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added method caching for GraphSON 3.0 deserialization of `P` and `TextP` instances.
 * Modified Gremlin Server `Settings` to be more extensible allowing for custom options with the YAML parser.
 
 [[release-3-4-10]]

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.structure.io.graphson;
 
 import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
@@ -52,6 +53,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.__;
 import static org.hamcrest.Matchers.either;
@@ -426,5 +428,23 @@ public class GraphSONMapperEmbeddedTypeTest extends AbstractGraphSONTest {
         // perhaps it can switch fully - TINKERPOP-2156
         final BigDecimal o = new BigDecimal("123456789987654321123456789987654321");
         assertEquals(o, mapper.readValue("{\"@type\": \"gx:BigDecimal\", \"@value\": 123456789987654321123456789987654321}", Object.class));
+    }
+
+    @Test
+    public void shouldHandlePExt() throws Exception  {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+
+        final P o = PExt.mix("bah");
+        assertEquals(o, serializeDeserialize(mapper, o, P.class));
+    }
+
+    public static class PExt<V> extends P<V> {
+        public PExt(final BiPredicate<V, V> biPredicate, final V value) {
+            super(biPredicate, value);
+        }
+
+        public static <V> P<V> mix(final V value) {
+            return new P(Compare.eq, value);
+        }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2168

Cached reflective method calls as they occur as was done with GraphBinary. Didn't bother to take this back to GraphSON 2.0.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1