### PR TITLE
Gremlin-Go: Add int8, uint, and uint64 serialization

### DIFF
--- a/gremlin-go/driver/graphBinary_test.go
+++ b/gremlin-go/driver/graphBinary_test.go
@@ -147,6 +147,16 @@ func TestGraphBinaryV1(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, source, res)
 		})
+		t.Run("read-write short int8", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := int8(123)
+			buf, err := shortWriter(source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readShort(&buf, &pos)
+			assert.Nil(t, err)
+			assert.Equal(t, int16(source), res)
+		})
 		t.Run("read-write long", func(t *testing.T) {
 			pos := 0
 			var buffer bytes.Buffer
@@ -166,6 +176,26 @@ func TestGraphBinaryV1(t *testing.T) {
 			res, err := readBigInt(&buf, &pos)
 			assert.Nil(t, err)
 			assert.Equal(t, source, res)
+		})
+		t.Run("read-write bigInt uint64", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := uint64(123)
+			buf, err := bigIntWriter(source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readBigInt(&buf, &pos)
+			assert.Nil(t, err)
+			assert.Equal(t, new(big.Int).SetUint64(source), res)
+		})
+		t.Run("read-write bigInt uint64", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := uint(123)
+			buf, err := bigIntWriter(source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readBigInt(&buf, &pos)
+			assert.Nil(t, err)
+			assert.Equal(t, new(big.Int).SetUint64(uint64(source)), res)
 		})
 		t.Run("read-write list", func(t *testing.T) {
 			pos := 0


### PR DESCRIPTION
Patching the go GraphBinary serializer with these 3 types. 

Serializing `int8` as Short, since there is no signed 8-bit integer type in GraphBinary I/O ([Byte](https://tinkerpop.apache.org/docs/3.6.0/dev/io/#_byte_3) is an unsigned 8-bit integer). Serializing both `uint` and `uint64` as BigIntegers, as they don't fit into Long.