### PR TITLE
[TINKERPOP-2740] first request suspend more than 9s when using gremlin-java-driver

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Handler.java
@@ -174,7 +174,7 @@ final class Handler {
         }
 
         private String getHostName(final ChannelHandlerContext channelHandlerContext) {
-            return ((InetSocketAddress)channelHandlerContext.channel().remoteAddress()).getAddress().getCanonicalHostName();
+            return ((InetSocketAddress)channelHandlerContext.channel().remoteAddress()).getAddress().getHostName();
         }
 
         /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2740

Replaced getCanonicalHostName() with getHostName() to to get rid of slow reverse DNS lookup