### PR TITLE
[TINKERPOP-2844] Adds tests for per-request-settings in GLV's

### DIFF
--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Util/SocketServerSettings.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Util/SocketServerSettings.cs
@@ -77,6 +77,14 @@ public class SocketServerSettings
     [YamlMember(Alias = "USER_AGENT_REQUEST_ID", ApplyNamingConventions = false)]
     public Guid UserAgentRequestId { get; set; }
     
+    /**
+     * If a request with this ID comes to the server, the server responds with a string containing all overridden
+     * per request settings from the request message. String will be of the form
+     * "requestId=19436d9e-f8fc-4b67-8a76-deec60918424 evaluationTimeout=1234, batchSize=12, userAgent=testUserAgent"
+     */
+    [YamlMember(Alias = "PER_REQUEST_SETTINGS_REQUEST_ID", ApplyNamingConventions = false)]
+    public Guid PerRequestSettingsRequestId { get; set; }
+    
     public static SocketServerSettings FromYaml(String path)
     {
         var deserializer = new YamlDotNet.Serialization.DeserializerBuilder().Build();

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
@@ -47,7 +47,6 @@ describe('Client', function () {
             assert.equal(connectionClosed, true);
 
             let result = await client.submit('1', null, {requestId: settings.SINGLE_VERTEX_REQUEST_ID})
-            console.log("result received: "+JSON.stringify(result));
             assert.ok(result);
         });
         it('should include user agent in handshake request', async function () {
@@ -63,6 +62,16 @@ describe('Client', function () {
             assert.strictEqual(result.first(), "");
 
             await noUserAgentClient.close();
+        });
+        it('should send per request settings to server', async function () {
+            const resultSet = await client.submit('1', null, {
+                requestId: settings.PER_REQUEST_SETTINGS_REQUEST_ID,
+                evaluationTimeout: 1234,
+                batchSize: 12,
+                userAgent: "helloWorld"
+            })
+            const expectedResult = `requestId=${settings.PER_REQUEST_SETTINGS_REQUEST_ID} evaluationTimeout=1234, batchSize=12, userAgent=helloWorld`;
+            assert.equal(expectedResult, resultSet.first());
         });
     });
 });

--- a/gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml
+++ b/gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml
@@ -49,3 +49,8 @@ CLOSE_CONNECTION_REQUEST_ID_2: 3c4cf18a-c7f2-4dad-b9bf-5c701eb33000
 # If a request with this ID comes to the server, the server responds with the user agent (if any)
 # that was captured during the web socket handshake.
 USER_AGENT_REQUEST_ID: 20ad7bfb-4abf-d7f4-f9d3-9f1d55bee4ad
+
+# If a request with this ID comes to the server, the server responds with a string containing all overridden
+# per request settings from the request message. String will be of the form
+# "requestId=19436d9e-f8fc-4b67-8a76-deec60918424 evaluationTimeout=1234, batchSize=12, userAgent=testUserAgent"
+PER_REQUEST_SETTINGS_REQUEST_ID: 19436d9e-f8fc-4b67-8a76-deec60918424

--- a/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/SocketServerSettings.java
+++ b/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/SocketServerSettings.java
@@ -72,6 +72,13 @@ public class SocketServerSettings {
      */
     public UUID USER_AGENT_REQUEST_ID = null;
 
+    /**
+     * If a request with this ID comes to the server, the server responds with a string containing all overridden
+     * per request settings from the request message. String will be of the form
+     * "requestId=19436d9e-f8fc-4b67-8a76-deec60918424 evaluationTimeout=1234, batchSize=12, userAgent=testUserAgent"
+     */
+    public UUID PER_REQUEST_SETTINGS_REQUEST_ID = null;
+
     public static SocketServerSettings read(final Path confFilePath) throws IOException {
         return read(Files.newInputStream(confFilePath));
     }

--- a/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/TestWSGremlinInitializer.java
+++ b/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/TestWSGremlinInitializer.java
@@ -137,6 +137,11 @@ public class TestWSGremlinInitializer extends TestChannelizers.TestWebSocketServ
                 ctx.channel().writeAndFlush(new CloseWebSocketFrame());
             } else if (msg.getRequestId().equals(settings.USER_AGENT_REQUEST_ID)) {
                 ctx.channel().writeAndFlush(new BinaryWebSocketFrame(returnSimpleBinaryResponse(settings.USER_AGENT_REQUEST_ID, userAgent)));
+            } else if (msg.getRequestId().equals(settings.PER_REQUEST_SETTINGS_REQUEST_ID)) {
+                String response = String.format("requestId=%s evaluationTimeout=%d, batchSize=%d, userAgent=%s",
+                        msg.getRequestId(), msg.getArgs().get("evaluationTimeout"),
+                        msg.getArgs().get("batchSize"), msg.getArgs().get("userAgent"));
+                ctx.channel().writeAndFlush(new BinaryWebSocketFrame(returnSimpleBinaryResponse(settings.PER_REQUEST_SETTINGS_REQUEST_ID, response)));
             } else {
                 try {
                     Thread.sleep(Long.parseLong((String) msg.getArgs().get("gremlin")));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2844

Creates a test where a driver sends a request to gremlin-socket-server with all per-request settings set. gremlin-socket-server extracts these arguments and returns them in a string to the driver.

I expanded the scope of the ticket a bit and added this test to Java, .net, and JS in addition to Python. Go is excluded from this commit as the test is failing and needs additional work. The go per request settings issue is being tracked by [TINKERPOP-2841](https://issues.apache.org/jira/browse/TINKERPOP-2841)