### PR TITLE
TINKERPOP-2765 Fix concurrency issue during script translation in the GremlinGroovyScriptEngine.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Changed label generation in `PathProcessorStrategy` to be more deterministic.
 * Bumped to Apache `commons-configuration` 2.8.0 to fix security vulnerability.
+* Fixed issue where the `GremlinGroovyScriptEngine` reused the same translator concurrently which lead to incorrect translations.
 
 [[release-3-5-4]]
 === TinkerPop 3.5.4 (Release Date: July 18, 2022)

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -1087,4 +1087,26 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             cluster.close();
         }
     }
+
+    /**
+     * Reproducer for TINKERPOP-2765 when run using the UnifiedChannelizer.
+     */
+    @Test
+    public void shouldHandleMultipleLambdaTranslationsInParallel() throws Exception {
+        final GraphTraversalSource g = traversal().withRemote(conf);
+
+        final CompletableFuture<Traversal<Object, Object>> firstRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> secondRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> thirdRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+
+        try {
+            firstRes.get();
+            secondRes.get();
+            thirdRes.get();
+        } catch (Exception ce) {
+            fail("An exception was not expected because the traversals are all valid.");
+        } finally {
+            g.close();
+        }
+    }
 }


### PR DESCRIPTION
An issue occurs when the GremlinGroovyScriptEngine is called from multiple threads to evaluate bytecode that contains lambdas. The default translator is not thread-safe which results in queries being interlaced with one another. This is fixed by creating a new instance of the translator per translation so that the translation process isn't interfered with. This primarily affects the UnifiedChannelizer because it currently uses the same instance of the translator from multiple threads.

Fixes https://issues.apache.org/jira/browse/TINKERPOP-2765