### PR TITLE
TINKERPOP-2568 Pushed the Graph instance into child traverals 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-4-12, 3.4.12>>.
 
 * Fixed bug in Javascript error message related to validating anonymous traversal spawns.
+* Fixed bug where the `Graph` instance was not being assigned to child traversals.
 * Removed sending of deprecated session close message from Gremlin.Net driver.
 
 [[release-3-5-0]]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -132,6 +132,13 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
         // steps get reId'd and traverser requirements are set.
         if (isRoot() || this.getParent() instanceof VertexProgramStep) {
 
+            // prepare the traversal and all its children for strategy application
+            TraversalHelper.applyTraversalRecursively(t -> {
+                if (hasGraph) t.setGraph(this.graph);
+                t.setStrategies(this.strategies);
+                t.setSideEffects(this.sideEffects);
+            }, this);
+
             // note that prior to applying strategies to children we used to set side-effects and strategies of all
             // children to that of the parent. under this revised model of strategy application from TINKERPOP-1568
             // it doesn't appear to be necessary to do that (at least from the perspective of the test suite). by,
@@ -148,7 +155,6 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
             TraversalHelper.applyTraversalRecursively(t -> {
                 if (hasGraph) t.setGraph(this.graph);
                 if(!(t.isRoot()) && t != this && !t.isLocked()) {
-                    t.setStrategies(new DefaultTraversalStrategies());
                     t.setSideEffects(this.sideEffects);
                     t.applyStrategies();
                 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/EventStrategyProcessTest.java
@@ -1964,7 +1964,6 @@ public class EventStrategyProcessTest extends AbstractGremlinProcessTest {
 
     @Test
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
-    @org.junit.Ignore("TINKERPOP-2579")
     public void shouldTriggerAddVertexAndPropertyUpdateWithCoalescePattern() {
         final StubMutationListener listener1 = new StubMutationListener();
         final StubMutationListener listener2 = new StubMutationListener();

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -865,7 +865,7 @@ public class TinkerGraphTest {
         final GraphTraversalSource g = traversal().withEmbedded(graph).withStrategies(new TraversalStrategy.ProviderOptimizationStrategy() {
             @Override
             public void apply(final Traversal.Admin<?, ?> traversal) {
-                final Graph graph = TraversalHelper.getRootTraversal(traversal).getGraph().get();
+                final Graph graph = traversal.getGraph().get();
                 graph.addVertex("person");
             }
         });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2568
https://issues.apache.org/jira/browse/TINKERPOP-2579

This should have been there at 3.5.0 but we didn't have tests to enforce the behavior. We have those tests now though so it will be enforced going forward. Also fixes TINKERPOP-2579.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1