### PR TITLE
Specify ujson version of 2.0.0 or greater

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -24,11 +24,6 @@ import struct
 # import kerberos    Optional dependency imported in relevant codeblock
 import six
 
-try:
-    import ujson as json
-except ImportError:
-    import json
-
 from gremlin_python.driver import request
 from gremlin_python.driver.resultset import ResultSet
 

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -16,13 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-try:
-    import ujson as json
-except ImportError:
-    import json
+
+import logging
 import struct
 import uuid
 import io
+try:
+    import ujson as json
+    if int(json.__version__[0]) < 2:
+        logging.warning("Detected ujson version below 2.0.0. This is not recommended as precision may be lost.")
+except ImportError:
+    import json
 
 from gremlin_python.structure.io import graphbinaryV1
 from gremlin_python.structure.io import graphsonV2d0

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -79,8 +79,9 @@ setup(
         'PyHamcrest>=1.9.0,<2.0.0'
     ],
     install_requires=install_requires,
-    extra_require={
-        'kerberos': 'kerberos>=1.3.0,<2.0.0'    # Does not install in Microsoft Windows
+    extras_require={
+        'kerberos': 'kerberos>=1.3.0,<2.0.0',    # Does not install in Microsoft Windows
+        'ujson': 'ujson>=2.0.0'
     },
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TINKERPOP-2631

Since ujson is an optional dependency, hard enforcing a version may cause problems for users.

Instead, a version >= 2.0.0 is specified to be automatically resolved by the Python package manager if someone were to use install gremlin-python with ujson enabled. A warning is also given when using a version below 2.0.0 is detected.