### PR TITLE
TINKERPOP-2647 Deactivate active plugins during Uninstallation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ This release also includes changes from <<release-3-6-XXX, 3.6.XXX>>.
 * Moves `SimpleSocketServer` and its initializers to a new `gremlin-tools/gremlin-socket-server` module.
 * Configures `gremlin-socket-server` to build a docker image which can be used for testing GLV's. (Can be skipped with -DskipImageBuild)
 * Reduces dependency from `gremlin-server` onto `gremlin-driver` to a test scope only.
+* TINKERPOP-2647 Disable active plugins on uninstall to prevent errors during startup
 
 == TinkerPop 3.6.0 (Tinkerheart)
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TINKERPOP-2647

When a plugin is used and uninstalled without being deactivated first, the console would fail to start up. This PR aims to deactivate such plugins when uninstall is called to prevent errors.

Ran `mvn clean install` to success and performed manual testing in the Gremlin Console