### PR TITLE
TINKERPOP-2749: Hadoop Gremlin Windows Build Note

### DIFF
--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -46,7 +46,11 @@ IMPORTANT: For those who intend to offer a contribution, building with a minimal
 when submitting a pull request. Consider setting up the full environment.
 
 NOTE: For those using Windows, efforts have been made to keep the build OS independent, but, in practice, it is likely
-that TinkerPop's build system will only allow for a minimum build at best.
+that TinkerPop's build system will only allow for a minimum build at best. +
+ +
+ For Hadoop Gremlin to work on Windows, the `winutils.exe` binary needs to be downloaded and placed in local folder in
+ the following file structure: `hadoop/bin/winutils.exe` and `HADOOP_HOME` must point to the `hadoop` folder as an
+ environment variable. The binary for Hadoop-2.7.7 can be found https://github.com/cdarlint/winutils/blob/master/hadoop-2.7.7/bin/winutils.exe[here]
 
 [[groovy-environment]]
 === Groovy Environment


### PR DESCRIPTION
This change adds to the note of the Windows Build in `development-environment.asciidoc` to include details on making the local build of Hadoop Gremlin work as expected on Windows.

Issue: [TINKERPOP-2749](https://issues.apache.org/jira/browse/TINKERPOP-2749)