### PR TITLE
Allow connections from IPv6 for `test-server-start.groovy` server

### DIFF
--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -29,7 +29,7 @@
 # gremlin-server/src/test/resources/scripts/test-server-start.groovy
 ###############################################################################
 
-host: localhost
+host: 0.0.0.0
 port: 45940
 evaluationTimeout: 30000
 graphs: {


### PR DESCRIPTION
Attempting to reach localhost on Windows with a client can be resolved with IPv6 and IPv4 addresses. The WebSocket client tries to establish a connection to the IPv6 address with a timeout of 1 sec and attempts to do this 2 times. Gremlin Server does not accept connection for IPv6, so it refuses it. Then the client connects to IPv4 address.

With 0.0.0.0 server will accept all connections, including IPv6.