### PR TITLE
TINKERPOP-2853: Throw explaining exception when reading unsupported GraphBinary type

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/TypeSerializerRegistry.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/TypeSerializerRegistry.cs
@@ -209,7 +209,7 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
                 }
             }
 
-            throw new InvalidOperationException($"No serializer found for type ${valueType}.");
+            throw new InvalidOperationException($"No serializer found for type '{valueType}'.");
         }
 
         private static bool IsDictionaryType(Type type, out Type keyType, out Type valueType)
@@ -266,7 +266,9 @@ namespace Gremlin.Net.Structure.IO.GraphBinary
         /// <returns>A serializer for the provided custom type name.</returns>
         public CustomTypeSerializer GetSerializerForCustomType(string typeName)
         {
-            return _serializerByCustomTypeName[typeName];
+            return _serializerByCustomTypeName.TryGetValue(typeName, out var serializer)
+                ? serializer
+                : throw new InvalidOperationException($"No serializer found for type '{typeName}'.");
         }
         
         /// <summary>


### PR DESCRIPTION
Fixes: https://issues.apache.org/jira/browse/TINKERPOP-2853

When reading a non-registered custom type with GraphBinary, a generic exception is thrown:

    System.Collections.Generic.KeyNotFoundException: The given key 'janusgraph.RelationIdentifier' was not 
    present in the dictionary. 

Now the following exception gets thrown instead:

    System.InvalidOperationException: No serializer found for type 'janusgraph.RelationIdentifier'

This is the same exception and message that gets throw when _writing_ a non-registered custom type. 

The change has been verified by writing two new tests:

- One to document the added _read_ behaviour
- One to document the existing _write_ behaviour (which was undocumented)

And running the `Gremlin.Net` test suite