### PR TITLE
docs: Fix GraphBinary Path type spec typo

### DIFF
--- a/docs/src/dev/io/graphbinary.asciidoc
+++ b/docs/src/dev/io/graphbinary.asciidoc
@@ -279,8 +279,8 @@ Format: `{labels}{objects}`
 
 Where:
 
-- `{labels}` is a `List` in which each item is a `Set` of `String`.
-- `{objects}` is a `List` of fully qualified typed values.
+- `{labels}` is a fully qualified `List` in which each item is a fully qualified `Set` of `String`.
+- `{objects}` is a fully qualified `List` of fully qualified typed values.
 
 ==== Property
 


### PR DESCRIPTION
Mentioned List and Set are expected to be fully qualified according to the
actual behaviour of gremlin-server.