### PR TITLE
TINKERPOP-2719 Avoid unintentionally opening another transaction

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -640,9 +640,14 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                         break;
                     }
 
+                    // track whether there is anything left in the iterator because it needs to be accessed after
+                    // the transaction could be closed - in that case a call to hasNext() could open a new transaction
+                    // unintentionally
+                    final boolean moreInIterator = itty.hasNext();
+
                     try {
                         // only need to reset the aggregation list if there's more stuff to write
-                        if (itty.hasNext())
+                        if (moreInIterator)
                             aggregate = new ArrayList<>(resultIterationBatchSize);
                         else {
                             // iteration and serialization are both complete which means this finished successfully. note that
@@ -664,7 +669,7 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                         throw ex;
                     }
 
-                    if (!itty.hasNext()) iterateComplete(nettyContext, msg, itty);
+                    if (!moreInIterator) iterateComplete(nettyContext, msg, itty);
 
                     // the flush is called after the commit has potentially occurred.  in this way, if a commit was
                     // required then it will be 100% complete before the client receives it. the "frame" at this point


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2719

`AbstractOpProcessor` already has a mechanism to avoid calling `hasNext()` after the iteration is already complete. We simply copied this mechanism to `SessionOpProcessor` and `TraversalOpProcessor`.

This should avoid problems where a transaction is used again after it was already closed.

Co-authored-by: Florian Grieskamp <florian.grieskamp@gdata.de>
Co-authored-by: kdrblkbs <kdrblkbs@gmail.com>

VOTE +1