### PR TITLE
Fix dotnet tests for Windows GHA

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -187,7 +187,10 @@ jobs:
     name: .NET
     timeout-minutes: 20
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK11

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MessagesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MessagesTests.cs
@@ -102,7 +102,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
             using (var gremlinClient = new GremlinClient(gremlinServer))
             {
                 const long timeOutInMs = 1L;
-                const int scriptSleepTimeInMs = 30000;
+                const int scriptSleepTimeInMs = 60000;
                 var sleepScript = _requestMessageProvider.GetSleepGremlinScript(scriptSleepTimeInMs);
 
                 var requestMsg =
@@ -120,7 +120,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
                 Assert.Contains("ServerTimeout", thrownException.Message);
                 Assert.Contains(timeOutInMs.ToString(), thrownException.Message);
                 Assert.True(evaluationStopWatch.ElapsedMilliseconds < scriptSleepTimeInMs,
-                    $"Elapsed {evaluationStopWatch.ElapsedMilliseconds} > 5000");
+                    $"Elapsed {evaluationStopWatch.ElapsedMilliseconds} > {scriptSleepTimeInMs}");
             }
         }
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MessagesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MessagesTests.cs
@@ -102,7 +102,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
             using (var gremlinClient = new GremlinClient(gremlinServer))
             {
                 const long timeOutInMs = 1L;
-                const int scriptSleepTimeInMs = 5000;
+                const int scriptSleepTimeInMs = 30000;
                 var sleepScript = _requestMessageProvider.GetSleepGremlinScript(scriptSleepTimeInMs);
 
                 var requestMsg =
@@ -119,7 +119,8 @@ namespace Gremlin.Net.IntegrationTest.Driver
                 evaluationStopWatch.Stop();
                 Assert.Contains("ServerTimeout", thrownException.Message);
                 Assert.Contains(timeOutInMs.ToString(), thrownException.Message);
-                Assert.True(evaluationStopWatch.ElapsedMilliseconds < scriptSleepTimeInMs);
+                Assert.True(evaluationStopWatch.ElapsedMilliseconds < scriptSleepTimeInMs,
+                    $"Elapsed {evaluationStopWatch.ElapsedMilliseconds} > 5000");
             }
         }
 

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
@@ -165,6 +165,8 @@ namespace Gremlin.Net.UnitTest.Driver
 
             // Release the connection close message.
             receiveSempahore.Release();
+            // delay to set new mocked response for mockedClientWebSocket
+            await Task.Delay(100);
 
             // Assert that both requests get notified with the closed exception.
             await AssertExpectedConnectionClosedException(closeResult.CloseStatus, closeResult.CloseStatusDescription, () => request1);

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
@@ -166,7 +166,10 @@ namespace Gremlin.Net.UnitTest.Driver
             // Release the connection close message.
             receiveSempahore.Release();
             // delay to set new mocked response for mockedClientWebSocket
-            await Task.Delay(100);
+            while (mockedClientWebSocket.Object.State != WebSocketState.CloseReceived)
+            {
+                await Task.Delay(5);
+            }
 
             // Assert that both requests get notified with the closed exception.
             await AssertExpectedConnectionClosedException(closeResult.CloseStatus, closeResult.CloseStatusDescription, () => request1);

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
@@ -165,15 +165,16 @@ namespace Gremlin.Net.UnitTest.Driver
 
             // Release the connection close message.
             receiveSempahore.Release();
-            // delay to set new mocked response for mockedClientWebSocket
-            while (mockedClientWebSocket.Object.State != WebSocketState.CloseReceived)
-            {
-                await Task.Delay(5);
-            }
 
             // Assert that both requests get notified with the closed exception.
             await AssertExpectedConnectionClosedException(closeResult.CloseStatus, closeResult.CloseStatusDescription, () => request1);
             await AssertExpectedConnectionClosedException(closeResult.CloseStatus, closeResult.CloseStatusDescription, () => request2);
+
+            // delay for NotifyAboutConnectionFailure running in another thread
+            while (connection.NrRequestsInFlight == 2)
+            {
+                await Task.Delay(5);
+            }
 
             Assert.False(connection.IsOpen);
             Assert.Equal(0, connection.NrRequestsInFlight);

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
@@ -171,7 +171,8 @@ namespace Gremlin.Net.UnitTest.Driver
             await AssertExpectedConnectionClosedException(closeResult.CloseStatus, closeResult.CloseStatusDescription, () => request2);
 
             // delay for NotifyAboutConnectionFailure running in another thread
-            while (connection.NrRequestsInFlight == 2)
+            var runs = 0;
+            while (connection.NrRequestsInFlight == 2 && ++runs < 5)
             {
                 await Task.Delay(5);
             }


### PR DESCRIPTION
Enabled running dotnet tests on Windows on GitHub Actions.

Fixed dotnet tests for Windows GHA:
- test ShouldUseSpecifiedEvaluationTimeout. The test checks that EvalTimeout parameter works. Usual test request waiting time on server before execution is ~10-25 seconds, so I increased timeout to have time to spare.
- test ShouldHandleCloseMessageForInFlightRequestsAsync. In dotnet driver, sending requests and reading responses is carried out in different threads without synchronization. If an error occurs, it is processed by the reading thread (Connection.NotifyAboutConnectionFailure method), so there is a race condition between the two threads to read/update the connection.NrRequestsInFlight property (based on _callbackByRequestId field).