### PR TITLE
gremlin-go: fix data race on serializers and deserializers initialization

### DIFF
--- a/gremlin-go/driver/graphBinary_test.go
+++ b/gremlin-go/driver/graphBinary_test.go
@@ -34,8 +34,6 @@ import (
 func TestGraphBinaryV1(t *testing.T) {
 	t.Run("graphBinaryTypeSerializer tests", func(t *testing.T) {
 		serializer := graphBinaryTypeSerializer{newLogHandler(&defaultLogger{}, Error, language.English)}
-		initSerializers()
-		initDeserializers()
 
 		t.Run("getType should return correct type for simple type", func(t *testing.T) {
 			res, err := serializer.getType(int32(1))
@@ -75,9 +73,6 @@ func TestGraphBinaryV1(t *testing.T) {
 	})
 
 	t.Run("read-write tests", func(t *testing.T) {
-		initSerializers()
-		initDeserializers()
-
 		t.Run("read-write string", func(t *testing.T) {
 			pos := 0
 			var buffer bytes.Buffer

--- a/gremlin-go/driver/serializer.go
+++ b/gremlin-go/driver/serializer.go
@@ -48,6 +48,11 @@ type reader func(data *[]byte, i *int) (interface{}, error)
 var deserializers map[dataType]reader
 var serializers map[dataType]writer
 
+func init() {
+	initSerializers()
+	initDeserializers()
+}
+
 func newGraphBinarySerializer(handler *logHandler) serializer {
 	serializer := graphBinaryTypeSerializer{handler}
 	return graphBinarySerializer{&serializer}
@@ -84,8 +89,6 @@ func convertArgs(request *request, gs graphBinarySerializer) (map[string]interfa
 
 // serializeMessage serializes a request message into GraphBinary.
 func (gs graphBinarySerializer) serializeMessage(request *request) ([]byte, error) {
-	initSerializers()
-
 	args, err := convertArgs(request, gs)
 	if err != nil {
 		return nil, err
@@ -182,8 +185,6 @@ func (gs graphBinarySerializer) deserializeMessage(message []byte) (response, er
 		return msg, newError(err0405ReadValueInvalidNullInputError)
 	}
 
-	initDeserializers()
-
 	// Skip version and nullable byte.
 	i := 2
 	id, err := readUuid(&message, &i)
@@ -218,109 +219,105 @@ func (gs graphBinarySerializer) deserializeMessage(message []byte) (response, er
 }
 
 func initSerializers() {
-	if serializers == nil || len(serializers) == 0 {
-		serializers = map[dataType]writer{
-			bytecodeType:   bytecodeWriter,
-			stringType:     stringWriter,
-			bigDecimalType: bigDecimalWriter,
-			bigIntegerType: bigIntWriter,
-			longType:       longWriter,
-			intType:        intWriter,
-			shortType:      shortWriter,
-			byteType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
-				err := binary.Write(buffer, binary.BigEndian, value.(uint8))
-				return buffer.Bytes(), err
-			},
-			booleanType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
-				err := binary.Write(buffer, binary.BigEndian, value.(bool))
-				return buffer.Bytes(), err
-			},
-			uuidType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
-				err := binary.Write(buffer, binary.BigEndian, value)
-				return buffer.Bytes(), err
-			},
-			floatType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
-				err := binary.Write(buffer, binary.BigEndian, value)
-				return buffer.Bytes(), err
-			},
-			doubleType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
-				err := binary.Write(buffer, binary.BigEndian, value)
-				return buffer.Bytes(), err
-			},
-			vertexType:            vertexWriter,
-			edgeType:              edgeWriter,
-			propertyType:          propertyWriter,
-			vertexPropertyType:    vertexPropertyWriter,
-			lambdaType:            lambdaWriter,
-			traversalStrategyType: traversalStrategyWriter,
-			pathType:              pathWriter,
-			setType:               setWriter,
-			dateType:              timeWriter,
-			durationType:          durationWriter,
-			cardinalityType:       enumWriter,
-			columnType:            enumWriter,
-			directionType:         enumWriter,
-			operatorType:          enumWriter,
-			orderType:             enumWriter,
-			pickType:              enumWriter,
-			popType:               enumWriter,
-			tType:                 enumWriter,
-			barrierType:           enumWriter,
-			scopeType:             enumWriter,
-			pType:                 pWriter,
-			textPType:             textPWriter,
-			bindingType:           bindingWriter,
-			mapType:               mapWriter,
-			listType:              listWriter,
-			byteBuffer:            byteBufferWriter,
-			classType:             classWriter,
-		}
+	serializers = map[dataType]writer{
+		bytecodeType:   bytecodeWriter,
+		stringType:     stringWriter,
+		bigDecimalType: bigDecimalWriter,
+		bigIntegerType: bigIntWriter,
+		longType:       longWriter,
+		intType:        intWriter,
+		shortType:      shortWriter,
+		byteType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
+			err := binary.Write(buffer, binary.BigEndian, value.(uint8))
+			return buffer.Bytes(), err
+		},
+		booleanType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
+			err := binary.Write(buffer, binary.BigEndian, value.(bool))
+			return buffer.Bytes(), err
+		},
+		uuidType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
+			err := binary.Write(buffer, binary.BigEndian, value)
+			return buffer.Bytes(), err
+		},
+		floatType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
+			err := binary.Write(buffer, binary.BigEndian, value)
+			return buffer.Bytes(), err
+		},
+		doubleType: func(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
+			err := binary.Write(buffer, binary.BigEndian, value)
+			return buffer.Bytes(), err
+		},
+		vertexType:            vertexWriter,
+		edgeType:              edgeWriter,
+		propertyType:          propertyWriter,
+		vertexPropertyType:    vertexPropertyWriter,
+		lambdaType:            lambdaWriter,
+		traversalStrategyType: traversalStrategyWriter,
+		pathType:              pathWriter,
+		setType:               setWriter,
+		dateType:              timeWriter,
+		durationType:          durationWriter,
+		cardinalityType:       enumWriter,
+		columnType:            enumWriter,
+		directionType:         enumWriter,
+		operatorType:          enumWriter,
+		orderType:             enumWriter,
+		pickType:              enumWriter,
+		popType:               enumWriter,
+		tType:                 enumWriter,
+		barrierType:           enumWriter,
+		scopeType:             enumWriter,
+		pType:                 pWriter,
+		textPType:             textPWriter,
+		bindingType:           bindingWriter,
+		mapType:               mapWriter,
+		listType:              listWriter,
+		byteBuffer:            byteBufferWriter,
+		classType:             classWriter,
 	}
 }
 
 func initDeserializers() {
-	if deserializers == nil || len(deserializers) == 0 {
-		deserializers = map[dataType]reader{
-			// Primitive
-			booleanType:    readBoolean,
-			byteType:       readByte,
-			shortType:      readShort,
-			intType:        readInt,
-			longType:       readLong,
-			bigDecimalType: readBigDecimal,
-			bigIntegerType: readBigInt,
-			floatType:      readFloat,
-			doubleType:     readDouble,
-			stringType:     readString,
+	deserializers = map[dataType]reader{
+		// Primitive
+		booleanType:    readBoolean,
+		byteType:       readByte,
+		shortType:      readShort,
+		intType:        readInt,
+		longType:       readLong,
+		bigDecimalType: readBigDecimal,
+		bigIntegerType: readBigInt,
+		floatType:      readFloat,
+		doubleType:     readDouble,
+		stringType:     readString,
 
-			// Composite
-			listType:   readList,
-			mapType:    readMap,
-			setType:    readSet,
-			uuidType:   readUuid,
-			byteBuffer: readByteBuffer,
-			classType:  readClass,
+		// Composite
+		listType:   readList,
+		mapType:    readMap,
+		setType:    readSet,
+		uuidType:   readUuid,
+		byteBuffer: readByteBuffer,
+		classType:  readClass,
 
-			// Date Time
-			dateType:      timeReader,
-			timestampType: timeReader,
-			durationType:  durationReader,
+		// Date Time
+		dateType:      timeReader,
+		timestampType: timeReader,
+		durationType:  durationReader,
 
-			// Graph
-			traverserType:      traverserReader,
-			vertexType:         vertexReader,
-			edgeType:           edgeReader,
-			propertyType:       propertyReader,
-			vertexPropertyType: vertexPropertyReader,
-			pathType:           pathReader,
-			bulkSetType:        bulkSetReader,
-			tType:              enumReader,
-			directionType:      enumReader,
-			bindingType:        bindingReader,
+		// Graph
+		traverserType:      traverserReader,
+		vertexType:         vertexReader,
+		edgeType:           edgeReader,
+		propertyType:       propertyReader,
+		vertexPropertyType: vertexPropertyReader,
+		pathType:           pathReader,
+		bulkSetType:        bulkSetReader,
+		tType:              enumReader,
+		directionType:      enumReader,
+		bindingType:        bindingReader,
 
-			// Metrics
-			metricsType:          metricsReader,
-			traversalMetricsType: traversalMetricsReader,
-		}
+		// Metrics
+		metricsType:          metricsReader,
+		traversalMetricsType: traversalMetricsReader,
 	}
 }


### PR DESCRIPTION
Move the initialization of the serializers and deserializers to an init function, so no data race happens because multiple goroutines try to access them at the same time.

The following stack trace shows an instance of this problem (beware, some pending PRs have been applied, so line numbers could differ):

```
WARNING: DATA RACE
Read at 0x000000bc9f68 by goroutine 18:
  github.com/apache/tinkerpop/gremlin-go/v3/driver.initSerializers()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/serializer.go:221 +0x44
  github.com/apache/tinkerpop/gremlin-go/v3/driver.graphBinarySerializer.serializeMessage()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/serializer.go:87 +0x49
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*gremlinServerWSProtocol).write()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/protocol.go:157 +0x53
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*connection).write()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/connection.go:86 +0x46a
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*loadBalancingPool).write()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/connectionPool.go:78 +0x144
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*Client).submitBytecode()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/client.go:162 +0x256
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*DriverRemoteConnection).submitBytecode()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/driverRemoteConnection.go:177 +0x9c
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*Traversal).GetResultSet()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/traversal.go:121 +0x7e
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*Traversal).Next()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/traversal.go:107 +0x30
  main.worker()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:56 +0x224
  main.main.func1()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:33 +0x35
  main.main.func2()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:35 +0x47

Previous write at 0x000000bc9f68 by goroutine 8:
  github.com/apache/tinkerpop/gremlin-go/v3/driver.initSerializers()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/serializer.go:222 +0xea7
  github.com/apache/tinkerpop/gremlin-go/v3/driver.graphBinarySerializer.serializeMessage()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/serializer.go:87 +0x49
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*gremlinServerWSProtocol).write()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/protocol.go:157 +0x53
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*connection).write()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/connection.go:86 +0x46a
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*loadBalancingPool).write()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/connectionPool.go:78 +0x144
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*Client).submitBytecode()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/client.go:162 +0x256
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*DriverRemoteConnection).submitBytecode()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/driverRemoteConnection.go:177 +0x9c
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*Traversal).GetResultSet()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/traversal.go:121 +0x7e
  github.com/apache/tinkerpop/gremlin-go/v3/driver.(*Traversal).Next()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/traversal.go:107 +0x30
  main.worker()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:56 +0x224
  main.main.func1()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:33 +0x35
  main.main.func2()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:35 +0x47

Goroutine 18 (running) created at:
  main.main()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:32 +0x77

Goroutine 8 (running) created at:
  main.main()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:32 +0x77
```