### PR TITLE
Set an exception thrown instead of the root cause during the Client initialization

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ This release also includes changes from <<release-3-5-4, 3.5.4>>.
 
 * Made GraphBinary the default serialization format for .NET and Python.
 * Added missing `ResponseStatusCodeEnum` entry for 595 for .NET.
+* Set the exact exception in initializationFailure on the client instead of the root cause.
 
 [[release-3-6-0]]
 === TinkerPop 3.6.0 (Release Date: April 4, 2022)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -534,14 +534,8 @@ public abstract class Client {
                                 .toArray(CompletableFuture[]::new))
                         .join();
             } catch (CompletionException ex) {
-                Throwable cause = ExceptionUtils.getRootCause(ex);
-                if (null != cause) {
-                    logger.error("", cause);
-                    this.initializationFailure = cause;
-                } else {
-                    logger.error("", ex);
-                    this.initializationFailure = ex;
-                }
+                logger.error("Initialization failed", ex);
+                this.initializationFailure = ex;
             } finally {
                 hostExecutor.shutdown();
             }
@@ -559,9 +553,9 @@ public abstract class Client {
         }
 
         private void throwNoHostAvailableException() {
+            final Throwable rootCause = ExceptionUtils.getRootCause(initializationFailure);
             // allow the certain exceptions to propagate as a cause
-            if (initializationFailure != null && (initializationFailure instanceof SSLException ||
-                    initializationFailure instanceof ConnectException)) {
+            if (rootCause instanceof SSLException || rootCause instanceof ConnectException) {
                 throw new NoHostAvailableException(initializationFailure);
             } else {
                 throw new NoHostAvailableException();


### PR DESCRIPTION
When we print an exception by logger, it is more helpful if we have full stack trace instead of just printing the exact root cause.