### PR TITLE
TINKERPOP-2649 use long's to construct dates and timestamps for java

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslator.java
@@ -144,12 +144,12 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
 
         @Override
         protected String getSyntax(final Date o) {
-            return "new Date(" + o.getTime() + ")";
+            return "new Date(" + o.getTime() + "L)";
         }
 
         @Override
         protected String getSyntax(final Timestamp o) {
-            return "new Timestamp(" + o.getTime() + ")";
+            return "new Timestamp(" + o.getTime() + "L)";
         }
 
         @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslatorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslatorTest.java
@@ -135,7 +135,7 @@ public class GroovyTranslatorTest {
         final Calendar c = Calendar.getInstance();
         c.set(1975, Calendar.SEPTEMBER, 7);
         final Date d = c.getTime();
-        assertTranslation(String.format("new Date(%s)", d.getTime()), d);
+        assertTranslation(String.format("new Date(%sL)", d.getTime()), d);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class GroovyTranslatorTest {
         final Calendar c = Calendar.getInstance();
         c.set(1975, Calendar.SEPTEMBER, 7);
         final Timestamp t = new Timestamp(c.getTime().getTime());
-        assertTranslation(String.format("new Timestamp(%s)", t.getTime()), t);
+        assertTranslation(String.format("new Timestamp(%sL)", t.getTime()), t);
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2649

When running Gremlin queries through the translator Dates and Timestamps need to be long's, not int's

The gremlin-console supports both so this fix is mainly for runnig the translated queries in Java

edit:

forgot to mention that `docker/build.sh -t -i -n` passes all tests