### PR TITLE
TINKERPOP-2616: Provide better exceptions with SSL related failures

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Created `GremlinParser` to construct `Traversal` objects from `gremlin-language`.
 * Added getter method for `bypassTraversal` in `AbstractLambdaTraversal`.
 * Added support for custom GraphBinary types in .NET.
+* NoAvailableHostException now describes what caused it and removed some potential unnecessary exception wrapping
 
 [[release-3-5-1]]
 === TinkerPop 3.5.1 (Release Date: July 19, 2021)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/exception/NoHostAvailableException.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/exception/NoHostAvailableException.java
@@ -24,6 +24,10 @@ public class NoHostAvailableException extends RuntimeException {
         super("All hosts are considered unavailable due to previous exceptions. Check the error log to find the actual reason.");
     }
 
+    public NoHostAvailableException(Throwable ex) {
+        super(ex);
+    }
+
     @Override
     public synchronized Throwable fillInStackTrace() {
         return this;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.driver.RequestOptions;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
+import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
 import org.apache.tinkerpop.gremlin.driver.exception.NoHostAvailableException;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.handler.WebSocketClientHandler;
@@ -63,6 +64,7 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
 import java.io.File;
+import java.net.ConnectException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -449,8 +451,9 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             client.submit("1+1").all().join().get(0).getInt();
             fail("Should not have gone through because the server is not running");
         } catch (Exception i) {
+            assertThat(i, instanceOf(NoHostAvailableException.class));
             final Throwable root = ExceptionUtils.getRootCause(i);
-            assertThat(root, instanceOf(NoHostAvailableException.class));
+            assertThat(root, instanceOf(ConnectException.class));
         }
 
         startServer();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -88,8 +88,9 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
             client.submit("1+1").all().get();
             fail("This should not succeed as the client did not enable SSL");
         } catch(Exception ex) {
+            assertThat(ex, instanceOf(NoHostAvailableException.class));
             final Throwable root = ExceptionUtils.getRootCause(ex);
-            assertEquals(NoHostAvailableException.class, root.getClass());
+            assertThat(root, instanceOf(RuntimeException.class));
         } finally {
             cluster.close();
         }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -934,7 +934,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         } catch (RuntimeException re) {
             // Client would have no active connections to the host, hence it would encounter a timeout
             // trying to find an alive connection to the host.
-            assertThat(re.getCause().getCause() instanceof TimeoutException, is(true));
+            assertThat(re.getCause(), instanceOf(TimeoutException.class));
 
             //
             // should recover when the server comes back

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSslIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSslIntegrateTest.java
@@ -30,6 +30,8 @@ import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.exception.NoHostAvailableException;
 import org.junit.Test;
 
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeoutException;
@@ -177,8 +179,9 @@ public class GremlinServerSslIntegrateTest extends AbstractGremlinServerIntegrat
             client.submit("'test'").one();
             fail("Should throw exception because ssl is enabled on the server but not on client");
         } catch(Exception x) {
+            assertThat(x, instanceOf(NoHostAvailableException.class));
             final Throwable root = ExceptionUtils.getRootCause(x);
-            assertThat(root, instanceOf(NoHostAvailableException.class));
+            assertThat(root, instanceOf(RuntimeException.class));
         } finally {
             cluster.close();
         }
@@ -220,8 +223,9 @@ public class GremlinServerSslIntegrateTest extends AbstractGremlinServerIntegrat
             client.submit("'test'").one();
             fail("Should throw exception because ssl client auth is enabled on the server but client does not have a cert");
         } catch (Exception x) {
+            assertThat(x, instanceOf(NoHostAvailableException.class));
             final Throwable root = ExceptionUtils.getRootCause(x);
-            assertThat(root, instanceOf(NoHostAvailableException.class));
+            assertThat(root, instanceOf(SSLException.class));
         } finally {
             cluster.close();
         }
@@ -237,8 +241,9 @@ public class GremlinServerSslIntegrateTest extends AbstractGremlinServerIntegrat
             client.submit("'test'").one();
             fail("Should throw exception because ssl client auth is enabled on the server but does not trust client's cert");
         } catch (Exception x) {
+            assertThat(x, instanceOf(NoHostAvailableException.class));
             final Throwable root = ExceptionUtils.getRootCause(x);
-            assertThat(root, instanceOf(NoHostAvailableException.class));
+            assertThat(root, instanceOf(SSLException.class));
         } finally {
             cluster.close();
         }
@@ -254,8 +259,9 @@ public class GremlinServerSslIntegrateTest extends AbstractGremlinServerIntegrat
             client.submit("'test'").one();
             fail("Should throw exception because ssl client requires TLSv1.2 whereas server supports only TLSv1.1");
         } catch (Exception x) {
+            assertThat(x, instanceOf(NoHostAvailableException.class));
             final Throwable root = ExceptionUtils.getRootCause(x);
-            assertThat(root, instanceOf(NoHostAvailableException.class));
+            assertThat(root, instanceOf(SSLException.class));
         } finally {
             cluster.close();
         }
@@ -271,8 +277,9 @@ public class GremlinServerSslIntegrateTest extends AbstractGremlinServerIntegrat
             client.submit("'test'").one();
             fail("Should throw exception because ssl client requires TLSv1.2 whereas server supports only TLSv1.1");
         } catch (Exception x) {
+            assertThat(x, instanceOf(NoHostAvailableException.class));
             final Throwable root = ExceptionUtils.getRootCause(x);
-            assertThat(root, instanceOf(NoHostAvailableException.class));
+            assertThat(root, instanceOf(SSLException.class));
         } finally {
             cluster.close();
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2616

NoAvailableHostException now contains the context for what caused it. A limitation to this is that it takes the last failed ConnectionPool initialization as its cause. Alternatively I considered adding a list of exceptions to NoAvailableHostException so that the user could see every failure - not sure if this is desirable though - let me know if this is something that is thought of as a good idea and I can update this PR.

Also, some of the exception handling needed some care, specifically there was a lot of `catch (Exception e)` blocks which were unnecessarily wrapping RuntimeExceptions, and any children Exceptions, in a new RuntimeException when they could be directly returned to the user.