### PR TITLE
TINKERPOP-2679 update javascript driver to support stream processing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-5-2]]
 === TinkerPop 3.5.2 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Added an optional callback function when submitting scripts through the JavaScript driver which allows processing each batch of result sets as they come in, rather than waiting for the entire result set to complete before allowing processing.
 * Added an `AnonymizingTypeTranslator` for use with `GroovyTranslator` which strips PII (anonymizes any String, Numeric, Date, Timestamp, or UUID data)
 * Added support for `g.tx()` in Python.
 * Added logging in in Python.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1721,6 +1721,32 @@ IMPORTANT: The preferred method for setting a per-request timeout for scripts is
 with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple
 timeouts will be interpreted as a sum of all timeouts identified in the script for that request.
 
+
+==== Processing results as they are returned from the Gremlin server
+
+
+The Gremlin JavaScript driver maintains a WebSocket connection to the Gremlin server and receives messages according to the `batchSize` parameter on the per request settings or the `resultIterationBatchSize` value configured for the Gremlin server. When submitting scripts the default behavior is to wait for the entire result set to be returned from a query before allowing any processing on the result set. 
+
+The following examples assume that you have 100 vertices in your graph.
+
+[source,javascript]
+----
+const result = await client.submit("g.V()");
+console.log(result.toArray()); // 100 - all the vertices in your graph
+----
+
+When working with larger result sets it may be beneficial for memory management to process each chunk of data as it is returned from the gremlin server. The Gremlin JavaScript driver can accept an optional callback to run on each chunk of data returned.
+
+[source,javascript]
+----
+
+await client.submit("g.V()", {}, { batchSize: 25 }, (data) => {
+  console.log(data.toArray().length); // 25 - this callback will be called 4 times (100 / 25 = 4)
+})
+----
+
+If the callback is provided, each chunk of data will be processed as it comes in, rather than waiting for the entire result set to be returned.
+
 [[gremlin-javascript-dsl]]
 === Domain Specific Languages
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
@@ -74,5 +74,20 @@ describe('Client', function () {
           assert.ok(rs.attributes.get('host'));
         });
     });
+
+    it('should accept an optional callback to process data in chunks according to the batchSize parameter', async () => {
+      const data = [];
+      let calls = 0;
+      await client.submit('g.V().limit(3)', {}, { batchSize: 2 }, (chunk) => {
+        calls += 1;
+        for (const v of chunk) {
+          data.push(v);
+        }
+      });
+
+      assert.strictEqual(calls, 2); // limit of 3 with batchSize of 2 should be two function calls
+      assert.strictEqual(data.length, 3);
+      assert.ok(data[0] instanceof graphModule.Vertex);
+    });
   });
 });


### PR DESCRIPTION
This PR implements a change to javascript driver for allowing an optional callback which will be run with the result set of each chunk of data returned from the gremlin server rather than waiting for the entire query to finish.

docker/build.sh -t -i -n passes all tests