### PR TITLE
TINKERPOP-2794 Add support for cancellation 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `SparkIOUtil` utility to load graph into Spark RDD.
 * Changed `JavaTranslator` exception handling so that an `IllegalArgumentException` is used for cases where the method exists but the signature can't be discerned given the arguments supplied.
 * Dockerized all test environment for .NET, JavaScript, Python, Go, and Python-based tests for Console, and added Docker as a build requirement.
+* Async operations in .NET can now be cancelled. This however does not cancel work that is already happening on the server.
 * Bumped to `snakeyaml` 1.32 to fix security vulnerability.
 
 ==== Bugs

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
@@ -24,8 +24,6 @@
 using System;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Remote;
-using Gremlin.Net.Structure;
-
 using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.Template

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
@@ -41,8 +41,9 @@ namespace Gremlin.Net.Driver
 
         public IConnection CreateConnection()
         {
-            return new Connection(ProxyClientWebSocket.CreateClientWebSocket(), _gremlinServer.Uri, _gremlinServer.Username, 
-                _gremlinServer.Password, _messageSerializer, _webSocketSettings, _sessionId);
+            return new Connection(
+                new WebSocketConnection(ProxyClientWebSocket.CreateClientWebSocket(), _webSocketSettings),
+                _gremlinServer.Uri, _gremlinServer.Username, _gremlinServer.Password, _messageSerializer, _sessionId);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Net.WebSockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Structure.IO;
@@ -194,10 +195,10 @@ namespace Gremlin.Net.Driver
         public int NrConnections => _connectionPool.NrConnections;
 
         /// <inheritdoc />
-        public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
+        public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage, CancellationToken cancellationToken = default)
         {
             using var connection = _connectionPool.GetAvailableConnection();
-            return await connection.SubmitAsync<T>(requestMessage).ConfigureAwait(false);
+            return await connection.SubmitAsync<T>(requestMessage, cancellationToken).ConfigureAwait(false);
         }
 
         #region IDisposable Support

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClientExtensions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClientExtensions.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 
@@ -45,6 +46,7 @@ namespace Gremlin.Net.Driver
         /// <param name="gremlinClient">The <see cref="IGremlinClient" /> that submits the request.</param>
         /// <param name="requestScript">The Gremlin request script to send.</param>
         /// <param name="bindings">Bindings for parameters used in the requestScript.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A single result received from the Gremlin Server.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
@@ -52,9 +54,11 @@ namespace Gremlin.Net.Driver
         /// </exception>
         public static async Task<T> SubmitWithSingleResultAsync<T>(this IGremlinClient gremlinClient,
             string requestScript,
-            Dictionary<string, object> bindings = null)
+            Dictionary<string, object> bindings = null,
+            CancellationToken cancellationToken = default)
         {
-            var resultCollection = await gremlinClient.SubmitAsync<T>(requestScript, bindings).ConfigureAwait(false);
+            var resultCollection = await gremlinClient.SubmitAsync<T>(requestScript, bindings, cancellationToken)
+                .ConfigureAwait(false);
             return resultCollection.FirstOrDefault();
         }
 
@@ -68,15 +72,17 @@ namespace Gremlin.Net.Driver
         /// <typeparam name="T">The type of the expected result.</typeparam>
         /// <param name="gremlinClient">The <see cref="IGremlinClient" /> that submits the request.</param>
         /// <param name="requestMessage">The <see cref="RequestMessage" /> to send.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A single result received from the Gremlin Server.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
         public static async Task<T> SubmitWithSingleResultAsync<T>(this IGremlinClient gremlinClient,
-            RequestMessage requestMessage)
+            RequestMessage requestMessage, CancellationToken cancellationToken = default)
         {
-            var resultCollection = await gremlinClient.SubmitAsync<T>(requestMessage).ConfigureAwait(false);
+            var resultCollection =
+                await gremlinClient.SubmitAsync<T>(requestMessage, cancellationToken).ConfigureAwait(false);
             return resultCollection.FirstOrDefault();
         }
 
@@ -87,15 +93,16 @@ namespace Gremlin.Net.Driver
         /// <param name="gremlinClient">The <see cref="IGremlinClient" /> that submits the request.</param>
         /// <param name="requestScript">The Gremlin request script to send.</param>
         /// <param name="bindings">Bindings for parameters used in the requestScript.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
         public static async Task SubmitAsync(this IGremlinClient gremlinClient, string requestScript,
-            Dictionary<string, object> bindings = null)
+            Dictionary<string, object> bindings = null, CancellationToken cancellationToken = default)
         {
-            await gremlinClient.SubmitAsync<object>(requestScript, bindings).ConfigureAwait(false);
+            await gremlinClient.SubmitAsync<object>(requestScript, bindings, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -104,14 +111,16 @@ namespace Gremlin.Net.Driver
         /// </summary>
         /// <param name="gremlinClient">The <see cref="IGremlinClient" /> that submits the request.</param>
         /// <param name="requestMessage">The <see cref="RequestMessage" /> to send.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
-        public static async Task SubmitAsync(this IGremlinClient gremlinClient, RequestMessage requestMessage)
+        public static async Task SubmitAsync(this IGremlinClient gremlinClient, RequestMessage requestMessage,
+            CancellationToken cancellationToken = default)
         {
-            await gremlinClient.SubmitAsync<object>(requestMessage).ConfigureAwait(false);
+            await gremlinClient.SubmitAsync<object>(requestMessage, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -121,6 +130,7 @@ namespace Gremlin.Net.Driver
         /// <param name="gremlinClient">The <see cref="IGremlinClient" /> that submits the request.</param>
         /// <param name="requestScript">The Gremlin request script to send.</param>
         /// <param name="bindings">Bindings for parameters used in the requestScript.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A <see cref="ResultSet{T}"/> containing the data and status attributes returned from the server.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
@@ -128,13 +138,14 @@ namespace Gremlin.Net.Driver
         /// </exception>
         public static async Task<ResultSet<T>> SubmitAsync<T>(this IGremlinClient gremlinClient,
             string requestScript,
-            Dictionary<string, object> bindings = null)
+            Dictionary<string, object> bindings = null,
+            CancellationToken cancellationToken = default)
         {
             var msgBuilder = RequestMessage.Build(Tokens.OpsEval).AddArgument(Tokens.ArgsGremlin, requestScript);
             if (bindings != null)
                 msgBuilder.AddArgument(Tokens.ArgsBindings, bindings);
             var msg = msgBuilder.Create();
-            return await gremlinClient.SubmitAsync<T>(msg).ConfigureAwait(false);
+            return await gremlinClient.SubmitAsync<T>(msg, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/IConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/IConnection.cs
@@ -22,7 +22,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
@@ -32,7 +31,7 @@ namespace Gremlin.Net.Driver
     internal interface IConnection : IDisposable
     {
         Task ConnectAsync(CancellationToken cancellationToken);
-        Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage);
+        Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage, CancellationToken cancellationToken);
         int NrRequestsInFlight { get; }
         bool IsOpen { get; }
         Task CloseAsync();

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/IGremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/IGremlinClient.cs
@@ -22,7 +22,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 
@@ -38,11 +38,12 @@ namespace Gremlin.Net.Driver
         /// </summary>
         /// <typeparam name="T">The type of the expected results.</typeparam>
         /// <param name="requestMessage">The <see cref="RequestMessage" /> to send.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A <see cref="ResultSet{T}"/> containing the data and status attributes returned from the server.</returns>
         /// <exception cref="Exceptions.ResponseException">
         ///     Thrown when a response is received from Gremlin Server that indicates
         ///     that an error occurred.
         /// </exception>
-        Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage);
+        Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage, CancellationToken cancellationToken = default);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/IMessageSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/IMessageSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 
@@ -36,14 +37,18 @@ namespace Gremlin.Net.Driver
         ///     Serializes a <see cref="RequestMessage"/>.
         /// </summary>
         /// <param name="requestMessage">The <see cref="RequestMessage"/> to serialize.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The serialized message.</returns>
-        Task<byte[]> SerializeMessageAsync(RequestMessage requestMessage);
-        
+        Task<byte[]> SerializeMessageAsync(RequestMessage requestMessage,
+            CancellationToken cancellationToken = default);
+
         /// <summary>
         ///     Deserializes a <see cref="ResponseMessage{T}"/> from a byte array.
         /// </summary>
         /// <param name="message">The serialized message to deserialize.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The deserialized <see cref="ResponseMessage{T}"/>.</returns>
-        Task<ResponseMessage<List<object>>> DeserializeMessageAsync(byte[] message);
+        Task<ResponseMessage<List<object>>> DeserializeMessageAsync(byte[] message,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ProxyConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ProxyConnection.cs
@@ -22,7 +22,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
@@ -45,9 +44,10 @@ namespace Gremlin.Net.Driver
             await ProxiedConnection.ConnectAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage)
+        public async Task<ResultSet<T>> SubmitAsync<T>(RequestMessage requestMessage,
+            CancellationToken cancellationToken)
         {
-            return await ProxiedConnection.SubmitAsync<T>(requestMessage).ConfigureAwait(false);
+            return await ProxiedConnection.SubmitAsync<T>(requestMessage, cancellationToken).ConfigureAwait(false);
         }
 
         public int NrRequestsInFlight => ProxiedConnection.NrRequestsInFlight;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Process.Remote;
@@ -106,15 +107,18 @@ namespace Gremlin.Net.Driver.Remote
         ///     Submits <see cref="Bytecode" /> for evaluation to a remote Gremlin Server.
         /// </summary>
         /// <param name="bytecode">The <see cref="Bytecode" /> to submit.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A <see cref="ITraversal" /> allowing to access the results and side-effects.</returns>
-        public async Task<ITraversal<S, E>> SubmitAsync<S, E>(Bytecode bytecode)
+        public async Task<ITraversal<S, E>> SubmitAsync<S, E>(Bytecode bytecode,
+            CancellationToken cancellationToken = default)
         {
             var requestId = Guid.NewGuid();
-            var resultSet = await SubmitBytecodeAsync(requestId, bytecode).ConfigureAwait(false);
+            var resultSet = await SubmitBytecodeAsync(requestId, bytecode, cancellationToken).ConfigureAwait(false);
             return new DriverRemoteTraversal<S, E>(_client, requestId, resultSet);
         }
 
-        private async Task<IEnumerable<Traverser>> SubmitBytecodeAsync(Guid requestid, Bytecode bytecode)
+        private async Task<IEnumerable<Traverser>> SubmitBytecodeAsync(Guid requestid, Bytecode bytecode,
+            CancellationToken cancellationToken)
         {
             var requestMsg =
                 RequestMessage.Build(Tokens.OpsBytecode)
@@ -142,7 +146,7 @@ namespace Gremlin.Net.Driver.Remote
                 }
             }
             
-            return await _client.SubmitAsync<Traverser>(requestMsg.Create()).ConfigureAwait(false);
+            return await _client.SubmitAsync<Traverser>(requestMsg.Create(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ResponseHandlerForSingleRequestMessage.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ResponseHandlerForSingleRequestMessage.cs
@@ -56,5 +56,10 @@ namespace Gremlin.Net.Driver
         {
             _tcs.TrySetException(objException);
         }
+
+        public void Cancel()
+        {
+            _tcs.SetCanceled();
+        }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Gremlin.Net.Driver.Messages;
 
 namespace Gremlin.Net.Driver

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/WebSocketConnection.cs
@@ -30,7 +30,19 @@ using System.Threading.Tasks;
 
 namespace Gremlin.Net.Driver
 {
-    internal class WebSocketConnection : IDisposable
+    internal interface IWebSocketConnection : IDisposable
+    {
+        Task ConnectAsync(Uri uri, CancellationToken cancellationToken);
+        Task CloseAsync();
+        Task SendMessageAsync(byte[] message, CancellationToken cancellationToken);
+#if NET6_0_OR_GREATER
+        Task SendMessageUncompressedAsync(byte[] message, CancellationToken cancellationToken);
+#endif
+        Task<byte[]> ReceiveMessageAsync();
+        bool IsOpen { get; }
+    }
+
+    internal class WebSocketConnection : IWebSocketConnection
     {
         private const int ReceiveBufferSize = 1024;
         private const WebSocketMessageType MessageType = WebSocketMessageType.Binary;
@@ -75,19 +87,19 @@ namespace Gremlin.Net.Driver
                                             _client.State == WebSocketState.CloseSent;
         
 #if NET6_0_OR_GREATER
-        public async Task SendMessageUncompressedAsync(byte[] message)
+        public async Task SendMessageUncompressedAsync(byte[] message, CancellationToken cancellationToken)
         {
             await _client.SendAsync(new ArraySegment<byte>(message), MessageType,
                     WebSocketMessageFlags.EndOfMessage | WebSocketMessageFlags.DisableCompression,
-                    CancellationToken.None)
+                    cancellationToken)
                 .ConfigureAwait(false);
         }
 #endif
         
-        public async Task SendMessageAsync(byte[] message)
+        public async Task SendMessageAsync(byte[] message, CancellationToken cancellationToken)
         {
             await
-                _client.SendAsync(new ArraySegment<byte>(message), MessageType, true, CancellationToken.None)
+                _client.SendAsync(new ArraySegment<byte>(message), MessageType, true, cancellationToken)
                     .ConfigureAwait(false);
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Remote/IRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Remote/IRemoteConnection.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -36,8 +37,9 @@ namespace Gremlin.Net.Process.Remote
         ///     <see cref="ITraversal" />.
         /// </summary>
         /// <param name="bytecode">The <see cref="Bytecode" /> to send.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The <see cref="ITraversal" /> with the results and optional side-effects.</returns>
-        Task<ITraversal<S, E>> SubmitAsync<S, E>(Bytecode bytecode);
+        Task<ITraversal<S, E>> SubmitAsync<S, E>(Bytecode bytecode, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Creates a <see cref="RemoteTransaction" /> in the context of a <see cref="GraphTraversalSource" /> designed to work with

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteStrategy.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -46,14 +47,15 @@ namespace Gremlin.Net.Process.Remote
         /// <inheritdoc />
         public void Apply<S, E>(ITraversal<S, E> traversal)
         {
-            ApplyAsync(traversal).WaitUnwrap();
+            ApplyAsync(traversal, CancellationToken.None).WaitUnwrap();
         }
 
         /// <inheritdoc />
-        public async Task ApplyAsync<S, E>(ITraversal<S, E> traversal)
+        public async Task ApplyAsync<S, E>(ITraversal<S, E> traversal, CancellationToken cancellationToken = default)
         {
             if (traversal.Traversers != null) return;
-            var remoteTraversal = await _remoteConnection.SubmitAsync<S, E>(traversal.Bytecode).ConfigureAwait(false);
+            var remoteTraversal = await _remoteConnection.SubmitAsync<S, E>(traversal.Bytecode, cancellationToken)
+                .ConfigureAwait(false);
             traversal.Traversers = remoteTraversal.Traversers;
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteTransaction.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Remote/RemoteTransaction.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -68,9 +69,11 @@ namespace Gremlin.Net.Process.Remote
         /// <summary>
         ///     Commits the transaction.
         /// </summary>
-        public async Task CommitAsync()
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public async Task CommitAsync(CancellationToken cancellationToken = default)
         {
-            await _sessionBasedConnection.SubmitAsync<object, object>(GraphOp.Commit).ConfigureAwait(false);
+            await _sessionBasedConnection.SubmitAsync<object, object>(GraphOp.Commit, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ConnectedComponent.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ConnectedComponent.cs
@@ -22,10 +22,6 @@
 #endregion
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Gremlin.Net.Process.Traversal
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Process.Traversal
@@ -177,10 +178,10 @@ namespace Gremlin.Net.Process.Traversal
                 strategy.Apply(this);
         }
 
-        private async Task ApplyStrategiesAsync()
+        private async Task ApplyStrategiesAsync(CancellationToken cancellationToken)
         {
             foreach (var strategy in TraversalStrategies)
-                await strategy.ApplyAsync(this).ConfigureAwait(false);
+                await strategy.ApplyAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -264,10 +265,12 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         /// <typeparam name="TReturn">The return type of the <paramref name="callback" />.</typeparam>
         /// <param name="callback">The function to execute on the current traversal.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The result of the executed <paramref name="callback" />.</returns>
-        public async Task<TReturn> Promise<TReturn>(Func<ITraversal<S, E>, TReturn> callback)
+        public async Task<TReturn> Promise<TReturn>(Func<ITraversal<S, E>, TReturn> callback,
+            CancellationToken cancellationToken = default)
         {
-            await ApplyStrategiesAsync().ConfigureAwait(false);
+            await ApplyStrategiesAsync(cancellationToken).ConfigureAwait(false);
             return callback(this);
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Gremlin.Net.Driver.Remote;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure;

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/IO.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/IO.cs
@@ -22,10 +22,6 @@
 #endregion
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Gremlin.Net.Process.Traversal
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversal.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Process.Traversal
@@ -109,7 +110,9 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         /// <typeparam name="TReturn">The return type of the <paramref name="callback" />.</typeparam>
         /// <param name="callback">The function to execute on the current traversal.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The result of the executed <paramref name="callback" />.</returns>
-        Task<TReturn> Promise<TReturn>(Func<ITraversal<S, E>, TReturn> callback);
+        Task<TReturn> Promise<TReturn>(Func<ITraversal<S, E>, TReturn> callback,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversalStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ITraversalStrategy.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Process.Traversal
@@ -41,6 +42,7 @@ namespace Gremlin.Net.Process.Traversal
         ///     Applies the strategy to the given <see cref="ITraversal" /> asynchronously.
         /// </summary>
         /// <param name="traversal">The <see cref="ITraversal" /> the strategy should be applied to.</param>
-        Task ApplyAsync<S, E>(ITraversal<S, E> traversal);
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        Task ApplyAsync<S, E>(ITraversal<S, E> traversal, CancellationToken cancellationToken = default);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/PageRank.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/PageRank.cs
@@ -22,10 +22,6 @@
 #endregion
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Gremlin.Net.Process.Traversal
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/PeerPressure.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/PeerPressure.cs
@@ -22,10 +22,6 @@
 #endregion
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Gremlin.Net.Process.Traversal
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ShortestPath.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/ShortestPath.cs
@@ -22,10 +22,6 @@
 #endregion
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Gremlin.Net.Process.Traversal
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/AbstractTraversalStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/AbstractTraversalStrategy.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Process.Traversal.Strategy
@@ -99,7 +100,7 @@ namespace Gremlin.Net.Process.Traversal.Strategy
         }
 
         /// <inheritdoc />
-        public virtual Task ApplyAsync<S, E>(ITraversal<S, E> traversal)
+        public virtual Task ApplyAsync<S, E>(ITraversal<S, E> traversal, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/SeedStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Decoration/SeedStrategy.cs
@@ -21,8 +21,6 @@
 
 #endregion
 
-using System.Collections.Generic;
-
 namespace Gremlin.Net.Process.Traversal.Strategy.Decoration
 {
     /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/GraphBinaryReader.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/GraphBinaryReader.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary
@@ -41,32 +42,36 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         {
             _registry = registry ?? TypeSerializerRegistry.Instance;
         }
-        
+
         /// <summary>
         /// Reads only the value for a specific type <typeparamref name="T"/>.
         /// </summary>
         /// <param name="stream">The GraphBinary data to parse.</param>
         /// <param name="nullable">Whether or not the value can be null.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <typeparam name="T">The type of the object to read.</typeparam>
         /// <returns>The read value.</returns>
-        public async Task<object> ReadValueAsync<T>(Stream stream, bool nullable)
+        public async Task<object> ReadValueAsync<T>(Stream stream, bool nullable,
+            CancellationToken cancellationToken = default)
         {
             var typedSerializer = _registry.GetSerializerFor(typeof(T));
-            return await typedSerializer.ReadValueAsync(stream, this, nullable).ConfigureAwait(false);
+            return await typedSerializer.ReadValueAsync(stream, this, nullable, cancellationToken)
+                .ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Reads the type code, information and value with fully-qualified format.
         /// </summary>
         /// <param name="stream">The GraphBinary data to parse.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read value.</returns>
-        public async Task<object> ReadAsync(Stream stream)
+        public async Task<object> ReadAsync(Stream stream, CancellationToken cancellationToken = default)
         {
-            var type = DataType.FromTypeCode(await stream.ReadByteAsync().ConfigureAwait(false));
+            var type = DataType.FromTypeCode(await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false));
 
             if (type == DataType.UnspecifiedNull)
             {
-                await stream.ReadByteAsync().ConfigureAwait(false); // read value byte to advance the index
+                await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false); // read value byte to advance the index
                 return default; // should be null (TODO?)
             }
 
@@ -77,11 +82,12 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
             }
             else
             {
-                var customTypeName = (string)await ReadValueAsync<string>(stream, false).ConfigureAwait(false);
+                var customTypeName =
+                    (string)await ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false);
                 typeSerializer = _registry.GetSerializerForCustomType(customTypeName);
             }
             
-            return await typeSerializer.ReadAsync(stream, this).ConfigureAwait(false);
+            return await typeSerializer.ReadAsync(stream, this, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/ITypeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/ITypeSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary
@@ -42,8 +43,10 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// <param name="value">The value to write.</param>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="writer">A <see cref="GraphBinaryWriter"/> that can be used to write nested values.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer);
+        Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Writes the value to a stream, composed by the value flag and the sequence of bytes.
@@ -52,16 +55,19 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// <param name="stream">The stream to write to.</param>
         /// <param name="writer">A <see cref="GraphBinaryWriter"/> that can be used to write nested values.</param>
         /// <param name="nullable">Whether or not the value can be null.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable);
+        Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Reads the type information and value from the stream.
         /// </summary>
         /// <param name="stream">The GraphBinary data to parse.</param>
         /// <param name="reader">A <see cref="GraphBinaryReader"/> that can be used to read nested values.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read value.</returns>
-        Task<object> ReadAsync(Stream stream, GraphBinaryReader reader);
+        Task<object> ReadAsync(Stream stream, GraphBinaryReader reader, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Reads the value from the stream (not the type information).
@@ -69,7 +75,9 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// <param name="stream">The GraphBinary data to parse.</param>
         /// <param name="reader">A <see cref="GraphBinaryReader"/> that can be used to read nested values.</param>
         /// <param name="nullable">Whether or not the value can be null.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read value.</returns>
-        Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable);
+        Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/RequestMessageSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/RequestMessageSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 
@@ -38,14 +39,20 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// <param name="requestMessage">The message to serialize.</param>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="writer">A <see cref="GraphBinaryWriter"/> that can be used to write nested values.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        public async Task WriteValueAsync(RequestMessage requestMessage, MemoryStream stream, GraphBinaryWriter writer)
+        public async Task WriteValueAsync(RequestMessage requestMessage, MemoryStream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await stream.WriteByteAsync(GraphBinaryWriter.VersionByte).ConfigureAwait(false);
-            await writer.WriteValueAsync(requestMessage.RequestId, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(requestMessage.Operation, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(requestMessage.Processor, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(requestMessage.Arguments, stream, false).ConfigureAwait(false);
+            await stream.WriteByteAsync(GraphBinaryWriter.VersionByte, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(requestMessage.RequestId, stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            await writer.WriteValueAsync(requestMessage.Operation, stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            await writer.WriteValueAsync(requestMessage.Processor, stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            await writer.WriteValueAsync(requestMessage.Arguments, stream, false, cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/StreamExtensions.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/StreamExtensions.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary
@@ -38,20 +39,23 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="byte"/> to.</param>
         /// <param name="value">The <see cref="byte"/> to write.</param>
-        public static async Task WriteByteAsync(this Stream stream, byte value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteByteAsync(this Stream stream, byte value,
+            CancellationToken cancellationToken = default)
         {
-            await stream.WriteAsync(new[] {value}, 0, 1).ConfigureAwait(false);
+            await stream.WriteAsync(new[] {value}, 0, 1, cancellationToken).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         ///     Asynchronously reads a <see cref="byte"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="byte"/>.</returns>
-        public static async Task<byte> ReadByteAsync(this Stream stream)
+        public static async Task<byte> ReadByteAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
             var readBuffer = new byte[1];
-            await stream.ReadAsync(readBuffer, 0, 1).ConfigureAwait(false);
+            await stream.ReadAsync(readBuffer, 0, 1, cancellationToken).ConfigureAwait(false);
             return readBuffer[0];
         }
 
@@ -60,140 +64,162 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="int"/> to.</param>
         /// <param name="value">The <see cref="int"/> to write.</param>
-        public static async Task WriteIntAsync(this Stream stream, int value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteIntAsync(this Stream stream, int value,
+            CancellationToken cancellationToken = default)
         {
             var bytes = BitConverter.GetBytes(value);
-            await stream.WriteAsync(new[] { bytes[3], bytes[2], bytes[1], bytes[0] }, 0, 4).ConfigureAwait(false);
+            await stream.WriteAsync(new[] { bytes[3], bytes[2], bytes[1], bytes[0] }, 0, 4, cancellationToken).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         ///     Asynchronously reads an <see cref="int"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="int"/>.</returns>
-        public static async Task<int> ReadIntAsync(this Stream stream)
+        public static async Task<int> ReadIntAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
             var bytes = new byte[4];
-            await stream.ReadAsync(bytes, 0, 4).ConfigureAwait(false);
+            await stream.ReadAsync(bytes, 0, 4, cancellationToken).ConfigureAwait(false);
             return BitConverter.ToInt32(new []{bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
-        
+
         /// <summary>
         ///     Asynchronously writes a <see cref="long"/> to a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="long"/> to.</param>
         /// <param name="value">The <see cref="long"/> to write.</param>
-        public static async Task WriteLongAsync(this Stream stream, long value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteLongAsync(this Stream stream, long value,
+            CancellationToken cancellationToken = default)
         {
             var bytes = BitConverter.GetBytes(value);
             await stream
-                .WriteAsync(new[] {bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]}, 0,
-                    8).ConfigureAwait(false);
+                .WriteAsync(new[] { bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0] }, 0,
+                    8, cancellationToken).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         ///     Asynchronously reads a <see cref="long"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="long"/>.</returns>
-        public static async Task<long> ReadLongAsync(this Stream stream)
+        public static async Task<long> ReadLongAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
             var bytes = new byte[8];
-            await stream.ReadAsync(bytes, 0, 8).ConfigureAwait(false);
+            await stream.ReadAsync(bytes, 0, 8, cancellationToken).ConfigureAwait(false);
             return BitConverter.ToInt64(
                 new[] {bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
-        
+
         /// <summary>
         ///     Asynchronously writes a <see cref="float"/> to a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="float"/> to.</param>
         /// <param name="value">The <see cref="float"/> to write.</param>
-        public static async Task WriteFloatAsync(this Stream stream, float value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteFloatAsync(this Stream stream, float value,
+            CancellationToken cancellationToken = default)
         {
             var bytes = BitConverter.GetBytes(value);
-            await stream.WriteAsync(new[] { bytes[3], bytes[2], bytes[1], bytes[0] }, 0, 4).ConfigureAwait(false);
+            await stream.WriteAsync(new[] { bytes[3], bytes[2], bytes[1], bytes[0] }, 0, 4, cancellationToken)
+                .ConfigureAwait(false);
         }
-        
+
         /// <summary>
         ///     Asynchronously reads a <see cref="float"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="float"/>.</returns>
-        public static async Task<float> ReadFloatAsync(this Stream stream)
+        public static async Task<float> ReadFloatAsync(this Stream stream,
+            CancellationToken cancellationToken = default)
         {
             var bytes = new byte[4];
-            await stream.ReadAsync(bytes, 0, 4).ConfigureAwait(false);
+            await stream.ReadAsync(bytes, 0, 4, cancellationToken).ConfigureAwait(false);
             return BitConverter.ToSingle(new []{bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
-        
+
         /// <summary>
         ///     Asynchronously writes a <see cref="double"/> to a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="double"/> to.</param>
         /// <param name="value">The <see cref="double"/> to write.</param>
-        public static async Task WriteDoubleAsync(this Stream stream, double value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteDoubleAsync(this Stream stream, double value,
+            CancellationToken cancellationToken = default)
         {
             var bytes = BitConverter.GetBytes(value);
             await stream
                 .WriteAsync(new[] {bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]}, 0,
-                    8).ConfigureAwait(false);
+                    8, cancellationToken).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         ///     Asynchronously reads a <see cref="double"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="double"/>.</returns>
-        public static async Task<double> ReadDoubleAsync(this Stream stream)
+        public static async Task<double> ReadDoubleAsync(this Stream stream,
+            CancellationToken cancellationToken = default)
         {
             var bytes = new byte[8];
-            await stream.ReadAsync(bytes, 0, 8).ConfigureAwait(false);
+            await stream.ReadAsync(bytes, 0, 8, cancellationToken).ConfigureAwait(false);
             return BitConverter.ToDouble(
                 new[] {bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]}, 0);
         }
-        
+
         /// <summary>
         ///     Asynchronously writes a <see cref="short"/> to a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="short"/> to.</param>
         /// <param name="value">The <see cref="short"/> to write.</param>
-        public static async Task WriteShortAsync(this Stream stream, short value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteShortAsync(this Stream stream, short value,
+            CancellationToken cancellationToken = default)
         {
             var bytes = BitConverter.GetBytes(value);
-            await stream.WriteAsync(new[] {bytes[1], bytes[0]}, 0, 2).ConfigureAwait(false);
+            await stream.WriteAsync(new[] { bytes[1], bytes[0] }, 0, 2, cancellationToken).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         ///     Asynchronously reads a <see cref="short"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="short"/>.</returns>
-        public static async Task<short> ReadShortAsync(this Stream stream)
+        public static async Task<short> ReadShortAsync(this Stream stream,
+            CancellationToken cancellationToken = default)
         {
             var bytes = new byte[2];
-            await stream.ReadAsync(bytes, 0, 2).ConfigureAwait(false);
+            await stream.ReadAsync(bytes, 0, 2, cancellationToken).ConfigureAwait(false);
             return BitConverter.ToInt16(new []{bytes[1], bytes[0]}, 0);
         }
-        
+
         /// <summary>
         ///     Asynchronously writes a <see cref="bool"/> to a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="bool"/> to.</param>
         /// <param name="value">The <see cref="bool"/> to write.</param>
-        public static async Task WriteBoolAsync(this Stream stream, bool value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteBoolAsync(this Stream stream, bool value,
+            CancellationToken cancellationToken = default)
         {
-            await stream.WriteByteAsync((byte) (value ? 1 : 0)).ConfigureAwait(false);
+            await stream.WriteByteAsync((byte)(value ? 1 : 0), cancellationToken).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         ///     Asynchronously reads a <see cref="bool"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="bool"/>.</returns>
-        public static async Task<bool> ReadBoolAsync(this Stream stream)
+        public static async Task<bool> ReadBoolAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
-            var b = await stream.ReadByteAsync().ConfigureAwait(false);
+            var b = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             return b switch
             {
                 1 => true,
@@ -201,15 +227,17 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
                 _ => throw new IOException($"Cannot read byte {b} as a boolean.")
             };
         }
-        
+
         /// <summary>
         ///     Asynchronously writes a <see cref="T:byte[]"/> to a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to write the <see cref="T:byte[]"/> to.</param>
         /// <param name="value">The <see cref="T:byte[]"/> to write.</param>
-        public static async Task WriteAsync(this Stream stream, byte[] value)
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
+        public static async Task WriteAsync(this Stream stream, byte[] value,
+            CancellationToken cancellationToken = default)
         {
-            await stream.WriteAsync(value, 0, value.Length).ConfigureAwait(false);
+            await stream.WriteAsync(value, 0, value.Length, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -217,11 +245,13 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to read from.</param>
         /// <param name="count">The number of bytes to read.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read <see cref="T:byte[]"/>.</returns>
-        public static async Task<byte[]> ReadAsync(this Stream stream, int count)
+        public static async Task<byte[]> ReadAsync(this Stream stream, int count,
+            CancellationToken cancellationToken = default)
         {
             var buffer = new byte[count];
-            await stream.ReadAsync(buffer, 0, count).ConfigureAwait(false);
+            await stream.ReadAsync(buffer, 0, count, cancellationToken).ConfigureAwait(false);
             return buffer;
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ArraySerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ArraySerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -41,20 +42,22 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(TMember[] value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(TMember[] value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Length, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Length, stream, false, cancellationToken).ConfigureAwait(false);
             
             foreach (var item in value)
             {
-                await writer.WriteAsync(item, stream).ConfigureAwait(false);
+                await writer.WriteAsync(item, stream, cancellationToken).ConfigureAwait(false);
             }
         }
         
         /// <summary>
         /// Currently not supported as GraphBinary has no array data type.
         /// </summary>
-        protected override Task<TMember[]> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override Task<TMember[]> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException("Reading an array is not supported");
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BigDecimalSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BigDecimalSerializer.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using System.Numerics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -41,11 +42,12 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(decimal value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(decimal value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             var (unscaledValue, scale) = GetUnscaledValueAndScale(value);
-            await writer.WriteValueAsync(scale, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(unscaledValue, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(scale, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(unscaledValue, stream, false, cancellationToken).ConfigureAwait(false);
         }
         
         private static (BigInteger, int) GetUnscaledValueAndScale(decimal input)
@@ -74,10 +76,12 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task<decimal> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<decimal> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var scale = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
-            var unscaled = (BigInteger) await reader.ReadValueAsync<BigInteger>(stream, false).ConfigureAwait(false);
+            var scale = (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
+            var unscaled = (BigInteger)await reader.ReadValueAsync<BigInteger>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
 
             return ConvertScaleAndUnscaledValue(scale, unscaled);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BigIntegerSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BigIntegerSerializer.cs
@@ -24,6 +24,7 @@
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -41,18 +42,20 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(BigInteger value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(BigInteger value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             var bytes = value.ToByteArray().Reverse().ToArray();
-            await writer.WriteValueAsync(bytes.Length, stream, false).ConfigureAwait(false);
-            await stream.WriteAsync(bytes).ConfigureAwait(false);
+            await writer.WriteValueAsync(bytes.Length, stream, false, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<BigInteger> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<BigInteger> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var length = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
-            var bytes = await stream.ReadAsync(length).ConfigureAwait(false);
+            var length = (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
+            var bytes = await stream.ReadAsync(length, cancellationToken).ConfigureAwait(false);
             return new BigInteger(bytes.Reverse().ToArray());
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BindingSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BindingSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -40,17 +41,20 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Binding value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Binding value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Key, stream, false).ConfigureAwait(false);
-            await writer.WriteAsync(value.Value, stream).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Key, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(value.Value, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<Binding> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Binding> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var key = (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false);
-            var value = await reader.ReadAsync(stream).ConfigureAwait(false);
+            var key = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            var value = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             return new Binding(key, value);
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BulkSetSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/BulkSetSerializer.cs
@@ -23,6 +23,7 @@
 
 using System.Collections;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -45,21 +46,24 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         /// <summary>
         /// Currently not supported.
         /// </summary>
-        protected override Task WriteValueAsync(TList value, Stream stream, GraphBinaryWriter writer)
+        protected override Task WriteValueAsync(TList value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             throw new System.NotImplementedException("Writing a BulkSet is not supported");
         }
 
         /// <inheritdoc />
-        protected override async Task<TList> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<TList> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var length = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var length = (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
 
             var result = new TList();
             for (var i = 0; i < length; i++)
             {
-                var value = await reader.ReadAsync(stream).ConfigureAwait(false);
-                var bulk = (long) await reader.ReadValueAsync<long>(stream, false).ConfigureAwait(false);
+                var value = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+                var bulk = (long)await reader.ReadValueAsync<long>(stream, false, cancellationToken)
+                    .ConfigureAwait(false);
                 for (var j = 0; j < bulk; j++)
                 {
                     result.Add(value);

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ByteBufferSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ByteBufferSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -40,18 +41,20 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(byte[] value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(byte[] value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Length, stream, false).ConfigureAwait(false);
-            await stream.WriteAsync(value, 0, value.Length).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Length, stream, false, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(value, 0, value.Length, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<byte[]> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<byte[]> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var length = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var length = (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
             var buffer = new byte[length];
-            await stream.ReadAsync(buffer, 0, length).ConfigureAwait(false);
+            await stream.ReadAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
             return buffer;
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ByteCodeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ByteCodeSerializer.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -41,63 +42,74 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Bytecode value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Bytecode value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await WriteInstructionsAsync(value.StepInstructions, stream, writer).ConfigureAwait(false);
-            await WriteInstructionsAsync(value.SourceInstructions, stream, writer).ConfigureAwait(false);
+            await WriteInstructionsAsync(value.StepInstructions, stream, writer, cancellationToken)
+                .ConfigureAwait(false);
+            await WriteInstructionsAsync(value.SourceInstructions, stream, writer, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         private static async Task WriteInstructionsAsync(IReadOnlyCollection<Instruction> instructions, Stream stream,
-            GraphBinaryWriter writer)
+            GraphBinaryWriter writer, CancellationToken cancellationToken)
         {
-            await writer.WriteValueAsync(instructions.Count, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(instructions.Count, stream, false, cancellationToken).ConfigureAwait(false);
 
             foreach (var instruction in instructions)
             {
-                await writer.WriteValueAsync(instruction.OperatorName, stream, false).ConfigureAwait(false);
-                await WriteArgumentsAsync(instruction.Arguments, stream, writer).ConfigureAwait(false);
+                await writer.WriteValueAsync(instruction.OperatorName, stream, false, cancellationToken)
+                    .ConfigureAwait(false);
+                await WriteArgumentsAsync(instruction.Arguments, stream, writer, cancellationToken)
+                    .ConfigureAwait(false);
             }
         }
 
-        private static async Task WriteArgumentsAsync(object[] arguments, Stream stream, GraphBinaryWriter writer)
+        private static async Task WriteArgumentsAsync(object[] arguments, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken)
         {
-            await writer.WriteValueAsync(arguments.Length, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(arguments.Length, stream, false, cancellationToken).ConfigureAwait(false);
 
             foreach (var value in arguments)
             {
-                await writer.WriteAsync(value, stream).ConfigureAwait(false);
+                await writer.WriteAsync(value, stream, cancellationToken).ConfigureAwait(false);
             }
         }
 
         /// <inheritdoc />
-        protected override async Task<Bytecode> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Bytecode> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             var result = new Bytecode();
 
-            var stepsLength = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var stepsLength = (int) await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
             for (var i = 0; i < stepsLength; i++)
             {
-                result.AddStep((string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false),
-                    await ReadArgumentsAsync(stream, reader).ConfigureAwait(false));
+                result.AddStep(
+                    (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false),
+                    await ReadArgumentsAsync(stream, reader, cancellationToken).ConfigureAwait(false));
             }
             
-            var sourcesLength = await stream.ReadIntAsync().ConfigureAwait(false);
+            var sourcesLength = await stream.ReadIntAsync(cancellationToken).ConfigureAwait(false);
             for (var i = 0; i < sourcesLength; i++)
             {
-                result.AddSource((string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false),
-                    await ReadArgumentsAsync(stream, reader).ConfigureAwait(false));
+                result.AddSource(
+                    (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false),
+                    await ReadArgumentsAsync(stream, reader, cancellationToken).ConfigureAwait(false));
             }
             
             return result;
         }
 
-        private static async Task<object[]> ReadArgumentsAsync(Stream stream, GraphBinaryReader reader)
+        private static async Task<object[]> ReadArgumentsAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken)
         {
-            var valuesLength = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var valuesLength =
+                (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
             var values = new object[valuesLength];
             for (var i = 0; i < valuesLength; i++)
             {
-                values[i] = await reader.ReadAsync(stream).ConfigureAwait(false);
+                values[i] = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             }
             return values;
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ClassSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ClassSerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -41,16 +42,18 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(GremlinType value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(GremlinType value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Fqcn, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Fqcn, stream, false, cancellationToken).ConfigureAwait(false);
         }
 
         
         /// <summary>
         /// Currently not supported.
         /// </summary>
-        protected override Task<GremlinType> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override Task<GremlinType> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException("Reading a Class is not supported");
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/CustomTypeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/CustomTypeSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -40,15 +41,19 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         public DataType DataType => DataType.Custom;
 
         /// <inheritdoc />
-        public abstract Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer);
+        public abstract Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
-        public abstract Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable);
+        public abstract Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable,
+            CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
-        public abstract Task<object> ReadAsync(Stream stream, GraphBinaryReader reader);
+        public abstract Task<object> ReadAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
-        public abstract Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable);
+        public abstract Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/DateTimeOffsetSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/DateTimeOffsetSerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -49,15 +50,18 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(DateTimeOffset value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(DateTimeOffset value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await stream.WriteLongAsync(value.ToUnixTimeMilliseconds()).ConfigureAwait(false);
+            await stream.WriteLongAsync(value.ToUnixTimeMilliseconds(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<DateTimeOffset> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<DateTimeOffset> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            return DateTimeOffset.FromUnixTimeMilliseconds(await stream.ReadLongAsync().ConfigureAwait(false));
+            return DateTimeOffset.FromUnixTimeMilliseconds(await stream.ReadLongAsync(cancellationToken)
+                .ConfigureAwait(false));
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/DurationSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/DurationSerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -40,17 +41,19 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(TimeSpan value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(TimeSpan value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await stream.WriteLongAsync((long) value.TotalSeconds).ConfigureAwait(false);
-            await stream.WriteIntAsync(value.Milliseconds * 1_000_000).ConfigureAwait(false);
+            await stream.WriteLongAsync((long) value.TotalSeconds, cancellationToken).ConfigureAwait(false);
+            await stream.WriteIntAsync(value.Milliseconds * 1_000_000, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<TimeSpan> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<TimeSpan> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var seconds = await stream.ReadLongAsync().ConfigureAwait(false);
-            var nanoseconds = await stream.ReadIntAsync().ConfigureAwait(false);
+            var seconds = await stream.ReadLongAsync(cancellationToken).ConfigureAwait(false);
+            var nanoseconds = await stream.ReadIntAsync(cancellationToken).ConfigureAwait(false);
 
             return TimeSpan.FromSeconds(seconds) + TimeSpan.FromMilliseconds(nanoseconds / 1_000_000);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/EdgeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/EdgeSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -39,39 +40,42 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Edge value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Edge value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteAsync(value.Id, stream).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.Label, stream, false).ConfigureAwait(false);
+            await writer.WriteAsync(value.Id, stream, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Label, stream, false, cancellationToken).ConfigureAwait(false);
             
-            await writer.WriteAsync(value.InV.Id, stream).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.InV.Label, stream, false).ConfigureAwait(false);
-            await writer.WriteAsync(value.OutV.Id, stream).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.OutV.Label, stream, false).ConfigureAwait(false);
+            await writer.WriteAsync(value.InV.Id, stream, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.InV.Label, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(value.OutV.Id, stream, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.OutV.Label, stream, false, cancellationToken).ConfigureAwait(false);
 
             // Placeholder for the parent vertex
-            await writer.WriteAsync(null, stream).ConfigureAwait(false);
+            await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
             
             // placeholder for the properties
-            await writer.WriteAsync(null, stream).ConfigureAwait(false);
+            await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<Edge> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Edge> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var id = await reader.ReadAsync(stream).ConfigureAwait(false);
-            var label = (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false);
+            var id = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+            var label = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
 
-            var inV = new Vertex(await reader.ReadAsync(stream).ConfigureAwait(false),
-                (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false));
-            var outV = new Vertex(await reader.ReadAsync(stream).ConfigureAwait(false),
-                (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false));
+            var inV = new Vertex(await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false),
+                (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false));
+            var outV = new Vertex(await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false),
+                (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false));
             
             // discard possible parent vertex
-            await reader.ReadAsync(stream).ConfigureAwait(false);
+            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
             // discard possible properties
-            await reader.ReadAsync(stream).ConfigureAwait(false);
+            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
             return new Edge(id, outV, label, inV);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/EnumSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/EnumSerializer.cs
@@ -23,8 +23,10 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
+using Barrier = Gremlin.Net.Process.Traversal.Barrier;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
 {
@@ -34,7 +36,7 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
     public static class EnumSerializers
     {
         /// <summary>
-        /// A serializer for <see cref="Barrier"/> values.
+        /// A serializer for <see cref="Process.Traversal.Barrier"/> values.
         /// </summary>
         public static readonly EnumSerializer<Barrier> BarrierSerializer =
             new EnumSerializer<Barrier>(DataType.Barrier, Barrier.GetByValue);
@@ -109,15 +111,17 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(TEnum value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(TEnum value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteAsync(value.EnumValue, stream).ConfigureAwait(false);
+            await writer.WriteAsync(value.EnumValue, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<TEnum> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<TEnum> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var enumValue = (string) await reader.ReadAsync(stream).ConfigureAwait(false);
+            var enumValue = (string) await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             return _readFunc.Invoke(enumValue);
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/LambdaSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/LambdaSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -40,21 +41,26 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(ILambda value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(ILambda value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Language, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.LambdaExpression, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.Arguments, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Language, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.LambdaExpression, stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Arguments, stream, false, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<ILambda> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<ILambda> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var language = (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false);
-            var expression = (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false);
+            var language = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            var expression = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
             
             // discard the arguments
-            await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
 
             return new StringBasedLambda(expression, language);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ListSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/ListSerializer.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -41,24 +42,26 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(IList<TMember> value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(IList<TMember> value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Count, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Count, stream, false, cancellationToken).ConfigureAwait(false);
             
             foreach (var item in value)
             {
-                await writer.WriteAsync(item, stream).ConfigureAwait(false);
+                await writer.WriteAsync(item, stream, cancellationToken).ConfigureAwait(false);
             }
         }
 
         /// <inheritdoc />
-        protected override async Task<IList<TMember>> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<IList<TMember>> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var length = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var length = (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
             var result = new List<TMember>(length);
             for (var i = 0; i < length; i++)
             {
-                result.Add((TMember) await reader.ReadAsync(stream).ConfigureAwait(false));
+                result.Add((TMember) await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false));
             }
 
             return result;

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/MapSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/MapSerializer.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -42,27 +43,29 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(IDictionary<TKey, TValue> value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(IDictionary<TKey, TValue> value, Stream stream,
+            GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Count, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Count, stream, false, cancellationToken).ConfigureAwait(false);
 
             foreach (var key in value.Keys)
             {
-                await writer.WriteAsync(key, stream).ConfigureAwait(false);
-                await writer.WriteAsync(value[key], stream).ConfigureAwait(false);
+                await writer.WriteAsync(key, stream, cancellationToken).ConfigureAwait(false);
+                await writer.WriteAsync(value[key], stream, cancellationToken).ConfigureAwait(false);
             }
         }
 
         /// <inheritdoc />
-        protected override async Task<IDictionary<TKey, TValue>> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<IDictionary<TKey, TValue>> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var length = await stream.ReadIntAsync().ConfigureAwait(false);
+            var length = await stream.ReadIntAsync(cancellationToken).ConfigureAwait(false);
             var result = new Dictionary<TKey, TValue>(length);
             
             for (var i = 0; i < length; i++)
             {
-                var key = (TKey) await reader.ReadAsync(stream).ConfigureAwait(false);
-                var value = (TValue) await reader.ReadAsync(stream).ConfigureAwait(false);
+                var key = (TKey) await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+                var value = (TValue) await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
                 result.Add(key, value);
             }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/PSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/PSerializer.cs
@@ -24,6 +24,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -42,36 +43,40 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(P value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(P value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             ICollection args = value.Value is ICollection ? value.Value : new List<object> {value.Value};
 
             var argsLength = value.Other == null ? args.Count : args.Count + 1;
-            
-            await writer.WriteValueAsync(value.OperatorName, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(argsLength, stream, false).ConfigureAwait(false);
+
+            await writer.WriteValueAsync(value.OperatorName, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(argsLength, stream, false, cancellationToken).ConfigureAwait(false);
 
             foreach (var arg in args)
             {
-                await writer.WriteAsync(arg, stream).ConfigureAwait(false);
+                await writer.WriteAsync(arg, stream, cancellationToken).ConfigureAwait(false);
             }
 
             if (value.Other != null)
             {
-                await writer.WriteAsync(value.Other, stream).ConfigureAwait(false);
+                await writer.WriteAsync(value.Other, stream, cancellationToken).ConfigureAwait(false);
             }
         }
 
         /// <inheritdoc />
-        protected override async Task<P> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<P> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var operatorName = (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false);
-            var argsLength = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var operatorName = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            var argsLength =
+                (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
 
             var args = new object[argsLength];
             for (var i = 0; i < argsLength; i++)
             {
-                args[i] = await reader.ReadAsync(stream).ConfigureAwait(false);
+                args[i] = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             }
 
             if (operatorName == "and" || operatorName == "or")

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/PathSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/PathSerializer.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -40,16 +41,19 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Path value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Path value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteAsync(value.Labels, stream).ConfigureAwait(false);
-            await writer.WriteAsync(value.Objects, stream).ConfigureAwait(false);
+            await writer.WriteAsync(value.Labels, stream, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(value.Objects, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<Path> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Path> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var readLabelObjects = (List<object>) await reader.ReadAsync(stream).ConfigureAwait(false);
+            var readLabelObjects =
+                (List<object>)await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             var labels = new List<ISet<string>>();
             foreach (var labelObjectList in readLabelObjects)
             {
@@ -61,7 +65,7 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
                 labels.Add(labelSet);
             }
             
-            var objects = (List<object>) await reader.ReadAsync(stream).ConfigureAwait(false);
+            var objects = (List<object>) await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             
             return new Path(labels, objects);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/PropertySerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/PropertySerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -39,23 +40,26 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Property value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Property value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Key, stream, false).ConfigureAwait(false);
-            await writer.WriteAsync(value.Value, stream).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Key, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(value.Value, stream, cancellationToken).ConfigureAwait(false);
             
             // placeholder for the parent element
-            await writer.WriteAsync(null, stream).ConfigureAwait(false);
+            await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<Property> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Property> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var p = new Property((string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false),
-                await reader.ReadAsync(stream).ConfigureAwait(false));
+            var p = new Property(
+                (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false),
+                await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false));
 
             // discard parent element
-            await reader.ReadAsync(stream).ConfigureAwait(false);
+            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             
             return p;
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/SetSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/SetSerializer.cs
@@ -25,6 +25,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -45,27 +46,29 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(TSet value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(TSet value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             var enumerable = (IEnumerable) value;
             var list = enumerable.Cast<object>().ToList();
 
-            await writer.WriteValueAsync(list.Count, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(list.Count, stream, false, cancellationToken).ConfigureAwait(false);
             
             foreach (var item in list)
             {
-                await writer.WriteAsync(item, stream).ConfigureAwait(false);
+                await writer.WriteAsync(item, stream, cancellationToken).ConfigureAwait(false);
             }
         }
 
         /// <inheritdoc />
-        protected override async Task<TSet> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<TSet> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var length = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var length = (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
             var result = new TSet();
             for (var i = 0; i < length; i++)
             {
-                result.Add((TMember) await reader.ReadAsync(stream).ConfigureAwait(false));
+                result.Add((TMember) await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false));
             }
 
             return result;

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/SimpleTypeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/SimpleTypeSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -45,13 +46,15 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         public DataType DataType { get; }
 
         /// <inheritdoc />
-        public async Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer)
+        public async Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await WriteValueAsync((T) value, stream, writer, true).ConfigureAwait(false);
+            await WriteValueAsync((T) value, stream, writer, true, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable)
+        public async Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable,
+            CancellationToken cancellationToken = default)
         {
             if (value == null)
             {
@@ -60,16 +63,16 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
                     throw new IOException("Unexpected null value when nullable is false");
                 }
 
-                await writer.WriteValueFlagNullAsync(stream).ConfigureAwait(false);
+                await writer.WriteValueFlagNullAsync(stream, cancellationToken).ConfigureAwait(false);
                 return;
             }
 
             if (nullable)
             {
-                await writer.WriteValueFlagNoneAsync(stream).ConfigureAwait(false);
+                await writer.WriteValueFlagNoneAsync(stream, cancellationToken).ConfigureAwait(false);
             }
 
-            await WriteValueAsync((T) value, stream, writer).ConfigureAwait(false);
+            await WriteValueAsync((T) value, stream, writer, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -78,28 +81,32 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         /// <param name="value">The value to write.</param>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="writer">A <see cref="GraphBinaryWriter"/>.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        protected abstract Task WriteValueAsync(T value, Stream stream, GraphBinaryWriter writer);
+        protected abstract Task WriteValueAsync(T value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
-        public async Task<object> ReadAsync(Stream stream, GraphBinaryReader reader)
+        public async Task<object> ReadAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            return await ReadValueAsync(stream, reader, true).ConfigureAwait(false);
+            return await ReadValueAsync(stream, reader, true, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable)
+        public async Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable,
+            CancellationToken cancellationToken = default)
         {
             if (nullable)
             {
-                var valueFlag = await stream.ReadByteAsync().ConfigureAwait(false);
+                var valueFlag = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
                 if ((valueFlag & 1) == 1)
                 {
                     return null;
                 }
             }
 
-            return await ReadValueAsync(stream, reader).ConfigureAwait(false);
+            return await ReadValueAsync(stream, reader, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -107,7 +114,9 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         /// </summary>
         /// <param name="stream">The GraphBinary data to parse.</param>
         /// <param name="reader">A <see cref="GraphBinaryReader"/>.</param>
+        /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read value.</returns>
-        protected abstract Task<T> ReadValueAsync(Stream stream, GraphBinaryReader reader);
+        protected abstract Task<T> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/SingleTypeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/SingleTypeSerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -37,47 +38,54 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         /// A serializer for <see cref="int"/> values.
         /// </summary>
         public static readonly SingleTypeSerializer<int> IntSerializer = new SingleTypeSerializer<int>(DataType.Int,
-            (value, stream) => stream.WriteIntAsync(value), stream => stream.ReadIntAsync());
-        
+            (value, stream, cancellationToken) => stream.WriteIntAsync(value, cancellationToken),
+            (stream, cancellationToken) => stream.ReadIntAsync(cancellationToken));
+
         /// <summary>
         /// A serializer for <see cref="long"/> values.
         /// </summary>
         public static readonly SingleTypeSerializer<long> LongSerializer = new SingleTypeSerializer<long>(DataType.Long,
-            (value, stream) => stream.WriteLongAsync(value), stream => stream.ReadLongAsync());
+            (value, stream, cancellationToken) => stream.WriteLongAsync(value, cancellationToken),
+            (stream, cancellationToken) => stream.ReadLongAsync(cancellationToken));
 
         /// <summary>
         /// A serializer for <see cref="double"/> values.
         /// </summary>
         public static readonly SingleTypeSerializer<double> DoubleSerializer =
-            new SingleTypeSerializer<double>(DataType.Double, (value, stream) => stream.WriteDoubleAsync(value),
-                stream => stream.ReadDoubleAsync());
+            new SingleTypeSerializer<double>(DataType.Double,
+                (value, stream, cancellationToken) => stream.WriteDoubleAsync(value, cancellationToken),
+                (stream, cancellationToken) => stream.ReadDoubleAsync(cancellationToken));
 
         /// <summary>
         /// A serializer for <see cref="float"/> values.
         /// </summary>
         public static readonly SingleTypeSerializer<float> FloatSerializer =
-            new SingleTypeSerializer<float>(DataType.Float, (value, stream) => stream.WriteFloatAsync(value),
-                stream => stream.ReadFloatAsync());
+            new SingleTypeSerializer<float>(DataType.Float,
+                (value, stream, cancellationToken) => stream.WriteFloatAsync(value, cancellationToken),
+                (stream, cancellationToken) => stream.ReadFloatAsync(cancellationToken));
 
         /// <summary>
         /// A serializer for <see cref="short"/> values.
         /// </summary>
         public static readonly SingleTypeSerializer<short> ShortSerializer =
-            new SingleTypeSerializer<short>(DataType.Short, (value, stream) => stream.WriteShortAsync(value),
-                stream => stream.ReadShortAsync());
+            new SingleTypeSerializer<short>(DataType.Short,
+                (value, stream, cancellationToken) => stream.WriteShortAsync(value, cancellationToken),
+                (stream, cancellationToken) => stream.ReadShortAsync(cancellationToken));
 
         /// <summary>
         /// A serializer for <see cref="bool"/> values.
         /// </summary>
         public static readonly SingleTypeSerializer<bool> BooleanSerializer =
-            new SingleTypeSerializer<bool>(DataType.Boolean, (value, stream) => stream.WriteBoolAsync(value),
-                stream => stream.ReadBoolAsync());
+            new SingleTypeSerializer<bool>(DataType.Boolean,
+                (value, stream, cancellationToken) => stream.WriteBoolAsync(value, cancellationToken),
+                (stream, cancellationToken) => stream.ReadBoolAsync(cancellationToken));
 
         /// <summary>
         /// A serializer for <see cref="byte"/> values.
         /// </summary>
         public static readonly SingleTypeSerializer<byte> ByteSerializer = new SingleTypeSerializer<byte>(DataType.Byte,
-            (value, stream) => stream.WriteByteAsync(value), stream => stream.ReadByteAsync());
+            (value, stream, cancellationToken) => stream.WriteByteAsync(value, cancellationToken),
+            (stream, cancellationToken) => stream.ReadByteAsync(cancellationToken));
     }
     
     /// <summary>
@@ -86,10 +94,11 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
     /// </summary>
     public class SingleTypeSerializer<T> : SimpleTypeSerializer<T>
     {
-        private readonly Func<T, Stream, Task> _writeFunc;
-        private readonly Func<Stream, Task<T>> _readFunc;
+        private readonly Func<T, Stream, CancellationToken, Task> _writeFunc;
+        private readonly Func<Stream, CancellationToken, Task<T>> _readFunc;
 
-        internal SingleTypeSerializer(DataType dataType, Func<T, Stream, Task> writeFunc, Func<Stream, Task<T>> readFunc)
+        internal SingleTypeSerializer(DataType dataType, Func<T, Stream, CancellationToken, Task> writeFunc,
+            Func<Stream, CancellationToken, Task<T>> readFunc)
             : base(dataType)
         {
             _writeFunc = writeFunc;
@@ -97,15 +106,17 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(T value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(T value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await _writeFunc.Invoke(value, stream).ConfigureAwait(false);
+            await _writeFunc.Invoke(value, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<T> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<T> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            return await _readFunc.Invoke(stream).ConfigureAwait(false);
+            return await _readFunc.Invoke(stream, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/StringSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/StringSerializer.cs
@@ -23,6 +23,7 @@
 
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -40,19 +41,21 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(string value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(string value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             var bytes = Encoding.UTF8.GetBytes(value);
-            await writer.WriteValueAsync(bytes.Length, stream, false).ConfigureAwait(false);
-            await stream.WriteAsync(bytes).ConfigureAwait(false);
+            await writer.WriteValueAsync(bytes.Length, stream, false, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<string> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<string> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var length = (int) await reader.ReadValueAsync<int>(stream, false).ConfigureAwait(false);
+            var length = (int)await reader.ReadValueAsync<int>(stream, false, cancellationToken).ConfigureAwait(false);
             var bytes = new byte[length];
-            await stream.ReadAsync(bytes, 0, length).ConfigureAwait(false);
+            await stream.ReadAsync(bytes, 0, length, cancellationToken).ConfigureAwait(false);
             return Encoding.UTF8.GetString(bytes);
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TraversalSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TraversalSerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -41,15 +42,17 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(ITraversal value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(ITraversal value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Bytecode, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Bytecode, stream, false, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Currently not supported.
         /// </summary>
-        protected override Task<ITraversal> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override Task<ITraversal> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException("Reading a traversal is not supported");
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TraversalStrategySerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TraversalStrategySerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal.Strategy;
 
@@ -42,16 +43,18 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
 
         /// <inheritdoc />
         protected override async Task WriteValueAsync(AbstractTraversalStrategy value, Stream stream,
-            GraphBinaryWriter writer)
+            GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(GremlinType.FromFqcn(value.Fqcn), stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.Configuration, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(GremlinType.FromFqcn(value.Fqcn), stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Configuration, stream, false, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Currently not supported.
         /// </summary>
-        protected override Task<AbstractTraversalStrategy> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override Task<AbstractTraversalStrategy> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException("Reading a TraversalStrategy is not supported");
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TraverserSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TraverserSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -40,17 +41,19 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Traverser value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Traverser value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.Bulk, stream, false).ConfigureAwait(false);
-            await writer.WriteAsync(value.Object, stream).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Bulk, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(value.Object, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<Traverser> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Traverser> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var bulk = (long) await reader.ReadValueAsync<long>(stream, false).ConfigureAwait(false);
-            var v = await reader.ReadAsync(stream).ConfigureAwait(false);
+            var bulk = (long)await reader.ReadValueAsync<long>(stream, false, cancellationToken).ConfigureAwait(false);
+            var v = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             return new Traverser(v, bulk);
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TypeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/TypeSerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal.Strategy;
 
@@ -42,12 +43,14 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Type value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Type value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             if (typeof(AbstractTraversalStrategy).IsAssignableFrom(value))
             {
                 var strategyInstance = (AbstractTraversalStrategy) Activator.CreateInstance(value);
-                await writer.WriteValueAsync(strategyInstance.Fqcn, stream, false).ConfigureAwait(false);
+                await writer.WriteValueAsync(strategyInstance.Fqcn, stream, false, cancellationToken)
+                    .ConfigureAwait(false);
             }
             else
             {
@@ -58,7 +61,8 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         /// <summary>
         /// Currently not supported.
         /// </summary>
-        protected override Task<Type> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override Task<Type> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException("Reading a Type is not supported");
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/UuidSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/UuidSerializer.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -40,67 +41,69 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Guid value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Guid value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             var bytes = value.ToByteArray();
             
             // first 4 bytes in reverse order:
-            await stream.WriteByteAsync(bytes[3]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[2]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[1]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[0]).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[3], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[2], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[1], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[0], cancellationToken).ConfigureAwait(false);
             
             // 2 bytes in reverse order:
-            await stream.WriteByteAsync(bytes[5]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[4]).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[5], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[4], cancellationToken).ConfigureAwait(false);
             
             // 3 bytes in reverse order:
-            await stream.WriteByteAsync(bytes[7]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[6]).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[7], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[6], cancellationToken).ConfigureAwait(false);
             
             // 3 bytes:
-            await stream.WriteByteAsync(bytes[8]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[9]).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[8], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[9], cancellationToken).ConfigureAwait(false);
             
             // last 6 bytes:
-            await stream.WriteByteAsync(bytes[10]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[11]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[12]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[13]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[14]).ConfigureAwait(false);
-            await stream.WriteByteAsync(bytes[15]).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[10], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[11], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[12], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[13], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[14], cancellationToken).ConfigureAwait(false);
+            await stream.WriteByteAsync(bytes[15], cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<Guid> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Guid> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             var bytes = new byte[16];
 
             // first 4 bytes in reverse order:
-            bytes[3] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[2] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[1] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[0] = await stream.ReadByteAsync().ConfigureAwait(false);
+            bytes[3] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[2] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[1] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[0] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             
             // 2 bytes in reverse order:
-            bytes[5] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[4] = await stream.ReadByteAsync().ConfigureAwait(false);
+            bytes[5] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[4] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             
             // 2 bytes in reverse order:
-            bytes[7] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[6] = await stream.ReadByteAsync().ConfigureAwait(false);
+            bytes[7] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[6] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             
             // 2 bytes:
-            bytes[8] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[9] = await stream.ReadByteAsync().ConfigureAwait(false);
+            bytes[8] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[9] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             
             // last 6 bytes:
-            bytes[10] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[11] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[12] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[13] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[14] = await stream.ReadByteAsync().ConfigureAwait(false);
-            bytes[15] = await stream.ReadByteAsync().ConfigureAwait(false);
+            bytes[10] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[11] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[12] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[13] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[14] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            bytes[15] = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             
             return new Guid(bytes);
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexPropertySerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexPropertySerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -39,32 +40,34 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(VertexProperty value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(VertexProperty value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteAsync(value.Id, stream).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.Label, stream, false).ConfigureAwait(false);
-            await writer.WriteAsync(value.Value, stream).ConfigureAwait(false);
+            await writer.WriteAsync(value.Id, stream, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Label, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(value.Value, stream, cancellationToken).ConfigureAwait(false);
             
             // placeholder for the parent vertex
-            await writer.WriteAsync(null, stream).ConfigureAwait(false);
+            await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
             
             // placeholder for properties
-            await writer.WriteAsync(null, stream).ConfigureAwait(false);
+            await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
 
         }
 
         /// <inheritdoc />
-        protected override async Task<VertexProperty> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<VertexProperty> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var vp = new VertexProperty(await reader.ReadAsync(stream).ConfigureAwait(false),
-                (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false),
-                await reader.ReadAsync(stream).ConfigureAwait(false));
+            var vp = new VertexProperty(await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false),
+                (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false),
+                await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false));
 
             // discard the parent vertex
-            await reader.ReadAsync(stream).ConfigureAwait(false);
+            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             
             // discard the properties
-            await reader.ReadAsync(stream).ConfigureAwait(false);
+            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             
             return vp;
         }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexSerializer.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Gremlin.Net.Structure.IO.GraphBinary.Types
@@ -39,22 +40,24 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        protected override async Task WriteValueAsync(Vertex value, Stream stream, GraphBinaryWriter writer)
+        protected override async Task WriteValueAsync(Vertex value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
-            await writer.WriteAsync(value.Id, stream).ConfigureAwait(false);
-            await writer.WriteValueAsync(value.Label, stream, false).ConfigureAwait(false);
-            await writer.WriteAsync(null, stream).ConfigureAwait(false);
+            await writer.WriteAsync(value.Id, stream, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.Label, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override async Task<Vertex> ReadValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<Vertex> ReadValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
 
-            var v = new Vertex(await reader.ReadAsync(stream).ConfigureAwait(false),
-                (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false));
+            var v = new Vertex(await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false),
+                (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken).ConfigureAwait(false));
             
             // discard properties
-            await reader.ReadAsync(stream).ConfigureAwait(false);
+            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             return v;
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONMessageSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONMessageSerializer.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Messages;
@@ -57,8 +58,10 @@ namespace Gremlin.Net.Structure.IO.GraphSON
         }
 
         /// <inheritdoc />
-        public virtual Task<byte[]> SerializeMessageAsync(RequestMessage requestMessage)
+        public virtual Task<byte[]> SerializeMessageAsync(RequestMessage requestMessage,
+            CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.CanBeCanceled) cancellationToken.ThrowIfCancellationRequested();
             var graphSONMessage = _graphSONWriter.WriteObject(requestMessage);
             return Task.FromResult(Encoding.UTF8.GetBytes(MessageWithHeader(graphSONMessage)));
         }
@@ -69,9 +72,11 @@ namespace Gremlin.Net.Structure.IO.GraphSON
         }
 
         /// <inheritdoc />
-        public virtual Task<ResponseMessage<List<object>>> DeserializeMessageAsync(byte[] message)
+        public virtual Task<ResponseMessage<List<object>>> DeserializeMessageAsync(byte[] message,
+            CancellationToken cancellationToken = default)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
+            if (cancellationToken.CanBeCanceled) cancellationToken.ThrowIfCancellationRequested();
             if (message.Length == 0) return Task.FromResult<ResponseMessage<List<object>>>(null);
             
             var reader = new Utf8JsonReader(message);

--- a/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Program.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Program.cs
@@ -21,9 +21,6 @@
 
 #endregion
 
-using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
 
 namespace Gremlin.Net.Benchmarks

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Remote;
 using Gremlin.Net.Process.Traversal;
 // tag::traversalSourceUsing[]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientAuthenticationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientAuthenticationTests.cs
@@ -22,7 +22,6 @@
 #endregion
 
 using System;
-using System.Net.Http;
 using System.Net.WebSockets;
 using System.Threading.Tasks;
 using System.Net.Security;

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
@@ -32,7 +32,6 @@ using System;
 using System.Collections.Generic;
 using Gremlin.Net.Structure;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Process.Traversal.Strategy.Optimization;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 
 namespace Gremlin.Net.IntegrationTest.Gherkin

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
@@ -43,17 +43,17 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
             _messageSerializer = messageSerializer ?? new GraphSON3MessageSerializer();
         }
         
-        public IRemoteConnection CreateRemoteConnection()
+        public IRemoteConnection CreateRemoteConnection(int connectionPoolSize = 2)
         {
             // gmodern is the standard test traversalsource that the main body of test uses
-            return CreateRemoteConnection("gmodern");
+            return CreateRemoteConnection("gmodern", connectionPoolSize);
         }
 
-        public IRemoteConnection CreateRemoteConnection(string traversalSource)
+        public IRemoteConnection CreateRemoteConnection(string traversalSource, int connectionPoolSize = 2)
         {
             var c = new DriverRemoteConnectionImpl(
                 new GremlinClient(new GremlinServer(TestHost, TestPort), _messageSerializer,
-                    connectionPoolSettings: new ConnectionPoolSettings {PoolSize = 2}),
+                    connectionPoolSettings: new ConnectionPoolSettings { PoolSize = connectionPoolSize }),
                 traversalSource);
             _connections.Add(c);
             return c;

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionPoolTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionPoolTests.cs
@@ -187,7 +187,7 @@ namespace Gremlin.Net.UnitTest.Driver
             fakedConnection.Setup(f => f.IsOpen).Returns(false);
             mockedConnectionFactory.Setup(m => m.CreateConnection()).Returns(OpenConnection);
 
-            await returnedConnection.SubmitAsync<bool>(null);
+            await returnedConnection.SubmitAsync<bool>(null, CancellationToken.None);
             returnedConnection.Dispose();
 
             Assert.Equal(1, pool.NrConnections);

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionTests.cs
@@ -22,13 +22,14 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Exceptions;
 using Gremlin.Net.Driver.Messages;
-using Gremlin.Net.Structure.IO.GraphSON;
+using Gremlin.Net.Structure.IO.GraphBinary;
 using Moq;
 using Xunit;
 
@@ -47,7 +48,7 @@ namespace Gremlin.Net.UnitTest.Driver
                 .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
 
             Uri uri = new Uri("wss://localhost:8182");
-            Connection connection = GetConnection(mockedClientWebSocket, uri);
+            Connection connection = GetConnection(mockedClientWebSocket, uri: uri);
 
             await connection.ConnectAsync(CancellationToken.None);
 
@@ -97,13 +98,12 @@ namespace Gremlin.Net.UnitTest.Driver
             // This is to test that race bugs don't get introduced which would cause submitted requests to hang if the
             // connection is being closed/aborted or is not connected. In these cases, WebSocket.SendAsync should throw for the underlying
             // websocket is not open and the caller should be notified of that failure.
-            Uri uri = new Uri("wss://localhost:8182");
             var mockedClientWebSocket = new Mock<IClientWebSocket>();
 
             mockedClientWebSocket
                 .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
 
-            Connection connection = GetConnection(mockedClientWebSocket, uri);
+            Connection connection = GetConnection(mockedClientWebSocket);
             RequestMessage request = RequestMessage.Build("gremlin").Create();
 
             // Simulate the SendAsync exception behavior if the underlying websocket is closed (see reference https://docs.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocket.sendasync?view=net-6.0)
@@ -112,22 +112,22 @@ namespace Gremlin.Net.UnitTest.Driver
 
             // Test various closing/closed WebSocketStates with SubmitAsync.
             mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.Closed);
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request, CancellationToken.None));
 
             mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.CloseSent);
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request, CancellationToken.None));
 
             mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.CloseReceived);
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request, CancellationToken.None));
 
             mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.Aborted);
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => connection.SubmitAsync<dynamic>(request, CancellationToken.None));
 
             // Simulate SendAsync exception behavior if underlying websocket is not connected.
             mockedClientWebSocket.Setup(m => m.SendAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new InvalidOperationException("Socket not connected"));
             mockedClientWebSocket.Setup(m => m.State).Returns(WebSocketState.Connecting);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SubmitAsync<dynamic>(request));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SubmitAsync<dynamic>(request, CancellationToken.None));
         }
 
         [Fact]
@@ -151,14 +151,14 @@ namespace Gremlin.Net.UnitTest.Driver
             mockedClientWebSocket
                 .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
 
-            Connection connection = GetConnection(mockedClientWebSocket, uri);
+            var connection = GetConnection(mockedClientWebSocket, uri: uri);
             await connection.ConnectAsync(CancellationToken.None);
 
             // Create two in-flight requests that will block on waiting for a response.
             RequestMessage requestMsg1 = RequestMessage.Build("gremlin").Create();
             RequestMessage requestMsg2 = RequestMessage.Build("gremlin").Create();
-            Task request1 = connection.SubmitAsync<dynamic>(requestMsg1);
-            Task request2 = connection.SubmitAsync<dynamic>(requestMsg2);
+            Task request1 = connection.SubmitAsync<dynamic>(requestMsg1, CancellationToken.None);
+            Task request2 = connection.SubmitAsync<dynamic>(requestMsg2, CancellationToken.None);
 
             // Confirm the requests are in-flight.
             Assert.Equal(2, connection.NrRequestsInFlight);
@@ -184,16 +184,155 @@ namespace Gremlin.Net.UnitTest.Driver
             mockedClientWebSocket.Verify(m => m.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, It.IsAny<CancellationToken>()), Times.Once);
         }
 
-
-        private static Connection GetConnection(Mock<IClientWebSocket> mockedClientWebSocket, Uri uri)
+        [Fact]
+        public async Task ShouldProperlyHandleCancellationForSubmitAsync()
         {
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+            var connection = GetConnection(mockedClientWebSocket);
+            var cts = new CancellationTokenSource();
+
+            var task = connection.SubmitAsync<object>(RequestMessage.Build(string.Empty).Create(),
+                cts.Token);
+            cts.Cancel();
+            
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+            Assert.True(task.IsCanceled);
+            mockedClientWebSocket.Verify(m => m.SendAsync(It.IsAny<ArraySegment<byte>>(),
+                It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), cts.Token), Times.Once);
+            mockedClientWebSocket.Verify(
+                m => m.CloseAsync(It.IsAny<WebSocketCloseStatus>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            mockedClientWebSocket.Verify(
+                m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), cts.Token), Times.Never);
+        }
+        
+        [Fact]
+        public async Task ShouldProperlyHandleCancellationForSubmitAsyncIfAlreadyCancelled()
+        {
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+            var connection = GetConnection(mockedClientWebSocket);
+            var token = new CancellationToken(canceled: true);
+
+            var task = connection.SubmitAsync<object>(RequestMessage.Build(string.Empty).Create(),
+                token);
+            
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+            Assert.True(task.IsCanceled);
+            mockedClientWebSocket.Verify(
+                m => m.SendAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()), Times.Never);
+            mockedClientWebSocket.Verify(
+                m => m.CloseAsync(It.IsAny<WebSocketCloseStatus>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            mockedClientWebSocket.Verify(
+                m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), token), Times.Never);
+        }
+        
+        [Fact]
+        public async Task ShouldContinueSubmittingOtherMessagesIfOneIsCancelled()
+        {
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+            var tcs = new TaskCompletionSource();
+            mockedClientWebSocket.Setup(m => m.SendAsync(It.IsAny<ArraySegment<byte>>(),
+                It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(tcs.Task);
+            var connection = GetConnection(mockedClientWebSocket);
+            var cts = new CancellationTokenSource();
+            
+            var taskToCancel = connection.SubmitAsync<object>(RequestMessage.Build(string.Empty).Create(),
+                cts.Token);
+            var taskToComplete = connection.SubmitAsync<object>(RequestMessage.Build(string.Empty).Create(),
+                CancellationToken.None);
+            cts.Cancel();
+            var taskToComplete2 = connection.SubmitAsync<object>(RequestMessage.Build(string.Empty).Create(),
+                CancellationToken.None);
+            tcs.TrySetResult();
+            
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await taskToCancel);
+            Assert.True(taskToCancel.IsCanceled);
+            await Task.Delay(TimeSpan.FromMilliseconds(200)); // wait a bit to let the messages being sent
+            mockedClientWebSocket.Verify(m => m.SendAsync(It.IsAny<ArraySegment<byte>>(),
+                It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+        }
+        
+        [Fact]
+        public async Task ShouldContinueSubmittingOtherMessagesIfOneIsAlreadyCancelled()
+        {
+            var mockedClientWebSocket = new Mock<IClientWebSocket>();
+            mockedClientWebSocket
+                .SetupGet(m => m.Options).Returns(new ClientWebSocket().Options);
+            var cancelledToken = new CancellationToken(canceled: true);
+            mockedClientWebSocket
+                .Setup(m => m.SendAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<WebSocketMessageType>(),
+                    It.IsAny<bool>(), cancelledToken))
+                .ThrowsAsync(new TaskCanceledException(null, null, cancelledToken));
+            var messageToSend = RequestMessage.Build(string.Empty).Create();
+            var fakeMessageSerializer = new Mock<IMessageSerializer>();
+            var bytesToSend = new byte[] { 1, 2, 3 };
+            fakeMessageSerializer.Setup(f => f.SerializeMessageAsync(messageToSend, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(bytesToSend);
+            var connection = GetConnection(mockedClientWebSocket, fakeMessageSerializer.Object);
+            
+            var taskToCancel = connection.SubmitAsync<object>(RequestMessage.Build(string.Empty).Create(),
+                cancelledToken);
+            var taskToComplete = connection.SubmitAsync<object>(messageToSend, CancellationToken.None);
+            
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await taskToCancel);
+            Assert.True(taskToCancel.IsCanceled);
+            mockedClientWebSocket.Verify(m => m.SendAsync(bytesToSend,
+                It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+        }
+
+        [Fact]
+        public async Task ShouldNotProcessReceivedMessageForCancelledRequest()
+        {
+            var fakeMessageSerializer = new Mock<IMessageSerializer>();
+            var receivedBytes = new byte[] { 1, 2, 3 };
+            var messageToCancel = RequestMessage.Build(string.Empty).Create();
+            var receivedMessage = new ResponseMessage<List<object>>
+            {
+                RequestId = messageToCancel.RequestId, Status = new ResponseStatus { Code = ResponseStatusCode.Success }
+            };
+            fakeMessageSerializer.Setup(f => f.DeserializeMessageAsync(receivedBytes, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(receivedMessage);
+            var fakeWebSocketConnection = new Mock<IWebSocketConnection>();
+            var receiveTaskCompletionSource = new TaskCompletionSource<byte[]>();
+            fakeWebSocketConnection.Setup(m => m.ReceiveMessageAsync()).Returns(receiveTaskCompletionSource.Task);
+            var connection = GetConnection(fakeWebSocketConnection.Object, fakeMessageSerializer.Object);
+            await connection.ConnectAsync(CancellationToken.None);
+            var cts = new CancellationTokenSource();
+            
+            var submitTask = connection.SubmitAsync<object>(messageToCancel, cts.Token);
+            cts.Cancel();
+            receiveTaskCompletionSource.SetResult(receivedBytes);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => submitTask);
+            
+            Assert.Equal(0, connection.NrRequestsInFlight);
+        }
+
+        private static Connection GetConnection(IMock<IClientWebSocket> mockedClientWebSocket,
+            IMessageSerializer messageSerializer = null, Uri uri = null)
+        {
+            return GetConnection(new WebSocketConnection(mockedClientWebSocket.Object, new WebSocketSettings()),
+                messageSerializer, uri);
+        }
+        
+        private static Connection GetConnection(IWebSocketConnection webSocketConnection,
+            IMessageSerializer messageSerializer = null, Uri uri = null)
+        {
+            uri ??= new Uri("wss://localhost:8182");
+            messageSerializer ??= new GraphBinaryMessageSerializer();
             return new Connection(
-                mockedClientWebSocket.Object,
+                webSocketConnection,
                 uri: uri,
                 username: "user",
                 password: "password",
-                messageSerializer: new GraphSON3MessageSerializer(),
-                webSocketSettings: new WebSocketSettings(),
+                messageSerializer: messageSerializer,
                 sessionId: null);
         }
 

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
@@ -25,8 +25,6 @@ using System;
 using Gremlin.Net.Process.Traversal;
 using Xunit;
 
-using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
-
 namespace Gremlin.Net.UnitTest.Process.Traversal
 {
     public class GraphTraversalSourceTests

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversalStrategy.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TestTraversalStrategy.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
 
@@ -41,7 +42,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
             traversal.Traversers = _traversers;
         }
 
-        public Task ApplyAsync<S, E>(ITraversal<S, E> traversal)
+        public Task ApplyAsync<S, E>(ITraversal<S, E> traversal, CancellationToken cancellationToken)
         {
             traversal.Traversers = _traversers;
             return Task.CompletedTask;

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphBinary/GraphBinaryMessageSerializerTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphBinary/GraphBinaryMessageSerializerTests.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Structure.IO.GraphBinary;
@@ -62,13 +63,36 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphBinary
             };
             var msg = RequestMessage.Build("eval").OverrideRequestId(Guid.Parse("4005b374-b121-401b-9157-ab1f1ecc894e"))
                 .AddArgument("gremlin", "'Hello' + 'World'").Create();
-
-            var serializer = new GraphBinaryMessageSerializer();
+            var serializer = CreateMessageSerializer();
 
             var actual = await serializer.SerializeMessageAsync(msg);
 
 
             Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public async Task SerializeMessageAsyncShouldSupportCancellation()
+        {
+            var serializer = CreateMessageSerializer();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await serializer.SerializeMessageAsync(RequestMessage.Build(default).Create(),
+                    new CancellationToken(true)));
+        }
+    
+        [Fact]
+        public async Task DeserializeMessageAsyncShouldSupportCancellation()
+        {
+            var serializer = CreateMessageSerializer();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await serializer.DeserializeMessageAsync(Array.Empty<byte>(), new CancellationToken(true)));
+        }
+
+        private static GraphBinaryMessageSerializer CreateMessageSerializer()
+        {
+            return new GraphBinaryMessageSerializer();
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphBinary/GraphBinaryTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphBinary/GraphBinaryTests.cs
@@ -28,7 +28,6 @@ using System.IO;
 using System.Numerics;
 using System.Threading.Tasks;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure;
 using Gremlin.Net.Structure.IO.GraphBinary;
 using Xunit;

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphBinary/Types/Sample/SamplePersonSerializer.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphBinary/Types/Sample/SamplePersonSerializer.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Structure.IO.GraphBinary;
 using Gremlin.Net.Structure.IO.GraphBinary.Types;
@@ -33,15 +34,17 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphBinary.Types.Sample
     public class SamplePersonSerializer : CustomTypeSerializer
     {
         private readonly byte[] _typeInfoBytes = { 0, 0, 0, 0 };
-        
-        public override async Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer)
+
+        public override async Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
         {
             // Write {custom type info}, {value_flag} and {value}
-            await stream.WriteAsync(_typeInfoBytes).ConfigureAwait(false);
-            await WriteValueAsync(value, stream, writer, true);
+            await stream.WriteAsync(_typeInfoBytes, cancellationToken).ConfigureAwait(false);
+            await WriteValueAsync(value, stream, writer, true, cancellationToken);
         }
 
-        public override async Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable)
+        public override async Task WriteValueAsync(object value, Stream stream, GraphBinaryWriter writer, bool nullable,
+            CancellationToken cancellationToken = default)
         {
             if (value == null)
             {
@@ -50,42 +53,46 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphBinary.Types.Sample
                     throw new IOException("Unexpected null value when nullable is false");
                 }
 
-                await writer.WriteValueFlagNullAsync(stream).ConfigureAwait(false);
+                await writer.WriteValueFlagNullAsync(stream, cancellationToken).ConfigureAwait(false);
                 return;
             }
 
             if (nullable)
             {
-                await writer.WriteValueFlagNoneAsync(stream).ConfigureAwait(false);
+                await writer.WriteValueFlagNoneAsync(stream, cancellationToken).ConfigureAwait(false);
             }
 
             var samplePerson = (SamplePerson)value;
             var name = samplePerson.Name;
             
             // value_length = name_byte_length + name_bytes + long
-            await stream.WriteIntAsync(4 + Encoding.UTF8.GetBytes(name).Length + 8).ConfigureAwait(false);
+            await stream.WriteIntAsync(4 + Encoding.UTF8.GetBytes(name).Length + 8, cancellationToken)
+                .ConfigureAwait(false);
 
-            await writer.WriteValueAsync(name, stream, false).ConfigureAwait(false);
-            await writer.WriteValueAsync(samplePerson.BirthDate, stream, false).ConfigureAwait(false);
+            await writer.WriteValueAsync(name, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(samplePerson.BirthDate, stream, false, cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        public override async Task<object> ReadAsync(Stream stream, GraphBinaryReader reader)
+        public override async Task<object> ReadAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
             // {custom type info}, {value_flag} and {value}
             // No custom_type_info
-            if (await stream.ReadIntAsync().ConfigureAwait(false) != 0)
+            if (await stream.ReadIntAsync(cancellationToken).ConfigureAwait(false) != 0)
             {
                 throw new IOException("{custom_type_info} should not be provided for this custom type");
             }
 
-            return await ReadValueAsync(stream, reader, true).ConfigureAwait(false);
+            return await ReadValueAsync(stream, reader, true, cancellationToken).ConfigureAwait(false);
         }
 
-        public override async Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable)
+        public override async Task<object> ReadValueAsync(Stream stream, GraphBinaryReader reader, bool nullable,
+            CancellationToken cancellationToken = default)
         {
             if (nullable)
             {
-                var valueFlag = await stream.ReadByteAsync().ConfigureAwait(false);
+                var valueFlag = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
                 if ((valueFlag & 1) == 1)
                 {
                     return null;
@@ -93,7 +100,7 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphBinary.Types.Sample
             }
             
             // Read the byte length of the value bytes
-            var valueLength = await stream.ReadIntAsync().ConfigureAwait(false);
+            var valueLength = await stream.ReadIntAsync(cancellationToken).ConfigureAwait(false);
 
             if (valueLength <= 0)
             {
@@ -105,9 +112,11 @@ namespace Gremlin.Net.UnitTest.Structure.IO.GraphBinary.Types.Sample
                 throw new IOException($"Not enough readable bytes: {valueLength} (expected: {stream.Length})");
             }
 
-            var name = (string) await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false);
+            var name = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
             var birthDate =
-                (DateTimeOffset)await reader.ReadValueAsync<DateTimeOffset>(stream, false).ConfigureAwait(false);
+                (DateTimeOffset)await reader.ReadValueAsync<DateTimeOffset>(stream, false, cancellationToken)
+                    .ConfigureAwait(false);
 
             return new SamplePerson(name, birthDate);
         }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSON3MessageSerializerTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Structure/IO/GraphSON/GraphSON3MessageSerializerTests.cs
@@ -1,0 +1,58 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver.Messages;
+using Gremlin.Net.Structure.IO.GraphSON;
+using Xunit;
+
+namespace Gremlin.Net.UnitTest.Structure.IO.GraphSON;
+
+public class GraphSON3MessageSerializerTests
+{
+    [Fact]
+    public async Task SerializeMessageAsyncShouldSupportCancellation()
+    {
+        var serializer = CreateMessageSerializer();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await serializer.SerializeMessageAsync(RequestMessage.Build(default).Create(),
+                new CancellationToken(true)));
+    }
+    
+    [Fact]
+    public async Task DeserializeMessageAsyncShouldSupportCancellation()
+    {
+        var serializer = CreateMessageSerializer();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await serializer.DeserializeMessageAsync(Array.Empty<byte>(), new CancellationToken(true)));
+    }
+
+    private static GraphSON3MessageSerializer CreateMessageSerializer()
+    {
+        return new GraphSON3MessageSerializer();
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2794

This enables users to cancel the evaluation of a single traversal / the execution of a submitted script.
Cancellation on the server is however out of scope for this contribution as we first need TINKERPOP-2210 for that. So this frees up resources on the client and requests that were not successfully submitted to the server yet can also be cancelled completely.

The first commit comes from #1817 which I used here already as this change adds a lot of changes that are technically breaking changes and would therefore require a lot of suppressions for compatibility warnings.

VOTE +1