### PR TITLE
fix: Traversal.graph is empty in StepStrategy.apply() with `count().is(0)`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated and removed functionality of the `connectOnStartup` option in `gremlin-javascript` to resolve potential `unhandledRejection` and race conditions.
 * Fixed potential `NullPointerException` in `gremlin-driver` where initialization of a `ConnectionPool` would fail but not throw an exception due to centralized error check being satisfied by a different process.
 * Fixed a bug where the JavaScript client would hang indefinitely on traversals if the connection to the server was terminated.
+* Fixed Traversal.graph is empty in StepStrategy.apply() with `count().is(0)`.
 
 [[release-3-5-3]]
 === TinkerPop 3.5.3 (Release Date: April 4, 2022)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategy.java
@@ -164,6 +164,7 @@ public final class CountStrategy extends AbstractTraversalStrategy<TraversalStra
                                 } else {
                                     inner = __.identity().asAdmin();
                                 }
+                                traversal.getGraph().ifPresent(graph -> inner.setGraph(graph));
                                 if (prev != null)
                                     TraversalHelper.replaceStep(prev, new NotStep<>(traversal, inner), traversal);
                                 else


### PR DESCRIPTION
This PR fixed:
`traversal.getGraph()` is empty in `StepStrategy.apply()` method `VertexStepStrategy.apply(Traversal.Admin traversal)` for the following Gremlin:
```java
g.V(3).repeat(inE('child').outV().simplePath())
 .until(or(inE().count().is(0),loops().is(eq(2))))
 .path()
```

#### Initial data:
```
g.addV('node').property(id, 1).as('1')
 .addV('node').property(id, 2).as('2')
 .addV('node').property(id, 3).as('3')
 .addV('node').property(id, 4).as('4')
 .addE('child').from('1').to('2')
 .addE('child').from('2').to('3')
 .addE('child').from('4').to('3')
```

#### Cause analysis:
In the case of a non `count().is(0)` statement, the graph context is passed here:
https://github.com/apache/tinkerpop/blob/f8af06198ee5d112599fb938f97ff9707a83c81c/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java#L138

So we can get the graph context when Strategy.apply() is called:
https://github.com/apache/tinkerpop/blob/f8af06198ee5d112599fb938f97ff9707a83c81c/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java#L152

But when using the `count().is(0)` statement, the graph context is missing because the original traversal is replaced with a new traversal by `__.start()`:
https://github.com/apache/tinkerpop/blob/7f7d3a485c7f100f98047b71672a0c2c9ab855b4/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategy.java#L154

The `__.start()` method implementation:
https://github.com/apache/tinkerpop/blob/2c24493f7643139cd8197ed27a03180a924a5704/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java#L59