### PR TITLE
gremlin-python: enable opt-out for some pkg reqs

### DIFF
--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -45,11 +45,21 @@ from gremlin_python import __version__
 version = __version__.version
 
 install_requires = [
-    'nest_asyncio',
-    'aiohttp>=3.8.0,<=3.8.1',
     'aenum>=1.4.5,<4.0.0',
     'isodate>=0.6.0,<1.0.0'
 ]
+
+# Users who plan to use a custom transport (instead of AiohttpTransport) can
+# opt out of installing the aiohttp and nest_asyncio packages by setting the
+# environment variable GREMLINPYTHON_NO_AIOHTTP, and installing from source:
+#   export GREMLINPYTHON_NO_AIOHTTP=1
+#   pip install --no-binary gremlinpython gremlinpython
+opt_out_aiohttp = bool(os.getenv("GREMLINPYTHON_NO_AIOHTTP"))
+if not opt_out_aiohttp:
+    install_requires += [
+        'nest_asyncio',
+        'aiohttp>=3.8.0,<=3.8.1'
+    ]
 
 if sys.version_info < (3, 5):
     install_requires += ['pyparsing>=2.4.7,<3.0.0']


### PR DESCRIPTION
For `gremlin-python` users who plan to use a custom transport, there may be no need to install the `aiohttp` or `nest_asyncio` packages. These packages bring quite a few recursive requirements with them as well.

These packages should _not_ be moved to `extras_require` in `setup.py`, since this would break existing deployments.

Instead, there is a pattern for opting out of requirements at installation time, using environment variables. It is discussed for example [here](https://github.com/aio-libs/aioredis-py/issues/663#issuecomment-555555554).

EDIT: Associated JIRA ticket: <https://issues.apache.org/jira/browse/TINKERPOP-2752>