### PR TITLE
Adds status_message as a property on GremlinServerError

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,6 +35,7 @@ class GremlinServerError(Exception):
         super(GremlinServerError, self).__init__('{0}: {1}'.format(status['code'], status['message']))
         self._status_attributes = status['attributes']
         self.status_code = status['code']
+        self.status_message = status['message']
 
     @property
     def status_attributes(self):


### PR DESCRIPTION
AWS Neptune uses a JSON error object for its status message with error details. This PR allows end-users to directly access the status message returned by AWS, so they can deserialize the JSON and access AWS's error message fields

Example Neptune Response

```
GremlinServerError
500: {"detailedMessage":"Failed to complete Insert operation for a Vertex due to conflicting concurrent operations. Please retry. 0 transactions are currently rolling back.","code":"ConcurrentModificationException","requestId":"b163032b-0c78-444b-9d80-07eacd88b74f"}
```