### PR TITLE
TINKERPOP-2513 Improved error messaging in Gremlin construction.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ This release also includes changes from <<release-3-4-3, 3.4.3>>.
 * Fixed a bug where spark-gremlin was not re-attaching properties when using `dedup()`.
 * Ensured better consistency of the use of `null` as arguments to mutation steps.
 * Prevented `TraversalStrategy` instances from being added more than once, where the new instance replaces the old.
+* Improved error message for `addE()` when the `from()` or `to()` does not resolve to a `Vertex`.
+* Improved error message for `addE()` when cardinality is specified on `property()` assignments.
 * Allowed `property(T.label,Object)` to be used if no value was supplied to `addV(String)`.
 * Allowed additional arguments to `Client.submit()` in Javascript driver to enable setting of parameters like `scriptEvaluationTimeout`.
 * Gremlin.Net driver no longer supports skipping deserialization by default. Users can however create their own `IMessageSerializer` if they need this functionality.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -96,15 +96,28 @@ public class AddEdgeStep<S> extends ScalarMapStep<S, Edge>
 
     @Override
     protected Edge map(final Traverser.Admin<S> traverser) {
-        Vertex toVertex = this.parameters.get(traverser, TO, () -> (Vertex) traverser.get()).get(0);
-        Vertex fromVertex = this.parameters.get(traverser, FROM, () -> (Vertex) traverser.get()).get(0);
+        final String edgeLabel = this.parameters.get(traverser, T.label, () -> Edge.DEFAULT_LABEL).get(0);
+        final Object theTo = this.parameters.get(traverser, TO, traverser::get).get(0);
+        if (!(theTo instanceof Vertex))
+            throw new IllegalStateException(String.format(
+                    "addE(%s) could not find a Vertex for to() - encountered: %s", edgeLabel,
+                    null == theTo ? "null" : theTo.getClass().getSimpleName()));
+
+        final Object theFrom = this.parameters.get(traverser, FROM, traverser::get).get(0);
+        if (!(theFrom instanceof Vertex))
+            throw new IllegalStateException(String.format(
+                    "addE(%s) could not find a Vertex for from() - encountered: %s", edgeLabel,
+                    null == theFrom ? "null" : theFrom.getClass().getSimpleName()));
+
+        Vertex toVertex = (Vertex) theTo;
+        Vertex fromVertex = (Vertex) theFrom;
+
         if (toVertex instanceof Attachable)
             toVertex = ((Attachable<Vertex>) toVertex)
                     .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
         if (fromVertex instanceof Attachable)
             fromVertex = ((Attachable<Vertex>) fromVertex)
                     .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
-        final String edgeLabel = this.parameters.get(traverser, T.label, () -> Edge.DEFAULT_LABEL).get(0);
 
         final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));
         if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
@@ -98,6 +98,14 @@ public class AddPropertyStep<S extends Element> extends SideEffectStep<S>
 
         final Element element = traverser.get();
 
+        // can't set cardinality if the element is something other than a vertex as only vertices can have
+        // a cardinality of properties. if we don't throw an error here we end up with a confusing cast exception
+        // which doesn't explain what went wrong
+        if (this.cardinality != null && !(element instanceof Vertex))
+            throw new IllegalStateException(String.format(
+                    "Property cardinality can only be set for a Vertex but the traversal encountered %s for key: %s",
+                    element.getClass().getSimpleName(), key));
+
         if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
             getTraversal().getStrategies().getStrategy(EventStrategy.class)
                     .ifPresent(eventStrategy -> {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2513

Focused mostly on addE() with property() cardinality and improper from()/to() usage. This is a bit of a patch for the exact issues described in the JIRA, but probably needs to be implemented more generally as described in TINKERPOP-800. I targetted 3.5.0 with this since it does introduce some new exceptions which could be helpful to users but might also make their upgrades more challenging. As we look to release 3.5.0 shortly and likely focus more efforts there this seems like a safe move. 

All tests pass with `docker/build.sh -t -n -i`

VOTE +1