### PR TITLE
TINKERPOP-2741 Fix GraphMLWriter error message

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLWriter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphml/GraphMLWriter.java
@@ -432,7 +432,8 @@ public final class GraphMLWriter implements GraphWriter {
         final VertexProperty<Object> currentValue = properties.next();
 
         if (properties.hasNext())
-            throw new IllegalStateException("Multiple properties exists for the provided key: [%s] and multi-properties are not directly supported by GraphML format");
+            throw new IllegalStateException(String.format("Multiple properties exist for the provided key: [%s]. " +
+                "Multi-properties are not directly supported by GraphML format", key));
         return currentValue;
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoTest.java
@@ -368,7 +368,7 @@ public class IoTest {
                 w.writeGraph(bos, graph);
                 fail("Should not be able to write multi-properties to GraphML");
             } catch (IllegalStateException iae) {
-                assertThat(iae.getMessage(), containsString("multi-properties are not directly supported by GraphML format"));
+                assertEquals(iae.getMessage(), "Multiple properties exist for the provided key: [location]. Multi-properties are not directly supported by GraphML format");
             }
         }
 


### PR DESCRIPTION
Now the error message looks like:

> Multiple properties exist for the provided key: [feature0]. Multi-properties are not directly supported by GraphML format