### PR TITLE
Gremlin-Go: Fixed bug for GHA, increased server wait retries & fixed traversal int casting

### DIFF
--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - RUN_BASIC_AUTH_INTEGRATION_TESTS=true
       - TEST_TRANSACTIONS=true
     working_dir: /go_app
-    command: ["./wait-for-server.sh", gremlin-test-server, "45940", "90", "bash", "-c",
+    command: ["./wait-for-server.sh", gremlin-test-server, "45940", "180", "bash", "-c",
       "go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
       && go test -v -json ./... -race -covermode=atomic -coverprofile=\"coverage.out\" -coverpkg=./... | gotestfmt"]
     depends_on:

--- a/gremlin-go/driver/graphTraversal.go
+++ b/gremlin-go/driver/graphTraversal.go
@@ -676,7 +676,7 @@ func (g *GraphTraversal) Write(args ...interface{}) *GraphTraversal {
 	return g
 }
 
-func int32Args(args ...interface{}) []interface{} {
+func int32Args(args []interface{}) []interface{} {
 	for i, arg := range args {
 		switch val := arg.(type) {
 		case uint:

--- a/gremlin-go/run.sh
+++ b/gremlin-go/run.sh
@@ -44,7 +44,8 @@ GREMLIN_SERVER_VERSION=$(grep tinkerpop -A2 pom.xml | grep -Po '(?<=<version>)([
 export GREMLIN_SERVER="${1:-$GREMLIN_SERVER_VERSION}"
 echo "$GREMLIN_SERVER"
 
-# Passes current gremlin server version into docker compose as environment variable
+# Passes current gremlin server version into docker compose as environment variable & removes all service containers
 docker-compose up --build --exit-code-from gremlin-go-integration-tests
-# Removes all service containers
+EXIT_CODE=$?
 docker-compose down
+exit $EXIT_CODE


### PR DESCRIPTION
GHA was not capturing the exit code from `docker-compose up` because `docker-compose down` was executed separately. Now exiting upon the compose up exit code at the end of `run.sh`, and GHA should correctly capture failed golang tests.

Fixed the failing golang test related to recent [PR](https://github.com/apache/tinkerpop/pull/1743) that was missed due to the above mistake. 

Doubled the wait-for-server retry count as sometimes neo4j takes longer to get installed in GHA, to prevent premature exit of the tests. 