### PR TITLE
[TINKERPOP-2849] fix for GraphTraversalSource.With

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,6 +58,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Removed the delay for reconnecting to a potentially unhealthy `Host` only marking it as unavailable after that initial retry fails.
 * Prevented fast `NoHostAvailableException` in favor of more direct exceptions when borrowing connections from the `ConnectionPool`.
 * Fixed an issue in Go and Python GLVs where modifying per request settings to override request_id's was not working correctly.
+* Fixed incorrect implementation for `GraphTraversalSource.With` in `gremlin-go`.
 
 ==== Bugs
 

--- a/gremlin-go/driver/graphTraversalSource_test.go
+++ b/gremlin-go/driver/graphTraversalSource_test.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package gremlingo
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGraphTraversalSource(t *testing.T) {
+
+	t.Run("GraphTraversalSource.With tests", func(t *testing.T) {
+		t.Run("Test for single param", func(t *testing.T) {
+			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
+			traversal := g.With("foo", "bar")
+			assert.NotNil(t, traversal)
+			assert.Equal(t, 1, len(traversal.bytecode.sourceInstructions))
+			instruction := traversal.bytecode.sourceInstructions[0]
+			assert.Equal(t, "withStrategies", instruction.operator)
+			assert.Equal(t, "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy",
+				instruction.arguments[0].(*traversalStrategy).name)
+			config := instruction.arguments[0].(*traversalStrategy).configuration
+			assert.Equal(t, map[string]interface{}{"foo": "bar"}, config)
+		})
+
+		t.Run("Test for multiple param", func(t *testing.T) {
+			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
+			traversal := g.With("foo", "bar").With("foo2", "bar2")
+			assert.NotNil(t, traversal)
+			assert.Equal(t, 1, len(traversal.bytecode.sourceInstructions))
+			instruction := traversal.bytecode.sourceInstructions[0]
+			assert.Equal(t, "withStrategies", instruction.operator)
+			assert.Equal(t, "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy",
+				instruction.arguments[0].(*traversalStrategy).name)
+			config := instruction.arguments[0].(*traversalStrategy).configuration
+			assert.Equal(t, map[string]interface{}{"foo": "bar", "foo2": "bar2"}, config)
+		})
+
+		t.Run("Test for param replacement", func(t *testing.T) {
+			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
+			traversal := g.With("foo", "bar").With("foo", "not bar")
+			assert.NotNil(t, traversal)
+			assert.Equal(t, 1, len(traversal.bytecode.sourceInstructions))
+			instruction := traversal.bytecode.sourceInstructions[0]
+			assert.Equal(t, "withStrategies", instruction.operator)
+			assert.Equal(t, "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy",
+				instruction.arguments[0].(*traversalStrategy).name)
+			config := instruction.arguments[0].(*traversalStrategy).configuration
+			assert.Equal(t, map[string]interface{}{"foo": "not bar"}, config)
+		})
+	})
+}


### PR DESCRIPTION
Fix for incorrect implementation for `GraphTraversalSource.With` in gremlin-go

https://issues.apache.org/jira/browse/TINKERPOP-2849