### PR TITLE
TINKERPOP-2771: bump commons.configuration.version to 2.8.0 to fix vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ limitations under the License.
         <antlr4.version>4.9.1</antlr4.version>
         <caffeine.version>2.3.1</caffeine.version>
         <commons.collections.version>3.2.2</commons.collections.version>
-        <commons.configuration.version>2.7</commons.configuration.version>
+        <commons.configuration.version>2.8.0</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang3.version>3.11</commons.lang3.version>


### PR DESCRIPTION
As per reported https://issues.apache.org/jira/browse/TINKERPOP-2771.