### PR TITLE
TINKERPOP-2735: Backport fix to close request error in UnifiedChannelizer to 3.5-dev

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/UnifiedHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/UnifiedHandler.java
@@ -136,6 +136,15 @@ public class UnifiedHandler extends SimpleChannelInboundHandler<RequestMessage> 
                 return;
             }
 
+            // this is for backward compatibility for drivers still sending a close message. the close message was
+            // removed in 3.5.0 but then added back for 3.5.2.
+            if (msg.getOp().equals(Tokens.OPS_CLOSE)) {
+                ctx.writeAndFlush(ResponseMessage.build(msg)
+                        .code(ResponseStatusCode.NO_CONTENT)
+                        .create());
+                return;
+            }
+
             final Optional<String> optMultiTaskSession = msg.optionalArgs(Tokens.ARGS_SESSION);
             final String sessionId = optMultiTaskSession.orElse(msg.getRequestId().toString());
 


### PR DESCRIPTION
A fix to the error message on session close reported in https://issues.apache.org/jira/browse/TINKERPOP-2735. 

Session `close` request will output `Unrecognized content` error message in 3.5.x server, the fix is in 3.6.0 where `UnifiedHandler` has an added [check](https://github.com/apache/tinkerpop/blob/225035c0b943a532152073da393cdb466b311693/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/UnifiedHandler.java#L141) to handle close requests, whereas the 3.5.x server does not, and that causes the request to fall through into the exception [here](https://github.com/apache/tinkerpop/blob/287499e207faef9bea28ec20234026e132b63d33/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java#L844) with a null content type for the gremlin args field. 

This PR backports that check in 3.6 for `close` requests into 3.5-dev