### PR TITLE
Fix RequestId Override

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed mechanism for determining `Host` health which should make the driver more resilient to intermittent network failures.
 * Removed the delay for reconnecting to a potentially unhealthy `Host` only marking it as unavailable after that initial retry fails.
 * Prevented fast `NoHostAvailableException` in favor of more direct exceptions when borrowing connections from the `ConnectionPool`.
+* Fixed an issue in Go and Python GLVs where modifying per request settings to override request_id's was not working correctly.
 
 ==== Bugs
 

--- a/gremlin-go/driver/request.go
+++ b/gremlin-go/driver/request.go
@@ -19,7 +19,10 @@ under the License.
 
 package gremlingo
 
-import "github.com/google/uuid"
+import (
+	"fmt"
+	"github.com/google/uuid"
+)
 
 // request represents a request to the server.
 type request struct {
@@ -47,11 +50,17 @@ func makeStringRequest(stringGremlin string, traversalSource string, sessionId s
 		newProcessor = sessionProcessor
 		newArgs["session"] = sessionId
 	}
+	requestId := uuid.New()
 	if len(bindings) > 0 {
 		newArgs["bindings"] = bindings[0]
+		customRequestId, err := uuid.Parse(fmt.Sprintf("%v", bindings[0]["requestId"]))
+		if err == nil {
+			requestId = customRequestId
+		}
 	}
+
 	return request{
-		requestID: uuid.New(),
+		requestID: requestId,
 		op:        stringOp,
 		processor: newProcessor,
 		args:      newArgs,

--- a/gremlin-go/driver/request_test.go
+++ b/gremlin-go/driver/request_test.go
@@ -1,0 +1,50 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package gremlingo
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequest(t *testing.T) {
+	t.Run("Test makeStringRequest() with custom requestID", func(t *testing.T) {
+		requestId := fmt.Sprintf("%v", uuid.New())
+		r := makeStringRequest("g.V()", "g", "", map[string]interface{}{"requestId": requestId})
+		assert.Equal(t, requestId, fmt.Sprintf("%v", r.requestID))
+	})
+
+	t.Run("Test makeStringRequest() with no bindings", func(t *testing.T) {
+		r := makeStringRequest("g.V()", "g", "")
+		assert.NotNil(t, r.requestID)
+		assert.NotEqual(t, uuid.Nil, r.requestID)
+	})
+
+	t.Run("Test makeStringRequest() with custom evaluationTimeout", func(t *testing.T) {
+		r := makeStringRequest("g.V()", "g", "", map[string]interface{}{"evaluationTimeout": 1234})
+		assert.NotNil(t, r.requestID)
+		assert.NotEqual(t, uuid.Nil, r.requestID)
+		bindings := r.args["bindings"].(map[string]interface{})
+		assert.Equal(t, 1234, bindings["evaluationTimeout"])
+	})
+}

--- a/gremlin-python/src/main/python/gremlin_python/driver/connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/connection.py
@@ -59,6 +59,8 @@ class Connection:
         if not self._inited:
             self.connect()
         request_id = str(uuid.uuid4())
+        if request_message.args.get("requestId"):
+            request_id = request_message.args.get("requestId")
         result_set = resultset.ResultSet(queue.Queue(), request_id)
         self._results[request_id] = result_set
         # Create write task


### PR DESCRIPTION
I believe this fix is small enough for review to be done in CTR fashion. If any commiter agrees with this I would like to merge this in without a lengthy initial review.

Fixes a bug where python and go glv's were not using the correct request_id when overriden. This is detailed in TINKERPOP-2841 and TINKERPOP-2844. This commit is not sufficient to close those tickets as further investigation is needed to ensure the other per-request settings work as intended, this commit provides an immediate fix to the broken request_id functionality.

Also fixes a typo in the python reference docs.