### PR TITLE
TINKERPOP-2569 Reconnect if java driver fails to initialize

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed bug in Java driver where it would not reconnect to a host that it did not successfully connect to at initialization.
+* Changed behavior for Java driver `Client` such that a failed initialization will notify other existing `Client` instances of a dead host and therefore throw `NoHostAvailableException`.
 
 [[release-3-4-11]]
 === TinkerPop 3.4.11 (Release Date: May 3, 2021)

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptor.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.driver.RequestOptions;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
+import org.apache.tinkerpop.gremlin.driver.exception.NoHostAvailableException;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.jsr223.console.GremlinShellEnvironment;
@@ -112,6 +113,8 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
             return String.format("Configured %s", this.currentCluster) + getSessionStringSegment();
         } catch (final FileNotFoundException ignored) {
             throw new RemoteException("The 'connect' option must be accompanied by a valid configuration file");
+        } catch (NoHostAvailableException nhae) {
+          return "Host was not available - the Gremlin Console is making attempts to reconnect in accordance with the 'reconnectInterval' driver configuration but you may wish to close this remote and investigate the problem directly";
         } catch (final Exception ex) {
             throw new RemoteException("Error during 'connect' - " + ex.getMessage(), ex);
         }

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
@@ -31,8 +31,8 @@ import java.util.Arrays;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -131,6 +131,6 @@ public class DriverRemoteAcceptorTest {
         // there is no gremlin server running for this test, but gremlin-driver lazily connects so this should
         // be ok to just validate that a connection is created
         assertThat(acceptor.connect(Arrays.asList(Storage.toPath(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp")))).toString(),
-                   startsWith("Configured "));
+                   startsWith("Host was not available "));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2569

Does result in a slight change in behavior as client initialization is now aware of dead hosts and will throw a `NoHostAvailableException` earlier (used to wait for a request to be submitted). This is probably better behavior. It seems unlikely that anyone would rely on this behavior for normal usage so pushing it to 3.4.x seems safe.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1