### PR TITLE
Added an `AnonymizingTypeTranslator` for use with `GroovyTranslator` …

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-5-2]]
 === TinkerPop 3.5.2 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added an `AnonymizingTypeTranslator` for use with `GroovyTranslator` which strips PII (anonymizes any String, Numeric, Date, Timestamp, or UUID data)
 * Added support for `g.Tx()` in Python.
 * Added logging in in Python.
 * Fixed shutdown cleanup issue in Python aiohttp transport layer.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/AnonymizingTypeTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/AnonymizingTypeTranslator.java
@@ -1,0 +1,170 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.translator;
+
+import org.apache.tinkerpop.gremlin.process.traversal.*;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+
+import java.sql.Timestamp;
+import java.util.*;
+
+
+/**
+ * This Translator will translate {@link Bytecode} into a representation that has been stripped of any user data
+ * (anonymized). A default anonymizer is provided, but can be replaced with a custom anonymizer as needed. The
+ * default anonymizer replaces any String, Numeric, Date, Timestamp, or UUID with a type-based token. Identical values
+ * will receive the same token (e.g. if "foo" is assigned "string0" then all occurrences of "foo" will be replaced
+ * with "string0").
+ */
+public class AnonymizingTypeTranslator extends GroovyTranslator.DefaultTypeTranslator {
+
+    /**
+     * Customizable anonymizer interface.
+     */
+    public interface Anonymizer {
+        /**
+         * Return an anonymized token for the supplied object.
+         *
+         * @param obj a {@link Traversal} object of one of the following types: String, Long, Double, FLoat, Integer,
+         *            Class, TImestamp, Date, UUID, {@link Vertex}, {@link Edge}, {@link VertexProperty}
+         * @return    an anonymized version of the supplied object
+         */
+        Object anonymize(Object obj);
+    }
+
+    /**
+     * This default implementation keeps a map from type (Java Class) to another map from instances to anonymized
+     * token.
+     */
+    public static class DefaultAnonymizer implements Anonymizer {
+        /*
+         * Map<ClassName, Map<Object, AnonymizedValue>>
+         */
+        private final Map<String, Map<Object, String>> simpleNameToObjectCache = new HashMap<>();
+
+        /**
+         * Return an anonymized token for the supplied object of the form "type:instance#".
+         */
+        @Override
+        public Object anonymize(Object obj) {
+            final String type = obj.getClass().getSimpleName();
+
+            Map<Object, String> objectToAnonymizedString = simpleNameToObjectCache.get(type);
+            if (objectToAnonymizedString != null){
+                // this object type has been handled at least once before
+                final String innerValue = objectToAnonymizedString.get(obj);
+                if (innerValue != null){
+                    return innerValue;
+                } else {
+                    final String anonymizedValue = type.toLowerCase() + objectToAnonymizedString.size();
+                    objectToAnonymizedString.put(obj, anonymizedValue);
+                    return anonymizedValue;
+                }
+            } else {
+                objectToAnonymizedString = new HashMap<>();
+                simpleNameToObjectCache.put(type, objectToAnonymizedString);
+                final String anonymizedValue = type.toLowerCase() + objectToAnonymizedString.size();
+                objectToAnonymizedString.put(obj, anonymizedValue);
+                return anonymizedValue;
+            }
+        }
+    }
+
+    private final Anonymizer anonymizer;
+
+    /**
+     * Default constructor creates a {@link DefaultAnonymizer} + withParameters=false.
+     */
+    public AnonymizingTypeTranslator() {
+        this(new DefaultAnonymizer(), false);
+    }
+
+    public AnonymizingTypeTranslator(final boolean withParameters) {
+        this(new DefaultAnonymizer(), withParameters);
+    }
+
+    public AnonymizingTypeTranslator(final Anonymizer anonymizer, final boolean withParameters) {
+        super(withParameters);
+        this.anonymizer = anonymizer;
+    }
+
+    @Override
+    protected String getSyntax(final String o) {
+        return anonymizer.anonymize(o).toString();
+//      Original syntax:
+//        return (o.contains("\"") ? "\"\"\"" + StringEscapeUtils.escapeJava(o) + "\"\"\"" : "\"" + StringEscapeUtils.escapeJava(o) + "\"")
+//                .replace("$", "\\$");
+    }
+
+    @Override
+    protected String getSyntax(final Date o) {
+        return anonymizer.anonymize(o).toString();
+//      Original syntax:
+//        return "new Date(" + o.getTime() + "L)";
+    }
+
+    @Override
+    protected String getSyntax(final Timestamp o) {
+        return anonymizer.anonymize(o).toString();
+//      Original syntax:
+//        return "new Timestamp(" + o.getTime() + "L)";
+    }
+
+    @Override
+    protected String getSyntax(final UUID o) {
+        return anonymizer.anonymize(o).toString();
+//      Original syntax:
+//        return "UUID.fromString('" + o.toString() + "')";
+    }
+
+    @Override
+    protected String getSyntax(final Number o) {
+        return anonymizer.anonymize(o).toString();
+//      Original syntax:
+//        if (o instanceof Long)
+//            return o + "L";
+//        else if (o instanceof Double)
+//            return o + "d";
+//        else if (o instanceof Float)
+//            return o + "f";
+//        else if (o instanceof Integer)
+//            return "(int) " + o;
+//        else if (o instanceof Byte)
+//            return "(byte) " + o;
+//        if (o instanceof Short)
+//            return "(short) " + o;
+//        else if (o instanceof BigInteger)
+//            return "new BigInteger('" + o.toString() + "')";
+//        else if (o instanceof BigDecimal)
+//            return "new BigDecimal('" + o.toString() + "')";
+//        else
+//            return o.toString();
+    }
+
+    @Override
+    protected Script produceScript(final Class<?> o) {
+        return script.append(anonymizer.anonymize(o).toString());
+//      Original syntax:
+//        return script.append(CoreImports.getClassImports().contains(o) ? o.getSimpleName() : o.getCanonicalName());
+    }
+
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/AnonymizingTypeTranslatorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/AnonymizingTypeTranslatorTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.translator;
+
+import org.apache.tinkerpop.gremlin.language.grammar.GremlinQueryParser;
+import org.apache.tinkerpop.gremlin.language.grammar.NoOpTerminalVisitor;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.Translator;
+import org.javatuples.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+
+public class AnonymizingTypeTranslatorTest {
+
+    private void testAnonymize(final String query, final String expected) {
+        try {
+            final Bytecode bc = (Bytecode) GremlinQueryParser.parse(query, new NoOpTerminalVisitor());
+            final Translator.ScriptTranslator translator = GroovyTranslator.of("g", new AnonymizingTypeTranslator());
+            final String converted = translator.translate(bc).getScript();
+            Assert.assertEquals(expected, converted);
+        } catch (Exception ex) {
+            throw ex instanceof RuntimeException ? (RuntimeException) ex : new RuntimeException(ex);
+        }
+    }
+
+    @Test
+    public void testAnonymize() {
+
+        new LinkedList<Pair<String,String>>() {
+            {
+                add(new Pair<>("g.V().hasLabel('person')",
+                               "g.V().hasLabel(string0)"));
+                add(new Pair<>("g.V('3').valueMap(true).unfold().toList()",
+                               "g.V(string0).valueMap(true).unfold().toList()"));
+                add(new Pair<>("g.V().has('code','AUS').out().out().out().has('code','AGR').path().by('code').toList()",
+                               "g.V().has(string0,string1).out().out().out().has(string0,string2).path().by(string0).toList()"));
+                add(new Pair<>("g.V().has('length', 10L)",
+                               "g.V().has(string0,long0)"));
+                add(new Pair<>("g.V().hasId(between('1','3'))",
+                               "g.V().hasId(P.gte(string0).and(P.lt(string1)))"));
+                add(new Pair<>("g.V().hasId(between(1.0d,6.0d))",
+                               "g.V().hasId(P.gte(double0).and(P.lt(double1)))"));
+                add(new Pair<>("g.V().where(label().is(eq('airport'))).count().toList()",
+                               "g.V().where(__.label().is(P.eq(string0))).count().toList()"));
+                add(new Pair<>("g.V().has(label,'person').count()",
+                               "g.V().has(T.label,string0).count()"));
+                add(new Pair<>("g.V().has('runways',inside(1,3)).values('code','airport').toList()",
+                               "g.V().has(string0,P.gt(integer0).and(P.lt(integer1))).values(string1,string2).toList()"));
+                add(new Pair<>("g.V().hasId(within(100..115)).out().hasId(lte(46)).count().toList()",
+                               "g.V().hasId(P.within([integer0, integer1, integer2, integer3, integer4, integer5, integer6, integer7, integer8, integer9, integer10, integer11, integer12, integer13, integer14, integer15])).out().hasId(P.lte(integer16)).count().toList()"));
+                add(new Pair<>("g.V().out('nothing').tryNext()",
+                               "g.V().out(string0).tryNext()"));
+                add(new Pair<>("g.V().out('created').next(2)",
+                               "g.V().out(string0).next(integer0)"));
+                add(new Pair<>("g.V().out('created').toList()",
+                               "g.V().out(string0).toList()"));
+                add(new Pair<>("g.V().out('created').toSet()",
+                               "g.V().out(string0).toSet()"));
+                add(new Pair<>("g.V().out('created').explain()",
+                               "g.V().out(string0).explain()"));
+                add(new Pair<>("g.V().out('created').toBulkSet()",
+                               "g.V().out(string0).toBulkSet()"));
+                add(new Pair<>("g.V(1).property('city','santa fe').property('state','new mexico').valueMap()",
+                               "g.V(integer0).property(string0,string1).property(string2,string3).valueMap()"));
+            }
+        }.forEach(test -> testAnonymize(test.getValue0(), test.getValue1()));
+
+    }
+}


### PR DESCRIPTION
…which strips PII (anonymizes any String, Numeric, Date, Timestamp, or UUID data).

  https://issues.apache.org/jira/browse/TINKERPOP-2666