### PR TITLE
TINKERPOP-2646 Make StreamExtensions accessible

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/StreamExtensions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/StreamExtensions.cs
@@ -27,26 +27,50 @@ using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary
 {
-    internal static class StreamExtensions
+    /// <summary>
+    ///     Provides extension methods for <see cref="Stream" /> that are mostly useful when implementing GraphBinary
+    ///     serializers.
+    /// </summary>
+    public static class StreamExtensions
     {
+        /// <summary>
+        ///     Asynchronously writes a <see cref="byte"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="byte"/> to.</param>
+        /// <param name="value">The <see cref="byte"/> to write.</param>
         public static async Task WriteByteAsync(this Stream stream, byte value)
         {
             await stream.WriteAsync(new[] {value}, 0, 1).ConfigureAwait(false);
         }
         
+        /// <summary>
+        ///     Asynchronously reads a <see cref="byte"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <returns>The read <see cref="byte"/>.</returns>
         public static async Task<byte> ReadByteAsync(this Stream stream)
         {
             var readBuffer = new byte[1];
-            await stream.ReadAsync(readBuffer, 0, 1);
+            await stream.ReadAsync(readBuffer, 0, 1).ConfigureAwait(false);
             return readBuffer[0];
         }
 
+        /// <summary>
+        ///     Asynchronously writes an <see cref="int"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="int"/> to.</param>
+        /// <param name="value">The <see cref="int"/> to write.</param>
         public static async Task WriteIntAsync(this Stream stream, int value)
         {
             var bytes = BitConverter.GetBytes(value);
-            await stream.WriteAsync(new[] {bytes[3], bytes[2], bytes[1], bytes[0]}, 0, 4).ConfigureAwait(false);
+            await stream.WriteAsync(new[] { bytes[3], bytes[2], bytes[1], bytes[0] }, 0, 4).ConfigureAwait(false);
         }
         
+        /// <summary>
+        ///     Asynchronously reads an <see cref="int"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <returns>The read <see cref="int"/>.</returns>
         public static async Task<int> ReadIntAsync(this Stream stream)
         {
             var bytes = new byte[4];
@@ -54,6 +78,11 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
             return BitConverter.ToInt32(new []{bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
         
+        /// <summary>
+        ///     Asynchronously writes a <see cref="long"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="long"/> to.</param>
+        /// <param name="value">The <see cref="long"/> to write.</param>
         public static async Task WriteLongAsync(this Stream stream, long value)
         {
             var bytes = BitConverter.GetBytes(value);
@@ -62,6 +91,11 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
                     8).ConfigureAwait(false);
         }
         
+        /// <summary>
+        ///     Asynchronously reads a <see cref="long"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <returns>The read <see cref="long"/>.</returns>
         public static async Task<long> ReadLongAsync(this Stream stream)
         {
             var bytes = new byte[8];
@@ -70,12 +104,22 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
                 new[] {bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
         
+        /// <summary>
+        ///     Asynchronously writes a <see cref="float"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="float"/> to.</param>
+        /// <param name="value">The <see cref="float"/> to write.</param>
         public static async Task WriteFloatAsync(this Stream stream, float value)
         {
             var bytes = BitConverter.GetBytes(value);
-            await stream.WriteAsync(new[] {bytes[3], bytes[2], bytes[1], bytes[0]}, 0, 4).ConfigureAwait(false);
+            await stream.WriteAsync(new[] { bytes[3], bytes[2], bytes[1], bytes[0] }, 0, 4).ConfigureAwait(false);
         }
         
+        /// <summary>
+        ///     Asynchronously reads a <see cref="float"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <returns>The read <see cref="float"/>.</returns>
         public static async Task<float> ReadFloatAsync(this Stream stream)
         {
             var bytes = new byte[4];
@@ -83,6 +127,11 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
             return BitConverter.ToSingle(new []{bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
         
+        /// <summary>
+        ///     Asynchronously writes a <see cref="double"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="double"/> to.</param>
+        /// <param name="value">The <see cref="double"/> to write.</param>
         public static async Task WriteDoubleAsync(this Stream stream, double value)
         {
             var bytes = BitConverter.GetBytes(value);
@@ -91,6 +140,11 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
                     8).ConfigureAwait(false);
         }
         
+        /// <summary>
+        ///     Asynchronously reads a <see cref="double"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <returns>The read <see cref="double"/>.</returns>
         public static async Task<double> ReadDoubleAsync(this Stream stream)
         {
             var bytes = new byte[8];
@@ -99,12 +153,22 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
                 new[] {bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
         
+        /// <summary>
+        ///     Asynchronously writes a <see cref="short"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="short"/> to.</param>
+        /// <param name="value">The <see cref="short"/> to write.</param>
         public static async Task WriteShortAsync(this Stream stream, short value)
         {
             var bytes = BitConverter.GetBytes(value);
             await stream.WriteAsync(new[] {bytes[1], bytes[0]}, 0, 2).ConfigureAwait(false);
         }
         
+        /// <summary>
+        ///     Asynchronously reads a <see cref="short"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <returns>The read <see cref="short"/>.</returns>
         public static async Task<short> ReadShortAsync(this Stream stream)
         {
             var bytes = new byte[2];
@@ -112,33 +176,53 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
             return BitConverter.ToInt16(new []{bytes[1], bytes[0]}, 0);
         }
         
+        /// <summary>
+        ///     Asynchronously writes a <see cref="bool"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="bool"/> to.</param>
+        /// <param name="value">The <see cref="bool"/> to write.</param>
         public static async Task WriteBoolAsync(this Stream stream, bool value)
         {
             await stream.WriteByteAsync((byte) (value ? 1 : 0)).ConfigureAwait(false);
         }
         
+        /// <summary>
+        ///     Asynchronously reads a <see cref="bool"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <returns>The read <see cref="bool"/>.</returns>
         public static async Task<bool> ReadBoolAsync(this Stream stream)
         {
             var b = await stream.ReadByteAsync().ConfigureAwait(false);
-            switch (b)
+            return b switch
             {
-                case 1:
-                    return true;
-                case 0:
-                    return false;
-                default:
-                    throw new IOException($"Cannot read byte {b} as a boolean.");
-            }
+                1 => true,
+                0 => false,
+                _ => throw new IOException($"Cannot read byte {b} as a boolean.")
+            };
         }
         
+        /// <summary>
+        ///     Asynchronously writes a <see cref="T:byte[]"/> to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the <see cref="T:byte[]"/> to.</param>
+        /// <param name="value">The <see cref="T:byte[]"/> to write.</param>
         public static async Task WriteAsync(this Stream stream, byte[] value)
         {
             await stream.WriteAsync(value, 0, value.Length).ConfigureAwait(false);
         }
 
-        public static async Task ReadAsync(this Stream stream, byte[] buffer)
+        /// <summary>
+        ///     Asynchronously reads a <see cref="T:byte[]"/> from a <see cref="Stream"/> into a buffer.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <returns>The read <see cref="T:byte[]"/>.</returns>
+        public static async Task<byte[]> ReadAsync(this Stream stream, int count)
         {
-            await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+            var buffer = new byte[count];
+            await stream.ReadAsync(buffer, 0, count).ConfigureAwait(false);
+            return buffer;
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BigIntegerSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BigIntegerSerializer.cs
@@ -52,8 +52,7 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         protected override async Task<BigInteger> ReadValueAsync(Stream stream, GraphBinaryReader reader)
         {
             var length = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
-            var bytes = new byte[length];
-            await stream.ReadAsync(bytes).ConfigureAwait(false);
+            var bytes = await stream.ReadAsync(length).ConfigureAwait(false);
             return new BigInteger(bytes.Reverse().ToArray());
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2646

They can now also be used by users and driver providers who implement their own custom GraphBinary types.
I decided to change the signature of `ReadAsync()` a bit as it's easier to use if only the number of bytes to read has to be provided instead of a buffer that needs to have the correct length.

VOTE +1