### PR TITLE
Add LICENSE and NOTICE files for gremlin-go

### DIFF
--- a/gremlin-go/LICENSE
+++ b/gremlin-go/LICENSE
@@ -200,14 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-========================================================================
-MIT Licenses
-========================================================================
-
-The Apache TinkerPop project bundles the following components under the MIT License:
-
-     bootstrap/carousel 3.3.5 (http://getbootstrap.com/) - for details, see licenses/bootstrap
-     jquery 1.11.0 (https://jquery.com/) - for details, see licenses/jquery
-     normalize.css 2.1.2 (http://necolas.github.io/normalize.css/) - for details, see licenses/normalize
-     prism.css/js (http://prismjs.com) - for details, see licenses/prism

--- a/gremlin-go/NOTICE
+++ b/gremlin-go/NOTICE
@@ -1,0 +1,5 @@
+Apache TinkerPop
+Copyright 2015-2022 The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Just a quick update to license files. Adding LICENSE and NOTICE to gremlin-go as per recent discussion in the dev list. Also a minor fix to filepaths referenced in the root LICENSE file.