### PR TITLE
Match 3.5 changes in `gremlin-dotnet`

### DIFF
--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -65,14 +65,16 @@ limitations under the License.
                             </properties>
                             <scripts>
                                 <script>
-def file = new File(projectBaseDir,"Gremlin.Net/Gremlin.Net.csproj")
-file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
+                                    def mavenVersion = "${project.version}"
+                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist", "").replace("\\", "/")
+                                    def file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj")
+                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
-file = new File(projectBaseDir,"Gremlin.Net.Template/Gremlin.Net.Template.csproj")
-file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
+                                    file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+                                    file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
-file = new File(projectBaseDir,"Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
-file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
+                                    file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+                                    file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
                                 </script>
                             </scripts>
                         </configuration>


### PR DESCRIPTION
Changes were made to `3.5` in `gremlin-dotnet` that were not propagated to `3.6`. This PR keeps the changes consistent between the two branches.

Link to closed PR: #1690 