### PR TITLE
TINKERPOP-2480 Add User-Agent to Python Driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added user agent to web socket handshake in java driver. Can be controlled by a new enableUserAgentOnConnect configuration. It is enabled by default.
 * Added user agent to web socket handshake in Gremlin.Net driver. Can be controlled by `EnableUserAgentOnConnect` in `ConnectionPoolSettings`. It is enabled by default.
 * Added user agent to web socket handshake in go driver. Can be controlled by a new `EnableUserAgentOnConnect` setting. It is enabled by default.
+* Added user agent to web socket handshake in python driver. Can be controlled by a new `enable_user_agent_on_connect` setting. It is enabled by default.
 * Added logging in .NET.
 * Added `addDefaultXModule` to `GraphSONMapper` as a shortcut for including a version matched GraphSON extension module.
 * Modified `GraphSONRecordReader` and `GraphSONRecordWriter` to include the GraphSON extension module by default.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -2037,6 +2037,9 @@ can be passed to the `Client` or `DriverRemoteConnection` instance as keyword ar
 |username |The username to submit on requests that require authentication. |""
 |kerberized_service |the first part of the principal name configured for the gremlin service|"""
 |session | A unique string-based identifier (typically a UUID) to enable a <<sessions,session-based connection>>. This is not a valid configuration for `DriverRemoteConnection`. |None
+|enable_user_agent_on_connect |Enables sending a user agent to the server during connection requests.
+More details can be found in provider docs
+link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|True
 |=========================================================
 
 Note that the `transport_factory` can allow for additional configuration of the `AiohttpTransport`, which allows

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -41,11 +41,12 @@ class Client:
                  transport_factory=None, pool_size=None, max_workers=None,
                  message_serializer=None, username="", password="",
                  kerberized_service="", headers=None, session=None,
-                 **transport_kwargs):
+                 enable_user_agent_on_connect=True, **transport_kwargs):
         logging.info("Creating Client with url '%s'", url)
         self._closed = False
         self._url = url
         self._headers = headers
+        self._enable_user_agent_on_connect = enable_user_agent_on_connect
         self._traversal_source = traversal_source
         if "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
@@ -140,7 +141,7 @@ class Client:
         return connection.Connection(
             self._url, self._traversal_source, protocol,
             self._transport_factory, self._executor, self._pool,
-            headers=self._headers)
+            headers=self._headers, enable_user_agent_on_connect=self._enable_user_agent_on_connect)
 
     def submit(self, message, bindings=None, request_options=None):
         return self.submit_async(message, bindings=bindings, request_options=request_options).result()

--- a/gremlin-python/src/main/python/gremlin_python/driver/connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/connection.py
@@ -18,7 +18,7 @@ import uuid
 from concurrent.futures import Future
 from six.moves import queue
 
-from gremlin_python.driver import resultset
+from gremlin_python.driver import resultset, useragent
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
@@ -26,7 +26,7 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 class Connection:
 
     def __init__(self, url, traversal_source, protocol, transport_factory,
-                 executor, pool, headers=None):
+                 executor, pool, headers=None, enable_user_agent_on_connect=True):
         self._url = url
         self._headers = headers
         self._traversal_source = traversal_source
@@ -37,6 +37,11 @@ class Connection:
         self._pool = pool
         self._results = {}
         self._inited = False
+        self._enable_user_agent_on_connect = enable_user_agent_on_connect
+        if self._enable_user_agent_on_connect:
+            if self._headers is None:
+                self._headers = dict()
+            self._headers[useragent.userAgentHeader] = useragent.userAgent
 
     def connect(self):
         if self._transport:

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -37,7 +37,7 @@ class DriverRemoteConnection(RemoteConnection):
                  username="", password="", kerberized_service='',
                  message_serializer=None, graphson_reader=None,
                  graphson_writer=None, headers=None, session=None,
-                 **transport_kwargs):
+                 enable_user_agent_on_connect=True, **transport_kwargs):
         logging.info("Creating DriverRemoteConnection with url '%s'", str(url))
         self.__url = url
         self.__traversal_source = traversal_source
@@ -53,6 +53,7 @@ class DriverRemoteConnection(RemoteConnection):
         self.__graphson_writer = graphson_writer
         self.__headers = headers
         self.__session = session
+        self.__enable_user_agent_on_connect = enable_user_agent_on_connect
         self.__transport_kwargs = transport_kwargs
 
         # keeps a list of sessions that have been spawned from this DriverRemoteConnection
@@ -74,6 +75,7 @@ class DriverRemoteConnection(RemoteConnection):
                                      kerberized_service=kerberized_service,
                                      headers=headers,
                                      session=session,
+                                     enable_user_agent_on_connect=enable_user_agent_on_connect,
                                      **transport_kwargs)
         self._url = self._client._url
         self._traversal_source = self._client._traversal_source
@@ -148,6 +150,7 @@ class DriverRemoteConnection(RemoteConnection):
                                       graphson_writer=self.__graphson_writer,
                                       headers=self.__headers,
                                       session=uuid.uuid4(),
+                                      enable_user_agent_on_connect=self.__enable_user_agent_on_connect,
                                       **self.__transport_kwargs)
         self.__spawned_sessions.append(conn)
         return conn

--- a/gremlin-python/src/main/python/gremlin_python/driver/useragent.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/useragent.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import platform
+
+
+def _generate_user_agent():
+    application_name = "NotAvailable"
+    try:
+        from gremlin_python import __version__
+        driver_version = __version__.version.replace(" ", "_")
+    except ImportError:
+        driver_version = "NotAvailable"
+    runtime_version = platform.python_version().replace(" ", "_")
+    os_name = platform.system().replace(" ", "_")
+    os_version = platform.release().replace(" ", "_")
+    architecture = platform.machine().replace(" ", "_")
+    user_agent = "{appName} Gremlin-Python.{driverVersion} {runtimeVersion} {osName}.{osVersion} {cpuArch}".format(
+                    appName=application_name, driverVersion=driver_version, runtimeVersion=runtime_version,
+                    osName=os_name, osVersion=os_version, cpuArch=architecture)
+
+    return user_agent
+
+
+userAgent = _generate_user_agent()
+userAgentHeader = "User-Agent"


### PR DESCRIPTION
Progress towards [TINKERPOP-2480](https://issues.apache.org/jira/browse/TINKERPOP-2480)

Adds a user agent to gremlin-python which is sent as a request header during the web socket handshake.

User agent follows the form of [Application Name] [GLV Name].[Version] [Language Runtime Version] [OS].[Version] [CPU Architecture]

This behavior is enabled by default but can be disabled by setting the enable_user_agent_on_connect configuration to false.

Note: There are no tests included as part of this PR. My intention is to add integration tests to ensure that the user agent is being sent correctly once [TINKERPOP-2819](https://issues.apache.org/jira/browse/TINKERPOP-2819) has been merged. The existing python glv tests are sufficient to show that this change does not introduce any faults into the driver. I have conducted manual tests to ensure that the changes are currently functioning correctly. My thoughts are that with a potential release approaching, it is worthwhile to have the user agent introduced now, with full validation coming soon.