### PR TITLE
TINKERPOP-2745: Add getter method for properties

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/VertexProgram.java
@@ -20,6 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.computer;
 
 import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -27,6 +28,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.lang.reflect.Constructor;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,6 +49,10 @@ import java.util.Set;
 public interface VertexProgram<M> extends Cloneable {
 
     public static final String VERTEX_PROGRAM = "gremlin.vertexProgram";
+
+    default List<Pair<String, Class>> getVertexPropertyKeys() {
+        return Collections.emptyList();
+    }
 
     /**
      * When it is necessary to store the state of the VertexProgram, this method is called.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/connected/ConnectedComponentVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/connected/ConnectedComponentVertexProgram.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.computer.clustering.connected;
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ConfigurationUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
@@ -43,12 +44,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
+
+import static org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram.ACTIVE_TRAVERSERS;
+import static org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram.HALTED_TRAVERSERS;
 
 /**
  * Identifies "Connected Component" instances in a graph by assigning a component identifier (the lexicographically
@@ -75,6 +74,14 @@ public class ConnectedComponentVertexProgram implements VertexProgram<String> {
     private IndexedTraverserSet<Vertex, Vertex> haltedTraversersIndex;
 
     private ConnectedComponentVertexProgram() {}
+
+    @Override
+    public List<Pair<String, Class>> getVertexPropertyKeys() {
+        return Arrays.asList(
+            org.apache.commons.lang3.tuple.Pair.of(HALTED_TRAVERSERS, Object.class),
+            org.apache.commons.lang3.tuple.Pair.of(ACTIVE_TRAVERSERS, Object.class),
+            org.apache.commons.lang3.tuple.Pair.of(COMPONENT, Object.class));
+    }
 
     @Override
     public void loadState(final Graph graph, final Configuration config) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -44,12 +44,10 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.javatuples.Pair;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
+import static org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram.ACTIVE_TRAVERSERS;
+import static org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram.HALTED_TRAVERSERS;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -79,6 +77,16 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
     private PeerPressureVertexProgram() {
 
     }
+
+    @Override
+    public List<org.apache.commons.lang3.tuple.Pair<String, Class>> getVertexPropertyKeys() {
+        return Arrays.asList(
+            org.apache.commons.lang3.tuple.Pair.of(HALTED_TRAVERSERS, Object.class),
+            org.apache.commons.lang3.tuple.Pair.of(ACTIVE_TRAVERSERS, Object.class),
+            org.apache.commons.lang3.tuple.Pair.of(CLUSTER, Object.class),
+            org.apache.commons.lang3.tuple.Pair.of(VOTE_STRENGTH, Double.class));
+    }
+
 
     @Override
     public void loadState(final Graph graph, final Configuration configuration) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank;
 
 import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
@@ -42,10 +43,10 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+
+import static org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram.ACTIVE_TRAVERSERS;
+import static org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram.HALTED_TRAVERSERS;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -79,6 +80,16 @@ public class PageRankVertexProgram implements VertexProgram<Double> {
     private PageRankVertexProgram() {
 
     }
+
+    @Override
+    public List<Pair<String, Class>> getVertexPropertyKeys() {
+        return Arrays.asList(
+            Pair.of(EDGE_COUNT, Double.class),
+            Pair.of(PAGE_RANK, Double.class),
+            Pair.of(HALTED_TRAVERSERS, Object.class),
+            Pair.of(ACTIVE_TRAVERSERS, Object.class));
+    }
+
 
     @Override
     public void loadState(final Graph graph, final Configuration configuration) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.computer.traversal;
 
 import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
@@ -131,6 +132,13 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
      */
     public PureTraversal<?, ?> getTraversal() {
         return this.traversal;
+    }
+
+    @Override
+    public List<Pair<String, Class>> getVertexPropertyKeys() {
+        return Arrays.asList(
+            Pair.of(HALTED_TRAVERSERS, Object.class),
+            Pair.of(ACTIVE_TRAVERSERS, Object.class));
     }
 
     public static <R> TraverserSet<R> loadHaltedTraversers(final Configuration configuration) {


### PR DESCRIPTION
This commit adds VertexProgram::getVertexPropertyKeys method
which returns a list of (property key, class type) pairs. The
pairs contain vertex property keys that are read or written in
the execution of the vertex program. Graph providers could
leverage this information to create schema ahead.