### PR TITLE
Fixed NPE during the ResponseMessageDeserializer#createObject

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
@@ -294,7 +294,7 @@ public abstract class AbstractGraphSONMessageSerializerV2d0 extends AbstractMess
             final Map<String, Object> result = (Map<String, Object>) data.get(SerTokens.TOKEN_RESULT);
             return ResponseMessage.build(UUID.fromString(data.get(SerTokens.TOKEN_REQUEST).toString()))
                     .code(ResponseStatusCode.getFromValue((Integer) status.get(SerTokens.TOKEN_CODE)))
-                    .statusMessage(status.get(SerTokens.TOKEN_MESSAGE).toString())
+                    .statusMessage(String.valueOf(status.get(SerTokens.TOKEN_MESSAGE)))
                     .statusAttributes((Map<String, Object>) status.get(SerTokens.TOKEN_ATTRIBUTES))
                     .result(result.get(SerTokens.TOKEN_DATA))
                     .responseMetaData((Map<String, Object>) result.get(SerTokens.TOKEN_META))

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/ResponseMessageDeserializerTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/ResponseMessageDeserializerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.ser;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.AbstractObjectDeserializer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.tinkerpop.gremlin.driver.ser.AbstractGraphSONMessageSerializerV2d0.ResponseMessageDeserializer;
+
+public class ResponseMessageDeserializerTest {
+
+    @Test
+    public void shouldNotFailOnCreateObjectWithNullMessage() {
+        final Map<String, Object> result = new HashMap<>();
+        result.put(SerTokens.TOKEN_DATA, null);
+        result.put(SerTokens.TOKEN_META, Collections.emptyMap());
+
+        final Map<String, Object> status = new HashMap<>();
+        status.put(SerTokens.TOKEN_MESSAGE, null);
+        status.put(SerTokens.TOKEN_CODE, 500);
+        status.put(SerTokens.TOKEN_ATTRIBUTES, Collections.emptyMap());
+
+        final Map<String, Object> data = new HashMap<>();
+        data.put(SerTokens.TOKEN_REQUEST, UUID.randomUUID().toString());
+        data.put(SerTokens.TOKEN_RESULT, result);
+        data.put(SerTokens.TOKEN_STATUS, status);
+
+        final AbstractObjectDeserializer<ResponseMessage> deserializer = new ResponseMessageDeserializer();
+        Assert.assertNotNull(deserializer.createObject(data));
+    }
+
+}


### PR DESCRIPTION
Hi guys!
It's a small change that fixes annoying NPE's on ResponseMessageDeserializer#createObject.

Background:
I use JanusGraph & Gremlin, and when some kind of runtime exceptions occurred in the server, the server responds with a null message (I assume it just gets the exception.getMessage() as-is, and it can be null). 
So the typical response at that point looks like:
```
{requestId=c7465b5e-2c12-4f66-a293-3cdf2c276e17, status={message=null, code=500, attributes={stackTrace=java.lang.ClassCastException
, exceptions=[java.lang.ClassCastException]}}, result={data=null, meta={}}}
```
and the NPE's stacktrace begins with:
```
AbstractGraphSONMessageSerializerV2d0 - Response [PooledUnsafeDirectByteBuf(ridx: 311, widx: 311, cap: 311)] could not be deserialized by org.apache.tinkerpop.gremlin.driver.ser.AbstractGraphSONMessageSerializerV2d0.
java.lang.NullPointerException: null
	at org.apache.tinkerpop.gremlin.driver.ser.AbstractGraphSONMessageSerializerV2d0$ResponseMessageDeserializer.createObject(AbstractGraphSONMessageSerializerV2d0.java:298)
```
When I was fixing that NPE, I found the duplicating code of ResponseMessage creation in:
```
AbstractGraphSONMessageSerializerV1d0
GraphSONMessageSerializerV1d0
``` 
but I didn't touch it cause I'm not sure if it accidentally looks the same or not.
If it's the same logic, maybe it's time to extract that code into some small utility component that will handle the ResponseMessage creation from the raw map?