### PR TITLE
TINKERPOP-2544: Modify site publishing scripts to include gremlint

### DIFF
--- a/bin/generate-home.sh
+++ b/bin/generate-home.sh
@@ -23,12 +23,21 @@ cd `dirname $0`/..
 rm -rf target/site/home
 mkdir -p target/site/
 
+pushd docs/gremlint
+
+npm install
+npm run build
+
+popd
+
 hash rsync 2> /dev/null
 
 if [ $? -eq 0 ]; then
   rsync -avq docs/site/home target/site --exclude template
+  rsync -avq docs/gremlint/build/ target/site/home/gremlint
 else
   cp -R docs/site/home target/site
+  cp -R docs/gremlint/build/. target/site/home/gremlint
   rm -rf target/site/home/template
 fi
 

--- a/docs/gremlint/package.json
+++ b/docs/gremlint/package.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://gremlint.com",
+  "homepage": "/gremlint",
   "name": "gremlint.com",
   "version": "0.1.0",
   "private": true,

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -230,6 +230,12 @@ When building `gremlin-javascript`, mvn command will include a local copy of Nod
 using `com.github.eirslett:frontend-maven-plugin` plugin. This copy of the Node.js runtime will not affect any
 other existing Node.js runtime instances in your machine.
 
+To run the development and build scripts of `gremlint` and its corresponding web page `docs/gremlint`, Node.js and npm
+have to be installed. When generating or publishing the TinkerPop website, the `docs/gremlint` web page has to be
+built. Consequently, the scripts `bin/generate-home.sh` and `bin/publish-home.sh` require that Node.js and npm are
+installed. Version 5.2.0 or newer of npm is recommended, as it comes pre-bundled with npx which provides tooling to
+easily serve the generated website locally. This is covered in more detail in the <<site,Site>> section.
+
 TIP: For those who do not have a full Maven environment, please see <<docker-integration,this section>> for how Docker
 can be used to help run tests.
 

--- a/docs/src/dev/developer/for-committers.asciidoc
+++ b/docs/src/dev/developer/for-committers.asciidoc
@@ -766,8 +766,13 @@ Cause: link:https://github.com/asciidoctor/asciidoctor/issues/1514[#1514]
 The content for the TinkerPop home page and related pages that make up the web site at link://tinkerpop.apache.org[tinkerpop.apache.org]
 is stored in the git repository under `/docs/site`. In this way, it becomes easier for the community to provide content
 presented there, because the content can be accepted via the standard workflow of a pull request. To generate the site
-for local viewing, run `bin/generate-home.sh`, which will build the site in `target/site/`. PMC members can officially
-publish the site with `bin/publish-home.sh <username>`.
+for local viewing, run `bin/generate-home.sh`, which will build the site in `target/site/`. Note that Node.js and npm
+have to be installed in order for the script to work. See the <<nodejs-environment,JavaScript Environment>> section for
+more info about what parts of TinkerPop depend on Node.js and npm. While most of the generated website files can be
+viewed locally by opening them in a browser, some of them rely on imported resources that will be blocked by the
+browser's same-origin policy if not served from a single origin using a web server. The generated website can be served
+locally by running `npx serve target/site/home`. PMC members can officially publish the site with
+`bin/publish-home.sh <username>`.
 
 "Publishing" does not publish documentation (e.g. reference docs, javadocs, etc) and only publishes what is generated
 from the content in `/docs/site`. Publishing the site can be performed out of band with the release cycle and is no


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2544

Updates the `bin/generate-home.sh` script to build the gremlint web page to an optimized production build which can be hosted by a static server and then copy it from `docs/gremlint/build` to `target/site/home/gremlint`.

If I understand the `bin/generate-home.sh` script correctly, it uses `rsync` to do the file copying if it is available. I've tested the script with and without `rsync`, and in both cases I've tested it with and without the page having previously been generated. I've only tested on a Linux machine.

I'll need some help to test if the `bin/publish-home.sh` script will simply just work, or if it needs modification to properly publish the built gremlint web page.