### PR TITLE
fix toString() for P class when value is array

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -254,13 +254,20 @@ class P {
    */
   toString() {
     function formatValue(value){
+      if (Array.isArray(valueToFormat)) {
+        let acc = [];
+        for (const item of valueToFormat) {
+          acc.push(formatValue(item));
+        }
+        return acc;
+      }
       if (value && typeof value === "string"){
         return "'" + value + "'";
       }
       return value;
     }
 
-    if (this.other === undefined) {
+    if (this.other === undefined || this.other === null) {
       return this.operator + '(' + formatValue(this.value) + ')';
     }
     return this.operator + '(' + formatValue(this.value) + ', ' + formatValue(this.other) + ')';


### PR DESCRIPTION
example is `P.within(["a", "b"])` predicate where ["a", "b"] is an array. In such case toString() must return `within("a","b")` and not within(a,b)
