### PR TITLE
gremlin-go: fix deadlock on (*DriverRemoteConnection).Close

### DIFF
--- a/gremlin-go/driver/protocol.go
+++ b/gremlin-go/driver/protocol.go
@@ -161,15 +161,21 @@ func (protocol *gremlinServerWSProtocol) write(request *request) error {
 	return protocol.transporter.Write(bytes)
 }
 
-func (protocol *gremlinServerWSProtocol) close() (err error) {
+func (protocol *gremlinServerWSProtocol) close() error {
 	protocol.mutex.Lock()
-	if !protocol.closed {
-		err = protocol.transporter.Close()
-		protocol.closed = true
+
+	if protocol.closed {
+		protocol.mutex.Unlock()
+		return nil
 	}
+
+	err := protocol.transporter.Close()
+	protocol.closed = true
 	protocol.mutex.Unlock()
+
 	protocol.wg.Wait()
-	return
+
+	return err
 }
 
 func newGremlinServerWSProtocol(handler *logHandler, transporterType TransporterType, url string, connSettings *connectionSettings, results *synchronizedMap,

--- a/gremlin-go/driver/protocol_test.go
+++ b/gremlin-go/driver/protocol_test.go
@@ -41,6 +41,9 @@ func TestProtocol(t *testing.T) {
 		assert.Nil(t, protocol)
 	})
 
+	// protocol.closed is only modified by protocol.close(). If it is true
+	// it means that protocol.wg.Wait() has already been called, so it
+	// should not be called again.
 	t.Run("Test protocol close when closed", func(t *testing.T) {
 		wg := &sync.WaitGroup{}
 		protocol := &gremlinServerWSProtocol{

--- a/gremlin-go/driver/protocol_test.go
+++ b/gremlin-go/driver/protocol_test.go
@@ -20,12 +20,15 @@ under the License.
 package gremlingo
 
 import (
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
-	"testing"
 )
 
-func Test(t *testing.T) {
+func TestProtocol(t *testing.T) {
 	t.Run("Test protocol connect error.", func(t *testing.T) {
 		connSettings := newDefaultConnectionSettings()
 		connSettings.authInfo, connSettings.tlsConfig = nil, nil
@@ -36,5 +39,28 @@ func Test(t *testing.T) {
 			nil, nil)
 		assert.NotNil(t, err)
 		assert.Nil(t, protocol)
+	})
+
+	t.Run("Test protocol close when closed", func(t *testing.T) {
+		wg := &sync.WaitGroup{}
+		protocol := &gremlinServerWSProtocol{
+			closed: true,
+			mutex:  sync.Mutex{},
+			wg:     wg,
+		}
+		wg.Add(1)
+
+		done := make(chan bool)
+
+		go func() {
+			protocol.close()
+			done <- true
+		}()
+
+		select {
+		case <-time.After(1 * time.Second):
+			t.Fatal("timeout")
+		case <-done:
+		}
 	})
 }


### PR DESCRIPTION
Fix a deadlock when a remote connection is closed and, at the same time, the connection fails. The following call graphs illustrate the issue:

goroutine run by main:

```
(*DriverRemoteConnection).Close
  (*Client).Close
    (*loadBalancingPool).close
      (*connection).close
        (*gremlinServerWSProtocol).close
          (*WaitGroup).Wait
```

gremlin-go's readLoop goroutine:

```
(*gremlinServerWSProtocol).readLoop
  readErrorHandler
    (*connection).errorCallback-fm
      (*connection).errorCallback
        (*gremlinServerWSProtocol).close
          (*WaitGroup).Wait
  (*WaitGroup).Done
```

`protocol.closed` is only modified by `(*gremlinServerWSProtocol).close`. If it is true it means that `(*WaitGroup).Wait` has already been called, so it should not be called again.