### PR TITLE
TINKERPOP-2810 allow newer aiohttp versions

### DIFF
--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -46,7 +46,7 @@ version = __version__.version
 
 install_requires = [
     'nest_asyncio',
-    'aiohttp>=3.8.0,<=3.8.1',
+    'aiohttp>=3.8.0,<4.0.0',
     'aenum>=1.4.5,<4.0.0',
     'isodate>=0.6.0,<1.0.0'
 ]


### PR DESCRIPTION
Requirement had been >=3.8.0,<=3.8.1 in order to avoid a bug in versions <=3.7.4, but in the meantime, newer versions have been released.