### PR TITLE
TINKERPOP-2656 update python translator to provide an option for non synantic sugar translations

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-5-2]]
 === TinkerPop 3.5.2 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added a `NoSugarTranslator` translator to `PythonTranslator` which translates Gremlin queries to Python without syntactic sugar (ex `g.V().limit(1)` instead of `g.V()[0:1]`)
 * Added support for `g.Tx()` in .NET.
 * Added support for `with()` constant options to `io()`.
 * Changed `GroovyTranslator` to generate code more compatible to Java with `Date` and `Timestamp`.

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -4886,9 +4886,36 @@ System.out.println(s.parameters);
 // OUTPUT: Optional[{_args_0=person, _args_2=marko, _args_1=name, _args_4=age, _args_3=knows}]
 ----
 
-Finally, the `GroovyTranslator` can take a `TypeTranslator` argument which allows some customization of how types get
+The `GroovyTranslator` can take a `TypeTranslator` argument which allows some customization of how types get
 converted to script form. The `DefaultTypeTranslator` is used if a specific implementation is not specified. A built-in
 alternative to this implementation is the `LanguageTypeTranslator` which will prefer use of the Gremlin language
 `datetime()` function rather than the JVM specific `Date` and `Timestamp` conversions. This translator can be helpful
 when generating scripts that will be sent to Gremlin Server or Remote Graph Providers supporting the `datetime()` form.
+
+The `PythonTranslator` can take a `TypeTranslator` argument to disable the syntactic sugar which the default translator
+applies to converted queries. The `DefaultTypeTranslator` is used if a specific implementation is not specified.
+
+[source,java]
+----
+Traversal<Vertex,String> t = g.V().range(0, 10).has("person","name","marko").
+                                limit(2).
+                                values("name");
+// default translator
+Translator.ScriptTranslator translator = PythonTranslator.of("g");
+String defaultQueryTranslation = translator.translate(t)
+System.out.println(defaultQueryTranslation);
+// OUTPUT: g.V()[0:10].has('person','name','marko')[0:2].name
+
+// no synantic sugar translator
+Translator.ScriptTranslator noSugarTranslator = PythonTranslator.of("g", new PythonTranslator.NoSugarTranslator(false));
+String noSugarTranslation = noSugarTranslator.translate(t)
+System.out.println(noSugarTranslation);
+// OUTPUT: g.V().range_(0,10).has('person','name','marko').limit(2).values('name')
+
+// With parameter extraction
+Translator.ScriptTranslator noSugarTranslatorWithParameters = PythonTranslator.of("g", new PythonTranslator.NoSugarTranslator(true));
+String noSugarTranslationWithParameters = noSugarTranslatorWithParameters.translate(t)
+System.out.println(noSugarTranslationWithParameters);
+// OUTPUT: g.V().range_(0,10).has(_args_0,_args_1,_args_2).limit(2).values(_args_1)
+----
 

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
@@ -507,6 +507,6 @@ public class GremlinGroovyScriptEngineTest {
         assertThat(bytecodeBindings.containsKey("two"), is(true));
         assertThat(bytecodeBindings.containsKey("three"), is(true));
 
-        assertEquals("g.V(v1Id).has('person','age',29).has('person','active',x).in_('knows').choose(__.out().count()).option(two,__.name).option(three,__.age).filter(__.outE().count().is_(y)).map(l).order().by('name',o)", gremlinAsPython);
+        assertEquals("g.V(v1Id).has('person','age',29).has('person','active',x).in_('knows').choose(__.out().count()).option(two,__.name).option(three,__.age).filter_(__.outE().count().is_(y)).map(l).order().by('name',o)", gremlinAsPython);
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2656

This PR implements two changes to the python translator

1. The `SymbolHelper` map has been updated to include the missing
reserved words/global functions differences for built in Python keywords
https://tinkerpop.apache.org/docs/3.5.1/reference/#gremlin-python-differences
2. A new translator type, `NoSugarTranslator`, has been added which
translates the Gremlin query without using any of the syntax sugar.

Given the following query:
```
g.V().range(0, 10).has("person", "name", "marko").limit(2).values("name")
```

Default translator:
```
g.V()[0:10].has('person','name','marko')[0:2].name
```

No sugar translator:
```
g.V().range_(0,10).has('person','name','marko').limit(2).values('name')
```

docker/build.sh -t -i -n passes all tests