### PR TITLE
TINKERPOP-2626 Added explicit closed state to DefaultTraversal

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.4.13 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Fixed `RangeGlobalStep` which was prematurely closing the iterator.
+* Added explicit state to `DefaultTraversal` to track whether or not it was fully iterated and closed to ensure it released resources properly.
 * Prevented XML External Entity (XXE) style attacks via `GraphMLReader` by disabling DTD and external entities by default.
 * Improved error message for failed serialization for HTTP-based requests.
 * Fixed a `NullPointerException` that could occur during a failed `Connection` initialization due to uninstantiated `AtomicInteger`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
@@ -285,7 +285,8 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
     }
 
     /**
-     * Releases resources opened in any steps that implement {@link AutoCloseable}.
+     * Releases resources opened in any steps that implement {@link AutoCloseable}. If this method is overridden,the
+     * implementer should invoke {@link #notifyClose()}.
      */
     @Override
     public default void close() throws Exception {
@@ -293,6 +294,17 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable, A
             if (step instanceof AutoCloseable)
                 ((AutoCloseable) step).close();
         }
+
+        notifyClose();
+    }
+
+    /**
+     * Gets a callback from {@link #close()} for additional operations specific to the {@link Traversal} implementation.
+     * A good implementation will use {@link #close()} to release resources in steps and this method to release
+     * resources specific to the {@link Traversal} implementations.
+     */
+    public default void notifyClose() {
+        // do nothing by default
     }
 
     /**


### PR DESCRIPTION
This is a bit of a follow on to the previous PR on this issue. The closed state prevents further iteration on a traversal when it has been exhausted and resources have been released. This change is non-breaking but should likely be refactored when merged to branch that can take a breaking change.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1