### PR TITLE
TINKERPOP-2742: Warn users of vertex property cardinality mismatch

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1622,6 +1622,10 @@ time is not critical) that are loading to an empty graph - incremental loading i
 writing perspective is not that different in there are no parallel operations in play, however streaming the output
 to disk requires a single pass of the data without high memory requirements for larger datasets.
 
+IMPORTANT: Default graph formats don't contain information about property cardinality, so it is up to the graph
+provider to choose the appropriate one. You will see a warning message if the chosen cardinality is SINGLE
+while your graph input contains multiple values for that property.
+
 In general, TinkerPop recommends that users examine the native bulk import/export tools of the graph implementation
 that they choose. Those tools will often outperform the `io()`-step and perhaps be easier to use with a greater
 feature set. That said, graph providers do have the option to optimize `io()` to back it with their own


### PR DESCRIPTION
Related to #1657

Demo:
```
gremlin> graph = TinkerGraph.open()
==>tinkergraph[vertices:0 edges:0]
gremlin> g = graph.traversal()
==>graphtraversalsource[tinkergraph[vertices:0 edges:0], standard]
gremlin> v1 = g.addV().property("feature0", "0.0").property("feature0", "1.1").next()
==>v[0]
gremlin> g.V().valueMap()
==>[feature0:[0.0,1.1]]
gremlin> g.io("graph.json").write().iterate()
gremlin> g.V().drop()
gremlin> g.io("graph.json").read().iterate()
WARN  org.apache.tinkerpop.gremlin.structure.util.Attachable  - feature0 has SINGLE cardinality but with more than one value: [vp[feature0->0.0], vp[feature0->1.1]]. Only last value will be retained.
gremlin> g.V().valueMap()
==>[feature0:[1.1]]
```