### PR TITLE
TINKERPOP-2480 Add User-Agent request header to Java Driver and Server

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Dockerized all test environment for .NET, JavaScript, Python, Go, and Python-based tests for Console, and added Docker as a build requirement.
 * Async operations in .NET can now be cancelled. This however does not cancel work that is already happening on the server.
 * Bumped to `snakeyaml` 1.32 to fix security vulnerability.
+* Added user agent to web socket handshake in java driver. Can be controlled by a new enableUserAgentOnConnect configuration. It is enabled by default.
 * Added logging in .NET.
 
 ==== Bugs

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -848,6 +848,14 @@ Server returns for a single request.  Again, this description of Gremlin Server'
 out-of-the-box configuration.  It is quite possible to construct other flows, that might be more amenable to a
 particular language or style of processing.
 
+It is recommended but not required that a driver include a `User-Agent` header as part of any web socket
+handshake request to Gremlin Server. Gremlin Server uses the user agent in building usage metrics
+as well as debugging. The standard format for connection user agents is:
+
+`"[Application Name] [GLV Name].[Version] [Language Runtime Version] [OS].[Version] [CPU Architecture]"`
+For example:
+`"MyTestApplication Gremlin-Java.3.5.4 11.0.16.1 Mac_OS_X.12.6.1 aarch64"`
+
 To formulate a request to Gremlin Server, a `RequestMessage` needs to be constructed.  The `RequestMessage` is a
 generalized representation of a request that carries a set of "standard" values in addition to optional ones that are
 dependent on the operation being performed.  A `RequestMessage` has these fields:

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1279,6 +1279,10 @@ session-based requests where "engine-name" will be the actual name of the engine
 * `engine-name.sessionless.*` - Metrics related to different `GremlinScriptEngine` instances configured for sessionless
 requests where "engine-name" will be the actual name of the engine, such as "gremlin-groovy". This metric is not
 measured under the `UnifiedChannelizer`.
+* `user-agent.*` - Counts the number of connection requests from clients providing a given user agent.
+
+NOTE: Gremlin Server has a limit of 10000 unique user agents to be tracked by metrics. If this cap is exceeded
+any additional unique user agents will be counted as `user-agent.other`.
 
 ==== As A Service
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -329,6 +329,7 @@ The following table describes the various configuration options for the Gremlin 
 |serializer.config |A `Map` of configuration settings for the serializer. |_none_
 |username |The username to submit on requests that require authentication. |_none_
 |workerPoolSize |Size of the pool for handling background work. |available processors * 2
+|enableUserAgentOnConnect |Enables sending a user agent to the server during connection requests. More details can be found in provider docs link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|true
 |=========================================================
 
 Please see the link:https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/driver/Cluster.Builder.html[Cluster.Builder javadoc] to get more information on these settings.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -27,10 +27,11 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.http.EmptyHttpHeaders;
-import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.ssl.SslContext;
@@ -178,10 +179,14 @@ public interface Channelizer extends ChannelHandler {
                 throw new IllegalStateException("To use wss scheme ensure that enableSsl is set to true in configuration");
 
             final int maxContentLength = cluster.connectionPoolSettings().maxContentLength;
+            final HttpHeaders httpHeaders = new DefaultHttpHeaders();
+            if(connection.getCluster().isUserAgentOnConnectEnabled()) {
+                httpHeaders.set(UserAgent.USER_AGENT_HEADER_NAME, UserAgent.USER_AGENT);
+            }
             handler = new WebSocketClientHandler(
                     new WebSocketClientHandler.InterceptedWebSocketClientHandshaker13(
-                            connection.getUri(), WebSocketVersion.V13, null,true,
-                            EmptyHttpHeaders.INSTANCE, maxContentLength, true, false, -1,
+                            connection.getUri(), WebSocketVersion.V13, null, true,
+                            httpHeaders, maxContentLength, true, false, -1,
                             cluster.getHandshakeInterceptor()), cluster.getConnectionSetupTimeout());
 
             final int keepAliveInterval = toIntExact(TimeUnit.SECONDS.convert(

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -99,6 +99,11 @@ final class Settings {
     public String protocol = null;
 
     /**
+     * Toggles if user agent should be sent in web socket handshakes.
+     */
+    public boolean enableUserAgentOnConnect = true;
+
+    /**
      * Read configuration from a file into a new {@link Settings} object.
      *
      * @param stream an input stream containing a Gremlin Server YAML configuration
@@ -142,6 +147,9 @@ final class Settings {
 
         if (conf.containsKey("protocol"))
             settings.protocol = conf.getString("protocol");
+
+        if (conf.containsKey("enableUserAgentOnConnect"))
+            settings.enableUserAgentOnConnect = conf.getBoolean("enableUserAgentOnConnect");
 
         if (conf.containsKey("hosts"))
             settings.hosts = conf.getList("hosts").stream().map(Object::toString).collect(Collectors.toList());

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/UserAgent.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/UserAgent.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.apache.tinkerpop.gremlin.util.Gremlin;
+import javax.naming.NamingException;
+
+public class UserAgent {
+
+    /**
+     * Request header name for user agent
+     */
+    public static final String USER_AGENT_HEADER_NAME = "User-Agent";
+    /**
+     * User Agent body to be sent in web socket handshake
+     * Has the form of:
+     * [Application Name] [GLV Name]/[Version] [Language Runtime Version] [OS]/[Version] [CPU Architecture]
+     */
+    public static final String USER_AGENT;
+
+    static {
+        String applicationName = "";
+        try {
+            applicationName = ((String)(new javax.naming.InitialContext().lookup("java:app/AppName"))).replace(' ', '_');
+        } catch (NamingException e) {
+            applicationName = "NotAvailable";
+        };
+
+        final String glvVersion = Gremlin.version().replace(' ', '_');
+        final String javaVersion = System.getProperty("java.version", "NotAvailable").replace(' ', '_');
+        final String osName = System.getProperty("os.name", "NotAvailable").replace(' ', '_');
+        final String osVersion = System.getProperty("os.version", "NotAvailable").replace(' ', '_');
+        final String cpuArch = System.getProperty("os.arch", "NotAvailable").replace(' ', '_');
+
+        USER_AGENT =  String.format("%s Gremlin-Java.%s %s %s.%s %s",
+                                            applicationName, glvVersion, javaVersion,
+                                            osName, osVersion, cpuArch);
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -46,6 +46,7 @@ public class SettingsTest {
         conf.setProperty("hosts", Arrays.asList("255.0.0.1", "255.0.0.2", "255.0.0.3"));
         conf.setProperty("serializer.className", "my.serializers.MySerializer");
         conf.setProperty("serializer.config.any", "thing");
+        conf.setProperty("enableUserAgentOnConnect", false);
         conf.setProperty("connectionPool.enableSsl", true);
         conf.setProperty("connectionPool.keyStore", "server.jks");
         conf.setProperty("connectionPool.keyStorePassword", "password2");
@@ -82,6 +83,7 @@ public class SettingsTest {
         assertEquals(Arrays.asList("255.0.0.1", "255.0.0.2", "255.0.0.3"), settings.hosts);
         assertEquals("my.serializers.MySerializer", settings.serializer.className);
         assertEquals("thing", settings.serializer.config.get("any"));
+        assertEquals(false, settings.enableUserAgentOnConnect);
         assertThat(settings.connectionPool.enableSsl, is(true));
         assertEquals("server.jks", settings.connectionPool.keyStore);
         assertEquals("password2", settings.connectionPool.keyStorePassword);

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWSGremlinInitializer.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/TestWSGremlinInitializer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
@@ -69,6 +71,12 @@ public class TestWSGremlinInitializer extends TestWebSocketServerInitializer {
             UUID.fromString("3c4cf18a-c7f2-4dad-b9bf-5c701eb33000");
     public static final UUID RESPONSE_CONTAINS_SERVER_ERROR_REQUEST_ID =
             UUID.fromString("0d333b1d-6e91-4807-b915-50b9ad721d20");
+    /**
+     * If a request with this ID comes to the server, the server responds with the user agent (if any) that was captured
+     * during the web socket handshake.
+     */
+    public static final UUID USER_AGENT_REQUEST_ID =
+            UUID.fromString("20ad7bfb-4abf-d7f4-f9d3-9f1d55bee4ad");
 
     /**
      * Gremlin serializer used for serializing/deserializing the request/response. This should be same as client.
@@ -84,6 +92,7 @@ public class TestWSGremlinInitializer extends TestWebSocketServerInitializer {
      * Handler introduced in the server pipeline to configure expected response for test cases.
      */
     private static class ClientTestConfigurableHandler extends MessageToMessageDecoder<BinaryWebSocketFrame> {
+        private String userAgent = "";
         @Override
         protected void decode(final ChannelHandlerContext ctx, final BinaryWebSocketFrame frame, final List<Object> objects)
                 throws Exception {
@@ -127,6 +136,9 @@ public class TestWSGremlinInitializer extends TestWebSocketServerInitializer {
                 Thread.sleep(1000);
                 ctx.channel().writeAndFlush(new CloseWebSocketFrame());
             }
+            else if (msg.getRequestId().equals(USER_AGENT_REQUEST_ID)) {
+                ctx.channel().writeAndFlush(new TextWebSocketFrame(returnSimpleStringResponse(USER_AGENT_REQUEST_ID, userAgent)));
+            }
         }
 
         private String returnSingleVertexResponse(final UUID requestID) throws SerializationException {
@@ -135,6 +147,31 @@ public class TestWSGremlinInitializer extends TestWebSocketServerInitializer {
             final Vertex t = g.V().limit(1).next();
 
             return SERIALIZER.serializeResponseAsString(ResponseMessage.build(requestID).result(t).create());
+        }
+
+        /**
+         * Packages a string message into a ResponseMessage, serializes it, and returns the serialized string
+         * @throws SerializationException
+         */
+        private String returnSimpleStringResponse(final UUID requestID, String message) throws SerializationException {
+            return SERIALIZER.serializeResponseAsString(ResponseMessage.build(requestID).result(message).create());
+        }
+
+        /**
+         * Captures and stores User-Agent if included in header
+         */
+        @Override
+        public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+            if(evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
+                WebSocketServerProtocolHandler.HandshakeComplete handshake = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
+                HttpHeaders requestHeaders = handshake.requestHeaders();
+                if(requestHeaders.contains(UserAgent.USER_AGENT_HEADER_NAME)) {
+                    userAgent = requestHeaders.get(UserAgent.USER_AGENT_HEADER_NAME);
+                }
+                else {
+                    ctx.fireUserEventTriggered(evt);
+                }
+            }
         }
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -89,6 +89,44 @@ public class WebSocketClientBehaviorIntegrateTest {
     }
 
     /**
+     * Tests that client is correctly sending user agent during web socket handshake by having the server return
+     * the captured user agent.
+     */
+    @Test
+    public void shouldIncludeUserAgentInHandshakeRequest() {
+        final Cluster cluster = Cluster.build("localhost").port(SimpleSocketServer.PORT)
+                .minConnectionPoolSize(1)
+                .maxConnectionPoolSize(1)
+                .serializer(Serializers.GRAPHSON_V2D0)
+                .create();
+        final Client.ClusteredClient client = cluster.connect();
+
+        // trigger the testing server to return captured user agent
+        String returnedUserAgent = client.submit("1", RequestOptions.build()
+                        .overrideRequestId(TestWSGremlinInitializer.USER_AGENT_REQUEST_ID).create()).one().getString();
+        assertEquals(UserAgent.USER_AGENT, returnedUserAgent);
+    }
+
+    /**
+     * Tests that no user agent is sent to server when that behaviour is disabled.
+     */
+    @Test
+    public void shouldNotIncludeUserAgentInHandshakeRequestIfDisabled() {
+        final Cluster cluster = Cluster.build("localhost").port(SimpleSocketServer.PORT)
+                .minConnectionPoolSize(1)
+                .maxConnectionPoolSize(1)
+                .serializer(Serializers.GRAPHSON_V2D0)
+                .enableUserAgentOnConnect(false)
+                .create();
+        final Client.ClusteredClient client = cluster.connect();
+
+        // trigger the testing server to return captured user agent
+        String returnedUserAgent = client.submit("1", RequestOptions.build()
+                .overrideRequestId(TestWSGremlinInitializer.USER_AGENT_REQUEST_ID).create()).one().getString();
+        assertEquals("", returnedUserAgent);
+    }
+
+    /**
      * Constructs a deadlock situation when initializing a {@link Client} object in sessionless form that leads to
      * hanging behavior in low resource environments (TINKERPOP-2504) and for certain configurations of the
      * {@link Cluster} object where there are simply not enough threads to properly allow the {@link Host} and its

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelHandlerContext;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinScriptChecker;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.server.handler.Frame;
+import org.apache.tinkerpop.gremlin.server.handler.WsUserAgentHandler;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,6 +152,15 @@ public class Context {
      */
     public GremlinExecutor getGremlinExecutor() {
         return gremlinExecutor;
+    }
+
+    /**
+     * Returns the user agent (if any) which was sent from the client during the web socket handshake.
+     * Returns empty string if no user agent exists
+     */
+    public String getUserAgent() {
+        return getChannelHandlerContext().channel().hasAttr(WsUserAgentHandler.USER_AGENT_ATTR_KEY) ?
+                getChannelHandlerContext().channel().attr(WsUserAgentHandler.USER_AGENT_ATTR_KEY).get() : "";
     }
 
     /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
@@ -25,7 +25,6 @@ import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
 import org.apache.tinkerpop.gremlin.server.Channelizer;
 import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
 import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
-import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.handler.WebSocketAuthorizationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.SaslAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.WsGremlinBinaryRequestDecoder;
@@ -33,6 +32,8 @@ import org.apache.tinkerpop.gremlin.server.handler.WsGremlinCloseRequestDecoder;
 import org.apache.tinkerpop.gremlin.server.handler.GremlinResponseFrameEncoder;
 import org.apache.tinkerpop.gremlin.server.handler.WsGremlinResponseFrameEncoder;
 import org.apache.tinkerpop.gremlin.server.handler.WsGremlinTextRequestDecoder;
+import org.apache.tinkerpop.gremlin.server.handler.WsUserAgentHandler;
+import org.apache.tinkerpop.gremlin.server.Settings;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
@@ -108,7 +109,7 @@ public class WebSocketChannelizer extends AbstractChannelizer {
                 closeOnProtocolViolation(false).allowExtensions(true).maxFramePayloadLength(settings.maxContentLength).build();
         pipeline.addLast(PIPELINE_REQUEST_HANDLER, new WebSocketServerProtocolHandler(GREMLIN_ENDPOINT,
                 null, false, false, 10000L, wsDecoderConfig));
-
+        pipeline.addLast("ws-user-agent-handler", new WsUserAgentHandler());
         if (logger.isDebugEnabled())
             pipeline.addLast(new LoggingHandler("log-aggregator-encoder", LogLevel.DEBUG));
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsUserAgentHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsUserAgentHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.util.AttributeKey;
+import org.apache.tinkerpop.gremlin.driver.UserAgent;
+import org.apache.tinkerpop.gremlin.server.GremlinServer;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Channel handler which extracts a user agent header from a web socket handshake if present
+ * then logs the user agent and stores it as a channel attribute for future reference.
+ */
+public class WsUserAgentHandler extends ChannelInboundHandlerAdapter {
+    /**
+     * This constant caps the number of unique user agents which will be tracked in the metrics. Any new unique
+     * user agents will be replaced with "other" in the metrics after this cap has been reached.
+     */
+    private static final int MAX_USER_AGENT_METRICS = 10000;
+
+    private static final Logger logger = LoggerFactory.getLogger(WsUserAgentHandler.class);
+    public static final AttributeKey<String> USER_AGENT_ATTR_KEY = AttributeKey.valueOf(UserAgent.USER_AGENT_HEADER_NAME);
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, java.lang.Object evt){
+        if(evt instanceof WebSocketServerProtocolHandler.HandshakeComplete){
+            final HttpHeaders requestHeaders = ((WebSocketServerProtocolHandler.HandshakeComplete) evt).requestHeaders();
+
+            if(requestHeaders.contains(UserAgent.USER_AGENT_HEADER_NAME)){
+                String userAgent = requestHeaders.get(UserAgent.USER_AGENT_HEADER_NAME);
+
+                ctx.channel().attr(USER_AGENT_ATTR_KEY).set(userAgent);
+                logger.debug("New Connection on channel [{}] with user agent [{}]", ctx.channel().id().asShortText(), userAgent);
+
+                String metricName = MetricRegistry.name(GremlinServer.class, "user-agent", userAgent);
+
+                // This check is to address a concern that an attacker may try to fill the server's memory with a very
+                // large number of unique user agents. For this reason the user agent is replaced with "other"
+                // for the purpose of metrics if this cap is ever exceeded and the user agent is not already being tracked.
+                if(MetricManager.INSTANCE.getCounterSize() > MAX_USER_AGENT_METRICS &&
+                    !MetricManager.INSTANCE.contains(metricName)){
+                    metricName = MetricRegistry.name(GremlinServer.class, "user-agent", "other");
+                }
+                MetricManager.INSTANCE.getCounter(metricName).inc();
+            }
+            else{
+                logger.debug("New Connection on channel [{}] with no user agent provided", ctx.channel().id().asShortText());
+            }
+        }
+        ctx.fireUserEventTriggered(evt);
+    }
+}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/MetricManager.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/MetricManager.java
@@ -392,6 +392,14 @@ public enum MetricManager {
         getRegistry().removeMatching((s, metric) -> true);
     }
 
+    public int getCounterSize() {
+        return INSTANCE.getRegistry().getCounters().size();
+    }
+
+    public boolean contains(String name) {
+        return INSTANCE.getRegistry().getNames().contains(name);
+    }
+
     public Counter getCounter(final String name) {
         return getRegistry().counter(name);
     }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/TestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/TestChannelizer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.tinkerpop.gremlin.server.Channelizer;
+
+public interface TestChannelizer extends Channelizer {
+    public ChannelHandlerContext getMostRecentChannelHandlerContext();
+
+    @ChannelHandler.Sharable
+    class ContextHandler extends ChannelInboundHandlerAdapter {
+
+        private ChannelHandlerContext ctx;
+
+        @Override
+        public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
+            super.channelRead(ctx, msg);
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
+            super.userEventTriggered(ctx, evt);
+            this.ctx = ctx;
+        }
+
+        public ChannelHandlerContext getMostRecentChannelHandlerContext() {
+            return this.ctx;
+        }
+    }
+}
+
+

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/UnifiedTestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/UnifiedTestChannelizer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+
+/**
+ * A wrapper around UnifiedChannelizer which saves and exposes the ChannelHandlerContext for testing purposes
+ */
+public class UnifiedTestChannelizer extends UnifiedChannelizer implements TestChannelizer {
+
+    final ContextHandler contextHandler;
+
+    public UnifiedTestChannelizer() {
+        contextHandler = new ContextHandler();
+    }
+
+    @Override
+    public void configure(final ChannelPipeline pipeline) {
+        super.configure(pipeline);
+        pipeline.addLast(contextHandler);
+    }
+
+    public ChannelHandlerContext getMostRecentChannelHandlerContext() {
+        return contextHandler.getMostRecentChannelHandlerContext();
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketTestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketTestChannelizer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+
+/**
+ * A wrapper around WebSocketChannelizer which saves and exposes the ChannelHandlerContext for testing purposes
+ */
+public class WebSocketTestChannelizer extends WebSocketChannelizer implements TestChannelizer {
+
+    final ContextHandler contextHandler;
+
+    public WebSocketTestChannelizer() {
+        contextHandler = new ContextHandler();
+    }
+
+    @Override
+    public void configure(final ChannelPipeline pipeline) {
+        super.configure(pipeline);
+        pipeline.addLast(contextHandler);
+    }
+
+    public ChannelHandlerContext getMostRecentChannelHandlerContext() {
+        return contextHandler.getMostRecentChannelHandlerContext();
+    }
+}


### PR DESCRIPTION
Progress towards [TINKERPOP-2480](https://issues.apache.org/jira/browse/TINKERPOP-2480)

Adds a user agent to gremlin-driver which is sent during the web socket handshake.

User agent follows the form of [Application Name] [GLV Name].[Version] [Language Runtime Version] [OS].[Version] [CPU Architecture]

This behaviour is enabled by default but can be disabled by setting the enableWsHandshakeUserAgent configuration to false.