### PR TITLE
TINKERPOP-2507 Allowed graph filters with mixed id types

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ limitations under the License.
 === TinkerPop 3.6.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * `TraversalOpProcessor` no longer accepts a `String` representation of `Bytecode` for the "gremlin" argument which was left to support older versions of the drivers.
+* Removed requirement that "ids" used to filter vertices and edges need to be all of a single type.
 
 == TinkerPop 3.5.0 (The Sleeping Gremlin: No. 18 Entr'acte Symphonique)
 
@@ -364,6 +365,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Changed TinkerGraph to allow identifiers to be heterogeneous when filtering.
 * Fixed bug in the `vertexLabelKey` validation for `GraphMLWriter` which was inadvertently validating the `edgeLabelKey`.
 * Changed `IndexStep` to make it easier for providers to determine the type of indexer being used.
 

--- a/docs/src/upgrade/release-3.6.x.asciidoc
+++ b/docs/src/upgrade/release-3.6.x.asciidoc
@@ -1,0 +1,43 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+////
+
+= TinkerPop 3.6.0
+
+*NOT NAMED YET*
+
+== TinkerPop 3.6.0
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.6.0/CHANGELOG.asciidoc#release-3-6-0[changelog] for a complete list of all the modifications that are part of this release.
+
+=== Upgrading for Users
+
+
+=== Upgrading for Providers
+
+==== Graph System Providers
+
+===== Filters with Mixed Id Types
+
+The requirement that "ids" passed to `Graph.vertices` and `Graph.edges` all be of a single type has been removed. This
+requirement was a bit to prescriptive when there really wasn't a need to enforce such a validation. It even conflicted
+with TinkerGraph operations where mixed `T.id` types is a feature. Graph providers may continue to support this
+requirement if they wish, but it is no longer enforced by TinkerPop and the `Graph.idArgsMustBeEitherIdOrElement` has
+been removed so providers will need to construct their own exception.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2507[TINKERPOP-2507]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -1228,10 +1228,6 @@ public interface Graph extends AutoCloseable, Host {
             return new IllegalArgumentException(String.format("Edge with id already exists: %s", id));
         }
 
-        public static IllegalArgumentException idArgsMustBeEitherIdOrElement() {
-            return new IllegalArgumentException("id arguments must be either ids or Elements");
-        }
-
         public static IllegalArgumentException argumentCanNotBeNull(final String argument) {
             return new IllegalArgumentException(String.format("The provided argument can not be null: %s", argument));
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/ElementHelper.java
@@ -67,23 +67,6 @@ public final class ElementHelper {
     }
 
     /**
-     * Determine whether an array of ids are either all elements or ids of elements. This is typically used as a pre-condition check.
-     *
-     * @param clazz the class of the element for which the ids will bind
-     * @param ids   the ids that must be either elements or id objects, else
-     * {@link org.apache.tinkerpop.gremlin.structure.Graph.Exceptions#idArgsMustBeEitherIdOrElement()} is thrown.
-     */
-    public static void validateMixedElementIds(final Class<? extends Element> clazz, final Object... ids) throws IllegalArgumentException {
-        if (ids.length > 1) {
-            final boolean element = clazz.isAssignableFrom(ids[0].getClass());
-            for (int i = 1; i < ids.length; i++) {
-                if (clazz.isAssignableFrom(ids[i].getClass()) != element)
-                    throw Graph.Exceptions.idArgsMustBeEitherIdOrElement();
-            }
-        }
-    }
-
-    /**
      * Determines whether the property key/value for the specified thing can be legally set. This is typically used as
      * a pre-condition check prior to setting a property.
      *
@@ -557,8 +540,9 @@ public final class ElementHelper {
 
         // it is OK to evaluate equality of ids via toString() now given that the toString() the test suite
         // enforces the value of id.()toString() to be a first class representation of the identifier
-        if (1 == providedIds.length) return id.toString().equals(providedIds[0].toString());
-        else {
+        if (1 == providedIds.length) {
+            return id.toString().equals(providedIds[0].toString());
+        } else {
             for (final Object temp : providedIds) {
                 if (temp.toString().equals(id.toString()))
                     return true;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/AbortiveMultiIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/AbortiveMultiIterator.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.util.iterator;
+
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * An {@code Iterator} that checks a {@code Predicate} prior to processing the specified child {@code Iterator}
+ * instances.
+ */
+public final class AbortiveMultiIterator<T> implements Iterator<T>, Serializable, AutoCloseable {
+
+    private final List<Iterator<T>> iterators = new ArrayList<>();
+    private final List<Predicate<Long>> checks = new ArrayList<>();
+    private long counter = 0;
+    private int current = 0;
+
+    /**
+     * Adds an {@code Iterator} that will always be iterated.
+     */
+    public void addIterator(final Iterator<T> iterator) {
+        addIterator(iterator, c -> true);
+    }
+
+    /**
+     * Adds an {@code Iterator} that will iterate only if the {@code check} passes.
+     *
+     * @param check when returning {@code true} processing of the associated {@code Iterator} will proceed
+     */
+    public void addIterator(final Iterator<T> iterator, final Predicate<Long> check) {
+        this.iterators.add(iterator);
+        this.checks.add(check);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (this.current >= this.iterators.size())
+            return false;
+
+        Iterator<T> currentIterator = this.iterators.get(this.current);
+
+        while (true) {
+            if (currentIterator.hasNext()) {
+                return true;
+            } else {
+                this.current++;
+                if (this.current >= iterators.size() || !checks.get(current).test(counter))
+                    break;
+                currentIterator = iterators.get(this.current);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void remove() {
+        this.iterators.get(this.current).remove();
+    }
+
+    @Override
+    public T next() {
+        if (this.iterators.isEmpty()) throw FastNoSuchElementException.instance();
+
+        Iterator<T> currentIterator = iterators.get(this.current);
+
+        while (true) {
+            if (currentIterator.hasNext()) {
+                this.counter++;
+                return currentIterator.next();
+            } else {
+                this.current++;
+                if (this.current >= iterators.size() || !checks.get(current).test(counter))
+                    break;
+                currentIterator = iterators.get(current);
+            }
+        }
+        throw FastNoSuchElementException.instance();
+    }
+
+    public void clear() {
+        this.iterators.clear();
+        this.checks.clear();
+        this.counter = 0;
+        this.current = 0;
+    }
+
+    /**
+     * Close the underlying iterators if auto-closeable. Note that when Exception is thrown from any iterator
+     * in the for loop on closing, remaining iterators possibly left unclosed.
+     */
+    @Override
+    public void close() {
+        for (Iterator<T> iterator : this.iterators) {
+            CloseableIterator.closeIterator(iterator);
+        }
+    }
+}

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/CoreTraversalTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/CoreTraversalTest.java
@@ -169,13 +169,10 @@ public class CoreTraversalTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    public void shouldThrowExceptionWhenIdsMixed() {
+    public void shouldAllowIdsOfMixedTypes() {
         final List<Vertex> vertices = g.V().toList();
-        try {
-            g.V(vertices.get(0), vertices.get(1).id()).toList();
-        } catch (Exception ex) {
-            validateException(Graph.Exceptions.idArgsMustBeEitherIdOrElement(), ex);
-        }
+        assertEquals(2, g.V(vertices.get(0), vertices.get(1).id()).count().next().intValue());
+        assertEquals(2, g.V(vertices.get(0).id(), vertices.get(1)).count().next().intValue());
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -701,38 +701,6 @@ public class GraphTest extends AbstractGremlinTest {
 
     @Test
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ANY_IDS)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_STRING_IDS)
-    public void shouldNotMixTypesForGettingSpecificVerticesWithVertexFirst() {
-        final Vertex v1 = graph.addVertex();
-        try {
-            graph.vertices(v1, graphProvider.convertId("1", Vertex.class));
-            fail("Should have thrown an exception because id arguments were mixed.");
-        } catch (Exception ex) {
-            final Exception expected = Graph.Exceptions.idArgsMustBeEitherIdOrElement();
-            assertEquals(expected.getClass(), ex.getClass());
-            assertEquals(expected.getMessage(), ex.getMessage());
-        }
-    }
-
-    @Test
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ANY_IDS)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_STRING_IDS)
-    public void shouldNotMixTypesForGettingSpecificVerticesWithStringFirst() {
-        final Vertex v1 = graph.addVertex();
-        try {
-            graph.vertices(graphProvider.convertId("1", Vertex.class), v1);
-            fail("Should have thrown an exception because id arguments were mixed.");
-        } catch (Exception ex) {
-            final Exception expected = Graph.Exceptions.idArgsMustBeEitherIdOrElement();
-            assertEquals(expected.getClass(), ex.getClass());
-            assertEquals(expected.getMessage(), ex.getMessage());
-        }
-    }
-
-    @Test
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_STRING_IDS)
     public void shouldIterateVerticesWithStringIdSupportUsingVertex() {
         // if the graph supports id assigned, it should allow it.  if the graph does not, it will generate one
@@ -1640,42 +1608,6 @@ public class GraphTest extends AbstractGremlinTest {
         tryCommit(graph, graph -> {
             assertEquals(2, IteratorUtils.count(graph.edges(e1.id().toString(), e2.id().toString())));
         });
-    }
-
-    @Test
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ANY_IDS)
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_STRING_IDS)
-    public void shouldNotMixTypesForGettingSpecificEdgesWithEdgeFirst() {
-        final Vertex v = graph.addVertex();
-        final Edge e1 = v.addEdge("self", v);
-        try {
-            graph.edges(e1, graphProvider.convertId("1", Edge.class));
-            fail("Should have thrown an exception because id arguments were mixed.");
-        } catch (Exception ex) {
-            final Exception expected = Graph.Exceptions.idArgsMustBeEitherIdOrElement();
-            assertEquals(expected.getClass(), ex.getClass());
-            assertEquals(expected.getMessage(), ex.getMessage());
-        }
-    }
-
-    @Test
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ANY_IDS)
-    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_STRING_IDS)
-    public void shouldNotMixTypesForGettingSpecificEdgesWithStringFirst() {
-        final Vertex v = graph.addVertex();
-        final Edge e1 = v.addEdge("self", v);
-        try {
-            graph.edges(graphProvider.convertId("1", Edge.class), e1);
-            fail("Should have thrown an exception because id arguments were mixed.");
-        } catch (Exception ex) {
-            final Exception expected = Graph.Exceptions.idArgsMustBeEitherIdOrElement();
-            assertEquals(expected.getClass(), ex.getClass());
-            assertEquals(expected.getMessage(), ex.getMessage());
-        }
     }
 
     @Test

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
@@ -143,7 +143,6 @@ public final class Neo4jGraph implements Graph, WrappedGraph<Neo4jGraphAPI> {
             return IteratorUtils.stream(this.getBaseGraph().allNodes())
                     .map(node -> (Vertex) new Neo4jVertex(node, this)).iterator();
         } else {
-            ElementHelper.validateMixedElementIds(Vertex.class, vertexIds);
             return Stream.of(vertexIds)
                     .map(id -> {
                         if (id instanceof Number)
@@ -174,7 +173,6 @@ public final class Neo4jGraph implements Graph, WrappedGraph<Neo4jGraphAPI> {
             return IteratorUtils.stream(this.getBaseGraph().allRelationships())
                     .map(relationship -> (Edge) new Neo4jEdge(relationship, this)).iterator();
         } else {
-            ElementHelper.validateMixedElementIds(Edge.class, edgeIds);
             return Stream.of(edgeIds)
                     .map(id -> {
                         if (id instanceof Number)

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIdManagerTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIdManagerTest.java
@@ -54,7 +54,8 @@ public class TinkerGraphIdManagerTest {
                     {"coerceInt", 100, 200, 300},
                     {"coerceDouble", 100d, 200d, 300d},
                     {"coerceFloat", 100f, 200f, 300f},
-                    {"coerceString", "100", "200", "300"}});
+                    {"coerceString", "100", "200", "300"},
+                    {"coerceMixed", 100d, 200f, "300"}});
         }
 
         @Parameterized.Parameter(value = 0)
@@ -120,7 +121,8 @@ public class TinkerGraphIdManagerTest {
         public static Iterable<Object[]> data() {
             return Arrays.asList(new Object[][]{
                     {"coerceUuid", vertexId, edgeId, vertexPropertyId},
-                    {"coerceString", vertexId.toString(), edgeId.toString(), vertexPropertyId.toString()}});
+                    {"coerceString", vertexId.toString(), edgeId.toString(), vertexPropertyId.toString()},
+                    {"coerceMixed", vertexId, edgeId, vertexPropertyId.toString()}});
         }
 
         @Parameterized.Parameter(value = 0)

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -877,6 +878,24 @@ public class TinkerGraphTest {
         // adds two persons by way of the strategy one for the parent and one for the child
         g.inject(0).sideEffect(__.addV()).iterate();
         assertEquals(3, traversal().withEmbedded(graph).V().hasLabel("person").count().next().intValue());
+    }
+
+    @Test
+    public void shouldAllowHeterogeneousIdsWithAnyManager() {
+        final Configuration anyManagerConfig = new BaseConfiguration();
+        anyManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER, TinkerGraph.DefaultIdManager.ANY.name());
+        anyManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER, TinkerGraph.DefaultIdManager.ANY.name());
+        anyManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER, TinkerGraph.DefaultIdManager.ANY.name());
+        final Graph graph = TinkerGraph.open(anyManagerConfig);
+        final GraphTraversalSource g = traversal().withEmbedded(graph);
+
+        final UUID uuid = UUID.fromString("0E939658-ADD2-4598-A722-2FC178E9B741");
+        g.addV("person").property(T.id, 100).
+                addV("person").property(T.id, "1000").
+                addV("person").property(T.id, "1001").
+                addV("person").property(T.id, uuid).iterate();
+
+        assertEquals(3, g.V(100, "1000", uuid).count().next().intValue());
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2507

Upgrade docs in this commit explain this change fairly well. There doesn't seem to be a need to be so prescriptive about the types that can be filtered on and it should be up to each graph to decide how they handle such input. Removed the general exception, tests and updated the behavior of graphs to support the change.

Decided to put this on 3.6.0 rather than bring what amounts to a behavior change in the middle of 3.4.x/3.5.x. 

All tests pass with `docker/build.sh -t -n -i`

VOTE +1