### PR TITLE
TINKERPOP-2814 Add configuration for SSL handshake timeout.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bumped to Groovy 2.5.19.
 * Bumped to Netty 4.1.85.
 * Bumped `ivy` to 2.5.1 to fix security vulnerability
+* Removed default SSL handshake timeout. The SSL handshake timeout will instead be capped by setting `connectionSetupTimeoutMillis`.
 
 ==== Bugs
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -993,9 +993,6 @@ public final class Cluster {
         /**
          * Sets the duration of time in milliseconds provided for connection setup to complete which includes WebSocket
          * handshake and SSL handshake. Beyond this duration an exception would be thrown.
-         *
-         * Note that this value should be greater that SSL handshake timeout defined in
-         * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake.
          */
         public Builder connectionSetupTimeoutMillis(final long connectionSetupTimeoutMillis) {
             this.connectionSetupTimeoutMillis = connectionSetupTimeoutMillis;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -407,9 +407,6 @@ final class Settings {
          * Duration of time in milliseconds provided for connection setup to complete which includes WebSocket
          * handshake and SSL handshake. Beyond this duration an exception would be thrown if the handshake is not
          * complete by then.
-         *
-         * Note that this value should be greater that SSL handshake timeout defined in
-         * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake.
          */
         public long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/WebSocketClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/WebSocketClient.java
@@ -69,7 +69,7 @@ public class WebSocketClient extends AbstractClient {
 
         try {
             final WebSocketClientHandler wsHandler = new WebSocketClientHandler(WebSocketClientHandshakerFactory.newHandshaker(
-                    uri, WebSocketVersion.V13, null, true, EmptyHttpHeaders.INSTANCE, 65536), 10000);
+                    uri, WebSocketVersion.V13, null, true, EmptyHttpHeaders.INSTANCE, 65536), 10000, false);
             final MessageSerializer<GraphBinaryMapper> serializer = new GraphBinaryMessageSerializerV1();
             b.channel(NioSocketChannel.class)
                     .handler(new ChannelInitializer<SocketChannel>() {

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/NoOpWebSocketServerHandler.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/NoOpWebSocketServerHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.ReferenceCountUtil;
+
+/**
+* Handler that will drop requests to the WebSocket path.
+*/
+public class NoOpWebSocketServerHandler extends ChannelInboundHandlerAdapter {
+    private String websocketPath;
+
+    public NoOpWebSocketServerHandler(String websocketPath) {
+        this.websocketPath = websocketPath;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if ((msg instanceof HttpRequest) && ((HttpRequest) msg).uri().endsWith(websocketPath)) {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestHttpServerInitializer.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestHttpServerInitializer.java
@@ -18,26 +18,23 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
-import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
 
 /**
- * A vanilla WebSocket server Initializer implementation using Netty. This initializer would configure the server for
- * WebSocket handshake and decoding incoming WebSocket frames.
+ * A base ChannelInitializer that setups the pipeline for HTTP handling. This class should be sub-classed by a handler
+ * that handles the actual data being received.
  */
-public abstract class TestWebSocketServerInitializer extends TestHttpServerInitializer {
+public class TestHttpServerInitializer extends ChannelInitializer<SocketChannel> {
+    protected static final String WEBSOCKET_PATH = "/gremlin";
 
     @Override
     public void initChannel(SocketChannel ch) {
-        super.initChannel(ch);
-
         final ChannelPipeline pipeline = ch.pipeline();
-        pipeline.addLast(new WebSocketServerCompressionHandler());
-        pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
-        this.postInit(ch.pipeline());
+        pipeline.addLast(new HttpServerCodec());
+        pipeline.addLast(new HttpObjectAggregator(65536));
     }
-
-    public abstract void postInit(final ChannelPipeline ch);
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWSNoOpInitializer.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWSNoOpInitializer.java
@@ -18,26 +18,16 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
-import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
 
 /**
- * A vanilla WebSocket server Initializer implementation using Netty. This initializer would configure the server for
- * WebSocket handshake and decoding incoming WebSocket frames.
+ * An initializer that adds a handler that will drop WebSocket frames.
  */
-public abstract class TestWebSocketServerInitializer extends TestHttpServerInitializer {
+public class TestWSNoOpInitializer extends TestHttpServerInitializer {
 
     @Override
     public void initChannel(SocketChannel ch) {
         super.initChannel(ch);
-
-        final ChannelPipeline pipeline = ch.pipeline();
-        pipeline.addLast(new WebSocketServerCompressionHandler());
-        pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
-        this.postInit(ch.pipeline());
+        ch.pipeline().addLast(new NoOpWebSocketServerHandler(WEBSOCKET_PATH));
     }
-
-    public abstract void postInit(final ChannelPipeline ch);
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.log4j.Level;
+import org.apache.tinkerpop.gremlin.driver.exception.NoHostAvailableException;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
@@ -41,6 +42,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class WebSocketClientBehaviorIntegrateTest {
     @Rule
@@ -67,7 +69,12 @@ public class WebSocketClientBehaviorIntegrateTest {
         rootLogger.addAppender(recordingAppender);
 
         server = new SimpleSocketServer();
-        server.start(new TestWSGremlinInitializer());
+        if (name.getMethodName().equals("shouldAttemptHandshakeForLongerThanDefaultNettySslHandshakeTimeout") ||
+                name.getMethodName().equals("shouldPrintCorrectErrorForRegularWebSocketHandshakeTimeout")) {
+            server.start(new TestWSNoOpInitializer());
+        } else {
+            server.start(new TestWSGremlinInitializer());
+        }
     }
 
     @After
@@ -308,5 +315,60 @@ public class WebSocketClientBehaviorIntegrateTest {
                 recordingAppender.getMessages().stream()
                         .filter(str -> str.contains("Considering new connection on"))
                         .count());
+    }
+
+    /**
+     * (TINKERPOP-2814) Tests to make sure that the SSL handshake is now capped by connectionSetupTimeoutMillis and not
+     * the default Netty SSL handshake timeout of 10,000ms.
+     */
+    @Test
+    public void shouldAttemptHandshakeForLongerThanDefaultNettySslHandshakeTimeout() {
+        final Cluster cluster = Cluster.build("localhost").port(SimpleSocketServer.PORT)
+                .minConnectionPoolSize(1)
+                .maxConnectionPoolSize(1)
+                .connectionSetupTimeoutMillis(20000) // needs to be larger than 10000ms.
+                .enableSsl(true)
+                .create();
+
+        final Client.ClusteredClient client = cluster.connect();
+        final long start = System.currentTimeMillis();
+
+        Exception caught = null;
+        try {
+            client.submit("1");
+        } catch (Exception e) {
+            caught = e;
+        } finally {
+            // Test against 15000ms which should give a big enough buffer to avoid timing issues.
+            assertTrue(System.currentTimeMillis() - start > 15000);
+            assertTrue(caught != null);
+            assertTrue(caught instanceof NoHostAvailableException);
+            assertTrue(recordingAppender.getMessages().stream().anyMatch(str -> str.contains("SSL handshake not completed")));
+        }
+    }
+
+    /**
+     * Tests to make sure that the correct error message is logged when a non-SSL connection attempt times out.
+     */
+    @Test
+    public void shouldPrintCorrectErrorForRegularWebSocketHandshakeTimeout() {
+        final Cluster cluster = Cluster.build("localhost").port(SimpleSocketServer.PORT)
+                .minConnectionPoolSize(1)
+                .maxConnectionPoolSize(1)
+                .connectionSetupTimeoutMillis(100)
+                .create();
+
+        final Client.ClusteredClient client = cluster.connect();
+
+        Exception caught = null;
+        try {
+            client.submit("1");
+        } catch (Exception e) {
+            caught = e;
+        } finally {
+            assertTrue(caught != null);
+            assertTrue(caught instanceof NoHostAvailableException);
+            assertTrue(recordingAppender.getMessages().stream().anyMatch(str -> str.contains("WebSocket handshake not completed")));
+        }
     }
 }


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/TINKERPOP-2814

Note: The default timeouts were increased because they may be too low and can contribute to connection exceptions. This increase can be removed if it is deemed that the defaults shouldn't be changed in 3.5-dev.