### PR TITLE
TINKERPOP-2708 follow-up: Remove javascript connectOnStartup API on master branch

### DIFF
--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -1,0 +1,45 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+////
+
+= TinkerPop 3.7.0
+
+image::https://3.7.x/place/holder/image[width=225]
+
+*3.7.0*
+
+== TinkerPop 3.7.0
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/tinkerpop/blob/master/CHANGELOG.asciidoc#release-3-7.0[changelog] for a
+complete list of all the modifications that are part of this release.
+
+=== Upgrading for Users
+
+==== Removed connectOnStartup option in gremlin-javascript
+Removed the `connectOnStartup` option for Gremlin Javascript API to resolve potential `unhandledRejection` and race conditions.
+
+New DriverRemoteConnection objects no longer initiate connection by default at startup. Call `open()` explicitly if one wishes to connect on startup.
+For example:
+
+[source,javascript]
+----
+const drc = new DriverRemoteConnection(url);
+drc.open().catch(err => {
+   // Handle error upon open.
+})
+----

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/.eslintrc.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
   env: {
     commonjs: true,
     es6: true,
-    node: true,
   },
   parserOptions: {
     ecmaVersion: 2017,

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -67,7 +67,6 @@ class Connection extends EventEmitter {
    * @param {Boolean} [options.pingEnabled] Setup ping interval. Defaults to: true.
    * @param {Number} [options.pingInterval] Ping request interval in ms if ping enabled. Defaults to: 60000.
    * @param {Number} [options.pongTimeout] Timeout of pong response in ms after sending a ping. Defaults to: 30000.
-   * @param {Boolean} [options.connectOnStartup] Deprecated and non-functional. Open websocket on startup.
    * @constructor
    */
   constructor(url, options) {
@@ -102,12 +101,6 @@ class Connection extends EventEmitter {
     this._pingEnabled = this.options.pingEnabled === false ? false : true;
     this._pingIntervalDelay = this.options.pingInterval || pingIntervalDelay;
     this._pongTimeoutDelay = this.options.pongTimeout || pongTimeoutDelay;
-
-    if (this.options.connectOnStartup) {
-      console.warn(
-        'connectOnStartup is now deprecated and non-functional. To open a connection, please call open() after instantiating connection object.',
-      );
-    }
   }
 
   /**


### PR DESCRIPTION
For issue https://issues.apache.org/jira/browse/TINKERPOP-2708. 

Follow-up on https://github.com/apache/tinkerpop/pull/1680 PR to remove connectOnStartup API in master branch, and added the release/upgrade skeleton doc for 3.7.0. 