### PR TITLE
Export Result interface

### DIFF
--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -21,6 +21,9 @@ package gremlingo
 
 import (
 	"crypto/tls"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 	"math/big"
 	"os"
 	"reflect"
@@ -30,10 +33,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/text/language"
 )
 
 const personLabel = "Person"

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -21,9 +21,6 @@ package gremlingo
 
 import (
 	"crypto/tls"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/text/language"
 	"math/big"
 	"os"
 	"reflect"
@@ -33,6 +30,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 const personLabel = "Person"
@@ -857,7 +858,7 @@ func TestConnection(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, r)
 		assert.Equal(t, 1, len(r))
-		metrics := r[0].result.(*TraversalMetrics)
+		metrics := r[0].Result.(*TraversalMetrics)
 		assert.NotNil(t, metrics)
 		assert.GreaterOrEqual(t, len(metrics.Metrics), 2)
 
@@ -878,7 +879,7 @@ func TestConnection(t *testing.T) {
 
 		r, err := g.V().HasLabel("type_test").Values("data").Next()
 		assert.Nil(t, err)
-		assert.Equal(t, prop, r.result.(*GremlinType))
+		assert.Equal(t, prop, r.Result.(*GremlinType))
 
 		resetGraph(t, g)
 	})
@@ -897,7 +898,7 @@ func TestConnection(t *testing.T) {
 
 		r, err := g.V().HasLabel("type_test").Values("data").Next()
 		assert.Nil(t, err)
-		assert.Equal(t, prop, r.result.(*BigDecimal))
+		assert.Equal(t, prop, r.Result.(*BigDecimal))
 
 		resetGraph(t, g)
 	})
@@ -916,7 +917,7 @@ func TestConnection(t *testing.T) {
 
 		r, err := g.V().HasLabel("type_test").Values("data").Next()
 		assert.Nil(t, err)
-		assert.Equal(t, prop, r.result)
+		assert.Equal(t, prop, r.Result)
 
 		resetGraph(t, g)
 	})

--- a/gremlin-go/driver/result.go
+++ b/gremlin-go/driver/result.go
@@ -32,12 +32,12 @@ type Result struct {
 
 // String returns the string representation of the Result struct in Go-syntax format.
 func (r *Result) String() string {
-	return fmt.Sprintf("result{object=%v class=%T}", r.result, r.result)
+	return fmt.Sprintf("result{object=%v class=%T}", r.Result, r.Result)
 }
 
 // GetString gets the string representation of the result.
 func (r *Result) GetString() string {
-	return fmt.Sprintf("%v", r.result)
+	return fmt.Sprintf("%v", r.Result)
 }
 
 // GetInt gets the result by coercing it into an int, else returns an error if not parsable.
@@ -139,12 +139,12 @@ func (r *Result) GetBool() (bool, error) {
 
 // IsNil checks if the result is null.
 func (r *Result) IsNil() bool {
-	return nil == r.result
+	return nil == r.Result
 }
 
 // GetVertex returns the result if it is a Vertex, otherwise returns an error.
 func (r *Result) GetVertex() (*Vertex, error) {
-	res, ok := r.result.(*Vertex)
+	res, ok := r.Result.(*Vertex)
 	if !ok {
 		return nil, newError(err0601ResultNotVertexError)
 	}
@@ -153,7 +153,7 @@ func (r *Result) GetVertex() (*Vertex, error) {
 
 // GetEdge returns the result if it is an edge, otherwise returns an error.
 func (r *Result) GetEdge() (*Edge, error) {
-	res, ok := r.result.(*Edge)
+	res, ok := r.Result.(*Edge)
 	if !ok {
 		return nil, newError(err0602ResultNotEdgeError)
 	}
@@ -162,7 +162,7 @@ func (r *Result) GetEdge() (*Edge, error) {
 
 // GetElement returns the result if it is an Element, otherwise returns an error.
 func (r *Result) GetElement() (*Element, error) {
-	res, ok := r.result.(*Element)
+	res, ok := r.Result.(*Element)
 	if !ok {
 		return nil, newError(err0603ResultNotElementError)
 	}
@@ -171,7 +171,7 @@ func (r *Result) GetElement() (*Element, error) {
 
 // GetPath returns the result if it is a path, otherwise returns an error.
 func (r *Result) GetPath() (*Path, error) {
-	res, ok := r.result.(*Path)
+	res, ok := r.Result.(*Path)
 	if !ok {
 		return nil, newError(err0604ResultNotPathError)
 	}
@@ -180,7 +180,7 @@ func (r *Result) GetPath() (*Path, error) {
 
 // GetProperty returns the result if it is a property, otherwise returns an error.
 func (r *Result) GetProperty() (*Property, error) {
-	res, ok := r.result.(*Property)
+	res, ok := r.Result.(*Property)
 	if !ok {
 		return nil, newError(err0605ResultNotPropertyError)
 	}
@@ -189,7 +189,7 @@ func (r *Result) GetProperty() (*Property, error) {
 
 // GetVertexProperty returns the result if it is a Vertex property, otherwise returns an error.
 func (r *Result) GetVertexProperty() (*VertexProperty, error) {
-	res, ok := r.result.(*VertexProperty)
+	res, ok := r.Result.(*VertexProperty)
 	if !ok {
 		return nil, newError(err0606ResultNotVertexPropertyError)
 	}
@@ -198,7 +198,7 @@ func (r *Result) GetVertexProperty() (*VertexProperty, error) {
 
 // GetTraverser returns the Result if it is a Traverser, otherwise returns an error.
 func (r *Result) GetTraverser() (*Traverser, error) {
-	res, ok := r.result.(Traverser)
+	res, ok := r.Result.(Traverser)
 	if !ok {
 		return nil, newError(err0607ResultNotTraverserError)
 	}
@@ -207,7 +207,7 @@ func (r *Result) GetTraverser() (*Traverser, error) {
 
 // GetSlice returns the Result if it is a Slice, otherwise returns an error.
 func (r *Result) GetSlice() (*[]interface{}, error) {
-	res, ok := r.result.([]interface{})
+	res, ok := r.Result.([]interface{})
 	if !ok {
 		return nil, newError(err0608ResultNotSliceError)
 	}
@@ -216,10 +216,10 @@ func (r *Result) GetSlice() (*[]interface{}, error) {
 
 // GetType returns the type of the result.
 func (r *Result) GetType() reflect.Type {
-	return reflect.TypeOf(r.result)
+	return reflect.TypeOf(r.Result)
 }
 
 // GetInterface returns the result item.
 func (r *Result) GetInterface() interface{} {
-	return r.result
+	return r.Result
 }

--- a/gremlin-go/driver/result.go
+++ b/gremlin-go/driver/result.go
@@ -27,7 +27,7 @@ import (
 
 // Result Struct to abstract the Result and provide functions to use it.
 type Result struct {
-	result interface{}
+	Result interface{}
 }
 
 // String returns the string representation of the Result struct in Go-syntax format.

--- a/gremlin-go/driver/resultSet.go
+++ b/gremlin-go/driver/resultSet.go
@@ -188,7 +188,7 @@ func (channelResultSet *channelResultSet) All() ([]*Result, error) {
 func (channelResultSet *channelResultSet) addResult(r *Result) {
 	channelResultSet.channelMutex.Lock()
 	if r.GetType().Kind() == reflect.Array || r.GetType().Kind() == reflect.Slice {
-		for _, v := range r.result.([]interface{}) {
+		for _, v := range r.Result.([]interface{}) {
 			if reflect.TypeOf(v) == reflect.TypeOf(&Traverser{}) {
 				for i := int64(0); i < (v.(*Traverser)).bulk; i++ {
 					channelResultSet.channel <- &Result{(v.(*Traverser)).value}
@@ -198,7 +198,7 @@ func (channelResultSet *channelResultSet) addResult(r *Result) {
 			}
 		}
 	} else {
-		channelResultSet.channel <- &Result{r.result}
+		channelResultSet.channel <- &Result{r.Result}
 	}
 	channelResultSet.channelMutex.Unlock()
 	channelResultSet.sendSignal()


### PR DESCRIPTION
The `Result` struct does not allow for any assigning of data, which makes it impossible to mock out for testing. While the `ResultSet` interface and its methods can be mocked out, they must match the original function signature, and return the `Result` type. Since you cannot assign to the unexported `Result` type, it is not possible to mock out returning data from the various methods of `ResultSet`.