### PR TITLE
Fixed issue on comparing BigDecimal with Double/Float infinite numbers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 [[release-3-5-3]]
 === TinkerPop 3.5.3 (Release Date: NOT OFFICIALLY RELEASED YET)
+* Fixed issue with implicit conversion of Infinity numbers into BigDecimals.
 
 
 [[release-3-5-2]]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
@@ -255,7 +255,17 @@ public final class NumberHelper {
                 }
                 return bigDecimalValue(b);
             },
-            (a, b) -> bigDecimalValue(a).compareTo(bigDecimalValue(b)));
+            (a, b) -> {
+                if( a instanceof Float && Float.isInfinite((Float) a))
+                    return 1;
+                else if( b instanceof Float && Float.isInfinite((Float) b))
+                    return -1;
+                else if( a instanceof Double && Double.isInfinite((Double) a))
+                    return 1;
+                else if( b instanceof Double && Double.isInfinite((Double) b))
+                    return -1;
+                return bigDecimalValue(a).compareTo(bigDecimalValue(b));
+            });
 
     public final BiFunction<Number, Number, Number> add;
     public final BiFunction<Number, Number, Number> sub;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
@@ -256,14 +256,22 @@ public final class NumberHelper {
                 return bigDecimalValue(b);
             },
             (a, b) -> {
-                if( a instanceof Float && Float.isInfinite((Float) a))
+                if( a instanceof Float && ((Float) a) == Float.POSITIVE_INFINITY)
                     return 1;
-                else if( b instanceof Float && Float.isInfinite((Float) b))
+                else if( a instanceof Float && ((Float) a) == Float.NEGATIVE_INFINITY)
                     return -1;
-                else if( a instanceof Double && Double.isInfinite((Double) a))
+                else if( b instanceof Float && ((Float) b) == Float.POSITIVE_INFINITY)
+                    return -1;
+                else if( b instanceof Float && ((Float) b) == Float.NEGATIVE_INFINITY)
                     return 1;
-                else if( b instanceof Double && Double.isInfinite((Double) b))
+                else if( a instanceof Double && ((Double) a) == Double.POSITIVE_INFINITY)
+                    return 1;
+                else if( a instanceof Double && ((Double) a) == Double.NEGATIVE_INFINITY)
                     return -1;
+                else if( b instanceof Double && ((Double) b) == Double.POSITIVE_INFINITY)
+                    return -1;
+                else if( b instanceof Double && ((Double) b) == Double.NEGATIVE_INFINITY)
+                    return 1;
                 return bigDecimalValue(a).compareTo(bigDecimalValue(b));
             });
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/CompareTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/CompareTest.java
@@ -196,25 +196,25 @@ public class CompareTest {
             {Compare.gte, doubleNegativeInfinite, big500, false},
             {Compare.lte, doubleNegativeInfinite, big500, true},
         }));
-//
-//        // Compare bigdecimal numbers with float infinite
-//        final Float floatNegativeInfinite = Float.NEGATIVE_INFINITY;
-//        testCases.addAll(Arrays.asList(new Object[][]{
-//            // big500 - floatNegativeInfinite
-//            {Compare.eq, big500, floatNegativeInfinite, false},
-//            {Compare.neq, big500, floatNegativeInfinite, true},
-//            {Compare.gt, big500, floatNegativeInfinite, true},
-//            {Compare.lt, big500, floatNegativeInfinite, false},
-//            {Compare.gte, big500, floatNegativeInfinite, true},
-//            {Compare.lte, big500, floatNegativeInfinite, false},
-//            // floatNegativeInfinite - big500
-//            {Compare.eq, floatNegativeInfinite, big500, false},
-//            {Compare.neq, floatNegativeInfinite, big500, true},
-//            {Compare.gt, floatNegativeInfinite, big500, false},
-//            {Compare.lt, floatNegativeInfinite, big500, true},
-//            {Compare.gte, floatNegativeInfinite, big500, false},
-//            {Compare.lte, floatNegativeInfinite, big500, true},
-//        }));
+
+        // Compare bigdecimal numbers with float infinite
+        final Float floatNegativeInfinite = Float.NEGATIVE_INFINITY;
+        testCases.addAll(Arrays.asList(new Object[][]{
+            // big500 - floatNegativeInfinite
+            {Compare.eq, big500, floatNegativeInfinite, false},
+            {Compare.neq, big500, floatNegativeInfinite, true},
+            {Compare.gt, big500, floatNegativeInfinite, true},
+            {Compare.lt, big500, floatNegativeInfinite, false},
+            {Compare.gte, big500, floatNegativeInfinite, true},
+            {Compare.lte, big500, floatNegativeInfinite, false},
+            // floatNegativeInfinite - big500
+            {Compare.eq, floatNegativeInfinite, big500, false},
+            {Compare.neq, floatNegativeInfinite, big500, true},
+            {Compare.gt, floatNegativeInfinite, big500, false},
+            {Compare.lt, floatNegativeInfinite, big500, true},
+            {Compare.gte, floatNegativeInfinite, big500, false},
+            {Compare.lte, floatNegativeInfinite, big500, true},
+        }));
 
         return testCases;
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/CompareTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/CompareTest.java
@@ -138,6 +138,84 @@ public class CompareTest {
                 {Compare.gte, big2, big1, true},
                 {Compare.lte, big2, big1, false},
         }));
+
+        // Compare bigdecimal numbers with double infinite
+        final BigDecimal big500 = new BigDecimal("500.00");
+
+        final Double doubleInfinite = Double.POSITIVE_INFINITY;
+        testCases.addAll(Arrays.asList(new Object[][]{
+            // big500 - doubleInfinite
+            {Compare.eq, big500, doubleInfinite, false},
+            {Compare.neq, big500, doubleInfinite, true},
+            {Compare.gt, big500, doubleInfinite, false},
+            {Compare.lt, big500, doubleInfinite, true},
+            {Compare.gte, big500, doubleInfinite, false},
+            {Compare.lte, big500, doubleInfinite, true},
+            // doubleInfinite - big500
+            {Compare.eq, doubleInfinite, big500, false},
+            {Compare.neq, doubleInfinite, big500, true},
+            {Compare.gt, doubleInfinite, big500, true},
+            {Compare.lt, doubleInfinite, big500, false},
+            {Compare.gte, doubleInfinite, big500, true},
+            {Compare.lte, doubleInfinite, big500, false},
+        }));
+
+        // Compare bigdecimal numbers with float infinite
+        final Float floatInfinite = Float.POSITIVE_INFINITY;
+        testCases.addAll(Arrays.asList(new Object[][]{
+            // big500 - floatInfinite
+            {Compare.eq, big500, floatInfinite, false},
+            {Compare.neq, big500, floatInfinite, true},
+            {Compare.gt, big500, floatInfinite, false},
+            {Compare.lt, big500, floatInfinite, true},
+            {Compare.gte, big500, floatInfinite, false},
+            {Compare.lte, big500, floatInfinite, true},
+            // floatInfinite - big500
+            {Compare.eq, floatInfinite, big500, false},
+            {Compare.neq, floatInfinite, big500, true},
+            {Compare.gt, floatInfinite, big500, true},
+            {Compare.lt, floatInfinite, big500, false},
+            {Compare.gte, floatInfinite, big500, true},
+            {Compare.lte, floatInfinite, big500, false},
+        }));
+
+        final Double doubleNegativeInfinite = Double.NEGATIVE_INFINITY;
+        testCases.addAll(Arrays.asList(new Object[][]{
+            // big500 - doubleNegativeInfinite
+            {Compare.eq, big500, doubleNegativeInfinite, false},
+            {Compare.neq, big500, doubleNegativeInfinite, true},
+            {Compare.gt, big500, doubleNegativeInfinite, true},
+            {Compare.lt, big500, doubleNegativeInfinite, false},
+            {Compare.gte, big500, doubleNegativeInfinite, true},
+            {Compare.lte, big500, doubleNegativeInfinite, false},
+            // doubleNegativeInfinite - big500
+            {Compare.eq, doubleNegativeInfinite, big500, false},
+            {Compare.neq, doubleNegativeInfinite, big500, true},
+            {Compare.gt, doubleNegativeInfinite, big500, false},
+            {Compare.lt, doubleNegativeInfinite, big500, true},
+            {Compare.gte, doubleNegativeInfinite, big500, false},
+            {Compare.lte, doubleNegativeInfinite, big500, true},
+        }));
+//
+//        // Compare bigdecimal numbers with float infinite
+//        final Float floatNegativeInfinite = Float.NEGATIVE_INFINITY;
+//        testCases.addAll(Arrays.asList(new Object[][]{
+//            // big500 - floatNegativeInfinite
+//            {Compare.eq, big500, floatNegativeInfinite, false},
+//            {Compare.neq, big500, floatNegativeInfinite, true},
+//            {Compare.gt, big500, floatNegativeInfinite, true},
+//            {Compare.lt, big500, floatNegativeInfinite, false},
+//            {Compare.gte, big500, floatNegativeInfinite, true},
+//            {Compare.lte, big500, floatNegativeInfinite, false},
+//            // floatNegativeInfinite - big500
+//            {Compare.eq, floatNegativeInfinite, big500, false},
+//            {Compare.neq, floatNegativeInfinite, big500, true},
+//            {Compare.gt, floatNegativeInfinite, big500, false},
+//            {Compare.lt, floatNegativeInfinite, big500, true},
+//            {Compare.gte, floatNegativeInfinite, big500, false},
+//            {Compare.lte, floatNegativeInfinite, big500, true},
+//        }));
+
         return testCases;
     }
 


### PR DESCRIPTION
Since there is no such concept of "Infinite" number in BigDecimal, a comparison between a BigDecimal and a Float.INFINITE or Double.INFINITE causes a parsing exception.

Example:

```java
Vertex alice = g.addV("person").property("hair", Double.POSITIVE_INFINITY ).next();
Vertex bob = g.addV("person").property("hair", 500 ).next();
String query =“g.V().has('hair',500.00)”;
```

For more information: https://github.com/ArcadeData/arcadedb/issues/289