### PR TITLE
gremlin-go: fix data race on localizer initialization

### DIFF
--- a/gremlin-go/driver/error_codes.go
+++ b/gremlin-go/driver/error_codes.go
@@ -99,10 +99,13 @@ const (
 	err1104TransactionRepeatedCloseError     errorCode = "E1104_TRANSACTION_REPEATED_CLOSE_ERROR"
 )
 
+var localizer *i18n.Localizer
+
+func init() {
+	initializeLocalizer(language.English)
+}
+
 func initializeLocalizer(locale language.Tag) {
-	if localizer != nil {
-		return
-	}
 	bundle := i18n.NewBundle(language.English)
 	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
 
@@ -113,10 +116,7 @@ func initializeLocalizer(locale language.Tag) {
 	localizer = i18n.NewLocalizer(bundle, locale.String())
 }
 
-var localizer *i18n.Localizer
-
 func newError(errorCode errorCode, args ...interface{}) error {
-	initializeLocalizer(language.English)
 	config := i18n.LocalizeConfig{
 		MessageID: string(errorCode),
 	}


### PR DESCRIPTION
Move the initialization of the localizer to an init function, so no data race happens because multiple goroutines call `NewError` during its initialization.

The following stack trace shows an instance of this problem (beware, some pending PRs have been applied, so line numbers could differ):

```
WARNING: DATA RACE
Read at 0x00c0026a9580 by goroutine 2515:
  github.com/nicksnyder/go-i18n/v2/i18n.(*Bundle).getMessageTemplate()
      /home/n/go/pkg/mod/github.com/nicksnyder/go-i18n/v2@v2.2.0/i18n/bundle.go:139 +0x1e8
  github.com/nicksnyder/go-i18n/v2/i18n.(*Localizer).getMessageTemplate()
      /home/n/go/pkg/mod/github.com/nicksnyder/go-i18n/v2@v2.2.0/i18n/localizer.go:175 +0x18a
  github.com/nicksnyder/go-i18n/v2/i18n.(*Localizer).LocalizeWithTag()
      /home/n/go/pkg/mod/github.com/nicksnyder/go-i18n/v2@v2.2.0/i18n/localizer.go:149 +0x46a
  github.com/nicksnyder/go-i18n/v2/i18n.(*Localizer).Localize()
      /home/n/go/pkg/mod/github.com/nicksnyder/go-i18n/v2@v2.2.0/i18n/localizer.go:104 +0xcd
  github.com/apache/tinkerpop/gremlin-go/v3/driver.newError()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/error_codes.go:123 +0xb1
  github.com/apache/tinkerpop/gremlin-go/v3/driver.newLoadBalancingPool()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/connectionPool.go:166 +0x70a
  github.com/apache/tinkerpop/gremlin-go/v3/driver.NewDriverRemoteConnection()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/driverRemoteConnection.go:121 +0xacb
  main.worker()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:43 +0x76
  main.main.func1()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:33 +0x35
  main.main.func2()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:35 +0x47

Previous write at 0x00c0026a9580 by goroutine 1003:
  github.com/nicksnyder/go-i18n/v2/i18n.NewBundle()
      /home/n/go/pkg/mod/github.com/nicksnyder/go-i18n/v2@v2.2.0/i18n/bundle.go:35 +0x69
  github.com/apache/tinkerpop/gremlin-go/v3/driver.initializeLocalizer()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/error_codes.go:106 +0xa5
  github.com/apache/tinkerpop/gremlin-go/v3/driver.newError()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/error_codes.go:119 +0x7e
  github.com/apache/tinkerpop/gremlin-go/v3/driver.newLoadBalancingPool()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/connectionPool.go:166 +0x70a
  github.com/apache/tinkerpop/gremlin-go/v3/driver.NewDriverRemoteConnection()
      /home/n/src/tinkerpop/.wt/dev/gremlin-go/driver/driverRemoteConnection.go:121 +0xacb
  main.worker()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:43 +0x76
  main.main.func1()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:33 +0x35
  main.main.func2()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:35 +0x47

Goroutine 2515 (running) created at:
  main.main()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:32 +0x77

Goroutine 1003 (running) created at:
  main.main()
      /home/n/tmp/tinkerpop-repros/gremlin-go-data-race/main.go:32 +0x77
```