### PR TITLE
[TINKERPOP-2819] Adds gremlin socket server tests in GLVs

### DIFF
--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       timeout: 10s
       retries: 30
       start_period: 30s
+    depends_on:
+      - gremlin-socket-server
 
   gremlin-dotnet-integration-tests:
     container_name: gremlin-dotnet-integration-tests
@@ -50,6 +52,7 @@ services:
       - .:/gremlin-dotnet
       - ../gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features:/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features
       - ../docker/gremlin-test-server:/gremlin-dotnet/gremlin-test-server
+      - ../gremlin-tools/gremlin-socket-server/conf:/gremlin-dotnet/gremlin-socket-server/conf/
     environment:
       - DOCKER_ENVIRONMENT=true
       - TEST_TRANSACTIONS=true
@@ -59,3 +62,10 @@ services:
     depends_on:
       gremlin-server-test-dotnet:
         condition: service_healthy
+
+  gremlin-socket-server:
+    container_name: gremlin-socket-server
+    image: tinkerpop/gremlin-socket-server:${GREMLIN_SERVER}
+    ports:
+      - "45943:45943"
+

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/ConfigProvider.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/ConfigProvider.cs
@@ -46,6 +46,8 @@ namespace Gremlin.Net.IntegrationTest
             if (Convert.ToBoolean(Environment.GetEnvironmentVariable("DOCKER_ENVIRONMENT")))
             {
                 config["TestServerIpAddress"] = config["TestServerIpAddressDocker"];
+                config["GremlinSocketServerIpAddress"] = config["GremlinSocketServerIpAddressDocker"];
+                config["GremlinSocketServerConfig"] = config["GremlinSocketServerConfigDocker"];
             }
 
             return config;

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientBehaviorIntegrationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/GremlinClientBehaviorIntegrationTests.cs
@@ -1,0 +1,88 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Exceptions;
+using Gremlin.Net.Driver.Messages;
+using Gremlin.Net.IntegrationTest.Util;
+using Gremlin.Net.Structure;
+using Gremlin.Net.Structure.IO.GraphBinary;
+using Gremlin.Net.Structure.IO.GraphSON;
+using Xunit;
+
+namespace Gremlin.Net.IntegrationTest.Driver
+{
+    public class GremlinClientBehaviorIntegrationTests
+    {
+        private static readonly string TestHost = ConfigProvider.Configuration["GremlinSocketServerIpAddress"]!;
+
+        private static readonly SocketServerSettings Settings =
+            SocketServerSettings.FromYaml(ConfigProvider.Configuration["GremlinSocketServerConfig"]);
+
+        private static IMessageSerializer Serializer;
+
+        public GremlinClientBehaviorIntegrationTests()
+        {
+            switch (Settings.Serializer)
+            {
+                case "GraphSONV2":
+                    Serializer = new GraphSON2MessageSerializer();
+                    break;
+                case "GraphSONV3":
+                    Serializer = new GraphSON3MessageSerializer();
+                    break;
+                case "GraphBinaryV1":
+                default:
+                    Serializer = new GraphBinaryMessageSerializer();
+                    break;
+            }
+        }
+
+        [Fact]
+        public async Task ShouldTryCreateNewConnectionIfClosedByServer()
+        {
+            var sessionId = Guid.NewGuid().ToString();
+            var poolSettings = new ConnectionPoolSettings {PoolSize = 1};
+            
+            var gremlinServer = new GremlinServer(TestHost, Settings.Port);
+            var gremlinClient = new GremlinClient(gremlinServer, messageSerializer: Serializer,
+                connectionPoolSettings: poolSettings, sessionId: sessionId);
+
+            Assert.Equal(1, gremlinClient.NrConnections);
+            
+            //Send close request to server, ensure server closes connection
+            await Assert.ThrowsAsync<ConnectionClosedException>(async () =>
+                await gremlinClient.SubmitWithSingleResultAsync<Vertex>(RequestMessage.Build("1")
+                    .OverrideRequestId(Settings.CloseConnectionRequestId).Create()));
+            
+            //verify that new client reconnects and new requests can be made again
+            var response2 = await gremlinClient.SubmitWithSingleResultAsync<Vertex>(RequestMessage.Build("1")
+                .OverrideRequestId(Settings.SingleVertexRequestId).Create());
+            Assert.NotNull(response2);
+            Assert.Equal(1, gremlinClient.NrConnections);
+        }
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="YamlDotNet" Version="12.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Util/SocketServerSettings.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Util/SocketServerSettings.cs
@@ -1,3 +1,5 @@
+#region License
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -7,7 +9,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,69 +18,69 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.tinkerpop.gremlin.socket.server;
 
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+#endregion
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Objects;
-import java.util.UUID;
+using System;
+using System.IO;
+using YamlDotNet.Serialization;
 
-/**
- * Encapsulates all constants that are needed by SimpleSocketServer. UUID request id constants are used
- * to coordinate custom response behavior between a test client and the server.
- */
-public class SocketServerSettings {
-    public int PORT = 0;
+namespace Gremlin.Net.IntegrationTest.Util;
+
+public class SocketServerSettings
+{
+    [YamlMember(Alias = "PORT", ApplyNamingConventions = false)]
+    public int Port { get; set; }
 
     /**
      * Configures which serializer will be used. Ex: "GraphBinaryV1" or "GraphSONV2"
      */
-    public String SERIALIZER = "GraphBinaryV1";
+    [YamlMember(Alias = "SERIALIZER", ApplyNamingConventions = false)]
+    public String Serializer { get; set; }
+
     /**
      * If a request with this ID comes to the server, the server responds back with a single vertex picked from Modern
      * graph.
      */
-    public UUID SINGLE_VERTEX_REQUEST_ID = null;
+    [YamlMember(Alias = "SINGLE_VERTEX_REQUEST_ID", ApplyNamingConventions = false)]
+    public Guid SingleVertexRequestId { get; set; }
 
     /**
      * If a request with this ID comes to the server, the server responds back with a single vertex picked from Modern
      * graph. After a 2 second delay, server sends a Close WebSocket frame on the same connection.
      */
-    public UUID SINGLE_VERTEX_DELAYED_CLOSE_CONNECTION_REQUEST_ID = null;
+    [YamlMember(Alias = "SINGLE_VERTEX_DELAYED_CLOSE_CONNECTION_REQUEST_ID", ApplyNamingConventions = false)]
+    public Guid SingleVertexDelayedCloseConnectionRequestId { get; set; }
 
     /**
      * Server waits for 1 second, then responds with a 500 error status code
      */
-    public UUID FAILED_AFTER_DELAY_REQUEST_ID = null;
+    [YamlMember(Alias = "FAILED_AFTER_DELAY_REQUEST_ID", ApplyNamingConventions = false)]
+    public Guid FailedAfterDelayRequestId { get; set; }
 
     /**
      * Server waits for 1 second then responds with a close web socket frame
      */
-    public UUID CLOSE_CONNECTION_REQUEST_ID = null;
+    [YamlMember(Alias = "CLOSE_CONNECTION_REQUEST_ID", ApplyNamingConventions = false)]
+    public Guid CloseConnectionRequestId { get; set; }
 
     /**
      * Same as CLOSE_CONNECTION_REQUEST_ID
      */
-    public UUID CLOSE_CONNECTION_REQUEST_ID_2 = null;
+    [YamlMember(Alias = "CLOSE_CONNECTION_REQUEST_ID_2", ApplyNamingConventions = false)]
+    public Guid CloseConnectionRequestId2 { get; set; }
 
     /**
      * If a request with this ID comes to the server, the server responds with the user agent (if any) that was captured
      * during the web socket handshake.
      */
-    public UUID USER_AGENT_REQUEST_ID = null;
+    [YamlMember(Alias = "USER_AGENT_REQUEST_ID", ApplyNamingConventions = false)]
+    public Guid UserAgentRequestId { get; set; }
+    
+    public static SocketServerSettings FromYaml(String path)
+    {
+        var deserializer = new YamlDotNet.Serialization.DeserializerBuilder().Build();
 
-    public static SocketServerSettings read(final Path confFilePath) throws IOException {
-        return read(Files.newInputStream(confFilePath));
-    }
-
-    public static SocketServerSettings read(final InputStream confInputStream) {
-        Objects.requireNonNull(confInputStream);
-        final Yaml yaml = new Yaml(new Constructor(SocketServerSettings.class));
-        return yaml.load(confInputStream);
+        return deserializer.Deserialize<SocketServerSettings>(File.ReadAllText(path));
     }
 }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/appsettings.json
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/appsettings.json
@@ -2,5 +2,9 @@
   "TestServerIpAddress": "localhost",
   "TestServerIpAddressDocker": "gremlin-server-test-dotnet",
   "TestServerPort": 45940,
-  "TestSecureServerPort": 45941
+  "TestSecureServerPort": 45941,
+  "GremlinSocketServerIpAddress": "localhost",
+  "GremlinSocketServerIpAddressDocker": "gremlin-socket-server",
+  "GremlinSocketServerConfig": "../../../../../../gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml",
+  "GremlinSocketServerConfigDocker": "../../../../../gremlin-socket-server/conf/test-ws-gremlin.yaml"
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/WebSocketClientBehaviorIntegrateTest.java
@@ -70,6 +70,7 @@ public class WebSocketClientBehaviorIntegrateTest {
 
     public WebSocketClientBehaviorIntegrateTest() throws IOException {
         settings = SocketServerSettings.read(FileSystems.getDefault().getPath("..","gremlin-tools", "gremlin-socket-server", "conf", "test-ws-gremlin.yaml"));
+        settings.SERIALIZER = "GraphSONV2";
     }
 
     @BeforeClass

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       timeout: 10s
       retries: 30
       start_period: 30s
+    depends_on:
+      - gremlin-socket-server
 
   gremlin-go-integration-tests:
     container_name: gremlin-go-integration-tests
@@ -50,6 +52,7 @@ services:
       - .:/go_app
       - ../gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features:/gremlin-test
       - ../docker/gremlin-test-server:/go_app/gremlin-test-server
+      - ../gremlin-tools/gremlin-socket-server/conf:/go_app/gremlin-socket-server/conf/
     environment:
       - CUCUMBER_FEATURE_FOLDER=/gremlin-test
       - GREMLIN_SERVER_URL=ws://gremlin-server-test:45940/gremlin
@@ -58,6 +61,8 @@ services:
       - RUN_INTEGRATION_WITH_ALIAS_TESTS=true
       - RUN_BASIC_AUTH_INTEGRATION_TESTS=true
       - TEST_TRANSACTIONS=true
+      - GREMLIN_SOCKET_SERVER_URL=ws://gremlin-socket-server-go
+      - GREMLIN_SOCKET_SERVER_CONFIG_PATH=/go_app/gremlin-socket-server/conf/test-ws-gremlin.yaml
     working_dir: /go_app
     command: >
       bash -c "go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
@@ -65,3 +70,9 @@ services:
     depends_on:
       gremlin-server-test:
         condition: service_healthy
+
+  gremlin-socket-server:
+    container_name: gremlin-socket-server-go
+    image: tinkerpop/gremlin-socket-server:${GREMLIN_SERVER}
+    ports:
+      - "45943:45943"

--- a/gremlin-go/go.sum
+++ b/gremlin-go/go.sum
@@ -53,6 +53,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
+github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - .:/js_app
       - ../../../../../gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features:/gremlin-test
       - ../../../../../docker/gremlin-test-server:/js_app/gremlin-test-server
+      - ../../../../../gremlin-tools/gremlin-socket-server/conf:/js_app/gremlin-socket-server/conf/
     environment:
       - DOCKER_ENVIRONMENT=true
       - TEST_TRANSACTIONS=true
@@ -60,3 +61,8 @@ services:
     depends_on:
       gremlin-server-test-js:
         condition: service_healthy
+  gremlin-socket-server:
+    container_name: gremlin-socket-server-js
+    image: tinkerpop/gremlin-socket-server:${GREMLIN_SERVER}
+    ports:
+      - "45943:45943"

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
@@ -27,14 +27,23 @@ const DriverRemoteConnection = require('../lib/driver/driver-remote-connection')
 const Client = require('../lib/driver/client');
 const PlainTextSaslAuthenticator = require('../lib/driver/auth/plain-text-sasl-authenticator');
 
+const yaml = require('js-yaml');
+const fs   = require('fs');
+
 let serverUrl;
 let serverAuthUrl;
+let socketServerUrl;
+let sockerServerConfigPath;
 if (process.env.DOCKER_ENVIRONMENT === 'true') {
   serverUrl = 'ws://gremlin-server-test-js:45940/gremlin';
   serverAuthUrl = 'wss://gremlin-server-test-js:45941/gremlin';
+  socketServerUrl = 'ws://gremlin-socket-server-js:';
+  sockerServerConfigPath = '/js_app/gremlin-socket-server/conf/test-ws-gremlin.yaml';
 } else {
   serverUrl = 'ws://localhost:45940/gremlin';
   serverAuthUrl = 'wss://localhost:45941/gremlin';
+  socketServerUrl = 'ws://localhost:';
+  sockerServerConfigPath = '../../../../../gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml';
 }
 
 /** @returns {DriverRemoteConnection} */
@@ -67,4 +76,28 @@ exports.getSessionClient = function getSessionClient(traversalSource) {
     'session': sessionId.toString(),
     mimeType: process.env.CLIENT_MIMETYPE,
   });
+};
+
+exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(traversalSource) {
+  let settings = exports.getGremlinSocketServerSettings();
+  let url = socketServerUrl + settings.PORT + '/gremlin';
+  let mimeType;
+  switch(settings.SERIALIZER) {
+    case "GraphSONV2":
+      mimeType = 'application/vnd.gremlin-v2.0+json';
+      break;
+    case "GraphSONV3":
+      mimeType = 'application/vnd.gremlin-v3.0+json';
+      break;
+    case "GraphBinaryV1":
+    default:
+      mimeType = 'application/vnd.graphbinary-v1.0';
+      break;
+  }
+  return new Client(url, { traversalSource, mimeType: mimeType });
+};
+
+exports.getGremlinSocketServerSettings = function getGremlinSocketServerSettings() {
+  const settings = yaml.load(fs.readFileSync(sockerServerConfigPath, 'utf8'));
+  return settings;
 };

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
@@ -79,8 +79,8 @@ exports.getSessionClient = function getSessionClient(traversalSource) {
 };
 
 exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(traversalSource) {
-  let settings = exports.getGremlinSocketServerSettings();
-  let url = socketServerUrl + settings.PORT + '/gremlin';
+  const settings = exports.getGremlinSocketServerSettings();
+  const url = socketServerUrl + settings.PORT + '/gremlin';
   let mimeType;
   switch(settings.SERIALIZER) {
     case "GraphSONV2":
@@ -94,7 +94,7 @@ exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(tra
       mimeType = 'application/vnd.graphbinary-v1.0';
       break;
   }
-  return new Client(url, { traversalSource, mimeType: mimeType });
+  return new Client(url, { traversalSource, mimeType });
 };
 
 exports.getGremlinSocketServerSettings = function getGremlinSocketServerSettings() {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
@@ -1,0 +1,53 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const helper = require('../helper');
+
+let client;
+let settings;
+
+describe('Client', function () {
+    before(function () {
+        client = helper.getGremlinSocketServerClient('gmodern');
+        settings = helper.getGremlinSocketServerSettings();
+        return client.open();
+    });
+    after(function () {
+        return client.close();
+    });
+    describe('#submit()', function () {
+        it('should reconnect after server closes connection', async function () {
+            let connectionClosed = false;
+            await client.submit('1', null, {requestId: settings.CLOSE_CONNECTION_REQUEST_ID})
+                .catch(function(error){
+                    assert.equal(error.toString(), 'Error: Connection has been closed.');
+                    connectionClosed = true;
+                });
+
+            assert.equal(connectionClosed, true);
+
+            let result = await client.submit('1', null, {requestId: settings.SINGLE_VERTEX_REQUEST_ID})
+            console.log("result received: "+JSON.stringify(result));
+            assert.ok(result);
+        });
+    });
+});

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       timeout: 10s
       retries: 30
       start_period: 30s
+    depends_on:
+      - gremlin-socket-server
 
   gremlin-python-integration-tests:
     container_name: gremlin-python-integration-tests
@@ -51,6 +53,8 @@ services:
       - ${BUILD_DIR:-./src/main/python}:/python_app
       - ../gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features:/python_app/gremlin-test/features
       - ../docker/gremlin-test-server:/python_app/gremlin-test-server
+      - ../gremlin-tools/gremlin-socket-server/conf:/python_app/gremlin-socket-server/conf/
+
     environment:
       - TEST_TRANSACTIONS=${TEST_TRANSACTIONS:-true}
       - DEBIAN_FRONTEND=noninteractive
@@ -60,6 +64,8 @@ services:
       - GREMLIN_SERVER_BASIC_AUTH_URL=wss://gremlin-server-test-python:{}/gremlin
       - KRB_HOSTNAME=${KRB_HOSTNAME:-gremlin-server-test}
       - VERSION=${VERSION}
+      - GREMLIN_SOCKET_SERVER_URL=ws://gremlin-socket-server-python:{}/gremlin
+      - GREMLIN_SOCKET_SERVER_CONFIG_PATH=/python_app/gremlin-socket-server/conf/test-ws-gremlin.yaml
     working_dir: /python_app
     command: >
       bash -c "apt-get update && apt-get -y install libkrb5-dev krb5-user
@@ -87,3 +93,9 @@ services:
     command: >
       bash -c "python3 setup.py sdist bdist_wheel;
       EXIT_CODE=$$?; chown -R `stat -c "%u:%g" .` .; exit $$EXIT_CODE"
+
+  gremlin-socket-server:
+    container_name: gremlin-socket-server-python
+    image: tinkerpop/gremlin-socket-server:${GREMLIN_SERVER}
+    ports:
+      - "45943:45943"

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -75,7 +75,8 @@ setup(
         'pytest>=4.6.4,<7.2.0',
         'mock>=3.0.5,<5.0.0',
         'radish-bdd==0.13.4',
-        'PyHamcrest>=1.9.0,<3.0.0'
+        'PyHamcrest>=1.9.0,<3.0.0',
+        'PyYAML>=5.3'
     ],
     install_requires=install_requires,
     extras_require={

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -25,6 +25,8 @@ import socket
 import logging
 import queue
 
+import yaml
+
 from gremlin_python.driver.client import Client
 from gremlin_python.driver.connection import Connection
 from gremlin_python.driver import serializer
@@ -38,15 +40,21 @@ from gremlin_python.driver.aiohttp.transport import AiohttpTransport
 
 gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
 gremlin_basic_auth_url = os.environ.get('GREMLIN_SERVER_BASIC_AUTH_URL', 'wss://localhost:{}/gremlin')
+gremlin_socket_server_url = os.environ.get('GREMLIN_SOCKET_SERVER_URL', 'ws://localhost:{}/gremlin')
+gremlin_socket_server_config_path = os.environ.get("GREMLIN_SOCKET_SERVER_CONFIG_PATH",
+                                                   "../../../../../../gremlin-tools/gremlin-socket-server/conf/"
+                                                   "test-ws-gremlin.yaml")
 kerberos_hostname = os.environ.get('KRB_HOSTNAME', socket.gethostname())
 anonymous_url = gremlin_server_url.format(45940)
 basic_url = gremlin_basic_auth_url.format(45941)
 kerberos_url = gremlin_server_url.format(45942)
+
 kerberized_service = 'test-service@{}'.format(kerberos_hostname)
 verbose_logging = False
 
 logging.basicConfig(format='%(asctime)s [%(levelname)8s] [%(filename)15s:%(lineno)d - %(funcName)10s()] - %(message)s',
                     level=logging.DEBUG if verbose_logging else logging.INFO)
+
 
 @pytest.fixture
 def connection(request):
@@ -83,6 +91,35 @@ def client(request):
         request.addfinalizer(fin)
         return client
 
+
+@pytest.fixture
+def socket_server_client(request, socket_server_settings):
+    url = gremlin_socket_server_url.format(socket_server_settings["PORT"])
+    if socket_server_settings["SERIALIZER"] == "GraphBinaryV1":
+        ser = serializer.GraphBinarySerializersV1()
+    elif socket_server_settings["SERIALIZER"] == "GraphSONV2":
+        ser = serializer.GraphSONSerializersV2d0()
+    elif socket_server_settings["SERIALIZER"] == "GraphSONV3":
+        ser = serializer.GraphSONSerializersV3d0()
+    else:
+        ser = serializer.GraphBinarySerializersV1()
+    try:
+        client = Client(url, 'g', pool_size=1, message_serializer=ser)
+    except OSError:
+        pytest.skip('Gremlin Socket Server is not running')
+    else:
+        def fin():
+            client.close()
+
+        request.addfinalizer(fin)
+        return client
+
+
+@pytest.fixture
+def socket_server_settings(request):
+    with open(gremlin_socket_server_config_path, mode="rb") as file:
+        settings = yaml.safe_load(file)
+    return settings
 
 @pytest.fixture(params=['basic', 'kerberos'])
 def authenticated_client(request):

--- a/gremlin-python/src/main/python/tests/driver/test_web_socket_client_behavior.py
+++ b/gremlin-python/src/main/python/tests/driver/test_web_socket_client_behavior.py
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+__author__ = 'Cole Greer (cole@colegreer.ca)'
+
+# Note: This test demonstrates different behavior in response to a server sending a close frame than the other GLV's.
+# Other GLV's will respond to this by trying to reconnect. This test is also demonstrating incorrect behavior of
+# client.is_closed() as it appears unaware that the event loop is dead.
+# These differences from other GLV's are being tracked in [TINKERPOP-2846]. If this behavior is changed to resemble
+# other GLV's, this test should be updated to show a vertex is being received by the second request.
+def test_does_not_create_new_connection_if_closed_by_server(socket_server_client, socket_server_settings):
+    try:
+        socket_server_client.submit(
+            "1", request_options={'requestId': socket_server_settings["CLOSE_CONNECTION_REQUEST_ID"]}).all().result()
+    except RuntimeError as err:
+        assert str(err) == "Connection was closed by server."
+
+    assert not socket_server_client.is_closed()
+
+    try:
+        response = socket_server_client.submit(
+            "1", request_options={'requestId': socket_server_settings["SINGLE_VERTEX_REQUEST_ID"]}).all().result()
+    except RuntimeError as err:
+        assert str(err) == "Event loop is closed"
+
+    assert not socket_server_client.is_closed()

--- a/gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml
+++ b/gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml
@@ -25,9 +25,12 @@
 # Port exposed by gremlin-socket-server
 PORT: 45943
 
+# Configures which serializer will be used. Ex: GraphBinaryV1 or GraphSONV2
+SERIALIZER: GraphBinaryV1
+
 # If a request with this ID comes to the server, the server responds back with a single
 # vertex picked from Modern graph.
-SINGLE_VERTEX_REQUEST_ID: 6457272A-4018-4538-B9AE-08DD5DDC0AA1
+SINGLE_VERTEX_REQUEST_ID: 6457272a-4018-4538-b9ae-08dd5ddc0aa1
 
 # If a request with this ID comes to the server, the server responds back with a single
 # vertex picked from Modern graph. After a 2 second delay, server sends a Close WebSocket


### PR DESCRIPTION
[TINKERPOP-2819](https://issues.apache.org/jira/browse/TINKERPOP-2819)

Modifies the GLV's docker compose files to additionally run gremlin-socket-server during integration testing.

Configures each of the GLVs to import the default config yaml for gremlin socket server.

Adds at least one reference test in each GLV which demonstrates it's use.

Also modifies gremlin-socket-server slightly to allow for any of graphSON2, graphSON3, or graphBinaryV1 to be used. Previously gremlin socket server only used graphSON2.

It's worth noting that the tests implemented here are quite basic as this PR was mostly focused on setting up the configuration to enable the tests. Even so several bugs were discovered when creating these tests. More tests which emulate network errors or connection issues would be a great benefit.