### PR TITLE
patch: Adding for null checks in generateUserAgent() to avoid undefined runtime errors

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
@@ -90,10 +90,23 @@ function generateUserAgent() {
   } catch (e) {
     driverVersion = 'NotAvailable';
   }
-  const runtimeVersion = process?.version?.replace(' ', '_');
-  const osName = os?.platform().replace(' ', '_');
-  const osVersion = os?.release().replace(' ', '_');
-  const cpuArch = process?.arch?.replace(' ', '_');
+  let runtimeVersion = osName = osVersion = cpuArch = 'NotAvailable';
+  
+  // process != null is equal to process != null && process != undefined
+  if(process != null) {
+    if(process.version != null) {
+      runtimeVersion = process?.version?.replace(' ', '_');
+    }
+    if(process.arch != null) {
+      cpuArch = process?.arch?.replace(' ', '_');
+    }
+  }
+  
+  if(os != null) {
+    osName = os?.platform().replace(' ', '_');
+    osVersion = os?.release().replace(' ', '_');
+  }
+ 
   const userAgent = `${applicationName} Gremlin-Javascript.${driverVersion} ${runtimeVersion} ${osName}.${osVersion} ${cpuArch}`;
 
   return userAgent;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/utils.js
@@ -90,10 +90,10 @@ function generateUserAgent() {
   } catch (e) {
     driverVersion = 'NotAvailable';
   }
-  const runtimeVersion = process.version.replace(' ', '_');
-  const osName = os.platform().replace(' ', '_');
-  const osVersion = os.release().replace(' ', '_');
-  const cpuArch = process.arch.replace(' ', '_');
+  const runtimeVersion = process?.version?.replace(' ', '_');
+  const osName = os?.platform().replace(' ', '_');
+  const osVersion = os?.release().replace(' ', '_');
+  const cpuArch = process?.arch?.replace(' ', '_');
   const userAgent = `${applicationName} Gremlin-Javascript.${driverVersion} ${runtimeVersion} ${osName}.${osVersion} ${cpuArch}`;
 
   return userAgent;


### PR DESCRIPTION
While using Gremlin-javascript in production, I faced an undefined error in `lib/utils.js`. Further investigation revealed that the fields were not correctly checked for nulls. This PR aims to add proper null checks to avoid undefined errors on runtime.

The error screenshot:
<img width="446" alt="Screenshot 2023-01-30 at 4 24 22 PM" src="https://user-images.githubusercontent.com/41549829/215464175-79faf65f-7917-4f90-baf5-bb4270fd9caf.png">

Gremlin version: v3.6.2
Node version: v14.17.4
NPM version: 7.19.1
