### PR TITLE
TINKERPOP-2840 Fixed Flaky Tests

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/ParameterizedGroovyTranslatorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/ParameterizedGroovyTranslatorTest.java
@@ -42,7 +42,7 @@ import javax.script.SimpleBindings;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.function.Function;
 
@@ -134,7 +134,7 @@ public class ParameterizedGroovyTranslatorTest {
 
     @Test
     public void shouldHandleSet() {
-        final Script script = translator.translate(g.V().id().is(new HashSet<Object>() {{
+        final Script script = translator.translate(g.V().id().is(new LinkedHashSet<Object>() {{
             add(3);
             add(Arrays.asList(1, 2, 3.1d));
             add(3);
@@ -144,11 +144,12 @@ public class ParameterizedGroovyTranslatorTest {
         script.getParameters().ifPresent(bindings::putAll);
         assertEquals(5, bindings.size());
         assertEquals(Integer.valueOf(3), bindings.get("_args_0"));
-        assertEquals("3", bindings.get("_args_1"));
-        assertEquals(Integer.valueOf(1), bindings.get("_args_2"));
-        assertEquals(Integer.valueOf(2), bindings.get("_args_3"));
-        assertEquals(Double.valueOf(3.1), bindings.get("_args_4"));
-        assertEquals("g.V().id().is([_args_0, _args_1, [_args_2, _args_3, _args_4]] as Set)", script.getScript());
+        assertEquals(Integer.valueOf(1), bindings.get("_args_1"));
+        assertEquals(Integer.valueOf(2), bindings.get("_args_2"));
+        assertEquals(Double.valueOf(3.1), bindings.get("_args_3"));
+        assertEquals("3", bindings.get("_args_4"));
+
+        assertEquals("g.V().id().is([_args_0, [_args_1, _args_2, _args_3], _args_4] as Set)", script.getScript());
     }
 
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtilsTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtilsTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -174,7 +174,7 @@ public class IteratorUtilsTest {
 
     @Test
     public void shouldConvertMapToIterator() {
-        final Map<String,String> m = new HashMap<>();
+        final Map<String,String> m = new LinkedHashMap<>();
         m.put("key1", "val1");
         m.put("key2", "val2");
         m.put("key3", "val3");
@@ -238,7 +238,7 @@ public class IteratorUtilsTest {
 
     @Test
     public void shouldConvertMapToList() {
-        final Map<String,String> m = new HashMap<>();
+        final Map<String,String> m = new LinkedHashMap<>();
         m.put("key1", "val1");
         m.put("key2", "val2");
         m.put("key3", "val3");


### PR DESCRIPTION
Tests in IteratorUtilsTest and ParameterizedGroovyTranslatorTest express non-deterministic behavior and change the order of the attributes. The fix is changing HashMap to LinkedHashMap and changing HashSet to LinkedHashSet to guarantee determinism.

[Issue] (https://issues.apache.org/jira/browse/TINKERPOP-2840)

After resolving the issues successfully, the tests pass with NonDex - 

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/52324780/206881584-f160ee65-3ea2-447b-8113-7ea7f7a112c3.png">
