### PR TITLE
Fix broken link in documentation

### DIFF
--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -499,7 +499,7 @@ being where the traversal is submitted.
 
 NOTE: This model of graph traversal in a BSP system was first implemented by the
 link:https://github.com/thinkaurelius/faunus/wiki[Faunus] graph analytics engine and originally described in
-link:http://markorodriguez.com/2011/04/19/local-and-distributed-traversal-engines/[Local and Distributed Traversal Engines].
+link:https://dzone.com/articles/local-and-distributed-graph[Local and Distributed Traversal Engines].
 
 [gremlin-groovy,modern]
 ----


### PR DESCRIPTION
Web page http://markorodriguez.com/2011/04/19/local-and-distributed-traversal-engines/ is not available anymore (404).

We could use either of the following web pages instead:
1. https://dzone.com/articles/local-and-distributed-graph
2. https://web.archive.org/web/20190729094051/https://markorodriguez.com/2011/04/19/local-and-distributed-traversal-engines/