### PR TITLE
TINKERPOP-2562 Removed support for GraphSON 2 based string in Request Message for TraversalOpProcessor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ limitations under the License.
 [[release-3-6-0]]
 === TinkerPop 3.6.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* `TraversalOpProcessor` no longer accepts a `String` representation of `Bytecode` for the "gremlin" argument which was left to support older versions of the drivers.
 
 == TinkerPop 3.5.0 (The Sleeping Gremlin: No. 18 Entr'acte Symphonique)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2562

This was retained to support much older drivers. No driver sends Bytecode this way anymore so it should be safe to remove. It probably should have been done in 3.5.0, but was missed. The UnifiedHandler never supported this message form.

Builds with `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE +1