### PR TITLE
TINKERPOP-2806 Provide method for provider plugins to get notified on script/query processing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-5-5, 3.5.5>>.
 
 * Fixed bug in the Gremlin grammar for parsing of empty queries.
+* TINKERPOP-2806 Provide method for provider plugins to get notified on script/query processing
 
 [[release-3-6-1]]
 === TinkerPop 3.6.1 (Release Date: July 18, 2022)

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -33,6 +33,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalInterruptedE
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.bytebuddy.implementation.bytecode.Throw;
+
 import javax.script.Bindings;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
@@ -554,8 +556,19 @@ public class GremlinExecutor implements AutoCloseable {
             return this;
         }
 
+         /**
+         * @deprecated As of release 3.6.2, replaced by {@link #afterTimeout(BiConsumer)}.
+         */
+        @Deprecated
+        public Builder afterTimeout(final Consumer<Bindings> afterTimeout) {
+          BiConsumer<Bindings, Throwable> updatedAfterTimeout = (b, t) -> {
+            afterTimeout.accept(b);
+          };
+          return afterTimeout(updatedAfterTimeout);
+        }
+
         /**
-         * A {@link Consumer} to execute if the script times out.
+         * A {@link BiConsumer} to execute if the script times out.
          */
         public Builder afterTimeout(final BiConsumer<Bindings, Throwable> afterTimeout) {
             this.afterTimeout = afterTimeout;
@@ -711,6 +724,23 @@ public class GremlinExecutor implements AutoCloseable {
             public Builder afterTimeout(final BiConsumer<Bindings, Throwable> afterTimeout) {
                 this.afterTimeout = afterTimeout;
                 return this;
+            }
+
+            /**
+             * Specifies the function to execute if the script evaluation times out. This
+             * function can also be
+             * specified globally on
+             * {@link GremlinExecutor.Builder#afterTimeout(BiConsumer)}.
+             */
+            public Builder afterTimeout(final Consumer<Bindings> afterTimeout) {
+              this.afterTimeout = new BiConsumer<Bindings,Throwable>() {
+                @Override
+                public void accept(Bindings arg0, Throwable arg1) {
+                  // TODO Auto-generated method stub
+                  
+                }
+              };
+              return this;
             }
 
             /**

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -88,7 +88,7 @@ public class GremlinExecutor implements AutoCloseable {
     private final ScheduledExecutorService scheduledExecutorService;
     private final Consumer<Bindings> beforeEval;
     private final Consumer<Bindings> afterSuccess;
-    private final Consumer<Bindings> afterTimeout;
+    private final BiConsumer<Bindings, Throwable> afterTimeout;
     private final BiConsumer<Bindings, Throwable> afterFailure;
     private final boolean suppliedExecutor;
     private final boolean suppliedScheduledExecutor;
@@ -297,7 +297,7 @@ public class GremlinExecutor implements AutoCloseable {
                 if (root instanceof InterruptedException
                         || root instanceof TraversalInterruptedException
                         || root instanceof InterruptedIOException) {
-                    lifeCycle.getAfterTimeout().orElse(afterTimeout).accept(bindings);
+                    lifeCycle.getAfterTimeout().orElse(afterTimeout).accept(bindings, root);
                     evaluationFuture.completeExceptionally(new TimeoutException(
                             String.format("Evaluation exceeded the configured 'evaluationTimeout' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]: %s", scriptEvalTimeOut, script, root.getMessage())));
                 } else {
@@ -477,7 +477,7 @@ public class GremlinExecutor implements AutoCloseable {
         };
         private Consumer<Bindings> afterSuccess = (b) -> {
         };
-        private Consumer<Bindings> afterTimeout = (b) -> {
+        private BiConsumer<Bindings, Throwable> afterTimeout = (b, e) -> {
         };
         private BiConsumer<Bindings, Throwable> afterFailure = (b, e) -> {
         };
@@ -557,7 +557,7 @@ public class GremlinExecutor implements AutoCloseable {
         /**
          * A {@link Consumer} to execute if the script times out.
          */
-        public Builder afterTimeout(final Consumer<Bindings> afterTimeout) {
+        public Builder afterTimeout(final BiConsumer<Bindings, Throwable> afterTimeout) {
             this.afterTimeout = afterTimeout;
             return this;
         }
@@ -610,7 +610,7 @@ public class GremlinExecutor implements AutoCloseable {
         private final Optional<Function<Object, Object>> transformResult;
         private final Optional<Consumer<Object>> withResult;
         private final Optional<Consumer<Bindings>> afterSuccess;
-        private final Optional<Consumer<Bindings>> afterTimeout;
+        private final Optional<BiConsumer<Bindings, Throwable>> afterTimeout;
         private final Optional<BiConsumer<Bindings, Throwable>> afterFailure;
         private final Optional<Long> evaluationTimeoutOverride;
 
@@ -644,7 +644,7 @@ public class GremlinExecutor implements AutoCloseable {
             return afterSuccess;
         }
 
-        public Optional<Consumer<Bindings>> getAfterTimeout() {
+        public Optional<BiConsumer<Bindings, Throwable>> getAfterTimeout() {
             return afterTimeout;
         }
 
@@ -661,7 +661,7 @@ public class GremlinExecutor implements AutoCloseable {
             private Function<Object, Object> transformResult = null;
             private Consumer<Object> withResult = null;
             private Consumer<Bindings> afterSuccess = null;
-            private Consumer<Bindings> afterTimeout = null;
+            private BiConsumer<Bindings, Throwable> afterTimeout = null;
             private BiConsumer<Bindings, Throwable> afterFailure = null;
             private Long evaluationTimeoutOverride = null;
 
@@ -703,10 +703,12 @@ public class GremlinExecutor implements AutoCloseable {
             }
 
             /**
-             * Specifies the function to execute if the script evaluation times out.  This function can also be
-             * specified globally on {@link GremlinExecutor.Builder#afterTimeout(Consumer)}.
+             * Specifies the function to execute if the script evaluation times out. This
+             * function can also be
+             * specified globally on
+             * {@link GremlinExecutor.Builder#afterTimeout(BiConsumer)}.
              */
-            public Builder afterTimeout(final Consumer<Bindings> afterTimeout) {
+            public Builder afterTimeout(final BiConsumer<Bindings, Throwable> afterTimeout) {
                 this.afterTimeout = afterTimeout;
                 return this;
             }

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
@@ -270,7 +270,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
+                .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             gremlinExecutor.eval("Thread.sleep(1000);10").get();
             fail("This script should have timed out with an exception");
@@ -297,7 +297,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
+                .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             gremlinExecutor.eval("Thread.sleep(1000);10").get();
             fail("This script should have timed out with an exception");
@@ -324,7 +324,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
+                .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
                     .evaluationTimeoutOverride(250L).create();
@@ -353,7 +353,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
+                .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
                     .evaluationTimeoutOverride(250L).create();
@@ -423,7 +423,7 @@ public class GremlinExecutorTest {
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b, e) -> timeoutCalled.set(true)).create();
+                .afterTimeout((b) -> timeoutCalled.set(true)).create();
         try {
             gremlinExecutor.eval("10/0").get();
             fail();
@@ -446,7 +446,7 @@ public class GremlinExecutorTest {
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b, e) -> timeoutCalled.set(true)).create();
+                .afterTimeout((b) -> timeoutCalled.set(true)).create();
         assertEquals(2, gremlinExecutor.eval("1+1").get());
 
         // need to wait long enough for the callback to register

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
@@ -270,7 +270,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b) -> timeOutCount.countDown()).create();
+                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
         try {
             gremlinExecutor.eval("Thread.sleep(1000);10").get();
             fail("This script should have timed out with an exception");
@@ -297,7 +297,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b) -> timeOutCount.countDown()).create();
+                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
         try {
             gremlinExecutor.eval("Thread.sleep(1000);10").get();
             fail("This script should have timed out with an exception");
@@ -324,7 +324,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b) -> timeOutCount.countDown()).create();
+                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
                     .evaluationTimeoutOverride(250L).create();
@@ -353,7 +353,7 @@ public class GremlinExecutorTest {
                 .evaluationTimeout(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b) -> timeOutCount.countDown()).create();
+                .afterTimeout((b, e) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
                     .evaluationTimeoutOverride(250L).create();
@@ -423,7 +423,7 @@ public class GremlinExecutorTest {
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b) -> timeoutCalled.set(true)).create();
+                .afterTimeout((b, e) -> timeoutCalled.set(true)).create();
         try {
             gremlinExecutor.eval("10/0").get();
             fail();
@@ -446,7 +446,7 @@ public class GremlinExecutorTest {
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
-                .afterTimeout((b) -> timeoutCalled.set(true)).create();
+                .afterTimeout((b, e) -> timeoutCalled.set(true)).create();
         assertEquals(2, gremlinExecutor.eval("1+1").get());
 
         // need to wait long enough for the callback to register

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
@@ -123,5 +124,33 @@ public interface GraphManager {
             final Graph graph = getGraph(graphName);
             return graph.features().graph().supportsTransactions() && graph.tx().isOpen();
         });
+    }
+ 
+    /**
+     * This method will be called before a script or query is processed by the
+     * gremlin-server.
+     * The msg is the {@link RequestMessage} received by the gremlin-server.
+     */
+
+    default void beforeQueryStart(RequestMessage msg) {
+
+    }
+
+    /**
+     * This method will be called before a script or query is processed by the
+     * gremlin-server.
+     * The msg is the {@link RequestMessage} received by the gremlin-server.
+     * The error is the exception encounted during processing from the gremlin-server.
+     */
+    default void onQueryError(RequestMessage msg, Throwable error) {
+
+    }
+
+    /**
+     * When a script or query successfully completes this method will be called.
+     * The msg is the {@link RequestMessage} received by the gremlin-server.
+     */
+    default void onQuerySuccess(RequestMessage msg) {
+
     }
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -236,11 +236,7 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
                     graphManager.onQueryError(msg, t);
                     if (managedTransactionsForRequest) attemptRollback(msg, ctx.getGraphManager(), settings.strictTransactionManagement);
                 })
-                .afterTimeout(b -> {
-                  final String errorMessage = String.format(
-                  "A timeout occurred within the script during evaluation of [%s] - consider increasing the limit given to TimedInterruptCustomizerProvider",
-                  msg);
-                  TimeoutException t = new TimeoutException(errorMessage);
+                .afterTimeout((b, t) -> {
                   graphManager.onQueryError(msg, t);
                 })
                 .beforeEval(b -> {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -37,6 +37,7 @@ import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.server.Context;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.util.MetricManager;
 import org.apache.tinkerpop.gremlin.structure.util.TemporaryException;
@@ -211,6 +212,7 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
         final Timer.Context timerContext = evalOpTimer.time();
         final RequestMessage msg = ctx.getRequestMessage();
         final GremlinExecutor gremlinExecutor = gremlinExecutorSupplier.get();
+        final GraphManager graphManager = ctx.getGraphManager();
         final Settings settings = ctx.getSettings();
 
         final Map<String, Object> args = msg.getArgs();
@@ -231,9 +233,18 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
         final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
                 .evaluationTimeoutOverride(seto)
                 .afterFailure((b,t) -> {
+                    graphManager.onQueryError(msg, t);
                     if (managedTransactionsForRequest) attemptRollback(msg, ctx.getGraphManager(), settings.strictTransactionManagement);
                 })
+                .afterTimeout(b -> {
+                  final String errorMessage = String.format(
+                  "A timeout occurred within the script during evaluation of [%s] - consider increasing the limit given to TimedInterruptCustomizerProvider",
+                  msg);
+                  TimeoutException t = new TimeoutException(errorMessage);
+                  graphManager.onQueryError(msg, t);
+                })
                 .beforeEval(b -> {
+                    graphManager.beforeQueryStart(msg);
                     try {
                         b.putAll(bindingsSupplier.get());
                     } catch (OpProcessorException ope) {
@@ -258,6 +269,7 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
 
                     try {
                         handleIterator(ctx, itty);
+                        graphManager.onQuerySuccess(msg);
                     } catch (Exception ex) {
                         if (managedTransactionsForRequest) attemptRollback(msg, ctx.getGraphManager(), settings.strictTransactionManagement);
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
@@ -231,7 +231,7 @@ public class Session {
     private GremlinExecutor.Builder initializeGremlinExecutor() {
         final GremlinExecutor.Builder gremlinExecutorBuilder = GremlinExecutor.build()
                 .evaluationTimeout(settings.getEvaluationTimeout())
-                .afterTimeout(b -> {
+                .afterTimeout((b, e) -> {
                     graphManager.rollbackAll();
                     this.bindings.clear();
                     this.bindings.putAll(b);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
@@ -120,7 +120,7 @@ public class ServerGremlinExecutor {
                 .evaluationTimeout(settings.getEvaluationTimeout())
                 .afterFailure((b, e) -> this.graphManager.rollbackAll())
                 .beforeEval(b -> this.graphManager.rollbackAll())
-                .afterTimeout(b -> this.graphManager.rollbackAll())
+                .afterTimeout((b, e) -> this.graphManager.rollbackAll())
                 .globalBindings(this.graphManager.getAsBindings())
                 .executorService(this.gremlinExecutorService)
                 .scheduledExecutorService(this.scheduledExecutorService);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/notifications/GraphManagerNotificationsTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/notifications/GraphManagerNotificationsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.notifications;
+
+import org.apache.tinkerpop.gremlin.TestHelper;
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.RequestOptions;
+import org.apache.tinkerpop.gremlin.driver.Tokens;
+import org.apache.tinkerpop.gremlin.server.AbstractGremlinServerIntegrationTest;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.TestClientFactory;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+public class GraphManagerNotificationsTest extends AbstractGremlinServerIntegrationTest {
+
+  @Override
+  public Settings overrideSettings(final Settings settings) {
+    settings.graphManager = "org.apache.tinkerpop.gremlin.server.notifications.ProviderGraphManagerHelper";
+    return settings;
+  }
+
+  @Test
+  public void scriptSuccessShouldNotifyGraphManager() throws Exception {
+    final Cluster cluster = TestClientFactory.open();
+    final Client client = cluster.connect(name.getMethodName());
+    final Random random = TestHelper.RANDOM;
+    UUID requestID = new UUID(random.nextLong(), random.nextLong());
+    RequestOptions options = RequestOptions.build().overrideRequestId(requestID).create();
+
+    String script = "1+1";
+    client.submit(script, options).all().get().get(0);
+
+    ProviderGraphManagerHelper graphManager = (ProviderGraphManagerHelper) server.getServerGremlinExecutor()
+        .getGraphManager();
+    Map<String, Object> requestArgs = graphManager.getBeforeQueryStartTracking(requestID.toString());
+    assertEquals(script, requestArgs.get(Tokens.ARGS_GREMLIN));
+    assertEquals(true, graphManager.didRequestSucceed(requestID.toString()));
+    assertEquals(false, graphManager.didRequestFail(requestID.toString()));
+    cluster.close();
+  }
+
+  @Test
+  public void scriptFailureShouldNotifyGraphManager() throws Exception {
+    final Cluster cluster = TestClientFactory.open();
+    final Client client = cluster.connect(name.getMethodName());
+    final Random random = TestHelper.RANDOM;
+    UUID requestID = new UUID(random.nextLong(), random.nextLong());
+    RequestOptions options = RequestOptions.build().overrideRequestId(requestID).create();
+
+    String script = "x";
+    try {
+      client.submit(script, options).all().get().get(0);
+      fail("This script should fail since the variable x is not defined");
+    } catch (Exception e) {
+      //
+    }
+
+    ProviderGraphManagerHelper graphManager = (ProviderGraphManagerHelper) server.getServerGremlinExecutor()
+        .getGraphManager();
+    Map<String, Object> requestArgs = graphManager.getBeforeQueryStartTracking(requestID.toString());
+    assertEquals(script, requestArgs.get(Tokens.ARGS_GREMLIN));
+    assertEquals(false, graphManager.didRequestSucceed(requestID.toString()));
+    assertEquals(true, graphManager.didRequestFail(requestID.toString()));
+    cluster.close();
+  }
+
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/notifications/ProviderGraphManagerHelper.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/notifications/ProviderGraphManagerHelper.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.server.notifications;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.util.DefaultGraphManager;
+
+public class ProviderGraphManagerHelper extends DefaultGraphManager {
+
+  private Map<String, Map<String, Object>> beforeQueryStartTracking;
+
+  private List<String> onQuerySuccessCount;
+
+  private List<String> onQueryErrorCount;
+
+  public ProviderGraphManagerHelper(Settings settings) {
+    super(settings);
+    this.beforeQueryStartTracking = new HashMap<String, Map<String, Object>>();
+    this.onQuerySuccessCount = new ArrayList<String>();
+    this.onQueryErrorCount = new ArrayList<String>();
+  }
+ 
+  @Override
+  public void beforeQueryStart(RequestMessage msg) {
+    Map<String, Object> args = msg.getArgs();
+    String requestID = msg.getRequestId().toString();
+    this.beforeQueryStartTracking.put(requestID, args);
+  }
+
+  @Override
+  public void onQuerySuccess(RequestMessage msg) {
+    String requestID = msg.getRequestId().toString();
+    this.onQuerySuccessCount.add(requestID);
+  }
+
+  @Override
+  public void onQueryError(RequestMessage msg, Throwable e) {
+    String requestID = msg.getRequestId().toString();
+    this.onQueryErrorCount.add(requestID);
+  }
+
+  public Map<String, Object> getBeforeQueryStartTracking(String requestID) {
+    return this.beforeQueryStartTracking.get(requestID);
+  }
+
+  public boolean didRequestSucceed(String requestID) {
+    return this.onQuerySuccessCount.contains(requestID);
+  }
+
+  public boolean didRequestFail(String requestID) {
+    return this.onQueryErrorCount.contains(requestID);
+  }
+
+}


### PR DESCRIPTION
This PR adds 3 new default methods to the GraphManager interface allowing custom GraphManagers to opt into receiving notifications based on the lifecycle of scripts/traversals.

AbstractEvalOpProcessor and TraversalOpProcessor get the GraphManager from context and call the lifecycle methods as needed.

docker/build.sh -t -i -n passes all tests

I created a proposal thread on https://lists.apache.org/thread/b3k8b4j29gswyk39pl4cfsvd5ofozh4l but there wasn't much interaction, I'm hoping we can get some more discussion from a PR