### PR TITLE
TINKERPOP-2726 Fix boolean translation in Python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Renamed `GremlinBaseVisitor` to `DefaultGremlinBaseVisitor` in `gremlin-core` to prevent conflict with the generated `GremlinBaseVisitor` in `gremlin-language`.
 * Tracked transaction spawned connections and closed them when the parent connection was closed for `gremlin-python`.
 * Prevented unintentionally opening another transaction in `TraversalOpProcessor`` and `SessionOpProcessor` of Gremlin Server.
+* Fixed bug in `Translator` of `gremlin-python` around translation of Booleans.
 
 [[release-3-5-2]]
 === TinkerPop 3.5.2 (Release Date: January 10, 2022)

--- a/gremlin-python/src/main/python/gremlin_python/process/translator.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/translator.py
@@ -148,6 +148,8 @@ class Translator:
                     with_opts = True
                 elif type(p) == str:
                     script += f'\'{p}\''
+                elif type(p) == bool:
+                    script += 'true' if p else 'false'
                 else:
                     script += str(p)
                 c += 1

--- a/gremlin-python/src/main/python/tests/process/test_translator.py
+++ b/gremlin-python/src/main/python/tests/process/test_translator.py
@@ -44,7 +44,7 @@ class TestTraversalStrategies(object):
                      "g.V('1','2','3','4')"])
         # 2
         tests.append([g.V('3').valueMap(True),
-                     "g.V('3').valueMap(True)"])
+                     "g.V('3').valueMap(true)"])
         # 3
         tests.append([g.V().constant(5),
                      "g.V().constant(5)"])


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2726

This ensures that the GroovyTranslator in Python creates valid boolean values `true` /  `false` instead of `True` / `False`.

VOTE +1