### PR TITLE
TINKERPOP-2457 Added max_content_length as Python driver config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed `toString()` representation of `P` when string values are present in Javascript.
 * Exposed barrier size with getter for `NoOpBarrierStep`.
 * Bumped to Netty 4.1.59.
+* Added `max_content_length` as a Python driver setting.
 * Ensured that `barrier()` additions by strategies were controlled solely by `LazyBarrierStrategy`.
 * Fixed `NullPointerException` in `ResponseMessage` deserialization for GraphSON.
 * Enabled the Gremlin.Net driver to repair its connection pool after the server was temporarily unavailable.

--- a/gremlin-python/src/main/jython/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/client.py
@@ -39,10 +39,12 @@ class Client:
     def __init__(self, url, traversal_source, protocol_factory=None,
                  transport_factory=None, pool_size=None, max_workers=None,
                  message_serializer=None, username="", password="",
-                 headers=None, session=""):
+                 headers=None, session="", max_content_length=None):
         self._url = url
         self._headers = headers
         self._traversal_source = traversal_source
+        if max_content_length is None:
+            max_content_length = 10 * 1024 * 1024
         if message_serializer is None:
             message_serializer = serializer.GraphSONSerializersV3d0()
         self._message_serializer = message_serializer
@@ -58,7 +60,8 @@ class Client:
                 raise Exception("Please install Tornado or pass"
                                 "custom transport factory")
             else:
-                transport_factory = lambda: TornadoTransport()
+                transport_factory = lambda: TornadoTransport(
+                    max_content_length=max_content_length)
         self._transport_factory = transport_factory
         if protocol_factory is None:
             protocol_factory = lambda: protocol.GremlinServerWSProtocol(

--- a/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/driver_remote_connection.py
@@ -32,7 +32,7 @@ class DriverRemoteConnection(RemoteConnection):
                  transport_factory=None, pool_size=None, max_workers=None,
                  username="", password="", message_serializer=None,
                  graphson_reader=None, graphson_writer=None,
-                 headers=None):
+                 headers=None, max_content_length=None):
         if message_serializer is None:
             message_serializer = serializer.GraphSONMessageSerializer(
                 reader=graphson_reader,
@@ -45,7 +45,8 @@ class DriverRemoteConnection(RemoteConnection):
                                      message_serializer=message_serializer,
                                      username=username,
                                      password=password,
-                                     headers=headers)
+                                     headers=headers,
+                                     max_content_length=max_content_length)
         self._url = self._client._url
         self._traversal_source = self._client._traversal_source
 

--- a/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
+++ b/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py
@@ -26,21 +26,25 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 class TornadoTransport(AbstractBaseTransport):
 
+    _default_max_content_length = 10 * 1024 * 1024
+
     def __init__(self, read_timeout=None, write_timeout=None,
                  compression_options={'compression_level': 5, 'mem_level': 5},
-                 ssl_options=None):
+                 ssl_options=None, max_content_length=_default_max_content_length):
         self._loop = ioloop.IOLoop(make_current=False)
         self._ws = None
         self._read_timeout = read_timeout
         self._write_timeout = write_timeout
         self._compression_options = compression_options
         self._ssl_options = ssl_options
+        self._max_content_length = max_content_length
 
     def connect(self, url, headers=None):
         if headers or self._ssl_options:
             url = httpclient.HTTPRequest(url, headers=headers, ssl_options=self._ssl_options)
         self._ws = self._loop.run_sync(
-            lambda: websocket.websocket_connect(url, compression_options=self._compression_options))
+            lambda: websocket.websocket_connect(url, compression_options=self._compression_options,
+                                                max_message_size=self._max_content_length))
 
     def write(self, message):
         self._loop.run_sync(

--- a/gremlin-python/src/main/jython/tests/driver/test_client.py
+++ b/gremlin-python/src/main/jython/tests/driver/test_client.py
@@ -44,6 +44,17 @@ def test_connection(connection):
     assert 'host' in results_set.status_attributes
 
 
+def test_client_message_too_big(client):
+    try:
+        client = Client("http://localhost", 'g', max_content_length=1024)
+        client.submit("1+1").all().result()
+        assert False
+    except Exception:
+        assert True
+    finally:
+        client.close()
+
+
 def test_client_simple_eval(client):
     assert client.submit('1 + 1').all().result()[0] == 2
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2457

I'm not sure how this will merge to `master` at the moment, or whether that merge is relevant there given the work to move from tornado to aiohttp. I sense this work will merge before that, so we'll see how it becomes relevant or not.

Builds with `mvn clean install -pl gremlin-python`

VOTE +1