### PR TITLE
[Do Not Merge] TINKERPOP-2836 Demonstrate Github Actions Not Running Java Integration Tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,6 +176,22 @@ jobs:
           touch gremlin-python/.glv
           mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+  gremlin-driver:
+    name: gremlin-driver
+    timeout-minutes: 20
+    needs: cache-gremlin-server-docker-image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl gremlin-driver -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -108,6 +108,14 @@ public class WebSocketClientBehaviorIntegrateTest {
     }
 
     /**
+     * Deliberately fails
+     */
+    @Test
+    public void shouldFail() {
+        assertEquals(true, false);
+    }
+
+    /**
      * Tests that no user agent is sent to server when that behaviour is disabled.
      */
     @Test


### PR DESCRIPTION
This PR inserts a deliberately failing test into the java driver integration tests to demonstrate that these tests are not being run with the current configuration of github actions.

The first commit (42543bc) in this pr adds a failing test but the GHA run all passes.
The second commit (efa91cf) adds a new job to GHA and the test executes and fails the run as expected.