### PR TITLE
TINKERPOP-2531:  Make sure connection pool is restored and brought back to health if server is temporarily unavailable.

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -64,19 +64,21 @@ namespace Gremlin.Net.Driver
 
             return ProxiedConnection(connection);
         }
+        
+        private bool IsHealthy => _deadConnections.IsEmpty && _connections.Count == _settings.PoolSize;
 
         private TimeSpan ComputeRetrySleepDuration(int retryAttemptNr)
         {
             return TimeSpan.FromTicks(_settings.ReconnectionBaseDelay.Ticks * (long) Math.Pow(2, retryAttemptNr));
         }
-
+        
         /// <summary>
         ///     Replaces dead connections.
         /// </summary>
         /// <returns>True if the pool was repaired, false if repairing was not necessary.</returns>
         private async Task<bool> EnsurePoolIsHealthyAsync()
         {
-            if (_deadConnections.IsEmpty) return false;
+            if (IsHealthy) return false;
             var poolState = Interlocked.CompareExchange(ref _poolState, PoolPopulationInProgress, PoolIdle);
             if (poolState == PoolPopulationInProgress) return false;
             try
@@ -91,7 +93,7 @@ namespace Gremlin.Net.Driver
 
             return true;
         }
-        
+
         private async Task ReplaceDeadConnectionsAsync()
         {
             RemoveDeadConnections();
@@ -151,7 +153,11 @@ namespace Gremlin.Net.Driver
         private IConnection GetConnectionFromPool()
         {
             var connections = _connections.Snapshot;
-            if (connections.Length == 0) throw new ServerUnavailableException();
+            if (connections.Length == 0)
+            {
+                TriggerReplacementOfDeadConnections();
+                throw new ServerUnavailableException();
+            }
             return TryGetAvailableConnection(connections);
         }
         

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -153,11 +153,11 @@ namespace Gremlin.Net.Driver
         private IConnection GetConnectionFromPool()
         {
             var connections = _connections.Snapshot;
-            if (connections.Length == 0)
+            if (connections.Length < _settings.PoolSize)
             {
                 TriggerReplacementOfDeadConnections();
-                throw new ServerUnavailableException();
             }
+            if (connections.Length == 0) throw new ServerUnavailableException();
             return TryGetAvailableConnection(connections);
         }
         


### PR DESCRIPTION
Link to Jira ticket: https://issues.apache.org/jira/browse/TINKERPOP-2531

DESCRITPTION:
    If the server becomes unavailable for a period of time the connection pool might not be able to recreate a connection right after it closes. Even with a few retries with a backoff to recrete the connections, it might not be enough and the connections end up being removed from the _deadConnections array and never end up as valid ones in the _connections array.

    This change tries to account for that, and, despite the caller getting a ServerUnavailableException, if the caller chooses to continue using the GremlinClient it already has, the ConnectionPool will try to restore itself.

    Alternatives considered:
    - Once the server is deemed unavailable we could leave it up to the caller to handle it and potentially recreate the GremlinClient. In that case this change would not be needed and the only improvement might be to better document that ServerUnavailableException means that the connection will most likely not be restored even if the server becomes available again.

    Chose this approach over the alternative since it seems like a feature that a ConnectionPool should have. If done on the caller side it might end having to implement a logic very similar to the one in the ConnectionPool itself just centered around GremlinClients rather than websocket connections. 

TESTING: 
- Tested in our project setup with a Gremlin Client aimed at an AWS Neptune instance. Manually interrupted the connection / restarted or modified the instance to observe reconnecting behavior. 