### PR TITLE
return future when Client.submitAsync is called

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -152,7 +152,7 @@ class Client:
             "gremlin_python.driver.client.Client.submitAsync will be replaced by "
             "gremlin_python.driver.client.Client.submit_async.",
             DeprecationWarning)
-        self.submit_async(message, bindings, request_options)
+        return self.submit_async(message, bindings, request_options)
 
     def submit_async(self, message, bindings=None, request_options=None):
         log.debug("message '%s'", str(message))


### PR DESCRIPTION
driver.Client.submitAsync is not returning the result of self.submit_async, so the future is not being passed forward to the caller.

While it's understood this interface is deprecated, it should still behave as it previously did in 3.4 until it is removed.