### PR TITLE
 TINKERPOP-2569: Reconnect if java driver fails to initialize

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Prevented XML External Entity (XXE) style attacks via `GraphMLReader` by disabling DTD and external entities by default.
 * Fixed a `NullPointerException` that could occur during a failed `Connection` initialization due to uninstantiated `AtomicInteger`.
+* Minor changes to the initialization of Java driver `Cluster` and `Client` such that hosts are marked as available only after successfully initializing connection pools.
 
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: July 19, 2021)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -1283,8 +1283,6 @@ public final class Cluster {
 
             contactPoints.forEach(address -> {
                 final Host host = add(address);
-                if (host != null)
-                    host.makeAvailable();
             });
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2569

Made minor changes to the initialization of the Java driver Cluster and Client, such that hosts are marked as available only after successfully initializing connection pools, to fix reconnection failures when client was initialized on a dead host that restarts.