### PR TITLE
Gremlin-Python: added return in SingleByte and SingleChar & fixed if check bug

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/statics.py
+++ b/gremlin-python/src/main/python/gremlin_python/statics.py
@@ -59,7 +59,7 @@ class SingleByte(int):
     """
     def __new__(cls, b):
         if -128 <= b < 128:
-            int.__new__(cls, b)
+            return int.__new__(cls, b)
         else:
             raise ValueError("value must be between -128 and 127 inclusive")
 
@@ -69,8 +69,8 @@ class SingleChar(str):
     Provides a way to pass a single character via Gremlin.
     """
     def __new__(cls, c):
-        if len(b) == 1:
-            str.__new__(cls, c)
+        if len(c) == 1:
+            return str.__new__(cls, c)
         else:
             raise ValueError("string must contain a single character")
 

--- a/gremlin-python/src/main/python/tests/test_statics.py
+++ b/gremlin-python/src/main/python/tests/test_statics.py
@@ -37,3 +37,29 @@ class TestStatics(object):
         assert isinstance(first, Pop)
         assert first == Pop.first
         statics.unload_statics(globals())
+
+    def test_singlebyte(self):
+        assert -128 == statics.SingleByte(-128)
+        assert 1 == statics.SingleByte(1)
+        assert 127 == statics.SingleByte(127)
+        try:
+            statics.SingleByte(128)
+            raise Exception("SingleByte should throw a value error if input is larger than 127")
+        except ValueError:
+            pass
+
+        try:
+            statics.SingleByte(-129)
+            raise Exception("SingleByte should throw a value error if input is smaller than -128")
+        except ValueError:
+            pass
+
+    def test_singlechar(self):
+        assert 'a' == statics.SingleChar('a')
+        assert chr(76) == statics.SingleChar(chr(76))
+        assert chr(57344) == statics.SingleChar(chr(57344))
+        try:
+            statics.SingleChar('abc')
+            raise Exception("SingleChar should throw a value error if input is not a single character string")
+        except ValueError:
+            pass


### PR DESCRIPTION
Added missing return statements in SingleByte and SingleChar classes (e.g. `SingleByte(2)` will return `None` without the `return`), and fixed bug in SingleChar `if` check.