### PR TITLE
TINKERPOP-2742 Give graph providers a hint of property cardinality

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -553,7 +553,7 @@ public interface Graph extends AutoCloseable, Host {
             /**
              * Gets the {@link VertexProperty.Cardinality} for a key.  By default, this method will return
              * {@link VertexProperty.Cardinality#list}.  Implementations that employ a schema can consult it to
-             * determine the {@link VertexProperty.Cardinality}.  Those that do no have a schema can return their
+             * determine the {@link VertexProperty.Cardinality}.  Those that do not have a schema can return their
              * default {@link VertexProperty.Cardinality} for every key.
              * <p/>
              * Note that this method is primarily used by TinkerPop for internal usage and may not be suitable to
@@ -563,6 +563,16 @@ public interface Graph extends AutoCloseable, Host {
              */
             public default VertexProperty.Cardinality getCardinality(final String key) {
                 return VertexProperty.Cardinality.list;
+            }
+
+            /**
+             * Given a property name and one or more associated values, get the {@link VertexProperty.Cardinality} for a key.
+             * @param key name of property
+             * @param values value(s) associated with this property
+             * @return Cardinality that is most suitable for this key
+             */
+            public default VertexProperty.Cardinality getCardinality(final String key, final Object... values) {
+                return getCardinality(key);
             }
 
             /**

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -42,14 +42,7 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.strategy.optim
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -410,6 +403,15 @@ public final class TinkerGraph implements Graph {
         @Override
         public VertexProperty.Cardinality getCardinality(final String key) {
             return defaultVertexPropertyCardinality;
+        }
+
+        @Override
+        public VertexProperty.Cardinality getCardinality(final String key, final Object... values) {
+            VertexProperty.Cardinality cardinality = defaultVertexPropertyCardinality;
+            if (values.length > 1 && cardinality == VertexProperty.Cardinality.single) {
+                cardinality = VertexProperty.Cardinality.list;
+            }
+            return cardinality;
         }
     }
 

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
@@ -107,7 +107,7 @@ public class TinkerGraphProvider extends AbstractGraphProvider {
      */
     protected static boolean requiresListCardinalityAsDefault(final LoadGraphWith.GraphData loadGraphWith,
                                                             final Class<?> test, final String testMethodName) {
-        return loadGraphWith == LoadGraphWith.GraphData.CREW
+        return loadGraphWith == LoadGraphWith.GraphData.CREW && !testMethodName.startsWith("shouldReadWriteCrew")
                 || (test == StarGraphTest.class && testMethodName.equals("shouldAttachWithCreateMethod"))
                 || (test == DetachedGraphTest.class && testMethodName.equals("testAttachableCreateMethod"));
     }


### PR DESCRIPTION
Currently, Graph::getCardinality only takes a vertex property key as the parameter,
which sometimes is limited for the graph provider to make a proper choice
about the cardinality of the vertex property. This commit overloads this method
which takes both the property key and values as parameters so that the graph
provider can hopefully make a better choice. For example, a graph provider can
use list/set cardinality when it sees multiple values and uses single
cardinality when it only sees one value. This is particularly useful when loading
a graph using the IO step without a pre-defined schema.