### PR TITLE
TINKERPOP-2796: Bump snakeyaml to 1.32 due to security vulnerability

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Set the exact exception in `initializationFailure` on the Java driver instead of the root cause.
 * Added `SparkIOUtil` utility to load graph into Spark RDD.
 * Dockerized all test environment for .NET, JavaScript, Python, Go, and Python-based tests for Console, and added Docker as a build requirement.
+* Bumped to `snakeyaml` 1.32 to fix security vulnerability.
 
 [[release-3-5-4]]
 === TinkerPop 3.5.4 (Release Date: July 18, 2022)

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@ limitations under the License.
         <mockito.version>3.3.3</mockito.version>
         <netty.version>4.1.77.Final</netty.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <snakeyaml.version>1.27</snakeyaml.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
         <spark.version>3.0.0</spark.version>
         <powermock.version>2.0.9</powermock.version>
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TINKERPOP-2796