### PR TITLE
TINKERPOP-2707 Close of parent connection also calls close on spawned child sessions.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,9 +22,12 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 [[release-3-5-3]]
 === TinkerPop 3.5.3 (Release Date: NOT OFFICIALLY RELEASED YET)
-* Fixed issue with implicit conversion of Infinity numbers into BigDecimals.
 
+* Fixed issue with implicit conversion of `Infinity` number instances into `BigDecimal`.
 * Added support for WebSocket compression in the .NET driver. (Only available on .NET 6.)
+* Fixed bug in `DefaultTraversal.clone()` where the resulting `Traversal` copy could not be re-iterated.
+* Renamed `GremlinBaseVisitor` to `DefaultGremlinBaseVisitor` in `gremlin-core` to prevent conflict with the generated `GremlinBaseVisitor` in `gremlin-language`.
+* Tracked transaction spawned connections and closed them when the parent connection was closed for `gremlin-python`.
 
 [[release-3-5-2]]
 === TinkerPop 3.5.2 (Release Date: January 10, 2022)
@@ -39,7 +42,6 @@ This release also includes changes from <<release-3-4-13, 3.4.13>>.
 * Added a `NoSugarTranslator` translator to `PythonTranslator` which translates Gremlin queries to Python without syntactic sugar (ex `g.V().limit(1)` instead of `g.V()[0:1]`)
 * Added support for `g.Tx()` in .NET.
 * Added support for `with()` constant options to `io()`.
-* Renamed `GremlinBaseVisitor` to `DefaultGremlinBaseVisitor` in `gremlin-core` to prevent conflict with the generated `GremlinBaseVisitor` in `gremlin-language`.
 * Changed `GroovyTranslator` to generate code more compatible to Java with `Date` and `Timestamp`.
 * Fixed bug in the processing of the `io()` step when constructing a `Traversal` from the grammar.
 * Added the `ConnectedComponent` tokens required to properly process the `with()` of the `connectedComponent()` step.
@@ -55,7 +57,6 @@ This release also includes changes from <<release-3-4-13, 3.4.13>>.
 * Fixed support for `SeedStrategy` in the Gremlin Grammar.
 * Fixed bug in `Translator` of `gremlin-javascript` around array translation.
 * Fixed bugs in `PythonTranslator`, `JavascriptTranslator` and `DotNetTranslator` when translating `TraversalStrategy` objects to Javascript.
-* Fixed bug in `DefaultTraversal.clone()` where the resulting `Traversal` copy could not be re-iterated.
 * Prevented exception with `hasLabel(null)` and `hasKey(null)` and instead filter away traversers as these structural components can't ever be null.
 * Improved handling of `null` when passed to `P` predicates.
 * Handled `null` for mathematical reducing operations of `sum()`, `mean()`, `max()` and `min()`.

--- a/gremlin-python/src/main/python/gremlin_python/driver/remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/remote_connection.py
@@ -42,6 +42,9 @@ class RemoteConnection(object):
     def submit(self, bytecode):
         pass
 
+    def is_closed(self):
+        raise Exception('is_closed() must be implemented')
+
     def is_session_bound(self):
         return False
 

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -1078,6 +1078,11 @@ class Transaction:
     # Return whether or not transaction is open.
     # Allow camelcase function here to keep api consistent with other languages.
     def isOpen(self):
+        # if the underlying DriverRemoteConnection is closed then the Transaction can't be open
+        if (self._session_based_connection and self._session_based_connection.is_closed()) or \
+                self._remote_connection.is_closed():
+            self.__is_open = False
+
         return self.__is_open
 
     def __verify_transaction_state(self, state, error_message):

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -143,17 +143,6 @@ def test_client_bytecode_options(client):
     assert len(result_set.all().result()) == 6
 
 
-def test_client_message_too_big(client):
-    try:
-        client = Client("http://localhost", 'g', max_content_length=1024)
-        client.submit("1+1").all().result()
-        assert False
-    except Exception:
-        assert True
-    finally:
-        client.close()
-
-
 def test_iterate_result_set(client):
     g = Graph().traversal()
     t = g.V()

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-import pytest
-
 from gremlin_python import statics
 from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.statics import long
@@ -48,15 +46,15 @@ class TestDriverRemoteConnection(object):
         assert Traverser(Vertex(1)) == g.V(1).nextTraverser()
         assert 1 == len(g.V(1).toList())
         assert isinstance(g.V(1).toList(), list)
-        results = g.V().repeat(out()).times(2).name
+        results = g.V().repeat(__.out()).times(2).name
         results = results.toList()
         assert 2 == len(results)
         assert "lop" in results
         assert "ripple" in results
         # #
-        assert 10 == g.V().repeat(both()).times(5)[0:10].count().next()
-        assert 1 == g.V().repeat(both()).times(5)[0:1].count().next()
-        assert 0 == g.V().repeat(both()).times(5)[0:0].count().next()
+        assert 10 == g.V().repeat(__.both()).times(5)[0:10].count().next()
+        assert 1 == g.V().repeat(__.both()).times(5)[0:1].count().next()
+        assert 0 == g.V().repeat(__.both()).times(5)[0:0].count().next()
         assert 4 == g.V()[2:].count().next()
         assert 2 == g.V()[:2].count().next()
         # #
@@ -92,11 +90,11 @@ class TestDriverRemoteConnection(object):
         # this test just validates that the underscored versions of steps conflicting with Gremlin work
         # properly and can be removed when the old steps are removed - TINKERPOP-2272
         results = g.V().filter_(__.values('age').sum_().and_(
-            __.max_().is_(gt(0)), __.min_().is_(gt(0)))).range_(0, 1).id_().next()
+            __.max_().is_(P.gt(0)), __.min_().is_(P.gt(0)))).range_(0, 1).id_().next()
         assert 1 == results
         # #
         # test binding in P
-        results = g.V().has('person', 'age', Bindings.of('x', lt(30))).count().next()
+        results = g.V().has('person', 'age', Bindings.of('x', P.lt(30))).count().next()
         assert 2 == results
         # #
         # test dict keys which can only work on GraphBinary and GraphSON3 which include specific serialization


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2707

Not closing these sessions could end in a leak if a user opts to get a little loose with the expected API calls for properly handling sessions. This change should prevent accidents.

Builds with `mvn clean install -pl gremlin-python`

VOTE +1