### PR TITLE
Fix a javadoc comment in Cluster.Builder regarding maxInProcessPerCon…

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ This release also includes changes from <<release-3-5-4, 3.5.4>>.
 
 * Made GraphBinary the default serialization format for .NET and Python.
 * Added missing `ResponseStatusCodeEnum` entry for 595 for .NET.
+* Fix a javadoc comment in Cluster.Builder regarding maxInProcessPerConnection.
 
 [[release-3-6-0]]
 === TinkerPop 3.6.0 (Release Date: April 4, 2022)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -780,7 +780,7 @@ public final class Cluster {
          * {@link #maxSimultaneousUsagePerConnection} setting, but is slightly different in that it refers to
          * the total number of requests on a {@link Connection}.  In other words, a {@link Connection} might
          * be borrowed once to have multiple requests executed against it.  This number controls the maximum
-         * number of requests whereas {@link #maxInProcessPerConnection} controls the times borrowed.
+         * number of requests whereas {@link #maxSimultaneousUsagePerConnection} controls the times borrowed.
          */
         public Builder maxInProcessPerConnection(final int maxInProcessPerConnection) {
             this.maxInProcessPerConnection = maxInProcessPerConnection;


### PR DESCRIPTION
Just fixed a comment. No unit test should be required.