### PR TITLE
TINKERPOP-2578 Coerced set to list for P within/without in Python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Coerced single `set` arguments to `P.within` and `P.without` to `list` in Python which serializes to a more expected form for `P` instances.
 * Fixed bug in the `vertexLabelKey` validation for `GraphMLWriter` which was inadvertently validating the `edgeLabelKey`.
 * Changed `IndexStep` to make it easier for providers to determine the type of indexer being used.
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperEmbeddedTypeTest.java
@@ -48,6 +48,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -385,7 +386,7 @@ public class GraphSONMapperEmbeddedTypeTest extends AbstractGraphSONTest {
     }
 
     @Test
-    public void shouldHandlePMultiValueAsCollection() throws Exception  {
+    public void shouldHandlePMultiValueAsList() throws Exception  {
         assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
 
         final P o = P.within(Arrays.asList(1,2,3));
@@ -393,8 +394,24 @@ public class GraphSONMapperEmbeddedTypeTest extends AbstractGraphSONTest {
     }
 
     @Test
+    public void shouldHandlePMultiValueAsSet() throws Exception  {
+        assumeThat(version, startsWith("v3"));
+
+        final P o = P.within(new HashSet<>(Arrays.asList(1,2,3)));
+        assertEquals(o, serializeDeserialize(mapper, o, P.class));
+    }
+
+    @Test
+    public void shouldHandlePBetween() throws Exception  {
+        assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
+
+        final P o = P.between(1, 100);
+        assertEquals(o, serializeDeserialize(mapper, o, P.class));
+    }
+
+    @Test
     public void shouldReadPWithJsonArray() throws Exception {
-        // for some reason v3 is forgiving about the naked json array - leaving this here for backward compaitiblity,
+        // for some reason v3 is forgiving about the naked json array - leaving this here for backward compatibility,
         // but should be a g:List (i think)
         assumeThat(version, either(startsWith("v2")).or(startsWith("v3")));
 

--- a/gremlin-python/glv/TraversalSource.template
+++ b/gremlin-python/glv/TraversalSource.template
@@ -167,6 +167,8 @@ class P(object):
     def within(*args):
         if len(args) == 1 and type(args[0]) == list:
             return P("within", args[0])
+        elif len(args) == 1 and type(args[0]) == set:
+            return P("within", list(args[0]))
         else:
             return P("within", list(args))
         
@@ -174,6 +176,8 @@ class P(object):
     def without(*args):
         if len(args) == 1 and type(args[0]) == list:
             return P("without", args[0])
+        elif len(args) == 1 and type(args[0]) == set:
+            return P("without", list(args[0]))
         else:
             return P("without", list(args))
 

--- a/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/jython/gremlin_python/process/traversal.py
@@ -260,6 +260,8 @@ class P(object):
     def within(*args):
         if len(args) == 1 and type(args[0]) == list:
             return P("within", args[0])
+        elif len(args) == 1 and type(args[0]) == set:
+            return P("within", list(args[0]))
         else:
             return P("within", list(args))
         
@@ -267,6 +269,8 @@ class P(object):
     def without(*args):
         if len(args) == 1 and type(args[0]) == list:
             return P("without", args[0])
+        elif len(args) == 1 and type(args[0]) == set:
+            return P("without", list(args[0]))
         else:
             return P("without", list(args))
 

--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -48,15 +48,14 @@ install_requires = [
     'aenum>=1.4.5,<3.0.0',
     'tornado>=4.4.1,<6.0',
     'six>=1.10.0,<2.0.0',
-    'isodate>=0.6.0,<1.0.0',
-    'pyparsing>=2.4.7,<3.0.0'
+    'isodate>=0.6.0,<1.0.0'
 ]
 
 if sys.version_info < (3, 2):
     install_requires += ['futures>=3.0.5,<4.0.0']
 
 if sys.version_info < (3, 5):
-    install_requires += ['pyparsing>=2.4.6,<3.0.0']
+    install_requires += ['pyparsing>=2.4.7,<3.0.0']
 
 setup(
     name='gremlinpython',

--- a/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/jython/tests/structure/io/test_graphsonV3d0.py
@@ -398,11 +398,13 @@ class TestGraphSONWriter(object):
         result = {'@type': 'g:P', '@value': {'predicate': 'within', 'value': {'@type': 'g:List', '@value': [
             {"@type": "g:Int32", "@value": 1}, {"@type": "g:Int32", "@value": 2}]}}}
         assert result == json.loads(self.graphson_writer.writeObject(P.within([1, 2])))
+        assert result == json.loads(self.graphson_writer.writeObject(P.within({1, 2})))
         assert result == json.loads(self.graphson_writer.writeObject(P.within(1, 2)))
 
         result = {'@type': 'g:P', '@value': {'predicate': 'within', 'value': {'@type': 'g:List', '@value': [
             {"@type": "g:Int32", "@value": 1}]}}}
         assert result == json.loads(self.graphson_writer.writeObject(P.within([1])))
+        assert result == json.loads(self.graphson_writer.writeObject(P.within({1})))
         assert result == json.loads(self.graphson_writer.writeObject(P.within(1)))
 
     def test_strategies(self):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2578

This change sets up `P` to better serialize instances to the form expected for different serialization types.

Builds with `mvn clean install`

VOTE +1