### PR TITLE
TINKERPOP-2810 allow newer aiohttp versions

### DIFF
--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -46,7 +46,7 @@ version = __version__.version
 
 install_requires = [
     'nest_asyncio',
-    'aiohttp>=3.8.0,<=3.8.1',
+    'aiohttp>=3.8.0,<4.0.0',
     'aenum>=1.4.5,<3.0.0',
     'six>=1.10.0,<2.0.0',
     'isodate>=0.6.0,<1.0.0'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2810
Opening a new PR for this to back port the change to the 3.5.x and 3.6.x lines. This change was previously introduced to master but left out of the earlier dev branches.