### PR TITLE
Fix Python build by pinning peer dependency packaging to 20.9

### DIFF
--- a/gremlin-python/src/main/jython/setup.py
+++ b/gremlin-python/src/main/jython/setup.py
@@ -72,7 +72,8 @@ setup(
     data_files=[("", ["LICENSE", "NOTICE"])],
     setup_requires=[
         'pytest-runner==5.2',
-        'importlib-metadata<3.0.0'
+        'packaging==20.9',
+        'importlib-metadata<3.0.0'        
     ],
     tests_require=[
         'pytest>=4.6.4,<5.0.0',


### PR DESCRIPTION
The Python build is currently broken which is apparently caused by this peer dependency in version 21.
Pinning it to 20.9 seems to fix the build.
We can remove this pinning later when the problem is gone (so the builds goes through without this pinning) or when we drop 3.4-dev as the problem seems to be limited to that branch (probably Python 2).

I think we get this dependency through our dependency on `importlib-metadata` which is why I added the dependency before that package.

This could have been a CTR commit but I wasn't sure if this is the right way to solve this.
@spmallette Feel free to merge this if you agree with this change.

VOTE +1