### PR TITLE
Open up 'IsDictionaryType' to recognize more actual types

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/TypeSerializerRegistry.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/TypeSerializerRegistry.cs
@@ -212,10 +212,11 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
             throw new InvalidOperationException($"No serializer found for type ${valueType}.");
         }
 
-        private bool IsDictionaryType(Type type, out Type keyType, out Type valueType)
+        private static bool IsDictionaryType(Type type, out Type keyType, out Type valueType)
         {
-            var maybeInterfaceType = type.GetInterfaces()
-                .FirstOrDefault(interfaceType => interfaceType.IsConstructedGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+            var maybeInterfaceType = type
+                .GetInterfaces()
+                .FirstOrDefault(implementedInterfaceType => implementedInterfaceType.IsConstructedGenericType && implementedInterfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>));
 
             if (maybeInterfaceType is { } interfaceType)
             {

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/TypeSerializerRegistry.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/TypeSerializerRegistry.cs
@@ -164,10 +164,8 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
                 return _serializerByType[valueType];
             }
             
-            if (IsDictionaryType(valueType))
+            if (IsDictionaryType(valueType, out var dictKeyType, out var dictValueType))
             {
-                var dictKeyType = valueType.GetGenericArguments()[0];
-                var dictValueType = valueType.GetGenericArguments()[1];
                 var serializerType = typeof(MapSerializer<,>).MakeGenericType(dictKeyType, dictValueType);
                 var serializer = (ITypeSerializer) Activator.CreateInstance(serializerType);
                 _serializerByType[valueType] = serializer;
@@ -214,11 +212,25 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
             throw new InvalidOperationException($"No serializer found for type ${valueType}.");
         }
 
-        private static bool IsDictionaryType(Type type)
+        private bool IsDictionaryType(Type type, out Type keyType, out Type valueType)
         {
-            return type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>);
+            var maybeInterfaceType = type.GetInterfaces()
+                .FirstOrDefault(interfaceType => interfaceType.IsConstructedGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+            if (maybeInterfaceType is { } interfaceType)
+            {
+                keyType = interfaceType.GetGenericArguments()[0];
+                valueType = interfaceType.GetGenericArguments()[1];
+
+                return true;
+            }
+
+            keyType = null;
+            valueType = null;
+
+            return false;
         }
-        
+
         private static bool IsSetType(Type type)
         {
             return type.GetInterfaces().Any(implementedInterface => implementedInterface.IsConstructedGenericType &&

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
@@ -150,7 +150,10 @@ namespace Gremlin.Net.Structure.IO.GraphSON
         {
             return type
                 .GetInterfaces()
-                .Any(@interface => @interface.IsConstructedGenericType && @interface.GetGenericTypeDefinition() == typeof(IEnumerable<>) && @interface.GenericTypeArguments[0] is { IsConstructedGenericType: true } genericArgument && genericArgument.GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
+                .Any(interfaceType => interfaceType.IsConstructedGenericType
+                    && interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>) 
+                    && interfaceType.GenericTypeArguments[0] is { IsConstructedGenericType: true } genericArgument 
+                    && genericArgument.GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
         }
 
         private Dictionary<string, dynamic> DictToGraphSONDict(dynamic dict)

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
@@ -148,7 +148,9 @@ namespace Gremlin.Net.Structure.IO.GraphSON
 
         private bool IsDictionaryType(Type type)
         {
-            return type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>);
+            return type
+                .GetInterfaces()
+                .Any(@interface => @interface.IsConstructedGenericType && @interface.GetGenericTypeDefinition() == typeof(IEnumerable<>) && @interface.GenericTypeArguments[0] is { IsConstructedGenericType: true } genericArgument && genericArgument.GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
         }
 
         private Dictionary<string, dynamic> DictToGraphSONDict(dynamic dict)


### PR DESCRIPTION
Return true from GraphSONWriter.IsDictionaryType not only when the type is an actual Dictionary<,>, but even if it's something else that implements IEnumerable<KeyValuePair<,>>. This is useful when an instance of an ImmutableDictionary is passed as Bindings to a RequestMessage.