### PR TITLE
TINKERPOP-2671 Added tx() support in gremlin-language

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added an `AnonymizingTypeTranslator` for use with `GroovyTranslator` which strips PII (anonymizes any String, Numeric, Date, Timestamp, or UUID data)
 * Added support for `g.tx()` in Python.
 * Added logging in in Python.
+* Added `tx()` syntax to `gremlin-language`.
 * Fixed shutdown cleanup issue in Python aiohttp transport layer.
 * Added a `NoSugarTranslator` translator to `PythonTranslator` which translates Gremlin queries to Python without syntactic sugar (ex `g.V().limit(1)` instead of `g.V()[0:1]`)
 * Added support for `g.Tx()` in .NET.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinAntlrToJava.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinAntlrToJava.java
@@ -65,6 +65,11 @@ public class GremlinAntlrToJava extends GremlinBaseVisitor<Object> {
     final GremlinBaseVisitor<Traversal[]> tListVisitor;
 
     /**
+     * Handles transactions.
+     */
+    final GremlinBaseVisitor<Void> txVisitor;
+
+    /**
      * Creates a {@link GraphTraversal} implementation that is meant to be anonymous. This provides a way to change the
      * type of implementation that will be used as anonymous traversals. By default, it uses {@link __} which generates
      * a {@link DefaultGraphTraversal}
@@ -141,6 +146,7 @@ public class GremlinAntlrToJava extends GremlinBaseVisitor<Object> {
         this.tvisitor = new TraversalRootVisitor(this);
         this.tListVisitor = new NestedTraversalSourceListVisitor(this);
         this.createAnonymous = createAnonymous;
+        this.txVisitor = new TraversalSourceTxVisitor(g, this);
     }
 
     /**
@@ -157,7 +163,8 @@ public class GremlinAntlrToJava extends GremlinBaseVisitor<Object> {
                     return gvisitor.visitTraversalSource((GremlinParser.TraversalSourceContext) firstChild);
                 } else {
                     // handle traversalSource DOT transactionPart
-                    throw new GremlinParserException("Transaction operation is not supported yet");
+                    // third child is the tx info
+                    return txVisitor.visitTransactionPart((GremlinParser.TransactionPartContext) ctx.getChild(2));
                 }
             } else if (firstChild instanceof GremlinParser.EmptyQueryContext) {
                 // handle empty query

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinBaseVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GremlinBaseVisitor.java
@@ -30,7 +30,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
  * operations with no return type.
  */
 public class GremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements GremlinVisitor<T> {
-	private void notImplemented(ParseTree ctx) {
+	protected void notImplemented(final ParseTree ctx) {
 		final String className = (ctx != null)? ctx.getClass().getName() : "";
 		throw new UnsupportedOperationException("Method not implemented for context class " + className);
 	}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceTxVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceTxVisitor.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.language.grammar;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+/**
+ * Handles transactions via calls to {@code tx()}.
+ */
+public class TraversalSourceTxVisitor extends GremlinBaseVisitor<Void> {
+    private GraphTraversalSource source;
+    private final GremlinAntlrToJava antlr;
+
+    public TraversalSourceTxVisitor(final GraphTraversalSource source, final GremlinAntlrToJava antlr) {
+        this.source = source;
+        this.antlr = antlr;
+    }
+
+    @Override
+    public Void visitTransactionPart(final GremlinParser.TransactionPartContext ctx) {
+        // position 4 holds the tx command
+        final String cmd = ctx.getChild(4).getText();
+        switch (cmd) {
+            case "begin":
+                // script based transactions are automatic, meaning commit()/rollback() should keep g in a state
+                // where the transaction is opened on the next script execution. begin() is a more necessary syntax in
+                // remote client-side Gremlin where you need to construct a boundary for the session which hosts the
+                // transaction. we support begin() here to at least allow the function to be called without error so
+                // as to hold syntax consistency, but it is effectively a no-op.
+                // this.source.tx().begin();
+                break;
+            case "commit":
+                this.source.tx().commit();
+                break;
+            case "rollback":
+                this.source.tx().rollback();
+                break;
+            default:
+                notImplemented(ctx);
+                break;
+        }
+
+        return null;
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceTxVisitorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceTxVisitorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.language.grammar;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Can only test against {@link EmptyGraph} which won't support transactions so all it can verify is that {@code tx()}
+ * is called to fail.
+ */
+public class TraversalSourceTxVisitorTest {
+
+    private GraphTraversalSource g;
+    private GremlinAntlrToJava antlrToLanguage;
+
+    @Before
+    public void setup()  {
+        g = traversal().withEmbedded(EmptyGraph.instance());
+        antlrToLanguage = new GremlinAntlrToJava(g);
+    }
+
+    @Test
+    public void shouldHandleTxCommit() {
+        try {
+            eval("g.tx().commit()");
+            fail("Should not have succeeded because EmptyGraph does not support transactions.");
+        } catch(UnsupportedOperationException uoe) {
+            assertEquals("Graph does not support transactions", uoe.getMessage());
+        }
+    }
+
+    private Object eval(final String query) {
+        final GremlinLexer lexer = new GremlinLexer(CharStreams.fromString(query));
+        final GremlinParser parser = new GremlinParser(new CommonTokenStream(lexer));
+        return antlrToLanguage.visit(parser.queryList());
+    }
+}

--- a/gremlin-language/src/main/antlr4/Gremlin.g4
+++ b/gremlin-language/src/main/antlr4/Gremlin.g4
@@ -46,9 +46,9 @@ traversalSource
     ;
 
 transactionPart
-    : 'tx' LPAREN RPAREN DOT 'commit' LPAREN RPAREN
+    : 'tx' LPAREN RPAREN DOT 'begin' LPAREN RPAREN
+    | 'tx' LPAREN RPAREN DOT 'commit' LPAREN RPAREN
     | 'tx' LPAREN RPAREN DOT 'rollback' LPAREN RPAREN
-    | 'tx' LPAREN RPAREN
     ;
 
 rootTraversal


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2671

Adding tx() support to gremlin-language brings its grammar/parser closer in line with what is possible now with bytecode and with Groovy scripts. From the user's perspective there is now a clear way for them to signify that their transaction is closed with either rollback or commit. Support for begin() is present for consistency in the API but technically it is just a no-op. Documentation will arrive around gremlin-language for https://issues.apache.org/jira/browse/TINKERPOP-2644 - for now this lands a bit under the radar for 3.5.13.

All tests pass with `docker/build.sh -t -n -i`

VOTE +1