### PR TITLE
TINKERPOP-2373 Bump to Groovy 4.0.9/GMavenPlus 2.1.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,8 @@ This release also includes changes from <<release-3-6-XXX, 3.6.XXX>>.
 * Added functional properties to the graph structure components for .NET, GO and Python.
 * Modified the GremlinScriptChecker to extract the `materializeProperties` request option.
 * Neo4jVertexProperty no longer throw Exception for `properties()`, but return empty iterable.
+* Bumped Groovy to 4.0.9.
+* Bumped GMavenPlus to 2.1.0.
 
 == TinkerPop 3.6.0 (Tinkerheart)
 

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -136,6 +136,11 @@ limitations under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-cli-picocli</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>
@@ -281,6 +286,10 @@ limitations under the License.
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/licenses/slf4j</resource>
                                     <file>src/main/static/licenses/slf4j</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/treelayout</resource>
+                                    <file>src/main/static/licenses/treelayout</file>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Colorizer.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Colorizer.groovy
@@ -19,7 +19,7 @@
 
 package org.apache.tinkerpop.gremlin.console;
 
-import org.codehaus.groovy.tools.shell.AnsiDetector
+import org.apache.groovy.groovysh.AnsiDetector
 import org.fusesource.jansi.Ansi
 import org.fusesource.jansi.AnsiConsole
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -23,12 +23,16 @@ import groovy.cli.picocli.OptionAccessor
 import jline.TerminalFactory
 import jline.console.history.FileHistory
 
+import org.apache.groovy.groovysh.ExitNotification
+import org.apache.groovy.groovysh.Groovysh
+import org.apache.groovy.groovysh.InteractiveShellRunner
+import org.apache.groovy.groovysh.commands.SetCommand
 import org.apache.tinkerpop.gremlin.console.commands.BytecodeCommand
+import org.apache.tinkerpop.gremlin.console.commands.ClsCommand
 import org.apache.tinkerpop.gremlin.console.commands.GremlinSetCommand
 import org.apache.tinkerpop.gremlin.console.commands.InstallCommand
 import org.apache.tinkerpop.gremlin.console.commands.PluginCommand
 import org.apache.tinkerpop.gremlin.console.commands.RemoteCommand
-import org.apache.tinkerpop.gremlin.console.commands.ClsCommand
 import org.apache.tinkerpop.gremlin.console.commands.SubmitCommand
 import org.apache.tinkerpop.gremlin.console.commands.UninstallCommand
 import org.apache.tinkerpop.gremlin.groovy.loaders.GremlinLoader
@@ -37,11 +41,7 @@ import org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin
 import org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteException
 import org.apache.tinkerpop.gremlin.process.traversal.Failure
-import org.apache.tinkerpop.gremlin.process.traversal.Step
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep
-import org.apache.tinkerpop.gremlin.process.traversal.translator.GroovyTranslator
-import org.apache.tinkerpop.gremlin.process.traversal.traverser.B_LP_NL_O_P_S_SE_SL_Traverser
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation
 import org.apache.tinkerpop.gremlin.structure.Edge
@@ -49,11 +49,7 @@ import org.apache.tinkerpop.gremlin.structure.T
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import org.apache.tinkerpop.gremlin.util.Gremlin
 import org.apache.tinkerpop.gremlin.util.iterator.ArrayIterator
-import org.codehaus.groovy.tools.shell.ExitNotification
-import org.codehaus.groovy.tools.shell.Groovysh
 import org.codehaus.groovy.tools.shell.IO
-import org.codehaus.groovy.tools.shell.InteractiveShellRunner
-import org.codehaus.groovy.tools.shell.commands.SetCommand
 import org.fusesource.jansi.Ansi
 import sun.misc.Signal
 import sun.misc.SignalHandler

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/GremlinGroovysh.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/GremlinGroovysh.groovy
@@ -19,15 +19,15 @@
 package org.apache.tinkerpop.gremlin.console
 
 import groovy.transform.ThreadInterrupt
+import org.apache.groovy.groovysh.Command
+import org.apache.groovy.groovysh.Groovysh
+import org.apache.groovy.groovysh.ParseCode
+import org.apache.groovy.groovysh.Parser
+import org.apache.groovy.groovysh.util.CommandArgumentParser
 import org.apache.tinkerpop.gremlin.console.commands.GremlinSetCommand
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer
-import org.codehaus.groovy.tools.shell.Command
-import org.codehaus.groovy.tools.shell.Groovysh
 import org.codehaus.groovy.tools.shell.IO
-import org.codehaus.groovy.tools.shell.ParseCode
-import org.codehaus.groovy.tools.shell.Parser
-import org.codehaus.groovy.tools.shell.util.CommandArgumentParser
 
 /**
  * Overrides the posix style parsing of Groovysh allowing for commands to parse prior to Groovy 2.4.x.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/PluggedIn.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/PluggedIn.groovy
@@ -18,7 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.console
 
-import org.apache.tinkerpop.gremlin.console.Preferences;
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.jsr223.BindingsCustomizer
 import org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin
 import org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.jsr223.ScriptCustomizer
 import org.apache.tinkerpop.gremlin.jsr223.console.ConsoleCustomizer
 import org.apache.tinkerpop.gremlin.jsr223.console.GremlinShellEnvironment
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteAcceptor
-import org.codehaus.groovy.tools.shell.Groovysh
 import org.codehaus.groovy.tools.shell.IO
 
 /**

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Preferences.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Preferences.groovy
@@ -22,7 +22,7 @@ package org.apache.tinkerpop.gremlin.console;
 import java.util.prefs.PreferenceChangeEvent
 import java.util.prefs.PreferenceChangeListener
 
-import org.codehaus.groovy.tools.shell.Groovysh
+import org.apache.groovy.groovysh.Groovysh
 import org.codehaus.groovy.tools.shell.IO
 
 public class Preferences {

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/BytecodeCommand.groovy
@@ -18,6 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import org.apache.groovy.groovysh.ComplexCommandSupport
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.console.Mediator
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
@@ -28,8 +30,6 @@ import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONXModuleV3d0
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper
 import org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule
-import org.codehaus.groovy.tools.shell.ComplexCommandSupport
-import org.codehaus.groovy.tools.shell.Groovysh
 
 /**
  * Commands that help work with Gremlin bytecode.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/ClsCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/ClsCommand.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import org.apache.groovy.groovysh.CommandSupport
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.console.Mediator
-import org.codehaus.groovy.tools.shell.CommandSupport
-import org.codehaus.groovy.tools.shell.Groovysh
 
 /**
  * Clear the console.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/GremlinSetCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/GremlinSetCommand.groovy
@@ -20,11 +20,11 @@ package org.apache.tinkerpop.gremlin.console.commands
 
 import jline.console.completer.Completer
 
-import org.codehaus.groovy.tools.shell.Groovysh
-import org.codehaus.groovy.tools.shell.commands.SetCommand
-import org.codehaus.groovy.tools.shell.util.PackageHelper
+import org.apache.groovy.groovysh.Groovysh
+import org.apache.groovy.groovysh.commands.SetCommand
+import org.apache.groovy.groovysh.util.PackageHelper
+import org.apache.groovy.groovysh.util.SimpleCompleter
 import org.codehaus.groovy.tools.shell.util.Preferences
-import org.codehaus.groovy.tools.shell.util.SimpleCompletor
 
 /**
  * A Gremlin-specific implementation of the {@code SetCommand} provided by Groovy.  Didn't see another way to
@@ -79,8 +79,8 @@ class GremlinSetCommand extends SetCommand {
         }
 
         return [
-            new SimpleCompletor(loader),
-            null
+                new SimpleCompleter(loader),
+                null
         ]
     }
 }

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/InstallCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/InstallCommand.groovy
@@ -18,15 +18,15 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import groovy.grape.Grape
+import org.apache.groovy.groovysh.CommandSupport
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.console.ConsoleFs
 import org.apache.tinkerpop.gremlin.console.Mediator
 import org.apache.tinkerpop.gremlin.console.PluggedIn
-import groovy.grape.Grape
 import org.apache.tinkerpop.gremlin.groovy.util.Artifact
 import org.apache.tinkerpop.gremlin.groovy.util.DependencyGrabber
 import org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin
-import org.codehaus.groovy.tools.shell.CommandSupport
-import org.codehaus.groovy.tools.shell.Groovysh
 
 /**
  * Install a dependency into the console.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/PluginCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/PluginCommand.groovy
@@ -18,10 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import org.apache.groovy.groovysh.ComplexCommandSupport
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.console.ConsoleFs
 import org.apache.tinkerpop.gremlin.console.Mediator
-import org.codehaus.groovy.tools.shell.ComplexCommandSupport
-import org.codehaus.groovy.tools.shell.Groovysh
 
 /**
  * Activate and manage a plugin.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
@@ -18,11 +18,11 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import org.apache.groovy.groovysh.ComplexCommandSupport
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.console.Mediator
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteAcceptor
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteException
-import org.codehaus.groovy.tools.shell.ComplexCommandSupport
-import org.codehaus.groovy.tools.shell.Groovysh
 
 /**
  * Configure a remote connection to a Gremlin Server.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/SubmitCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/SubmitCommand.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import org.apache.groovy.groovysh.CommandSupport
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.console.Mediator
-import org.codehaus.groovy.tools.shell.CommandSupport
-import org.codehaus.groovy.tools.shell.Groovysh
 
 /**
  * Submit a script to a Gremlin Server instance.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/UninstallCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/UninstallCommand.groovy
@@ -18,10 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import org.apache.groovy.groovysh.CommandSupport
+import org.apache.groovy.groovysh.Groovysh
 import org.apache.tinkerpop.gremlin.console.ConsoleFs
 import org.apache.tinkerpop.gremlin.console.Mediator
-import org.codehaus.groovy.tools.shell.CommandSupport
-import org.codehaus.groovy.tools.shell.Groovysh
 
 /**
  * Uninstall a maven dependency from the Console's path.

--- a/gremlin-console/src/main/static/LICENSE
+++ b/gremlin-console/src/main/static/LICENSE
@@ -216,6 +216,7 @@ The Apache TinkerPop project bundles the following components under the BSD Lice
      minlog (com.esotericsoftware:minlog:1.3.0 - https://github.com/EsotericSoftware/minlog)
        - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.minlog
        - for details, see licenses/minlog
+     treelayout (org.abego.treelayout:org.abego.treelayout.core:1.0.3 - http://treelayout.sourceforge.net/) - for details, see licenses/treelayout
 
 ========================================================================
 MIT Licenses

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -18,15 +18,10 @@ Original source copyright:
 Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
 
 ------------------------------------------------------------------------
-Apache Groovy 2.5.15 (AL ASF)
+Apache Groovy 4.0.9 (AL ASF)
 ------------------------------------------------------------------------
-This product includes/uses ANTLR (http://www.antlr2.org/)
-developed by Terence Parr 1989-2006
-
-This product bundles icons from the famfamfam.com silk icons set
-http://www.famfamfam.com/lab/icons/silk/
-Licensed under the Creative Commons Attribution Licence v2.5
-http://creativecommons.org/licenses/by/2.5/
+This product includes/uses ANTLR4 (https://github.com/antlr/antlr4)
+Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
 
 ------------------------------------------------------------------------
 Apache Ivy 2.5.1 (AL ASF)

--- a/gremlin-console/src/main/static/licenses/treelayout
+++ b/gremlin-console/src/main/static/licenses/treelayout
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2011, abego Software GmbH, Germany (http://www.abego.org)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorIntegrateTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.console.jsr223;
 
+import org.apache.groovy.groovysh.Groovysh;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
@@ -27,7 +28,6 @@ import org.apache.tinkerpop.gremlin.jsr223.console.RemoteException;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.structure.io.Storage;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-import org.codehaus.groovy.tools.shell.Groovysh;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverRemoteAcceptorTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.console.jsr223;
 
+import org.apache.groovy.groovysh.Groovysh;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteException;
 import org.apache.tinkerpop.gremlin.structure.io.Storage;
-import org.codehaus.groovy.tools.shell.Groovysh;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/GephiRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/GephiRemoteAcceptorIntegrateTest.java
@@ -20,12 +20,12 @@ package org.apache.tinkerpop.gremlin.console.jsr223;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.input.NullInputStream;
+import org.apache.groovy.groovysh.Groovysh;
 import org.apache.tinkerpop.gremlin.console.GremlinGroovysh;
 import org.apache.tinkerpop.gremlin.console.Mediator;
 import org.apache.tinkerpop.gremlin.jsr223.console.RemoteException;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
-import org.codehaus.groovy.tools.shell.Groovysh;
 import org.codehaus.groovy.tools.shell.IO;
 import org.junit.Before;
 import org.junit.Rule;

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/MockGroovyGremlinShellEnvironment.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/MockGroovyGremlinShellEnvironment.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.console.jsr223;
 
+import org.apache.groovy.groovysh.Groovysh;
 import org.apache.tinkerpop.gremlin.jsr223.console.GremlinShellEnvironment;
-import org.codehaus.groovy.tools.shell.Groovysh;
 import org.codehaus.groovy.tools.shell.IO;
 
 /**

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/UtilitiesGremlinPluginTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/jsr223/UtilitiesGremlinPluginTest.java
@@ -19,9 +19,9 @@
 package org.apache.tinkerpop.gremlin.console.jsr223;
 
 import org.apache.commons.io.input.NullInputStream;
+import org.apache.groovy.groovysh.Groovysh;
 import org.apache.tinkerpop.gremlin.console.PluggedIn;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
-import org.codehaus.groovy.tools.shell.Groovysh;
 import org.codehaus.groovy.tools.shell.IO;
 import org.junit.Test;
 

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -38,7 +38,7 @@ limitations under the License.
                 <artifactId>gmavenplus-plugin</artifactId>
                 <dependencies>
                     <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                         <version>${groovy.version}</version>
                         <type>pom</type>
@@ -313,7 +313,7 @@ limitations under the License.
                                 <scope>runtime</scope>
                             </dependency>
                             <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
+                                <groupId>org.apache.groovy</groupId>
                                 <artifactId>groovy-all</artifactId>
                                 <version>${groovy.version}</version>
                                 <type>pom</type>

--- a/gremlin-dotnet/test/pom.xml
+++ b/gremlin-dotnet/test/pom.xml
@@ -177,7 +177,7 @@ limitations under the License.
                                 <scope>runtime</scope>
                             </dependency>
                             <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
+                                <groupId>org.apache.groovy</groupId>
                                 <artifactId>groovy-all</artifactId>
                                 <version>${groovy.version}</version>
                                 <type>pom</type>

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -158,8 +158,8 @@ limitations under the License.
                                     <exclude>ch.qos.logback:logback-classic</exclude>
                                     <exclude>org.slf4j:slf4j-api</exclude>
                                     <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                                    <exclude>org.codehaus.groovy:groovy</exclude>
-                                    <exclude>org.codehaus.groovy:groovy-json</exclude>
+                                    <exclude>org.apache.groovy:groovy</exclude>
+                                    <exclude>org.apache.groovy:groovy-json</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>

--- a/gremlin-go/pom.xml
+++ b/gremlin-go/pom.xml
@@ -170,7 +170,7 @@ limitations under the License.
                                 <version>${project.version}</version>
                             </dependency>
                             <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
+                                <groupId>org.apache.groovy</groupId>
                                 <artifactId>groovy-all</artifactId>
                                 <version>${groovy.version}</version>
                                 <type>pom</type>

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -43,49 +43,30 @@ limitations under the License.
             <version>2.5.1</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-groovysh</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
             <exclusions>
-                <!-- exclude non-indy type -->
                 <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-util</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-json</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
-            <exclusions>
-                <!-- exclude non-indy type -->
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-jsr223</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
-            <exclusions>
-                <!-- exclude non-indy type -->
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
@@ -124,7 +124,6 @@ public class GremlinGroovyScriptEngineTest {
     public void shouldPromoteDefinedVarsInInterpreterModeWithNoBindings() throws Exception {
         final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(new InterpreterModeGroovyCustomizer());
         engine.eval("def addItUp = { x, y -> x + y }");
-        engine.eval("def class A { def sub(int x, int y) {x - y}}");
         assertEquals(3, engine.eval("int xxx = 1 + 2"));
         assertEquals(4, engine.eval("yyy = xxx + 1"));
         assertEquals(7, engine.eval("def zzz = yyy + xxx"));
@@ -140,7 +139,6 @@ public class GremlinGroovyScriptEngineTest {
             assertThat(root, instanceOf(MissingPropertyException.class));
         }
 
-        assertEquals(9, engine.eval("new A().sub(10, 1)"));
         assertEquals(10, engine.eval("addItUp(zzz,xxx)"));
     }
 

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -79,7 +79,7 @@ limitations under the License.
 						<scope>runtime</scope>
 					</dependency>
                     <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                         <version>${groovy.version}</version>
                         <type>pom</type>

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -193,7 +193,7 @@ limitations under the License.
                                 <version>${project.version}</version>
                             </dependency>
                             <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
+                                <groupId>org.apache.groovy</groupId>
                                 <artifactId>groovy-all</artifactId>
                                 <version>${groovy.version}</version>
                                 <type>pom</type>

--- a/gremlin-server/src/main/static/LICENSE
+++ b/gremlin-server/src/main/static/LICENSE
@@ -216,6 +216,7 @@ The Apache TinkerPop project bundles the following components under the BSD Lice
      minlog (com.esotericsoftware:minlog:1.3.0 - https://github.com/EsotericSoftware/minlog)
        - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.minlog
        - for details, see licenses/minlog
+     treelayout (org.abego.treelayout:org.abego.treelayout.core:1.0.3 - http://treelayout.sourceforge.net/) - for details, see licenses/treelayout
 
 ========================================================================
 MIT Licenses

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -5,15 +5,10 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------
-Apache Groovy 2.5.15 (AL ASF)
+Apache Groovy 4.0.9 (AL ASF)
 ------------------------------------------------------------------------
-This product includes/uses ANTLR (http://www.antlr2.org/)
-developed by Terence Parr 1989-2006
-
-This product bundles icons from the famfamfam.com silk icons set
-http://www.famfamfam.com/lab/icons/silk/
-Licensed under the Creative Commons Attribution Licence v2.5
-http://creativecommons.org/licenses/by/2.5/
+This product includes/uses ANTLR4 (https://github.com/antlr/antlr4)
+Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
 
 ------------------------------------------------------------------------
 Apache Ivy 2.3.0 (AL ASF)

--- a/gremlin-server/src/main/static/licenses/treelayout
+++ b/gremlin-server/src/main/static/licenses/treelayout
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2011, abego Software GmbH, Germany (http://www.abego.org)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -967,7 +967,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         final Client client = cluster.connect();
 
         try {
-            client.submit("def class C { def C getC(){return this}}; new C()").all().join();
+            client.submit("class C { def C getC(){return this}}; new C()").all().join();
             fail("Should throw an exception.");
         } catch (RuntimeException re) {
             final Throwable root = ExceptionHelper.getRootCause(re);
@@ -1133,7 +1133,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
     @Test
     public void shouldProvideBetterExceptionForMethodCodeTooLarge() {
-        final int numberOfParameters = 4000;
+        final int numberOfParameters = 6000;
         final Map<String,Object> b = new HashMap<>();
 
         // generate a script with a ton of bindings usage to generate a "code too large" exception

--- a/gremlin-tools/gremlin-io-test/pom.xml
+++ b/gremlin-tools/gremlin-io-test/pom.xml
@@ -41,23 +41,14 @@ limitations under the License.
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-json</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
-            <exclusions>
-                <!-- exclude non-indy type -->
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -113,7 +104,7 @@ limitations under the License.
                         <artifactId>gmavenplus-plugin</artifactId>
                         <dependencies>
                             <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
+                                <groupId>org.apache.groovy</groupId>
                                 <artifactId>groovy-all</artifactId>
                                 <version>${groovy.version}</version>
                                 <type>pom</type>

--- a/gremlin-tools/gremlin-socket-server/pom.xml
+++ b/gremlin-tools/gremlin-socket-server/pom.xml
@@ -37,24 +37,15 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-json</artifactId>
             <version>${groovy.version}</version>
-            <classifier>indy</classifier>
-            <exclusions>
-                <!-- exclude non-indy type -->
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy</artifactId>
-                </exclusion>
-            </exclusions>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/gremlint/pom.xml
+++ b/gremlint/pom.xml
@@ -53,7 +53,7 @@ limitations under the License.
                 <artifactId>gmavenplus-plugin</artifactId>
                 <dependencies>
                     <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                         <version>${groovy.version}</version>
                         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -161,10 +161,7 @@ limitations under the License.
         <commons.text.version>1.10.0</commons.text.version>
         <cucumber.version>6.11.0</cucumber.version>
         <exp4j.version>0.4.8</exp4j.version>
-        <!-- performance after 2.5.15 is similar to the poor performance of 3.x and 4.x - we can't upgrade past this
-             version without a accepting a major performance hit. details related to this issue along with links
-             to attempts to solve the problem with the Groovy community can be found on: TINKERPOP-2373 -->
-        <groovy.version>2.5.15</groovy.version>
+        <groovy.version>4.0.9</groovy.version>
         <guice.version>4.2.3</guice.version>
         <hadoop.version>3.3.3</hadoop.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -609,7 +606,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
-                    <version>1.13.1</version>
+                    <version>2.1.0</version>
                     <configuration>
                         <targetBytecode>1.8</targetBytecode>
                     </configuration>
@@ -1480,28 +1477,24 @@ limitations under the License.
                                             <version>${project.version}</version>
                                         </additionalDependency>
                                         <additionalDependency>
-                                            <groupId>org.codehaus.groovy</groupId>
+                                            <groupId>org.apache.groovy</groupId>
                                             <artifactId>groovy</artifactId>
                                             <version>${groovy.version}</version>
-                                            <classifier>indy</classifier>
                                         </additionalDependency>
                                         <additionalDependency>
-                                            <groupId>org.codehaus.groovy</groupId>
+                                            <groupId>org.apache.groovy</groupId>
                                             <artifactId>groovy-jsr223</artifactId>
                                             <version>${groovy.version}</version>
-                                            <classifier>indy</classifier>
                                         </additionalDependency>
                                         <additionalDependency>
-                                            <groupId>org.codehaus.groovy</groupId>
+                                            <groupId>org.apache.groovy</groupId>
                                             <artifactId>groovy-groovysh</artifactId>
                                             <version>${groovy.version}</version>
-                                            <classifier>indy</classifier>
                                         </additionalDependency>
                                         <additionalDependency>
-                                            <groupId>org.codehaus.groovy</groupId>
+                                            <groupId>org.apache.groovy</groupId>
                                             <artifactId>groovy-json</artifactId>
                                             <version>${groovy.version}</version>
-                                            <classifier>indy</classifier>
                                         </additionalDependency>
                                         <additionalDependency>
                                             <groupId>org.apache.commons</groupId>
@@ -1698,16 +1691,14 @@ limitations under the License.
                                             <version>${project.version}</version>
                                         </additionalDependency>
                                         <additionalDependency>
-                                            <groupId>org.codehaus.groovy</groupId>
+                                            <groupId>org.apache.groovy</groupId>
                                             <artifactId>groovy-groovysh</artifactId>
                                             <version>${groovy.version}</version>
-                                            <classifier>indy</classifier>
                                         </additionalDependency>
                                         <additionalDependency>
-                                            <groupId>org.codehaus.groovy</groupId>
+                                            <groupId>org.apache.groovy</groupId>
                                             <artifactId>groovy-json</artifactId>
                                             <version>${groovy.version}</version>
-                                            <classifier>indy</classifier>
                                         </additionalDependency>
                                         <additionalDependency>
                                             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TINKERPOP-2373

Groovy 4 packages the indy version by default so it isn't necessary to use the classifier anymore. asm-util is a new dependency for groovysh but clashes with another asm dependency so we exclude it from groovysh since it isn't required when running (Groovy will use the version of asm from jarjarasm). Removed usages of "def class" since this no longer seems to be supported by Groovy. Updated the parameter size for shouldProvideBetterExceptionForMethodCodeTooLarge test as it no longer triggers the exception with the previous, smaller size.