### PR TITLE
TINKERPOP-2754: Fix indefinite hanging on JS client on server restart

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug in `PartitionStrategy` where the use of `AbstractLambdaTraversal` caused an unexpected exception.
 * Fixed bug where close requests for sessions were improperly validating the request in the `UnifiedChannelizer`.
 * Deprecated and removed functionality of the `connectOnStartup` option in `gremlin-javascript` to resolve potential `unhandledRejection` and race conditions.
+* Fixed a bug where the JavaScript client would hang indefinitely on traversals if the connection to the server was terminated.
 
 [[release-3-5-3]]
 === TinkerPop 3.5.3 (Release Date: April 4, 2022)

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -378,6 +378,11 @@ class Connection extends EventEmitter {
     }
     this._pongTimeout = null;
 
+    // Invoke waiting callbacks to complete Promises when closing the websocket
+    Object.keys(this._responseHandlers).forEach((requestId) => {
+      const handler = this._responseHandlers[requestId];
+      handler.callback(new Error('Connection has been closed.'));
+    });
     this._ws.removeAllListeners();
     this._openPromise = null;
     this._closePromise = null;


### PR DESCRIPTION
The JS implementation of the websocket resolves traversal promises by waiting for either "error" (reject) or "message" (resolve or reject depending on the contained data). However, upon the connection terminating (server restart), the "close" event is fired instead, so therefore we must let all waiting response handlers on the websocket know to reject the waiting promises.