### PR TITLE
Added getter method for bypassTraversal in AbstractLamdaTraversal

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Ensured `PathRetractionStrategy` is applied after `InlineFilterStrategy` which prevents an error in traverser mapping in certain conditions.
 * Deprecated `JsonBuilder` serialization for GraphSON and Gryo.
 * Created `GremlinParser` to construct `Traversal` objects from `gremlin-language`.
+* Added getter method for bypassTraversal in AbstractLambdaTraversal.
 
 [[release-3-5-1]]
 === TinkerPop 3.5.1 (Release Date: July 19, 2021)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
@@ -51,6 +51,10 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
         this.bypassTraversal = bypassTraversal;
     }
 
+    public Traversal.Admin<S, E> getBypassTraversal() {
+        return this.bypassTraversal;
+    }
+
     @Override
     public List<Step> getSteps() {
         return null == this.bypassTraversal ? Collections.emptyList() : this.bypassTraversal.getSteps();


### PR DESCRIPTION
Graph provider should be able to access bypassTraversal when analyzing traversal for query execution.