### PR TITLE
TINKERPOP-2547 Add a way to supply a callback on handshake requests with java driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Ensured that `barrier()` additions by strategies were controlled solely by `LazyBarrierStrategy`.
 * Fixed `NullPointerException` in `ResponseMessage` deserialization for GraphSON.
 * Enabled the Gremlin.Net driver to repair its connection pool after the server was temporarily unavailable.
+* Added the ability to supply a `HandshakeInterceptor` to a `Cluster` which will provide access to the initial HTTP request that establishes the websocket.
 
 [[release-3-4-10]]
 === TinkerPop 3.4.10 (Release Date: January 18, 2021)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -34,7 +34,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.ssl.SslContext;
@@ -230,9 +229,10 @@ public interface Channelizer extends ChannelHandler {
 
             final int maxContentLength = cluster.connectionPoolSettings().maxContentLength;
             handler = new WebSocketClientHandler(
-                    WebSocketClientHandshakerFactory.newHandshaker(
-                            connection.getUri(), WebSocketVersion.V13, null, /*allow extensions*/ true,
-                            EmptyHttpHeaders.INSTANCE, maxContentLength), cluster.getConnectionSetupTimeout());
+                    new WebSocketClientHandler.InterceptedWebSocketClientHandshaker13(
+                            connection.getUri(), WebSocketVersion.V13, null,true,
+                            EmptyHttpHeaders.INSTANCE, maxContentLength, true, false, -1,
+                            cluster.getHandshakeInterceptor()), cluster.getConnectionSetupTimeout());
 
             final int keepAliveInterval = toIntExact(TimeUnit.SECONDS.convert(cluster.connectionPoolSettings().keepAliveInterval, TimeUnit.MILLISECONDS));
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -28,7 +28,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.slf4j.Logger;
@@ -483,6 +482,10 @@ public final class Cluster {
         return manager.serializer;
     }
 
+    HandshakeInterceptor getHandshakeInterceptor() {
+        return manager.interceptor;
+    }
+
     ScheduledExecutorService executor() {
         return manager.executor;
     }
@@ -621,6 +624,7 @@ public final class Cluster {
         private boolean sslSkipCertValidation = false;
         private SslContext sslContext = null;
         private LoadBalancingStrategy loadBalancingStrategy = new LoadBalancingStrategy.RoundRobin();
+        private HandshakeInterceptor interceptor = HandshakeInterceptor.NO_OP;
         private AuthProperties authProps = new AuthProperties();
         private long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
 
@@ -994,6 +998,15 @@ public final class Cluster {
         }
 
         /**
+         * Specifies an {@link HandshakeInterceptor} that will allow manipulation of the
+         * {@code FullHttpRequest} prior to its being sent over the websocket.
+         */
+        public Builder handshakeInterceptor(final HandshakeInterceptor interceptor) {
+            this.interceptor = interceptor;
+            return this;
+        }
+
+        /**
          * Specifies parameters for authentication to Gremlin Server.
          */
         public Builder authProperties(final AuthProperties authProps) {
@@ -1114,6 +1127,7 @@ public final class Cluster {
         private final AuthProperties authProps;
         private final Optional<SslContext> sslContextOptional;
         private final Supplier<RequestMessage.Builder> validationRequest;
+        private final HandshakeInterceptor interceptor;
 
         private final ScheduledThreadPoolExecutor executor;
 
@@ -1132,6 +1146,7 @@ public final class Cluster {
             this.loadBalancingStrategy = builder.loadBalancingStrategy;
             this.authProps = builder.authProps;
             this.contactPoints = builder.getContactPoints();
+            this.interceptor = builder.interceptor;
 
             connectionPoolSettings = new Settings.ConnectionPoolSettings();
             connectionPoolSettings.maxInProcessPerConnection = builder.maxInProcessPerConnection;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/HandshakeInterceptor.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/HandshakeInterceptor.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * This function is called when the websocket handshake is attempted and the first {@code FullHttpRequest} is sent to
+ * the server. The interceptor allows this message to be modified as needed before it is sent to the server.
+ * Implementations are supplied to {@link Cluster.Builder#handshakeInterceptor(HandshakeInterceptor)}.
+ */
+public interface HandshakeInterceptor extends UnaryOperator<FullHttpRequest> {
+
+    /**
+     * The default implementation of a {@link HandshakeInterceptor} and behaves as a no-op.
+     */
+    public static final HandshakeInterceptor NO_OP = o -> o;
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2547

Added a `HandshakeInterceptor` interface that can be supplied to the `Cluster.Builder` which will act as a callback for the initial HTTP request that sets up the websocket through the Java driver.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1