### PR TITLE
TINKERPOP-2682 Enable WS compression in .NET

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.5.3 (Release Date: NOT OFFICIALLY RELEASED YET)
 * Fixed issue with implicit conversion of Infinity numbers into BigDecimals.
 
+* Added support for WebSocket compression in the .NET driver. (Only available on .NET 6.)
 
 [[release-3-5-2]]
 === TinkerPop 3.5.2 (Release Date: January 10, 2022)

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1276,6 +1276,18 @@ when a new request comes in.
 A `ServerUnavailableException` is thrown if no connection is available to the server to submit a request after
 `ReconnectionAttempts` retries.
 
+==== WebSocket Configuration
+
+The WebSocket connections can also be configured, directly as parameters of the `GremlinClient` constructor. It takes
+an optional delegate `webSocketConfiguration` that will be invoked for each connection. This makes it possible to
+configure more advanced options like the `KeepAliveInterval` or client certificates.
+
+Starting with .NET 6, it is also possible to use compression for WebSockets. This is enabled by default starting with
+TinkerPop 3.5.3 (again, only on .NET 6 or higher). Note that compression might make an application susceptible to
+attacks like CRIME/BREACH. Compression should therefore be turned off if the application sends sensitive data to the
+server as well as data that could potentially be controlled by an untrusted user. Compression can be disabled via the
+`disableCompression` parameter.
+
 [[gremlin-dotnet-serialization]]
 === Serialization
 

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -21,6 +21,26 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 *The Sleeping Gremlin: No. 18 Entr'acte Symphonique*
 
+== TinkerPop 3.5.3
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/3.5.3/CHANGELOG.asciidoc#release-3-5-3[changelog] for a
+complete list of all the modifications that are part of this release.
+
+=== Upgrading for Users
+
+==== .NET WebSocket Compression Support
+
+.NET 6 added support for WebSocket compression. This is now also enabled by default in Gremlin.NET.
+
+It should be noted however that compression might make an application susceptible to attacks like CRIME/BREACH.
+Compression should therefore be turned off if the application sends sensitive data to the server as well as data that
+could potentially be controlled by an untrusted user. Compression can be disabled via the `disableCompression`
+parameter on the `GremlinClient` constructor.
+
+See:link:https://issues.apache.org/jira/browse/TINKERPOP-2682[TINKERPOP-2682]
+
 == TinkerPop 3.5.2
 
 *Release Date: January 10, 2022*

--- a/gremlin-dotnet/src/Gremlin.Net/CompatibilitySuppressions.xml
+++ b/gremlin-dotnet/src/Gremlin.Net/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <!-- Added an optional parameter to the constructor. -->
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Gremlin.Net.Driver.GremlinClient.#ctor(Gremlin.Net.Driver.GremlinServer,Gremlin.Net.Driver.IMessageSerializer,Gremlin.Net.Driver.ConnectionPoolSettings,System.Action{System.Net.WebSockets.ClientWebSocketOptions},System.String)</Target>
+    <Left>lib/netstandard2.0/Gremlin.Net.dll</Left>
+    <Right>lib/netstandard2.0/Gremlin.Net.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
@@ -21,31 +21,28 @@
 
 #endregion
 
-using System;
-using System.Net.WebSockets;
-
 namespace Gremlin.Net.Driver
 {
     internal class ConnectionFactory : IConnectionFactory
     {
-        private readonly Action<ClientWebSocketOptions> _webSocketConfiguration;
+        private readonly WebSocketSettings _webSocketSettings;
         private readonly GremlinServer _gremlinServer;
         private readonly string _sessionId;
-        private IMessageSerializer _messageSerializer;
+        private readonly IMessageSerializer _messageSerializer;
 
         public ConnectionFactory(GremlinServer gremlinServer, IMessageSerializer messageSerializer,
-            Action<ClientWebSocketOptions> webSocketConfiguration, string sessionId)
+            WebSocketSettings webSocketSettings, string sessionId)
         {
             _gremlinServer = gremlinServer;
             _messageSerializer = messageSerializer;
             _sessionId = sessionId;
-            _webSocketConfiguration = webSocketConfiguration;
+            _webSocketSettings = webSocketSettings;
         }
 
         public IConnection CreateConnection()
         {
             return new Connection(_gremlinServer.Uri, _gremlinServer.Username, _gremlinServer.Password,
-                _messageSerializer, _webSocketConfiguration, _sessionId);
+                _messageSerializer, _webSocketSettings, _sessionId);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -35,10 +35,16 @@ namespace Gremlin.Net.Driver
         private const WebSocketMessageType MessageType = WebSocketMessageType.Binary;
         private readonly ClientWebSocket _client;
 
-        public WebSocketConnection(Action<ClientWebSocketOptions> webSocketConfiguration)
+        public WebSocketConnection(WebSocketSettings settings)
         {
             _client = new ClientWebSocket();
-            webSocketConfiguration?.Invoke(_client.Options);
+#if NET6_0_OR_GREATER
+            if (settings.UseCompression)
+            {
+                _client.Options.DangerousDeflateOptions = settings.CompressionOptions;
+            }
+#endif
+            settings.WebSocketConfigurationCallback?.Invoke(_client.Options);
         }
 
         public async Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
@@ -65,7 +71,17 @@ namespace Gremlin.Net.Driver
         private bool CloseAlreadyInitiated => _client.State == WebSocketState.Closed ||
                                             _client.State == WebSocketState.Aborted ||
                                             _client.State == WebSocketState.CloseSent;
-
+        
+#if NET6_0_OR_GREATER
+        public async Task SendMessageUncompressedAsync(byte[] message)
+        {
+            await _client.SendAsync(new ArraySegment<byte>(message), MessageType,
+                    WebSocketMessageFlags.EndOfMessage | WebSocketMessageFlags.DisableCompression,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+#endif
+        
         public async Task SendMessageAsync(byte[] message)
         {
             await
@@ -75,20 +91,18 @@ namespace Gremlin.Net.Driver
 
         public async Task<byte[]> ReceiveMessageAsync()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            WebSocketReceiveResult received;
+            var buffer = new byte[ReceiveBufferSize];
+
+            do
             {
-                WebSocketReceiveResult received;
-                var buffer = new byte[ReceiveBufferSize];
+                var receiveBuffer = new ArraySegment<byte>(buffer);
+                received = await _client.ReceiveAsync(receiveBuffer, CancellationToken.None).ConfigureAwait(false);
+                ms.Write(receiveBuffer.Array, receiveBuffer.Offset, received.Count);
+            } while (!received.EndOfMessage);
 
-                do
-                {
-                    var receiveBuffer = new ArraySegment<byte>(buffer);
-                    received = await _client.ReceiveAsync(receiveBuffer, CancellationToken.None).ConfigureAwait(false);
-                    ms.Write(receiveBuffer.Array, receiveBuffer.Offset, received.Count);
-                } while (!received.EndOfMessage);
-
-                return ms.ToArray();
-            }
+            return ms.ToArray();
         }
 
         public bool IsOpen => _client.State == WebSocketState.Open;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketSettings.cs
@@ -1,0 +1,55 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Net.WebSockets;
+
+namespace Gremlin.Net.Driver
+{
+    /// <summary>
+    ///     Holds settings for WebSocket connections.
+    /// </summary>
+    internal class WebSocketSettings
+    {
+        // We currently only use this internally so we don't have to pass these values through the different layers
+        // all the way down to the WebSocketConnection class. We can make this public however when we refactor the
+        // configuration in general.
+        
+        /// <summary>
+        ///     Gets or sets the delegate that will be invoked with the <see cref="ClientWebSocketOptions" />
+        ///     object used to configure WebSocket connections.
+        /// </summary>
+        public Action<ClientWebSocketOptions> WebSocketConfigurationCallback { get; set; }
+#if NET6_0_OR_GREATER
+        /// <summary>
+        ///     Gets or sets whether compressions will be used. The default is true. (Only available since .NET 6.)
+        /// </summary>
+        public bool UseCompression { get; set; } = true;
+
+        /// <summary>
+        ///     Gets or sets compression options. (Only available since .SET 6.)
+        /// </summary>
+        public WebSocketDeflateOptions CompressionOptions { get; set; } = new WebSocketDeflateOptions();
+#endif
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -18,7 +18,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8</LangVersion>
@@ -67,13 +67,18 @@ NOTE that versions suffixed with "-rc" are considered release candidates (i.e. p
     <RepositoryUrl>https://github.com/apache/tinkerpop</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>    
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>3.5.2</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
+  </ItemGroup>
+    
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/test/Gremlin.Net.Benchmarks/CompressionBenchmarks.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Benchmarks/CompressionBenchmarks.cs
@@ -1,0 +1,70 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+using Gremlin.Net.Structure.IO.GraphBinary;
+using Gremlin.Net.Structure.IO.GraphSON;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
+using static Gremlin.Net.Process.Traversal.__;
+
+namespace Gremlin.Net.Benchmarks;
+
+public class CompressionBenchmarks
+{
+    public static async Task GraphSONWithoutCompression()
+    {
+        var client = new GremlinClient(new GremlinServer("localhost", 45940), new GraphSON3MessageSerializer(),
+            disableCompression: true);
+        await PerformBenchmarkWithClient(client);
+    }
+    
+    public static async Task GraphSONWithCompression()
+    {
+        var client = new GremlinClient(new GremlinServer("localhost", 45940), new GraphSON3MessageSerializer());
+        await PerformBenchmarkWithClient(client);
+    }
+    
+    public static async Task GraphBinaryWithoutCompression()
+    {
+        var client = new GremlinClient(new GremlinServer("localhost", 45940), new GraphBinaryMessageSerializer(),
+            disableCompression: true);
+        await PerformBenchmarkWithClient(client);
+    }
+    
+    public static async Task GraphBinaryWithCompression()
+    {
+        var client = new GremlinClient(new GremlinServer("localhost", 45940), new GraphBinaryMessageSerializer());
+        await PerformBenchmarkWithClient(client);
+    }
+
+    private static async Task PerformBenchmarkWithClient(GremlinClient client)
+    {
+        var g = Traversal().WithRemote(new DriverRemoteConnection(client));
+        for (var i = 0; i < 5; i++)
+        {
+            await g.V().Repeat(Both()).Times(10).Emit().Fold().Promise(t => t.ToList());
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Gremlin.Net.Benchmarks.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Gremlin.Net.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Program.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Program.cs
@@ -21,6 +21,9 @@
 
 #endregion
 
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
 
 namespace Gremlin.Net.Benchmarks
@@ -31,5 +34,12 @@ namespace Gremlin.Net.Benchmarks
         {
             BenchmarkRunner.Run<MessageSerializerBenchmarks>();
         }
+        
+        // public static async Task Main()
+        // {
+        //     var watch = Stopwatch.StartNew();
+        //     await CompressionBenchmarks.GraphBinaryWithCompression();
+        //     Console.WriteLine(watch.Elapsed);
+        // }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2695

WebSocket support was only added in .NET 6 which made it necessary to explicitly add .NET 6 as an additional target framework. Compression will now be enabled by default on .NET 6 as it's only available there. This made it necessary to add conditional compilation based on the target framework.

### Package validation

I also enabled [package validation](https://docs.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview) so we a) notice if we introduce breaking changes by accident and b) ensure that our code compiled against .NET Standard 2.0 can also be run against .NET 6. This already helped me to keep the breaking change here to a minimum. It's just an added optional parameter here to be able to disable compression. We could refactor the `GremlinClient` constructors in the future in a way to avoid this problem of having to add optional parameters for new config options which is always a breaking change. The validation is executed on `dotnet pack` which gets already executed via `mvn verify` and is therefore also part of our GH actions.

Compatibility errors that we know about and that we accept should be added to the `CompatibilitySuppressions.xml` file which  can also be generated via

```
dotnet pack Gremlin.Net.csproj /p:GenerateCompatibilitySuppressionFile=true
```

### Possibly vulnerable to attacks (CRIME / BREACH)

WebSocket compression can be problematic due to attacks like CRIME/BREACH as noted in TINKERPOP-2682. So, I added an option to easily disable it for applications that might be vulnerable and added docs to make users aware of this.

I guess we should discuss how we want to deal with this in general as it's not specific to .NET. So, should we simply add similar notes to the Java/Python docs?

### Benchmarks

Lastly, some quick benchmarks I ran on my machine:



**GraphBinary:**

Without compression:
Packets transmitted: 3594
Bytes transmitted: 7MB
Runtime: 1min 1.5sec

With compression:
Packets transmitted: 62 (1.7%)
Bytes transmitted: 34KB (0.5%)
Runtime: 1.3sec

**GraphSON 3:**

Without compression:
Packets transmitted: 12029
Bytes transmitted: 25MB
Runtime: 1min 40sec

With compression:
Packets transmitted: 116 (1.0%)
Bytes transmitted: 103KB (0.4%)
Runtime: 1min 39sec

So, both for GraphSON as well as for GraphBinary the network traffic shrinks by a factor of ~100 while the total runtime is not affected. Note that this was just a very simple benchmark (I used the same traversal as @spmallette used in the PRs for Python and Java, just with a smaller number of iterations to keep the runtime to a minimum). The results will of course vary for different traversals / graphs.

VOTE +1