### PR TITLE
[TINKERPOP-2767] Fix server not handling StackOverflowError in bytecode traversals [For 3.6]

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -290,6 +290,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed `PartitionStrategy` to force its filters to the end of the chain for `Vertex` and `Edge` read steps, thus preserving order of the `has()`.
 * Added `RequestOptions` and `RequestOptionsBuilder` types to Go GLV to encapsulate per-request settings and bindings.
 * Added `SubmitWithOptions()` methods to `Client` and `DriverRemoteConnection` in Go GLV to pass `RequestOptions` to the server.
+* Fixed bug in which `gremlin-server` would not respond to clients if an `Error` was thrown during bytecode traversals.
 
 [[release-3-5-5]]
 === TinkerPop 3.5.5 (Release Date: January 16, 2023)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
@@ -281,8 +281,8 @@ public abstract class AbstractSession implements Session, AutoCloseable {
 
             if (itty.isPresent())
                 handleIterator(sessionTask, itty.get());
-        } catch (Exception ex) {
-            handleException(sessionTask, ex);
+        } catch (Throwable t) {
+            handleException(sessionTask, t);
         } finally {
             timer.stop();
         }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -451,10 +451,11 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                     }
                     onError(graph, context);
                 }
-            } catch (Exception ex) {
+
+            } catch (Throwable t) {
                 // if any exception in the chain is TemporaryException or Failure then we should respond with the
                 // right error code so that the client knows to retry
-                final Optional<Throwable> possibleSpecialException = determineIfSpecialException(ex);
+                final Optional<Throwable> possibleSpecialException = determineIfSpecialException(t);
                 if (possibleSpecialException.isPresent()) {
                     final Throwable special = possibleSpecialException.get();
                     final ResponseMessage.Builder specialResponseMsg = ResponseMessage.build(msg).
@@ -469,12 +470,15 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                     }
                     context.writeAndFlush(specialResponseMsg.create());
                 } else {
-                    logger.warn(String.format("Exception processing a Traversal on request [%s].", msg.getRequestId()), ex);
+                    logger.warn(String.format("Exception processing a Traversal on request [%s].", msg.getRequestId()), t);
                     context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR)
-                            .statusMessage(ex.getMessage())
-                            .statusAttributeException(ex).create());
+                            .statusMessage(t.getMessage())
+                            .statusAttributeException(t).create());
                 }
-                onError(graph, context);
+                if (t instanceof Error) {
+                    //Re-throw any errors to be handled by and set as the result of evalFuture
+                    throw t;
+                }
             } finally {
                 // todo: timer matter???
                 //timerContext.stop();
@@ -529,6 +533,7 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                                 .statusAttributes(attributes)
                                 .create());
 
+<<<<<<< HEAD
                     } catch (Exception ex) {
                         // if any exception in the chain is TemporaryException or Failure then we should respond with the
                         // right error code so that the client knows to retry
@@ -549,11 +554,25 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
                         } else {
                             logger.warn(String.format("Exception processing a Traversal on request [%s] to %s the transaction.",
                                     msg.getRequestId(), commit ? "commit" : "rollback"), ex);
-                            context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR)
-                                    .statusMessage(ex.getMessage())
-                                    .statusAttributeException(ex).create());
-                        }
+=======
+                    } catch (Throwable t) {
                         onError(graph, context);
+                        final Optional<Throwable> possibleTemporaryException = determineIfTemporaryException(t);
+                        if (possibleTemporaryException.isPresent()) {
+                            context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR_TEMPORARY)
+                                    .statusMessage(possibleTemporaryException.get().getMessage())
+                                    .statusAttributeException(possibleTemporaryException.get()).create());
+                        } else {
+                            logger.warn(String.format("Exception processing a Traversal on request [%s].", msg.getRequestId()), t);
+>>>>>>> c12e08cb55 (Fix server not handling StackOverflowError in bytecode traversals)
+                            context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR)
+                                    .statusMessage(t.getMessage())
+                                    .statusAttributeException(t).create());
+                        }
+                        if (t instanceof Error) {
+                            //Re-throw any errors to be handled by and set as the result the FutureTask
+                            throw t;
+                        }
                     }
 
                     return null;


### PR DESCRIPTION
Cherry picking previously approved changed to 3.6-dev to resolve conflicts.

Fixes TINKERPOP-2767.

The existing error handling in TraversalOpProcessor and SessionOpProcessor during bytecode iteration was catching all exceptions sending an appropriate error response to the client. The OpProcessor however was not catching a StackOverflowError which could be induced by running a query which contains a large repeat step. This Error was being caught by FutureTask.run() but GremlinServer never wait's on this task or checks the results which caused this Error to be lost. A similar issue was found to exist in AbstractSession.process().

This commit adjusts the existing error handling code to catch any Throwable during bytecode iteration so clients will receive error messages and codes for server errors as well as exceptions. Any errors are re-thrown such that the evalFuture FutureTask will continue to have an exception set correctly (although GremlinServer currently does not use this for anything).