### PR TITLE
Gremlin-Go: Update CI to run on Windows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Build with Maven Windows
         if: runner.os == 'Windows'
         run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -DskipImageBuild -Dci
       - name: Build with Maven Ubuntu
         if: runner.os == 'Linux'
         run: |
@@ -116,7 +116,7 @@ jobs:
       - name: Build with Maven Windows
         if: runner.os == 'Windows'
         run: |
-          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -DskipImageBuild -Dci
       - name: Build with Maven Ubuntu
         if: runner.os == 'Linux'
         run: |
@@ -240,10 +240,7 @@ jobs:
       - name: Build with Maven
         working-directory: .
         run: |
-          ls -la ./gremlin-go
-          touch ./gremlin-go/.glv
-          chmod +x ./gremlin-go/run.sh
-          ls -la ./gremlin-go
+          touch gremlin-go/.glv
           mvn verify -pl :gremlin-go
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3

--- a/gremlin-go/Dockerfile
+++ b/gremlin-go/Dockerfile
@@ -29,7 +29,9 @@ RUN chmod 755 /opt/docker-entrypoint.sh
 # Installing dos2unix to avoid errors in running the entrypoint script on Windows machines where their
 # carriage return is \r\n instead of the \n needed for linux/unix containers
 RUN apk update && apk add dos2unix
-RUN dos2unix /opt/docker-entrypoint.sh && apk del dos2unix
+RUN dos2unix /opt/docker-entrypoint.sh
+RUN dos2unix /opt/gremlin-server/bin/gremlin-server.conf
+RUN dos2unix /opt/gremlin-server/bin/gremlin-server.sh && apk del dos2unix
 
 ARG GREMLIN_SERVER
 ENV GREMLIN_SERVER_VER=$GREMLIN_SERVER

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -49,8 +49,10 @@ services:
       - RUN_BASIC_AUTH_INTEGRATION_TESTS=true
       - TEST_TRANSACTIONS=true
     working_dir: /go_app
-    command: ["./wait-for-server.sh", gremlin-test-server, "45940", "180", "bash", "-c",
-      "go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
-      && go test -v -json ./... -race -covermode=atomic -coverprofile=\"coverage.out\" -coverpkg=./... | gotestfmt"]
+    command: >
+      bash -c "apt-get update && apt-get install dos2unix && dos2unix ./wait-for-server.sh
+      && ./wait-for-server.sh gremlin-test-server 45940 300
+      && go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+      && go test -v -json ./... -race -covermode=atomic -coverprofile=\"coverage.out\" -coverpkg=./... | gotestfmt"
     depends_on:
       - gremlin-test-server

--- a/gremlin-go/driver/README.md
+++ b/gremlin-go/driver/README.md
@@ -119,24 +119,24 @@ Please review the [staticcheck documentation][scheck docs] for more details on i
 
 ## Testing with Docker
 
-Docker allows you to test the driver without installing any dependencies. Please make sure Docker is installed and running on your system.
-You will need to install both [Docker Engine][dengine] and [Docker Compose][dcompose], which are included in [Docker Desktop][ddesktop].
+Docker allows you to test the driver without installing any dependencies. Gremlin Go uses Docker for all of its testing. Please make sure Docker is installed and running on your system. You will need to install both [Docker Engine][dengine] and [Docker Compose][dcompose], which are included in [Docker Desktop][ddesktop].
 
 The docker compose environment variable `GREMLIN_SERVER` specifies the Gremlin server docker image to use, i.e. an image with the tag
 `tinkerpop/gremlin-server:$GREMLIN_SERVER`, and is a required environment variable. This also requires the specified docker image to exist,
 either locally or in [Docker Hub][dhub].
 
-If your OS Platform cannot build a local SNAPSHOT Gremlin server through `maven`, it is recommended to use the latest released server version
-from [Docker Hub][dhub] (do not use `GREMLIN_SERVER=latest`, use actual version number, e.g. `GREMLIN_SERVER=3.5.x` or `GREMLIN_SERVER=3.6.x`).
+Running `mvn clean install -pl gremlin-server -DskipTests -DskipIntegrationTests=true -Dci -am` in the main `tinkerpop` directory will automatically build a local SNAPSHOT Gremlin server image. If your OS Platform cannot build a local SNAPSHOT Gremlin server through `maven`, it is recommended to use the latest released server version from [Docker Hub][dhub] (do not use `GREMLIN_SERVER=latest`, use actual version number, e.g. `GREMLIN_SERVER=3.5.x` or `GREMLIN_SERVER=3.6.x`).
 
-There are 4 ways to launch the test suite and set the `GREMLIN_SERVER` environment variable depending on your Platform:
-- Execute tests via the `run.sh` script, which sets `GREMLIN_SERVER` by default. Run `./run.sh -h` for usage information (Unix/Linux - recommended).
-- Add `GREMLIN_SERVER=<server-image-version>` to an `.env` file inside `gremlin-go` and run `docker-compose up --exit-code-from gremlin-go-integration-tests` (Platform-agnostic).
+The docker compose environment variable `HOME` specifies the user home directory for mounting volumes during test image set up. This varibale is set by default in Unix/Linux, but will need to be set for Windows, for example, run `$env:HOME=$env:USERPROFILE` in PowerShell.
+
+There are different ways to launch the test suite and set the `GREMLIN_SERVER` environment variable depending on your Platform:
+- Run Maven commands, e.g. `mvn clean install` inside of `tinkerpop/gremlin-go`, or `mvn clean install -pl gremlin-go` inside of `tinkerpop` (platform-agnostic - recommended)
+- Run the `run.sh` script, which sets `GREMLIN_SERVER` by default. Run `./run.sh -h` for usage information (Unix/Linux - recommended).
+- Add `GREMLIN_SERVER=<server-image-version>` and `HOME=<user-home-directory>` to an `.env` file inside `gremlin-go` and run `docker-compose up --exit-code-from gremlin-go-integration-tests` (Platform-agnostic).
 - Run `GREMLIN_SERVER=<server-image-version> docker-compose up --exit-code-from gremlin-go-integration-tests` in Unix/Linux.
-- Run `$env:GREMLIN_SERVER="<server-image-version>";docker-compose up --exit-code-from gremlin-go-integration-tests` in Windows PowerShell.
+- Run `$env:GREMLIN_SERVER="<server-image-version>";$env:HOME=$env:USERPROFILE;docker-compose up --exit-code-from gremlin-go-integration-tests` in Windows PowerShell.
 
-You should see exit code 0 upon successful completion of the test suites. Run `docker-compose down` to remove the service containers (not needed
-if you executed `run.sh`), or `docker-compose down --rmi all` to remove the service containers while deleting all used images.
+You should see exit code 0 upon successful completion of the test suites. Run `docker-compose down` to remove the service containers (not needed if you executed Maven commands or `run.sh`), or `docker-compose down --rmi all` to remove the service containers while deleting all used images.
 
 [go]: https://go.dev/dl/
 [gomods]: https://go.dev/blog/using-go-modules

--- a/gremlin-go/pom.xml
+++ b/gremlin-go/pom.xml
@@ -95,7 +95,36 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <skip>${skipTests}</skip>
-                                    <executable>./run.sh</executable>
+                                    <environmentVariables>
+                                        <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
+                                        <!-- setting this env variable is needed to be cross-platform compatible -->
+                                        <HOME>${user.home}</HOME>
+                                    </environmentVariables>
+                                    <executable>docker-compose</executable>
+                                    <arguments>
+                                        <argument>up</argument>
+                                        <argument>--build</argument>
+                                        <argument>--exit-code-from</argument>
+                                        <argument>gremlin-go-integration-tests</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>shutdown-container</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <environmentVariables>
+                                        <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
+                                        <HOME>${user.home}</HOME>
+                                    </environmentVariables>
+                                    <executable>docker-compose</executable>
+                                    <arguments>
+                                        <argument>down</argument>
+                                    </arguments>
                                 </configuration>
                             </execution>
                         </executions>

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -25,6 +25,14 @@ limitations under the License.
     </parent>
     <artifactId>gremlin-server</artifactId>
     <name>Apache TinkerPop :: Gremlin Server</name>
+    <properties>
+        <!--
+        provides a way to convert maven.exec.skip value to skipImageBuild for use in skipping image building for testing
+        under incompatible platforms
+        -->
+        <maven.exec.skip>false</maven.exec.skip> <!-- default -->
+        <skipImageBuild>${maven.exec.skip}</skipImageBuild>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
@@ -148,47 +156,42 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <!--
+            gremlin server image will be generated on each build as language variants will need the latest to do
+            their work.
+            -->
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>build-image</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipImageBuild}</skip>
+                            <executable>docker</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-f</argument>
+                                <argument>./Dockerfile</argument>
+                                <argument>--build-arg</argument>
+                                <argument>GREMLIN_SERVER_DIR=target/apache-tinkerpop-${project.artifactId}-${project.version}-standalone</argument>
+                                <argument>-t</argument>
+                                <argument>tinkerpop/gremlin-server:${project.version}</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-            <!-- only build docker image for linux - this fails on windoze. gremlin server image will be generated
-                 on each build as language variants will need the latest to do their work. windows users will need
-                 to manually generate somehow until this is solved -->
-            <id>linux</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <os>
-                    <family>unix</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-image-build</id>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>${project.version}</tag>
-                                    <buildArgs>
-                                        <GREMLIN_SERVER_DIR>target/apache-tinkerpop-${project.artifactId}-${project.version}-standalone</GREMLIN_SERVER_DIR>
-                                    </buildArgs>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <repository>tinkerpop/gremlin-server</repository>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
         <profile>
             <id>use-epoll</id>


### PR DESCRIPTION
With these changes, users should be able to run `mvn clean install` in Windows with 3.5-dev successfully. 

Main changes are:
1. The removal of the plugin `dockerfile-maven-plugin`, as it is fails on Windows without clear resolution, we are using raw docker build execution in server for image building.
2. The use of `docker-compose` directly instead of the `run.sh` script, as bash script will not work in Windows. The `run.sh` script will remain as an optional tool in gremlin-go for uses to run the tests. 

A flag `-DskipImageBuild` is introduced to allow skipping the image building on incompatible platforms. Currently GHA Windows Servers fails when building linux based images (alpine jdk), and so the server image building have been disabled in Spark windows GHA while we investigate alternative resolutions. 

For 3.6-dev, running `mvn clean install -pl :gremlin-go` will work in Windows (with a `.glv` file) with this change, however, there are errors in other modules which were not encountered in 3.5-dev. These will be investigated and addressed separately. 