### PR TITLE
Fix non determinism in test shouldSerializeToTreeJson()

### DIFF
--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerGremlinV2d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerGremlinV2d0Test.java
@@ -286,20 +286,20 @@ public class GraphSONMessageSerializerGremlinV2d0Test {
         assertEquals(3, firstTree.size());
         Iterator<Vertex> vertexKeys = firstTree.keySet().iterator();
 
-        Tree t2 = (Tree)firstTree.get(vertexKeys.next());
-        VertexProperty vp = (VertexProperty)t2.keySet().iterator().next();
-        assertEquals(3, vp.id());
-        assertEquals("vadas", vp.value());
+        Map expectedValues = new HashMap<Integer, String>() {{
+            put(3, "vadas");
+            put(5, "lop");
+            put(7, "josh");
+        }};
+        
+        Map actualValues = new HashMap<Integer, String>();
+        for (int i = 0; i < 3; i++) {
+            Tree t2 = (Tree)firstTree.get(vertexKeys.next());
+            VertexProperty vp = (VertexProperty)t2.keySet().iterator().next();
+            actualValues.put(vp.id(), vp.value());
+        }
 
-        t2 = (Tree) firstTree.get(vertexKeys.next());
-        vp = (VertexProperty) t2.keySet().iterator().next();
-        assertEquals(5, vp.id());
-        assertEquals("lop", vp.value());
-
-        t2 = (Tree) firstTree.get(vertexKeys.next());
-        vp = (VertexProperty) t2.keySet().iterator().next();
-        assertEquals(7, vp.id());
-        assertEquals("josh", vp.value());
+        assertEquals(expectedValues, actualValues);
     }
 
     @Test

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV2d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV2d0Test.java
@@ -63,7 +63,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -453,35 +455,26 @@ public class GraphSONMessageSerializerV2d0Test {
                 .get(GraphSONTokens.VALUEPROP).get(GraphSONTokens.VALUE).asText());
 
         //check the leafs
-        assertEquals("vadas", converted.get(GraphSONTokens.VALUEPROP)
+        Set expectedValues = new HashSet<String>() {{
+            add("vadas");
+            add("lop");
+            add("josh");
+        }};
+        
+        Set actualValues = new HashSet<String>();
+        for (int i = 0; i < 3; i++) {
+            actualValues.add(converted.get(GraphSONTokens.VALUEPROP)
                 .get(0)
                 .get(GraphSONTokens.VALUE).get(GraphSONTokens.VALUEPROP)
-                .get(0)
+                .get(i)
                 .get(GraphSONTokens.KEY).get(GraphSONTokens.VALUEPROP)
                 .get(GraphSONTokens.PROPERTIES)
                 .get("name")
                 .get(0)
                 .get(GraphSONTokens.VALUEPROP).get(GraphSONTokens.VALUE).asText());
+        }
 
-        assertEquals("lop", converted.get(GraphSONTokens.VALUEPROP)
-                .get(0)
-                .get(GraphSONTokens.VALUE).get(GraphSONTokens.VALUEPROP)
-                .get(1)
-                .get(GraphSONTokens.KEY).get(GraphSONTokens.VALUEPROP)
-                .get(GraphSONTokens.PROPERTIES)
-                .get("name")
-                .get(0)
-                .get(GraphSONTokens.VALUEPROP).get(GraphSONTokens.VALUE).asText());
-
-        assertEquals("josh", converted.get(GraphSONTokens.VALUEPROP)
-                .get(0)
-                .get(GraphSONTokens.VALUE).get(GraphSONTokens.VALUEPROP)
-                .get(2)
-                .get(GraphSONTokens.KEY).get(GraphSONTokens.VALUEPROP)
-                .get(GraphSONTokens.PROPERTIES)
-                .get("name")
-                .get(0)
-                .get(GraphSONTokens.VALUEPROP).get(GraphSONTokens.VALUE).asText());
+        assertEquals(expectedValues, actualValues);
     }
 
     @Test

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV3d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV3d0Test.java
@@ -287,20 +287,20 @@ public class GraphSONMessageSerializerV3d0Test {
         assertEquals(3, firstTree.size());
         Iterator<Vertex> vertexKeys = firstTree.keySet().iterator();
 
-        Tree t2 = (Tree)firstTree.get(vertexKeys.next());
-        VertexProperty vp = (VertexProperty)t2.keySet().iterator().next();
-        assertEquals(3, vp.id());
-        assertEquals("vadas", vp.value());
+        Map expectedValues = new HashMap<Integer, String>() {{
+            put(3, "vadas");
+            put(5, "lop");
+            put(7, "josh");
+        }};
+        
+        Map actualValues = new HashMap<Integer, String>();
+        for (int i = 0; i < 3; i++) {
+            Tree t2 = (Tree)firstTree.get(vertexKeys.next());
+            VertexProperty vp = (VertexProperty)t2.keySet().iterator().next();
+            actualValues.put(vp.id(), vp.value());
+        }
 
-        t2 = (Tree) firstTree.get(vertexKeys.next());
-        vp = (VertexProperty) t2.keySet().iterator().next();
-        assertEquals(5, vp.id());
-        assertEquals("lop", vp.value());
-
-        t2 = (Tree) firstTree.get(vertexKeys.next());
-        vp = (VertexProperty) t2.keySet().iterator().next();
-        assertEquals(7, vp.id());
-        assertEquals("josh", vp.value());
+        assertEquals(expectedValues, actualValues);
     }
 
     @Test


### PR DESCRIPTION
The test `shouldSerializeToTreeJson()`, which is found in various test classes, is non deterministic. It is non-deterministic because it relies on a specific order in which the iterator will iterate on `firstTree`, which is a `HashMap` containing 3 elements - `"vadas", "lop", and "josh"`. The iteration order on a `HashMap` is not guaranteed by Java to be the same each time we iterate on it. This can cause the tests to non-deterministically fail sometimes.

This PR makes the test more robust by relaxing the ordering requirement on the elements within `firstTree`. Please let me know if you have any questions or feedback.

