### PR TITLE
TINKERPOP-2471 Add logging to .NET

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Dockerized all test environment for .NET, JavaScript, Python, Go, and Python-based tests for Console, and added Docker as a build requirement.
 * Async operations in .NET can now be cancelled. This however does not cancel work that is already happening on the server.
 * Bumped to `snakeyaml` 1.32 to fix security vulnerability.
+* Added logging in .NET.
 
 ==== Bugs
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1145,6 +1145,17 @@ attacks like CRIME/BREACH. Compression should therefore be turned off if the app
 server as well as data that could potentially be controlled by an untrusted user. Compression can be disabled via the
 `disableCompression` parameter.
 
+[[gremlin-dotnet-logging]]
+=== Logging
+
+It is possible to enable logging for the Gremlin.Net driver by providing an `ILoggerFactory` (from the
+`Microsoft.Extensions.Logging.Abstractions` package) to the `GremlinClient` constructor:
+
+[source,csharp]
+----
+include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs[tags=logging]
+----
+
 [[gremlin-dotnet-serialization]]
 === Serialization
 

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -30,7 +30,25 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
+==== Gremlin.NET: Add logging
 
+The Gremlin.NET driver can now be configured for logging to get more insights into its internal state, like when
+a connection was closed and will therefore be replaced. It uses `Microsoft.Extensions.Logging` for this so all kinds
+of different .NET logging implementations can be used.
+
+The following example shows how to provide a `LoggerFactory` that is configured to log to the console to
+`GremlinClient`:
+
+[source,csharp]
+----
+var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddConsole();
+});
+var client = new GremlinClient(new GremlinServer("localhost", 8182), loggerFactory: loggerFactory);
+----
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2471[TINKERPOP-2471]
 
 == TinkerPop 3.5.4
 

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
@@ -22,7 +22,8 @@ limitations under the License.
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup>    
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <!-- We need both reference elements until this is resolved: https://github.com/dotnet/sdk/issues/1151 -->
     <ProjectReference Include="../Gremlin.Net/Gremlin.Net.csproj" />
 

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
@@ -24,6 +24,7 @@
 using System;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Remote;
+using Microsoft.Extensions.Logging;
 using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace Gremlin.Net.Template
@@ -35,15 +36,18 @@ namespace Gremlin.Net.Template
 
         private static void Main()
         {
-            using (var client = new GremlinClient(new GremlinServer(GremlinServerHostname, GremlinServerPort)))
+            var loggerFactory = LoggerFactory.Create(builder =>
             {
-                var g = Traversal().WithRemote(new DriverRemoteConnection(client));
-                var service = new Service(g);
-                var creators = service.FindCreatorsOfSoftware("lop");
-                foreach (var c in creators)
-                {
-                    Console.WriteLine(c);
-                }
+                builder.AddConsole();
+            });
+            using var connection = new DriverRemoteConnection(new GremlinClient(
+                new GremlinServer(GremlinServerHostname, GremlinServerPort), loggerFactory: loggerFactory));
+            var g = Traversal().WithRemote(connection);
+            var service = new Service(g);
+            var creators = service.FindCreatorsOfSoftware("lop");
+            foreach (var c in creators)
+            {
+                Console.WriteLine(c);
             }
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Log.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Log.cs
@@ -1,0 +1,46 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using Gremlin.Net.Process.Traversal;
+using Microsoft.Extensions.Logging;
+
+namespace Gremlin.Net.Driver
+{
+    internal static partial class Log
+    {
+        [LoggerMessage(20000, LogLevel.Information, "Creating {nrConnections} new connections")]
+        public static partial void FillingPool(this ILogger logger, int nrConnections);
+
+        [LoggerMessage(20001, LogLevel.Warning,
+            "Could not get a connection from the pool. Will try again. Retry {retryCount} of {maxRetries}")]
+        public static partial void CouldNotGetConnectionFromPool(this ILogger logger, int retryCount, int maxRetries);
+
+        [LoggerMessage(20002, LogLevel.Information,
+            "A connection was closed. Removing it from the pool so it can be replaced.")]
+        public static partial void RemovingClosedConnectionFromPool(this ILogger logger);
+        
+        [LoggerMessage(20003, LogLevel.Debug, "Submitting Bytecode {bytecode} for request: {requestId}")]
+        public static partial void SubmittingBytecode(this ILogger logger, Bytecode bytecode, Guid requestId);
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
@@ -29,6 +29,8 @@ using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Process.Remote;
 using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Gremlin.Net.Driver.Remote
 {
@@ -39,49 +41,37 @@ namespace Gremlin.Net.Driver.Remote
     {
         private readonly IGremlinClient _client;
         private readonly string _traversalSource;
-        
+        private readonly ILogger<DriverRemoteConnection> _logger;
+
         /// <summary>
         /// Filter on these keys provided to OptionsStrategy and apply them to the request. Note that
         /// "scriptEvaluationTimeout" was deprecated in 3.3.9 but still supported in server implementations and will
         /// be removed in later versions. 
         /// </summary>
-        private readonly List<String> _allowedKeys = new List<string> 
-                    {Tokens.ArgsEvalTimeout, "scriptEvaluationTimeout", Tokens.ArgsBatchSize, 
-                     Tokens.RequestId, Tokens.ArgsUserAgent};
+        private readonly List<string> _allowedKeys = new()
+        {
+            Tokens.ArgsEvalTimeout, "scriptEvaluationTimeout", Tokens.ArgsBatchSize,
+            Tokens.RequestId, Tokens.ArgsUserAgent
+        };
 
         private readonly string _sessionId;
         private string Processor => IsSessionBound ? Tokens.ProcessorSession : Tokens.ProcessorTraversal;
 
         /// <inheritdoc />
         public bool IsSessionBound => _sessionId != null;
-
-        /// <summary>
-        ///     Initializes a new <see cref="IRemoteConnection" /> using "g" as the default remote TraversalSource name.
-        /// </summary>
-        /// <param name="host">The host to connect to.</param>
-        /// <param name="port">The port to connect to.</param>
-        /// <exception cref="ArgumentNullException">Thrown when client is null.</exception>
-        public DriverRemoteConnection(string host, int port):this(host, port, "g")
-        {
-        }
-
+        
         /// <summary>
         ///     Initializes a new <see cref="IRemoteConnection" />.
         /// </summary>
         /// <param name="host">The host to connect to.</param>
         /// <param name="port">The port to connect to.</param>
         /// <param name="traversalSource">The name of the traversal source on the server to bind to.</param>
+        /// <param name="loggerFactory">A factory to create loggers. If not provided, then nothing will be logged.</param>
         /// <exception cref="ArgumentNullException">Thrown when client is null.</exception>
-        public DriverRemoteConnection(string host, int port, string traversalSource):this(new GremlinClient(new GremlinServer(host, port)), traversalSource)
-        {
-        }
-
-        /// <summary>
-        ///     Initializes a new <see cref="IRemoteConnection" /> using "g" as the default remote TraversalSource name.
-        /// </summary>
-        /// <param name="client">The <see cref="IGremlinClient" /> that will be used for the connection.</param>
-        /// <exception cref="ArgumentNullException">Thrown when client is null.</exception>
-        public DriverRemoteConnection(IGremlinClient client):this(client, "g")
+        public DriverRemoteConnection(string host, int port, string traversalSource = "g",
+            ILoggerFactory loggerFactory = null) : this(
+            new GremlinClient(new GremlinServer(host, port), loggerFactory: loggerFactory), traversalSource,
+            logger: loggerFactory?.CreateLogger<DriverRemoteConnection>() ?? NullLogger<DriverRemoteConnection>.Instance)
         {
         }
 
@@ -90,17 +80,28 @@ namespace Gremlin.Net.Driver.Remote
         /// </summary>
         /// <param name="client">The <see cref="IGremlinClient" /> that will be used for the connection.</param>
         /// <param name="traversalSource">The name of the traversal source on the server to bind to.</param>
-        /// <exception cref="ArgumentNullException">Thrown when client is null.</exception>
-        public DriverRemoteConnection(IGremlinClient client, string traversalSource)
+        /// <exception cref="ArgumentNullException">Thrown when client or the traversalSource is null.</exception>
+        public DriverRemoteConnection(IGremlinClient client, string traversalSource = "g")
+            : this(client, traversalSource, null)
+        {
+        }
+
+        private DriverRemoteConnection(IGremlinClient client, string traversalSource, string sessionId = null,
+            ILogger<DriverRemoteConnection> logger = null)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _traversalSource = traversalSource ?? throw new ArgumentNullException(nameof(traversalSource));
-        }
 
-        private DriverRemoteConnection(IGremlinClient client, string traversalSource, Guid sessionId)
-            : this(client, traversalSource)
-        {
-            _sessionId = sessionId.ToString();
+            if (logger == null)
+            {
+                var loggerFactory = client is GremlinClient gremlinClient
+                    ? gremlinClient.LoggerFactory
+                    : NullLoggerFactory.Instance;
+
+                logger = loggerFactory.CreateLogger<DriverRemoteConnection>();
+            }
+            _logger = logger;
+            _sessionId = sessionId;
         }
 
         /// <summary>
@@ -120,6 +121,8 @@ namespace Gremlin.Net.Driver.Remote
         private async Task<IEnumerable<Traverser>> SubmitBytecodeAsync(Guid requestid, Bytecode bytecode,
             CancellationToken cancellationToken)
         {
+            _logger.SubmittingBytecode(bytecode, requestid);
+            
             var requestMsg =
                 RequestMessage.Build(Tokens.OpsBytecode)
                     .Processor(Processor)
@@ -145,14 +148,14 @@ namespace Gremlin.Net.Driver.Remote
                     }
                 }
             }
-            
+
             return await _client.SubmitAsync<Traverser>(requestMsg.Create(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public RemoteTransaction Tx(GraphTraversalSource g)
         {
-            var session = new DriverRemoteConnection(_client, _traversalSource, Guid.NewGuid());
+            var session = new DriverRemoteConnection(_client, _traversalSource, Guid.NewGuid().ToString(), _logger);
             return new RemoteTransaction(session, g);
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -21,7 +21,7 @@ limitations under the License.
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -71,6 +71,7 @@ NOTE that versions suffixed with "-rc" are considered release candidates (i.e. p
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="6.0.6" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Bytecode.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Bytecode.cs
@@ -168,5 +168,11 @@ namespace Gremlin.Net.Process.Traversal
         {
             return type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(HashSet<>);
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"[[{string.Join(", ", SourceInstructions)}], [{string.Join(", ", StepInstructions)}]]";
+        }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Instruction.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Instruction.cs
@@ -57,7 +57,7 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         public override string ToString()
         {
-            return OperatorName + " [" + String.Join(",", Arguments) + "]";
+            return $"{OperatorName}({string.Join(", ", Arguments.Select(a => a ?? "null"))})";
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -61,7 +61,7 @@ limitations under the License.
                                     file.write(file.getText("UTF-8").replaceFirst(/&lt;Version&gt;(.*)&lt;\/Version&gt;/, "&lt;Version&gt;" + mavenVersion + "&lt;/Version&gt;"))
 
                                     file = new File(platformAgnosticBaseDirPath + "/Gremlin.Net.Template/Gremlin.Net.Template.csproj")
-                                    file.write(file.getText("UTF-8").replaceFirst(/Version="(.*)"/, "Version=\"" + mavenVersion + "\""))
+                                    file.write(file.getText("UTF-8").replaceFirst(/Gremlin\.Net\" Version="(.*)"/, "Gremlin.Net\" Version=\"" + mavenVersion + "\""))
 
                                     file = new File(platformAgnosticBaseDirPath + "/Gremlin.Net.Template/Gremlin.Net.Template.nuspec")
                                     file.write(file.getText("UTF-8").replaceFirst(/&lt;version&gt;(.*)&lt;\/version&gt;/, "&lt;version&gt;" + mavenVersion + "&lt;/version&gt;"))

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
@@ -32,6 +32,7 @@ using Gremlin.Net.Process.Traversal.Step.Util;
 using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 using Gremlin.Net.Structure.IO.GraphBinary;
 using Gremlin.Net.Structure.IO.GraphSON;
+using Microsoft.Extensions.Logging;
 using Xunit;
 // tag::commonImports[]
 using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
@@ -58,9 +59,21 @@ namespace Gremlin.Net.IntegrationTest.Docs.Reference
         public void ConnectingTest()
         {
 // tag::connecting[]
-var remoteConnection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)), "g");
+using var remoteConnection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)), "g");
 var g = Traversal().WithRemote(remoteConnection);
 // end::connecting[]
+        }
+        
+        [Fact(Skip="No Server under localhost")]
+        public void LoggingTest()
+        {
+// tag::logging[]
+var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddConsole();
+});
+var client = new GremlinClient(new GremlinServer("localhost", 8182), loggerFactory: loggerFactory);
+// end::logging[]
         }
         
         [Fact(Skip="No Server under localhost")]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/DriverRemoteConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/DriverRemoteConnectionTests.cs
@@ -1,0 +1,97 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Remote;
+using Gremlin.Net.Process.Traversal;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Gremlin.Net.IntegrationTest.Driver;
+
+public class DriverRemoteConnectionTests
+{
+    private static readonly string TestHost = ConfigProvider.Configuration["TestServerIpAddress"];
+    private static readonly int TestPort = Convert.ToInt32(ConfigProvider.Configuration["TestServerPort"]);
+        
+    [Fact]
+    public async Task ShouldLogWithProvidedLoggerFactory()
+    {
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        var loggerMock = new Mock<ILogger>();
+        loggerMock.Setup(m => m.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        loggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+        using var driverRemoteConnection =
+            new DriverRemoteConnection(TestHost, TestPort, loggerFactory: loggerFactoryMock.Object);
+        var bytecodeToLog = SomeValidBytecode;
+
+        await driverRemoteConnection.SubmitAsync<object, object>(bytecodeToLog);
+        
+        loggerMock.VerifyMessageWasLogged(LogLevel.Debug, bytecodeToLog.ToString());
+    }
+    
+    [Fact]
+    public async Task ShouldNotLogForDisabledLogLevel()
+    {
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        var loggerMock = new Mock<ILogger>();
+        loggerMock.Setup(m => m.IsEnabled(It.IsAny<LogLevel>())).Returns(false);
+        loggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+        using var driverRemoteConnection =
+            new DriverRemoteConnection(TestHost, TestPort, loggerFactory: loggerFactoryMock.Object);
+
+        await driverRemoteConnection.SubmitAsync<object, object>(SomeValidBytecode);
+        
+        loggerMock.VerifyNothingWasLogged();
+    }
+            
+    [Fact]
+    public async Task ShouldLogWithLoggerFactoryFromGremlinClient()
+    {
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        var loggerMock = new Mock<ILogger>();
+        loggerMock.Setup(m => m.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        loggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+        using var gremlinClient =
+            new GremlinClient(new GremlinServer(TestHost, TestPort), loggerFactory: loggerFactoryMock.Object);
+        var driverRemoteConnection = new DriverRemoteConnection(gremlinClient);
+        var bytecodeToLog = SomeValidBytecode;
+
+        await driverRemoteConnection.SubmitAsync<object, object>(SomeValidBytecode);
+
+        loggerMock.VerifyMessageWasLogged(LogLevel.Debug, bytecodeToLog.ToString());
+    }
+
+    private static Bytecode SomeValidBytecode
+    {
+        get
+        {
+            var bytecode = new Bytecode();
+            bytecode.StepInstructions.Add(new Instruction("inject", 1, 2));
+            return bytecode;
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientTests.cs
@@ -31,6 +31,8 @@ using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Exceptions;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.IntegrationTest.Util;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Gremlin.Net.IntegrationTest.Driver
@@ -294,6 +296,34 @@ namespace Gremlin.Net.IntegrationTest.Driver
                     // do nothing
                 }
             }
+        }
+
+        [Fact]
+        public void ShouldLogWithProvidedLoggerFactory()
+        {
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            var loggerMock = new Mock<ILogger>();
+            loggerMock.Setup(m => m.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+            loggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+            var gremlinServer = new GremlinServer(TestHost, TestPort);
+            
+            using var gremlinClient = new GremlinClient(gremlinServer, loggerFactory: loggerFactoryMock.Object);
+
+            loggerMock.VerifyMessageWasLogged(LogLevel.Information, "connections");
+        }
+        
+        [Fact]
+        public void ShouldNotLogForDisabledLogLevel()
+        {
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            var loggerMock = new Mock<ILogger>();
+            loggerMock.Setup(m => m.IsEnabled(It.IsAny<LogLevel>())).Returns(false);
+            loggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+            var gremlinServer = new GremlinServer(TestHost, TestPort);
+            
+            using var gremlinClient = new GremlinClient(gremlinServer, loggerFactory: loggerFactoryMock.Object);
+
+            loggerMock.VerifyNothingWasLogged();
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MockedLoggerExtensions.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/MockedLoggerExtensions.cs
@@ -1,0 +1,47 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Gremlin.Net.IntegrationTest.Driver;
+
+public static class MockedLoggerExtensions
+{
+    public static void VerifyMessageWasLogged(this Mock<ILogger> mockedLogger, LogLevel expectedLogLevel,
+        string logMessagePart)
+    {
+        mockedLogger.Verify(
+            m => m.Log(expectedLogLevel, It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, _) => o.ToString().Contains(logMessagePart)), null,
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Once);
+    }
+    
+    public static void VerifyNothingWasLogged(this Mock<ILogger> mockedLogger)
+    {
+        mockedLogger.Verify(
+            m => m.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Never);
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
@@ -12,7 +12,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="gherkin" Version="24.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionPoolTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/ConnectionPoolTests.cs
@@ -27,6 +27,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Exceptions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -389,12 +390,11 @@ namespace Gremlin.Net.UnitTest.Driver
         private static ConnectionPool CreateConnectionPool(IConnectionFactory connectionFactory, int poolSize = 2,
             int reconnectionAttempts = 1)
         {
-            return new ConnectionPool(connectionFactory,
-                new ConnectionPoolSettings
-                {
-                    PoolSize = poolSize, ReconnectionAttempts = reconnectionAttempts,
-                    ReconnectionBaseDelay = TimeSpan.FromMilliseconds(10)   // let the tests execute fast
-                });
+            return new ConnectionPool(connectionFactory, new ConnectionPoolSettings
+            {
+                PoolSize = poolSize, ReconnectionAttempts = reconnectionAttempts,
+                ReconnectionBaseDelay = TimeSpan.FromMilliseconds(10) // let the tests execute fast
+            }, NullLogger<ConnectionPool>.Instance);
         }
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/BytecodeTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/BytecodeTests.cs
@@ -172,5 +172,19 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
             var arg = bytecode.SourceInstructions[0].Arguments[0] as ISet<object>;
             Assert.Equal(new Binding("setVariable", "setValue"), arg.ToList()[1]);
         }
+
+        [Fact]
+        public void ShouldIncludeStepAndSourceInstructionsForToString()
+        {
+            var bytecode = new Bytecode();
+            bytecode.AddSource("source", 1, 2);
+            bytecode.AddStep("step1", 9, 8);
+            bytecode.AddStep("step2", 0);
+            bytecode.AddStep("step3", 0, null, 0d);
+            bytecode.AddStep("step4", "0), stepX(\"hello\"");
+
+            Assert.Equal("[[source(1, 2)], [step1(9, 8), step2(0), step3(0, null, 0), step4(0), stepX(\"hello\")]]",
+                bytecode.ToString());
+        }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2471

It's a bit unfortunate that I had to add loggers to the constructors of `GremlinClient` as well as `DriverRemoteConnection`, but I don't see a way around that as both are ways to initialize the driver.

VOTE +1

------
edit: Some additional short information about the implementation:

We are using [compile-time logging source generation](https://learn.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator) for logging as it provides a highly performant logging implementation.