### PR TITLE
Bumped eslint to ecmaVersion 2021

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/.eslintrc.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     node: true,
   },
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2021,
   },
   ignorePatterns: ['test/**/*.js', 'doc/**/*.js'],
   extends: ['eslint:recommended', 'prettier'],


### PR DESCRIPTION
Unlocks language features such as `.?` and `??` which have been available since node v14 but have been blocked by eslint. According to https://node.green/#ES2021, node v16.13 (which is the current version in tinkerpop 3.6.x) fully supports ecma 2021.