### PR TITLE
Fixed NPE during the ResponseMessageDeserializer#createObject

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug with Javascript Groovy `Translator` when generating Gremlin with multiple embedded traversals.
 * Modified Gremlin Server `Settings` to be more extensible allowing for custom options with the YAML parser.
 * Fixed `toString()` representation of `P` when string values are present in Javascript.
+* Fixed NullPointerException in ResponseMessage deserialization for GraphSON.
 
 [[release-3-4-10]]
 === TinkerPop 3.4.10 (Release Date: January 18, 2021)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0.java
@@ -137,7 +137,7 @@ public abstract class AbstractGraphSONMessageSerializerV1d0 extends AbstractMess
             final Map<String, Object> result = (Map<String, Object>) responseData.get(SerTokens.TOKEN_RESULT);
             return ResponseMessage.build(UUID.fromString(responseData.get(SerTokens.TOKEN_REQUEST).toString()))
                     .code(ResponseStatusCode.getFromValue((Integer) status.get(SerTokens.TOKEN_CODE)))
-                    .statusMessage(status.get(SerTokens.TOKEN_MESSAGE).toString())
+                    .statusMessage(String.valueOf(status.get(SerTokens.TOKEN_MESSAGE)))
                     .statusAttributes((Map<String, Object>) status.get(SerTokens.TOKEN_ATTRIBUTES))
                     .result(result.get(SerTokens.TOKEN_DATA))
                     .responseMetaData((Map<String, Object>) result.get(SerTokens.TOKEN_META))

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
@@ -294,7 +294,7 @@ public abstract class AbstractGraphSONMessageSerializerV2d0 extends AbstractMess
             final Map<String, Object> result = (Map<String, Object>) data.get(SerTokens.TOKEN_RESULT);
             return ResponseMessage.build(UUID.fromString(data.get(SerTokens.TOKEN_REQUEST).toString()))
                     .code(ResponseStatusCode.getFromValue((Integer) status.get(SerTokens.TOKEN_CODE)))
-                    .statusMessage(status.get(SerTokens.TOKEN_MESSAGE).toString())
+                    .statusMessage(String.valueOf(status.get(SerTokens.TOKEN_MESSAGE)))
                     .statusAttributes((Map<String, Object>) status.get(SerTokens.TOKEN_ATTRIBUTES))
                     .result(result.get(SerTokens.TOKEN_DATA))
                     .responseMetaData((Map<String, Object>) result.get(SerTokens.TOKEN_META))

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0.java
@@ -82,7 +82,7 @@ public final class GraphSONMessageSerializerV1d0 extends AbstractGraphSONMessage
             final Map<String, Object> result = (Map<String, Object>) responseData.get(SerTokens.TOKEN_RESULT);
             return ResponseMessage.build(UUID.fromString(responseData.get(SerTokens.TOKEN_REQUEST).toString()))
                     .code(ResponseStatusCode.getFromValue((Integer) status.get(SerTokens.TOKEN_CODE)))
-                    .statusMessage(status.get(SerTokens.TOKEN_MESSAGE).toString())
+                    .statusMessage(String.valueOf(status.get(SerTokens.TOKEN_MESSAGE)))
                     .statusAttributes((Map<String, Object>) status.get(SerTokens.TOKEN_ATTRIBUTES))
                     .result(result.get(SerTokens.TOKEN_DATA))
                     .responseMetaData((Map<String, Object>) result.get(SerTokens.TOKEN_META))

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerGremlinV2d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerGremlinV2d0Test.java
@@ -32,13 +32,16 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.AbstractObjectDeserializer;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.apache.tinkerpop.shaded.jackson.databind.util.StdDateFormat;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -46,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.apache.tinkerpop.gremlin.driver.ser.AbstractGraphSONMessageSerializerV2d0.ResponseMessageDeserializer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -339,7 +343,27 @@ public class GraphSONMessageSerializerGremlinV2d0Test {
         assertEquals("bytecode", m.getOp());
         assertNotNull(m.getArgs());
     }
-    
+
+    @Test
+    public void responseMessageDeserializerShouldNotFailOnCreateObjectWithNullMessage() {
+        final Map<String, Object> result = new HashMap<>();
+        result.put(SerTokens.TOKEN_DATA, null);
+        result.put(SerTokens.TOKEN_META, Collections.emptyMap());
+
+        final Map<String, Object> status = new HashMap<>();
+        status.put(SerTokens.TOKEN_MESSAGE, null);
+        status.put(SerTokens.TOKEN_CODE, 500);
+        status.put(SerTokens.TOKEN_ATTRIBUTES, Collections.emptyMap());
+
+        final Map<String, Object> data = new HashMap<>();
+        data.put(SerTokens.TOKEN_REQUEST, UUID.randomUUID().toString());
+        data.put(SerTokens.TOKEN_RESULT, result);
+        data.put(SerTokens.TOKEN_STATUS, status);
+
+        final AbstractObjectDeserializer<ResponseMessage> deserializer = new ResponseMessageDeserializer();
+        Assert.assertNotNull(deserializer.createObject(data));
+    }
+
     private void assertCommon(final ResponseMessage response) {
         assertEquals(requestId, response.getRequestId());
         assertEquals(ResponseStatusCode.SUCCESS, response.getStatus().getCode());

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0Test.java
@@ -43,12 +43,14 @@ import org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule;
 import org.apache.tinkerpop.shaded.jackson.databind.node.NullNode;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdSerializer;
 import org.apache.tinkerpop.shaded.jackson.databind.util.StdDateFormat;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.awt.Color;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -403,7 +405,30 @@ public class GraphSONMessageSerializerV1d0Test {
         assertEquals(ResponseStatusCode.SUCCESS.getValue(), deserialized.getStatus().getCode().getValue());
         assertEquals("worked", deserialized.getStatus().getMessage());
     }
-    
+
+    @Test
+    public void shouldDeserializeResponseMessageWithNullMessage() throws Exception {
+        final UUID id = UUID.randomUUID();
+
+        final Map<String, Object> metaData = new HashMap<>();
+        metaData.put("test", UUID.randomUUID().toString());
+        final Map<String, Object> attributes = Collections.emptyMap();
+
+        final ResponseMessage response = ResponseMessage.build(id)
+                .responseMetaData(metaData)
+                .code(ResponseStatusCode.SERVER_ERROR)
+                .result("some-result")
+                .statusAttributes(attributes)
+                // explicitly pass the null value
+                .statusMessage(null)
+                .create();
+
+        final String results = SERIALIZER.serializeResponseAsString(response);
+        final ResponseMessage deserialized = SERIALIZER.deserializeResponse(results);
+        Assert.assertNotNull(SERIALIZER.getClass().getSimpleName() + " should be able to deserialize ResponseMessage "
+                        + "with null message field", deserialized);
+    }
+
     @Test
     public void shouldSerializeToJsonTree() throws Exception {
         final TinkerGraph graph = TinkerFactory.createClassic();


### PR DESCRIPTION
Supersedes #1394 

@spmallette I'm not sure about the other serializers, but I've checked the:
```
AbstractGryoMessageSerializerV1d0 (& GryoMessageSerializerV1d0)
AbstractGryoMessageSerializerV3d0 (& GryoMessageSerializerV3d0)
GraphBinaryMessageSerializerV1
``` 
It's ok with the null message. If you mean some other serializers, please let me know.