### PR TITLE
TINKERPOP-2486 Fix load balancing across connections

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,7 +37,8 @@ limitations under the License.
 * Bumped to Apache Hadoop 3.3.1.
 * Bumped to Apache Spark 3.1.2.
 * Changed `NumberHelper` to properly cast to `byte` and `short` rather than default coercing to `Integer`.
-* Modified some driver defaults (maximum content length, pool size, maximum in process) to be more consistent with one another. 
+* Modified some driver defaults (maximum content length, pool size, maximum in process) to be more consistent with one another.
+* Fixed a potential connection load balancing issue due to a race condition not updating the usage count.
 
 == TinkerPop 3.5.0 (The Sleeping Gremlin: No. 18 Entr'acte Symphonique)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2486

The method to select the least used connection is now synchronized and now includes the increment on its usage count so that it will not be fetched by multiple threads if it is not the least used connection. It now instead will decrement the usage if we deem that it will not be used. 

Also, simplified and cleaned-up some logic currently using unnecessary `while (true)` loops.