### PR TITLE
TINKERPOP-2808 Improving ARM Compatibility

### DIFF
--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -569,6 +569,10 @@ You should see exit code 0 upon successful completion of the test suites. Run `d
 service containers (not needed if you executed Maven commands or `run.sh`), or `docker-compose down --rmi all` to 
 remove the service containers while deleting all used images.
 
+Note for running docker with MacOS on ARM processors: Docker's performance is extremely poor on ARM Mac's in its
+default configuration. It is recommended to enable both the "New Virtualization Framework" and "VirtioFS" under
+Docker Desktop Settings -> Experimental Features.
+
 [[intellij]]
 == Intellij Usage
 

--- a/gremlin-console/Dockerfile
+++ b/gremlin-console/Dockerfile
@@ -15,13 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM adoptopenjdk/openjdk11:alpine-slim
+FROM alpine
 
 LABEL maintainer="dev@tinkerpop.apache.org"
 
 ARG GREMLIN_CONSOLE_DIR
 
-RUN apk add --no-cache --update bash
+RUN apk add --no-cache --update \
+    bash \
+    openjdk11-jdk
 
 COPY src/main/docker/docker-entrypoint.sh /
 COPY ${GREMLIN_CONSOLE_DIR} /opt/gremlin-console

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -60,6 +60,11 @@ limitations under the License.
             <artifactId>log4j</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <version>1.17.1</version>
+        </dependency>
         <!-- TESTING -->
         <dependency>
             <groupId>junit</groupId>

--- a/gremlin-server/Dockerfile
+++ b/gremlin-server/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM adoptopenjdk/openjdk11:alpine-slim
+FROM alpine
 
 LABEL maintainer="dev@tinkerpop.apache.org"
 
@@ -23,7 +23,8 @@ ARG GREMLIN_SERVER_DIR
 
 RUN apk add --no-cache --update \
     bash \
-    perl
+    perl \
+    openjdk11-jdk
 
 COPY src/main/docker/docker-entrypoint.sh /
 COPY ${GREMLIN_SERVER_DIR} /opt/gremlin-server


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2808

Compatibility fixes for ARM based Macs

Updated base images for gremlin-server and gremlin-console docker images to support arm64:

The previously used adopt openjdk11 alpine linux image does not support arm64. In fact none of the major openjdk distributions maintain a jdk11 alpine image for arm64. Changed base image to alpine and installed oracle openjdk 11. Oracle openjdk 11 was chosen as it is already maintained in the APK community repository.

Added jansi as an explicit dependency of gremlin-console. Previously it was a dependency of jline which itself is a dependency of groovy. The console is able to run just fine on x64 architectures but it cannot run on arm JDK's without importing Jansi directly. This change resolves [TINKERPOP-2584](https://issues.apache.org/jira/browse/TINKERPOP-2584) at least for ARM Macs.

Updated dev docs with instructions to configure docker desktop for better performance on apple silicon.