### PR TITLE
Gremlin-Go: skipping gremlin-go in TinkerPop Docker build integration

### DIFF
--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -67,7 +67,9 @@ if [ -d "${TINKERMEM_PATH}" ]; then
   cd ${TINKERMEM_PATH}
 fi
 
-touch {gremlin-dotnet,gremlin-go,gremlin-dotnet/src,gremlin-dotnet/test,gremlin-python,gremlin-javascript}/.glv
+# omitting gremlin-go for now to avoid docker in docker as it builds via docker compose
+# progress to restructure and add gremlin-go back will be tracked here https://issues.apache.org/jira/browse/TINKERPOP-2737
+touch {gremlin-dotnet,gremlin-dotnet/src,gremlin-dotnet/test,gremlin-python,gremlin-javascript}/.glv
 
 # use a custom maven settings.xml
 if [ -r "settings.xml" ]; then

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -402,6 +402,9 @@ TinkerPop provides a shell script, that can start several build tasks within a D
 required Docker images will be built automatically if they don't exist yet. Thus the first invocation
 of the Docker script is expected to take some time.
 
+NOTE: Currently, `gremlin-go` integration is not supported within this Docker container, but can be run separately with Docker.
+Please see the `Testing With Docker` section under the xref:../../../../gremlin-go/driver/README.md[Gremlin Go Driver] for details.
+
 The script can be found under `PROJECT_HOME/docker/build.sh`. The following tasks are currently
 supported:
 


### PR DESCRIPTION
To avoid the Docker-in-Docker issue when a user tries to run Docker Integration with `docker/build.sh`, we'd like to remove the gremlin-go build from the build script for now. 

A note is added in the documentations to direct users to run Gremlin-Go in Docker separately as instructed under `gremlin-go/driver/README.md`. 

Progress involved in resolving this issue and re-enabling gremlin-go will be tracked under https://issues.apache.org/jira/browse/TINKERPOP-2737. 