### PR TITLE
Improved user agent handling of cases where gremlin version is not available

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Prevented fast `NoHostAvailableException` in favor of more direct exceptions when borrowing connections from the `ConnectionPool`.
 * Fixed an issue in Go and Python GLVs where modifying per request settings to override request_id's was not working correctly.
 * Fixed incorrect implementation for `GraphTraversalSource.With` in `gremlin-go`.
+* Changed Gremlin.version() to return `"VersionNotFound"` if the version is missing from the manifest.
 
 ==== Bugs
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/Gremlin.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/Gremlin.java
@@ -29,12 +29,21 @@ public final class Gremlin {
     private static String version;
 
     static {
-        version = Manifests.read("version");
+        try {
+            version = Manifests.read("version");
+        }
+        catch (Exception e) {
+            version = "VersionNotFound";
+        }
     }
 
     private Gremlin() {
     }
 
+    /**
+     * Get the current version of tinkerpop. Will return "VersionNotFound" if there are any issues finding
+     * the version. This typically would be the result of the version being missing from the manifest file.
+     */
     public static String version() {
         return version;
     }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
@@ -25,7 +25,7 @@
 
 const crypto = require('crypto');
 const os = require('os');
-const gremlinVersion = require(__dirname + '/../package.json').version;
+const { readFileSync } = require('fs');
 
 exports.toLong = function toLong(value) {
   return new Long(value);
@@ -84,7 +84,12 @@ exports.ImmutableMap = ImmutableMap;
 
 function generateUserAgent() {
   const applicationName = (process.env.npm_package_name || 'NotAvailable').replace('_', ' ');
-  const driverVersion = gremlinVersion.replace('_', ' ');
+  let driverVersion;
+  try {
+    driverVersion = JSON.parse(readFileSync(__dirname + '/../package.json')).version.replace('_', ' ');
+  } catch (e) {
+    driverVersion = 'NotAvailable';
+  }
   const runtimeVersion = process.version.replace(' ', '_');
   const osName = os.platform().replace(' ', '_');
   const osVersion = os.release().replace(' ', '_');


### PR DESCRIPTION
It was observed in the java driver that the UserAgent class could fail to load if the manifest file was excluded from the jar. This is because the user agent relies on the manifest to extract the current version of gremlin. This PR adds a bit of extra error handling and will insert a value of "NotAvailable" in case of any failures. A similar issue was also present in JS which is also fixed here.

This PR also updates Gremlin.version() to return "VersionNotFound" if the manifest read fails as this is preferable to the current behavior of throwing a ExceptionInInitializerError.

Thanks @kenhuuu for discovering this issue.