### PR TITLE
docs: Fix GraphBinary enum like types specification

### DIFF
--- a/docs/src/dev/io/graphbinary.asciidoc
+++ b/docs/src/dev/io/graphbinary.asciidoc
@@ -356,7 +356,7 @@ properties. Note that as TinkerPop currently send "references" only, this value 
 
 ==== Barrier
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Binding
 
@@ -386,31 +386,31 @@ Where:
 
 ==== Cardinality
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Column
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Direction
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Operator
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Order
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Pick
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Pop
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Lambda
 
@@ -433,11 +433,11 @@ Where:
 
 ==== Scope
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== T
 
-Format: a single `String` representing the enum value.
+Format: a fully qualified single `String` representing the enum value.
 
 ==== Traverser
 


### PR DESCRIPTION
Enum like types (Barrier, Cardinality, Column, Direction, Operator, Order, Pick, Pop, Scope, T) should provide enum element name as a fully-qualified string, i.e. as `{type_code}{type_info}{value_flag}{value}`.