### PR TITLE
Updated Maven Download url. Now points to Archive domain

### DIFF
--- a/.travis.install-maven.sh
+++ b/.travis.install-maven.sh
@@ -8,8 +8,7 @@ if [ ! -f "${MVN_INSTALL_DIR}/lib/maven-artifact-${MVN_VERSION}.jar" ]; then
   rm -Rf "${MVN_INSTALL_DIR}"
   mkdir -p "${MVN_INSTALL_DIR}"
 
-  APACHE_MIRROR="$(curl -sL https://www.apache.org/dyn/closer.cgi?asjson=1 | python3 -c 'import sys, json; print(json.load(sys.stdin)["preferred"])')"
-  curl -o "${HOME}/apache-maven-$MVN_VERSION-bin.tar.gz" "$APACHE_MIRROR/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz"
+  curl -o "${HOME}/apache-maven-$MVN_VERSION-bin.tar.gz" "https://archive.apache.org/dist/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz"
   cd "${MVN_INSTALL_DIR}"
   tar -xzf "${HOME}/apache-maven-$MVN_VERSION-bin.tar.gz" --strip 1
   chmod +x "${MVN_INSTALL_DIR}/bin/mvn"


### PR DESCRIPTION
Requested by @spmallette [here](https://github.com/apache/tinkerpop/pull/1792).   
Updates the source from which maven is installed, required as original CDN no longer hosts the relevant binary.
- CDN Link that no longer works: https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/
- Archive CDN Link: https://archive.apache.org/dist/maven/maven-3/3.8.5/binaries/
