### PR TITLE
Add a TraversalStrategyProxy.toString() method

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyProxy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/TraversalStrategyProxy.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.io.Serializable;
 
@@ -63,5 +64,10 @@ public final class TraversalStrategyProxy<T extends TraversalStrategy> implement
     @Override
     public int compareTo(final Object o) {
         throw new UnsupportedOperationException("TraversalStrategyProxy is not meant to be used directly as a TraversalStrategy and is for serialization purposes only");
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.traversalStrategyProxyString(this);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
@@ -36,6 +36,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileSideEffectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ProfileStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -177,6 +178,10 @@ public final class StringFactory {
 
     public static String traversalStrategyString(final TraversalStrategy traversalStrategy) {
         return traversalStrategy.getClass().getSimpleName();
+    }
+
+    public static String traversalStrategyProxyString(final TraversalStrategyProxy traversalStrategyProxy) {
+        return traversalStrategyProxy.getStrategyClass().getSimpleName();
     }
 
     public static String translatorString(final Translator translator) {


### PR DESCRIPTION
On request timeout, TinkerPop logs a RequestMessage with a reference to a TraversalStrategyProxy instance:
```
A timeout occurred during traversal evaluation of [RequestMessage{, requestId=2095f7ee-1187-415d-8cbb-6884813a4054, op='bytecode', processor='traversal', args={gremlin=[[withStrategies(org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy@2eef7570)], )], [V(), count()]]}}] - consider increasing the limit given to evaluationTimeout
```

This happens because TraversalStrategyProxy, which is [used on *Strategy deserialization](https://github.com/apache/tinkerpop/blob/39167fccab8616ef04b9114db8464e7ac385f6b4/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java#L529-L560) does not override toString(), to the contrary of others *Strategy classes.

Here is a test to reproduce the issue:
```
public class RequestMessageTest {
    @Test
    public void printCorrectRequestMessageStringRepr() {
        final RequestMessage msg = newRequestMessageWithOptionsStrategy();
        System.out.println(msg);
        // RequestMessage{, requestId=2095f7ee-1187-415d-8cbb-6884813a4054, op='bytecode', processor='traversal', args={gremlin=[[withStrategies(OptionsStrategy)], [V(), count()]]}}
    }

    @Test
    public void printIncorrectRequestMessageStringRepr() throws SerializationException {
        // Simulate the request being serialized on the client and deserialized on the server.
        // This has an effect on the classes used (TraversalStrategyProxy appears on deserialization).
        MessageTextSerializer serializer = new GraphSONMessageSerializerV3d0();
        final RequestMessage msg = serializer.deserializeRequest(serializer.serializeRequestAsString(newRequestMessageWithOptionsStrategy()));
        System.out.println(msg);
        // RequestMessage{, requestId=1df6613b-4154-4d63-8b12-d33ed591f811, op='bytecode', processor='traversal', args={gremlin=[[withStrategies(org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy@60015ef5)], [V(), count()]]}}
    }

    private static RequestMessage newRequestMessageWithOptionsStrategy() {
        final Graph graph = EmptyGraph.instance();
        final GraphTraversalSource g = graph.traversal().with("evaluationTimeout", 1000);
        return RequestMessage.build(Tokens.OPS_BYTECODE).processor("traversal")
                             .addArg(Tokens.ARGS_GREMLIN, g.V().count().asAdmin().getBytecode())
                             .create();
    }
}
```

With this patch, the second test (`printIncorrectRequestMessageStringRepr`) correctly prints `OptionsStrategy` instead of `org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy@394a2528`.