### PR TITLE
TINKERPOP-2837 Fix NPE caused by a thread safe issue

### DIFF
--- a/gremlin-core/pom.xml
+++ b/gremlin-core/pom.xml
@@ -166,6 +166,11 @@ limitations under the License.
               </exclusion>
             </exclusions>
         </dependency>
+	<dependency>
+            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
+            <artifactId>concurrentlinkedhashmap-lru</artifactId>
+            <version>1.4.2</version>
+	</dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ImmutableMetrics.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ImmutableMetrics.java
@@ -18,12 +18,14 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
+import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
+
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -42,7 +44,8 @@ public class ImmutableMetrics implements Metrics, Serializable {
     protected String name;
     protected Map<String, AtomicLong> counts = new ConcurrentHashMap<>();
     protected long durationNs = 0l;
-    protected final Map<String, Object> annotations = Collections.synchronizedMap(new LinkedHashMap<>());
+    protected final Map<String, Object> annotations = new ConcurrentLinkedHashMap
+            .Builder<String, Object>().maximumWeightedCapacity(Integer.MAX_VALUE).build();
     protected final Map<String, ImmutableMetrics> nested = new LinkedHashMap<>();
 
     protected ImmutableMetrics() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.structure.io.gryo;
 
+import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.io.IoRegistry;
@@ -99,6 +100,7 @@ public final class GryoMapper implements Mapper<Kryo> {
         kryo.setReferences(referenceTracking);
         for (TypeRegistration tr : typeRegistrations)
             tr.registerWith(kryo);
+        kryo.register(ConcurrentLinkedHashMap.class);
         return kryo;
     }
 


### PR DESCRIPTION
The current annotations object created by Collections.synchronizedMap() will be shared across multiple threads, and some methods which access this object do not apply lock (synchronized), as a result, NPE occurs. This patch fixed this issue.

