### PR TITLE
Update board reports docs

### DIFF
--- a/docs/src/dev/developer/administration.asciidoc
+++ b/docs/src/dev/developer/administration.asciidoc
@@ -146,41 +146,12 @@ complete the process. Use link:https://whimsy.apache.org/roster/committee/[Whims
 == Board Reports
 
 The PMC Chair is responsible for submitting a link:http://www.apache.org/foundation/board/reporting[report to the board]
-on a quarterly basis. TinkerPop reports on the following months: January, April, July, October. The report has the
-following format:
-
-[source,text]
-----
-## Description:
- Apache TinkerPop is a graph computing framework for both graph databases
- (OLTP) and graph analytic systems (OLAP).
-
-## Activity:
- <discuss general project health, project direction, community growth/activity, etc.>
-
-## Issues:
- There are no issues requiring board attention at this time.
-
-## Releases:
- - x.y.z (<month> <day>, <year>)
- - x.y.z (<month> <day>, <year>)
-
-## PMC/Committer:
-
- - Last PMC addition was <name> - <month> <year>
- - Last committer addition was <name> - <month> <year>
-
-## Links
-
-[1] <hyperlink to external reference, if a reference was made in the report>
-----
+on a quarterly basis. TinkerPop reports on the following months: January, April, July, October.
 
 A draft of the report should be sent to the TinkerPop developer mailing list for review at least three days prior to
-submitting to the board. The final report should be sent in plain-text format to `board@apache.org` and should be
-committed to the appropriate meeting agenda in SVN at:
-
-[source,text]
-https://svn.apache.org/repos/private/foundation/board
+submitting to the board. The final report can be submitted via link:https://whimsy.apache.org/board/agenda/[Whimsy] or
+via the link:https://reporter.apache.org[Apache Reporter Service] which already provides a template for the report and
+explains the different sections.
 
 [[contributor-listing]]
 == Contributor Listing


### PR DESCRIPTION
The Apache Reporter Service now seems to be the preferred way to submit board reports, but Whimsy is also a good alternative.

I've removed the template for the report because I've just changed the format in the last report according to what's suggested by the reporter service so we now have two different formats that we've used.
I also think that anybody who might at any point submit such a report has already read enough other reports so that they know the format and have enough older reports as a reference.

VOTE +1

@spmallette: I could have probably committed this via CTR, but I wanted to give you a chance to review this at least.