### PR TITLE
TINKERPOP-2532 Add public getter for maxBarrierSize

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
@@ -116,4 +116,8 @@ public final class NoOpBarrierStep<S> extends AbstractStep<S, S> implements Loca
         super.reset();
         this.barrier.clear();
     }
+
+    public int getMaxBarrierSize() {
+        return maxBarrierSize;
+    }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStepTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Florian Grieskamp
+ */
+public class NoOpBarrierStepTest extends StepTest {
+
+    @Override
+    protected List<Traversal> getTraversals() {
+        return Collections.singletonList(__.barrier());
+    }
+
+    @Test
+    public void testGetDefaultMaxBarrierSize() {
+        final Traversal.Admin<?, ?> traversal = __.barrier().asAdmin();
+        final NoOpBarrierStep<?> barrier = (NoOpBarrierStep<?>) traversal.getStartStep();
+        assertEquals(Integer.MAX_VALUE, barrier.getMaxBarrierSize());
+    }
+
+    @Test
+    public void testGetCustomMaxBarrierSize() {
+        int customBarrierSize = 1234;
+        final Traversal.Admin<?, ?> traversal = __.barrier(customBarrierSize).asAdmin();
+        final NoOpBarrierStep<?> barrier = (NoOpBarrierStep<?>) traversal.getStartStep();
+        assertEquals(customBarrierSize, barrier.getMaxBarrierSize());
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2532

This change allows vendors to use the configured barrier sizes to enable and improve batch processing (e.g. [Janusgraph-2514](https://github.com/JanusGraph/janusgraph/issues/2514)).
I also added a test class because no class existed for `NoOpBarrierStep`. I hope my implementation of `getTraversals()` does what it is expected to do. If anyone has more experience with tests for `Step` classes and would like to issue changes, please let me know.