### PR TITLE
Fix declarative Gremlin example on the TinkerPop website

### DIFF
--- a/docs/site/home/gremlin.html
+++ b/docs/site/home/gremlin.html
@@ -323,7 +323,7 @@ g.V().has("name","gremlin").as("a").
                     <div class="col-md-12 col-lg-6 mb-4 mb-lg-0">
                         <div class="code-box h-100">
                                                     <code>
-                                                        <span class="text-purpal">g</span><span class="text-blue">.V</span><span class="text-success">().</span><span class="text-blue">has</span><span class="text-success">("name","gremlin").</span> <span class="text-blue">as</span><span class="text-success">("a").</span>
+                                                        <span class="text-purpal">g</span><span class="text-blue">.V</span><span class="text-success">().</span><span class="text-blue">has</span><span class="text-success">("name","gremlin").</span><span class="text-blue">as</span><span class="text-success">("a").</span>
 
                                                             <br>&nbsp;&nbsp;<span class="text-blue">out</span><span class="text-success">("created").</span><span class="text-blue">in</span><span class="text-success">("created").</span>
 
@@ -355,9 +355,9 @@ g.V().has("name","gremlin").as("a").
 
                                                             <br>&nbsp;&nbsp;<span class="text-blue">as</span><span class="text-success">("a").</span><span class="text-blue">out</span><span class="text-success">("created").as("b"),</span>
 
-                                                            <br>&nbsp;&nbsp;<span class="text-blue">as</span><span class="text-success">("a").</span><span class="text-blue">in</span><span class="text-success">("created").as("c"),</span>
+                                                            <br>&nbsp;&nbsp;<span class="text-blue">as</span><span class="text-success">("b").</span><span class="text-blue">in</span><span class="text-success">("created").as("c"),</span>
 
-                                                            <br>&nbsp;&nbsp;<span class="text-blue">as</span><span class="text-success">("a").</span><span class="text-blue">in</span><span class="text-success">("manages").as("d"),</span>
+                                                            <br>&nbsp;&nbsp;<span class="text-blue">as</span><span class="text-success">("c").</span><span class="text-blue">in</span><span class="text-success">("manages").as("d"),</span>
 
                                                             <br>&nbsp;&nbsp;&nbsp;<span class="text-blue">where</span><span class="text-success">("a",</span><span class="text-blue">neq</span><span class="text-success">("c"))).</span>
 


### PR DESCRIPTION
The Gremlin example of declarative traversal on the TinkerPop website is incorrect, as the graph pattern specified does not yield the correct results. This PR fixes the example.

Screenshot of how the example looks _before_ this edit:
![image](https://user-images.githubusercontent.com/18127325/179193674-d24f3deb-4911-4c4d-ab4a-5968d865291d.png)

Screenshot of how the example looks _after_ this edit:
![image](https://user-images.githubusercontent.com/18127325/179193746-012663a9-72cd-4241-adc0-3c237a9712de.png)

I tested these changes by creating a [minimal example on Gremlify](https://gremlify.com/1xjysyo1wzt/1), you can use it to verify that the new query example is correct.

I also removed a random space in the imperative traversal example which looked weird on the site.
