### PR TITLE
TINKERPOP-2833 Read/Write optimization in TestSupport

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/TestSupport.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/TestSupport.java
@@ -185,10 +185,11 @@ public class TestSupport {
 
         // fill it with the desired contents
         try (final FileOutputStream outputStream = new FileOutputStream(tempFile)) {
-            int data;
+            final byte[] buf = new byte[1024]; // use a buffer to boost the read/write speed
+            int sz;
             try (final InputStream inputStream = resourceClass.getResourceAsStream(resourceName)) {
-                while ((data = inputStream.read()) != -1) {
-                    outputStream.write(data);
+                while ((sz = inputStream.read(buf)) != -1) {
+                    outputStream.write(buf, 0, sz);
                 }
             }
         }


### PR DESCRIPTION
This patch gives ~50X acceleration to load all the test data specified in AbstractFileGraphProvider.java. Before this optimization, it takes 15s to finish. After applying this patch, it takes ~216ms.