### PR TITLE
Document lessons learned releasing 3.4.12/3.5.1

### DIFF
--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -253,7 +253,6 @@ username = <username>
 password =
 
 [pypi]
-repository = https://pypi.python.org/pypi
 username = <username>
 password =
 ----

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -124,6 +124,11 @@ bin/process-docs.sh
 Documentation is generated to the `target/docs` directory. It is also possible to generate documentation locally with
 Docker. `docker/build.sh -d`.
 
+NOTE: The installation of plugins sometimes fails in this step with the error: `Error grabbing grapes - download
+failed`. It often helps in this case to delete the directories for the dependencies that cannot be downloaded
+in the `.m2` (`~/.m2/`) and in the `grapes` (`~/.groovy/grapes/`) cache. E.g., if the error is about
+`asm#asm;3.2!asm.jar`, then remove the `asm/asm` sub directory in both directories.
+
 To generate the web site locally, there is no need for any of the above infrastructure. Site generation is a simple
 shell script:
 
@@ -223,11 +228,7 @@ which enables the "docker-images" Maven profile.
 === Release Environment
 
 This section is only useful to TinkerPop release managers and describes prerequisites related to deploying an official
-release of TinkerPop. All Apache releases must be signed. Please see link:http://www.apache.org/dev/release-signing.html[this guide]
-in the Apache documentation for instructions on to set up gpg. Keys should be added to KEYS files in both the
-link:https://dist.apache.org/repos/dist/dev/tinkerpop/KEYS[development] and
-link:https://dist.apache.org/repos/dist/release/tinkerpop/KEYS[release] distribution directories and committed
-using Apache Subversion (SVN).
+release of TinkerPop.
 
 Maven needs to be configured to deploy maven artifacts. Apache LDAP credentials can be used for this. Release
 managers should encrypt their Apache LDAP password as described

--- a/docs/src/dev/developer/release.asciidoc
+++ b/docs/src/dev/developer/release.asciidoc
@@ -79,23 +79,22 @@ Take care to commit or not commit changes related to that as necessary.
 == Release Manager Requirements
 
 If this is your first time as release manager, you will need to setup keys for signing purposes per the Apache
-release process.  Generally speaking, this will mean that you will need to generate a key-pair and then upload your
-public key to a public keyserver.
+release process. Generally speaking, this will mean that you will need to generate a key-pair and then publish your
+public key.
 
-For a general overview of key basics, refer to link:https://www.apache.org/dev/release-signing.html#key-basics[this].  For detailed
-step-by-step instructions, please follow the instructions link:https://www.apache.org/dev/openpgp.html#generate-key[here].
+For a general overview of key basics, refer to link:https://www.apache.org/dev/release-signing.html#key-basics[this]. 
+For detailed step-by-step instructions, please follow the instructions
+link:https://www.apache.org/dev/openpgp.html#generate-key[here].
 
-After completing the key-pair setup instructions, be sure to add yourself to the `PGP signature` section of `bin/validate-distribution.sh`.
+After completing the key-pair setup instructions, be sure to upload your public key to `keys.openpgp.org` and add it into your
+link:https://id.apache.org[Apache LDAP] entry (under `OpenPGP Public Key Primary Fingerprint`). This ensures that the
+key will be added automatically to this link:https://people.apache.org/keys/committer/[list of committer keys] which
+will be used to validate the distribution.
 
-[source,text]
-----
-echo -n "  * PGP signature ... "
-[ `gpg ${ZIP_FILENAME}.asc 2>&1 | grep -c '^gpg: Good signature from "Stephen Mallette <spmallette@apache.org>"$'` -eq 1 ] || \
-[ `gpg ${ZIP_FILENAME}.asc 2>&1 | grep -c '^gpg: Good signature from "Marko Rodriguez <okram@apache.org>"$'` -eq 1 ] || \
-[ `gpg ${ZIP_FILENAME}.asc 2>&1 | grep -c '^gpg: Good signature from "Theodore Ratte Wilmes (CODE SIGNING KEY) <twilmes@apache.org>"'` -eq 1 ] || \
-{ echo "failed"; exit 1; }
-echo "OK"
-----
+Your public key also needs to be added to KEYS files in both the
+link:https://dist.apache.org/repos/dist/dev/tinkerpop/KEYS[development] and
+link:https://dist.apache.org/repos/dist/release/tinkerpop/KEYS[release] distribution directories and committed
+using Apache Subversion (SVN).
 
 == Pre-flight Check
 

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -455,16 +455,6 @@ limitations under the License.
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>docker-image-tag-latest</id>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>docker-image-push</id>
                                 <phase>deploy</phase>
                                 <goals>
@@ -483,17 +473,6 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <tag>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>docker-image-push-latest</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>push</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
                                     <skip>${only.when.is.prerelease.version}</skip>
                                 </configuration>
                             </execution>

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -297,16 +297,6 @@ limitations under the License.
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>docker-image-tag-latest</id>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>docker-image-push</id>
                                 <phase>deploy</phase>
                                 <goals>
@@ -325,17 +315,6 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <tag>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>docker-image-push-latest</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>push</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
                                     <skip>${only.when.is.prerelease.version}</skip>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
This adds my lessons learned from the release process. I also noticed that we tag the docker images on `3.4-dev` with `latest` which we shouldn't do anymore now that we have 3.5.z releases as those should always be the latest release. So this removes the `latest` tag from the `3.4-branch` and I'll open another branch to target `3.5-dev` which keeps the `latest` tag there.

The deployment of Docker images failed for me through Maven so I had to manually posh the images. This seems to be a known issue for our Maven plugin: spotify/dockerfile-maven#344.
If I'm the only one affected by this, then we don't need to do anything from my side, but if others also run into this problem, then we should probably check whether we can replace that Maven plugin as it's also not actively maintained any more.

VOTE +1