### PR TITLE
gremlin-go: support per-request arguments in bytecode

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1451,7 +1451,7 @@ results, err := g.With("evaluationTimeout", 500).V().Out("knows").ToList()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent` and
-`evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated).
+`evaluationTimeout`.
 
 anchor:go-imports[]
 [[gremlin-go-imports]]
@@ -1627,7 +1627,7 @@ resultSet, err := client.Submit("g.V().repeat(both()).times(100)", map[string]in
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent` and
-`evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated).
+`evaluationTimeout`.
 
 IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
 with bytecode may try `g.with("evaluationTimeout", 500)` within a script. Scripts with multiple traversals and multiple

--- a/gremlin-go/docker/gremlin-server-integration-secure.yaml
+++ b/gremlin-go/docker/gremlin-server-integration-secure.yaml
@@ -18,7 +18,7 @@
 host: 0.0.0.0
 port: 45941
 evaluationTimeout: 30000
-channelizer: org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizer
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
 graphs: {
   graph: scripts/tinkergraph-empty.properties,
   immutable: scripts/tinkergraph-empty.properties,

--- a/gremlin-go/docker/gremlin-server-integration.yaml
+++ b/gremlin-go/docker/gremlin-server-integration.yaml
@@ -18,7 +18,7 @@
 host: 0.0.0.0
 port: 45940
 evaluationTimeout: 30000
-channelizer: org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizer
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
 graphs: {
   graph: scripts/tinkergraph-empty.properties,
   immutable: scripts/tinkergraph-empty.properties,

--- a/gremlin-go/driver/request.go
+++ b/gremlin-go/driver/request.go
@@ -91,11 +91,10 @@ func makeBytecodeRequest(bytecodeGremlin *Bytecode, traversalSource string, sess
 // allowedReqArgs contains the arguments that will be extracted from the
 // bytecode and sent with the request.
 var allowedReqArgs = map[string]bool{
-	"evaluationTimeout":       true,
-	"scriptEvaluationTimeout": true,
-	"batchSize":               true,
-	"requestId":               true,
-	"userAgent":               true,
+	"evaluationTimeout": true,
+	"batchSize":         true,
+	"requestId":         true,
+	"userAgent":         true,
 }
 
 // extractReqArgs extracts request arguments from the provided bytecode.

--- a/gremlin-go/driver/request.go
+++ b/gremlin-go/driver/request.go
@@ -108,7 +108,7 @@ func extractReqArgs(bytecode *Bytecode) map[string]interface{} {
 				args[k] = v
 			}
 		case "with":
-			if k, v := extractWithReqArgs(insn); k != "" {
+			if k, v := extractWithReqArg(insn); k != "" {
 				args[k] = v
 			}
 		}
@@ -145,9 +145,9 @@ func extractWithStrategiesReqArgs(insn instruction) map[string]interface{} {
 	return args
 }
 
-// extractWithReqArgs extracts a request argument from the passed "with" source
+// extractWithReqArg extracts a request argument from the passed "with" source
 // instruction.
-func extractWithReqArgs(insn instruction) (key string, value interface{}) {
+func extractWithReqArg(insn instruction) (key string, value interface{}) {
 	if len(insn.arguments) != 2 {
 		// (*GraphTraversalSource).With accepts two parameters. Thus,
 		// this should be unreachable.


### PR DESCRIPTION
The issue that triggered this change is that per-request options were not working with gremlin-go. For instance setting a per-request timeout this way:

```go
	result, err := g.With("evaluationTimeout", 5000).V().Count().Next()
	if err != nil {
		// Handle error.
	}
```

A very similar problem was described some time ago for the Python GLV in the JIRA issue [TINKERPOP-2296](https://issues.apache.org/jira/browse/TINKERPOP-2296) and solved in the pull-request [apache/tinkerpop#1329](https://github.com/apache/tinkerpop/pull/1329).

Stephen Mallette explains the root cause of the issue in a comment in JIRA:

> There is no real strategy application in GLVs - the strategies are simply shipped to the server as bytecode configurations. By that point, it's already bypassed the point where the server will care about the timeout (or other request setting) overrides.

The Python GLV fixes this issue by:

1. Converting the "with" options into an OptionsStrategy.
2. Extracting a whitelisted set of options from the OptionsStrategy.
3. Sending the extracted options as part of the bytecode request.

However, this means that the generated bytecode will not always match the code written by the users. E.g.

```
	with(k, v) -> withStrategies(OptionsStrategy({k: v}))
```

So, this PR takes a slightly different approach. It extracts the whitelisted set of per-request options in makeBytecodeRequests() and adds them to the bytecode request without modifying the generated bytecode.