### PR TITLE
TINKERPOP-2663 Allowed for Vertex/ReferenceVertex in grammar

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ limitations under the License.
 * Improved behavior of `V()` and `E()` when `null` is an argument producing a filtering behavior rather than an exception.
 * Prevented metrics computation unless the traversal is in a locked state.
 * Added syntax to Gremlin grammar to explicitly define `byte`, `short` and `BigInteger`.
+* Added syntax to Gremlin grammar to allow construction of a reference `Vertex`.
 * Created a way to produce a corpus of Gremlin traversals via `FeatureReader` and `DocumentationReader` in `gremlin-language`.
 * Exposed Gherkin tests as part of the provider test suite.
 * Packaged Gherkin tests and data as standalone package as a convenience distribution.

--- a/docs/src/dev/developer/for-committers.asciidoc
+++ b/docs/src/dev/developer/for-committers.asciidoc
@@ -412,6 +412,9 @@ And the traversal of
   """
 ----
 
+The traversal must be written so that it can be parsed by both `gremlin-groovy` and `gremlin-language`. Using syntax
+particular to one but not the other may result in test execution errors.
+
 It will be the results of this traversal that end up being asserted by Gherkin. When writing these test traversals,
 be sure to always use the method and enum prefixes. For example, use  `__.out()` for an anonymous traversal rather
 than just `out()` and prefer `Scope.local` rather than just `local`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GenericLiteralVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GenericLiteralVisitor.java
@@ -57,7 +57,7 @@ public class GenericLiteralVisitor extends GremlinBaseVisitor<Object> {
         this.antlr = antlr;
     }
 
-    public static GenericLiteralVisitor getInstance() {
+    public static GenericLiteralVisitor instance() {
         if (instance == null) {
             instance = new GenericLiteralVisitor();
         }
@@ -66,17 +66,25 @@ public class GenericLiteralVisitor extends GremlinBaseVisitor<Object> {
     }
 
     /**
+     * @deprecated As of release 3.5.2, replaced by {@link #instance()}.
+     */
+    @Deprecated
+    public static GenericLiteralVisitor getInstance() {
+        return instance();
+    }
+
+    /**
      * Parse a string literal context and return the string literal
      */
     public static String getStringLiteral(final GremlinParser.StringLiteralContext stringLiteral) {
-        return (String) (getInstance().visitStringLiteral(stringLiteral));
+        return (String) (instance().visitStringLiteral(stringLiteral));
     }
 
     /**
      * Parse a boolean literal context and return the boolean literal
      */
     public static boolean getBooleanLiteral(final GremlinParser.BooleanLiteralContext booleanLiteral) {
-        return (boolean) (getInstance().visitBooleanLiteral(booleanLiteral));
+        return (boolean) (instance().visitBooleanLiteral(booleanLiteral));
     }
 
     /**
@@ -89,7 +97,7 @@ public class GenericLiteralVisitor extends GremlinBaseVisitor<Object> {
         return stringLiteralList.stringLiteralExpr().stringLiteral()
                 .stream()
                 .filter(Objects::nonNull)
-                .map(stringLiteral -> getInstance().visitStringLiteral(stringLiteral))
+                .map(stringLiteral -> instance().visitStringLiteral(stringLiteral))
                 .toArray(String[]::new);
     }
 
@@ -103,7 +111,7 @@ public class GenericLiteralVisitor extends GremlinBaseVisitor<Object> {
         return objectLiteralList.genericLiteralExpr().genericLiteral()
                 .stream()
                 .filter(Objects::nonNull)
-                .map(genericLiteral -> getInstance().visitGenericLiteral(genericLiteral))
+                .map(genericLiteral -> instance().visitGenericLiteral(genericLiteral))
                 .toArray(Object[]::new);
     }
 
@@ -417,11 +425,11 @@ public class GenericLiteralVisitor extends GremlinBaseVisitor<Object> {
         // https://docs.oracle.com/javase/tutorial/java/data/characters.html
         // http://groovy-lang.org/syntax.html#_escaping_special_characters
         if (ctx.gremlinStringConstants() != null) {
-            return GremlinStringConstantsVisitor.getInstance().visitChildren(ctx);
+            return GremlinStringConstantsVisitor.instance().visitChildren(ctx);
         }
 
         if (ctx.NullLiteral() != null) {
-            return GremlinStringConstantsVisitor.getInstance().visitChildren(ctx);
+            return GremlinStringConstantsVisitor.instance().visitChildren(ctx);
         }
 
         return StringEscapeUtils.unescapeJava(stripQuotes(ctx.getText()));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinBaseVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinBaseVisitor.java
@@ -379,6 +379,11 @@ public class GremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> implement
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
+	public T visitTraversalMethod_from_Vertex(final GremlinParser.TraversalMethod_from_VertexContext ctx) { notImplemented(ctx); return null; }
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override public T visitTraversalMethod_group_Empty(final GremlinParser.TraversalMethod_group_EmptyContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
@@ -808,6 +813,11 @@ public class GremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> implement
 	 * {@inheritDoc}
 	 */
 	@Override public T visitTraversalMethod_to_Traversal(final GremlinParser.TraversalMethod_to_TraversalContext ctx) { notImplemented(ctx); return null; }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public T visitTraversalMethod_to_Vertex(final GremlinParser.TraversalMethod_to_VertexContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1475,7 +1485,7 @@ public class GremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> implement
 
 	@Override
 	public T visitGremlinStringConstants_connectedComponentStringConstants_propertyName(GremlinParser.GremlinStringConstants_connectedComponentStringConstants_propertyNameContext ctx) {
-		return null;
+		notImplemented(ctx); return null;
 	}
 
 	@Override
@@ -1488,6 +1498,14 @@ public class GremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> implement
 	 */
 	@Override
 	public T visitIoOptionsStringConstant(final GremlinParser.IoOptionsStringConstantContext ctx) {
+		notImplemented(ctx); return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public T visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
 		notImplemented(ctx); return null;
 	}
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinStringConstantsVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinStringConstantsVisitor.java
@@ -35,11 +35,18 @@ public class GremlinStringConstantsVisitor extends GremlinBaseVisitor<Object> {
 
     private static GremlinStringConstantsVisitor instance;
 
-    public static GremlinStringConstantsVisitor getInstance() {
+    public static GremlinStringConstantsVisitor instance() {
         if (instance == null) {
             instance = new GremlinStringConstantsVisitor();
         }
         return instance;
+    }
+
+    /**
+     * @deprecated As of release 3.5.2, replaced by {@link #instance()}
+     */
+    public static GremlinStringConstantsVisitor getInstance() {
+        return instance();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/StructureElementVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/StructureElementVisitor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.language.grammar;
+
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
+
+public class StructureElementVisitor extends GremlinBaseVisitor<Element> {
+
+    private StructureElementVisitor() {}
+
+    private static StructureElementVisitor instance;
+
+    public static StructureElementVisitor instance() {
+        if (instance == null) {
+            instance = new StructureElementVisitor();
+        }
+        return instance;
+    }
+
+    @Override
+    public Vertex visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
+        return new ReferenceVertex(GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral()),
+                GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral()));
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalFunctionVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalFunctionVisitor.java
@@ -32,11 +32,19 @@ public class TraversalFunctionVisitor extends GremlinBaseVisitor<Function> {
 
     private static TraversalFunctionVisitor instance;
 
-    public static TraversalFunctionVisitor getInstance() {
+    public static TraversalFunctionVisitor instance() {
         if (instance == null) {
             instance = new TraversalFunctionVisitor();
         }
         return instance;
+    }
+
+    /**
+     * @deprecated As of release 3.5.2, replaced by {@link #instance()}.
+     */
+    @Deprecated
+    public static TraversalFunctionVisitor getInstance() {
+        return instance();
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalMethodVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalMethodVisitor.java
@@ -221,7 +221,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_by_Function(final GremlinParser.TraversalMethod_by_FunctionContext ctx) {
-        return graphTraversal.by(TraversalFunctionVisitor.getInstance().visitTraversalFunction(ctx.traversalFunction()));
+        return graphTraversal.by(TraversalFunctionVisitor.instance().visitTraversalFunction(ctx.traversalFunction()));
     }
 
     /**
@@ -229,7 +229,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_by_Function_Comparator(final GremlinParser.TraversalMethod_by_Function_ComparatorContext ctx) {
-        return graphTraversal.by(TraversalFunctionVisitor.getInstance().visitTraversalFunction(ctx.traversalFunction()),
+        return graphTraversal.by(TraversalFunctionVisitor.instance().visitTraversalFunction(ctx.traversalFunction()),
                 TraversalEnumParser.parseTraversalEnumFromContext(Order.class, ctx.getChild(4)));
     }
 
@@ -301,7 +301,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_choose_Function(final GremlinParser.TraversalMethod_choose_FunctionContext ctx) {
-        return graphTraversal.choose(TraversalFunctionVisitor.getInstance().visitTraversalFunction(ctx.traversalFunction()));
+        return graphTraversal.choose(TraversalFunctionVisitor.instance().visitTraversalFunction(ctx.traversalFunction()));
     }
 
     /**
@@ -309,7 +309,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_choose_Predicate_Traversal(final GremlinParser.TraversalMethod_choose_Predicate_TraversalContext ctx) {
-        return graphTraversal.choose(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()),
+        return graphTraversal.choose(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()),
                 antlr.tvisitor.visitNestedTraversal(ctx.nestedTraversal()));
     }
 
@@ -318,7 +318,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_choose_Predicate_Traversal_Traversal(final GremlinParser.TraversalMethod_choose_Predicate_Traversal_TraversalContext ctx) {
-        return graphTraversal.choose(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()),
+        return graphTraversal.choose(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()),
                 antlr.tvisitor.visitNestedTraversal(ctx.nestedTraversal(0)),
                 antlr.tvisitor.visitNestedTraversal(ctx.nestedTraversal(1)));
     }
@@ -373,7 +373,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_constant(final GremlinParser.TraversalMethod_constantContext ctx) {
         return graphTraversal
-                .constant(GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral()));
+                .constant(GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral()));
     }
 
     /**
@@ -438,7 +438,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_emit_Predicate(final GremlinParser.TraversalMethod_emit_PredicateContext ctx) {
-        return graphTraversal.emit(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.emit(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -454,7 +454,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_filter_Predicate(final GremlinParser.TraversalMethod_filter_PredicateContext ctx) {
-        return graphTraversal.filter(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.filter(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -487,7 +487,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_fold_Object_BiFunction(final GremlinParser.TraversalMethod_fold_Object_BiFunctionContext ctx) {
         return graphTraversal.fold(
-                GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral()),
+                GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral()),
                 (BiFunction) TraversalEnumParser.parseTraversalEnumFromContext(Operator.class, ctx.getChild(4)));
     }
 
@@ -544,7 +544,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasId_Object_Object(final GremlinParser.TraversalMethod_hasId_Object_ObjectContext ctx) {
-        return graphTraversal.hasId(GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral()),
+        return graphTraversal.hasId(GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral()),
                 GenericLiteralVisitor.getGenericLiteralList(ctx.genericLiteralList()));
     }
 
@@ -553,7 +553,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasId_P(final GremlinParser.TraversalMethod_hasId_PContext ctx) {
-        return graphTraversal.hasId(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.hasId(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -561,7 +561,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasKey_P(final GremlinParser.TraversalMethod_hasKey_PContext ctx) {
-        return graphTraversal.hasKey(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.hasKey(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -582,7 +582,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasLabel_P(final GremlinParser.TraversalMethod_hasLabel_PContext ctx) {
-        return graphTraversal.hasLabel(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.hasLabel(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -611,7 +611,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasValue_Object_Object(final GremlinParser.TraversalMethod_hasValue_Object_ObjectContext ctx) {
-        return graphTraversal.hasValue(GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral()),
+        return graphTraversal.hasValue(GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral()),
                 GenericLiteralVisitor.getGenericLiteralList(ctx.genericLiteralList()));
     }
 
@@ -620,7 +620,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasValue_P(final GremlinParser.TraversalMethod_hasValue_PContext ctx) {
-        return graphTraversal.hasValue(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.hasValue(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -646,7 +646,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_has_String_P(final GremlinParser.TraversalMethod_has_String_PContext ctx) {
         return graphTraversal.has(GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral()),
-                TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+                TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -656,7 +656,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_has_String_String_Object(final GremlinParser.TraversalMethod_has_String_String_ObjectContext ctx) {
         return graphTraversal.has(GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(0)),
                 GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(1)),
-                GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral()));
+                GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral()));
     }
 
     /**
@@ -666,7 +666,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_has_String_String_P(final GremlinParser.TraversalMethod_has_String_String_PContext ctx) {
         return graphTraversal.has(GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(0)),
                 GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(1)),
-                TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+                TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -693,7 +693,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_has_T_P(final GremlinParser.TraversalMethod_has_T_PContext ctx) {
         return graphTraversal.has(TraversalEnumParser.parseTraversalEnumFromContext(T.class, ctx.getChild(2)),
-                TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+                TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -763,7 +763,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_is_Object(final GremlinParser.TraversalMethod_is_ObjectContext ctx) {
-        return graphTraversal.is(GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral()));
+        return graphTraversal.is(GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral()));
     }
 
     /**
@@ -771,7 +771,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_is_P(final GremlinParser.TraversalMethod_is_PContext ctx) {
-        return graphTraversal.is(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.is(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -1113,8 +1113,8 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_property_Cardinality_Object_Object_Object(final GremlinParser.TraversalMethod_property_Cardinality_Object_Object_ObjectContext ctx) {
         return graphTraversal.property(TraversalEnumParser.parseTraversalEnumFromContext(VertexProperty.Cardinality.class, ctx.getChild(2)),
-                GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral(0)),
-                GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral(1)),
+                GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral(0)),
+                GenericLiteralVisitor.instance().visitGenericLiteral(ctx.genericLiteral(1)),
                 GenericLiteralVisitor.getGenericLiteralList(ctx.genericLiteralList()));
     }
 
@@ -1431,7 +1431,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_until_Predicate(final GremlinParser.TraversalMethod_until_PredicateContext ctx) {
-        return graphTraversal.until(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.until(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -1484,7 +1484,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_where_P(final GremlinParser.TraversalMethod_where_PContext ctx) {
-        return graphTraversal.where(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        return graphTraversal.where(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -1493,7 +1493,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_where_String_P(final GremlinParser.TraversalMethod_where_String_PContext ctx) {
         return graphTraversal.where(GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral()),
-                TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+                TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()));
     }
 
     /**
@@ -1517,8 +1517,18 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public Traversal visitTraversalMethod_option_Predicate_Traversal(final GremlinParser.TraversalMethod_option_Predicate_TraversalContext ctx) {
-        return graphTraversal.option(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()),
+        return graphTraversal.option(TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx.traversalPredicate()),
                 antlr.tvisitor.visitNestedTraversal(ctx.nestedTraversal()));
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_from_Vertex(final GremlinParser.TraversalMethod_from_VertexContext ctx) {
+        return graphTraversal.from(StructureElementVisitor.instance().visitStructureVertex(ctx.structureVertex()));
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_to_Vertex(final GremlinParser.TraversalMethod_to_VertexContext ctx) {
+        return graphTraversal.to(StructureElementVisitor.instance().visitStructureVertex(ctx.structureVertex()));
     }
 
     public GraphTraversal[] getNestedTraversalList(final GremlinParser.NestedTraversalListContext ctx) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalPredicateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalPredicateVisitor.java
@@ -29,11 +29,19 @@ import java.util.Set;
 public class TraversalPredicateVisitor extends GremlinBaseVisitor<P> {
     private static TraversalPredicateVisitor instance;
 
-    public static TraversalPredicateVisitor getInstance() {
+    public static TraversalPredicateVisitor instance() {
         if (instance == null) {
             instance = new TraversalPredicateVisitor();
         }
         return instance;
+    }
+
+    /**
+     * @deprecated As of release 3.5.2, replaced by {@link #instance()}.
+     */
+    @Deprecated
+    public static TraversalPredicateVisitor getInstance() {
+        return instance();
     }
 
     private TraversalPredicateVisitor() {}
@@ -84,7 +92,7 @@ public class TraversalPredicateVisitor extends GremlinBaseVisitor<P> {
     private Object getSingleGenericLiteralArgument(final ParseTree ctx) {
         final int childIndexOfParameterValue = 2;
 
-        return GenericLiteralVisitor.getInstance().visitGenericLiteral(
+        return GenericLiteralVisitor.instance().visitGenericLiteral(
                 ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterValue));
     }
 
@@ -138,9 +146,9 @@ public class TraversalPredicateVisitor extends GremlinBaseVisitor<P> {
         final int childIndexOfParameterFirst = 2;
         final int childIndexOfParameterSecond = 4;
 
-        final Object first = GenericLiteralVisitor.getInstance().visitGenericLiteral(
+        final Object first = GenericLiteralVisitor.instance().visitGenericLiteral(
                 ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterFirst));
-        final Object second = GenericLiteralVisitor.getInstance().visitGenericLiteral(
+        final Object second = GenericLiteralVisitor.instance().visitGenericLiteral(
                 ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterSecond));
 
         return new Object[]{first, second};
@@ -179,7 +187,7 @@ public class TraversalPredicateVisitor extends GremlinBaseVisitor<P> {
         // called with no args which is valid for java/groovy
         if (ctx.getChildCount() == 3) return P.within();
 
-        final Object arguments = GenericLiteralVisitor.getInstance().visitGenericLiteralList(
+        final Object arguments = GenericLiteralVisitor.instance().visitGenericLiteralList(
                 ParseTreeContextCastHelper.castChildToGenericLiteralList(ctx, childIndexOfParameterValues));
 
         if (arguments instanceof Object[]) {
@@ -203,7 +211,7 @@ public class TraversalPredicateVisitor extends GremlinBaseVisitor<P> {
         // called with no args which is valid for java/groovy
         if (ctx.getChildCount() == 3) return P.without();
 
-        final Object arguments = GenericLiteralVisitor.getInstance().visitGenericLiteralList(
+        final Object arguments = GenericLiteralVisitor.instance().visitGenericLiteralList(
                 ParseTreeContextCastHelper.castChildToGenericLiteralList(ctx, childIndexOfParameterValues));
 
         if (arguments instanceof Object[]) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceSelfMethodVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceSelfMethodVisitor.java
@@ -56,7 +56,7 @@ public class TraversalSourceSelfMethodVisitor extends GremlinBaseVisitor<GraphTr
     {
         final int childIndexOfParameterUseBulk = 2;
 
-        final Boolean useBulk = (Boolean)(GenericLiteralVisitor.getInstance().visitBooleanLiteral(
+        final Boolean useBulk = (Boolean)(GenericLiteralVisitor.instance().visitBooleanLiteral(
                 (GremlinParser.BooleanLiteralContext)(ctx.getChild(childIndexOfParameterUseBulk))));
 
         return source.withBulk(useBulk);
@@ -80,12 +80,12 @@ public class TraversalSourceSelfMethodVisitor extends GremlinBaseVisitor<GraphTr
         final int childIndexOfParameterInitialValue = 2;
 
         if (ctx.getChildCount() == 4) {
-            return source.withSack(GenericLiteralVisitor.getInstance().visitGenericLiteral(
+            return source.withSack(GenericLiteralVisitor.instance().visitGenericLiteral(
                     ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterInitialValue)));
         } else {
             final int childIndexOfParameterMergeOperator = 4;
 
-            return source.withSack(GenericLiteralVisitor.getInstance().visitGenericLiteral(
+            return source.withSack(GenericLiteralVisitor.instance().visitGenericLiteral(
                     ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterInitialValue)),
                     TraversalEnumParser.parseTraversalEnumFromContext(Operator.class, ctx.getChild(childIndexOfParameterMergeOperator)));
         }
@@ -100,9 +100,9 @@ public class TraversalSourceSelfMethodVisitor extends GremlinBaseVisitor<GraphTr
         final int childIndexOfParameterKey = 2;
         final int childIndexOfParameterInitialValue = 4;
 
-        final String argument1 = (String)(GenericLiteralVisitor.getInstance().visitStringLiteral(
+        final String argument1 = (String)(GenericLiteralVisitor.instance().visitStringLiteral(
                 (GremlinParser.StringLiteralContext)(ctx.getChild(childIndexOfParameterKey))));
-        final Object argument2 = GenericLiteralVisitor.getInstance().visitGenericLiteral(
+        final Object argument2 = GenericLiteralVisitor.instance().visitGenericLiteral(
                 (GremlinParser.GenericLiteralContext)(ctx.getChild(childIndexOfParameterInitialValue)));
 
         return source.withSideEffect(argument1, argument2);
@@ -136,15 +136,15 @@ public class TraversalSourceSelfMethodVisitor extends GremlinBaseVisitor<GraphTr
         final int childIndexOfParameterKey = 2;
 
         if (ctx.getChildCount() == 4) {
-            final String argument1 = (String)(GenericLiteralVisitor.getInstance().visitStringLiteral(
+            final String argument1 = (String)(GenericLiteralVisitor.instance().visitStringLiteral(
                     (GremlinParser.StringLiteralContext)(ctx.getChild(childIndexOfParameterKey))));
             return source.with(argument1);
         } else {
             final int childIndexOfParameterInitialValue = 4;
 
-            final String argument1 = (String)(GenericLiteralVisitor.getInstance().visitStringLiteral(
+            final String argument1 = (String)(GenericLiteralVisitor.instance().visitStringLiteral(
                     (GremlinParser.StringLiteralContext)(ctx.getChild(childIndexOfParameterKey))));
-            final Object argument2 = GenericLiteralVisitor.getInstance().visitGenericLiteral(
+            final Object argument2 = GenericLiteralVisitor.instance().visitGenericLiteral(
                     (GremlinParser.GenericLiteralContext)(ctx.getChild(childIndexOfParameterInitialValue)));
             return source.with(argument1, argument2);
         }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/GeneralLiteralVisitorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/GeneralLiteralVisitorTest.java
@@ -349,7 +349,7 @@ public class GeneralLiteralVisitorTest {
             final GremlinParser parser = new GremlinParser(new CommonTokenStream(lexer));
             final GremlinParser.IntegerLiteralContext ctx = parser.integerLiteral();
 
-            final Object actualValue = GenericLiteralVisitor.getInstance().visitIntegerLiteral(ctx);
+            final Object actualValue = GenericLiteralVisitor.instance().visitIntegerLiteral(ctx);
             assertEquals(expected, actualValue);
         }
     }
@@ -396,33 +396,34 @@ public class GeneralLiteralVisitorTest {
         public String script;
 
         @Parameterized.Parameter(value = 1)
-        public Object expected;
+        public String expected;
+
+        @Parameterized.Parameter(value = 2)
+        public String type;
 
         @Parameterized.Parameters()
         public static Iterable<Object[]> generateTestParameters() {
             return Arrays.asList(new Object[][]{
-                    {"1.1m", new BigDecimal("1.1")},
-                    {"1.1M", new BigDecimal("1.1")},
-                    {"1.1", new BigDecimal("1.1")},
-                    {"-0.1", new BigDecimal("-0.1")},
-                    {"1.0E+12", new BigDecimal("1.0E12")},
-                    {"-0.1E-12", new BigDecimal("-0.1E-12")},
-                    {"1E12", new BigDecimal("1E12")},
+                    {"1.1", "1.1", "java.math.BigDecimal"},
+                    {"-0.1", "-0.1", "java.math.BigDecimal"},
+                    {"1.0E+12", "1.0E12", "java.math.BigDecimal"},
+                    {"-0.1E-12", "-0.1E-12", "java.math.BigDecimal"},
+                    {"1E12", "1E12", "java.math.BigDecimal"},
                     // float
-                    {"1.1f", 1.1F},
-                    {"-0.1F", -0.1F},
-                    {"1.0E+12f", 1.0E12F},
-                    {"-0.1E-12F", -0.1E-12F},
-                    {"1E12f", 1E12F},
-                    {"1F", 1F},
+                    {"1.1f", "1.1", "java.lang.Float"},
+                    {"-0.1F", "-0.1", "java.lang.Float"},
+                    {"1.0E+12f", "1.0E12", "java.lang.Float"},
+                    {"-0.1E-12F", "-0.1E-12", "java.lang.Float"},
+                    {"1E12f", "1E12", "java.lang.Float"},
+                    {"1F", "1", "java.lang.Float"},
 
                     // double
-                    {"1.1d", 1.1D},
-                    {"-0.1D", -0.1D},
-                    {"1.0E+12d", 1.0E12D},
-                    {"-0.1E-12D", -0.1E-12D},
-                    {"1E12d", 1E12D},
-                    {"1D", 1D}
+                    {"1.1d", "1.1", "java.lang.Double"},
+                    {"-0.1D", "-0.1", "java.lang.Double"},
+                    {"1.0E+12d", "1.0E12", "java.lang.Double"},
+                    {"-0.1E-12D", "-0.1E-12", "java.lang.Double"},
+                    {"1E12d", "1E12", "java.lang.Double"},
+                    {"1D", "1", "java.lang.Double"}
             });
         }
 
@@ -432,7 +433,11 @@ public class GeneralLiteralVisitorTest {
             final GremlinParser parser = new GremlinParser(new CommonTokenStream(lexer));
             final GremlinParser.FloatLiteralContext ctx = parser.floatLiteral();
 
-            assertEquals(expected, GenericLiteralVisitor.getInstance().visitFloatLiteral(ctx));
+            final Class<?> clazz = Class.forName(type);
+            final Constructor<?> ctor = clazz.getConstructor(String.class);
+            final Object expectedValue = ctor.newInstance(expected);
+
+            assertEquals(expectedValue, GenericLiteralVisitor.getInstance().visitFloatLiteral(ctx));
         }
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/StructureElementVisitorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/StructureElementVisitorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.language.grammar;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StructureElementVisitorTest {
+
+    private static final GraphTraversalSource g = EmptyGraph.instance().traversal();
+
+    @Test
+    public void shouldParseVertex() {
+        assertEquals(g.addE("knows").from(new ReferenceVertex(2, "person")), eval("g.addE('knows').from(new Vertex(2, 'person'))"));
+        assertEquals(g.addE("knows").to(new ReferenceVertex("1", "person")), eval("g.addE('knows').to(new Vertex('1', 'person'))"));
+        assertEquals(g.addE("knows").from(new ReferenceVertex(2, "person")), eval("g.addE('knows').from(new ReferenceVertex(2, 'person'))"));
+        assertEquals(g.addE("knows").to(new ReferenceVertex("1", "person")), eval("g.addE('knows').to(new ReferenceVertex('1', 'person'))"));
+    }
+
+    private static Object eval(final String query) {
+        final GremlinLexer lexer = new GremlinLexer(CharStreams.fromString(query));
+        final GremlinParser parser = new GremlinParser(new CommonTokenStream(lexer));
+        final GremlinAntlrToJava antlrToLanguage = new GremlinAntlrToJava();
+        return antlrToLanguage.visit(parser.queryList());
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalPredicateVisitorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalPredicateVisitorTest.java
@@ -98,7 +98,7 @@ public class TraversalPredicateVisitorTest {
         final GremlinLexer lexer = new GremlinLexer(CharStreams.fromString(script));
         final GremlinParser parser = new GremlinParser(new CommonTokenStream(lexer));
         final GremlinParser.TraversalPredicateContext ctx = parser.traversalPredicate();
-        final P predicate = TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx);
+        final P predicate = TraversalPredicateVisitor.instance().visitTraversalPredicate(ctx);
 
         Assert.assertEquals(expected, predicate);
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslatorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslatorTest.java
@@ -37,6 +37,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.junit.Test;
 
@@ -158,13 +159,23 @@ public class GroovyTranslatorTest {
     }
 
     @Test
-    public void shouldTranslateDateUsingDatetimeFunction() {
+    public void shouldTranslateDateUsingLanguageTypeTranslator() {
         final Translator.ScriptTranslator t = GroovyTranslator.of("g",
                 new GroovyTranslator.LanguageTypeTranslator(false));
         final Date datetime = Date.from(ZonedDateTime.of(2018, 03, 22, 00, 35, 44, 741000000, UTC).toInstant());
         final Date date = Date.from(ZonedDateTime.of(2018, 03, 22, 0, 0, 0, 0, UTC).toInstant());
         assertEquals("g.inject(datetime('2018-03-22T00:00:00Z'),datetime('2018-03-22T00:35:44.741Z'))",
                 t.translate(g.inject(date, datetime)).getScript());
+
+    }
+
+    @Test
+    public void shouldTranslateVertexUsingLanguageTypeTranslator() {
+        final Translator.ScriptTranslator t = GroovyTranslator.of("g",
+                new GroovyTranslator.LanguageTypeTranslator(false));
+
+        assertEquals("g.addE(\"knows\").from(new Vertex(1I,\"person\"))",
+                t.translate(g.addE("knows").from(new ReferenceVertex(1, "person"))).getScript());
 
     }
 

--- a/gremlin-language/src/main/antlr4/Gremlin.g4
+++ b/gremlin-language/src/main/antlr4/Gremlin.g4
@@ -392,6 +392,7 @@ traversalMethod_fold
 
 traversalMethod_from
 	: 'from' LPAREN stringLiteral RPAREN #traversalMethod_from_String
+	| 'from' LPAREN structureVertex RPAREN #traversalMethod_from_Vertex
 	| 'from' LPAREN nestedTraversal RPAREN #traversalMethod_from_Traversal
 	;
 
@@ -679,6 +680,7 @@ traversalMethod_times
 traversalMethod_to
 	: 'to' LPAREN traversalDirection (COMMA stringLiteralList)? RPAREN #traversalMethod_to_Direction_String
 	| 'to' LPAREN stringLiteral RPAREN #traversalMethod_to_String
+	| 'to' LPAREN structureVertex RPAREN #traversalMethod_to_Vertex
 	| 'to' LPAREN nestedTraversal RPAREN #traversalMethod_to_Traversal
 	;
 
@@ -740,24 +742,32 @@ traversalMethod_write
     ARGUMENT AND TERMINAL RULES
 **********************************************/
 
+// There is syntax available in the construction of a ReferenceVertex, that allows the label to not be specified.
+// That use case is related to OLAP when the StarGraph does not preserve the label of adjacent vertices or other
+// fail fast scenarios in that processing model. It is not relevant to the grammar however when a user is creating
+// the Vertex to be used in a Traversal and therefore both id and label are required.
+structureVertex
+    : NEW ('Vertex'|'ReferenceVertex') LPAREN genericLiteral COMMA stringLiteral RPAREN
+    ;
+
 traversalStrategy
 //  : 'ConnectiveStrategy' - not supported as it is a default strategy and we don't allow removal at this time
 //  | 'ElementIdStrategy' - not supported as the configuration takes a lambda
 //  | 'EventStrategy' - not supported as there is no way to send events back to the client
 //  | 'HaltedTraverserStrategy' - not supported as it is not typically relevant to OLTP
 //  | 'OptionsStrategy' - not supported as it's internal to with()
-    : 'new' 'PartitionStrategy' LPAREN traversalStrategyArgs_PartitionStrategy? (COMMA traversalStrategyArgs_PartitionStrategy)* RPAREN
+    : NEW 'PartitionStrategy' LPAREN traversalStrategyArgs_PartitionStrategy? (COMMA traversalStrategyArgs_PartitionStrategy)* RPAREN
 //  | 'RequirementStrategy' - not supported as it's internally relevant only
 //  | 'SackStrategy' - not supported directly as it's internal to withSack()
-    | 'new' 'SeedStrategy' LPAREN 'seed' COLON integerLiteral RPAREN
+    | NEW 'SeedStrategy' LPAREN 'seed' COLON integerLiteral RPAREN
 //  | 'SideEffectStrategy' - not supported directly as it's internal to withSideEffect()
-    | 'new' 'SubgraphStrategy' LPAREN traversalStrategyArgs_SubgraphStrategy? (COMMA traversalStrategyArgs_SubgraphStrategy)* RPAREN
+    | NEW 'SubgraphStrategy' LPAREN traversalStrategyArgs_SubgraphStrategy? (COMMA traversalStrategyArgs_SubgraphStrategy)* RPAREN
 //  | 'MatchAlgorithmStrategy' - not supported directly as it's internal to match()
 //  | 'ProfileStrategy' - not supported directly as it's internal to profile()
 //  | 'ReferenceElementStrategy' - not supported directly as users really can't/shouldn't change this in our context of a remote Gremlin provider
 //  | 'AdjacentToIncidentStrategy' - not supported as it is a default strategy and we don't allow removal at this time
 //  | 'ByModulatorOptimizationStrategy' - not supported as it is a default strategy and we don't allow removal at this time
-    | 'new'? 'ProductiveByStrategy' (LPAREN traversalStrategyArgs_ProductiveByStrategy? RPAREN)?
+    | NEW? 'ProductiveByStrategy' (LPAREN traversalStrategyArgs_ProductiveByStrategy? RPAREN)?
 //  | 'CountStrategy' - not supported as it is a default strategy and we don't allow removal at this time
 //  | 'EarlyLimitStrategy' - not supported as it is a default strategy and we don't allow removal at this time
 //  | 'FilterRankingStrategy' - not supported as it is a default strategy and we don't allow removal at this time
@@ -771,10 +781,10 @@ traversalStrategy
 //  | 'PathRetractionStrategy' - not supported as it is a default strategy and we don't allow removal at this time
 //  | 'RepeatUnrollStrategy' - not supported as it is a default strategy and we don't allow removal at this time
 //  | 'ComputerVerificationStrategy' - not supported since it's GraphComputer related
-    | 'new' 'EdgeLabelVerificationStrategy' LPAREN traversalStrategyArgs_EdgeLabelVerificationStrategy? (COMMA traversalStrategyArgs_EdgeLabelVerificationStrategy)* RPAREN
+    | NEW 'EdgeLabelVerificationStrategy' LPAREN traversalStrategyArgs_EdgeLabelVerificationStrategy? (COMMA traversalStrategyArgs_EdgeLabelVerificationStrategy)* RPAREN
 //  | 'LambdaRestrictionStrategy' - not supported as we don't support lambdas in any situation
     | 'ReadOnlyStrategy'
-    | 'new' 'ReservedKeysVerificationStrategy' LPAREN traversalStrategyArgs_ReservedKeysVerificationStrategy? (COMMA traversalStrategyArgs_ReservedKeysVerificationStrategy)* RPAREN
+    | NEW 'ReservedKeysVerificationStrategy' LPAREN traversalStrategyArgs_ReservedKeysVerificationStrategy? (COMMA traversalStrategyArgs_ReservedKeysVerificationStrategy)* RPAREN
 //  | 'StandardVerificationStrategy' - not supported since this is an interal strategy
     ;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2663

This is helpful for `addE()` with `from()` and `to()` to be consistent with `Vertex` object signatures.

VOTE +1