### PR TITLE
TINKERPOP-2857 add GraphFilter support for GraphSONRecordReader

### DIFF
--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/RecordReaderWriterTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/RecordReaderWriterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.hadoop.structure.io;
 
+import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
@@ -33,7 +34,12 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.tinkerpop.gremlin.TestHelper;
+import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.HadoopGraphProvider;
+import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
+import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -83,6 +89,16 @@ public abstract class RecordReaderWriterTest {
         }
     }
 
+    protected Configuration configureWithFilter(Configuration config) {
+        GraphFilter filter = new GraphFilter();
+        filter.setVertexFilter(__.hasLabel("artist"));
+        String labelKey = "filter";
+        final BaseConfiguration filterConfig = new BaseConfiguration();
+        VertexProgramHelper.serialize(filter, filterConfig, labelKey);
+        config.set(Constants.GREMLIN_HADOOP_GRAPH_FILTER, filterConfig.getProperty(labelKey).toString());
+        return config;
+    }
+
     protected Configuration configure(final File outputDirectory) {
         final Configuration configuration = new Configuration(false);
         configuration.set("fs.file.impl", LocalFileSystem.class.getName());
@@ -115,6 +131,12 @@ public abstract class RecordReaderWriterTest {
         final OutputFormat<NullWritable, VertexWritable> outputFormat = outFormatClass.isPresent() ? ReflectionUtils.newInstance(outFormatClass.get(), configuration) : null;
         final RecordWriter<NullWritable, VertexWritable> writer = null == outputFormat ? null : outputFormat.getRecordWriter(job);
 
+        GraphFilter graphFilter = null;
+        if (configuration.get(Constants.GREMLIN_HADOOP_GRAPH_FILTER, null) != null) {
+            graphFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(configuration),
+                    Constants.GREMLIN_HADOOP_GRAPH_FILTER);
+        }
+
         boolean foundKeyValue = false;
         for (final FileSplit split : fileSplits) {
             logger.info("\treading file split {}", split.getPath().getName() + " ({}", split.getStart() + "..." + (split.getStart() + split.getLength()), "{} {} bytes)");
@@ -127,6 +149,10 @@ public abstract class RecordReaderWriterTest {
                 assertTrue(progress >= lastProgress);
                 assertEquals(NullWritable.class, reader.getCurrentKey().getClass());
                 final VertexWritable vertexWritable = (VertexWritable) reader.getCurrentValue();
+                if (graphFilter != null) {
+                    // check whether the filter takes effect
+                    assertTrue(vertexWritable.get().applyGraphFilter(graphFilter).isPresent());
+                }
                 if (null != writer) writer.write(NullWritable.get(), vertexWritable);
                 vertexCount++;
                 outEdgeCount = outEdgeCount + (int) IteratorUtils.count(vertexWritable.get().edges(Direction.OUT));
@@ -147,13 +173,15 @@ public abstract class RecordReaderWriterTest {
             }
         }
 
-        if (getInputFilename().startsWith("grateful-dead-v")) {
+        if (getInputFilename().startsWith("grateful-dead-v") && graphFilter == null) {
             assertEquals(8049, outEdgeCount);
             assertEquals(8049, inEdgeCount);
             assertEquals(808, vertexCount);
             assertTrue(foundKeyValue);
         }
-        assertEquals(outEdgeCount, inEdgeCount);
+        if (graphFilter == null) {
+            assertEquals(outEdgeCount, inEdgeCount);
+        }
 
         if (null != writer) {
             writer.close(new TaskAttemptContextImpl(configuration, job.getTaskAttemptID()));

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/graphson/GraphSONV3d0RecordReaderFilterTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/graphson/GraphSONV3d0RecordReaderFilterTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.tinkerpop.gremlin.hadoop.structure.io.graphson;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.RecordReaderWriterTest;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
+
+import java.io.File;
+
+public class GraphSONV3d0RecordReaderFilterTest extends RecordReaderWriterTest {
+
+    @Override
+    protected String getInputFilename() {
+        return "grateful-dead-v3d0.json";
+    }
+
+    @Override
+    protected Class<? extends InputFormat<NullWritable, VertexWritable>> getInputFormat() {
+        return GraphSONInputFormat.class;
+    }
+
+    @Override
+    protected Class<? extends OutputFormat<NullWritable, VertexWritable>> getOutputFormat() {
+        return GraphSONOutputFormat.class;
+    }
+
+    protected Configuration configure(final File outputDirectory) {
+        Configuration config = super.configure(outputDirectory);
+        return configureWithFilter(config);
+    }
+}

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReaderFilterTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReaderFilterTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.hadoop.structure.io.gryo;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.RecordReaderWriterTest;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
+
+
+import java.io.File;
+
+public class GryoRecordReaderFilterTest extends RecordReaderWriterTest {
+    @Override
+    protected String getInputFilename() {
+        return "grateful-dead-v3d0.kryo";
+    }
+
+    @Override
+    protected Class<? extends InputFormat<NullWritable, VertexWritable>> getInputFormat() {
+        return GryoInputFormat.class;
+    }
+
+    @Override
+    protected Class<? extends OutputFormat<NullWritable, VertexWritable>> getOutputFormat() {
+        return GryoOutputFormat.class;
+    }
+
+    protected Configuration configure(final File outputDirectory) {
+        Configuration config = super.configure(outputDirectory);
+        return configureWithFilter(config);
+    }
+}


### PR DESCRIPTION
The GraphSONRecordReader does not provide the GraphFilter to filter vetex during deserialization. This PR fixed it. In addition, two UTs for vertex filtering of both GraphSONRecordReader and GryoRecordReader were added.