### PR TITLE
Adds CodeQL vulnerability scanning to Github Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,99 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master", "3.5-dev", "3.6-dev" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master", "3.5-dev", "3.6-dev" ]
+  schedule:
+    - cron: '22 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go', 'java', 'javascript', 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"
+
+  # .Net is run as a separate job as the integration tests take far too long to build
+  analyze_dotnet:
+    name: Analyze .Net
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: 'csharp'
+
+      - run: |
+          echo "Build .NET"
+          dotnet build gremlin-dotnet/src/Gremlin.Net;
+          dotnet build gremlin-dotnet/src/Gremlin.Net.Template
+          dotnet build gremlin-dotnet/test/Gremlin.Net.UnitTest
+          dotnet build gremlin-dotnet/test/Gremlin.Net.Benchmarks
+#          Excluded due to extremely long (~45m) build time in github actions
+#          dotnet build gremlin-dotnet/test/Gremlin.Net.IntegrationTest
+#          dotnet build gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:csharp"

--- a/gremlin-go/driver/result.go
+++ b/gremlin-go/driver/result.go
@@ -20,7 +20,10 @@ under the License.
 package gremlingo
 
 import (
+	"errors"
 	"fmt"
+	"math"
+	"math/bits"
 	"reflect"
 	"strconv"
 )
@@ -56,11 +59,14 @@ func (r *Result) GetByte() (byte, error) {
 
 // GetUint gets the result by coercing it into an int, else returns an error if not parsable.
 func (r *Result) GetUint() (uint, error) {
-	res, err := strconv.ParseUint(r.GetString(), 10, 64)
+	res, err := strconv.ParseUint(r.GetString(), 10, bits.UintSize)
 	if err != nil {
 		return 0, err
 	}
-	return uint(res), nil
+	if res <= math.MaxUint {
+		return uint(res), nil
+	}
+	return 0, errors.New("parsed value is greater than MaxUint")
 }
 
 // GetUint16 gets the result by coercing it into an int16, else returns an error if not parsable.


### PR DESCRIPTION
Adds new workflow which runs CodeQL vulnerability scanning on any pushes or pull requests to master, 3.5-dev, or 3.6-dev.

Also includes a small fix in go to prevent a possible lossy type conversion.

CodeQL will result in a failing check if a push or PR introduces a new vulnerability. It will not fail the checks for vulnerabilities which were pre-existing in the branch. Existing vulnerabilities are tracked and listed in Github under Security -> Vulnerability and Alerts -> Code scanning (Only visible to committers)

There are 3 vulnerabilities which have been found in the initial scan. I would ask that a committer dismiss the go warning as a "false positive". The warning is due to a potentially unsafe type conversion from a uint64 to a uint. During it's initialization, the size of the uint64 is being bounded to the size of uint making a lossy conversion impossible.

The remaining 2 vulnerabilities are due to inefficient regex in prism.js which is is included in our sources as part of the website. This seems like a low priority to me and I would suggest we either dismiss these warnings as "won't do" or leave them open for added visibility with no immediate plan for a patch.