### PR TITLE
TINKERPOP-2761: fix version key race in Manifest

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/Gremlin.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/Gremlin.java
@@ -26,10 +26,10 @@ import java.io.IOException;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public final class Gremlin {
-    private static String version;
+    private static final String version;
 
     static {
-        version = Manifests.read("version");
+        version = Manifests.read("tinkerpop-version");
     }
 
     private Gremlin() {

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,7 @@ limitations under the License.
                         <manifestEntries>
                             <version>${project.version}</version>
                             <hash>${buildNumber}</hash>
+                            <tinkerpop-version>${project.version}</tinkerpop-version>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
- use a more specific key to avoid race on version
- see: https://github.com/JanusGraph/janusgraph/discussions/3004

Fixes https://issues.apache.org/jira/browse/TINKERPOP-2761
