### PR TITLE
TINKERPOP-2717 handle websocket close message and add ConnectionClosedException in Gremlin.NET

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -87,7 +87,6 @@ namespace Gremlin.Net.Driver
             _callbackByRequestId.GetOrAdd(requestMessage.RequestId, receiver);
             _writeQueue.Enqueue(requestMessage);
             BeginSendingMessages();
-
             return receiver.Result;
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -56,7 +56,7 @@ namespace Gremlin.Net.Driver
         private int _writeInProgress = 0;
         private const int Closed = 1;
 
-        public Connection(Uri uri, string username, string password, IMessageSerializer messageSerializer,
+        public Connection(IClientWebSocket clientWebSocket, Uri uri, string username, string password, IMessageSerializer messageSerializer,
             WebSocketSettings webSocketSettings, string sessionId)
         {
             _uri = uri;
@@ -68,7 +68,7 @@ namespace Gremlin.Net.Driver
                 _sessionEnabled = true;
             }
             _messageSerializer = messageSerializer;
-            _webSocketConnection = new WebSocketConnection(webSocketSettings);
+            _webSocketConnection = new WebSocketConnection(clientWebSocket, webSocketSettings);
         }
 
         public async Task ConnectAsync(CancellationToken cancellationToken)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,6 +87,7 @@ namespace Gremlin.Net.Driver
             _callbackByRequestId.GetOrAdd(requestMessage.RequestId, receiver);
             _writeQueue.Enqueue(requestMessage);
             BeginSendingMessages();
+
             return receiver.Result;
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
@@ -41,8 +41,8 @@ namespace Gremlin.Net.Driver
 
         public IConnection CreateConnection()
         {
-            return new Connection(_gremlinServer.Uri, _gremlinServer.Username, _gremlinServer.Password,
-                _messageSerializer, _webSocketSettings, _sessionId);
+            return new Connection(ProxyClientWebSocket.CreateClientWebSocket(), _gremlinServer.Uri, _gremlinServer.Username, 
+                _gremlinServer.Password, _messageSerializer, _webSocketSettings, _sessionId);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ConnectionClosedException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ConnectionClosedException.cs
@@ -1,0 +1,65 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Net.WebSockets;
+
+namespace Gremlin.Net.Driver.Exceptions
+{
+    /// <summary>
+    ///     The exception that is thrown for requests that in-flight when the underlyingg websocket is closed by the server.
+    ///     Requests that recieve this exception will be in a non-deteministic state and may need to be retried.
+    /// </summary>
+    /// <remarks>
+    ///     It is recommended to use the same request retry policy that is applied when a <see cref="System.Net.WebSockets.WebSocketException" />,
+    ///     <see cref="System.Net.Sockets.SocketException"/>, <see cref="System.IO.IOException" />.
+    /// </remarks>
+    public class ConnectionClosedException : Exception
+    {
+        /// <summary>
+        ///     Gets the well-known WebSocket close status code provided by the server.
+        /// </summary>
+        public WebSocketCloseStatus? Status { get; }
+
+        /// <summary>
+        ///     Gets the Websocket closure description provided by the server.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ConnectionClosedException" /> class.
+        /// </summary>
+        public ConnectionClosedException(WebSocketCloseStatus? status, string description)
+            : base(CreateMessage(status, description))
+        {
+            Status = status;
+            Description = description;
+        }
+
+        private static string CreateMessage(WebSocketCloseStatus? status, string description)
+        {
+            return $"Connection closed by server. CloseStatus: {status?.ToString() ?? "<none>"}, CloseDescription: {description ?? "<none>"}." +
+                " Any in-progress requests on the connection will be in an unknown state, and may need to be retried.";
+        }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/IClientWebSocket.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/IClientWebSocket.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 
 namespace Gremlin.Net.Driver
 {
-    interface IClientWebSocket : IDisposable
+    internal interface IClientWebSocket : IDisposable
     {
         WebSocketState State { get; }
         ClientWebSocketOptions Options { get; }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/IClientWebSocket.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/IClientWebSocket.cs
@@ -1,0 +1,43 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gremlin.Net.Driver
+{
+    interface IClientWebSocket : IDisposable
+    {
+        WebSocketState State { get; }
+        ClientWebSocketOptions Options { get; }
+        Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken);
+        Task ConnectAsync(Uri uri, CancellationToken cancellationToken);
+        Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken);
+        Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken);
+#if NET6_0_OR_GREATER
+        ValueTask SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken);
+#endif
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ProxyClientWebSocket.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ProxyClientWebSocket.cs
@@ -1,0 +1,81 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gremlin.Net.Driver
+{
+    internal class ProxyClientWebSocket : IClientWebSocket
+    {
+        private readonly ClientWebSocket _client;
+
+        public ProxyClientWebSocket(ClientWebSocket client)
+        {
+            _client = client;
+        }
+
+        public WebSocketState State => _client.State;
+
+        public ClientWebSocketOptions Options => _client.Options;
+
+        public static IClientWebSocket CreateClientWebSocket()
+        {
+            return new ProxyClientWebSocket(new ClientWebSocket());
+        }
+
+        public Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+        {
+            return _client.CloseAsync(closeStatus, statusDescription, cancellationToken);
+        }
+
+        public Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
+        {
+            return _client.ConnectAsync(uri, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
+
+        public Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            return _client.ReceiveAsync(buffer, cancellationToken);
+        }
+
+        public Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            return _client.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+        }
+
+#if NET6_0_OR_GREATER
+            public ValueTask SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken)
+            {
+                return _client.SendAsync(buffer, messageType, messageFlags, cancellationToken);
+            }
+#endif
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -36,9 +36,9 @@ namespace Gremlin.Net.Driver
         private const WebSocketMessageType MessageType = WebSocketMessageType.Binary;
         private readonly IClientWebSocket _client;
 
-        public WebSocketConnection(WebSocketSettings settings)
+        public WebSocketConnection(IClientWebSocket client, WebSocketSettings settings)
         {
-            _client = CreateClientWebSocket(settings);
+            _client = client;
 
 #if NET6_0_OR_GREATER
             if (settings.UseCompression)
@@ -135,61 +135,5 @@ namespace Gremlin.Net.Driver
         }
 
         #endregion
-
-        private static IClientWebSocket CreateClientWebSocket(WebSocketSettings settings)
-        {
-            if (settings.WebSocketFactoryCallback != null)
-            {
-                return settings.WebSocketFactoryCallback(settings);
-            }
-
-            return new ProxyClientWebSocket(new ClientWebSocket());
-        }
-
-        private class ProxyClientWebSocket : IClientWebSocket
-        {
-            private readonly ClientWebSocket client;
-
-            public ProxyClientWebSocket(ClientWebSocket client)
-            {
-                this.client = client;
-            }
-
-            public WebSocketState State => this.client.State;
-
-            public ClientWebSocketOptions Options => this.client.Options;
-
-            public Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
-            {
-                return this.client.CloseAsync(closeStatus, statusDescription, cancellationToken);
-            }
-
-            public Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
-            {
-                return this.client.ConnectAsync(uri, cancellationToken);
-            }
-
-            public void Dispose()
-            {
-                this.client.Dispose();
-            }
-
-            public Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
-            {
-                return this.client.ReceiveAsync(buffer, cancellationToken);
-            }
-
-            public Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
-            {
-                return this.client.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
-            }
-
-#if NET6_0_OR_GREATER
-            public ValueTask SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken)
-            {
-                return this.client.SendAsync(buffer, messageType, messageFlags, cancellationToken);
-            }
-#endif
-        }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketSettings.cs
@@ -41,12 +41,6 @@ namespace Gremlin.Net.Driver
         /// </summary>
         public Action<ClientWebSocketOptions> WebSocketConfigurationCallback { get; set; }
 
-        /// <summary>
-        /// Used for unit test to substitute a mocked <see cref="IClientWebSocket"/>. By default <see cref="WebSocketConnection.ProxyClientWebSocket"/> instance
-        /// is created which forwards calls to <see cref="ClientWebSocket"/>.
-        /// </summary>
-        internal Func<WebSocketSettings, IClientWebSocket> WebSocketFactoryCallback { get; set; }
-       
 #if NET6_0_OR_GREATER
         /// <summary>
         ///     Gets or sets whether compressions will be used. The default is true. (Only available since .NET 6.)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketSettings.cs
@@ -40,6 +40,13 @@ namespace Gremlin.Net.Driver
         ///     object used to configure WebSocket connections.
         /// </summary>
         public Action<ClientWebSocketOptions> WebSocketConfigurationCallback { get; set; }
+
+        /// <summary>
+        /// Used for unit test to substitute a mocked <see cref="IClientWebSocket"/>. By default <see cref="WebSocketConnection.ProxyClientWebSocket"/> instance
+        /// is created which forwards calls to <see cref="ClientWebSocket"/>.
+        /// </summary>
+        internal Func<WebSocketSettings, IClientWebSocket> WebSocketFactoryCallback { get; set; }
+       
 #if NET6_0_OR_GREATER
         /// <summary>
         ///     Gets or sets whether compressions will be used. The default is true. (Only available since .NET 6.)

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
@@ -1,0 +1,204 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Exceptions;
+using Gremlin.Net.Driver.Messages;
+using Gremlin.Net.Structure.IO.GraphSON;
+using Moq;
+using Xunit;
+
+namespace Gremlin.Net.UnitTest.Driver
+{
+    public class ConnectionTests
+    {
+        [Fact]
+        public async Task ShouldHandleCloseMessageAfterConnectAsync()
+        {
+            var mockedConnectionFactory = new Mock<IConnectionFactory>();
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+            mockedClientWebSocket
+                .Setup(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None))
+                .ReturnsAsync(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true, WebSocketCloseStatus.MessageTooBig, "Message is too large"));
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+
+            Uri uri = new Uri("wss://localhost:8182");
+            Connection connection = GetConnection(mockedClientWebSocket, uri);
+
+            await connection.ConnectAsync(CancellationToken.None);
+
+            Assert.False(connection.IsOpen);
+            Assert.Equal(0, connection.NrRequestsInFlight);
+            mockedClientWebSocket.Verify(m => m.ConnectAsync(uri, CancellationToken.None), Times.Once);
+            mockedClientWebSocket.Verify(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None), Times.Once);
+            mockedClientWebSocket.Verify(m => m.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task ShouldThrowIfClosedMessageRecievedWithValidPropertiesAsync()
+        {
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+
+            WebSocketConnection webSocketConnection = new WebSocketConnection(new WebSocketSettings()
+            {
+                WebSocketFactoryCallback = (s) => mockedClientWebSocket.Object
+            });
+
+            // Test all known close statuses
+            foreach (Enum closeStatus in Enum.GetValues(typeof(WebSocketCloseStatus)))
+            {
+                mockedClientWebSocket
+                    .Setup(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None))
+                    .ReturnsAsync(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true, (WebSocketCloseStatus)closeStatus, closeStatus.ToString()));
+    
+                await AssertExpectedConnectionClosedException((WebSocketCloseStatus?)closeStatus, closeStatus.ToString(), () => webSocketConnection.ReceiveMessageAsync());
+            }
+
+            // Test null/empty close property values as well.
+            mockedClientWebSocket
+                .Setup(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None))
+                .ReturnsAsync(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true, null, null));
+            await AssertExpectedConnectionClosedException(null, null, () => webSocketConnection.ReceiveMessageAsync());
+            
+            mockedClientWebSocket
+                .Setup(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None))
+                .ReturnsAsync(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true, null, String.Empty));
+            await AssertExpectedConnectionClosedException(null, String.Empty, () => webSocketConnection.ReceiveMessageAsync());
+        }
+
+        [Fact]
+        public async Task ShouldThrowOnSubmitRequestIfWebSocketIsNotOpen()
+        {
+            // This is to test that race bugs don't get introduced which would cause submitted requests to hang if the
+            // connection is being closed/aborted or is not connected. In these cases, WebSocket.SendAsync should throw for the underlying
+            // websocket is not open and the caller should be notified of that failure.
+            Uri uri = new Uri("wss://localhost:8182");
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+
+            Connection connection = GetConnection(mockedClientWebSocket, uri);
+            RequestMessage request = RequestMessage.Build("gremlin").Create();
+
+            // Simulate the SendAsync exception behavior if the underlying websocket is closed (see reference https://docs.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocket.sendasync?view=net-6.0)
+            mockedClientWebSocket.Setup(m => m.SendAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ObjectDisposedException(nameof(ClientWebSocket), "Socket closed"));
+
+            // Test various closing/closed WebSocketStates with SubmitAsync.
+            mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.Closed);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+
+            mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.CloseSent);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+
+            mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.CloseReceived);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+
+            mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.Aborted);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+
+            // Simulate SendAsync exception behavior if underlying websocket is not connected.
+            mockedClientWebSocket.Setup(m => m.SendAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Socket not connected"));
+            mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.Connecting);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SubmitAsync<dynamic>(request));
+        }
+
+        [Fact]
+        public async Task ShouldHandleCloseMessageForInFlightRequestsAsync()
+        {
+            // Tests that in-flight requests will get notified if a connection close message is received.
+            Uri uri = new Uri("wss://localhost:8182");
+            WebSocketReceiveResult closeResult = new WebSocketReceiveResult(0, WebSocketMessageType.Close, true, WebSocketCloseStatus.EndpointUnavailable, "Server shutdown");
+
+            var receiveSempahore = new SemaphoreSlim(0, 1);
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+            mockedClientWebSocket
+                .Setup(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    await receiveSempahore.WaitAsync();
+                    mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.CloseReceived);
+                    return closeResult;
+                });
+            mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.Open);
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+
+            Connection connection = GetConnection(mockedClientWebSocket, uri);
+            await connection.ConnectAsync(CancellationToken.None);
+
+            // Create two in-flight requests that will block on waiting for a response.
+            RequestMessage requestMsg1 = RequestMessage.Build("gremlin").Create();
+            RequestMessage requestMsg2 = RequestMessage.Build("gremlin").Create();
+            Task request1 = connection.SubmitAsync<dynamic>(requestMsg1);
+            Task request2 = connection.SubmitAsync<dynamic>(requestMsg2);
+
+            // Confirm the requests are in-flight.
+            Assert.Equal(2, connection.NrRequestsInFlight);
+
+            // Release the connection close message.
+            receiveSempahore.Release();
+
+            // Assert that both requests get notified with the closed exception.
+            await AssertExpectedConnectionClosedException(closeResult.CloseStatus, closeResult.CloseStatusDescription, () => request1);
+            await AssertExpectedConnectionClosedException(closeResult.CloseStatus, closeResult.CloseStatusDescription, () => request2);
+
+            Assert.False(connection.IsOpen);
+            Assert.Equal(0, connection.NrRequestsInFlight);
+            mockedClientWebSocket.Verify(m => m.ConnectAsync(uri, CancellationToken.None), Times.Once);
+            mockedClientWebSocket.Verify(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None), Times.Once);
+            mockedClientWebSocket.Verify(m => m.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None), Times.Once);
+        }
+
+
+        private static Connection GetConnection(Mock<IClientWebSocket> mockedClientWebSocket, Uri uri)
+        {
+            return new Connection(
+                uri: uri,
+                username: "user",
+                password: "password",
+                messageSerializer: new GraphSON3MessageSerializer(),
+                webSocketSettings: new WebSocketSettings()
+                {
+                    WebSocketFactoryCallback = (s) => mockedClientWebSocket.Object
+                },
+                sessionId: null);
+        }
+
+        private static async Task AssertExpectedConnectionClosedException(WebSocketCloseStatus? expectedCloseStatus, string expectedCloseDescription, Func<Task> func)
+        {
+            ConnectionClosedException exception = await Assert.ThrowsAsync<ConnectionClosedException>(func);
+            Assert.Equal(expectedCloseStatus, exception.Status);
+            Assert.Equal(expectedCloseDescription, exception.Description);
+        }
+    }
+}


### PR DESCRIPTION
### Issue:
https://issues.apache.org/jira/browse/TINKERPOP-2717

### Problem:
Per [RFC 6455 WebSocket](https://datatracker.ietf.org/doc/html/rfc6455#section-1.4), either peer in a websocket an initiate a close handshake by sending a close message frame. In practical terms, a Gremlin server can send a close message to the client and the client should notify in-flight requests and acknowledge the closure.

Currently, Gremln.NET does not check for a `WebSocketMessageType.Close`, resulting in a `NullReferenceException` when attempting to deserialize an empty message body.

### Fix:
Change addresses this in the following way:
1. Adds `ConnectionClosedException` that includes CloseStatus and CloseDescription properties that a WebSocket close message can return.
2. Checks for `WebSocketMessageType.Close` in WebSocketConnection.ReceiveMessageAsync` and throws the exception.

From there, `Connection.ReceiveMessagesAsync` already handles catching any exception thrown by the `WebSocketConnection` and will complete the close handshake and notify all in-flight requests of the exception.

### Additional Changes:

- Added `IClientWebSocket`/`ProxyClientWebSocket` to enable unit testing on interactions with `System.Net.Websockets.ClientWebSocket`. This included adding internal property `WebSocketSettings.WebSocketFactoryCallback` so that a mocked version of `IClientWebSocket` can be injected.
- Added `ConnectionTests` to validate proper handling of close message and `ConnectionClosedException` propagation to in-flight requests.