### PR TITLE
TINKERPOP-2597 Fix NPE due to CompletionException in ConectionPool

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.4.13 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Prevented XML External Entity (XXE) style attacks via `GraphMLReader` by disabling DTD and external entities by default.
+* Fixed a `NullPointerException` that could occur during a failed `Connection` initialization due to uninstantiated `AtomicInteger`.
 
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: July 19, 2021)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -93,6 +93,7 @@ final class ConnectionPool {
         this.minInProcess = settings.minInProcessPerConnection;
 
         this.connections = new CopyOnWriteArrayList<>();
+        this.open = new AtomicInteger();
 
         try {
             final List<CompletableFuture<Void>> connectionCreationFutures = new ArrayList<>();
@@ -100,6 +101,7 @@ final class ConnectionPool {
                 connectionCreationFutures.add(CompletableFuture.runAsync(() -> {
                     try {
                         this.connections.add(new Connection(host.getHostUri(), this, settings.maxInProcessPerConnection));
+                        this.open.incrementAndGet();
                     } catch (ConnectionException e) {
                         throw new CompletionException(e);
                     }
@@ -127,8 +129,6 @@ final class ConnectionPool {
 
             throw new CompletionException(errMsg, result);
         }
-
-        this.open = new AtomicInteger(connections.size());
 
         logger.info("Opening connection pool on {} with core size of {}", host, minPoolSize);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2597

The clean-up method was looking to call a method on the AtomicInteger which was not instantiated. This change instantiates it before any connections are made and increments for every successful Connection created instead of setting it after all of them are created.