### PR TITLE
Gremlin-Go: Add DSL support documentation 

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1645,6 +1645,130 @@ In the above example, defines a timeout of 500 milliseconds, but the script has 
 two internal settings for the timeout using `with()`. The request timeout used by the server will therefore be 1000
 milliseconds (overriding the 500 which itself was an override for whatever configuration was on the server).
 
+[[gremlin-go-dsl]]
+=== Domain Specific Languages
+
+Writing a Gremlin <<dsl,Domain Specific Language>> (DSL) in Go requires embedding of several structs and interfaces:
+
+* `GraphTraversal` - which exposes the various steps used in traversal writing
+* `GraphTraversalSource` - which spawns `GraphTraversal` instances
+* `AnonymousTraversal` - which spawns anonymous traversals from steps
+
+The Social DSL based on the link:https://tinkerpop.apache.org/docs/current/images/tinkerpop-modern.png["modern" toy graph]
+might look like this:
+
+[source,go]
+----
+// Optional syntactic sugar.
+var __ = gremlingo.T__
+var P = gremlingo.P
+var gt = gremlingo.P.Gt
+// Optional alias for import convenience.
+type GraphTraversal = gremlingo.GraphTraversal
+type GraphTraversalSource = gremlingo.GraphTraversalSource
+type AnonymousTraversal = gremlingo.AnonymousTraversal
+
+// Embed Graph traversal inside custom traversal struct to add custom traversal functions.
+// In go, capitalizing the first letter exports (makes public) the struct/method to outside of package, for this example
+// we have defined everything package private. In actual usage, please see fit to your application.
+type socialTraversal struct {
+	*GraphTraversal
+}
+
+func (s *socialTraversal) knows(personName string) *socialTraversal {
+	return &socialTraversal{s.Out("knows").HasLabel("person").Has("name", personName)}
+}
+
+func (s *socialTraversal) youngestFriendsAge() *socialTraversal {
+	return &socialTraversal{s.Out("knows").HasLabel("person").Values("age").Min()}
+}
+
+func (s *socialTraversal) createdAtLeast(number int) *socialTraversal {
+	return &socialTraversal{s.OutE("created").Count().Is(gt(number))}
+}
+
+// Add custom social traversal source to spaw custom traversals.
+type socialTraversalSource struct {
+	*GraphTraversalSource
+}
+
+// Define the source step function by adding steps to the bytecode.
+func (sts *socialTraversalSource) persons(personNames ...interface{}) *socialTraversal {
+	t := sts.GetGraphTraversal()
+	t.Bytecode.AddStep("V")
+	t.Bytecode.AddStep("hasLabel", "person")
+	if personNames != nil {
+		t.Bytecode.AddStep("has", "name", P.Within(personNames...))
+	}
+	return &socialTraversal{t}
+}
+
+
+// Create the social anonymous traversal interface to embed and extend the anonymous traversal functions.
+type iSocialAnonymousTraversal interface {
+	AnonymousTraversal
+	knows(personName string) *GraphTraversal
+	youngestFriendsAge() *GraphTraversal
+	createdAtLeast(number int) *GraphTraversal
+}
+
+// Add the struct to implement the iSocialAnonymousTraversal interface.
+type socialAnonymousTraversal struct {
+	AnonymousTraversal
+	socialTraversal func() *socialTraversal
+}
+
+// Add the variable s__ to call anonymous traversal step functions in place of __.
+var s__ iSocialAnonymousTraversal = &socialAnonymousTraversal{
+	__,
+	func() *socialTraversal {
+		return &socialTraversal{gremlingo.NewGraphTraversal(nil, gremlingo.NewBytecode(nil), nil)}
+	},
+}
+
+// Extended anonymous traversal functions need to return GraphTraversal for serialization purposes
+func (sat *socialAnonymousTraversal) knows(personName string) *GraphTraversal {
+	return sat.socialTraversal().knows(personName).GraphTraversal
+}
+
+func (sat *socialAnonymousTraversal) youngestFriendsAge() *GraphTraversal {
+	return sat.socialTraversal().youngestFriendsAge().GraphTraversal
+}
+
+func (sat *socialAnonymousTraversal) createdAtLeast(number int) *GraphTraversal {
+	return sat.socialTraversal().createdAtLeast(number).GraphTraversal
+}
+----
+
+Using the DSL requires a social traversal source to be created from the default traversal source:
+
+[source,go]
+----
+// Creating the driver remote connection as regular.
+driverRemoteConnection, _ := gremlingo.NewDriverRemoteConnection("ws://localhost:8182/gremlin",
+	func(settings *gremlingo.DriverRemoteConnectionSettings) {
+		settings.TraversalSource = "gmodern"
+	})
+defer driverRemoteConnection.Close()
+
+// Create social traversal source from graph traversal source.
+social := &socialTraversalSource{gremlingo.Traversal_().WithRemote(driverRemoteConnection)}
+
+// We can now use the social traversal source as well as traversal steps
+resBool, _ := social.persons("marko", "stephen").knows("josh").HasNext()
+fmt.Println(resBool)
+
+// Using the createdAtLeast step.
+resCreated, _ := social.persons().createdAtLeast(1).Next()
+fmt.Println(resCreated.GetString())
+
+// Using the social anonymous traversal.
+resAnon, _ := social.persons().Filter(s__.createdAtLeast(1)).Count().Next()
+fmt.Println(resAnon.GetString())
+
+// Note that error handling has been omitted with _ from the above examples.
+----
+
 [[gremlin-go-differences]]
 === Differences
 

--- a/gremlin-go/driver/anonymousTraversal.go
+++ b/gremlin-go/driver/anonymousTraversal.go
@@ -259,7 +259,7 @@ type anonymousTraversal struct {
 
 var T__ AnonymousTraversal = &anonymousTraversal{
 	func() *GraphTraversal {
-		return NewGraphTraversal(nil, newBytecode(nil), nil)
+		return NewGraphTraversal(nil, NewBytecode(nil), nil)
 	},
 }
 

--- a/gremlin-go/driver/bytecode.go
+++ b/gremlin-go/driver/bytecode.go
@@ -24,13 +24,15 @@ import (
 	"reflect"
 )
 
-type bytecode struct {
+// Bytecode a list of ordered instructions for traversal that can be serialized between environments and machines.
+type Bytecode struct {
 	sourceInstructions []instruction
 	stepInstructions   []instruction
 	bindings           map[string]interface{}
 }
 
-func newBytecode(bc *bytecode) *bytecode {
+// NewBytecode creates a new Bytecode to be used in traversals.
+func NewBytecode(bc *Bytecode) *Bytecode {
 	sourceInstructions := make([]instruction, 0)
 	stepInstructions := make([]instruction, 0)
 	bindingMap := make(map[string]interface{})
@@ -39,14 +41,14 @@ func newBytecode(bc *bytecode) *bytecode {
 		stepInstructions = append(stepInstructions, bc.stepInstructions...)
 	}
 
-	return &bytecode{
+	return &Bytecode{
 		sourceInstructions: sourceInstructions,
 		stepInstructions:   stepInstructions,
 		bindings:           bindingMap,
 	}
 }
 
-func (bytecode *bytecode) createInstruction(operator string, args ...interface{}) (*instruction, error) {
+func (bytecode *Bytecode) createInstruction(operator string, args ...interface{}) (*instruction, error) {
 	instruction := &instruction{
 		operator:  operator,
 		arguments: make([]interface{}, 0),
@@ -63,7 +65,8 @@ func (bytecode *bytecode) createInstruction(operator string, args ...interface{}
 	return instruction, nil
 }
 
-func (bytecode *bytecode) addSource(sourceName string, args ...interface{}) error {
+// AddSource add a traversal source instruction to the bytecode.
+func (bytecode *Bytecode) AddSource(sourceName string, args ...interface{}) error {
 	instruction, err := bytecode.createInstruction(sourceName, args...)
 	if err != nil {
 		return err
@@ -73,7 +76,8 @@ func (bytecode *bytecode) addSource(sourceName string, args ...interface{}) erro
 	return err
 }
 
-func (bytecode *bytecode) addStep(stepName string, args ...interface{}) error {
+// AddStep adds a traversal instruction to the bytecode
+func (bytecode *Bytecode) AddStep(stepName string, args ...interface{}) error {
 	instruction, err := bytecode.createInstruction(stepName, args...)
 	if err != nil {
 		return err
@@ -83,7 +87,7 @@ func (bytecode *bytecode) addStep(stepName string, args ...interface{}) error {
 	return err
 }
 
-func (bytecode *bytecode) convertArgument(arg interface{}) (interface{}, error) {
+func (bytecode *Bytecode) convertArgument(arg interface{}) (interface{}, error) {
 	if arg == nil {
 		return nil, nil
 	}
@@ -136,10 +140,10 @@ func (bytecode *bytecode) convertArgument(arg interface{}) (interface{}, error) 
 			if v.graph != nil {
 				return nil, newError(err1001ConvertArgumentChildTraversalNotFromAnonError)
 			}
-			for k, val := range v.bytecode.bindings {
+			for k, val := range v.Bytecode.bindings {
 				bytecode.bindings[k] = val
 			}
-			return v.bytecode, nil
+			return v.Bytecode, nil
 		default:
 			return arg, nil
 		}

--- a/gremlin-go/driver/bytecode_test.go
+++ b/gremlin-go/driver/bytecode_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestBytecode(t *testing.T) {
 	t.Run("Constructor", func(t *testing.T) {
-		bc1 := newBytecode(nil)
+		bc1 := NewBytecode(nil)
 		assert.NotNil(t, bc1.bindings)
 		assert.NotNil(t, bc1.sourceInstructions)
 		assert.NotNil(t, bc1.stepInstructions)
@@ -49,7 +49,7 @@ func TestBytecode(t *testing.T) {
 		bc1.stepInstructions = stepInstructions
 		bc1.bindings = bindingMap
 
-		bc2 := newBytecode(bc1)
+		bc2 := NewBytecode(bc1)
 		assert.NotNil(t, bc2.bindings)
 		assert.NotNil(t, bc2.sourceInstructions)
 		assert.NotNil(t, bc2.stepInstructions)
@@ -58,13 +58,13 @@ func TestBytecode(t *testing.T) {
 		assert.Equal(t, stepInstructions, bc2.stepInstructions)
 	})
 
-	t.Run("addSource", func(t *testing.T) {
+	t.Run("AddSource", func(t *testing.T) {
 		expectedSourceInstructions := []instruction{{
 			operator:  "mockSource",
 			arguments: []interface{}{123},
 		}}
-		bc := newBytecode(nil)
-		err := bc.addSource("mockSource", 123)
+		bc := NewBytecode(nil)
+		err := bc.AddSource("mockSource", 123)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedSourceInstructions, bc.sourceInstructions)
 	})
@@ -74,14 +74,14 @@ func TestBytecode(t *testing.T) {
 			operator:  "mockStep",
 			arguments: []interface{}{123},
 		}}
-		bc := newBytecode(nil)
-		err := bc.addStep("mockStep", 123)
+		bc := NewBytecode(nil)
+		err := bc.AddStep("mockStep", 123)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedStepInstructions, bc.stepInstructions)
 	})
 
 	t.Run("convertArgument", func(t *testing.T) {
-		bc := newBytecode(nil)
+		bc := NewBytecode(nil)
 
 		t.Run("map", func(t *testing.T) {
 			testMap := make(map[string]int)
@@ -119,41 +119,41 @@ func TestBytecode(t *testing.T) {
 		})
 	})
 
-	t.Run("Test bytecode traversal argument conversion without Graph", func(t *testing.T) {
-		bc := bytecode{}
+	t.Run("Test Bytecode traversal argument conversion without Graph", func(t *testing.T) {
+		bc := Bytecode{}
 		traversal := &GraphTraversal{
 			&Traversal{},
 		}
 		traversal.graph = nil
-		traversal.bytecode = &bytecode{}
+		traversal.Bytecode = &Bytecode{}
 		traversalBytecode, err := bc.convertArgument(traversal)
 		assert.Nil(t, err)
-		assert.Equal(t, traversal.bytecode, traversalBytecode)
+		assert.Equal(t, traversal.Bytecode, traversalBytecode)
 	})
 
-	t.Run("Test bytecode traversal argument conversion with Graph", func(t *testing.T) {
+	t.Run("Test Bytecode traversal argument conversion with Graph", func(t *testing.T) {
 		// This should fail.
-		bc := bytecode{}
+		bc := Bytecode{}
 		traversal := &GraphTraversal{
 			&Traversal{},
 		}
 		traversal.graph = &Graph{}
-		traversal.bytecode = &bytecode{}
+		traversal.Bytecode = &Bytecode{}
 		traversalBytecode, err := bc.convertArgument(traversal)
 		assert.Equal(t, newError(err1001ConvertArgumentChildTraversalNotFromAnonError), err)
 		assert.Nil(t, traversalBytecode)
 	})
 
-	t.Run("Test bytecode traversal argument multiple bindings", func(t *testing.T) {
-		bc := bytecode{}
+	t.Run("Test Bytecode traversal argument multiple bindings", func(t *testing.T) {
+		bc := Bytecode{}
 		bc.bindings = map[string]interface{}{}
 		testTraversal := &GraphTraversal{
 			&Traversal{},
 		}
-		testTraversal.bytecode = &bytecode{}
-		testTraversal.bytecode.bindings = map[string]interface{}{"mock": "123"}
+		testTraversal.Bytecode = &Bytecode{}
+		testTraversal.Bytecode.bindings = map[string]interface{}{"mock": "123"}
 		traversalBytecode, err := bc.convertArgument(testTraversal)
 		assert.Nil(t, err)
-		assert.Equal(t, testTraversal.bytecode, traversalBytecode)
+		assert.Equal(t, testTraversal.Bytecode, traversalBytecode)
 	})
 }

--- a/gremlin-go/driver/client.go
+++ b/gremlin-go/driver/client.go
@@ -155,8 +155,8 @@ func (client *Client) Submit(traversalString string, bindings ...map[string]inte
 	return result, err
 }
 
-// submitBytecode submits bytecode to the server to execute and returns a ResultSet.
-func (client *Client) submitBytecode(bytecode *bytecode) (ResultSet, error) {
+// submitBytecode submits Bytecode to the server to execute and returns a ResultSet.
+func (client *Client) submitBytecode(bytecode *Bytecode) (ResultSet, error) {
 	client.logHandler.logf(Debug, submitStartedBytecode, *bytecode)
 	request := makeBytecodeRequest(bytecode, client.traversalSource, client.session)
 	return client.connections.write(&request)

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -603,8 +603,8 @@ func TestConnection(t *testing.T) {
 		assert.True(t, ok)
 		assert.NotNil(t, result)
 
-		g := cloneGraphTraversalSource(&Graph{}, newBytecode(nil), nil)
-		b := g.V().Count().bytecode
+		g := cloneGraphTraversalSource(&Graph{}, NewBytecode(nil), nil)
+		b := g.V().Count().Bytecode
 		resultSet, err = client.submitBytecode(b)
 		assert.Nil(t, err)
 		assert.NotNil(t, resultSet)

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -169,8 +169,8 @@ func (driver *DriverRemoteConnection) Submit(traversalString string) (ResultSet,
 	return result, err
 }
 
-// submitBytecode sends a bytecode traversal to the server.
-func (driver *DriverRemoteConnection) submitBytecode(bytecode *bytecode) (ResultSet, error) {
+// submitBytecode sends a Bytecode traversal to the server.
+func (driver *DriverRemoteConnection) submitBytecode(bytecode *Bytecode) (ResultSet, error) {
 	if driver.isClosed {
 		return nil, newError(err0203SubmitBytecodeToClosedConnectionError)
 	}
@@ -225,13 +225,13 @@ func (driver *DriverRemoteConnection) GetSessionId() string {
 }
 
 func (driver *DriverRemoteConnection) commit() (ResultSet, error) {
-	bc := &bytecode{}
-	bc.addSource("tx", "commit")
+	bc := &Bytecode{}
+	bc.AddSource("tx", "commit")
 	return driver.submitBytecode(bc)
 }
 
 func (driver *DriverRemoteConnection) rollback() (ResultSet, error) {
-	bc := &bytecode{}
-	bc.addSource("tx", "rollback")
+	bc := &Bytecode{}
+	bc.AddSource("tx", "rollback")
 	return driver.submitBytecode(bc)
 }

--- a/gremlin-go/driver/error_codes.go
+++ b/gremlin-go/driver/error_codes.go
@@ -89,7 +89,7 @@ const (
 	err0902IterateAnonTraversalError errorCode = "E0902_TRAVERSAL_ITERATE_ANON_TRAVERSAL_ERROR"
 	err0903NextNoResultsLeftError    errorCode = "E0903_TRAVERSAL_NEXT_NO_RESULTS_LEFT_ERROR"
 
-	// bytecode.go errors
+	// Bytecode.go errors
 	err1001ConvertArgumentChildTraversalNotFromAnonError errorCode = "E1001_BYTECODE_CHILD_T_NOT_ANON_ERROR"
 
 	// graphTraversal.go errors

--- a/gremlin-go/driver/graphBinary.go
+++ b/gremlin-go/driver/graphBinary.go
@@ -228,13 +228,13 @@ func instructionWriter(instructions []instruction, buffer *bytes.Buffer, typeSer
 //		{values_length} is an Int describing the amount values.
 //		{value_i} is a fully qualified typed value composed of {type_code}{type_info}{value_flag}{value} describing the step argument.
 func bytecodeWriter(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
-	var bc bytecode
+	var bc Bytecode
 	switch typedVal := value.(type) {
 	case *GraphTraversal:
-		bc = *typedVal.bytecode
-	case bytecode:
+		bc = *typedVal.Bytecode
+	case Bytecode:
 		bc = typedVal
-	case *bytecode:
+	case *Bytecode:
 		bc = *typedVal
 	default:
 		return nil, newError(err0402BytecodeWriterError)
@@ -632,7 +632,7 @@ func bindingWriter(value interface{}, buffer *bytes.Buffer, typeSerializer *grap
 
 func (serializer *graphBinaryTypeSerializer) getType(val interface{}) (dataType, error) {
 	switch val.(type) {
-	case *bytecode, bytecode, *GraphTraversal:
+	case *Bytecode, Bytecode, *GraphTraversal:
 		return bytecodeType, nil
 	case string:
 		return stringType, nil

--- a/gremlin-go/driver/graphTraversal.go
+++ b/gremlin-go/driver/graphTraversal.go
@@ -34,11 +34,12 @@ type GraphTraversal struct {
 }
 
 // NewGraphTraversal make a new GraphTraversal.
-func NewGraphTraversal(graph *Graph, bytecode *bytecode, remote *DriverRemoteConnection) *GraphTraversal {
+// why is this taking a non exported field as an exported function - remove or replace?
+func NewGraphTraversal(graph *Graph, bytecode *Bytecode, remote *DriverRemoteConnection) *GraphTraversal {
 	gt := &GraphTraversal{
 		Traversal: &Traversal{
 			graph:    graph,
-			bytecode: bytecode,
+			Bytecode: bytecode,
 			remote:   remote,
 		},
 	}
@@ -47,624 +48,624 @@ func NewGraphTraversal(graph *Graph, bytecode *bytecode, remote *DriverRemoteCon
 
 // Clone make a copy of a traversal that is reset for iteration.
 func (g *GraphTraversal) Clone() *GraphTraversal {
-	return NewGraphTraversal(g.graph, newBytecode(g.bytecode), g.remote)
+	return NewGraphTraversal(g.graph, NewBytecode(g.Bytecode), g.remote)
 }
 
 // V adds the v step to the GraphTraversal.
 func (g *GraphTraversal) V(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("V", args...)
+	g.Bytecode.AddStep("V", args...)
 	return g
 }
 
 // AddE adds the addE step to the GraphTraversal.
 func (g *GraphTraversal) AddE(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("addE", args...)
+	g.Bytecode.AddStep("addE", args...)
 	return g
 }
 
 // AddV adds the addV step to the GraphTraversal.
 func (g *GraphTraversal) AddV(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("addV", args...)
+	g.Bytecode.AddStep("addV", args...)
 	return g
 }
 
 // Aggregate adds the aggregate step to the GraphTraversal.
 func (g *GraphTraversal) Aggregate(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("aggregate", args...)
+	g.Bytecode.AddStep("aggregate", args...)
 	return g
 }
 
 // And adds the and step to the GraphTraversal.
 func (g *GraphTraversal) And(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("and", args...)
+	g.Bytecode.AddStep("and", args...)
 	return g
 }
 
 // As adds the as step to the GraphTraversal.
 func (g *GraphTraversal) As(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("as", args...)
+	g.Bytecode.AddStep("as", args...)
 	return g
 }
 
 // Barrier adds the barrier step to the GraphTraversal.
 func (g *GraphTraversal) Barrier(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("barrier", args...)
+	g.Bytecode.AddStep("barrier", args...)
 	return g
 }
 
 // Both adds the both step to the GraphTraversal.
 func (g *GraphTraversal) Both(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("both", args...)
+	g.Bytecode.AddStep("both", args...)
 	return g
 }
 
 // BothE adds the bothE step to the GraphTraversal.
 func (g *GraphTraversal) BothE(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("bothE", args...)
+	g.Bytecode.AddStep("bothE", args...)
 	return g
 }
 
 // BothV adds the bothV step to the GraphTraversal.
 func (g *GraphTraversal) BothV(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("bothV", args...)
+	g.Bytecode.AddStep("bothV", args...)
 	return g
 }
 
 // Branch adds the branch step to the GraphTraversal.
 func (g *GraphTraversal) Branch(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("branch", args...)
+	g.Bytecode.AddStep("branch", args...)
 	return g
 }
 
 // By adds the by step to the GraphTraversal.
 func (g *GraphTraversal) By(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("by", args...)
+	g.Bytecode.AddStep("by", args...)
 	return g
 }
 
 // Cap adds the cap step to the GraphTraversal.
 func (g *GraphTraversal) Cap(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("cap", args...)
+	g.Bytecode.AddStep("cap", args...)
 	return g
 }
 
 // Choose adds the choose step to the GraphTraversal.
 func (g *GraphTraversal) Choose(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("choose", args...)
+	g.Bytecode.AddStep("choose", args...)
 	return g
 }
 
 // Coalesce adds the coalesce step to the GraphTraversal.
 func (g *GraphTraversal) Coalesce(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("coalesce", args...)
+	g.Bytecode.AddStep("coalesce", args...)
 	return g
 }
 
 // Coin adds the coint step to the GraphTraversal.
 func (g *GraphTraversal) Coin(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("coin", args...)
+	g.Bytecode.AddStep("coin", args...)
 	return g
 }
 
 // ConnectedComponent adds the connectedComponent step to the GraphTraversal.
 func (g *GraphTraversal) ConnectedComponent(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("connectedComponent", args...)
+	g.Bytecode.AddStep("connectedComponent", args...)
 	return g
 }
 
 // Constant adds the constant step to the GraphTraversal.
 func (g *GraphTraversal) Constant(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("constant", args...)
+	g.Bytecode.AddStep("constant", args...)
 	return g
 }
 
 // Count adds the count step to the GraphTraversal.
 func (g *GraphTraversal) Count(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("count", args...)
+	g.Bytecode.AddStep("count", args...)
 	return g
 }
 
 // CyclicPath adds the cyclicPath step to the GraphTraversal.
 func (g *GraphTraversal) CyclicPath(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("cyclicPath", args...)
+	g.Bytecode.AddStep("cyclicPath", args...)
 	return g
 }
 
 // Dedup adds the dedup step to the GraphTraversal.
 func (g *GraphTraversal) Dedup(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("dedup", args...)
+	g.Bytecode.AddStep("dedup", args...)
 	return g
 }
 
 // Drop adds the drop step to the GraphTraversal.
 func (g *GraphTraversal) Drop(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("drop", args...)
+	g.Bytecode.AddStep("drop", args...)
 	return g
 }
 
 // ElementMap adds the elementMap step to the GraphTraversal.
 func (g *GraphTraversal) ElementMap(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("elementMap", args...)
+	g.Bytecode.AddStep("elementMap", args...)
 	return g
 }
 
 // Emit adds the emit step to the GraphTraversal.
 func (g *GraphTraversal) Emit(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("emit", args...)
+	g.Bytecode.AddStep("emit", args...)
 	return g
 }
 
 // Filter adds the filter step to the GraphTraversal.
 func (g *GraphTraversal) Filter(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("filter", args...)
+	g.Bytecode.AddStep("filter", args...)
 	return g
 }
 
 // FlatMap adds the flatMap step to the GraphTraversal.
 func (g *GraphTraversal) FlatMap(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("flatMap", args...)
+	g.Bytecode.AddStep("flatMap", args...)
 	return g
 }
 
 // Fold adds the fold step to the GraphTraversal.
 func (g *GraphTraversal) Fold(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("fold", args...)
+	g.Bytecode.AddStep("fold", args...)
 	return g
 }
 
 // From adds the from step to the GraphTraversal.
 func (g *GraphTraversal) From(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("from", args...)
+	g.Bytecode.AddStep("from", args...)
 	return g
 }
 
 // Group adds the group step to the GraphTraversal.
 func (g *GraphTraversal) Group(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("group", args...)
+	g.Bytecode.AddStep("group", args...)
 	return g
 }
 
 // GroupCount adds the groupCount step to the GraphTraversal.
 func (g *GraphTraversal) GroupCount(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("groupCount", args...)
+	g.Bytecode.AddStep("groupCount", args...)
 	return g
 }
 
 // Has adds the has step to the GraphTraversal.
 func (g *GraphTraversal) Has(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("has", args...)
+	g.Bytecode.AddStep("has", args...)
 	return g
 }
 
 // HasId adds the hasId step to the GraphTraversal.
 func (g *GraphTraversal) HasId(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("hasId", args...)
+	g.Bytecode.AddStep("hasId", args...)
 	return g
 }
 
 // HasKey adds the hasKey step to the GraphTraversal.
 func (g *GraphTraversal) HasKey(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("hasKey", args...)
+	g.Bytecode.AddStep("hasKey", args...)
 	return g
 }
 
 // HasLabel adds the hasLabel step to the GraphTraversal.
 func (g *GraphTraversal) HasLabel(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("hasLabel", args...)
+	g.Bytecode.AddStep("hasLabel", args...)
 	return g
 }
 
 // HasNot adds the hasNot step to the GraphTraversal.
 func (g *GraphTraversal) HasNot(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("hasNot", args...)
+	g.Bytecode.AddStep("hasNot", args...)
 	return g
 }
 
 // HasValue adds the hasValue step to the GraphTraversal.
 func (g *GraphTraversal) HasValue(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("hasValue", args...)
+	g.Bytecode.AddStep("hasValue", args...)
 	return g
 }
 
 // Id adds the id step to the GraphTraversal.
 func (g *GraphTraversal) Id(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("id", args...)
+	g.Bytecode.AddStep("id", args...)
 	return g
 }
 
 // Identity adds the identity step to the GraphTraversal.
 func (g *GraphTraversal) Identity(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("identity", args...)
+	g.Bytecode.AddStep("identity", args...)
 	return g
 }
 
 // InE adds the inE step to the GraphTraversal.
 func (g *GraphTraversal) InE(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("inE", args...)
+	g.Bytecode.AddStep("inE", args...)
 	return g
 }
 
 // InV adds the inV step to the GraphTraversal.
 func (g *GraphTraversal) InV(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("inV", args...)
+	g.Bytecode.AddStep("inV", args...)
 	return g
 }
 
 // In adds the in step to the GraphTraversal.
 func (g *GraphTraversal) In(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("in", args...)
+	g.Bytecode.AddStep("in", args...)
 	return g
 }
 
 // Index adds the index step to the GraphTraversal.
 func (g *GraphTraversal) Index(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("index", args...)
+	g.Bytecode.AddStep("index", args...)
 	return g
 }
 
 // Inject adds the inject step to the GraphTraversal.
 func (g *GraphTraversal) Inject(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("inject", args...)
+	g.Bytecode.AddStep("inject", args...)
 	return g
 }
 
 // Is adds the is step to the GraphTraversal.
 func (g *GraphTraversal) Is(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("is", args...)
+	g.Bytecode.AddStep("is", args...)
 	return g
 }
 
 // Key adds the key step to the GraphTraversal.
 func (g *GraphTraversal) Key(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("key", args...)
+	g.Bytecode.AddStep("key", args...)
 	return g
 }
 
 // Label adds the label step to the GraphTraversal.
 func (g *GraphTraversal) Label(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("label", args...)
+	g.Bytecode.AddStep("label", args...)
 	return g
 }
 
 // Limit adds the limit step to the GraphTraversal.
 func (g *GraphTraversal) Limit(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("limit", args...)
+	g.Bytecode.AddStep("limit", args...)
 	return g
 }
 
 // Local adds the local step to the GraphTraversal.
 func (g *GraphTraversal) Local(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("local", args...)
+	g.Bytecode.AddStep("local", args...)
 	return g
 }
 
 // Loops adds the loops step to the GraphTraversal.
 func (g *GraphTraversal) Loops(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("loops", args...)
+	g.Bytecode.AddStep("loops", args...)
 	return g
 }
 
 // Map adds the map step to the GraphTraversal.
 func (g *GraphTraversal) Map(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("map", args...)
+	g.Bytecode.AddStep("map", args...)
 	return g
 }
 
 // Match adds the match step to the GraphTraversal.
 func (g *GraphTraversal) Match(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("match", args...)
+	g.Bytecode.AddStep("match", args...)
 	return g
 }
 
 // Math adds the math step to the GraphTraversal.
 func (g *GraphTraversal) Math(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("math", args...)
+	g.Bytecode.AddStep("math", args...)
 	return g
 }
 
 // Max adds the max step to the GraphTraversal.
 func (g *GraphTraversal) Max(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("max", args...)
+	g.Bytecode.AddStep("max", args...)
 	return g
 }
 
 // Mean adds the mean step to the GraphTraversal.
 func (g *GraphTraversal) Mean(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("mean", args...)
+	g.Bytecode.AddStep("mean", args...)
 	return g
 }
 
 // Min adds the min step to the GraphTraversal.
 func (g *GraphTraversal) Min(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("min", args...)
+	g.Bytecode.AddStep("min", args...)
 	return g
 }
 
 // None adds the none step to the GraphTraversal.
 func (g *GraphTraversal) None(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("none", args...)
+	g.Bytecode.AddStep("none", args...)
 	return g
 }
 
 // Not adds the not step to the GraphTraversal.
 func (g *GraphTraversal) Not(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("not", args...)
+	g.Bytecode.AddStep("not", args...)
 	return g
 }
 
 // Option adds the option step to the GraphTraversal.
 func (g *GraphTraversal) Option(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("option", args...)
+	g.Bytecode.AddStep("option", args...)
 	return g
 }
 
 // Optional adds the optional step to the GraphTraversal.
 func (g *GraphTraversal) Optional(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("optional", args...)
+	g.Bytecode.AddStep("optional", args...)
 	return g
 }
 
 // Or adds the or step to the GraphTraversal.
 func (g *GraphTraversal) Or(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("or", args...)
+	g.Bytecode.AddStep("or", args...)
 	return g
 }
 
 // Order adds the order step to the GraphTraversal.
 func (g *GraphTraversal) Order(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("order", args...)
+	g.Bytecode.AddStep("order", args...)
 	return g
 }
 
 // OtherV adds the otherV step to the GraphTraversal.
 func (g *GraphTraversal) OtherV(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("otherV", args...)
+	g.Bytecode.AddStep("otherV", args...)
 	return g
 }
 
 // Out adds the out step to the GraphTraversal.
 func (g *GraphTraversal) Out(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("out", args...)
+	g.Bytecode.AddStep("out", args...)
 	return g
 }
 
 // OutE adds the outE step to the GraphTraversal.
 func (g *GraphTraversal) OutE(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("outE", args...)
+	g.Bytecode.AddStep("outE", args...)
 	return g
 }
 
 // OutV adds the outV step to the GraphTraversal.
 func (g *GraphTraversal) OutV(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("outV", args...)
+	g.Bytecode.AddStep("outV", args...)
 	return g
 }
 
 // PageRank adds the pageRank step to the GraphTraversal.
 func (g *GraphTraversal) PageRank(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("pageRank", args...)
+	g.Bytecode.AddStep("pageRank", args...)
 	return g
 }
 
 // Path adds the path step to the GraphTraversal.
 func (g *GraphTraversal) Path(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("path", args...)
+	g.Bytecode.AddStep("path", args...)
 	return g
 }
 
 // PeerPressure adds the peerPressure step to the GraphTraversal.
 func (g *GraphTraversal) PeerPressure(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("peerPressure", args...)
+	g.Bytecode.AddStep("peerPressure", args...)
 	return g
 }
 
 // Profile adds the profile step to the GraphTraversal.
 func (g *GraphTraversal) Profile(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("profile", args...)
+	g.Bytecode.AddStep("profile", args...)
 	return g
 }
 
 // Program adds the program step to the GraphTraversal.
 func (g *GraphTraversal) Program(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("program", args...)
+	g.Bytecode.AddStep("program", args...)
 	return g
 }
 
 // Project adds the project step to the GraphTraversal.
 func (g *GraphTraversal) Project(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("project", args...)
+	g.Bytecode.AddStep("project", args...)
 	return g
 }
 
 // Properties adds the properties step to the GraphTraversal.
 func (g *GraphTraversal) Properties(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("properties", args...)
+	g.Bytecode.AddStep("properties", args...)
 	return g
 }
 
 // Property adds the property step to the GraphTraversal.
 func (g *GraphTraversal) Property(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("property", args...)
+	g.Bytecode.AddStep("property", args...)
 	return g
 }
 
 // PropertyMap adds the propertyMap step to the GraphTraversal.
 func (g *GraphTraversal) PropertyMap(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("propertyMap", args...)
+	g.Bytecode.AddStep("propertyMap", args...)
 	return g
 }
 
 // Range adds the range step to the GraphTraversal.
 func (g *GraphTraversal) Range(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("range", args...)
+	g.Bytecode.AddStep("range", args...)
 	return g
 }
 
 // Read adds the read step to the GraphTraversal.
 func (g *GraphTraversal) Read(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("read", args...)
+	g.Bytecode.AddStep("read", args...)
 	return g
 }
 
 // Repeat adds the repeat step to the GraphTraversal.
 func (g *GraphTraversal) Repeat(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("repeat", args...)
+	g.Bytecode.AddStep("repeat", args...)
 	return g
 }
 
 // Sack adds the sack step to the GraphTraversal.
 func (g *GraphTraversal) Sack(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("sack", args...)
+	g.Bytecode.AddStep("sack", args...)
 	return g
 }
 
 // Sample adds the sample step to the GraphTraversal.
 func (g *GraphTraversal) Sample(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("sample", args...)
+	g.Bytecode.AddStep("sample", args...)
 	return g
 }
 
 // Select adds the select step to the GraphTraversal.
 func (g *GraphTraversal) Select(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("select", args...)
+	g.Bytecode.AddStep("select", args...)
 	return g
 }
 
 // ShortestPath adds the shortestPath step to the GraphTraversal.
 func (g *GraphTraversal) ShortestPath(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("shortestPath", args...)
+	g.Bytecode.AddStep("shortestPath", args...)
 	return g
 }
 
 // SideEffect adds the sideEffect step to the GraphTraversal.
 func (g *GraphTraversal) SideEffect(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("sideEffect", args...)
+	g.Bytecode.AddStep("sideEffect", args...)
 	return g
 }
 
 // SimplePath adds the simplePath step to the GraphTraversal.
 func (g *GraphTraversal) SimplePath(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("simplePath", args...)
+	g.Bytecode.AddStep("simplePath", args...)
 	return g
 }
 
 // Skip adds the skip step to the GraphTraversal.
 func (g *GraphTraversal) Skip(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("skip", args...)
+	g.Bytecode.AddStep("skip", args...)
 	return g
 }
 
 // Store adds the store step to the GraphTraversal.
 func (g *GraphTraversal) Store(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("store", args...)
+	g.Bytecode.AddStep("store", args...)
 	return g
 }
 
 // Subgraph adds the subgraph step to the GraphTraversal.
 func (g *GraphTraversal) Subgraph(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("subgraph", args...)
+	g.Bytecode.AddStep("subgraph", args...)
 	return g
 }
 
 // Sum adds the sum step to the GraphTraversal.
 func (g *GraphTraversal) Sum(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("sum", args...)
+	g.Bytecode.AddStep("sum", args...)
 	return g
 }
 
 // Tail adds the tail step to the GraphTraversal.
 func (g *GraphTraversal) Tail(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("tail", args...)
+	g.Bytecode.AddStep("tail", args...)
 	return g
 }
 
 // TimeLimit adds the timeLimit step to the GraphTraversal.
 func (g *GraphTraversal) TimeLimit(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("timeLimit", args...)
+	g.Bytecode.AddStep("timeLimit", args...)
 	return g
 }
 
 // Times adds the times step to the GraphTraversal.
 func (g *GraphTraversal) Times(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("times", args...)
+	g.Bytecode.AddStep("times", args...)
 	return g
 }
 
 // To adds the to step to the GraphTraversal.
 func (g *GraphTraversal) To(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("to", args...)
+	g.Bytecode.AddStep("to", args...)
 	return g
 }
 
 // ToE adds the toE step to the GraphTraversal.
 func (g *GraphTraversal) ToE(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("toE", args...)
+	g.Bytecode.AddStep("toE", args...)
 	return g
 }
 
 // ToV adds the toV step to the GraphTraversal.
 func (g *GraphTraversal) ToV(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("toV", args...)
+	g.Bytecode.AddStep("toV", args...)
 	return g
 }
 
 // Tree adds the tree step to the GraphTraversal.
 func (g *GraphTraversal) Tree(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("tree", args...)
+	g.Bytecode.AddStep("tree", args...)
 	return g
 }
 
 // Unfold adds the unfold step to the GraphTraversal.
 func (g *GraphTraversal) Unfold(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("unfold", args...)
+	g.Bytecode.AddStep("unfold", args...)
 	return g
 }
 
 // Union adds the union step to the GraphTraversal.
 func (g *GraphTraversal) Union(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("union", args...)
+	g.Bytecode.AddStep("union", args...)
 	return g
 }
 
 // Until adds the until step to the GraphTraversal.
 func (g *GraphTraversal) Until(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("until", args...)
+	g.Bytecode.AddStep("until", args...)
 	return g
 }
 
 // Value adds the value step to the GraphTraversal.
 func (g *GraphTraversal) Value(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("value", args...)
+	g.Bytecode.AddStep("value", args...)
 	return g
 }
 
 // ValueMap adds the valueMap step to the GraphTraversal.
 func (g *GraphTraversal) ValueMap(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("valueMap", args...)
+	g.Bytecode.AddStep("valueMap", args...)
 	return g
 }
 
 // Values adds the values step to the GraphTraversal.
 func (g *GraphTraversal) Values(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("values", args...)
+	g.Bytecode.AddStep("values", args...)
 	return g
 }
 
 // Where adds the where step to the GraphTraversal.
 func (g *GraphTraversal) Where(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("where", args...)
+	g.Bytecode.AddStep("where", args...)
 	return g
 }
 
 // With adds the with step to the GraphTraversal.
 func (g *GraphTraversal) With(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("with", args...)
+	g.Bytecode.AddStep("with", args...)
 	return g
 }
 
 // Write adds the write step to the GraphTraversal.
 func (g *GraphTraversal) Write(args ...interface{}) *GraphTraversal {
-	g.bytecode.addStep("write", args...)
+	g.Bytecode.AddStep("write", args...)
 	return g
 }
 

--- a/gremlin-go/driver/graphTraversalSource.go
+++ b/gremlin-go/driver/graphTraversalSource.go
@@ -30,7 +30,7 @@ func convertStrategyVarargs(strategies []TraversalStrategy) []interface{} {
 // GraphTraversalSource can be used to start GraphTraversal.
 type GraphTraversalSource struct {
 	graph            *Graph
-	bytecode         *bytecode
+	bytecode         *Bytecode
 	remoteConnection *DriverRemoteConnection
 	graphTraversal   *GraphTraversal
 }
@@ -40,31 +40,31 @@ type GraphTraversalSource struct {
 func NewGraphTraversalSource(graph *Graph, remoteConnection *DriverRemoteConnection,
 	traversalStrategies ...TraversalStrategy) *GraphTraversalSource {
 	convertedArgs := convertStrategyVarargs(traversalStrategies)
-	bc := newBytecode(nil)
-	bc.addSource("withStrategies", convertedArgs...)
+	bc := NewBytecode(nil)
+	bc.AddSource("withStrategies", convertedArgs...)
 	return &GraphTraversalSource{graph: graph, bytecode: bc, remoteConnection: remoteConnection}
 }
 
 // NewDefaultGraphTraversalSource creates a new graph GraphTraversalSource without a graph, strategy, or existing traversal.
 func NewDefaultGraphTraversalSource() *GraphTraversalSource {
-	return &GraphTraversalSource{graph: nil, bytecode: newBytecode(nil), remoteConnection: nil}
+	return &GraphTraversalSource{graph: nil, bytecode: NewBytecode(nil), remoteConnection: nil}
 }
 
-// GetBytecode gets the traversal bytecode associated with this graph traversal source.
-func (gts *GraphTraversalSource) GetBytecode() *bytecode {
+// GetBytecode gets the traversal Bytecode associated with this graph traversal source.
+func (gts *GraphTraversalSource) GetBytecode() *Bytecode {
 	return gts.bytecode
 }
 
 // GetGraphTraversal gets the graph traversal associated with this graph traversal source.
 func (gts *GraphTraversalSource) GetGraphTraversal() *GraphTraversal {
-	return NewGraphTraversal(gts.graph, newBytecode(gts.bytecode), gts.remoteConnection)
+	return NewGraphTraversal(gts.graph, NewBytecode(gts.bytecode), gts.remoteConnection)
 }
 
 func (gts *GraphTraversalSource) clone() *GraphTraversalSource {
-	return cloneGraphTraversalSource(gts.graph, newBytecode(gts.bytecode), gts.remoteConnection)
+	return cloneGraphTraversalSource(gts.graph, NewBytecode(gts.bytecode), gts.remoteConnection)
 }
 
-func cloneGraphTraversalSource(graph *Graph, bc *bytecode, remoteConnection *DriverRemoteConnection) *GraphTraversalSource {
+func cloneGraphTraversalSource(graph *Graph, bc *Bytecode, remoteConnection *DriverRemoteConnection) *GraphTraversalSource {
 	return &GraphTraversalSource{graph: graph,
 		bytecode:         bc,
 		remoteConnection: remoteConnection,
@@ -74,7 +74,7 @@ func cloneGraphTraversalSource(graph *Graph, bc *bytecode, remoteConnection *Dri
 // WithBulk allows for control of bulking operations.
 func (gts *GraphTraversalSource) WithBulk(args ...interface{}) *GraphTraversalSource {
 	source := gts.clone()
-	err := source.bytecode.addSource("withBulk", args...)
+	err := source.bytecode.AddSource("withBulk", args...)
 	if err != nil {
 		return nil
 	}
@@ -84,21 +84,21 @@ func (gts *GraphTraversalSource) WithBulk(args ...interface{}) *GraphTraversalSo
 // WithPath adds a path to be used throughout the life of a spawned Traversal.
 func (gts *GraphTraversalSource) WithPath(args ...interface{}) *GraphTraversalSource {
 	source := gts.clone()
-	source.bytecode.addSource("withPath", args...)
+	source.bytecode.AddSource("withPath", args...)
 	return source
 }
 
 // WithSack adds a sack to be used throughout the life of a spawned Traversal.
 func (gts *GraphTraversalSource) WithSack(args ...interface{}) *GraphTraversalSource {
 	source := gts.clone()
-	source.bytecode.addSource("withSack", args...)
+	source.bytecode.AddSource("withSack", args...)
 	return source
 }
 
 // WithSideEffect adds a side effect to be used throughout the life of a spawned Traversal.
 func (gts *GraphTraversalSource) WithSideEffect(args ...interface{}) *GraphTraversalSource {
 	source := gts.clone()
-	source.bytecode.addSource("withSideEffect", args...)
+	source.bytecode.AddSource("withSideEffect", args...)
 	return source
 }
 
@@ -106,7 +106,7 @@ func (gts *GraphTraversalSource) WithSideEffect(args ...interface{}) *GraphTrave
 func (gts *GraphTraversalSource) WithStrategies(args ...TraversalStrategy) *GraphTraversalSource {
 	convertedArgs := convertStrategyVarargs(args)
 	source := gts.clone()
-	source.bytecode.addSource("withStrategies", convertedArgs...)
+	source.bytecode.AddSource("withStrategies", convertedArgs...)
 	return source
 }
 
@@ -114,14 +114,14 @@ func (gts *GraphTraversalSource) WithStrategies(args ...TraversalStrategy) *Grap
 func (gts *GraphTraversalSource) WithoutStrategies(args ...TraversalStrategy) *GraphTraversalSource {
 	convertedArgs := convertStrategyVarargs(args)
 	source := gts.clone()
-	source.bytecode.addSource("withoutStrategies", convertedArgs...)
+	source.bytecode.AddSource("withoutStrategies", convertedArgs...)
 	return source
 }
 
 // With provides a configuration to a traversal in the form of a key value pair.
 func (gts *GraphTraversalSource) With(key interface{}, value interface{}) *GraphTraversalSource {
 	source := gts.clone()
-	source.bytecode.addSource("with", key, value)
+	source.bytecode.AddSource("with", key, value)
 	return source
 }
 
@@ -137,42 +137,42 @@ func (gts *GraphTraversalSource) WithRemote(remoteConnection *DriverRemoteConnec
 // E reads edges from the graph to start the traversal.
 func (gts *GraphTraversalSource) E(args ...interface{}) *GraphTraversal {
 	traversal := gts.GetGraphTraversal()
-	traversal.bytecode.addStep("E", args...)
+	traversal.Bytecode.AddStep("E", args...)
 	return traversal
 }
 
 // V reads vertices from the graph to start the traversal.
 func (gts *GraphTraversalSource) V(args ...interface{}) *GraphTraversal {
 	traversal := gts.GetGraphTraversal()
-	traversal.bytecode.addStep("V", args...)
+	traversal.Bytecode.AddStep("V", args...)
 	return traversal
 }
 
 // AddE adds an Edge to start the traversal.
 func (gts *GraphTraversalSource) AddE(args ...interface{}) *GraphTraversal {
 	traversal := gts.GetGraphTraversal()
-	traversal.bytecode.addStep("addE", args...)
+	traversal.Bytecode.AddStep("addE", args...)
 	return traversal
 }
 
 // AddV adds a Vertex to start the traversal.
 func (gts *GraphTraversalSource) AddV(args ...interface{}) *GraphTraversal {
 	traversal := gts.GetGraphTraversal()
-	traversal.bytecode.addStep("addV", args...)
+	traversal.Bytecode.AddStep("addV", args...)
 	return traversal
 }
 
 // Inject inserts arbitrary objects to start the traversal.
 func (gts *GraphTraversalSource) Inject(args ...interface{}) *GraphTraversal {
 	traversal := gts.GetGraphTraversal()
-	traversal.bytecode.addStep("inject", args...)
+	traversal.Bytecode.AddStep("inject", args...)
 	return traversal
 }
 
 // Io adds the io steps to start the traversal.
 func (gts *GraphTraversalSource) Io(args ...interface{}) *GraphTraversal {
 	traversal := gts.GetGraphTraversal()
-	traversal.bytecode.addStep("io", args...)
+	traversal.Bytecode.AddStep("io", args...)
 	return traversal
 }
 

--- a/gremlin-go/driver/request.go
+++ b/gremlin-go/driver/request.go
@@ -34,7 +34,7 @@ const sessionProcessor = "session"
 const stringOp = "eval"
 const stringProcessor = ""
 
-// Bindings should be a key-object map (different from Binding class in bytecode).
+// Bindings should be a key-object map (different from Binding class in Bytecode).
 func makeStringRequest(stringGremlin string, traversalSource string, sessionId string, bindings ...map[string]interface{}) (req request) {
 	newProcessor := stringProcessor
 	newArgs := map[string]interface{}{
@@ -63,7 +63,7 @@ const bytecodeProcessor = "traversal"
 const authOp = "authentication"
 const authProcessor = "traversal"
 
-func makeBytecodeRequest(bytecodeGremlin *bytecode, traversalSource string, sessionId string) (req request) {
+func makeBytecodeRequest(bytecodeGremlin *Bytecode, traversalSource string, sessionId string) (req request) {
 	newProcessor := bytecodeProcessor
 	newArgs := map[string]interface{}{
 		"gremlin": *bytecodeGremlin,

--- a/gremlin-go/driver/serializer.go
+++ b/gremlin-go/driver/serializer.go
@@ -64,7 +64,7 @@ func convertArgs(request *request, gs graphBinarySerializer) (map[string]interfa
 	// args["gremlin"]: <serialized args["gremlin"]>
 	gremlin := request.args["gremlin"]
 	switch gremlin.(type) {
-	case bytecode:
+	case Bytecode:
 		buffer := bytes.Buffer{}
 		gremlinBuffer, err := gs.ser.write(gremlin, &buffer)
 		if err != nil {

--- a/gremlin-go/driver/strategies.go
+++ b/gremlin-go/driver/strategies.go
@@ -395,7 +395,7 @@ func RemoteStrategy(connection DriverRemoteConnection) TraversalStrategy {
 			return
 		}
 
-		rs, err := connection.submitBytecode(g.bytecode)
+		rs, err := connection.submitBytecode(g.Bytecode)
 		if err != nil {
 			return
 		}

--- a/gremlin-go/driver/strategies_test.go
+++ b/gremlin-go/driver/strategies_test.go
@@ -119,7 +119,7 @@ func TestStrategy(t *testing.T) {
 		assert.Equal(t, int32(0), val)
 	})
 
-	t.Run("Test bytecode generation for MatchAlgorithmStrategy", func(t *testing.T) {
+	t.Run("Test Bytecode generation for MatchAlgorithmStrategy", func(t *testing.T) {
 		g := getModernGraph(t, testNoAuthUrl, &AuthInfo{}, &tls.Config{})
 		defer g.remoteConnection.Close()
 

--- a/gremlin-go/driver/traversal.go
+++ b/gremlin-go/driver/traversal.go
@@ -30,7 +30,7 @@ type Traverser struct {
 // Traversal is the primary way in which graphs are processed.
 type Traversal struct {
 	graph    *Graph
-	bytecode *bytecode
+	Bytecode *Bytecode
 	remote   *DriverRemoteConnection
 	results  ResultSet
 }
@@ -41,7 +41,7 @@ func (t *Traversal) ToList() ([]*Result, error) {
 		return nil, newError(err0901ToListAnonTraversalError)
 	}
 
-	results, err := t.remote.submitBytecode(t.bytecode)
+	results, err := t.remote.submitBytecode(t.Bytecode)
 	if err != nil {
 		return nil, err
 	}
@@ -74,12 +74,12 @@ func (t *Traversal) Iterate() <-chan error {
 			return
 		}
 
-		if err := t.bytecode.addStep("none"); err != nil {
+		if err := t.Bytecode.AddStep("none"); err != nil {
 			r <- err
 			return
 		}
 
-		res, err := t.remote.submitBytecode(t.bytecode)
+		res, err := t.remote.submitBytecode(t.Bytecode)
 		if err != nil {
 			r <- err
 			return
@@ -118,7 +118,7 @@ func (t *Traversal) Next() (*Result, error) {
 // GetResultSet submits the traversal and returns the ResultSet.
 func (t *Traversal) GetResultSet() (ResultSet, error) {
 	if t.results == nil {
-		results, err := t.remote.submitBytecode(t.bytecode)
+		results, err := t.remote.submitBytecode(t.Bytecode)
 		if err != nil {
 			return nil, err
 		}

--- a/gremlin-go/driver/traversal_test.go
+++ b/gremlin-go/driver/traversal_test.go
@@ -30,36 +30,36 @@ func TestTraversal(t *testing.T) {
 	testTransactionEnable := getEnvOrDefaultBool("TEST_TRANSACTIONS", true)
 
 	t.Run("Test clone traversal", func(t *testing.T) {
-		g := cloneGraphTraversalSource(&Graph{}, newBytecode(nil), nil)
+		g := cloneGraphTraversalSource(&Graph{}, NewBytecode(nil), nil)
 		original := g.V().Out("created")
 		clone := original.Clone().Out("knows")
 		cloneClone := clone.Clone().Out("created")
 
-		assert.Equal(t, 2, len(original.bytecode.stepInstructions))
-		assert.Equal(t, 3, len(clone.bytecode.stepInstructions))
-		assert.Equal(t, 4, len(cloneClone.bytecode.stepInstructions))
+		assert.Equal(t, 2, len(original.Bytecode.stepInstructions))
+		assert.Equal(t, 3, len(clone.Bytecode.stepInstructions))
+		assert.Equal(t, 4, len(cloneClone.Bytecode.stepInstructions))
 
 		original.Has("person", "name", "marko")
 		clone.V().Out()
 
-		assert.Equal(t, 3, len(original.bytecode.stepInstructions))
-		assert.Equal(t, 5, len(clone.bytecode.stepInstructions))
-		assert.Equal(t, 4, len(cloneClone.bytecode.stepInstructions))
+		assert.Equal(t, 3, len(original.Bytecode.stepInstructions))
+		assert.Equal(t, 5, len(clone.Bytecode.stepInstructions))
+		assert.Equal(t, 4, len(cloneClone.Bytecode.stepInstructions))
 	})
 
 	t.Run("Test Iterate with empty removeConnection", func(t *testing.T) {
-		g := NewGraphTraversalSource(&Graph{}, nil, newBytecode(nil))
+		g := NewGraphTraversalSource(&Graph{}, nil, NewBytecode(nil))
 
 		promise := g.V().Count().Iterate()
 		assert.NotNil(t, <-promise)
 	})
 
 	t.Run("Test traversal with bindings", func(t *testing.T) {
-		g := cloneGraphTraversalSource(&Graph{}, newBytecode(nil), nil)
+		g := cloneGraphTraversalSource(&Graph{}, NewBytecode(nil), nil)
 		bytecode := g.V((&Bindings{}).Of("a", []int32{1, 2, 3})).
 			Out((&Bindings{}).Of("b", "created")).
 			Where(T__.In((&Bindings{}).Of("c", "created"), (&Bindings{}).Of("d", "knows")).
-				Count().Is((&Bindings{}).Of("e", P.Gt(2)))).bytecode
+				Count().Is((&Bindings{}).Of("e", P.Gt(2)))).Bytecode
 		assert.Equal(t, 5, len(bytecode.bindings))
 		assert.Equal(t, []int32{1, 2, 3}, bytecode.bindings["a"])
 		assert.Equal(t, "created", bytecode.bindings["b"])


### PR DESCRIPTION
Exported the Bytecode struct and methods for use with creating custom DSL in gremlin-go, which are minor edits that make up majority of the changes. 
Examples of how to use DSL in go has been added to the gremlin variants ascii documentation.