### PR TITLE
TINKERPOP-2813 Make gremlin-driver more optimistic about host availability

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bumped `ivy` to 2.5.1 to fix security vulnerability
 * Removed default SSL handshake timeout. The SSL handshake timeout will instead be capped by setting `connectionSetupTimeoutMillis`.
 * Improved logging for `gremlin-driver`.
+* Modified `Connection` and `Host` job scheduling in `gremlin-driver` by dividing their work to two different thread pools and sparing work from the primary pool responsible for submitting requests and reading results.
+* Prevented usage of the fork-join pool for `gremlin-driver` job scheduling.
+* Changed `Host` initialization within a `Client` to be parallel again in `gremlin-driver`.
 
 ==== Bugs
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Modified `Connection` and `Host` job scheduling in `gremlin-driver` by dividing their work to two different thread pools and sparing work from the primary pool responsible for submitting requests and reading results.
 * Prevented usage of the fork-join pool for `gremlin-driver` job scheduling.
 * Changed `Host` initialization within a `Client` to be parallel again in `gremlin-driver`.
+* Changed mechanism for determining `Host` health which should make the driver more resilient to intermittent network failures.
+* Removed the delay for reconnecting to a potentially unhealthy `Host` only marking it as unavailable after that initial retry fails.
+* Prevented fast `NoHostAvailableException` in favor of more direct exceptions when borrowing connections from the `ConnectionPool`.
 
 ==== Bugs
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bumped to Netty 4.1.85.
 * Bumped `ivy` to 2.5.1 to fix security vulnerability
 * Removed default SSL handshake timeout. The SSL handshake timeout will instead be capped by setting `connectionSetupTimeoutMillis`.
+* Improved logging for `gremlin-driver`.
 
 ==== Bugs
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -658,6 +658,31 @@ social.persons("marko").knows("josh");
 NOTE: Using Maven, as shown in the `gremlin-archetype-dsl` module, makes developing DSLs with the annotation processor
 straightforward in that it sets up appropriate paths to the generated code automatically.
 
+[[gremlin-java-troubleshooting]]
+=== Troubleshooting
+
+*Max frame length of 65536 has been exceeded*
+
+This error occurs when the driver attempts to process a request/response that exceeds the configured maximum size.
+The most direct way to fix this problem is to increase the `maxContentLength` setting in the driver. Ideally, the
+`maxContentLength` set for the driver should match the setting defined on the server.
+
+*TimeoutException*
+
+A `TimeoutException` is thrown by the driver when the time limit assigned by the `maxWaitForConnection` is exceeded
+when trying to borrow a connection from the connection pool for a particular host. There are generally two scenarios
+where this occurs:
+
+1. The server has actually reached its maximum capacity or the driver has just learned that the server is unreachable.
+2. The client is throttling requests.
+
+The latter of the two can be addressed from the driver side in the following ways:
+
+* Increase the `maxWaitForConnection` allowing the client to wait a bit longer for a connection to become available.
+* Increase the number of requests allowed per connection by increasing the `maxSimultaneousUsagePerConnection` and
+`maxInProcessPerConnection` settings.
+* Increase the number of connections available in the connection pool by increasing the `maxConnectionPoolSize`.
+
 anchor:java-application-examples[]
 anchor:gremlin-archetypes[]
 [[gremlin-java-examples]]

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -674,7 +674,7 @@ when trying to borrow a connection from the connection pool for a particular hos
 where this occurs:
 
 1. The server has actually reached its maximum capacity or the driver has just learned that the server is unreachable.
-2. The client is throttling requests.
+2. The client is throttling requests when the pool is exhausted.
 
 The latter of the two can be addressed from the driver side in the following ways:
 
@@ -682,6 +682,9 @@ The latter of the two can be addressed from the driver side in the following way
 * Increase the number of requests allowed per connection by increasing the `maxSimultaneousUsagePerConnection` and
 `maxInProcessPerConnection` settings.
 * Increase the number of connections available in the connection pool by increasing the `maxConnectionPoolSize`.
+
+The exception and logs (assuming they are enabled) should contain information about the state of the connection pool
+along with its connections which can help shed more light on which of these scenarios caused the problem.
 
 anchor:java-application-examples[]
 anchor:gremlin-archetypes[]

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -50,6 +50,43 @@ var client = new GremlinClient(new GremlinServer("localhost", 8182), loggerFacto
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2471[TINKERPOP-2471]
 
+==== gremlin-driver Host Availability
+
+The Java drivers approach to determine the health of the host to which it is connected is important to how it behaves.
+The driver has generally taken a pessimistic approach to make this determination, where a failure to borrow a
+connection from the pool would constitute enough evidence to mark the host as dead. Unfortunately a failure to borrow
+from the pool is not the best indicator for a dead host. Intermittent network failure, an overly busy client, or other
+temporary issues could have been at play while the server was perfectly available.
+
+The consequences for marking a host dead are fairly severe as the connection pool is shutdown. While it is shutdown
+in an orderly fashion so as to allow for existing requests to complete if at all possible, it immediately blocks new
+requests producing an immediate `NoHostAvailableException` (assuming there are actually no other hosts to route
+requests to). There is then some delay to reconnect to the server and re-establish each of the connections in the pool,
+which might take some time especially if there was a large pool. If an application were sending hundreds of request
+a second, it would quickly equate to hundreds of exceptions a second, filling logs quickly and making it hard to
+decipher the original root cause from that initial inability to simply borrow a connection.
+
+For 3.5.5, the driver has dropped some of its pessimistic ways and has taken a more optimistic posture when it comes
+to considering host availability. When the driver now has a problem borrowing a connection from the pool, it does not
+assume the worst of a failed host. It instead checks if the other connections in the pool are still alive. If at least
+one is alive it assumes the host is still available and the user simply gets a `TimeoutException` for waiting beyond
+the `maxWaitForConnection` setting. In the event that there are no connections deemed alive, the driver will try to
+issue an immediate reconnect to determine host health. If the reconnect succeeds then the host remains in an available
+state for future requests and if it fails it is finally marked as dead and thus unavailable.
+
+If a host is marked unavailable, the driver, like before, will try to route requests to other configured hosts that
+are healthy. If there are no such other hosts and all are unhealthy, the driver will now make an immediate attempt to
+route the request to a random unavailable host on the off chance it will come back online and the connection pool thus
+re-established. So, rather than a `NoHostAvailableException` flood, the user would instead see a `TimeoutException`
+per request made.
+
+Since the driver was already throwing `NoHostAvailableException` and `TimeoutException`, there shouldn't be too
+many code changes required on upgrade to this version. The main difference to consider is that
+`NoHostAvailableException` should appear less often, so any code that mitigated against a flood of these exceptions,
+such defenses might not be necessary anymore.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2813[TINKERPOP-2813]
+
 == TinkerPop 3.5.4
 
 *Release Date: July 18, 2022*

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -62,7 +62,7 @@ The consequences for marking a host dead are fairly severe as the connection poo
 in an orderly fashion so as to allow for existing requests to complete if at all possible, it immediately blocks new
 requests producing an immediate `NoHostAvailableException` (assuming there are actually no other hosts to route
 requests to). There is then some delay to reconnect to the server and re-establish each of the connections in the pool,
-which might take some time especially if there was a large pool. If an application were sending hundreds of request
+which might take some time especially if there was a large pool. If an application were sending hundreds of requests
 a second, it would quickly equate to hundreds of exceptions a second, filling logs quickly and making it hard to
 decipher the original root cause from that initial inability to simply borrow a connection.
 
@@ -76,14 +76,19 @@ state for future requests and if it fails it is finally marked as dead and thus 
 
 If a host is marked unavailable, the driver, like before, will try to route requests to other configured hosts that
 are healthy. If there are no such other hosts and all are unhealthy, the driver will now make an immediate attempt to
-route the request to a random unavailable host on the off chance it will come back online and the connection pool thus
+route the request to a random unavailable host on the chance it will come back online and the connection pool thus
 re-established. So, rather than a `NoHostAvailableException` flood, the user would instead see a `TimeoutException`
 per request made.
 
 Since the driver was already throwing `NoHostAvailableException` and `TimeoutException`, there shouldn't be too
 many code changes required on upgrade to this version. The main difference to consider is that
-`NoHostAvailableException` should appear less often, so any code that mitigated against a flood of these exceptions,
-such defenses might not be necessary anymore.
+`NoHostAvailableException` should appear less often, so any code that mitigated against a flood of these exceptions
+might not be necessary anymore. One should also consider that if code was relying on the asynchronous
+properties that `Client.submitAsync()` implies in its name, that code may now see more blocking behavior than
+before. In doing this refactoring, it was noted that the connection borrowing behavior has never behaved in a truly
+asynchronous manner and only the fast `NoHostAvailableException` aspect of that method behavior really contributed to
+an asynchronous looking call for failed connection borrowing. With the fast `NoHostAvailableException` gone, it may be
+more likely now to note blocking behavior when a connection cannot be obtained.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2813[TINKERPOP-2813]
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionFactory.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
+
+/**
+ * A factory that is responsible for creating a {@link Connection} instance. The {@link DefaultConnectionFactory}
+ * simply news up a {@code Connection} using its default constructor. This interface is mostly present to help
+ * enable better testing of the driver internals and likely shouldn't be used otherwise.
+ */
+interface ConnectionFactory {
+
+    /**
+     * Create a connection for the specified {@link ConnectionPool}.
+     */
+    public default Connection create(final ConnectionPool pool) throws ConnectionException {
+        return new Connection(pool.host.getHostUri(), pool, pool.settings().maxInProcessPerConnection);
+    }
+
+    /**
+     * Default implementation.
+     */
+    public static class DefaultConnectionFactory implements ConnectionFactory { }
+}

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -105,7 +105,7 @@ final class ConnectionPool {
                     } catch (ConnectionException e) {
                         throw new CompletionException(e);
                     }
-                }, cluster.executor()));
+                }, cluster.connectionScheduler()));
             }
 
             CompletableFuture.allOf(connectionCreationFutures.toArray(new CompletableFuture[0])).join();
@@ -311,7 +311,7 @@ final class ConnectionPool {
     }
 
     private void newConnection() {
-        cluster.executor().submit(() -> {
+        cluster.connectionScheduler().submit(() -> {
             addConnectionIfUnderMaximum();
             scheduledForCreation.decrementAndGet();
             return null;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -363,12 +363,12 @@ final class ConnectionPool {
 
         try {
             connections.add(connectionFactory.create(this));
-        } catch (Exception ce) {
+        } catch (Exception ex) {
             open.decrementAndGet();
             logger.error(String.format(
                     "Connections[%s] were under maximum allowed[%s], but there was an error creating a new connection",
                             openCountToActOn, maxPoolSize),
-                    ce);
+                    ex);
             considerHostUnavailable();
             return false;
         }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
@@ -77,7 +77,7 @@ public final class Host {
 
         // only do a connection re-attempt if one is not already in progress
         if (retryInProgress.compareAndSet(Boolean.FALSE, Boolean.TRUE)) {
-            retryThread = this.cluster.scheduler().scheduleAtFixedRate(() -> {
+            retryThread = this.cluster.hostScheduler().scheduleAtFixedRate(() -> {
                     logger.debug("Trying to reconnect to dead host at {}", this);
                     if (reconnect.apply(this)) reconnected();
                 }, cluster.connectionPoolSettings().reconnectInterval,

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -82,6 +83,23 @@ public final class Host {
                     if (reconnect.apply(this)) reconnected();
                 }, cluster.connectionPoolSettings().reconnectInterval,
                 cluster.connectionPoolSettings().reconnectInterval, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    void tryReconnectingImmediately(final Function<Host, Boolean> reconnect) {
+        // only do a connection re-attempt if one is not already in progress
+        if (retryInProgress.compareAndSet(Boolean.FALSE, Boolean.TRUE)) {
+            retryThread = this.cluster.hostScheduler().scheduleAtFixedRate(() -> {
+                        logger.debug("Trying to reconnect to host at {}", this);
+                        final boolean reconnected = reconnect.apply(this);
+                        if (reconnected)
+                            reconnected();
+                        else {
+                            logger.warn("Marking {} as unavailable. Trying to reconnect.", this);
+                            isAvailable = false;
+                        }
+                    }, 0,
+                    cluster.connectionPoolSettings().reconnectInterval, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -403,7 +403,6 @@ final class Settings {
         public String validationRequest = "''";
 
         /**
-         *
          * Duration of time in milliseconds provided for connection setup to complete which includes WebSocket
          * handshake and SSL handshake. Beyond this duration an exception would be thrown if the handshake is not
          * complete by then.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/exception/NoHostAvailableException.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/exception/NoHostAvailableException.java
@@ -21,10 +21,14 @@ package org.apache.tinkerpop.gremlin.driver.exception;
 public class NoHostAvailableException extends RuntimeException {
 
     public NoHostAvailableException() {
-        super("All hosts are considered unavailable due to previous exceptions. Check the error log to find the actual reason.");
+        this("All hosts are considered unavailable due to previous exceptions. Check the error log to find the actual reason.");
     }
 
-    public NoHostAvailableException(Throwable ex) {
+    public NoHostAvailableException(final String message) {
+        super(message);
+    }
+
+    public NoHostAvailableException(final Throwable ex) {
         super(ex);
     }
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientTest.java
@@ -58,7 +58,7 @@ public class ClientTest {
         when(mockAvailableHost.isAvailable()).thenReturn(true);
         when(cluster.allHosts()).thenReturn(Collections.singletonList(mockAvailableHost));
         when(cluster.executor()).thenReturn(executor);
-        when(cluster.scheduler()).thenReturn(scheduler);
+        when(cluster.hostScheduler()).thenReturn(scheduler);
     }
 
     @After

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -141,7 +141,7 @@ public class WebSocketClientBehaviorIntegrateTest {
      */
     @Test
     public void shouldNotDeadlockOnInitialization() throws Exception {
-        // it seems you cah add the same host more than once so while kinda weird it is helpful in faithfully
+        // it seems you can add the same host more than once so while kinda weird it is helpful in faithfully
         // recreating the deadlock situation, though it can/will happen with just one host. workerPoolSize at
         // "1" also helps faithfully reproduce the problem though it can happen at larger pool sizes depending
         // on the timing/interleaving of tasks. the larger connection pool sizes may not be required given the

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
@@ -184,6 +184,8 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
         // if there was a exception in the worker thread, then it had better be a TimeoutException
         assertThat(hadFailOtherThanTimeout.get(), is(false));
 
+        connectionFactory.jittery = false;
+
         cluster.close();
     }
 
@@ -212,7 +214,7 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
             if (jittery && connectionsCreated.incrementAndGet() % numberOfConnectionsBetweenErrors == 0) {
                 connectionFailures.incrementAndGet();
                 throw new ConnectionException(pool.host.getHostUri(),
-                        new SSLHandshakeException("SSL on the funk - server is big mad"));
+                        new SSLHandshakeException("SSL on the funk - server is big mad with the jitters"));
             }
 
             return ConnectionFactory.super.create(pool);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
@@ -21,6 +21,8 @@ package org.apache.tinkerpop.gremlin.driver;
 import io.netty.handler.codec.CorruptedFrameException;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
+import org.apache.tinkerpop.gremlin.driver.exception.NoHostAvailableException;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import org.apache.tinkerpop.gremlin.server.AbstractGremlinServerIntegrationTest;
 import org.apache.tinkerpop.gremlin.server.TestClientFactory;
@@ -28,13 +30,25 @@ import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrationTest {
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(ClientConnectionIntegrateTest.class);
     private Log4jRecordingAppender recordingAppender = null;
     private Level previousLogLevel;
 
@@ -109,5 +123,99 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
         // isDead=true indicating the connection that was closed due to CorruptedFrameException.
         assertThat(recordingAppender.logContainsAny("^(?!.*(isDead=false)).*isDead=true.*destroyed successfully.$"), is(true));
 
+    }
+
+    /**
+     * Added for TINKERPOP-2813 - this scenario would have previously thrown tons of
+     * {@link NoHostAvailableException}.
+     */
+    @Test
+    public void shouldSucceedWithJitteryConnection() throws Exception {
+        final Cluster cluster = TestClientFactory.build().minConnectionPoolSize(1).maxConnectionPoolSize(4).
+                reconnectInterval(1000).
+                maxWaitForConnection(4000).validationRequest("g.inject()").create();
+        final Client.ClusteredClient client = cluster.connect();
+
+        client.init();
+
+        // every 10 connections let's have some problems
+        final JitteryConnectionFactory connectionFactory = new JitteryConnectionFactory(3);
+        client.hostConnectionPools.forEach((h, pool) -> pool.connectionFactory = connectionFactory);
+
+        // get an initial connection which marks the host as available
+        assertEquals(2, client.submit("1+1").all().join().get(0).getInt());
+
+        // network is gonna get fishy - ConnectionPool should try to grow during the workload below and when it
+        // does some connections will fail to create in the background which should log some errors but not tank
+        // the submit() as connections that are currently still working and active should be able to handle the load.
+        connectionFactory.jittery = true;
+
+        // load up a hella ton of requests
+        final int requests = 1000;
+        final CountDownLatch latch = new CountDownLatch(requests);
+        final AtomicBoolean hadFailOtherThanTimeout = new AtomicBoolean(false);
+
+        new Thread(() -> {
+            IntStream.range(0, requests).forEach(i -> {
+                try {
+                    client.submitAsync("1 + " + i);
+                } catch (Exception ex) {
+                    // we could catch a TimeoutException here in some cases if the jitters cause a borrow of a
+                    // connection to take too long. submitAsync() will wrap in a RuntimeException. can't assert
+                    // this condition inside this thread or the test locks up
+                    hadFailOtherThanTimeout.compareAndSet(false, !(ex.getCause() instanceof TimeoutException));
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }, "worker-shouldSucceedWithJitteryConnection").start();
+
+        // wait long enough for the jitters to kick in at least a little
+        while (latch.getCount() > 500) {
+            TimeUnit.MILLISECONDS.sleep(50);
+        }
+
+        // wait for requests to complete
+        assertTrue(latch.await(30000, TimeUnit.MILLISECONDS));
+
+        // make sure we had some failures for sure coming out the factory
+        assertThat(connectionFactory.getNumberOfFailures(), is(greaterThan(0L)));
+
+        // if there was a exception in the worker thread, then it had better be a TimeoutException
+        assertThat(hadFailOtherThanTimeout.get(), is(false));
+
+        cluster.close();
+    }
+
+    /**
+     * Introduces random failures when creating a {@link Connection} for the {@link ConnectionPool}.
+     */
+    public static class JitteryConnectionFactory implements ConnectionFactory {
+
+        private volatile boolean jittery = false;
+        private final AtomicLong connectionsCreated = new AtomicLong(0);
+        private final AtomicLong connectionFailures = new AtomicLong(0);
+        private final int numberOfConnectionsBetweenErrors;
+
+        public JitteryConnectionFactory(final int numberOfConnectionsBetweenErrors) {
+            this.numberOfConnectionsBetweenErrors = numberOfConnectionsBetweenErrors;
+        }
+
+        public long getNumberOfFailures() {
+            return connectionFailures.get();
+        }
+
+        @Override
+        public Connection create(final ConnectionPool pool) {
+
+            // fail creating a connection every 10 attempts or so when jittery
+            if (jittery && connectionsCreated.incrementAndGet() % numberOfConnectionsBetweenErrors == 0) {
+                connectionFailures.incrementAndGet();
+                throw new ConnectionException(pool.host.getHostUri(),
+                        new SSLHandshakeException("SSL on the funk - server is big mad"));
+            }
+
+            return ConnectionFactory.super.create(pool);
+        }
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/driver/ClientConnectionIntegrateTest.java
@@ -48,7 +48,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrationTest {
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(ClientConnectionIntegrateTest.class);
     private Log4jRecordingAppender recordingAppender = null;
     private Level previousLogLevel;
 
@@ -171,7 +170,7 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
         }, "worker-shouldSucceedWithJitteryConnection").start();
 
         // wait long enough for the jitters to kick in at least a little
-        while (latch.getCount() > 500) {
+        while (latch.getCount() > (requests / 2)) {
             TimeUnit.MILLISECONDS.sleep(50);
         }
 
@@ -183,8 +182,6 @@ public class ClientConnectionIntegrateTest extends AbstractGremlinServerIntegrat
 
         // if there was a exception in the worker thread, then it had better be a TimeoutException
         assertThat(hadFailOtherThanTimeout.get(), is(false));
-
-        connectionFactory.jittery = false;
 
         cluster.close();
     }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.server;
 import org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizer;
 import org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizerIntegrateTest;
 import org.apache.tinkerpop.gremlin.server.op.OpLoader;
+import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assume.assumeThat;
@@ -117,6 +119,10 @@ public abstract class AbstractGremlinServerIntegrationTest {
     }
 
     public void startServer() throws Exception {
+        startServerAsync().join();
+    }
+
+    public CompletableFuture<ServerGremlinExecutor> startServerAsync() throws Exception {
         final InputStream stream = getSettingsInputStream();
         final Settings settings = Settings.read(stream);
         overriddenSettings = overrideSettings(settings);
@@ -131,7 +137,7 @@ public abstract class AbstractGremlinServerIntegrationTest {
 
         this.server = new GremlinServer(overriddenSettings);
 
-        server.start().join();
+        return server.start();
     }
 
     @After

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -55,7 +55,6 @@ import org.apache.tinkerpop.gremlin.util.function.FunctionUtils;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -63,7 +62,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
-import java.io.File;
 import java.net.ConnectException;
 import java.time.Instant;
 import java.util.ArrayList;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2813

Summarized the major points of the change in the Upgrade Docs. Might be best to start there if reviewing this. Made some other adjustments to log better data for debugging purposes with the `ConnectionPool`.  Ended up making a number of adjustments to the thread pools to which various jobs were being submitted. Untangling that led to the addition of two pools which helped bring back parallel host initialization and got rid of random usage of the fork/join pool. I sense that something could be done to eliminate some of these pools but I believe it will come at the cost of a much larger refactoring effort to untangle how some of these jobs get scheduled up. I dunno.....not super pleased with it but gotta go pencils down at some point.

there've been many days of continuous testing on these changes at this point from various folks and all results have been favorable. calling out @kenhuuu specifically, he did some basic performance testing and profiling and didn't find any problems to note:

```text
Test Case:
    2450 short queries (return in milliseconds)
    1280 mix of short and medium queries

Setup:
    m5.2xlarge
    3.5.4 Gremlin Server with gremlin-server.yaml
    Defaults for connection pooling and in flight per connection settings for Java driver

Results for Three Run Average.
    3.5.4:
        Short: 29912ms
        Mixed: 65689ms

    TINKERPOP-2813 branch:
        Short: 30161ms
        Mixed: 65422ms
```

