### PR TITLE
[TINKERPOP-2767] Fix server not handling StackOverflowError in bytecode traversals [For 3.6]

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
@@ -281,8 +281,8 @@ public abstract class AbstractSession implements Session, AutoCloseable {
 
             if (itty.isPresent())
                 handleIterator(sessionTask, itty.get());
-        } catch (Exception ex) {
-            handleException(sessionTask, ex);
+        } catch (Throwable t) {
+            handleException(sessionTask, t);
         } finally {
             timer.stop();
         }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -256,10 +256,11 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                     }
                     onError(graph, context, ex);
                 }
-            } catch (Exception ex) {
+            } catch (Throwable t) {
+                onError(graph, context, t);
                 // if any exception in the chain is TemporaryException or Failure then we should respond with the
                 // right error code so that the client knows to retry
-                final Optional<Throwable> possibleSpecialException = determineIfSpecialException(ex);
+                final Optional<Throwable> possibleSpecialException = determineIfSpecialException(t);
                 if (possibleSpecialException.isPresent()) {
                     final Throwable special = possibleSpecialException.get();
                     final ResponseMessage.Builder specialResponseMsg = ResponseMessage.build(msg).
@@ -274,12 +275,15 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                     }
                     context.writeAndFlush(specialResponseMsg.create());
                 } else {
-                    logger.warn(String.format("Exception processing a Traversal on request [%s].", msg.getRequestId()), ex);
+                    logger.warn(String.format("Exception processing a Traversal on request [%s].", msg.getRequestId()), t);
                     context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.SERVER_ERROR)
-                            .statusMessage(ex.getMessage())
-                            .statusAttributeException(ex).create());
+                            .statusMessage(t.getMessage())
+                            .statusAttributeException(t).create());
+                    if (t instanceof Error) {
+                        //Re-throw any errors to be handled by and set as the result of evalFuture
+                        throw t;
+                    }
                 }
-                onError(graph, context, ex);
             } finally {
                 timerContext.stop();
             }


### PR DESCRIPTION
Cherry picking previously approved changed to 3.6-dev to resolve conflicts.

Fixes TINKERPOP-2767.

The existing error handling in TraversalOpProcessor and SessionOpProcessor during bytecode iteration was catching all exceptions sending an appropriate error response to the client. The OpProcessor however was not catching a StackOverflowError which could be induced by running a query which contains a large repeat step. This Error was being caught by FutureTask.run() but GremlinServer never wait's on this task or checks the results which caused this Error to be lost. A similar issue was found to exist in AbstractSession.process().

This commit adjusts the existing error handling code to catch any Throwable during bytecode iteration so clients will receive error messages and codes for server errors as well as exceptions. Any errors are re-thrown such that the evalFuture FutureTask will continue to have an exception set correctly (although GremlinServer currently does not use this for anything).
