### PR TITLE
[TINKERPOP-2836] Fix Java Driver Integration Tests Not Running in GHA For 3.6

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,6 +176,22 @@ jobs:
           touch gremlin-python/.glv
           mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
+  gremlin-driver:
+    name: gremlin-driver
+    timeout-minutes: 20
+    needs: cache-gremlin-server-docker-image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: |
+          mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
+          mvn verify -pl gremlin-driver -DskipIntegrationTests=false
   javascript:
     name: javascript
     timeout-minutes: 15

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -278,6 +278,10 @@ public class WebSocketClientBehaviorIntegrateTest {
         // Initialize the client preemptively
         client.init();
 
+        // Clearing logCaptor before attempting to close the connection is in response to an issue where this test can
+        // be polluted by logs from a previous test when running on slow hardware.
+        logCaptor.clearLogs();
+
         // assert number of connections opened
         final ConnectionPool channelPool = client.hostConnectionPools.values().stream().findFirst().get();
         assertEquals(1, channelPool.getConnectionIDs().size());


### PR DESCRIPTION
This resolves an issue where previously java integration tests were not being run. See [TINKERPOP-2836].