### PR TITLE
TINKERPOP-2626 Prevent premature close of traversal

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-4-13]]
 === TinkerPop 3.4.13 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed `RangeGlobalStep` which was prematurely closing the iterator.
 * Prevented XML External Entity (XXE) style attacks via `GraphMLReader` by disabling DTD and external entities by default.
 * Improved error message for failed serialization for HTTP-based requests.
 * Fixed a `NullPointerException` that could occur during a failed `Connection` initialization due to uninstantiated `AtomicInteger`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
@@ -63,9 +63,6 @@ public final class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, 
         if (this.bypass) return true;
 
         if (this.high != -1 && this.counter.get() >= this.high) {
-            // This is a global step and this place would be the end of the traversal.
-            // Close the traversal to free up resources.
-            CloseableIterator.closeIterator(traversal);
             throw FastNoSuchElementException.instance();
         }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -193,7 +193,9 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     @Override
     public boolean hasNext() {
         if (!this.locked) this.applyStrategies();
-        return this.lastTraverser.bulk() > 0L || this.finalEndStep.hasNext();
+        final boolean more = this.lastTraverser.bulk() > 0L || this.finalEndStep.hasNext();
+        if (!more) CloseableIterator.closeIterator(this);
+        return more;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/CloseableIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/CloseableIterator.java
@@ -51,8 +51,7 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
         if (iterator instanceof AutoCloseable) {
             try {
                 ((AutoCloseable) iterator).close();
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2626

This is not a complete fix for this issue but does get rid of the premature close. Opted to try to close the Traversal as part of hasNext() as in a sense it is a way to complete iteration of the traversal. Without that change certain tests begin to fail so some additional change besides removing the premature close had to be added.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1