### PR TITLE
Dev Environments: Dockerize Testing for Python and Gremlin Console (Python-based tests only)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -173,6 +173,7 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: |
+          touch gremlin-python/.glv
           mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -212,7 +212,6 @@ jobs:
         run: docker load --input gremlin-server.tar
       - name: Build with Maven
         run: |
-          touch gremlin-javascript/.glv
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript,:gremlint
   python:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -218,7 +218,7 @@ jobs:
   python:
     name: python
     timeout-minutes: 20
-    needs: smoke
+    needs: cache-gremlin-server-docker-image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -231,16 +231,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - name: Setup Python requirements
-        run: |
-          sudo apt install gcc libkrb5-dev
-          python3 -m pip install --upgrade pip
-          pip install virtualenv
       - name: Build with Maven
         run: |
           touch gremlin-python/.glv
           mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl gremlin-python -DincludeNeo4j
+          mvn verify -pl gremlin-python
   dotnet:
     name: .NET
     timeout-minutes: 20

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docs/gremlint/
 gremlint/
 coverage.out
 .env
+gremlinconsoletest.egg-info

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug where tasks that haven't started running yet time out due to `evaluationTimeout` and never send a response back to the client.
 * Set the exact exception in `initializationFailure` on the Java driver instead of the root cause.
 * Added `SparkIOUtil` utility to load graph into Spark RDD.
+* Dockerized all test environment for .NET, JavaScript, Python, Go, and Python-based tests for Console, and added Docker as a build requirement.
 
 [[release-3-5-4]]
 === TinkerPop 3.5.4 (Release Date: July 18, 2022)

--- a/docker/gremlin-test-server/Dockerfile
+++ b/docker/gremlin-test-server/Dockerfile
@@ -24,7 +24,7 @@ USER root
 RUN mkdir -p /opt
 WORKDIR /opt
 COPY gremlin-server/src/test /opt/test/
-COPY docker/gremlin-server/docker-entrypoint.sh docker/gremlin-server/*.yaml /opt/
+COPY docker/gremlin-server/docker-entrypoint.sh docker/gremlin-server/*.yaml docker/gremlin-server/*.conf /opt/
 RUN chmod 755 /opt/docker-entrypoint.sh
 
 # Installing dos2unix to avoid errors in running the entrypoint script on Windows machines where their

--- a/docker/gremlin-test-server/krb5.conf
+++ b/docker/gremlin-test-server/krb5.conf
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[libdefaults]
+    kdc_realm = TEST.COM
+    default_realm = TEST.COM
+    udp_preference_limit = 4096
+    kdc_tcp_port = 4588
+    kdc_udp_port = 4588
+    dns_canonicalize_hostname = false
+    qualify_shortname = ""
+
+[realms]
+    TEST.COM = {
+        kdc = gremlin-server-test:4588
+    }

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -191,10 +191,9 @@ which enables the "glv-python" Maven profile or in a more automated fashion simp
 `gremlin-python` module which will signify to Maven that the environment is Python-ready. The `.glv` file need not have
 any contents and is ignored by Git. A standard `mvn clean install` will then build `gremlin-python` in full.
 
-The build also requires Python to execute `gremlin-console` integration tests. The integration test is configured by a
-"console-integration-tests" Maven profile. This profile can be activated manually or can more simply piggy-back on
-the `.glv` file in `gremlin-python`. Note that unlike `gremlin-python` the tests are actually integration tests and
-therefore must be actively switched on with `-DskipIntegrationTests=false`:
+The `.glv` file in `gremlin-python` also activates the "console-integration-tests" Maven profile to run gremlin-console
+integration tests. Alternatively, this profile can be activated manually. Note that unlike `gremlin-python` the tests
+are actually integration tests and therefore must be actively switched on with `-DskipIntegrationTests=false`:
 
 [source,text]
 mvn clean install -pl gremlin-console -DskipIntegrationTests=false

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -213,6 +213,9 @@ The build optionally requires link:https://dotnet.microsoft.com/download[.NET SD
 `gremlin-dotnet` module. If .NET SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
 
+`gremlin-dotnet` uses Docker for all of its testing. Please make sure Docker is installed and running on your system. 
+You will need to install both link:https://docs.docker.com/engine/install/[Docker Engine] and link:https://docs.docker.com/compose/install/[Docker Compose], which are included in link:https://docs.docker.com/desktop/[Docker Desktop].
+
 `gremlin-dotnet` can be built and tested from the command line with:
 
 [source,text]
@@ -247,6 +250,9 @@ To run the development and build scripts of `gremlint` and its corresponding web
 have to be installed. When generating or publishing the TinkerPop website, the `docs/gremlint` web page has to be
 built. Consequently, the scripts `bin/generate-home.sh` and `bin/publish-home.sh` require that Node.js and npm are
 installed. Version 6.x or newer of npm is required. This is covered in more detail in the <<site,Site>> section.
+
+`gremlin-javascript` uses Docker for all of its testing. Please make sure Docker is installed and running on your system. 
+You will need to install both link:https://docs.docker.com/engine/install/[Docker Engine] and link:https://docs.docker.com/compose/install/[Docker Compose], which are included in link:https://docs.docker.com/desktop/[Docker Desktop].
 
 IMPORTANT: Beware of unexpected or unwanted changes on `package-lock.json` files when committing and merging. 
 
@@ -496,6 +502,42 @@ docker/gremlin-server.sh 3.4.2
 
 To be a bit more clear, the version can not be a Docker tag like "latest" because there is no such TinkerPop artifact
 that has been published with that version number.
+
+[[docker-testing]]
+== Testing with Docker
+
+Currently gremlin-go, gremlin-javascript, gremlin-dotnet, gremlin-python and gremlin-console can be tested through Docker.
+
+Please make sure Docker is installed and running on your system. 
+You will need to install both link:https://docs.docker.com/engine/install/[Docker Engine] and link:https://docs.docker.com/compose/install/[Docker Compose], which are included in link:https://docs.docker.com/desktop/[Docker Desktop].
+
+The following environment variables used by Docker Compose will automatically be set when running with Maven.
+
+The docker compose environment variable `GREMLIN_SERVER` specifies the Gremlin server docker image to use, i.e. an
+image with the tag `tinkerpop/gremlin-server:$GREMLIN_SERVER`, and is a required environment variable. This also 
+requires the specified docker image to exist, either locally or in link:https://hub.docker.com/r/tinkerpop/gremlin-server[Docker Hub].
+
+Running `mvn clean install -pl gremlin-server -DskipTests -DskipIntegrationTests=true -Dci -am` in the main `tinkerpop` 
+directory will automatically build a local SNAPSHOT Gremlin server image. If your OS Platform cannot build a local 
+SNAPSHOT Gremlin server through `maven`, it is recommended to use the latest released server version from link:https://hub.docker.com/r/tinkerpop/gremlin-server[Docker Hub] (do not use `GREMLIN_SERVER=latest`,
+use actual version number, e.g. `GREMLIN_SERVER=3.5.x` or `GREMLIN_SERVER=3.6.x`).
+
+The docker compose environment variable `HOME` specifies the user home directory for mounting volumes during test image 
+set up. This variable is set by default in Unix/Linux, but will need to be set for Windows, for example, run 
+`$env:HOME=$env:USERPROFILE` in PowerShell.
+
+There are different ways to launch the test suite and set the `GREMLIN_SERVER` environment variable depending on 
+your Platform:
+
+* Run Maven commands, e.g. `mvn clean install` inside of project folder e.g. `tinkerpop/gremlin-go`, or `mvn clean install -pl gremlin-go` 
+inside of `tinkerpop` (platform-agnostic - recommended)
+* Add `GREMLIN_SERVER=<server-image-version>` and `HOME=<user-home-directory>` to an `.env` file inside project folder and run `docker-compose up --exit-code-from gremlin-go-integration-tests` (Platform-agnostic).
+* Run `GREMLIN_SERVER=<server-image-version> docker-compose up --exit-code-from gremlin-go-integration-tests` in Unix/Linux.
+* Run `$env:GREMLIN_SERVER="<server-image-version>";$env:HOME=$env:USERPROFILE;docker-compose up --exit-code-from gremlin-go-integration-tests` in Windows PowerShell.
+
+You should see exit code 0 upon successful completion of the test suites. Run `docker-compose down` to remove the 
+service containers (not needed if you executed Maven commands or `run.sh`), or `docker-compose down --rmi all` to 
+remove the service containers while deleting all used images.
 
 [[intellij]]
 == Intellij Usage

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -39,6 +39,12 @@ of the project and those will go untested.
 To gain the ability to execute all aspects of the TinkerPop build system, other environmental configurations must be
 established. Those prerequisites are defined in the following subsections.
 
+As of TinkerPop 3.5.5, environment configuration for Gremlin Language Variants can be optional, as Docker becomes a
+system requirement to build and test GLVs inside of Maven. Please make sure Docker is installed and running on your system.
+You will need to install both link:https://docs.docker.com/engine/install/[Docker Engine] and
+link:https://docs.docker.com/compose/install/[Docker Compose], which are included in
+link:https://docs.docker.com/desktop/[Docker Desktop].
+
 IMPORTANT: Use Java 11 for documentation generation with `bin/process-docs.sh` and for other build features outside
 of the basic `mvn clean install` sort of function.
 
@@ -181,6 +187,9 @@ therefore requires:
 [source,text]
 sudo apt install libkrb5-dev krb5-user
 
+As of TinkerPop 3.5.5, `gremlin-python` uses Docker for all tests inside of Maven, and Python installation will not be required to
+run `gremlin-python` through Maven. Please make sure Docker is installed and running on your system.
+
 Once the Python environment is established, the full building and testing of `gremlin-python` may commence. It
 can be done manually from the command line with:
 
@@ -212,8 +221,8 @@ The build optionally requires link:https://dotnet.microsoft.com/download[.NET SD
 `gremlin-dotnet` module. If .NET SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
 
-`gremlin-dotnet` uses Docker for all of its testing. Please make sure Docker is installed and running on your system. 
-You will need to install both link:https://docs.docker.com/engine/install/[Docker Engine] and link:https://docs.docker.com/compose/install/[Docker Compose], which are included in link:https://docs.docker.com/desktop/[Docker Desktop].
+As of TinkerPop 3.5.5, `gremlin-dotnet` uses Docker for running all test projects inside of Maven, and .NET SDK will not
+be required to run `gremlin-dotnet` tests through Maven. Please make sure Docker is installed and running on your system.
 
 `gremlin-dotnet` can be built and tested from the command line with:
 
@@ -250,8 +259,8 @@ have to be installed. When generating or publishing the TinkerPop website, the `
 built. Consequently, the scripts `bin/generate-home.sh` and `bin/publish-home.sh` require that Node.js and npm are
 installed. Version 6.x or newer of npm is required. This is covered in more detail in the <<site,Site>> section.
 
-`gremlin-javascript` uses Docker for all of its testing. Please make sure Docker is installed and running on your system. 
-You will need to install both link:https://docs.docker.com/engine/install/[Docker Engine] and link:https://docs.docker.com/compose/install/[Docker Compose], which are included in link:https://docs.docker.com/desktop/[Docker Desktop].
+As of TinkerPop 3.5.5, `gremlin-javascript` uses Docker for all tests inside of Maven. Please make sure Docker is
+installed and running on your system.
 
 IMPORTANT: Beware of unexpected or unwanted changes on `package-lock.json` files when committing and merging. 
 
@@ -265,9 +274,16 @@ See the <<release-environment,Release Environment>> section for more information
 [[go-environment]]
 === Go Environment
 
-The build optionally requires link:https://go.dev/dl/[Go] (>=1.17) to work with the `gremlin-go` module. If Go is not installed, TinkerPop will still build with Maven, but Go projects will be skipped.
+The build optionally requires link:https://go.dev/dl/[Go] (>=1.17) to work with the `gremlin-go` module. Creating an
+empty `.glv` file will enable running of tests inside of Maven. If `.glv` file does not exist, TinkerPop
+will still build with Maven, but Go projects will be skipped.
 
-`gremlin-go` can be built the command line with:
+`gremlin-go` can be built and tested from the command line with:
+
+[source,text]
+mvn clean install -pl gremlin-go
+
+Alternatively, after installing Go, `gremlin-go` can be built from the command line with:
 
 [source,text]
 go build
@@ -503,14 +519,16 @@ To be a bit more clear, the version can not be a Docker tag like "latest" becaus
 that has been published with that version number.
 
 [[docker-testing]]
-== Testing with Docker
+== Testing Sub-Modules with Docker
 
-Currently gremlin-go, gremlin-javascript, gremlin-dotnet, gremlin-python and gremlin-console can be tested through Docker.
+Currently the modules gremlin-go, gremlin-javascript, gremlin-dotnet, gremlin-python and gremlin-console can be tested
+through Docker.
 
-Please make sure Docker is installed and running on your system. 
-You will need to install both link:https://docs.docker.com/engine/install/[Docker Engine] and link:https://docs.docker.com/compose/install/[Docker Compose], which are included in link:https://docs.docker.com/desktop/[Docker Desktop].
+Please make sure Docker is installed and running on your system. You will need to install both
+link:https://docs.docker.com/engine/install/[Docker Engine] and link:https://docs.docker.com/compose/install/[Docker Compose],
+which are included in link:https://docs.docker.com/desktop/[Docker Desktop].
 
-The following environment variables used by Docker Compose will automatically be set when running with Maven.
+The following environment variables used by Docker Compose will automatically be set when running through Maven.
 
 The docker compose environment variable `GREMLIN_SERVER` specifies the Gremlin server docker image to use, i.e. an
 image with the tag `tinkerpop/gremlin-server:$GREMLIN_SERVER`, and is a required environment variable. This also 
@@ -518,8 +536,9 @@ requires the specified docker image to exist, either locally or in link:https://
 
 Running `mvn clean install -pl gremlin-server -DskipTests -DskipIntegrationTests=true -Dci -am` in the main `tinkerpop` 
 directory will automatically build a local SNAPSHOT Gremlin server image. If your OS Platform cannot build a local 
-SNAPSHOT Gremlin server through `maven`, it is recommended to use the latest released server version from link:https://hub.docker.com/r/tinkerpop/gremlin-server[Docker Hub] (do not use `GREMLIN_SERVER=latest`,
-use actual version number, e.g. `GREMLIN_SERVER=3.5.x` or `GREMLIN_SERVER=3.6.x`).
+SNAPSHOT Gremlin server through `maven`, it is recommended to use the latest released server version from
+link:https://hub.docker.com/r/tinkerpop/gremlin-server[Docker Hub] (do not use `GREMLIN_SERVER=latest`, use actual
+version number, e.g. `GREMLIN_SERVER=3.5.x` or `GREMLIN_SERVER=3.6.x`).
 
 The docker compose environment variable `HOME` specifies the user home directory for mounting volumes during test image 
 set up. This variable is set by default in Unix/Linux, but will need to be set for Windows, for example, run 

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -308,6 +308,9 @@ mvn clean install -pl gremlin-server,gremlin-console -DdockerImages
 
 which enables the "docker-images" Maven profile.
 
+As of TinkerPop 3.5.5, a docker image of the Gremlin Server will be built automatically with `mvn clean install`, which
+is use for GLV tests inside of Docker. To skip building this image, append the `-DskipImageBuild` flag to Maven commands.
+
 [[release-environment]]
 === Release Environment
 

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -308,84 +308,6 @@ limitations under the License.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
-                            <execution>
-                                <id>create-python-reports-directory</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <target>
-                                        <mkdir dir="${project.build.directory}/python-reports"/>
-                                        <mkdir dir="${project.build.directory}/python/env"/>
-                                    </target>
-                                </configuration>
-                            </execution>
-                            <!-- copy files in python directory to target/python and run virtual env to sandbox python.
-                                 there is no need to "activate" the virtualenv because all calls to python occur
-                                 directly from bin/ -->
-                            <execution>
-                                <id>setup-py-env</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <tasks>
-                                        <copy todir="${project.build.directory}/python">
-                                            <fileset dir="src/test/python"/>
-                                        </copy>
-                                        <exec dir="${project.build.directory}/python" executable="python3"
-                                              failonerror="true">
-                                            <arg line="--version"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python" executable="virtualenv"
-                                              failonerror="true">
-                                            <arg line="--version"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python" executable="virtualenv"
-                                              failonerror="true">
-                                            <arg line="--python=python3 env"/>
-                                        </exec>
-                                    </tasks>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>native-python-build</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
-                                              failonerror="true">
-                                            <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py build --build-lib ${project.build.outputDirectory}/Lib"/>
-                                        </exec>
-                                    </target>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>copy-gremlinsh</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <tasks>
-                                        <copy todir="${project.build.directory}/python/gremlin-console">
-                                            <fileset dir="${project.build.directory}/apache-tinkerpop-gremlin-console-${project.version}-standalone"/>
-                                        </copy>
-                                    </tasks>
-                                </configuration>
-                            </execution>
-
                             <!--
                             use pytest to execute native python tests - output of xunit output is configured in setup.cfg.
                             must run on integration tests because package phase has to execute to get the console binaries
@@ -400,10 +322,14 @@ limitations under the License.
                                 <configuration>
                                     <skip>${skipIntegrationTests}</skip>
                                     <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
-                                              failonerror="true">
-                                            <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py test"/>
+                                        <exec executable="docker" failonerror="true">
+                                            <!-- This build command relies on Docker's caching mechanism to reduce the amount of times it is run. -->
+                                            <arg line="build -t gremlin-console-test:py3.8jre11 ./src/test/python/docker"/>
+                                        </exec>
+                                        <exec executable="docker" failonerror="true">
+                                            <arg line="run --rm --mount type=bind,src=${project.basedir}/src/test/python,dst=/console_app
+                                            --mount type=bind,src=${project.basedir}/target/apache-tinkerpop-gremlin-console-${project.version}-standalone,dst=/console_app/gremlin-console
+                                            gremlin-console-test:py3.8jre11"/>
                                         </exec>
                                     </target>
                                 </configuration>

--- a/gremlin-console/src/test/python/docker/Dockerfile
+++ b/gremlin-console/src/test/python/docker/Dockerfile
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -14,9 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-[aliases]
-test=pytest
 
-[tool:pytest]
-addopts = --junitxml=./python-reports/TEST-native-python.xml
-norecursedirs = '.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg' lib lib64
+# Image used for running integration tests for gremlin-console.
+FROM python:3.8.12
+
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre && apt-get install dos2unix
+
+WORKDIR /console_app
+CMD bash -c "dos2unix ./gremlin-console/bin/gremlin.sh && python3 setup.py build && python3 setup.py test"

--- a/gremlin-go/driver/README.md
+++ b/gremlin-go/driver/README.md
@@ -127,7 +127,7 @@ either locally or in [Docker Hub][dhub].
 
 Running `mvn clean install -pl gremlin-server -DskipTests -DskipIntegrationTests=true -Dci -am` in the main `tinkerpop` directory will automatically build a local SNAPSHOT Gremlin server image. If your OS Platform cannot build a local SNAPSHOT Gremlin server through `maven`, it is recommended to use the latest released server version from [Docker Hub][dhub] (do not use `GREMLIN_SERVER=latest`, use actual version number, e.g. `GREMLIN_SERVER=3.5.x` or `GREMLIN_SERVER=3.6.x`).
 
-The docker compose environment variable `HOME` specifies the user home directory for mounting volumes during test image set up. This varibale is set by default in Unix/Linux, but will need to be set for Windows, for example, run `$env:HOME=$env:USERPROFILE` in PowerShell.
+The docker compose environment variable `HOME` specifies the user home directory for mounting volumes during test image set up. This variable is set by default in Unix/Linux, but will need to be set for Windows, for example, run `$env:HOME=$env:USERPROFILE` in PowerShell.
 
 There are different ways to launch the test suite and set the `GREMLIN_SERVER` environment variable depending on your Platform:
 - Run Maven commands, e.g. `mvn clean install` inside of `tinkerpop/gremlin-go`, or `mvn clean install -pl gremlin-go` inside of `tinkerpop` (platform-agnostic - recommended)

--- a/gremlin-go/pom.xml
+++ b/gremlin-go/pom.xml
@@ -97,7 +97,7 @@ limitations under the License.
                                     <skip>${skipTests}</skip>
                                     <environmentVariables>
                                         <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
-                                        <ABS_PROJECT_HOME>${project.basedir}</ABS_PROJECT_HOME>
+                                        <ABS_PROJECT_HOME>${project.basedir}/../</ABS_PROJECT_HOME>
                                         <!-- setting this env variable is needed to be cross-platform compatible -->
                                         <HOME>${user.home}</HOME>
                                     </environmentVariables>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -200,6 +200,65 @@ limitations under the License.
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.tinkerpop</groupId>
+                                <artifactId>gremlin-server</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.tinkerpop</groupId>
+                                <artifactId>gremlin-test</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.tinkerpop</groupId>
+                                <artifactId>neo4j-gremlin</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>commons-io</groupId>
+                                <artifactId>commons-io</artifactId>
+                                <version>${commons.io.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>log4j</groupId>
+                                <artifactId>log4j</artifactId>
+                                <version>${log4j.version}</version>
+                                <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.codehaus.groovy</groupId>
+                                <artifactId>groovy-all</artifactId>
+                                <version>${groovy.version}</version>
+                                <type>pom</type>
+                                <scope>runtime</scope>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>generate-radish-support</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <properties>
+                                        <property>
+                                            <name>projectBaseDir</name>
+                                            <value>${project.basedir}/../</value>
+                                        </property>
+                                    </properties>
+                                    <scripts>
+                                        <script>${project.basedir}/build/generate.groovy</script>
+                                    </scripts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -90,6 +90,7 @@ limitations under the License.
                                 <configuration>
                                     <skip>${skipTests}</skip>
                                     <environmentVariables>
+                                        <ABS_PROJECT_HOME>${project.basedir}/../</ABS_PROJECT_HOME>
                                         <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
                                         <ABS_PROJECT_HOME>${project.basedir}/../</ABS_PROJECT_HOME>
                                         <!-- setting this env variable is needed to be cross-platform compatible -->

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -90,7 +90,6 @@ limitations under the License.
                                 <configuration>
                                     <skip>${skipTests}</skip>
                                     <environmentVariables>
-                                        <ABS_PROJECT_HOME>${project.basedir}/../</ABS_PROJECT_HOME>
                                         <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
                                         <ABS_PROJECT_HOME>${project.basedir}/../</ABS_PROJECT_HOME>
                                         <!-- setting this env variable is needed to be cross-platform compatible -->
@@ -138,65 +137,6 @@ limitations under the License.
                                         <argument>label=maintainer=dev@tinkerpop.apache.org</argument>
                                         <argument>-f</argument>
                                     </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.gmavenplus</groupId>
-                        <artifactId>gmavenplus-plugin</artifactId>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.apache.tinkerpop</groupId>
-                                <artifactId>gremlin-server</artifactId>
-                                <version>${project.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.apache.tinkerpop</groupId>
-                                <artifactId>gremlin-test</artifactId>
-                                <version>${project.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.apache.tinkerpop</groupId>
-                                <artifactId>neo4j-gremlin</artifactId>
-                                <version>${project.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>commons-io</groupId>
-                                <artifactId>commons-io</artifactId>
-                                <version>${commons.io.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>log4j</groupId>
-                                <artifactId>log4j</artifactId>
-                                <version>${log4j.version}</version>
-                                <scope>runtime</scope>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-all</artifactId>
-                                <version>${groovy.version}</version>
-                                <type>pom</type>
-                                <scope>runtime</scope>
-                            </dependency>
-                        </dependencies>
-                        <executions>
-                            <execution>
-                                <id>generate-radish-support</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>execute</goal>
-                                </goals>
-                                <configuration>
-                                    <properties>
-                                        <property>
-                                            <name>projectBaseDir</name>
-                                            <value>${project.basedir}/../</value>
-                                        </property>
-                                    </properties>
-                                    <scripts>
-                                        <script>${project.basedir}/build/generate.groovy</script>
-                                    </scripts>
                                 </configuration>
                             </execution>
                         </executions>

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -1,0 +1,82 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#    or more contributor license agreements.  See the NOTICE file
+#    distributed with this work for additional information
+#    regarding copyright ownership.  The ASF licenses this file
+#    to you under the Apache License, Version 2.0 (the
+#    "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing,
+#    software distributed under the License is distributed on an
+#    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied.  See the License for the
+#    specific language governing permissions and limitations
+#    under the License.
+
+version: "3.8"
+
+services:
+
+  gremlin-server-test-python:
+    container_name: gremlin-server-test-python
+    image: tinkerpop:gremlin-server-test-${GREMLIN_SERVER}
+    hostname: gremlin-server-test
+    build:
+      context: ../
+      dockerfile: docker/gremlin-test-server/Dockerfile
+      args:
+        - GREMLIN_SERVER=${GREMLIN_SERVER}
+    ports:
+      - "45940:45940"
+      - "45941:45941"
+      - "45942:45942"
+      - "4588:4588"
+    volumes:
+      - ${HOME}/.groovy:/root/.groovy
+      - ${HOME}/.m2:/root/.m2
+      - ${ABS_PROJECT_HOME}/gremlin-test/target:/opt/gremlin-test
+
+  gremlin-python-integration-tests:
+    container_name: gremlin-python-integration-tests
+    image: python:3.8
+    volumes:
+      - ${BUILD_DIR:-./src/main/python}:/python_app
+      - ../gremlin-test/features:/python_app/gremlin-test/features
+      - ../docker/gremlin-test-server:/python_app/gremlin-test-server
+    environment:
+      - TEST_TRANSACTIONS=${TEST_TRANSACTIONS:-true}
+      - DEBIAN_FRONTEND=noninteractive
+      - KRB5_CONFIG=./gremlin-test-server/krb5.conf
+      - KRB5CCNAME=./test-tkt.cc
+      - GREMLIN_SERVER_URL=ws://gremlin-server-test-python:{}/gremlin
+      - GREMLIN_SERVER_BASIC_AUTH_URL=wss://gremlin-server-test-python:{}/gremlin
+      - KRB_HOSTNAME=${KRB_HOSTNAME:-gremlin-server-test}
+      - VERSION=${VERSION}
+    working_dir: /python_app
+    command: >
+      bash -c "apt-get update && apt-get install dos2unix && dos2unix ./gremlin-test-server/wait-for-server.sh
+      && ./gremlin-test-server/wait-for-server.sh gremlin-server-test-python 45940 300
+      && apt-get -y install libkrb5-dev krb5-user
+      && echo 'password' | kinit stephen
+      && klist
+      && pip install wheel radish-bdd PyHamcrest aenum isodate kerberos six
+      && python3 ./setup.py build
+      && python3 ./setup.py test
+      && python3 ./setup.py install
+      && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.gremlin-v3.0+json'
+      && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.graphbinary-v1.0'"
+    depends_on:
+      - gremlin-server-test-python
+
+  gremlin-python-package:
+    container_name: gremlin-python-package
+    image: python:3.8
+    volumes:
+      - ${PACKAGE_DIR:-./src/main/python}:/python_package
+    working_dir: /python_package
+    environment:
+      - VERSION=${VERSION}
+    command: >
+      bash -c "python3 setup.py sdist bdist_wheel"

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -37,6 +37,12 @@ services:
       - ${HOME}/.groovy:/root/.groovy
       - ${HOME}/.m2:/root/.m2
       - ${ABS_PROJECT_HOME}/gremlin-test/target:/opt/gremlin-test
+    healthcheck:
+      test: [ "CMD-SHELL", "apk add curl && curl -f http://localhost:45940?gremlin=100-1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 30s
 
   gremlin-python-integration-tests:
     container_name: gremlin-python-integration-tests
@@ -56,9 +62,7 @@ services:
       - VERSION=${VERSION}
     working_dir: /python_app
     command: >
-      bash -c "apt-get update && apt-get install dos2unix && dos2unix ./gremlin-test-server/wait-for-server.sh
-      && ./gremlin-test-server/wait-for-server.sh gremlin-server-test-python 45940 300
-      && apt-get -y install libkrb5-dev krb5-user
+      bash -c "apt-get update && apt-get -y install libkrb5-dev krb5-user
       && echo 'password' | kinit stephen
       && klist
       && pip install wheel radish-bdd PyHamcrest aenum isodate kerberos six
@@ -68,7 +72,8 @@ services:
       && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.gremlin-v3.0+json'
       && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.graphbinary-v1.0'"
     depends_on:
-      - gremlin-server-test-python
+      gremlin-server-test-python:
+        condition: service_healthy
 
   gremlin-python-package:
     container_name: gremlin-python-package

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -158,6 +158,11 @@ limitations under the License.
                                             <env key="BUILD_DIR" value="${project.build.directory}/python3"/>
                                             <arg line="down"/>
                                         </exec>
+                                        <exec executable="docker" failonerror="true">
+                                            <env key="PYTHONPATH" value=""/>
+                                            <env key="BUILD_DIR" value="${project.build.directory}/python3"/>
+                                            <arg line="image prune --filter label=maintainer=dev@tinkerpop.apache.org -f"/>
+                                        </exec>
                                     </target>
                                 </configuration>
                             </execution>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -83,102 +83,31 @@ limitations under the License.
             </activation>
             <build>
                 <plugins>
-                    <!-- need to create python-reports directory at this point or else pytest can't write the report to it -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
+                            <!-- copy source files in python directory to target/, to keep testing separate from packaging.
+                            We use target/python3 for testing and target/python-packaged for distribution tasks.-->
                             <execution>
-                                <id>create-python-reports-directory</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <mkdir dir="${project.build.directory}/python-reports"/>
-                                        <mkdir dir="${project.build.directory}/python-packaged/env"/>
-                                    </target>
-                                </configuration>
-                            </execution>
-                            <!-- copy files in python directory to target/py and run virtual env to sandbox python.
-                                 there is no need to "activate" the virtualenv because all calls to python occur
-                                 directly from bin/ -->
-                            <execution>
-                                <id>setup-py-env</id>
+                                <id>setup-env</id>
                                 <phase>process-resources</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
                                     <tasks>
-                                        <!-- seems like we need a few different copies of the same source. all the
-                                             different python stuff doesn't seem to want to share. we use
-                                             /python3 for basic tests and stuff and /python-packaged for distribution
-                                             tasks. some of the problem seems to stem from the python lifecycle not
-                                             binding perfectly well to the maven lifecycle (integration tests seems to
-                                             cause troubles specifically). note that the commands to install wheel are
-                                             largely for safety in case someone is using an older version of virtualenv
-                                             (which doesn't install wheel by default) -->
+                                        <!-- pytest will create python-reports inside target/python3/python-reports
+                                        as docker compose cannot access outside its working directory -->
                                         <copy todir="${project.build.directory}/python3">
                                             <fileset dir="src/main/python"/>
                                         </copy>
-                                        <exec dir="${project.build.directory}/python3" executable="python3"
-                                              failonerror="true">
-                                            <arg line="--version"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python3" executable="virtualenv"
-                                              failonerror="true">
-                                            <arg line="--version"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python3" executable="virtualenv"
-                                              failonerror="true">
-                                            <arg line="--python=python3 env"/>
-                                        </exec>
-                                        <!-- pin setuptools before the breaking change at
-                                             https://github.com/pypa/setuptools/issues/2086 with removal of lib2to3.
-                                             not sure if this our code that is causing this problem though. the error
-                                             in travis shows as:
-                                             Setup script exited with error in radish-parse_type setup command: use_2to3 is invalid.-->
-                                        <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
-                                              failonerror="true">
-                                            <arg line="install setuptools&lt;58.0.0"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python3" executable="env/bin/pip"
-                                              failonerror="true">
-                                            <arg line="install wheel radish-bdd PyHamcrest aenum isodate kerberos six"/>
-                                        </exec>
                                         <copy todir="${project.build.directory}/python-packaged">
                                             <fileset dir="src/main/python"/>
                                         </copy>
-                                        <exec dir="${project.build.directory}/python-packaged" executable="virtualenv"
-                                              failonerror="true">
-                                            <arg line="--python=python3 env"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python-packaged" executable="env/bin/pip"
-                                              failonerror="true">
-                                            <arg line="install wheel"/>
-                                        </exec>
                                     </tasks>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>native-python3-build</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python3"
-                                              failonerror="true">
-                                            <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py build --build-lib ${project.build.outputDirectory}/Lib"/>
-                                        </exec>
-                                    </target>
-                                </configuration>
-                            </execution>
-
                             <!--
                             build/package python source distribution and wheel archive. the version is bound to an
                             environment variable that gets used in setup.py to dynamically construct a module
@@ -192,20 +121,18 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python-packaged"
-                                              failonerror="true">
+                                        <exec executable="docker-compose" failonerror="true">
+                                            <env key="PACKAGE_DIR" value="${project.build.directory}/python-packaged"/>
                                             <env key="VERSION" value="${project.version}"/>
                                             <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py sdist bdist_wheel"/>
+                                            <arg line="up --build --abort-on-container-exit gremlin-python-package"/>
                                         </exec>
                                     </target>
                                 </configuration>
                             </execution>
 
                             <!--
-                            use pytest to execute native python tests - output of xunit output is configured in setup.cfg.
-                            this has to be an integration-test because we need gremlin-server running and the standard
-                            test phase doesn't have a pre/post event like integration-test does.
+                            use docker-compose to run unit tests, radish, and integration tests.
                             -->
                             <execution>
                                 <id>native-python3-test</id>
@@ -216,36 +143,18 @@ limitations under the License.
                                 <configuration>
                                     <skip>${skipTests}</skip>
                                     <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python3"
-                                              failonerror="true">
-                                            <env key="TEST_TRANSACTIONS" value="${TEST_TRANSACTIONS}"/>
+                                        <exec executable="docker-compose" failonerror="true">
+                                            <env key="VERSION" value="${project.version}"/>
                                             <env key="PYTHONPATH" value=""/>
-                                            <env key="KRB5_CONFIG" value="${project.build.directory}/kdc/krb5.conf"/>
-                                            <env key="KRB5CCNAME" value="${project.build.directory}/kdc/test-tkt.cc"/>
-                                            <arg line="setup.py test"/>
+                                            <env key="GREMLIN_SERVER" value="${project.version}"/>
+                                            <env key="ABS_PROJECT_HOME" value="${project.basedir}/../"/>
+                                            <env key="BUILD_DIR" value="${project.build.directory}/python3"/>
+                                            <arg line="up --build --abort-on-container-exit gremlin-server-test-python gremlin-python-integration-tests"/>
                                         </exec>
-                                        <!-- radish seems to like all dependencies in place -->
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python3"
-                                              failonerror="true">
-                                            <env key="TEST_TRANSACTIONS" value="${TEST_TRANSACTIONS}"/>
+                                        <exec executable="docker-compose" failonerror="true">
                                             <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py install"/>
-                                        </exec>
-                                        <!-- run for graphson 3.0 -->
-                                        <exec executable="env/bin/radish" dir="${project.build.directory}/python3"
-                                              failonerror="true">
-                                            <env key="TEST_TRANSACTIONS" value="${TEST_TRANSACTIONS}"/>
-                                            <env key="PYTHONPATH" value=""/>
-                                            <env key="PYTHONIOENCODING" value="utf-8:surrogateescape"/>
-                                            <arg line="-f dots -e -t -b ${project.build.directory}/python3/radish ${project.basedir}/../gremlin-test/features/ --user-data=&quot;serializer=application/vnd.gremlin-v3.0+json&quot;"/> <!-- -no-line-jump -->
-                                        </exec>
-                                        <!-- run for graphbinary 1.0 -->
-                                        <exec executable="env/bin/radish" dir="${project.build.directory}/python3"
-                                              failonerror="true">
-                                            <env key="TEST_TRANSACTIONS" value="${TEST_TRANSACTIONS}"/>
-                                            <env key="PYTHONPATH" value=""/>
-                                            <env key="PYTHONIOENCODING" value="utf-8:surrogateescape"/>
-                                            <arg line="-f dots -e -t -b ${project.build.directory}/python3/radish ${project.basedir}/../gremlin-test/features/ --user-data=&quot;serializer=application/vnd.graphbinary-v1.0&quot;"/> <!-- -no-line-jump -->
+                                            <env key="BUILD_DIR" value="${project.build.directory}/python3"/>
+                                            <arg line="down"/>
                                         </exec>
                                     </target>
                                 </configuration>
@@ -304,179 +213,7 @@ limitations under the License.
                                     </scripts>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>gremlin-server-start</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>execute</goal>
-                                </goals>
-                                <configuration>
-                                    <properties>
-                                        <property>
-                                            <name>skipTests</name>
-                                            <value>${skipTests}</value>
-                                        </property>
-                                        <property>
-                                            <name>gremlinServerDir</name>
-                                            <value>${gremlin.server.dir}</value>
-                                        </property>
-                                        <property>
-                                            <name>settingsFile</name>
-                                            <value>${gremlin.server.dir}/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml</value>
-                                        </property>
-                                        <property>
-                                            <name>executionName</name>
-                                            <value>${project.name}</value>
-                                        </property>
-                                        <property>
-                                            <name>projectBaseDir</name>
-                                            <value>${project.basedir}</value>
-                                        </property>
-                                        <property>
-                                            <name>tinkerpopRootDir</name>
-                                            <value>${tinkerpop.root.dir}</value>
-                                        </property>
-                                    </properties>
-                                    <scripts>
-                                        <script>${gremlin.server.dir}/src/test/scripts/test-server-start.groovy</script>
-                                    </scripts>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>gremlin-server-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>execute</goal>
-                                </goals>
-                                <configuration>
-                                    <properties>
-                                        <property>
-                                            <name>skipTests</name>
-                                            <value>${skipTests}</value>
-                                        </property>
-                                        <property>
-                                            <name>executionName</name>
-                                            <value>${project.name}</value>
-                                        </property>
-                                    </properties>
-                                    <scripts>
-                                        <script>${gremlin.server.dir}/src/test/scripts/test-server-stop.groovy</script>
-                                    </scripts>
-                                </configuration>
-                            </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <!--
-          This profile will include neo4j for purposes of transactional testing within Gremlin Server.
-          Tests that require neo4j specifically will be "ignored" if this profile is not turned on.
-        -->
-        <profile>
-            <id>include-neo4j</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>includeNeo4j</name>
-                </property>
-            </activation>
-            <properties>
-                <TEST_TRANSACTIONS>true</TEST_TRANSACTIONS>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.gmavenplus</groupId>
-                        <artifactId>gmavenplus-plugin</artifactId>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.neo4j</groupId>
-                                <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                                <version>0.9-3.4.0</version>
-                                <exclusions>
-                                    <exclusion>
-                                        <groupId>org.neo4j</groupId>
-                                        <artifactId>neo4j-kernel</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.apache.commons</groupId>
-                                        <artifactId>commons-lang3</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.apache.commons</groupId>
-                                        <artifactId>commons-text</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>com.github.ben-manes.caffeine</groupId>
-                                        <artifactId>caffeine</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.scala-lang</groupId>
-                                        <artifactId>scala-library</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.scala-lang</groupId>
-                                        <artifactId>scala-reflect</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.slf4j</groupId>
-                                        <artifactId>slf4j-api</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.slf4j</groupId>
-                                        <artifactId>slf4j-nop</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.apache.lucene</groupId>
-                                        <artifactId>lucene-core</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>io.dropwizard.metrics</groupId>
-                                        <artifactId>metrics-core</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>io.netty</groupId>
-                                        <artifactId>netty-all</artifactId>
-                                    </exclusion>
-                                    <exclusion>
-                                        <groupId>org.ow2.asm</groupId>
-                                        <artifactId>asm</artifactId>
-                                    </exclusion>
-                                </exclusions>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.scala-lang</groupId>
-                                <artifactId>scala-library</artifactId>
-                                <version>2.11.8</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.scala-lang</groupId>
-                                <artifactId>scala-reflect</artifactId>
-                                <version>2.11.8</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.apache.lucene</groupId>
-                                <artifactId>lucene-core</artifactId>
-                                <version>5.5.0</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>io.dropwizard.metrics</groupId>
-                                <artifactId>metrics-core</artifactId>
-                                <version>4.2.11</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.neo4j</groupId>
-                                <artifactId>neo4j-kernel</artifactId>
-                                <version>3.4.11</version>
-                                <exclusions>
-                                    <exclusion>
-                                        <groupId>io.netty</groupId>
-                                        <artifactId>netty-all</artifactId>
-                                    </exclusion>
-                                </exclusions>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -87,8 +87,10 @@ limitations under the License.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
-                            <!-- copy source files in python directory to target/, to keep testing separate from packaging.
-                            We use target/python3 for testing and target/python-packaged for distribution tasks.-->
+                            <!--
+                            copy source files in python directory to target/, to keep testing separate from packaging.
+                            we use target/python3 for testing and target/python-packaged for distribution tasks.
+                            -->
                             <execution>
                                 <id>setup-env</id>
                                 <phase>process-resources</phase>
@@ -96,7 +98,7 @@ limitations under the License.
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <!-- pytest will create python-reports inside target/python3/python-reports
                                         as docker compose cannot access outside its working directory -->
                                         <copy todir="${project.build.directory}/python3">
@@ -105,7 +107,7 @@ limitations under the License.
                                         <copy todir="${project.build.directory}/python-packaged">
                                             <fileset dir="src/main/python"/>
                                         </copy>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                             <!--
@@ -135,7 +137,7 @@ limitations under the License.
                             use docker-compose to run unit tests, radish, and integration tests.
                             -->
                             <execution>
-                                <id>native-python3-test</id>
+                                <id>python-tests</id>
                                 <phase>integration-test</phase>
                                 <goals>
                                     <goal>run</goal>
@@ -247,6 +249,15 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <target>
+                                        <!--
+                                        set up and run virtual env to sandbox python. there is no need to "activate"
+                                        the virtualenv because all calls to python occur directly from bin/
+                                        -->
+                                        <mkdir dir="${project.build.directory}/python-packaged/env"/>
+                                        <exec dir="${project.build.directory}/python-packaged" executable="virtualenv"
+                                              failonerror="true">
+                                            <arg line="--python=python3 env"/>
+                                        </exec>
                                         <!--
                                         seems like https://github.com/pypa/twine/issues/338 is the reason to stay bound
                                         to this old version of twine. as long as keyring gets in the way and can't be

--- a/gremlin-python/src/main/python/radish/terrain.py
+++ b/gremlin-python/src/main/python/radish/terrain.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import os
 
 from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.process.graph_traversal import __
@@ -28,7 +29,8 @@ label = __.label
 inV = __.inV
 project = __.project
 tail = __.tail
-
+gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
+test_no_auth_url = gremlin_server_url.format(45940)
 
 @before.all
 def prepare_static_traversal_source(features, marker):
@@ -95,4 +97,4 @@ def __create_remote(server_graph_name):
     else:
         raise ValueError('serializer not found - ' + world.config.user_data["serializer"])
 
-    return DriverRemoteConnection('ws://localhost:45940/gremlin', server_graph_name, message_serializer=s)
+    return DriverRemoteConnection(test_no_auth_url, server_graph_name, message_serializer=s)

--- a/gremlin-python/src/main/python/setup.cfg
+++ b/gremlin-python/src/main/python/setup.cfg
@@ -21,5 +21,5 @@ universal=1
 test=pytest
 
 [tool:pytest]
-addopts = --junitxml=../python-reports/TEST-native-python.xml
+addopts = --junitxml=./python-reports/TEST-native-python.xml -sv
 norecursedirs = '.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg' lib lib64

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -75,7 +75,7 @@ setup(
     tests_require=[
         'pytest>=4.6.4,<7.2.0',
         'mock>=3.0.5,<4.0.0',
-        'radish-bdd==0.8.6',
+        'radish-bdd==0.13.4',
         'PyHamcrest>=1.9.0,<2.0.0'
     ],
     install_requires=install_requires,

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -18,6 +18,7 @@
 #
 
 import concurrent.futures
+import os
 import ssl
 import pytest
 import socket
@@ -36,11 +37,13 @@ from gremlin_python.driver.serializer import (
     GraphBinarySerializersV1)
 from gremlin_python.driver.aiohttp.transport import AiohttpTransport
 
-gremlin_server_url = 'ws://localhost:{}/gremlin'
+gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
+gremlin_basic_auth_url = os.environ.get('GREMLIN_SERVER_BASIC_AUTH_URL', 'wss://localhost:{}/gremlin')
+kerberos_hostname = os.environ.get('KRB_HOSTNAME', socket.gethostname())
 anonymous_url = gremlin_server_url.format(45940)
-basic_url = 'wss://localhost:{}/gremlin'.format(45941)
+basic_url = gremlin_basic_auth_url.format(45941)
 kerberos_url = gremlin_server_url.format(45942)
-kerberized_service = 'test-service@{}'.format(socket.gethostname())
+kerberized_service = 'test-service@{}'.format(kerberos_hostname)
 verbose_logging = False
 
 logging.basicConfig(format='%(asctime)s [%(levelname)8s] [%(filename)15s:%(lineno)d - %(funcName)10s()] - %(message)s',

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import asyncio
+import os
 import threading
 import uuid
 
@@ -32,7 +33,8 @@ from asyncio import TimeoutError
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
-test_no_auth_url = 'ws://localhost:45940/gremlin'
+gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
+test_no_auth_url = gremlin_server_url.format(45940)
 
 
 def test_connection(connection):

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import os
 
 from gremlin_python import statics
 from gremlin_python.driver.protocol import GremlinServerError
@@ -33,6 +34,8 @@ from gremlin_python.driver.serializer import GraphSONSerializersV2d0
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
+gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
+test_no_auth_url = gremlin_server_url.format(45940)
 
 class TestDriverRemoteConnection(object):
     def test_traversals(self, remote_connection):
@@ -108,7 +111,7 @@ class TestDriverRemoteConnection(object):
 
     def test_lambda_traversals(self, remote_connection):
         statics.load_statics(globals())
-        assert "remoteconnection[ws://localhost:45940/gremlin,gmodern]" == str(remote_connection)
+        assert "remoteconnection[{},gmodern]".format(test_no_auth_url) == str(remote_connection)
         g = traversal().withRemote(remote_connection)
 
         assert 24.0 == g.withSack(1.0, lambda: ("x -> x + 1", "gremlin-groovy")).V().both().sack().sum().next()

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_threaded.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import concurrent.futures
+import os
 import sys
 from threading import Thread
 from six.moves import queue
@@ -27,6 +28,8 @@ from gremlin_python.process.anonymous_traversal import traversal
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
+gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
+test_no_auth_url = gremlin_server_url.format(45940)
 
 def test_conns_in_threads(remote_connection):
     q = queue.Queue()
@@ -59,8 +62,7 @@ def _executor(q, conn):
     if not conn:
         # This isn't a fixture so close manually
         close = True
-        conn = DriverRemoteConnection(
-            'ws://localhost:45940/gremlin', 'gmodern', pool_size=4)
+        conn = DriverRemoteConnection(test_no_auth_url, 'gmodern', pool_size=4)
     try:
         g = traversal().withRemote(conn)
         future = g.V().promise()
@@ -77,7 +79,7 @@ def _executor(q, conn):
 
 def handle_request():
     try:
-        remote_connection = DriverRemoteConnection("ws://localhost:45940/gremlin", "g")
+        remote_connection = DriverRemoteConnection(test_no_auth_url, "g")
         g = traversal().withRemote(remote_connection)
         g.V().limit(1).toList()
         remote_connection.close()

--- a/gremlin-python/src/main/python/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/python/tests/process/test_traversal.py
@@ -31,7 +31,7 @@ from gremlin_python.process.traversal import P
 from gremlin_python.process.traversal import Binding, Bindings
 from gremlin_python.process.graph_traversal import __
 
-gremlin_server_url = 'ws://localhost:{}/gremlin'
+gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
 anonymous_url = gremlin_server_url.format(45940)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,7 @@ limitations under the License.
                         <exclude>**/docfx/**</exclude>
                         <exclude>**/go.sum</exclude>
                         <exclude>**/coverage.out</exclude>
+                        <exclude>**/gremlinconsoletest.egg-info/**</exclude>
                     </excludes>
                     <licenses>
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>


### PR DESCRIPTION
Dockerized `gremlin-python` build and testing. Building, testing, and packaging of the python GLV are now executed inside of Docker, and python installation is no longer a system requirement. Outputs and distribution packages and are placed in the `target/` folder as before. Deployment of python still requires local Python installations. 

Dockerized `gremlin-console` python-based integration tests. Python 3.8 is used for the image because the version of pytest used isn't compatible with later versions of Python. Building our own Docker image also allows for greater control over the version of Python and Java used.

The location of the python test output was changed in order to fit better with the bind mounted volume for Docker.

Minor documentation updates included. We will be looking at the Develop Docs more holistically for more appropriate updates in a separate PR.

 Conflicts will be left alone for now, as we plan to rebased after the previous [PR](https://github.com/apache/tinkerpop/pull/1788) is merged.
