### PR TITLE
TINKERPOP-2379 Make defaults consistent with Java

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,7 +33,7 @@ limitations under the License.
 * Prevented metrics computation unless the traversal is in a locked state.
 * Bumped to Apache Hadoop 3.3.1.
 * Bumped to Apache Spark 3.1.2.
-* Changed some default initialization settings in Gremlin-Python and Gremlin-Dotnet to match Java.
+* Modified some driver defaults (maximum content length, pool size, maximum in process) to be more consistent with one another. 
 
 == TinkerPop 3.5.0 (The Sleeping Gremlin: No. 18 Entr'acte Symphonique)
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ limitations under the License.
 * Prevented metrics computation unless the traversal is in a locked state.
 * Bumped to Apache Hadoop 3.3.1.
 * Bumped to Apache Spark 3.1.2.
+* Changed some default initialization settings in Gremlin-Python and Gremlin-Dotnet to match Java.
 
 == TinkerPop 3.5.0 (The Sleeping Gremlin: No. 18 Entr'acte Symphonique)
 

--- a/docker/gremlin-server/gremlin-server-integration-krb5.yaml
+++ b/docker/gremlin-server/gremlin-server-integration-krb5.yaml
@@ -55,7 +55,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 1000000
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/docker/gremlin-server/gremlin-server-integration-secure.yaml
+++ b/docker/gremlin-server/gremlin-server-integration-secure.yaml
@@ -55,7 +55,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 1000000
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/docker/gremlin-server/gremlin-server-integration.yaml
+++ b/docker/gremlin-server/gremlin-server-integration.yaml
@@ -56,7 +56,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 1000000
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -36,9 +36,9 @@ Some default value settings were changed to be consistent across different langu
 
 * The default for `PoolSize` is now `8` instead of `4` in .NET.
 * The default for `MaxInProcessPerConnection` is now `32` instead of `16` in .NET.
+* The default for `maxContentLength` is now 10 mb in the Java builder instead of 65536.
 * The default for `pool_size` is now `8` instead of `4` in Python.
-* The default for `max_content_length` in `**transport_kwargs` for the Python client is now 65536 bytes instead of 10 mb.
-* If a `protocol_factory` is not specified, it now adheres to the `max_content_length` specified instead of alway susing 65536.
+* If a `protocol_factory` is not specified, it now adheres to the `max_content_length` specified instead of always using 65536 in Python.
 
 ==== Refinements to null
 

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -30,6 +30,16 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
+==== Changes to default values
+
+Some default value settings were changed to be consistent across different languages.
+
+* The default for `PoolSize` is now `8` instead of `4` in .NET.
+* The default for `MaxInProcessPerConnection` is now `32` instead of `16` in .NET.
+* The default for `pool_size` is now `8` instead of `4` in Python.
+* The default for `max_content_length` in `**transport_kwargs` for the Python client is now 65536 bytes instead of 10 mb.
+* If a `protocol_factory` is not specified, it now adheres to the `max_content_length` specified instead of alway susing 65536.
+
 ==== Refinements to null
 
 Release 3.5.0 introduce the ability for there to be traversers that contained a `null` value. Since that time it has

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
@@ -35,8 +35,8 @@ namespace Gremlin.Net.Driver
         private int _maxInProcessPerConnection = DefaultMaxInProcessPerConnection;
         private int _reconnectionAttempts = DefaultReconnectionAttempts;
         private TimeSpan _reconnectionBaseDelay = DefaultReconnectionBaseDelay;
-        private const int DefaultPoolSize = 4;
-        private const int DefaultMaxInProcessPerConnection = 32;
+        private const int DefaultPoolSize = 8;
+        private const int DefaultMaxInProcessPerConnection = 16;
         private const int DefaultReconnectionAttempts = 4;
         private static readonly TimeSpan DefaultReconnectionBaseDelay = TimeSpan.FromSeconds(1);
 
@@ -45,7 +45,7 @@ namespace Gremlin.Net.Driver
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">The specified pool size is less than or equal to zero.</exception>
         /// <remarks>
-        ///     The default value is 4.
+        ///     The default value is 8.
         /// </remarks>
         public int PoolSize
         {
@@ -63,7 +63,7 @@ namespace Gremlin.Net.Driver
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">The specified number is less than or equal to zero.</exception>
         /// <remarks>
-        ///     The default value is 32. A <see cref="ConnectionPoolBusyException" /> is thrown if this limit is reached
+        ///     The default value is 16. A <see cref="ConnectionPoolBusyException" /> is thrown if this limit is reached
         ///     on all connections when a new request comes in.
         /// </remarks>
         public int MaxInProcessPerConnection

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
-using Gremlin.Net.Driver;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -60,7 +60,7 @@ final class Connection {
     public static final int MIN_IN_PROCESS = 1;
     public static final int MAX_WAIT_FOR_CONNECTION = 16000;
     public static final int MAX_WAIT_FOR_CLOSE = 3000;
-    public static final int MAX_CONTENT_LENGTH = 65536;
+    public static final int MAX_CONTENT_LENGTH = 10 * 1024 * 1024;
 
     public static final int RECONNECT_INTERVAL = 1000;
     public static final int RESULT_ITERATION_BATCH_SIZE = 64;

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -45,7 +45,7 @@ class Client:
         self._headers = headers
         self._traversal_source = traversal_source
         if "max_content_length" not in transport_kwargs:
-            transport_kwargs["max_content_length"] = 65536
+            transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
             message_serializer = serializer.GraphSONSerializersV3d0()
         self._message_serializer = message_serializer

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -45,7 +45,7 @@ class Client:
         self._headers = headers
         self._traversal_source = traversal_source
         if "max_content_length" not in transport_kwargs:
-            transport_kwargs["max_content_length"] = 10 * 1024 * 1024
+            transport_kwargs["max_content_length"] = 65536
         if message_serializer is None:
             message_serializer = serializer.GraphSONSerializersV3d0()
         self._message_serializer = message_serializer
@@ -69,7 +69,8 @@ class Client:
                 self._message_serializer,
                 username=self._username,
                 password=self._password,
-                kerberized_service=kerberized_service)
+                kerberized_service=kerberized_service,
+                max_content_length=transport_kwargs["max_content_length"])
         self._protocol_factory = protocol_factory
         if self._sessionEnabled:
             if pool_size is None:
@@ -77,7 +78,7 @@ class Client:
             elif pool_size != 1:
                 raise Exception("PoolSize must be 1 on session mode!")
         if pool_size is None:
-            pool_size = 4
+            pool_size = 8
         self._pool_size = pool_size
         # This is until concurrent.futures backport 3.1.0 release
         if max_workers is None:

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -28,7 +28,7 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 class DriverRemoteConnection(RemoteConnection):
 
-    def __init__(self, url, traversal_source = "g", protocol_factory=None,
+    def __init__(self, url, traversal_source="g", protocol_factory=None,
                  transport_factory=None, pool_size=None, max_workers=None,
                  username="", password="", kerberized_service='',
                  message_serializer=None, graphson_reader=None,

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -67,15 +67,16 @@ class AbstractBaseProtocol:
 
 class GremlinServerWSProtocol(AbstractBaseProtocol):
 
-    MAX_CONTENT_LENGTH = 65536
     QOP_AUTH_BIT = 1
     _kerberos_context = None
+    _max_content_length = 65536
 
-    def __init__(self, message_serializer, username='', password='', kerberized_service=''):
+    def __init__(self, message_serializer, username='', password='', kerberized_service='', max_content_length=65536):
         self._message_serializer = message_serializer
         self._username = username
         self._password = password
         self._kerberized_service = kerberized_service
+        self._max_content_length = max_content_length
 
     def connection_made(self, transport):
         super(GremlinServerWSProtocol, self).connection_made(transport)
@@ -177,7 +178,7 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
 
         name_length = len(self._username)
         fmt = '!I' + str(name_length) + 's'
-        word = self.QOP_AUTH_BIT << 24 | self.MAX_CONTENT_LENGTH
+        word = self.QOP_AUTH_BIT << 24 | self._max_content_length
         out = struct.pack(fmt, word, self._username.encode("utf-8"),)
         encoded = base64.b64encode(out).decode('ascii')
         kerberos.authGSSClientWrap(self._kerberos_context, encoded)

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -69,9 +69,13 @@ class GremlinServerWSProtocol(AbstractBaseProtocol):
 
     QOP_AUTH_BIT = 1
     _kerberos_context = None
-    _max_content_length = 65536
+    _max_content_length = 10 * 1024 * 1024
 
-    def __init__(self, message_serializer, username='', password='', kerberized_service='', max_content_length=65536):
+    def __init__(self,
+                 message_serializer,
+                 username='', password='',
+                 kerberized_service='',
+                 max_content_length=10 * 1024 * 1024):
         self._message_serializer = message_serializer
         self._username = username
         self._password = password

--- a/gremlin-server/conf/gremlin-server-classic.yaml
+++ b/gremlin-server/conf/gremlin-server-classic.yaml
@@ -38,6 +38,6 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64

--- a/gremlin-server/conf/gremlin-server-modern-readonly.yaml
+++ b/gremlin-server/conf/gremlin-server-modern-readonly.yaml
@@ -38,6 +38,6 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64

--- a/gremlin-server/conf/gremlin-server-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-modern.yaml
@@ -39,6 +39,6 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64

--- a/gremlin-server/conf/gremlin-server-neo4j.yaml
+++ b/gremlin-server/conf/gremlin-server-neo4j.yaml
@@ -55,7 +55,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/gremlin-server/conf/gremlin-server-rest-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-modern.yaml
@@ -35,6 +35,6 @@ strictTransactionManagement: false
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -50,7 +50,7 @@ strictTransactionManagement: false
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -54,7 +54,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/gremlin-server/conf/gremlin-server-spark.yaml
+++ b/gremlin-server/conf/gremlin-server-spark.yaml
@@ -68,7 +68,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/gremlin-server/conf/gremlin-server.yaml
+++ b/gremlin-server/conf/gremlin-server.yaml
@@ -45,7 +45,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -143,7 +143,7 @@ public class Settings {
      * return a 413 - Request Entity Too Large status code.  A response exceeding this size will raise an internal
      * exception.
      */
-    public int maxContentLength = 1024 * 64;
+    public int maxContentLength = 1024 * 1024 * 10;
 
     /**
      * Maximum number of request components that can be aggregated for a message.

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -69,7 +69,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 1000000
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768


### PR DESCRIPTION
Changed the defaults where it appeared to have a corresponding setting to one in Java with a different value.

Was mentioned that the specific default changes should be mentioned in the changelog using 3.5.1 as a template in this file:  https://github.com/apache/tinkerpop/blob/3.5-dev/docs/src/upgrade/release-3.5.x.asciidoc but there didn't seem to be an apparently appropriate place to put it under 3.5.2 looking at the 3.5.1 template.