### PR TITLE
Release msg in finally block on HttpGremlinEndpointHandler

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ This release also includes changes from <<release-3-5-4, 3.5.4>>.
 
 * Made GraphBinary the default serialization format for .NET and Python.
 * Added missing `ResponseStatusCodeEnum` entry for 595 for .NET.
+* msg is released in finally block on HttpGremlinEndpointHandler.
 
 [[release-3-6-0]]
 === TinkerPop 3.6.0 (Release Date: April 4, 2022)


### PR DESCRIPTION
Just to make sure `msg` is released at the end instead of adding release logic everywhere.