### PR TITLE
Add a getter for selectKeys in SelectStep to retrieve keys with the s…

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ This release also includes changes from <<release-3-5-4, 3.5.4>>.
 
 * Made GraphBinary the default serialization format for .NET and Python.
 * Added missing `ResponseStatusCodeEnum` entry for 595 for .NET.
+* Added a getter for selectKeys in SelectStep
 
 [[release-3-6-0]]
 === TinkerPop 3.6.0 (Release Date: April 4, 2022)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -149,6 +149,17 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
         return this.selectKeysSet;
     }
 
+    /**
+     * Get the keys for this SelectStep. Unlike {@link SelectStep#getScopeKeys()}, this returns a list possibly with
+     * a duplicate key. This guarantees to return the keys in the same order as passed in.
+     * TODO: getScopeKeys should return order-aware data structure instead of HashSet so that graph providers can
+     *       get the keys in the order passed in a query, and can associate them with by-traversals in a correct sequence.
+     *
+     */
+    public List<String> getSelectKeys() {
+        return this.selectKeys;
+    }
+
     public Map<String, Traversal.Admin<Object, E>> getByTraversals() {
         final Map<String, Traversal.Admin<Object, E>> map = new HashMap<>();
         this.traversalRing.reset();


### PR DESCRIPTION
This is a band-aid solution for Graph Providers who want to access selectKeys in the order passed in a query.

A broader discussion is ongoing in https://issues.apache.org/jira/browse/TINKERPOP-2762