### PR TITLE
Fix permission issues with Docker generated files

### DIFF
--- a/gremlin-console/src/test/python/docker/Dockerfile
+++ b/gremlin-console/src/test/python/docker/Dockerfile
@@ -23,4 +23,5 @@ LABEL maintainer="dev@tinkerpop.apache.org"
 RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre && apt-get install dos2unix
 
 WORKDIR /console_app
-CMD bash -c "dos2unix ./gremlin-console/bin/gremlin.sh && python3 setup.py build && python3 setup.py test"
+CMD bash -c "dos2unix ./gremlin-console/bin/gremlin.sh && python3 setup.py build && python3 setup.py test \
+&& chown -R `stat -c '%u:%g' .` ."

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -70,7 +70,8 @@ services:
       && python3 ./setup.py test
       && python3 ./setup.py install
       && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.gremlin-v3.0+json'
-      && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.graphbinary-v1.0'"
+      && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.graphbinary-v1.0'
+      && chown -R `stat -c "%u:%g" .` ."
     depends_on:
       gremlin-server-test-python:
         condition: service_healthy
@@ -84,4 +85,5 @@ services:
     environment:
       - VERSION=${VERSION}
     command: >
-      bash -c "python3 setup.py sdist bdist_wheel"
+      bash -c "python3 setup.py sdist bdist_wheel
+      && chown -R `stat -c "%u:%g" .` ."


### PR DESCRIPTION
Docker containers run and create files with root permission by default. Adding `chown` to change permission of Docker created files to current user, so `sudo` isn't needed for maven operations. 