### PR TITLE
TINKERPOP-2660 Added back close message to drivers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Ensured `PathRetractionStrategy` is applied after `InlineFilterStrategy` which prevents an error in traverser mapping in certain conditions.
 * Deprecated `JsonBuilder` serialization for GraphSON and Gryo.
 * Added `ProductiveByStrategy` to ensure consistency of `by()` modulator behaviors when child traversal arguments contained no elements.
+* Changed drivers to once again send the previously deprecated and removed "close" message for sessions.
 * Allowed `null` string values in the Gremlin grammar.
 * Fixed support for `SeedStrategy` in the Gremlin Grammar.
 * Fixed bug in `Translator` of `gremlin-javascript` around array translation.

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -267,8 +267,21 @@ namespace Gremlin.Net.Driver
         public async Task CloseAsync()
         {
             Interlocked.Exchange(ref _connectionState, Closed);
+
+            if (_sessionEnabled)
+            {
+                await CloseSession().ConfigureAwait(false);
+            }
             
             await _webSocketConnection.CloseAsync().ConfigureAwait(false);
+        }
+
+        private async Task CloseSession()
+        {
+            // build a request to close this session
+            var msg = RequestMessage.Build(Tokens.OpsClose).Processor(Tokens.ProcessorSession).Create();
+
+            await SendMessageAsync(msg).ConfigureAwait(false);
         }
 
         #region IDisposable Support

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
@@ -54,7 +54,6 @@ namespace Gremlin.Net.Driver
         /// <summary>
         ///     Operation used to get all the keys of all side-effects as produced by a previously executed Traversal.
         /// </summary>
-        [Obsolete("The close message was removed from servers in 3.5.0 so it has no value any more.")]
         public static string OpsClose = "close";
 
         /// <summary>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -119,6 +119,10 @@ class Client {
    * @returns {Promise}
    */
   close() {
+    if (this._options.session && this._options.processor === 'session') {
+      const args = {'session': this._options.session};
+      return this._connection.submit(this._options.processor, 'close', args, null).then(() => this._connection.close());
+    }
     return this._connection.close();
   }
 

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -107,10 +107,19 @@ class Client:
             self._pool.put_nowait(conn)
 
     def close(self):
+        if self._sessionEnabled:
+            self._close_session()
         while not self._pool.empty():
             conn = self._pool.get(True)
             conn.close()
         self._executor.shutdown()
+
+    def _close_session(self):
+        message = request.RequestMessage(
+            processor='session', op='close',
+            args={'session': self._session})
+        conn = self._pool.get(True)
+        return conn.write(message).result()
 
     def _get_connection(self):
         protocol = self._protocol_factory()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2660

Adding them back may just be temporary, so the message remains deprecated on the server side. Session semantics needs better definition going forward at which point the final disposition for this message can be established.

VOTE +1