### PR TITLE
TINKERPOP-2569: Additional Fixes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Minor changes to the initialization of Java driver `Cluster` and `Client` such that hosts are marked as available only after successfully initializing connection pools.
 * `NoHostAvailableException` now contains a cause for the failure.
 * Bumped to Netty 4.1.72.
+* Added user-friendly message in Gremlin console for unavailable hosts upon initiation and fixed possible leak in `RemoteCommand.groovy` upon `RemoteException`.
 
 [[release-3-4-12]]
 === TinkerPop 3.4.12 (Release Date: July 19, 2021)

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
@@ -50,12 +50,13 @@ class RemoteCommand extends ComplexCommandSupport {
         def Optional<RemoteAcceptor> remoteAcceptor = pluggedIn.remoteAcceptor()
         if (!remoteAcceptor.isPresent()) return "${arguments[0]} does not accept remote configuration"
 
+        def remote = remoteAcceptor.get()
         try {
-            def remote = remoteAcceptor.get()
             def result = remote.connect(arguments.tail())
             mediator.addRemote(remote)
             return result
         } catch (RemoteException re) {
+            remote.close()
             return re.message
         }
     }

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
@@ -30,7 +30,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -124,9 +126,11 @@ public class DriverRemoteAcceptorTest {
         acceptor.configure(Arrays.asList("timeout", "-1"));
     }
 
-    @Test(expected = RemoteException.class)
-    public void shouldNotConnectWhenNoHostIsAvailable() throws Exception {
-        // there is no gremlin server running for this test, so this remote should throw due to NoHostAvailable exception thrown by the driver
-        acceptor.connect(Arrays.asList(Storage.toPath(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp"))));
+    @Test
+    public void shouldConnectWithError() throws Exception {
+        // there is no gremlin server running for this test, so the driver will throw NoHostAvailableException, log an
+        // error, and return with a message to the console.
+        assertThat(acceptor.connect(Arrays.asList(Storage.toPath(TestHelper.generateTempFileFromResource(this.getClass(),
+                        "remote.yaml", ".tmp")))).toString(), startsWith("Configured "));
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -1899,6 +1899,12 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             // trying to find an alive connection to the host.
             assertThat(re.getCause(), instanceOf(NoHostAvailableException.class));
 
+            try {
+                client.submit("1+1").all().get(3000, TimeUnit.MILLISECONDS);
+            } catch (RuntimeException re2) {
+                assertThat(re2.getCause(), instanceOf(NoHostAvailableException.class));
+            }
+
             //
             // should recover when the server comes back
             //


### PR DESCRIPTION
Additional minor fixes for https://issues.apache.org/jira/browse/TINKERPOP-2569 based on comments in https://github.com/apache/tinkerpop/pull/1476. 

Added user friendly message in Gremlin console when creating remote connection to hosts that are unavailable.
Added a `remote.close()` in `RemoteCommand.groovy` when `RemoteException` are thrown during connection in `do_connect` to fix possible leak. 