### PR TITLE
TINKERPOP-2651 Update to .NET 6

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,10 +176,10 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Set up .NET 3.1.x
+      - name: Set up .NET 6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
       - name: Build with Maven
         run: |
           touch gremlin-dotnet/src/.glv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update
 # include both java 8/11 so that we can use the same docker image for future builds on that version of the jdk as we do
 # for the older release branches. the java version to use is just controlled by JAVA_HOME hardcoded below
 RUN apt-get install -y openjdk-8-jdk openjdk-11-jdk gawk git maven openssh-server subversion zip
-RUN apt-get install -y --force-yes dotnet-sdk-3.1 mono-devel
+RUN apt-get install -y --force-yes dotnet-sdk-6.0 mono-devel
 
 # python3 on xenial install 3.5.2 which is insufficient for newer versions of python/typing#259 so
 # custom build and install 3.6.9 and upgrade pip along the way. this could be resolved by using bionic

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -203,8 +203,8 @@ See the <<release-environment,Release Environment>> section for more information
 [[dotnet-environment]]
 === DotNet Environment
 
-The build optionally requires link:https://www.microsoft.com/net/core[.NET Core SDK] (>=3.1) to work with the
-`gremlin-dotnet` module. If .NET Core SDK is not installed, TinkerPop will still build with Maven, but .NET projects
+The build optionally requires link:https://dotnet.microsoft.com/download[.NET SDK] (>=6.0) to work with the
+`gremlin-dotnet` module. If .NET SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
 
 `gremlin-dotnet` can be built and tested from the command line with:

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
@@ -19,7 +19,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -93,7 +93,7 @@ file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&
                 <packaging.type>pom</packaging.type>
             </properties>
         </profile>
-        <!-- activates the building of .NET components and requires that the .NET Core SDK be installed on the system -->
+        <!-- activates the building of .NET components and requires that the .NET SDK be installed on the system -->
         <profile>
             <id>gremlin-dotnet</id>
             <activation>

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -403,7 +403,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
 
         private string GetRootPath()
         {
-            var codeBaseUrl = new Uri(GetType().GetTypeInfo().Assembly.CodeBase);
+            var codeBaseUrl = new Uri(GetType().GetTypeInfo().Assembly.Location);
             var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
             DirectoryInfo rootDir = null;
             for (var dir = Directory.GetParent(Path.GetDirectoryName(codeBasePath));

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>

--- a/gremlin-dotnet/test/pom.xml
+++ b/gremlin-dotnet/test/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.
                 <packaging.type>pom</packaging.type>
             </properties>
         </profile>
-        <!-- activates the building of .NET components and requires that the .NET Core SDK be installed on the system -->
+        <!-- activates the building of .NET components and requires that the .NET SDK be installed on the system -->
         <profile>
             <id>gremlin-dotnet</id>
             <activation>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2651

Note that this only affects our build process and the Gremlin.Net.Template. Users of Gremlin.Net will not be affected by this change as that still targets .NET Standard 2.0 (and additionally .NET Standard 1.3 in `3.4-dev`).

This does not necessarily have to be merged before code freeze for 3.4.13/3.5.2/3.6.0. I'm just opening the PR now as I have the contribution ready, but I can also simply retarget this on `3.5-dev` if we don't get it merged before code freeze.

I verified that the Docker build also still works with `docker/build.sh -t`.

VOTE +1