### PR TITLE
TINKERPOP-2681 Use PascalCase for added Directions

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Direction.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Direction.cs
@@ -41,9 +41,9 @@ namespace Gremlin.Net.Process.Traversal
 
         public static Direction Out => new Direction("OUT");
 
-        public static Direction from = Out;
+        public static Direction From => Out;
 
-        public static Direction to = In;
+        public static Direction To => In;
 
         private static readonly IDictionary<string, Direction> Properties = new Dictionary<string, Direction>
         {


### PR DESCRIPTION
Using `=>` instead of `=` also makes these properties instead of fields which is more consistent with the other properties there.

These directions were only added in #1555 which wasn't released yet, so this is not breaking anything.

VOTE +1