### PR TITLE
TINKERPOP-2751: Throw exception if transaction attempted on non transaction supported Graph

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
@@ -666,6 +666,8 @@ public abstract class AbstractSession implements Session, AutoCloseable {
                 throw new IllegalStateException(String.format(
                         "Bytecode in request is not a recognized graph operation: %s", bytecode.toString()));
             }
+        } else {
+            throw Graph.Exceptions.transactionsNotSupported();
         }
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -526,6 +526,11 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                 throw new IllegalStateException(String.format(
                         "Bytecode in request is not a recognized graph operation: %s", bytecode.toString()));
             }
+        } else {
+            UnsupportedOperationException uoe = Graph.Exceptions.transactionsNotSupported();
+            context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR)
+                    .statusMessage(uoe.getMessage())
+                    .statusAttributeException(uoe).create());
         }
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -527,10 +527,7 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                         "Bytecode in request is not a recognized graph operation: %s", bytecode.toString()));
             }
         } else {
-            UnsupportedOperationException uoe = Graph.Exceptions.transactionsNotSupported();
-            context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR)
-                    .statusMessage(uoe.getMessage())
-                    .statusAttributeException(uoe).create());
+            throw Graph.Exceptions.transactionsNotSupported();
         }
     }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
@@ -690,8 +690,10 @@ public class GremlinServerSessionIntegrateTest extends AbstractGremlinServerInte
         }
     }
 
+    /**
+     * Reproducer for TINKERPOP-2751
+     */
     @Test(timeout=30000)
-    // Ref: TINKERPOP-2751
     public void shouldThrowExceptionOnTransactionUnsupportedGraph() throws Exception {
         final Cluster cluster = TestClientFactory.build().create();
         final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
@@ -18,6 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.ExceptionHelper;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -48,6 +55,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -685,5 +693,29 @@ public class GremlinServerSessionIntegrateTest extends AbstractGremlinServerInte
             assertEquals(ResponseStatusCode.SUCCESS, checkAgainstResponses.get(0).getStatus().getCode());
             assertThat(((List<Boolean>) checkAgainstResponses.get(0).getResult().getData()).get(0), is(false));
         }
+    }
+
+    @Test(timeout=30000)
+    // Ref: TINKERPOP-2751
+    public void shouldThrowExceptionOnTransactionUnsupportedGraph() throws Exception {
+        final Cluster cluster = TestClientFactory.build().create();
+        final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));
+
+        final GraphTraversalSource gtx = g.tx().begin();
+        assertThat(gtx.tx().isOpen(), is(true));
+
+        gtx.addV("person").iterate();
+        assertEquals(1, (long) gtx.V().count().next());
+
+        try {
+            // Without Neo4j plugin this should fail on gremlin-server
+            gtx.tx().commit();
+            fail("commit should throw exception on non-transaction supported graph");
+        } catch (Exception ex){
+            final Throwable root = ExceptionHelper.getRootCause(ex);
+            assertEquals("Graph does not support transactions", root.getMessage());
+        }
+
+        cluster.close();
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateTest.java
@@ -19,12 +19,7 @@
 package org.apache.tinkerpop.gremlin.server;
 
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
-import org.apache.tinkerpop.gremlin.process.traversal.Order;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
-import org.apache.tinkerpop.gremlin.structure.Column;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.ExceptionHelper;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateWithUnifiedChannelizerTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateWithUnifiedChannelizerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.tinkerpop.gremlin.server;
 
 import org.apache.tinkerpop.gremlin.driver.Cluster;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateWithUnifiedChannelizerTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateWithUnifiedChannelizerTest.java
@@ -1,0 +1,41 @@
+package org.apache.tinkerpop.gremlin.server;
+
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizerIntegrateTest;
+import org.apache.tinkerpop.gremlin.util.ExceptionHelper;
+import org.junit.Test;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class GremlinServerSessionIntegrateWithUnifiedChannelizerTest extends UnifiedChannelizerIntegrateTest {
+
+    @Test(timeout=30000)
+    // Ref: TINKERPOP-2751
+    public void shouldThrowExceptionOnTransactionUnsupportedGraph() throws Exception {
+        final Cluster cluster = TestClientFactory.build().create();
+        final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));
+
+        final GraphTraversalSource gtx = g.tx().begin();
+        assertThat(gtx.tx().isOpen(), is(true));
+
+        gtx.addV("person").iterate();
+        assertEquals(1, (long) gtx.V().count().next());
+
+        try {
+            // Without Neo4j plugin this should fail on gremlin-server
+            gtx.tx().commit();
+            fail("commit should throw exception on non-transaction supported graph");
+        } catch (Exception ex){
+            final Throwable root = ExceptionHelper.getRootCause(ex);
+            assertEquals("Graph does not support transactions", root.getMessage());
+        }
+
+        cluster.close();
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateWithUnifiedChannelizerTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSessionIntegrateWithUnifiedChannelizerTest.java
@@ -33,8 +33,10 @@ import static org.junit.Assert.fail;
 
 public class GremlinServerSessionIntegrateWithUnifiedChannelizerTest extends UnifiedChannelizerIntegrateTest {
 
+    /**
+     * Reproducer for TINKERPOP-2751
+     */
     @Test(timeout=30000)
-    // Ref: TINKERPOP-2751
     public void shouldThrowExceptionOnTransactionUnsupportedGraph() throws Exception {
         final Cluster cluster = TestClientFactory.build().create();
         final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));


### PR DESCRIPTION
Link to issue: [TINKERPOP 2751](https://issues.apache.org/jira/browse/TINKERPOP-2751)

If a transaction is attempted on a graph that does not support transactions, the client hangs as it waits for a response from the server. The change in this PR handles that case and responds to the client with a `transactionNotSupported()` exception.

Ideally, we would want the client to fail at `tx.begin()` but this would involve a much bigger change on the server and across the GLVs. For now, users should be notified that they need to use a transaction-enabled graph when attempting to perform a graph operation (rollback or commit)