### PR TITLE
Improved pathing changes made for Windows Build Support

### DIFF
--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -56,14 +56,14 @@ limitations under the License.
                             <scripts>
                                 <script>
                                     def mavenVersion = "${project.version}"
-                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist", "").replace("\\", "/")
-                                    def file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj")
+                                    def platformAgnosticBaseDirPath = project.basedir.getAbsolutePath().replace("\\", "/")
+                                    def file = new File(platformAgnosticBaseDirPath + "/Gremlin.Net/Gremlin.Net.csproj")
                                     file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
-                                    file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
+                                    file = new File(platformAgnosticBaseDirPath + "/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
                                     file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
 
-                                    file = new File(platformAgnosticBaseDirPath + "/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
+                                    file = new File(platformAgnosticBaseDirPath + "/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
                                     file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))
                                 </script>
                             </scripts>

--- a/gremlin-dotnet/test/pom.xml
+++ b/gremlin-dotnet/test/pom.xml
@@ -32,6 +32,7 @@ limitations under the License.
         <skipTests>${maven.test.skip}</skipTests>
         <!-- this path only works when maven is started from the direct parent directory, this should be fixed -->
         <gremlin.server.dir>${project.parent.parent.basedir}/gremlin-server</gremlin.server.dir>
+        <tinkerpop.root.dir>${project.parent.parent.basedir}</tinkerpop.root.dir>
     </properties>
 
     <build>
@@ -187,6 +188,10 @@ limitations under the License.
                                         <property>
                                             <name>projectBaseDir</name>
                                             <value>${project.basedir}</value>
+                                        </property>
+                                        <property>
+                                            <name>tinkerpopRootDir</name>
+                                            <value>${tinkerpop.root.dir}</value>
                                         </property>
                                     </properties>
                                     <scripts>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -29,6 +29,7 @@ limitations under the License.
         <maven.test.skip>false</maven.test.skip>
         <skipTests>${maven.test.skip}</skipTests>
         <gremlin.server.dir>${project.parent.basedir}/gremlin-server</gremlin.server.dir>
+        <tinkerpop.root.dir>${project.parent.basedir}</tinkerpop.root.dir>
         <npm.version>6.14.6</npm.version>
         <node.version>v10.22.0</node.version>
     </properties>
@@ -118,8 +119,8 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist", "").replace("\\", "/")
-                                    def file = new File(platformAgnosticBaseDirPath + "/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json")
+                                    def platformAgnosticBaseDirPath = project.basedir.getAbsolutePath().replace("\\", "/")
+                                    def file = new File(platformAgnosticBaseDirPath + "/src/main/javascript/gremlin-javascript/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>
                             </scripts>
@@ -152,6 +153,10 @@ limitations under the License.
                                 <property>
                                     <name>projectBaseDir</name>
                                     <value>${project.basedir}</value>
+                                </property>
+                                <property>
+                                    <name>tinkerpopRootDir</name>
+                                    <value>${tinkerpop.root.dir}</value>
                                 </property>
                             </properties>
                             <scripts>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -31,6 +31,7 @@ limitations under the License.
         <skipTests>${maven.test.skip}</skipTests>
         <TEST_TRANSACTIONS>false</TEST_TRANSACTIONS>
         <gremlin.server.dir>${project.parent.basedir}/gremlin-server</gremlin.server.dir>
+        <tinkerpop.root.dir>${project.parent.basedir}</tinkerpop.root.dir>
     </properties>
     <build>
         <directory>${basedir}/target</directory>
@@ -330,6 +331,10 @@ limitations under the License.
                                         <property>
                                             <name>projectBaseDir</name>
                                             <value>${project.basedir}</value>
+                                        </property>
+                                        <property>
+                                            <name>tinkerpopRootDir</name>
+                                            <value>${tinkerpop.root.dir}</value>
                                         </property>
                                     </properties>
                                     <scripts>

--- a/gremlin-server/src/test/scripts/test-server-start.groovy
+++ b/gremlin-server/src/test/scripts/test-server-start.groovy
@@ -48,12 +48,10 @@ if (testTransactions) {
 log.info("Starting Gremlin Server instances for native testing of ${executionName}")
 log.info("Transactions validated (enabled with -DincludeNeo4j and only available on port 45940): " + testTransactions)
 
-def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath
-        .replace("\\.this-definitely-does-not-exist", "") // Windows
-        .replace("\\", "/") // Windows
-        .replace("/.this-definitely-does-not-exist","") // Unix
+def platformAgnosticBaseDirPath = "${tinkerpopRootDir}".replace("\\", "/")
 def platformAgnosticGremlinServerDir = platformAgnosticBaseDirPath + "/gremlin-server"
-def platformAgnosticSettingsFile = platformAgnosticGremlinServerDir + "/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml"
+def platformAgnosticSettingsFile = platformAgnosticGremlinServerDir + "/src/test/resources/org" +
+        "/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml"
 
 def settings = Settings.read("${platformAgnosticSettingsFile}")
 settings.graphs.graph = platformAgnosticGremlinServerDir + "/src/test/scripts/tinkergraph-empty.properties"

--- a/gremlint/pom.xml
+++ b/gremlint/pom.xml
@@ -72,8 +72,8 @@ limitations under the License.
                                 <script>
                                     def mavenVersion = "${project.version}"
                                     def versionForJs = mavenVersion.replace("-SNAPSHOT", "-alpha1")
-                                    def platformAgnosticBaseDirPath = new File(".this-definitely-does-not-exist").absolutePath.replace("\\.this-definitely-does-not-exist", "").replace("/.this-definitely-does-not-exist", "").replace("\\","/")
-                                    def file = new File(platformAgnosticBaseDirPath + "/gremlint/package.json")
+                                    def platformAgnosticBaseDirPath = project.basedir.getAbsolutePath().replace("\\","/")
+                                    def file = new File(platformAgnosticBaseDirPath + "/package.json")
                                     file.write(file.getText("UTF-8").replaceFirst(/"version": "(.*)",/, "\"version\": \"" + versionForJs + "\","))
                                 </script>
                             </scripts>


### PR DESCRIPTION
Pathing changes introduced to support the windows build of `gremlin-javascript`, `gremlin-dotnet`, and `gremlint` would make it so that building Tinkerpop or its modules from anywhere other than the Tinkerpop root would not work. 

The changes in this PR would make it so that maven commands such as `install`, `verify`, `compile` and so on would work as expected from outside the root.