### PR TITLE
change js remote to use isomorphic ws so can be used in browser also

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -23,7 +23,7 @@
 'use strict';
 
 const EventEmitter = require('events');
-const WebSocket = require('ws');
+const WebSocket = require('isomorphic-ws');
 const util = require('util');
 const utils = require('../utils');
 const serializer = require('../structure/io/graph-serializer');


### PR DESCRIPTION
current js implementation can only be used on node/server, and main reason is due to dependency on ws and its advanced options. if we use `isomorphic-ws` the client can be used on browser also, while still resolving to `ws`, with advanced options if deployed on node/server  