### PR TITLE
TINKERPOP-2749: Gremlin Dotnet Windows Build fixes

### DIFF
--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -55,15 +55,16 @@ limitations under the License.
                         <configuration>
                             <scripts>
                                 <script>
-def mavenVersion = "${project.version}"
-def file = new File("${project.basedir}/Gremlin.Net/Gremlin.Net.csproj")
-file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
+                                    def mavenVersion = "${project.version}"
+                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist", "").replace("\\", "/")
+                                    def file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj")
+                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
-file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
-file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
+                                    file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+                                    file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
-file = new File("${project.basedir}/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
-file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
+                                    file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
                                 </script>
                             </scripts>
                         </configuration>

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -48,15 +48,22 @@ if (testTransactions) {
 log.info("Starting Gremlin Server instances for native testing of ${executionName}")
 log.info("Transactions validated (enabled with -DincludeNeo4j and only available on port 45940): " + testTransactions)
 
-def settings = Settings.read("${settingsFile}")
-settings.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.crew = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.grateful = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settings.graphs.sink = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-if (testTransactions) settings.graphs.tx = gremlinServerDir + "/src/test/scripts/neo4j-empty.properties"
-settings.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [gremlinServerDir + "/src/test/scripts/generate-all.groovy"]
+def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath
+        .replace("\\.this-definitely-does-not-exist", "") // Windows
+        .replace("\\", "/") // Windows
+        .replace("/.this-definitely-does-not-exist","") // Unix
+def platformAgnosticGremlinServerDir = platformAgnosticBaseDirPath + "/gremlin-server"
+def platformAgnosticSettingsFile = platformAgnosticGremlinServerDir + "/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml"
+
+def settings = Settings.read("${platformAgnosticSettingsFile}")
+settings.graphs.graph = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.classic = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.modern = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.crew = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.grateful = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settings.graphs.sink = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+if (testTransactions) settings.graphs.tx = platformAgnosticGremlinServerDir + "/src/test/scripts/neo4j-empty.properties"
+settings.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [platformAgnosticGremlinServerDir + "/src/test/scripts/generate-all.groovy"]
 settings.port = 45940
 
 def server = new GremlinServer(settings)
@@ -66,30 +73,30 @@ project.setContextValue("gremlin.server", server)
 log.info("Gremlin Server without authentication started on port 45940")
 
 
-def securePropsFile = new File("${projectBaseDir}/target/tinkergraph-credentials.properties")
+def securePropsFile = new File("${platformAgnosticBaseDirPath}/target/tinkergraph-credentials.properties")
 if (!securePropsFile.exists()) {
     securePropsFile.createNewFile()
     securePropsFile << "gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph\n"
     securePropsFile << "gremlin.tinkergraph.vertexIdManager=LONG\n"
-    securePropsFile << "gremlin.tinkergraph.graphLocation=${gremlinServerDir}/data/credentials.kryo\n"
+    securePropsFile << "gremlin.tinkergraph.graphLocation=${platformAgnosticGremlinServerDir}/data/credentials.kryo\n"
     securePropsFile << "gremlin.tinkergraph.graphFormat=gryo"
 }
 
-def settingsSecure = Settings.read("${settingsFile}")
-settingsSecure.graphs.graph = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.classic = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.modern = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.crew = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.grateful = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.graphs.sink = gremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
-settingsSecure.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [gremlinServerDir + "/src/test/scripts/generate-all.groovy"]
+def settingsSecure = Settings.read("${platformAgnosticSettingsFile}")
+settingsSecure.graphs.graph = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.classic = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.modern = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.crew = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.grateful = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.graphs.sink = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"
+settingsSecure.scriptEngines["gremlin-groovy"].plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"].files = [platformAgnosticGremlinServerDir + "/src/test/scripts/generate-all.groovy"]
 settingsSecure.port = 45941
 settingsSecure.authentication.authenticator = "org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator"
-settingsSecure.authentication.config = [credentialsDb: projectBaseDir + "/target/tinkergraph-credentials.properties"]
+settingsSecure.authentication.config = [credentialsDb: platformAgnosticBaseDirPath + "/target/tinkergraph-credentials.properties"]
 settingsSecure.ssl = new Settings.SslSettings()
 settingsSecure.ssl.enabled = true
 settingsSecure.ssl.sslEnabledProtocols = ["TLSv1.2"]
-settingsSecure.ssl.keyStore = gremlinServerDir + "/src/test/resources/server-key.jks"
+settingsSecure.ssl.keyStore = platformAgnosticGremlinServerDir + "/src/test/resources/server-key.jks"
 settingsSecure.ssl.keyStorePassword = "changeit"
 
 def serverSecure = new GremlinServer(settingsSecure)


### PR DESCRIPTION
Link to Issue: [TINKERPOP-2749](https://issues.apache.org/jira/browse/TINKERPOP-2749)

This PR addresses Errors that cause the Windows build of Gremlin Dotnet to fail.

Issues Addressed:
1. Fixed an issue where groovy script defined in `gremlin-dotnet/src/pom.xml` receives an incorrectly formatted path for Windows. Single `\` characters are invalid in groovy and using `${project.basedir}` returns a string with non-escaped `\` characters in Windows.

_Note: The .NET windows build workflow has not yet been activated as there were inconsistent failures popping up on GitHub actions. Around 1-2 out of 10 workflow runs would fail due to inconsistent test failures. This issue needs to be more thoroughly investigated. Locally, however, the build has no issues on Windows with these changes._

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
