### PR TITLE
Update Dockerfile: set pip version below 21.0 due to drop support of python 2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get install -y --force-yes python python-dev python-pip build-essential 
 RUN cd /opt && wget https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tgz && tar -xvf Python-3.5.3.tgz
 RUN cd /opt/Python-3.5.3 && ./configure && make && make install
 RUN ln -sf /usr/bin/python3.5.3 /usr/bin/python3
-RUN pip install --upgrade pip
+# pip drops support of Python 2 starting from version 21.0
+RUN pip install --upgrade "pip<21.0"
 RUN pip install virtualenv virtualenvwrapper
 
 RUN rm -rf /var/lib/apt/lists/* /var/cache/openjdk-8-jdk


### PR DESCRIPTION
After pip version is updated to 21.0 or up, `docker/build.sh -t -i -n` would have the following error:

```
Step 19/28 : RUN pip install virtualenv virtualenvwrapper
 ---> Running in 543385b5721a
Traceback (most recent call last):
  File "/usr/local/bin/pip", line 7, in <module>
    from pip._internal.cli.main import main
  File "/usr/local/lib/python2.7/dist-packages/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
The command '/bin/sh -c pip install virtualenv virtualenvwrapper' returned a non-zero code: 1
```

This is due to `pip` dropping support of python 2 starting from version 21.0

https://pip.pypa.io/en/stable/news/#id4

https://github.com/pypa/pip/issues/6148
