### PR TITLE
TINKERPOP-2747 Separate AuthInfo struct vs AuthInfoProvider interface for dynamic credentials

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed `with()` configuration for `ARGS_BATCH_SIZE` and `ARGS_EVAL_TIMEOUT` to be more forgiving on the type of `Number` used for the value.
 * Changed `gremlin-console` to add imports via an ImportCustomizer to reduce time spent resolving imports.
 * Bumped to Groovy 2.5.21.
+* Added `AuthInfoProvider` interface and `NewDynamicAuth()` to gremlin-go for dynamic authentication support.
 
 [[release-3-5-5]]
 === TinkerPop 3.5.5 (Release Date: January 16, 2023)

--- a/gremlin-go/driver/authInfo.go
+++ b/gremlin-go/driver/authInfo.go
@@ -69,13 +69,13 @@ func HeaderAuthInfo(header http.Header) *AuthInfo {
 
 // DynamicAuth is an AuthInfoProvider that allows dynamic credential generation.
 type DynamicAuth struct {
-	fn func() *AuthInfo
+	fn func() AuthInfoProvider
 }
 
 var _ AuthInfoProvider = (*DynamicAuth)(nil)
 
 // NewDynamicAuth provides a way to generate dynamic credentials with the specified generator function.
-func NewDynamicAuth(f func() *AuthInfo) *DynamicAuth {
+func NewDynamicAuth(f func() AuthInfoProvider) *DynamicAuth {
 	return &DynamicAuth{fn: f}
 }
 

--- a/gremlin-go/driver/authInfo.go
+++ b/gremlin-go/driver/authInfo.go
@@ -66,3 +66,25 @@ func BasicAuthInfo(username string, password string) *AuthInfo {
 func HeaderAuthInfo(header http.Header) *AuthInfo {
 	return &AuthInfo{Header: header}
 }
+
+// DynamicAuth is an AuthInfoProvider that allows dynamic credential generation.
+type DynamicAuth struct {
+	fn func() *AuthInfo
+}
+
+var _ AuthInfoProvider = (*DynamicAuth)(nil)
+
+// NewDynamicAuth provides a way to generate dynamic credentials with the specified generator function.
+func NewDynamicAuth(f func() *AuthInfo) *DynamicAuth {
+	return &DynamicAuth{fn: f}
+}
+
+// GetHeader calls the stored function to get the header dynamically.
+func (d *DynamicAuth) GetHeader() http.Header {
+	return d.fn().GetHeader()
+}
+
+// GetHeader calls the stored function to get basic authentication dynamically.
+func (d *DynamicAuth) GetBasicAuth() (bool, string, string) {
+	return d.fn().GetBasicAuth()
+}

--- a/gremlin-go/driver/authInfo.go
+++ b/gremlin-go/driver/authInfo.go
@@ -72,7 +72,12 @@ type DynamicAuth struct {
 	fn func() AuthInfoProvider
 }
 
-var _ AuthInfoProvider = (*DynamicAuth)(nil)
+var (
+	_ AuthInfoProvider = (*DynamicAuth)(nil)
+
+	// NoopAuthInfo is a no-op AuthInfoProvider that can be used to disable authentication.
+	NoopAuthInfo = NewDynamicAuth(func() AuthInfoProvider { return &AuthInfo{} })
+)
 
 // NewDynamicAuth provides a way to generate dynamic credentials with the specified generator function.
 func NewDynamicAuth(f func() AuthInfoProvider) *DynamicAuth {

--- a/gremlin-go/driver/authInfo.go
+++ b/gremlin-go/driver/authInfo.go
@@ -21,8 +21,14 @@ package gremlingo
 
 import "net/http"
 
-// AuthInfo is an option struct that allows authentication information to be specified.
-// Authentication can be provided via http.Header Header directly.
+// AuthInfoProvider is an interface that allows authentication information to be specified.
+type AuthInfoProvider interface {
+	GetHeader() http.Header
+	GetBasicAuth() (ok bool, username, password string)
+}
+
+// AuthInfo is an option struct that allows authentication information to be specified statically.
+// Authentication can be provided via http.Header directly.
 // Basic authentication can also be used via the BasicAuthInfo function.
 type AuthInfo struct {
 	Header   http.Header
@@ -30,9 +36,11 @@ type AuthInfo struct {
 	Password string
 }
 
-// getHeader provides a safe way to get a header from the AuthInfo even if it is nil.
+var _ AuthInfoProvider = (*AuthInfo)(nil)
+
+// GetHeader provides a safe way to get a header from the AuthInfo even if it is nil.
 // This way we don't need any additional logic in the transport layer.
-func (authInfo *AuthInfo) getHeader() http.Header {
+func (authInfo *AuthInfo) GetHeader() http.Header {
 	if authInfo == nil {
 		return nil
 	} else {
@@ -40,10 +48,13 @@ func (authInfo *AuthInfo) getHeader() http.Header {
 	}
 }
 
-// getUseBasicAuth provides a safe way to check if basic auth info is available from the AuthInfo even if it is nil.
+// GetBasicAuth provides a safe way to check if basic auth info is available from the AuthInfo even if it is nil.
 // This way we don't need any additional logic in the transport layer.
-func (authInfo *AuthInfo) getUseBasicAuth() bool {
-	return authInfo != nil && authInfo.Username != "" && authInfo.Password != ""
+func (authInfo *AuthInfo) GetBasicAuth() (bool, string, string) {
+	if authInfo == nil || (authInfo.Username == "" && authInfo.Password == "") {
+		return false, "", ""
+	}
+	return true, authInfo.Username, authInfo.Password
 }
 
 // BasicAuthInfo provides a way to generate AuthInfo. Enter username and password and get the AuthInfo back.

--- a/gremlin-go/driver/client.go
+++ b/gremlin-go/driver/client.go
@@ -21,9 +21,10 @@ package gremlingo
 
 import (
 	"crypto/tls"
-	"golang.org/x/text/language"
 	"runtime"
 	"time"
+
+	"golang.org/x/text/language"
 )
 
 // ClientSettings is used to modify a Client's settings on initialization.
@@ -33,7 +34,7 @@ type ClientSettings struct {
 	LogVerbosity      LogVerbosity
 	Logger            Logger
 	Language          language.Tag
-	AuthInfo          *AuthInfo
+	AuthInfo          AuthInfoProvider
 	TlsConfig         *tls.Config
 	KeepAliveInterval time.Duration
 	WriteDeadline     time.Duration

--- a/gremlin-go/driver/client_test.go
+++ b/gremlin-go/driver/client_test.go
@@ -21,8 +21,9 @@ package gremlingo
 
 import (
 	"crypto/tls"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient(t *testing.T) {
@@ -40,13 +41,13 @@ func TestClient(t *testing.T) {
 				settings.AuthInfo = testNoAuthAuthInfo
 			})
 		defer client.Close()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, client)
 		resultSet, err := client.Submit("g.V().count()")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, resultSet)
 		result, ok, err := resultSet.One()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, ok)
 		assert.NotNil(t, result)
 	})
@@ -59,13 +60,13 @@ func TestClient(t *testing.T) {
 				settings.AuthInfo = testNoAuthAuthInfo
 			})
 		defer client.Close()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, client)
 		resultSet, err := client.SubmitWithOptions("g.V().count()", *new(RequestOptions))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, resultSet)
 		result, ok, err := resultSet.One()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, ok)
 		assert.NotNil(t, result)
 	})

--- a/gremlin-go/driver/connection.go
+++ b/gremlin-go/driver/connection.go
@@ -42,15 +42,15 @@ type connection struct {
 }
 
 type connectionSettings struct {
-	authInfo         			*AuthInfo
-	tlsConfig         			*tls.Config
-	keepAliveInterval 			time.Duration
-	writeDeadline     			time.Duration
-	connectionTimeout 			time.Duration
-	enableCompression 			bool
-	readBufferSize				int
-	writeBufferSize				int
-	enableUserAgentOnConnect		bool
+	authInfo                 AuthInfoProvider
+	tlsConfig                *tls.Config
+	keepAliveInterval        time.Duration
+	writeDeadline            time.Duration
+	connectionTimeout        time.Duration
+	enableCompression        bool
+	readBufferSize           int
+	writeBufferSize          int
+	enableUserAgentOnConnect bool
 }
 
 func (connection *connection) errorCallback() {
@@ -95,10 +95,11 @@ func (connection *connection) activeResults() int {
 
 // createConnection establishes a connection with the given parameters. A connection should always be closed to avoid
 // leaking connections. The connection has the following states:
-// 		initialized: connection struct is created but has not established communication with server
-// 		established: connection has established communication established with the server
-// 		closed: connection was closed by the user.
-//		closedDueToError: connection was closed internally due to an error.
+//
+//	initialized: connection struct is created but has not established communication with server
+//	established: connection has established communication established with the server
+//	closed: connection was closed by the user.
+//	closedDueToError: connection was closed internally due to an error.
 func createConnection(url string, logHandler *logHandler, connSettings *connectionSettings) (*connection, error) {
 	conn := &connection{
 		logHandler,

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -91,7 +91,7 @@ func addTestData(t *testing.T, g *GraphTraversalSource) {
 	assert.Nil(t, <-promise)
 }
 
-func getTestGraph(t *testing.T, url string, auth *AuthInfo, tls *tls.Config) *GraphTraversalSource {
+func getTestGraph(t *testing.T, url string, auth AuthInfoProvider, tls *tls.Config) *GraphTraversalSource {
 	remote, err := NewDriverRemoteConnection(url,
 		func(settings *DriverRemoteConnectionSettings) {
 			settings.TlsConfig = tls
@@ -105,7 +105,7 @@ func getTestGraph(t *testing.T, url string, auth *AuthInfo, tls *tls.Config) *Gr
 	return g
 }
 
-func initializeGraph(t *testing.T, url string, auth *AuthInfo, tls *tls.Config) *GraphTraversalSource {
+func initializeGraph(t *testing.T, url string, auth AuthInfoProvider, tls *tls.Config) *GraphTraversalSource {
 	g := getTestGraph(t, url, auth, tls)
 
 	// Drop the graph and check that it is empty.

--- a/gremlin-go/driver/driverRemoteConnection.go
+++ b/gremlin-go/driver/driverRemoteConnection.go
@@ -21,10 +21,11 @@ package gremlingo
 
 import (
 	"crypto/tls"
-	"github.com/google/uuid"
-	"golang.org/x/text/language"
 	"runtime"
 	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/text/language"
 )
 
 // DriverRemoteConnectionSettings are used to configure the DriverRemoteConnection.
@@ -36,7 +37,7 @@ type DriverRemoteConnectionSettings struct {
 	LogVerbosity             LogVerbosity
 	Logger                   Logger
 	Language                 language.Tag
-	AuthInfo                 *AuthInfo
+	AuthInfo                 AuthInfoProvider
 	TlsConfig                *tls.Config
 	KeepAliveInterval        time.Duration
 	WriteDeadline            time.Duration

--- a/gremlin-go/driver/driverRemoteConnection_test.go
+++ b/gremlin-go/driver/driverRemoteConnection_test.go
@@ -20,26 +20,28 @@ under the License.
 package gremlingo
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthentication(t *testing.T) {
 
 	t.Run("Test BasicAuthInfo.", func(t *testing.T) {
 		header := BasicAuthInfo("Lyndon", "Bauto")
-		assert.Nil(t, header.getHeader())
-		assert.True(t, header.getUseBasicAuth())
+		assert.Nil(t, header.GetHeader())
+		b, _, _ := header.GetBasicAuth()
+		assert.True(t, b)
 	})
 
-	t.Run("Test getHeader.", func(t *testing.T) {
+	t.Run("Test GetHeader.", func(t *testing.T) {
 		header := &AuthInfo{}
-		assert.Nil(t, header.getHeader())
+		assert.Nil(t, header.GetHeader())
 		header = nil
-		assert.Nil(t, header.getHeader())
+		assert.Nil(t, header.GetHeader())
 		httpHeader := http.Header{}
 		header = &AuthInfo{Header: httpHeader}
-		assert.Equal(t, httpHeader, header.getHeader())
+		assert.Equal(t, httpHeader, header.GetHeader())
 	})
 }

--- a/gremlin-go/driver/gorillaTransporter.go
+++ b/gremlin-go/driver/gorillaTransporter.go
@@ -104,6 +104,9 @@ func (transporter *gorillaTransporter) Write(data []byte) error {
 }
 
 func (transporter *gorillaTransporter) getAuthInfo() AuthInfoProvider {
+	if transporter.connSettings.authInfo == nil {
+		return NoopAuthInfo
+	}
 	return transporter.connSettings.authInfo
 }
 

--- a/gremlin-go/driver/gorillaTransporter.go
+++ b/gremlin-go/driver/gorillaTransporter.go
@@ -65,7 +65,7 @@ func (transporter *gorillaTransporter) Connect() (err error) {
 		ReadBufferSize:    transporter.connSettings.readBufferSize,
 		WriteBufferSize:   transporter.connSettings.writeBufferSize,
 	}
-	header := transporter.connSettings.authInfo.getHeader()
+	header := transporter.connSettings.authInfo.GetHeader()
 	if transporter.connSettings.enableUserAgentOnConnect {
 		if header == nil {
 			header = make(http.Header)
@@ -103,7 +103,7 @@ func (transporter *gorillaTransporter) Write(data []byte) error {
 	return nil
 }
 
-func (transporter *gorillaTransporter) getAuthInfo() *AuthInfo {
+func (transporter *gorillaTransporter) getAuthInfo() AuthInfoProvider {
 	return transporter.connSettings.authInfo
 }
 

--- a/gremlin-go/driver/gorillaTransporter.go
+++ b/gremlin-go/driver/gorillaTransporter.go
@@ -65,7 +65,8 @@ func (transporter *gorillaTransporter) Connect() (err error) {
 		ReadBufferSize:    transporter.connSettings.readBufferSize,
 		WriteBufferSize:   transporter.connSettings.writeBufferSize,
 	}
-	header := transporter.connSettings.authInfo.GetHeader()
+
+	header := transporter.getAuthInfo().GetHeader()
 	if transporter.connSettings.enableUserAgentOnConnect {
 		if header == nil {
 			header = make(http.Header)

--- a/gremlin-go/driver/protocol.go
+++ b/gremlin-go/driver/protocol.go
@@ -123,15 +123,12 @@ func (protocol *gremlinServerWSProtocol) responseHandler(resultSets *synchronize
 		// http status code 151 is not defined here, but corresponds with 403, i.e. authentication has failed.
 		// Server has requested basic auth.
 		authInfo := protocol.transporter.getAuthInfo()
-		if authInfo.getUseBasicAuth() {
-			username := []byte(authInfo.Username)
-			password := []byte(authInfo.Password)
-
+		if ok, username, password := authInfo.GetBasicAuth(); ok {
 			authBytes := make([]byte, 0)
 			authBytes = append(authBytes, 0)
-			authBytes = append(authBytes, username...)
+			authBytes = append(authBytes, []byte(username)...)
 			authBytes = append(authBytes, 0)
-			authBytes = append(authBytes, password...)
+			authBytes = append(authBytes, []byte(password)...)
 			encoded := base64.StdEncoding.EncodeToString(authBytes)
 			request := makeBasicAuthRequest(encoded)
 			err := protocol.write(&request)

--- a/gremlin-go/driver/protocol_test.go
+++ b/gremlin-go/driver/protocol_test.go
@@ -31,7 +31,7 @@ import (
 func TestProtocol(t *testing.T) {
 	t.Run("Test protocol connect error.", func(t *testing.T) {
 		connSettings := newDefaultConnectionSettings()
-		connSettings.authInfo, connSettings.tlsConfig = NoopAuthInfo, nil
+		connSettings.authInfo, connSettings.tlsConfig = nil, nil
 		connSettings.keepAliveInterval, connSettings.writeDeadline, connSettings.writeDeadline = keepAliveIntervalDefault, writeDeadlineDefault, connectionTimeoutDefault
 
 		protocol, err := newGremlinServerWSProtocol(newLogHandler(&defaultLogger{}, Info, language.English), Gorilla,

--- a/gremlin-go/driver/protocol_test.go
+++ b/gremlin-go/driver/protocol_test.go
@@ -31,7 +31,7 @@ import (
 func TestProtocol(t *testing.T) {
 	t.Run("Test protocol connect error.", func(t *testing.T) {
 		connSettings := newDefaultConnectionSettings()
-		connSettings.authInfo, connSettings.tlsConfig = nil, nil
+		connSettings.authInfo, connSettings.tlsConfig = NoopAuthInfo, nil
 		connSettings.keepAliveInterval, connSettings.writeDeadline, connSettings.writeDeadline = keepAliveIntervalDefault, writeDeadlineDefault, connectionTimeoutDefault
 
 		protocol, err := newGremlinServerWSProtocol(newLogHandler(&defaultLogger{}, Info, language.English), Gorilla,

--- a/gremlin-go/driver/strategies_test.go
+++ b/gremlin-go/driver/strategies_test.go
@@ -21,11 +21,12 @@ package gremlingo
 
 import (
 	"crypto/tls"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func getModernGraph(t *testing.T, url string, auth *AuthInfo, tls *tls.Config) *GraphTraversalSource {
+func getModernGraph(t *testing.T, url string, auth AuthInfoProvider, tls *tls.Config) *GraphTraversalSource {
 	remote, err := NewDriverRemoteConnection(url,
 		func(settings *DriverRemoteConnectionSettings) {
 			settings.TlsConfig = tls

--- a/gremlin-go/driver/transporter.go
+++ b/gremlin-go/driver/transporter.go
@@ -27,7 +27,7 @@ type transporter interface {
 	Read() ([]byte, error)
 	Close() error
 	IsClosed() bool
-	getAuthInfo() *AuthInfo
+	getAuthInfo() AuthInfoProvider
 }
 
 type websocketConn interface {


### PR DESCRIPTION
This creates an `AuthInfoProvider` interface with the methods necessary to read credential/header information, changes the `AuthInfo` signature slightly to satisfy that interface, and updates call sites so that each call site calls the necessary interface method to re-read the credentials.

The interface looks like:
```go
type AuthInfoProvider interface {
	GetHeader() http.Header
	GetBasicAuth() (ok bool, username, password string)
}
```

It also adds a new `NewDynamicAuth(f func() AuthInfoProvider)` helper function that creates a generator based `AuthInfoProvider`, so that each time `GetHeader()` or `GetBasicAuth()` methods are called the given function is called to get a brand new `AuthInfoProvider` (which itself can be `AuthInfo` or something else) and the results are relayed to the caller.

With this, `AuthInfo`-related constructors (`BasicAuthInfo()` and `HeaderAuthInfo()`) are unchanged, but there's now the ability to have any object provide the values (implementing `AuthInfoProvider`) and they are called on-demand for each connection attempt, as opposed to having them as static values.

Note: This is my first contribution, and I couldn't get the local gremlin-server to play nicely to get the tests to run, but I've tried it elsewhere with AWS Neptune auth, like so:

```go
// ... code to set up aws-sdk-v2 credential chain ...
		signer := v4.NewSigner()

		gen := func() gremlingo.AuthInfoProvider {
			if err := signer.SignHTTP(ctx, cr, req, emptyStringSHA256, "neptune-db", "us-east-1", time.Now()); err != nil {
				panic(err) // not ideal, but it's always nil
			}
			return gremlingo.HeaderAuthInfo(req.Header)
		}
		return gremlingo.NewDynamicAuth(gen), nil
```