### PR TITLE
gremlin-go: improve docker-compose compatibility, fix run.sh command line parsing

### DIFF
--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -15,6 +15,8 @@
 #    specific language governing permissions and limitations
 #    under the License.
 
+version: "3.7"
+
 services:
 
   gremlin-test-server:

--- a/gremlin-go/run.sh
+++ b/gremlin-go/run.sh
@@ -41,10 +41,10 @@ fi
 
 # Parses current gremlin server version from project pom.xml file using perl regex
 GREMLIN_SERVER_VERSION=$(grep tinkerpop -A2 pom.xml | grep -Po '(?<=<version>)([0-9]+\.?){3}(-SNAPSHOT)?(?=<)')
-GREMLIN_SERVER="${1:-$GREMLIN_SERVER_VERSION}"
+export GREMLIN_SERVER="${1:-$GREMLIN_SERVER_VERSION}"
 echo "$GREMLIN_SERVER"
 
 # Passes current gremlin server version into docker compose as environment variable
-GREMLIN_SERVER="$GREMLIN_SERVER_VERSION" docker-compose up --build --exit-code-from gremlin-go-integration-tests
+docker-compose up --build --exit-code-from gremlin-go-integration-tests
 # Removes all service containers
 docker-compose down


### PR DESCRIPTION
The current `docker-compose.yml` file is not compatible with the docker-compose version packaged by some widely used Linux distributions. For instance, Debian bullseye (current stable) [packages docker-compose 1.25.0](https://packages.debian.org/bullseye/docker-compose).

docker-compose 1.25.0 [supports up to compose file format 3.7](https://github.com/docker/compose/releases/tag/1.25.0) and requires the version to be explicitly set in the `docker-compose.yml` file.

By setting the version of the `docker-compose.yml` file to 3.7 we support docker-compose 1.22.0+ and the only required change is adding the "version" field. Also, [version 3 has not been deprecated](https://docs.docker.com/compose/compose-file/compose-versioning/).

Finally, `run.sh` accepts a gremlin-server version as argument, however it is not used when running tests. This PR also fixes this.

I have tested this PR both with docker-compose 1.25.0 and 2.6.0 (latest docker-ce version). 