### PR TITLE
Fix deadlock on non response-specific read errors

### DIFF
--- a/gremlin-go/driver/connection.go
+++ b/gremlin-go/driver/connection.go
@@ -144,10 +144,11 @@ func (s *synchronizedMap) size() int {
 	return len(s.internalMap)
 }
 
-func (s *synchronizedMap) synchronizedRange(f func(key string, value ResultSet)) {
+func (s *synchronizedMap) closeAll(err error) {
 	s.syncLock.Lock()
 	defer s.syncLock.Unlock()
-	for k, v := range s.internalMap {
-		f(k, v)
+	for _, resultSet := range s.internalMap {
+		resultSet.setError(err)
+		resultSet.unlockedClose()
 	}
 }

--- a/gremlin-go/driver/protocol.go
+++ b/gremlin-go/driver/protocol.go
@@ -92,9 +92,7 @@ func (protocol *gremlinServerWSProtocol) readLoop(resultSets *synchronizedMap, e
 // If there is an error, we need to close the ResultSets and then pass the error back.
 func readErrorHandler(resultSets *synchronizedMap, errorCallback func(), err error, log *logHandler) {
 	log.logf(Error, readLoopError, err.Error())
-	resultSets.synchronizedRange(func(_ string, resultSet ResultSet) {
-		resultSet.Close()
-	})
+	resultSets.closeAll(err)
 	errorCallback()
 }
 


### PR DESCRIPTION
- Fixed a potential deadlock that would occur whenever reading from the server fails in a fashion that is not specific to a specific request, e.g. the connection is dead
- Fixed a potential edge case where a ResultSet would not return an error (it would only log it) alongside an incomplete set of results