### PR TITLE
[TINKERPOP-2824] Properties on Elements (#63)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,13 @@ This release also includes changes from <<release-3-6-XXX, 3.6.XXX>>.
 * Reduces dependency from `gremlin-server` onto `gremlin-driver` to a test scope only.
 * Added `RequestOptions` and `RequestOptionsBuilder` types to Go GLV to encapsulate per-request settings and bindings.
 * Added `SubmitWithOptions()` methods to `Client` and `DriverRemoteConnection` in Go GLV to pass `RequestOptions` to the server.
+* Changed default behavior for returning properties on Elements for OLTP queries. Properties now returned.
+* Detachment is no longer performed in `TraverserIterator`.
+* Added `materializeProperties` request option to control properties serialization.
+* Modified serializers in to handle serialization and deserialization of properties.
+* Added functional properties to the graph structure components for .NET, GO and Python.
+* Modified the GremlinScriptChecker to extract the `materializeProperties` request option.
+* Neo4jVertexProperty no longer throw Exception for `properties()`, but return empty iterable.
 
 == TinkerPop 3.6.0 (Tinkerheart)
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,7 +38,7 @@ This release also includes changes from <<release-3-6-XXX, 3.6.XXX>>.
 * Reduces dependency from `gremlin-server` onto `gremlin-driver` to a test scope only.
 * Added `RequestOptions` and `RequestOptionsBuilder` types to Go GLV to encapsulate per-request settings and bindings.
 * Added `SubmitWithOptions()` methods to `Client` and `DriverRemoteConnection` in Go GLV to pass `RequestOptions` to the server.
-* Changed default behavior for returning properties on Elements for OLTP queries. Properties now returned.
+* Changed default behavior for returning properties on Elements for OLTP queries. Properties are now returned.
 * Detachment is no longer performed in `TraverserIterator`.
 * Added `materializeProperties` request option to control properties serialization.
 * Modified serializers in to handle serialization and deserialization of properties.

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -194,7 +194,8 @@ The following bullets provide some tips to consider when implementing the struct
 * `VertexProperty`
 ** This interface is both a `Property` and an `Element` as `VertexProperty` is a first-class graph element in that it
 can have its own properties (i.e. meta-properties). Even if the implementation does not intend to support
-meta-properties, the `VertexProperty` needs to be implemented as an `Element`.
+meta-properties, the `VertexProperty` needs to be implemented as an `Element`. `VertexProperty` should return empty
+iterable for properties if not support meta-properties.
 
 [[olap-implementations]]
 ==== OLAP Implementations

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -195,7 +195,7 @@ The following bullets provide some tips to consider when implementing the struct
 ** This interface is both a `Property` and an `Element` as `VertexProperty` is a first-class graph element in that it
 can have its own properties (i.e. meta-properties). Even if the implementation does not intend to support
 meta-properties, the `VertexProperty` needs to be implemented as an `Element`. `VertexProperty` should return empty
-iterable for properties if not support meta-properties.
+iterable for properties if meta-properties is not supported.
 
 [[olap-implementations]]
 ==== OLAP Implementations

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -2250,10 +2250,23 @@ to as "detached elements" and cases where properties are not included are "refer
 With the type of request and detachment model in mind, it is now possible to discuss how best to consider element
 properties in relation to them all in concert.
 
-By default, Gremlin Server sample configurations utilize `ReferenceElementStrategy` when creating the out-of-the-box
-`GraphTraversalSource`. As the name suggests, this means that elements will be detached by reference and will
-therefore not have properties included. The relevant configuration from the Gremlin Server initialization script looks
-like this:
+By default, Gremlin Server configuration returns all properties.
+
+To manage properties for each request you can use the <<configuration-steps-with,with()>> configuration option 
+`materializeProperties`
+
+[source,groovy]
+----
+g.with('materializeProperties', 'tokens').V()
+----
+
+The `tokens` value for the `materializeProperties` means that only `id` and `label` should be returned.
+Another option, `all`, can be used to indicate that all properties should be returned and is the default value.
+
+In some cases it can be inconvenient to load Elements with properties due to large data size or for compatibility reasons.
+That can be solved by utilizing `ReferenceElementStrategy` when creating the out-of-the-box `GraphTraversalSource`.
+As the name suggests, this means that elements will be detached by reference and will therefore not have properties 
+included. The relevant configuration from the Gremlin Server initialization script looks like this:
 
 [source,groovy]
 ----
@@ -2261,39 +2274,12 @@ globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementS
 ----
 
 This configuration is global to Gremlin Server and therefore all methods of connection will always return elements
-without properties. If this strategy is not included, then there are other considerations to take into account such as
-the connection type (i.e. script or bytecode) and the serializer.
-
-For script-based requests, users should take care when returning graph elements. By default, elements will be returned
-as "detached elements" and depending on the serializer being used those detached elements may or may not have their
-properties carried with them. Gryo and GraphSON serializers will write all properties in the return payload in this
-case but GraphBinary will not. Therefore, script-based requests that use Gryo or GraphSON should definitely follow the
-best practice of only returning the data required by the application.
-
-For bytecode-based requests, graph elements have reference detachment and thus only return the `id` and `label` of
-the elements. While this approach alleviates a potential performance problem that the script approach exposes, it is
-still important to follow the practice of being specific about the data that is required by the requesting application
-as it won't arrive on the client side without that declaration.
+without properties. If this strategy is not included, then elements will be returned with properties.
 
 Ultimately, the detachment model should have little impact to Gremlin usage if the best practice of specifying only
-the data required by the application is adhered to. In other words, while there may be a difference in the contents
-of return values for these traversals:
+the data required by the application is adhered to. 
 
-[source,java]
-----
-// properties returned from g.V().hasLabel('person') because this is using the
-// Script API with full detachment
-Cluster cluster = Cluster.open();
-Client client = cluster.connect();
-ResultSet results = client.submit("g.V().hasLabel('person')");
-
-// no properties returned from g.V().hasLabel("person") because this is using
-// Bytecode API with reference detachment
-GraphTraversalSource g = traversal().withRemote('conf/remote-graph.properties');
-List<Vertex> results = g.V().hasLabel("person").toList();
-----
-
-There is no difference if re-written using the best practice of requesting only the data the application needs:
+The best practice of requesting only the data the application needs:
 
 [source,java]
 ----
@@ -2307,10 +2293,8 @@ List<Vertex> results = g.V().hasLabel("person").elementMap('name').toList();
 
 Both of the above requests return a list of `Map` instances that contain the `id`, `label` and the "name" property.
 
-TIP: The example graph configurations pre-packaged with Gremlin Server utilize `ReferenceElementStrategy`
-which convert all graph elements to references by initializing "g" using
-`withStrategies(ReferenceElementStrategy.instance()`. Consider utilizing `ReferenceElementStrategy` whenever creating
-a `GraphTraversalSource` in Java to ensure the most portable Gremlin.
+TIP: Consider utilizing `ReferenceElementStrategy` whenever creating a `GraphTraversalSource` in Java to ensure 
+the most portable Gremlin.
 
 NOTE: For those interested, please see link:https://lists.apache.org/thread.html/e959e85d4f8b3d46d281f2742a6e574c7d27c54bfc52f802f7c04af3%40%3Cdev.tinkerpop.apache.org%3E[this post]
 to the TinkerPop dev list which outlines the full history of this issue and related concerns.

--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -92,7 +92,7 @@ g.With("materializeProperties", "tokens").V(1).Next()
 
 ===== Possible issues
 
-ReferenceElement-type objects are no longer returned - you get a DetachedElement from remote requests. If you not have been coding to the `Element` interfaces then need to update the code with use the interfaces like `Vertex` and `Edge`.
+ReferenceElement-type objects are no longer returned - you get a DetachedElement from remote requests. If you have not been implementing the `Element` interfaces then you will need to update the code to use interfaces like `Vertex` and `Edge`.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2824[TINKERPOP-2824]
 

--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -29,6 +29,74 @@ Please see the link:https://github.com/apache/tinkerpop/blob/3.7.0/CHANGELOG.asc
 
 === Upgrading for Users
 
+==== Properties on Elements
+
+===== Introduction
+
+By default properties on `Element` are now returned for OLTP requests. Gremlin Server 3.5 and 3.6 can return properties only in some special cases. 
+More history details about serialization of properties can be found in the link:https://lists.apache.org/thread/xltcon4zxnwq4fyw2r2126syyrqm8spy[Stephen's post].
+
+===== Behavior for OLAP queries
+
+Queries still won't return properties on Elements. The main reason for this is performance considerations.
+If you need to get a property, then this can be explicitly configured with `HaltedTraverserStrategy`
+
+[source,java]
+----
+  g.withComputer().withStrategies(HaltedTraverserFactoryStrategy.detached())
+----
+
+===== Output comparison for Gremlin Server 3.5/3.6 and 3.7
+
+Let's take a closer look at a Javascript GLV code example in 3.6 and 3.7:
+
+[source,javascript]
+----
+  const client = new Client('ws://localhost:8182/gremlin',{traversalSource: 'gmodern'});
+  await client.open();
+  const result = await client.submit('g.V(1)');
+  console.log(JSON.stringify(result.first()));
+  await client.close();
+----
+
+The result will be different depending on the version of Gremlin Server.
+For 3.5/3.6:
+[source,json]
+----
+  {"id":1,"label":"person"}
+----
+
+For 3.7:
+[source,json]
+----
+  {"id":1,"label":"person","properties":{"name":[{"id":0,"label":"name","value":"marko","key":"name"}],"age":[{"id":1,"label":"age","value":29,"key":"age"}]}}
+---- 
+
+===== Enabling the previous behavior
+
+The GLVs in 3.5/3.6 will not be able to work correctly with properties on Elements. If you don't need to get properties then you can do one of the following:
+
+* To configure Gremlin Server to not return properties, update Gremlin Server initialization script with `ReferenceElementStrategy`.
+This method is better to use with 3.5/3.6 GLVs.
+For example 
+[source,groovy]
+----
+globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
+----
+
+* Use config per request `with('materializeProperties', 'tokens')`
+[source,csharp]
+----
+g.With("materializeProperties", "tokens").V(1).Next()
+----
+
+===== Possible issues
+
+ReferenceElement-type objects are no longer returned - you get a DetachedElement from remote requests. If you not have been coding to the `Element` interfaces then need to update the code with use the interfaces like `Vertex` and `Edge`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-2824[TINKERPOP-2824]
+
+
 ==== Gremlin.NET: Nullable Annotations
 
 Gremlin.NET now uses link:https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-variable-annotations[nullable annotations]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexProperty.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexProperty.java
@@ -104,7 +104,7 @@ public interface VertexProperty<V> extends Property<V>, Element {
         }
 
         public static UnsupportedOperationException metaPropertiesNotSupported() {
-            return new UnsupportedOperationException("Properties on a vertex property is not supported");
+            return new UnsupportedOperationException("Adding properties to a vertex property is not supported");
         }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/types/VertexSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/types/VertexSerializer.java
@@ -18,14 +18,20 @@
  */
 package org.apache.tinkerpop.gremlin.structure.io.binary.types;
 
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.binary.DataType;
 import org.apache.tinkerpop.gremlin.structure.io.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.structure.io.binary.GraphBinaryWriter;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.Buffer;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -37,19 +43,23 @@ public class VertexSerializer extends SimpleTypeSerializer<Vertex> {
 
     @Override
     protected Vertex readValue(final Buffer buffer, final GraphBinaryReader context) throws IOException {
-        final Vertex v = new ReferenceVertex(context.read(buffer), 
-                                             context.readValue(buffer, String.class, false));
-        
-        // discard the properties - as we only send "references" this should always be null, but will we change our
-        // minds some day????
-        context.read(buffer);
-        return v;
+        final Object id = context.read(buffer);
+        final String label = context.readValue(buffer, String.class, false);
+        final List<VertexProperty> properties = context.read(buffer);
+
+        return new DetachedVertex(id, label, properties);
     }
 
     @Override
     protected void writeValue(final Vertex value, final Buffer buffer, final GraphBinaryWriter context) throws IOException {
         context.write(value.id(), buffer);
         context.writeValue(value.label(), buffer, false);
-        context.write(null, buffer);
+        if (value.properties() == null) {
+            context.write(null, buffer);
+        }
+        else {
+            final List<?> asList = IteratorUtils.toList(value.properties());
+            context.write(asList, buffer);
+        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedEdge.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedEdge.java
@@ -25,11 +25,12 @@ import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-import org.javatuples.Pair;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -85,6 +86,24 @@ public class DetachedEdge extends DetachedElement<Edge> implements Edge {
                 } else {
                     this.properties.put(entry.getKey(), Collections.singletonList(new DetachedProperty<>(entry.getKey(), entry.getValue(), this)));
                 }
+            });
+        }
+    }
+
+    public DetachedEdge(final Object id, final String label,
+                        final List<Property> properties,
+                        final Object outVId, final String outVLabel,
+                        final Object inVId, final String inVLabel) {
+        super(id, label);
+        this.outVertex = new DetachedVertex(outVId, outVLabel, Collections.emptyMap());
+        this.inVertex = new DetachedVertex(inVId, inVLabel, Collections.emptyMap());
+        if (properties != null && !properties.isEmpty()) {
+            this.properties = new HashMap<>();
+            properties.iterator().forEachRemaining(property -> {
+                if (!this.properties.containsKey(property.key())) {
+                    this.properties.put(property.key(), new ArrayList());
+                }
+                this.properties.get(property.key()).add(property);
             });
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertex.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertex.java
@@ -86,6 +86,19 @@ public class DetachedVertex extends DetachedElement<Vertex> implements Vertex {
         }
     }
 
+    public DetachedVertex(final Object id, final String label, final List<VertexProperty> properties) {
+        super(id, label);
+        if (properties != null && !properties.isEmpty()) {
+            this.properties = new HashMap<>();
+            properties.iterator().forEachRemaining(property -> {
+                if (!this.properties.containsKey(property.key())) {
+                    this.properties.put(property.key(), new ArrayList());
+                }
+                this.properties.get(property.key()).add(property);
+            });
+        }
+    }
+
     @Override
     public <V> VertexProperty<V> property(final String key, final V value) {
         throw Element.Exceptions.propertyAdditionNotSupported();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertexProperty.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertexProperty.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.Host;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -67,7 +68,8 @@ public class DetachedVertexProperty<V> extends DetachedElement<VertexProperty<V>
 
         if (null != properties && !properties.isEmpty()) {
             this.properties = new HashMap<>();
-            properties.entrySet().iterator().forEachRemaining(entry -> this.properties.put(entry.getKey(), Collections.singletonList(new DetachedProperty<>(entry.getKey(), entry.getValue(), this))));
+            properties.entrySet().iterator().forEachRemaining(entry -> this.properties.put(entry.getKey(),
+                    Collections.singletonList(new DetachedProperty<>(entry.getKey(), entry.getValue(), this))));
         }
     }
 
@@ -81,7 +83,8 @@ public class DetachedVertexProperty<V> extends DetachedElement<VertexProperty<V>
 
         if (null != properties && !properties.isEmpty()) {
             this.properties = new HashMap<>();
-            properties.entrySet().iterator().forEachRemaining(entry -> this.properties.put(entry.getKey(), Collections.singletonList(new DetachedProperty<>(entry.getKey(), entry.getValue(), this))));
+            properties.entrySet().iterator().forEachRemaining(entry -> this.properties.put(entry.getKey(),
+                    Collections.singletonList(new DetachedProperty<>(entry.getKey(), entry.getValue(), this))));
         }
     }
 
@@ -129,7 +132,11 @@ public class DetachedVertexProperty<V> extends DetachedElement<VertexProperty<V>
     @Override
     void internalAddProperty(final Property p) {
         if (null == properties) properties = new HashMap<>();
-        this.properties.put(p.key(), Collections.singletonList(p));
+
+        if(!this.properties.containsKey(p.key())) {
+            this.properties.put(p.key(), new ArrayList());
+        }
+        this.properties.get(p.key()).add(p);
     }
 
     public void internalSetVertex(final DetachedVertex vertex) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ReferenceElementStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ReferenceElementStrategyTest.java
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ReferenceElementStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Remote/DriverRemoteConnection.cs
@@ -51,7 +51,7 @@ namespace Gremlin.Net.Driver.Remote
         private readonly List<string> _allowedKeys = new()
         {
             Tokens.ArgsEvalTimeout, "scriptEvaluationTimeout", Tokens.ArgsBatchSize,
-            Tokens.RequestId, Tokens.ArgsUserAgent
+            Tokens.RequestId, Tokens.ArgsUserAgent, Tokens.ArgMaterializeProperties
         };
 
         private readonly string? _sessionId;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
@@ -33,87 +33,93 @@ namespace Gremlin.Net.Driver
         /// <summary>
         ///     The key for the unique identifier of the request.
         /// </summary>
-        public static string RequestId = "requestId";
+        public const string RequestId = "requestId";
 
         /// <summary>
         ///     Operation used by the client to authenticate itself.
         /// </summary>
-        public static string OpsAuthentication = "authentication";
+        public const string OpsAuthentication = "authentication";
 
         /// <summary>
         ///     Operation used for a request that contains the Bytecode representation of a Traversal.
         /// </summary>
-        public static string OpsBytecode = "bytecode";
+        public const string OpsBytecode = "bytecode";
 
         /// <summary>
         ///     Operation used to evaluate a Gremlin script provided as a string.
         /// </summary>
-        public static string OpsEval = "eval";
+        public const string OpsEval = "eval";
 
         /// <summary>
         ///     Operation used to get all the keys of all side-effects as produced by a previously executed Traversal.
         /// </summary>
-        public static string OpsClose = "close";
+        public const string OpsClose = "close";
 
         /// <summary>
         ///     Default OpProcessor.
         /// </summary>
-        public static string ProcessorTraversal = "traversal";
+        public const string ProcessorTraversal = "traversal";
 
         /// <summary>
         ///     Session OpProcessor.
         /// </summary>
-        public static string ProcessorSession = "session";
+        public const string ProcessorSession = "session";
 
         /// <summary>
         ///     Argument name that allows the definition of the number of items each ResponseMessage should
         ///     contain from a particular result - overrides the resultIterationBatchSize server setting.
         /// </summary>
-        public static string ArgsBatchSize = "batchSize";
+        public const string ArgsBatchSize = "batchSize";
 
         /// <summary>
         ///     Argument name that allows definition of a map of key/value pairs to apply as variables in the
         ///     context of the Gremlin request sent to the server.
         /// </summary>
-        public static string ArgsBindings = "bindings";
+        public const string ArgsBindings = "bindings";
 
         /// <summary>
         ///     Argument name that allows definition of alias names for Graph and TraversalSource objects on the
         ///     remote system.
         /// </summary>
-        public static string ArgsAliases = "aliases";
+        public const string ArgsAliases = "aliases";
 
         /// <summary>
         ///     Argument name that corresponds to the Gremlin to evaluate.
         /// </summary>
-        public static string ArgsGremlin = "gremlin";
+        public const string ArgsGremlin = "gremlin";
 
         /// <summary>
         ///     Argument name that allows to define the id of session.
         /// </summary>
-        public static string ArgsSession = "session";
+        public const string ArgsSession = "session";
 
         /// <summary>
         ///     Argument name that allows a value that is a custom string that the user can pass to a server that
         ///     might accept it for purpose of identifying the kind of client it came from.
         /// </summary>
-        public static string ArgsUserAgent = "userAgent";
+        public const string ArgsUserAgent = "userAgent";
 
         /// <summary>
         ///     Argument name that allows definition of the flavor of Gremlin used (e.g. gremlin-groovy) to process the request.
         /// </summary>
-        public static string ArgsLanguage = "language";
+        public const string ArgsLanguage = "language";
 
         /// <summary>
         ///     Argument name that allows the override of the server setting that determines the maximum time to wait for a
         ///     request to execute on the server.
         /// </summary>
-        public static string ArgsEvalTimeout = "evaluationTimeout";
+        public const string ArgsEvalTimeout = "evaluationTimeout";
+
+        /// <summary>
+        ///     Argument name that allows the override of handling properties.
+        ///     Allowed values: all, tokens
+        /// </summary>
+        public const string ArgMaterializeProperties = "materializeProperties";
 
         /// <summary>
         ///     Argument name for the response to the server authentication challenge. This value is dependent on the SASL
         ///     authentication mechanism required by the server.
         /// </summary>
-        public static string ArgsSasl = "sasl";
+        public const string ArgsSasl = "sasl";
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Edge.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Edge.cs
@@ -21,6 +21,8 @@
 
 #endregion
 
+using System.Linq;
+
 namespace Gremlin.Net.Structure
 {
     /// <summary>
@@ -35,8 +37,9 @@ namespace Gremlin.Net.Structure
         /// <param name="outV">The outgoing/tail vertex of the edge.</param>
         /// <param name="label">The label of the edge.</param>
         /// <param name="inV">The incoming/head vertex of the edge.</param>
-        public Edge(object? id, Vertex outV, string label, Vertex inV)
-            : base(id, label)
+        /// <param name="properties">Optional properties of the edge.</param>
+        public Edge(object? id, Vertex outV, string label, Vertex inV, dynamic[]? properties = null)
+            : base(id, label, properties)
         {
             OutV = outV;
             InV = inV;
@@ -51,6 +54,15 @@ namespace Gremlin.Net.Structure
         ///     Gets the outgoing/tail vertex of this edge.
         /// </summary>
         public Vertex OutV { get; }
+
+        /// <summary>
+        /// Get property by key
+        /// </summary>
+        /// <returns>property or null when not found</returns>
+        public Property? Property(string key)
+        {
+            return Properties?.Cast<Property>().FirstOrDefault(p => p.Key == key);
+        }
 
         /// <inheritdoc />
         public override string ToString()

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Element.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Element.cs
@@ -22,6 +22,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 
 namespace Gremlin.Net.Structure
 {
@@ -35,10 +36,12 @@ namespace Gremlin.Net.Structure
         /// </summary>
         /// <param name="id">The id of the element.</param>
         /// <param name="label">The label of the element.</param>
-        protected Element(object? id, string label)
+        /// <param name="properties">Optional properties of the element.</param>
+        protected Element(object? id, string label, dynamic[]? properties = null)
         {
             Id = id;
             Label = label;
+            Properties = properties;
         }
 
         /// <summary>
@@ -50,6 +53,11 @@ namespace Gremlin.Net.Structure
         ///     Gets the label of this <see cref="Element" />.
         /// </summary>
         public string Label { get; }
+
+        /// <summary>
+        ///     Gets the properties of this <see cref="Element" />.
+        /// </summary>
+        public dynamic[]? Properties { get; }
 
         /// <inheritdoc />
         public bool Equals(Element? other)

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/EdgeSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/EdgeSerializer.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,7 +46,7 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         {
             await writer.WriteAsync(value.Id, stream, cancellationToken).ConfigureAwait(false);
             await writer.WriteNonNullableValueAsync(value.Label, stream, cancellationToken).ConfigureAwait(false);
-            
+
             await writer.WriteAsync(value.InV.Id, stream, cancellationToken).ConfigureAwait(false);
             await writer.WriteNonNullableValueAsync(value.InV.Label, stream, cancellationToken).ConfigureAwait(false);
             await writer.WriteAsync(value.OutV.Id, stream, cancellationToken).ConfigureAwait(false);
@@ -53,7 +54,7 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
 
             // Placeholder for the parent vertex
             await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
-            
+
             // placeholder for the properties
             await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
         }
@@ -70,14 +71,14 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
                 (string)await reader.ReadNonNullableValueAsync<string>(stream, cancellationToken).ConfigureAwait(false));
             var outV = new Vertex(await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false),
                 (string)await reader.ReadNonNullableValueAsync<string>(stream, cancellationToken).ConfigureAwait(false));
-            
+
             // discard possible parent vertex
             await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
-            // discard possible properties
-            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+            var properties = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+            var propertiesAsArray = (properties as List<object>)?.ToArray();
 
-            return new Edge(id, outV, label, inV);
+            return new Edge(id, outV, label, inV, propertiesAsArray);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexPropertySerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexPropertySerializer.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,24 +53,24 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
             
             // placeholder for properties
             await writer.WriteAsync(null, stream, cancellationToken).ConfigureAwait(false);
-
         }
 
         /// <inheritdoc />
         protected override async Task<VertexProperty> ReadValueAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default)
         {
-            var vp = new VertexProperty(await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false),
-                (string)await reader.ReadNonNullableValueAsync<string>(stream, cancellationToken).ConfigureAwait(false),
-                await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false));
+            var id = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+            var label = (string)await reader.ReadNonNullableValueAsync<string>(stream, cancellationToken)
+                .ConfigureAwait(false);
+            var value = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
             // discard the parent vertex
             await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
-            
-            // discard the properties
-            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
-            
-            return vp;
+
+            var properties = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+            var propertiesAsArray = (properties as List<object>)?.ToArray();
+
+            return new VertexProperty(id, label, value, null, propertiesAsArray);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexSerializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphBinary/Types/VertexSerializer.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,13 +53,13 @@ namespace Gremlin.Net.Structure.IO.GraphBinary.Types
         protected override async Task<Vertex> ReadValueAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default)
         {
+            var id = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+            var label = (string)await reader.ReadNonNullableValueAsync<string>(stream, cancellationToken).ConfigureAwait(false);
 
-            var v = new Vertex(await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false),
-                (string)await reader.ReadNonNullableValueAsync<string>(stream, cancellationToken).ConfigureAwait(false));
-            
-            // discard properties
-            await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
-            return v;
+            var properties = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+            var propertiesAsArray = (properties as List<object>)?.ToArray();
+
+            return new Vertex(id, label, propertiesAsArray);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/EdgeDeserializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/EdgeDeserializer.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Linq;
 using System.Text.Json;
 
 namespace Gremlin.Net.Structure.IO.GraphSON
@@ -43,7 +44,16 @@ namespace Gremlin.Net.Structure.IO.GraphSON
             var edgeLabel = graphsonObject.TryGetProperty("label", out var labelProperty)
                 ? labelProperty.GetString()
                 : "edge";
-            return new Edge(edgeId, outV, edgeLabel, inV);
+
+            dynamic?[]? properties = null;
+            if (graphsonObject.TryGetProperty("properties", out var propertiesObject)
+                && propertiesObject.ValueKind == JsonValueKind.Object)
+            {
+                properties = propertiesObject.EnumerateObject()
+                    .Select(p => reader.ToObject(p.Value)).ToArray();
+            }
+
+            return new Edge(edgeId, outV, edgeLabel, inV, properties);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/VertexDeserializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/VertexDeserializer.cs
@@ -21,6 +21,8 @@
 
 #endregion
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 
 namespace Gremlin.Net.Structure.IO.GraphSON
@@ -33,7 +35,16 @@ namespace Gremlin.Net.Structure.IO.GraphSON
             var label = graphsonObject.TryGetProperty("label", out var labelProperty)
                 ? labelProperty.GetString()
                 : Vertex.DefaultLabel;
-            return new Vertex(id, label);
+
+            dynamic?[]? properties = null;
+            if (graphsonObject.TryGetProperty("properties", out var propertiesObject)
+                && propertiesObject.ValueKind == JsonValueKind.Object)
+            {
+                properties = propertiesObject.EnumerateObject()
+                    .SelectMany(p => (reader.ToObject(p.Value) as IEnumerable<object>)!).ToArray();
+            }
+
+            return new Vertex(id, label, properties);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/VertexPropertyDeserializer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/VertexPropertyDeserializer.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System.Linq;
 using System.Text.Json;
 
 namespace Gremlin.Net.Structure.IO.GraphSON
@@ -35,7 +36,15 @@ namespace Gremlin.Net.Structure.IO.GraphSON
             var vertex = graphsonObject.TryGetProperty("vertex", out var vertexProperty)
                 ? new Vertex(reader.ToObject(vertexProperty))
                 : null;
-            return new VertexProperty(id, label, value, vertex);
+
+            dynamic?[]? properties = null;
+            if (graphsonObject.TryGetProperty("properties", out var propertiesObject)
+                && propertiesObject.ValueKind == JsonValueKind.Object)
+            {
+                properties = propertiesObject.EnumerateObject()
+                    .Select(p => new Property(p.Name, reader.ToObject(p.Value))).ToArray();
+            }
+            return new VertexProperty(id, label, value, vertex, properties);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/Vertex.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/Vertex.cs
@@ -21,6 +21,9 @@
 
 #endregion
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Gremlin.Net.Structure
 {
     /// <summary>
@@ -38,9 +41,19 @@ namespace Gremlin.Net.Structure
         /// </summary>
         /// <param name="id">The id of the vertex.</param>
         /// <param name="label">The label of the vertex.</param>
-        public Vertex(object? id, string label = DefaultLabel)
-            : base(id, label)
+        /// <param name="properties">Optional properties of the vertex.</param>
+        public Vertex(object? id, string label = DefaultLabel, dynamic[]? properties = null)
+            : base(id, label, properties)
         {
+        }
+
+        /// <summary>
+        /// Get property by key
+        /// </summary>
+        /// <returns>property or null when not found</returns>
+        public VertexProperty? Property(string key)
+        {
+            return Properties?.Cast<VertexProperty>().FirstOrDefault(p => p.Key == key);
         }
 
         /// <inheritdoc />

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/VertexProperty.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/VertexProperty.cs
@@ -21,6 +21,8 @@
 
 #endregion
 
+using System.Linq;
+
 namespace Gremlin.Net.Structure
 {
     /// <summary>
@@ -35,8 +37,9 @@ namespace Gremlin.Net.Structure
         /// <param name="label">The label of the vertex property.</param>
         /// <param name="value">The id of the vertex property.</param>
         /// <param name="vertex">The (optional) <see cref="Vertex" /> that owns this <see cref="VertexProperty" />.</param>
-        public VertexProperty(object? id, string label, dynamic? value, Vertex? vertex = null)
-            : base(id, label)
+        /// <param name="properties">Optional properties of the VertexProperty.</param>
+        public VertexProperty(object? id, string label, dynamic? value, Vertex? vertex = null, dynamic[]? properties = null)
+            : base(id, label, properties)
         {
             Value = value;
             Vertex = vertex;
@@ -56,6 +59,15 @@ namespace Gremlin.Net.Structure
         ///     The key of this <see cref="VertexProperty" />.
         /// </summary>
         public string Key => Label;
+
+        /// <summary>
+        /// Get property by key
+        /// </summary>
+        /// <returns>property or null when not found</returns>
+        public Property? Property(string key)
+        {
+            return Properties?.Cast<Property>().FirstOrDefault(p => p.Key == key);
+        }
 
         /// <inheritdoc />
         public override string ToString()

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/PropertyDeserializationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/PropertyDeserializationTests.cs
@@ -1,0 +1,241 @@
+﻿#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using Gremlin.Net.Driver;
+using Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection;
+using Gremlin.Net.Process.Traversal;
+using Gremlin.Net.Structure;
+using Gremlin.Net.Structure.IO.GraphBinary;
+using Gremlin.Net.Structure.IO.GraphSON;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Gremlin.Net.IntegrationTest.Driver
+{
+    public class PropertyDeserializationTests
+    {
+        private readonly RemoteConnectionFactory _connectionFactory = new();
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public void ShouldDeserializeVertexPropertiesForBytecode(IMessageSerializer serializer)
+        {
+            var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var vertex = g.V(1).Next();
+
+            VerifyVertexProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public void ShouldRespectMaterializePropertiesTokensForBytecode(IMessageSerializer serializer)
+        {
+            var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var vertex = g.With(Tokens.ArgMaterializeProperties, "tokens").V(1).Next();
+
+            VerifyEmptyProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public void ShouldRespectMaterializePropertiesAllForBytecode(IMessageSerializer serializer)
+        {
+            var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var vertex = g.With(Tokens.ArgMaterializeProperties, "all").V(1).Next();
+
+            VerifyVertexProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public void ShouldHandleEmptyVertexPropertiesForBytecode(IMessageSerializer serializer)
+        {
+            var connection = _connectionFactory.CreateRemoteConnection("gimmutable", 2, serializer);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var vertex = g.AddV("test").Next();
+
+            VerifyEmptyProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public async Task ShouldDeserializeVertexPropertiesForGremlin(IMessageSerializer serializer)
+        {
+            var client = _connectionFactory.CreateClient(serializer);
+
+            var vertex = await client.SubmitWithSingleResultAsync<Vertex>("gmodern.V(1)");
+
+            VerifyVertexProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public async Task ShouldHandleEmptyVertexPropertiesForGremlin(IMessageSerializer serializer)
+        {
+            var client = _connectionFactory.CreateClient(serializer);
+
+            var vertex = await client.SubmitWithSingleResultAsync<Vertex>("gimmutable.addV('test')");
+
+            VerifyEmptyProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public async Task ShouldRespectMaterializePropertiesAllForGremlin(IMessageSerializer serializer)
+        {
+            var client = _connectionFactory.CreateClient(serializer);
+
+            var vertex = await client.SubmitWithSingleResultAsync<Vertex>("gmodern.with('materializeProperties', 'all').V(1)");
+
+            VerifyVertexProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public async Task ShouldRespectMaterializePropertiesTokensForGremlin(IMessageSerializer serializer)
+        {
+            var client = _connectionFactory.CreateClient(serializer);
+
+            var vertex = await client.SubmitWithSingleResultAsync<Vertex>("gmodern.with('materializeProperties', 'tokens').V(1)");
+
+            VerifyEmptyProperties(vertex);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public void ShouldDeserializeEdgePropertiesForBytecode(IMessageSerializer serializer)
+        {
+            var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var edge = g.E(7).Next();
+
+            VerifyEdgeProperties(edge);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public void ShouldHandleEmptyEdgePropertiesForBytecode(IMessageSerializer serializer)
+        {
+            var connection = _connectionFactory.CreateRemoteConnection("gimmutable", 2, serializer);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var v1 = g.AddV("v1").Next();
+            var v2 = g.AddV("v2").Next();
+            var edge = g.AddE("test").From(v1).To(v2).Next();
+
+            VerifyEmptyProperties(edge);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public async Task ShouldDeserializeEdgePropertiesForGremlin(IMessageSerializer serializer)
+        {
+            var client = _connectionFactory.CreateClient(serializer);
+
+            var edge = await client.SubmitWithSingleResultAsync<Edge>("gmodern.E(7)");
+
+            VerifyEdgeProperties(edge);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public async Task ShouldHandleEmptyEdgePropertiesForGremlin(IMessageSerializer serializer)
+        {
+            var client = _connectionFactory.CreateClient(serializer);
+
+            var edge = await client.SubmitWithSingleResultAsync<Edge>(
+                "gimmutable.addV().as('v1').addV().as('v2').addE('test').from('v1').to('v2')");
+
+            VerifyEmptyProperties(edge);
+        }
+
+        [Theory]
+        [MemberData(nameof(Serializers))]
+        public void ShouldHandleMultiplePropertiesWithSameNameForVertex(IMessageSerializer serializer)
+        {
+            var connection = _connectionFactory.CreateRemoteConnection("gimmutable", 2, serializer);
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+
+            var vertex = g.AddV()
+                .Property(Cardinality.List, "test", "value1")
+                .Property(Cardinality.List, "test", "value2")
+                .Property(Cardinality.List, "test", "value3")
+                .Next()!;
+
+            vertex = g.V(vertex.Id).Next();
+
+            Assert.NotNull(vertex);
+
+            var properties = vertex.Properties!;
+            Assert.Equal(3, properties.Length);
+            var propertyValues = properties.Cast<VertexProperty>().Where(p => p.Key == "test").Select(p => p.Value).ToArray();
+            Assert.Equal(3, propertyValues.Length);
+            Assert.Equal(new[] { "value1", "value2", "value3" }, propertyValues);
+        }
+
+        private static void VerifyVertexProperties(Vertex? vertex)
+        {
+            Assert.NotNull(vertex);
+            Assert.Equal(1, vertex.Id);
+
+            Assert.Equal(2, vertex.Properties!.Length);
+            var age = vertex.Property("age");
+            Assert.NotNull(age);
+            Assert.Equal(29, age.Value);
+        }
+
+        private static void VerifyEdgeProperties(Edge? edge)
+        {
+            Assert.NotNull(edge);
+            Assert.Equal(7, edge.Id);
+
+            Assert.Single(edge.Properties!);
+            var weight = edge.Property("weight");
+            Assert.NotNull(weight);
+            Assert.Equal(0.5, weight.Value);
+        }
+
+        private static void VerifyEmptyProperties(Element? element)
+        {
+            Assert.NotNull(element);
+            Assert.True((element.Properties?.Length ?? 0) == 0);
+        }
+
+        public static List<object[]> Serializers => new()
+        {
+            new [] { new GraphSON2MessageSerializer() },
+            new [] { new GraphSON3MessageSerializer() },
+            new [] { new GraphBinaryMessageSerializer() }
+        };
+    }
+}

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/RemoteConnectionFactory.cs
@@ -35,33 +35,42 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         private static readonly string TestHost = ConfigProvider.Configuration["TestServerIpAddress"]!;
         private static readonly int TestPort = Convert.ToInt32(ConfigProvider.Configuration["TestServerPort"]);
 
-        private readonly IList<DriverRemoteConnectionImpl> _connections = new List<DriverRemoteConnectionImpl>();
+        private readonly IList<IDisposable> _cleanUp = new List<IDisposable>();
         private readonly IMessageSerializer _messageSerializer;
 
         public RemoteConnectionFactory(IMessageSerializer? messageSerializer = null)
         {
             _messageSerializer = messageSerializer ?? new GraphSON3MessageSerializer();
         }
-        
+
         public IRemoteConnection CreateRemoteConnection(int connectionPoolSize = 2)
         {
             // gmodern is the standard test traversalsource that the main body of test uses
             return CreateRemoteConnection("gmodern", connectionPoolSize);
         }
 
-        public IRemoteConnection CreateRemoteConnection(string traversalSource, int connectionPoolSize = 2)
+        public IRemoteConnection CreateRemoteConnection(string traversalSource,
+            int connectionPoolSize = 2,
+            IMessageSerializer? messageSerializer = null)
         {
-            var c = new DriverRemoteConnectionImpl(
-                new GremlinClient(new GremlinServer(TestHost, TestPort), _messageSerializer,
-                    connectionPoolSettings: new ConnectionPoolSettings { PoolSize = connectionPoolSize }),
-                traversalSource);
-            _connections.Add(c);
+            var c = new DriverRemoteConnectionImpl(CreateClient(messageSerializer, connectionPoolSize), traversalSource);
+            _cleanUp.Add(c);
+            return c;
+        }
+
+        public IGremlinClient CreateClient(IMessageSerializer? messageSerializer = null, int connectionPoolSize = 2)
+        {
+            var c = new GremlinClient(new GremlinServer(TestHost, TestPort),
+                    messageSerializer ?? _messageSerializer,
+                    connectionPoolSettings: new() { PoolSize = connectionPoolSize });
+
+            _cleanUp.Add(c);
             return c;
         }
 
         public void Dispose()
         {
-            foreach (var connection in _connections)
+            foreach (var connection in _cleanUp)
             {
                 connection.Dispose();
             }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -363,6 +363,7 @@ public abstract class Client {
         options.getOverrideRequestId().ifPresent(request::overrideRequestId);
         options.getUserAgent().ifPresent(userAgent -> request.addArg(Tokens.ARGS_USER_AGENT, userAgent));
         options.getLanguage().ifPresent(lang -> request.addArg(Tokens.ARGS_LANGUAGE, lang));
+        options.getMaterializeProperties().ifPresent(mp -> request.addArg(Tokens.ARGS_MATERIALIZE_PROPERTIES, mp));
 
         return submitAsync(request.create());
     }
@@ -660,6 +661,7 @@ public abstract class Client {
                 options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_EVAL_TIMEOUT, timeout));
                 options.getOverrideRequestId().ifPresent(request::overrideRequestId);
                 options.getUserAgent().ifPresent(userAgent -> request.add(Tokens.ARGS_USER_AGENT, userAgent));
+                options.getMaterializeProperties().ifPresent(mp -> request.addArg(Tokens.ARGS_MATERIALIZE_PROPERTIES, mp));
 
                 return submitAsync(request.create());
             } catch (RuntimeException re) {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
@@ -41,6 +41,7 @@ public final class RequestOptions {
     private final UUID overrideRequestId;
     private final String userAgent;
     private final String language;
+    private final String materializeProperties;
 
     private RequestOptions(final Builder builder) {
         this.aliases = builder.aliases;
@@ -50,6 +51,7 @@ public final class RequestOptions {
         this.overrideRequestId = builder.overrideRequestId;
         this.userAgent = builder.userAgent;
         this.language = builder.language;
+        this.materializeProperties = builder.materializeProperties;
     }
 
     public Optional<UUID> getOverrideRequestId() {
@@ -80,6 +82,8 @@ public final class RequestOptions {
         return Optional.ofNullable(language);
     }
 
+    public Optional<String> getMaterializeProperties() { return Optional.ofNullable(materializeProperties); }
+
     public static Builder build() {
         return new Builder();
     }
@@ -91,6 +95,7 @@ public final class RequestOptions {
         private Long timeout = null;
         private UUID overrideRequestId = null;
         private String userAgent = null;
+        private String materializeProperties = null;
         private String language = null;
         private boolean maintainStateAfterException = false;
 
@@ -156,6 +161,14 @@ public final class RequestOptions {
          */
         public Builder language(final String language) {
             this.language = language;
+            return this;
+        }
+
+        /**
+         * Sets the materializeProperties identifier to be sent on the request.
+         */
+        public Builder materializeProperties(final String materializeProperties) {
+            this.materializeProperties = materializeProperties;
             return this;
         }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -42,6 +42,8 @@ import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_BATCH_SIZE;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_EVAL_TIMEOUT;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_USER_AGENT;
 import static org.apache.tinkerpop.gremlin.util.Tokens.REQUEST_ID;
+import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_MATERIALIZE_PROPERTIES;
+
 
 /**
  * A {@link RemoteConnection} implementation for Gremlin Server. Each {@code DriverServerConnection} is bound to one
@@ -258,6 +260,8 @@ public class DriverRemoteConnection implements RemoteConnection {
                 builder.batchSize(((Number) options.get(ARGS_BATCH_SIZE)).intValue());
             if (options.containsKey(ARGS_USER_AGENT))
                 builder.userAgent((String) options.get(ARGS_USER_AGENT));
+            if (options.containsKey(ARGS_MATERIALIZE_PROPERTIES))
+                builder.materializeProperties((String) options.get(ARGS_MATERIALIZE_PROPERTIES));
         }
         return builder.create();
     }

--- a/gremlin-go/driver/client_test.go
+++ b/gremlin-go/driver/client_test.go
@@ -103,6 +103,52 @@ func TestClient(t *testing.T) {
 
 		AssertMarkoVertexWithoutProperties(t, result)
 	})
+
+	t.Run("Test deserialization of VertexProperty with properties", func(t *testing.T) {
+		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
+		client, err := NewClient(testNoAuthUrl,
+			func(settings *ClientSettings) {
+				settings.TlsConfig = testNoAuthTlsConfig
+				settings.AuthInfo = testNoAuthAuthInfo
+				settings.TraversalSource = testServerCrewGraphAlias
+			})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		defer client.Close()
+
+		resultSet, err := client.Submit("g.V(7)")
+		assert.NoError(t, err)
+		assert.NotNil(t, resultSet)
+		result, ok, err := resultSet.One()
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		AssertVertexPropertiesWithProperties(t, result)
+	})
+}
+
+func AssertVertexPropertiesWithProperties(t *testing.T, result *Result) {
+	assert.NotNil(t, result)
+
+	vertex, err := result.GetVertex()
+	assert.NoError(t, err)
+	assert.NotNil(t, vertex)
+
+	properties, ok := vertex.Properties.([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, 4, len(properties))
+
+	property, ok := properties[1].(*VertexProperty)
+	assert.True(t, ok)
+	assert.NotNil(t, property)
+	assert.Equal(t, "centreville", property.Value)
+	vertexPropertyProperties := property.Properties.([]interface{})
+	assert.Equal(t, 2, len(vertexPropertyProperties))
+	assert.Equal(t, "startTime", (vertexPropertyProperties[0].(*Property)).Key)
+	assert.Equal(t, int32(1990), (vertexPropertyProperties[0].(*Property)).Value)
+	assert.Equal(t, "endTime", (vertexPropertyProperties[1].(*Property)).Key)
+	assert.Equal(t, int32(2000), (vertexPropertyProperties[1].(*Property)).Value)
 }
 
 func AssertMarkoVertexWithProperties(t *testing.T, result *Result) {
@@ -211,9 +257,9 @@ func TestClientAgainstSocketServer(t *testing.T) {
 	t.Run("Should get single vertex response from gremlin socket server", func(t *testing.T) {
 		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
 		client, err := NewClient(testSocketServerUrl)
-		defer client.Close()
 		assert.Nil(t, err)
 		assert.NotNil(t, client)
+		defer client.Close()
 		resultSet, err := client.SubmitWithOptions("1", new(RequestOptionsBuilder).
 			SetRequestId(settings.SINGLE_VERTEX_REQUEST_ID).Create())
 		assert.Nil(t, err)
@@ -231,9 +277,9 @@ func TestClientAgainstSocketServer(t *testing.T) {
 	t.Run("Should include user agent in handshake request", func(t *testing.T) {
 		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
 		client, err := NewClient(testSocketServerUrl)
-		defer client.Close()
 		assert.Nil(t, err)
 		assert.NotNil(t, client)
+		defer client.Close()
 
 		resultSet, err := client.SubmitWithOptions("1", new(RequestOptionsBuilder).
 			SetRequestId(settings.USER_AGENT_REQUEST_ID).Create())
@@ -259,9 +305,9 @@ func TestClientAgainstSocketServer(t *testing.T) {
 			func(settings *ClientSettings) {
 				settings.EnableUserAgentOnConnect = false
 			})
-		defer client.Close()
 		assert.Nil(t, err)
 		assert.NotNil(t, client)
+		defer client.Close()
 
 		resultSet, err := client.SubmitWithOptions("1", new(RequestOptionsBuilder).
 			SetRequestId(settings.USER_AGENT_REQUEST_ID).Create())
@@ -286,9 +332,9 @@ func TestClientAgainstSocketServer(t *testing.T) {
 	t.Run("Should Send Per Request Settings To Server", func(t *testing.T) {
 		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
 		client, err := NewClient(testSocketServerUrl)
-		defer client.Close()
 		assert.Nil(t, err)
 		assert.NotNil(t, client)
+		defer client.Close()
 
 		resultSet, err := client.SubmitWithOptions("1", new(RequestOptionsBuilder).
 			SetRequestId(settings.PER_REQUEST_SETTINGS_REQUEST_ID).

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -45,6 +45,7 @@ const validHostInvalidPortValidPath = "ws://localhost:12341253/gremlin"
 const invalidHostValidPortValidPath = "ws://invalidhost:8182/gremlin"
 const testServerModernGraphAlias = "gmodern"
 const testServerGraphAlias = "gimmutable"
+const testServerCrewGraphAlias = "gcrew"
 const manualTestSuiteName = "manual"
 const nonRoutableIPForConnectionTimeout = "ws://10.255.255.1/"
 

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -1189,4 +1189,42 @@ func TestConnection(t *testing.T) {
 			assert.Equal(t, <-gotErrs[i] == nil, tt.nilErr, tt.msg)
 		}
 	})
+
+	t.Run("Get all properties when materializeProperties is all", func(t *testing.T) {
+		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
+
+		g := getModernGraph(t, testNoAuthUrl, &AuthInfo{}, &tls.Config{})
+		defer g.remoteConnection.Close()
+
+		// vertex contains 2 properties, name and age
+		r, err := g.With("materializeProperties", MaterializeProperties.All).V().Has("person", "name", "marko").Next()
+		assert.Nil(t, err)
+
+		AssertMarkoVertexWithProperties(t, r)
+	})
+
+	t.Run("Skip properties when materializeProperties is tokens", func(t *testing.T) {
+		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
+
+		g := getModernGraph(t, testNoAuthUrl, &AuthInfo{}, &tls.Config{})
+		defer g.remoteConnection.Close()
+
+		// vertex contains 2 properties, name and age
+		r, err := g.With("materializeProperties", MaterializeProperties.Tokens).V().Has("person", "name", "marko").Next()
+		assert.Nil(t, err)
+
+		AssertMarkoVertexWithoutProperties(t, r)
+	})
+
+	t.Run("Get all properties when no materializeProperties", func(t *testing.T) {
+		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
+
+		g := getModernGraph(t, testNoAuthUrl, &AuthInfo{}, &tls.Config{})
+		defer g.remoteConnection.Close()
+
+		r, err := g.V().Has("person", "name", "marko").Next()
+		assert.Nil(t, err)
+
+		AssertMarkoVertexWithProperties(t, r)
+	})
 }

--- a/gremlin-go/driver/graph.go
+++ b/gremlin-go/driver/graph.go
@@ -34,6 +34,7 @@ type Graph struct {
 type Element struct {
 	Id    interface{}
 	Label string
+	Properties interface{}
 }
 
 // Vertex contains a single Vertex which has a Label and an Id.

--- a/gremlin-go/driver/graphBinary.go
+++ b/gremlin-go/driver/graphBinary.go
@@ -1142,15 +1142,12 @@ func vertexPropertyReader(data *[]byte, i *int) (interface{}, error) {
 
 	*i += 2
 
-	v, err := readFullyQualifiedNullable(data, i, true)
+	props, err := readFullyQualifiedNullable(data, i, true)
 	if err != nil {
 		return nil, err
 	}
 
-	vertex, ok := v.(*Vertex)
-	if ok {
-		vp.Vertex = *vertex
-	}
+	vp.Properties = props
 
 	return vp, nil
 }

--- a/gremlin-go/driver/graphBinary.go
+++ b/gremlin-go/driver/graphBinary.go
@@ -23,11 +23,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/google/uuid"
 	"math"
 	"math/big"
 	"reflect"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Version 1.0
@@ -433,7 +434,7 @@ func edgeWriter(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBi
 	return buffer.Bytes(), nil
 }
 
-//Format: {Key}{Value}{parent}
+// Format: {Key}{Value}{parent}
 func propertyWriter(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
 	v := value.(*Property)
 
@@ -452,7 +453,7 @@ func propertyWriter(value interface{}, buffer *bytes.Buffer, typeSerializer *gra
 	return buffer.Bytes(), nil
 }
 
-//Format: {Id}{Label}{Value}{parent}{properties}
+// Format: {Id}{Label}{Value}{parent}{properties}
 func vertexPropertyWriter(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
 	vp := value.(*VertexProperty)
 	_, err := typeSerializer.write(vp.Id, buffer)
@@ -475,7 +476,7 @@ func vertexPropertyWriter(value interface{}, buffer *bytes.Buffer, typeSerialize
 	return buffer.Bytes(), nil
 }
 
-//Format: {Labels}{Objects}
+// Format: {Labels}{Objects}
 func pathWriter(value interface{}, buffer *bytes.Buffer, typeSerializer *graphBinaryTypeSerializer) ([]byte, error) {
 	p := value.(*Path)
 	_, err := typeSerializer.write(p.Labels, buffer)
@@ -1049,11 +1050,11 @@ func durationReader(data *[]byte, i *int) (interface{}, error) {
 
 // {fully qualified id}{unqualified label}
 func vertexReader(data *[]byte, i *int) (interface{}, error) {
-	return vertexReaderNullByte(data, i, true)
+	return vertexReaderReadingProperties(data, i, true)
 }
 
-// {fully qualified id}{unqualified label}{[unused null byte]}
-func vertexReaderNullByte(data *[]byte, i *int, unusedByte bool) (interface{}, error) {
+// {fully qualified id}{unqualified label}{fully qualified properties}
+func vertexReaderReadingProperties(data *[]byte, i *int, readProperties bool) (interface{}, error) {
 	var err error
 	v := new(Vertex)
 	v.Id, err = readFullyQualifiedNullable(data, i, true)
@@ -1065,33 +1066,43 @@ func vertexReaderNullByte(data *[]byte, i *int, unusedByte bool) (interface{}, e
 		return nil, err
 	}
 	v.Label = label.(string)
-	if unusedByte {
-		*i += 2
+	if readProperties {
+		v.Properties, err = readFullyQualifiedNullable(data, i, true)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return v, nil
 }
 
-// {fully qualified id}{unqualified label}{in vertex w/o null byte}{out vertex}{unused null byte}{unused null byte}
+// {fully qualified id}{unqualified label}{in vertex w/o null byte}{out vertex}{unused null byte}{fully qualified properties}
 func edgeReader(data *[]byte, i *int) (interface{}, error) {
 	var err error
 	e := new(Edge)
 	e.Id, err = readFullyQualifiedNullable(data, i, true)
+	if err != nil {
+		return nil, err
+	}
 	label, err := readUnqualified(data, i, stringType, false)
 	if err != nil {
 		return nil, err
 	}
 	e.Label = label.(string)
-	v, err := vertexReaderNullByte(data, i, false)
+	v, err := vertexReaderReadingProperties(data, i, false)
 	if err != nil {
 		return nil, err
 	}
 	e.InV = *v.(*Vertex)
-	v, err = vertexReaderNullByte(data, i, false)
+	v, err = vertexReaderReadingProperties(data, i, false)
 	if err != nil {
 		return nil, err
 	}
 	e.OutV = *v.(*Vertex)
-	*i += 4
+	*i += 2
+	e.Properties, err = readFullyQualifiedNullable(data, i, true)
+	if err != nil {
+		return nil, err
+	}
 	return e, nil
 }
 
@@ -1129,7 +1140,18 @@ func vertexPropertyReader(data *[]byte, i *int) (interface{}, error) {
 		return nil, err
 	}
 
-	*i += 4
+	*i += 2
+
+	v, err := readFullyQualifiedNullable(data, i, true)
+	if err != nil {
+		return nil, err
+	}
+
+	vertex, ok := v.(*Vertex)
+	if ok {
+		vp.Vertex = *vertex
+	}
+
 	return vp, nil
 }
 

--- a/gremlin-go/driver/graphTraversalSource_test.go
+++ b/gremlin-go/driver/graphTraversalSource_test.go
@@ -27,7 +27,7 @@ import (
 func TestGraphTraversalSource(t *testing.T) {
 
 	t.Run("GraphTraversalSource.With tests", func(t *testing.T) {
-		t.Run("Test for single param", func(t *testing.T) {
+		t.Run("Test for single property", func(t *testing.T) {
 			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
 			traversal := g.With("foo", "bar")
 			assert.NotNil(t, traversal)
@@ -40,7 +40,7 @@ func TestGraphTraversalSource(t *testing.T) {
 			assert.Equal(t, map[string]interface{}{"foo": "bar"}, config)
 		})
 
-		t.Run("Test for multiple param", func(t *testing.T) {
+		t.Run("Test for multiple property", func(t *testing.T) {
 			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
 			traversal := g.With("foo", "bar").With("foo2", "bar2")
 			assert.NotNil(t, traversal)
@@ -53,7 +53,7 @@ func TestGraphTraversalSource(t *testing.T) {
 			assert.Equal(t, map[string]interface{}{"foo": "bar", "foo2": "bar2"}, config)
 		})
 
-		t.Run("Test for param replacement", func(t *testing.T) {
+		t.Run("Test for property replacement", func(t *testing.T) {
 			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
 			traversal := g.With("foo", "bar").With("foo", "not bar")
 			assert.NotNil(t, traversal)

--- a/gremlin-go/driver/graph_test.go
+++ b/gremlin-go/driver/graph_test.go
@@ -30,7 +30,7 @@ import (
 func TestGraphStructureFunctions(t *testing.T) {
 	t.Run("Test Vertex.String()", func(t *testing.T) {
 		uid, _ := uuid.NewUUID()
-		v := Vertex{Element{uid, "Vertex-Label"}}
+		v := Vertex{Element{uid, "Vertex-Label", nil}}
 		assert.Equal(t, fmt.Sprintf("v[%s]", uid.String()), v.String())
 	})
 
@@ -38,21 +38,21 @@ func TestGraphStructureFunctions(t *testing.T) {
 		uidEdge, _ := uuid.NewUUID()
 		uidIn, _ := uuid.NewUUID()
 		uidOut, _ := uuid.NewUUID()
-		v := Edge{Element{uidEdge, "edge_label"}, Vertex{Element{uidOut, "vertex_out"}}, Vertex{Element{uidIn, "vertex_in"}}}
+		v := Edge{Element{uidEdge, "edge_label", nil}, Vertex{Element{uidOut, "vertex_out", nil}}, Vertex{Element{uidIn, "vertex_in", nil}}}
 		assert.Equal(t, fmt.Sprintf("e[%s][%s-edge_label->%s]", uidEdge.String(), uidOut.String(), uidIn.String()), v.String())
 	})
 
 	t.Run("Test VertexProperty.String()", func(t *testing.T) {
 		uidVProp, _ := uuid.NewUUID()
 		uidV, _ := uuid.NewUUID()
-		v := VertexProperty{Element{uidVProp, "Vertex-prop"}, "Vertex", []uint32{0, 1}, Vertex{Element{uidV, "Vertex"}}}
+		v := VertexProperty{Element{uidVProp, "Vertex-prop", nil}, "Vertex", []uint32{0, 1}, Vertex{Element{uidV, "Vertex", nil}}}
 		assert.Equal(t, "vp[Vertex-prop->[0 1]]", v.String())
 	})
 
 	t.Run("Test Property.String()", func(t *testing.T) {
 		uidElement, _ := uuid.NewUUID()
 		data := []uint32{0, 1}
-		p := Property{"property-Key", data, Element{uidElement, "prop"}}
+		p := Property{"property-Key", data, Element{uidElement, "prop", nil}}
 		assert.Equal(t, "p[property-Key->[0 1]]", p.String())
 	})
 

--- a/gremlin-go/driver/request.go
+++ b/gremlin-go/driver/request.go
@@ -71,6 +71,10 @@ func makeStringRequest(stringGremlin string, traversalSource string, sessionId s
 		newArgs["userAgent"] = requestOptions.userAgent
 	}
 
+	if requestOptions.materializeProperties != "" {
+		newArgs["materializeProperties"] = requestOptions.materializeProperties
+	}
+
 	return request{
 		requestID: requestId,
 		op:        stringOp,
@@ -112,10 +116,11 @@ func makeBytecodeRequest(bytecodeGremlin *Bytecode, traversalSource string, sess
 // allowedReqArgs contains the arguments that will be extracted from the
 // bytecode and sent with the request.
 var allowedReqArgs = map[string]bool{
-	"evaluationTimeout": true,
-	"batchSize":         true,
-	"requestId":         true,
-	"userAgent":         true,
+	"evaluationTimeout":     true,
+	"batchSize":             true,
+	"requestId":             true,
+	"userAgent":             true,
+	"materializeProperties": true,
 }
 
 // extractReqArgs extracts request arguments from the provided bytecode.

--- a/gremlin-go/driver/requestOptions.go
+++ b/gremlin-go/driver/requestOptions.go
@@ -24,19 +24,21 @@ import (
 )
 
 type RequestOptions struct {
-	requestID         uuid.UUID
-	evaluationTimeout int
-	batchSize         int
-	userAgent         string
-	bindings          map[string]interface{}
+	requestID             uuid.UUID
+	evaluationTimeout     int
+	batchSize             int
+	userAgent             string
+	bindings              map[string]interface{}
+	materializeProperties string
 }
 
 type RequestOptionsBuilder struct {
-	requestID         uuid.UUID
-	evaluationTimeout int
-	batchSize         int
-	userAgent         string
-	bindings          map[string]interface{}
+	requestID             uuid.UUID
+	evaluationTimeout     int
+	batchSize             int
+	userAgent             string
+	bindings              map[string]interface{}
+	materializeProperties string
 }
 
 func (builder *RequestOptionsBuilder) SetRequestId(requestId uuid.UUID) *RequestOptionsBuilder {
@@ -64,6 +66,11 @@ func (builder *RequestOptionsBuilder) SetBindings(bindings map[string]interface{
 	return builder
 }
 
+func (builder *RequestOptionsBuilder) SetMaterializeProperties(materializeProperties string) *RequestOptionsBuilder {
+	builder.materializeProperties = materializeProperties
+	return builder
+}
+
 func (builder *RequestOptionsBuilder) AddBinding(key string, binding interface{}) *RequestOptionsBuilder {
 	if builder.bindings == nil {
 		builder.bindings = make(map[string]interface{})
@@ -80,6 +87,7 @@ func (builder *RequestOptionsBuilder) Create() RequestOptions {
 	requestOptions.batchSize = builder.batchSize
 	requestOptions.userAgent = builder.userAgent
 	requestOptions.bindings = builder.bindings
+	requestOptions.materializeProperties = builder.materializeProperties
 
 	return *requestOptions
 }

--- a/gremlin-go/driver/requestOptions_test.go
+++ b/gremlin-go/driver/requestOptions_test.go
@@ -44,6 +44,10 @@ func TestRequestOptions(t *testing.T) {
 		r := new(RequestOptionsBuilder).SetUserAgent("TestUserAgent").Create()
 		assert.Equal(t, "TestUserAgent", r.userAgent)
 	})
+	t.Run("Test RequestOptionsBuilder with custom materializeProperties", func(t *testing.T) {
+		r := new(RequestOptionsBuilder).SetMaterializeProperties("TestMaterializeProperties").Create()
+		assert.Equal(t, "TestMaterializeProperties", r.materializeProperties)
+	})
 	t.Run("Test RequestOptionsBuilder with custom bindings", func(t *testing.T) {
 		bindings := map[string]interface{}{"x": 2, "y": 5}
 		r := new(RequestOptionsBuilder).SetBindings(bindings).Create()

--- a/gremlin-go/driver/result_test.go
+++ b/gremlin-go/driver/result_test.go
@@ -343,7 +343,7 @@ func TestResult(t *testing.T) {
 		element := Element{}
 		r := Result{&element}
 		res := r.String()
-		assert.Equal(t, "result{object=&{<nil> } class=*gremlingo.Element}", res)
+		assert.Equal(t, "result{object=&{<nil>  <nil>} class=*gremlingo.Element}", res)
 	})
 
 	t.Run("Test Result.GetType() simple type", func(t *testing.T) {

--- a/gremlin-go/driver/strategies.go
+++ b/gremlin-go/driver/strategies.go
@@ -307,9 +307,10 @@ func IdentityRemovalStrategy() TraversalStrategy {
 // IncidentToAdjacentStrategy looks for .OutE().InV(), .InE().OutV() and .BothE().OtherV()
 // and replaces these step sequences with .Out(), .In() or .Both() respectively.
 // The strategy won't modify the traversal if:
-//   the Edge step is labeled
-//   the traversal contains a Path step
-//   the traversal contains a Lambda step
+//
+//	the Edge step is labeled
+//	the traversal contains a Path step
+//	the traversal contains a Lambda step
 func IncidentToAdjacentStrategy() TraversalStrategy {
 	return &traversalStrategy{name: optimizationNamespace + "IncidentToAdjacentStrategy"}
 }
@@ -379,9 +380,10 @@ type ProductiveByStrategyConfig struct {
 // RepeatUnrollStrategy is an OLTP-only strategy that unrolls any RepeatStep if it uses a constant
 // number of loops (Times(x)) and doesn't emit intermittent elements. If any of the following 3 steps appears
 // within the Repeat-traversal, the strategy will not be applied:
-//   DedupGlobalStep
-//   LoopsStep
-//   LambdaHolder
+//
+//	DedupGlobalStep
+//	LoopsStep
+//	LambdaHolder
 func RepeatUnrollStrategy() TraversalStrategy {
 	return &traversalStrategy{name: optimizationNamespace + "RepeatUnrollStrategy"}
 }

--- a/gremlin-go/driver/traversal.go
+++ b/gremlin-go/driver/traversal.go
@@ -269,6 +269,17 @@ var T = ts{
 	Value: "value",
 }
 
+type materializeProperties struct {
+	All    string
+	Tokens string
+}
+
+// MaterializeProperties is string symbols.
+var MaterializeProperties = materializeProperties{
+	All:    "all",
+	Tokens: "tokens",
+}
+
 type merge string
 
 type merges struct {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -84,6 +84,7 @@ class Client {
    * @property {Number} batchSize - Indicates whether the Power component is present.
    * @property {String} userAgent - The size in which the result of a request is to be 'batched' back to the client
    * @property {Number} evaluationTimeout - The timeout for the evaluation of the request.
+   * @property {String} materializeProperties - Indicates whether element properties should be returned or not.
    */
 
   /**

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -74,7 +74,14 @@ class DriverRemoteConnection extends RemoteConnection {
     const optionsStrategy = bytecode.sourceInstructions.find(
       (i) => i[0] === 'withStrategies' && i[1] instanceof OptionsStrategy,
     );
-    const allowedKeys = ['evaluationTimeout', 'scriptEvaluationTimeout', 'batchSize', 'requestId', 'userAgent'];
+    const allowedKeys = [
+      'evaluationTimeout',
+      'scriptEvaluationTimeout',
+      'batchSize',
+      'requestId',
+      'userAgent',
+      'materializeProperties',
+    ];
 
     let requestOptions = undefined;
     if (optionsStrategy !== undefined) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/binary/internals/VertexPropertySerializer.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/io/binary/internals/VertexPropertySerializer.js
@@ -154,7 +154,7 @@ module.exports = class VertexPropertySerializer {
       // {properties} is a fully qualified typed value composed of {type_code}{type_info}{value_flag}{value} which contains properties. Note that as TinkerPop currently send "references" only, this value will always be null.
       let properties, properties_len;
       try {
-        ({ v: properties, len: properties_len } = this.ioc.unspecifiedNullSerializer.deserialize(cursor));
+        ({ v: properties, len: properties_len } = this.ioc.anySerializer.deserialize(cursor));
         len += properties_len;
       } catch (err) {
         err.message = '{properties}: ' + err.message;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -131,17 +131,30 @@ Given(/^using the parameter (.+) defined as "(.+)"$/, function (paramName, strin
   });
 });
 
+var removeProperties = function(p) {
+  if (p === undefined) {   
+  } else if (p instanceof graphModule.Vertex || p instanceof graphModule.Edge) {
+    p.properties = undefined;
+  } else if (p instanceof Array) {
+    p.forEach(removeProperties)
+  } else if (p instanceof Map) {
+    removeProperties(Array.from(p.keys()))
+    removeProperties(Array.from(p.values()))
+  } else if (p instanceof graphModule.Path) {
+    removeProperties(p.objects)
+  }
+
+  return p
+}
+
 When('iterated to list', function () {
-  return this.traversal.toList().then(list => this.result = list).catch(err => this.result = err);
+  return this.traversal.toList().then(list => this.result = removeProperties(list)).catch(err => this.result = err);
 });
 
 When('iterated next', function () {
   return this.traversal.next().then(it => {
-    this.result = it.value;
-    if (this.result instanceof Path) {
-      // Compare using the objects array
-      this.result = this.result.objects;
-    }
+    // for Path compare using the objects array
+    this.result = removeProperties(it.value instanceof Path ? it.value.objects : it.value )
   }).catch(err => this.result = err);
 });
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/world.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/world.js
@@ -108,7 +108,15 @@ Before({tags: "@AllowNullPropertyValues"}, function() {
 
 function getVertices(connection) {
   const g = traversal().withRemote(connection);
-  return g.V().group().by('name').by(__.tail()).next().then(it => it.value);
+  return g.V().group().by('name').by(__.tail()).next().then(it => {
+    // properties excluded from verification
+    if (it.value instanceof Map) {
+      for (const value of it.value.values()) {
+        value.properties = undefined
+      }
+    }
+    return it.value
+  });
 }
 
 function getEdges(connection) {
@@ -120,6 +128,8 @@ function getEdges(connection) {
     .then(it => {
       const edges = {};
       it.value.forEach((v, k) => {
+        // properties excluded from verification
+        v.properties = undefined
         edges[getEdgeKey(k)] = v;
       });
       return edges;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
@@ -68,7 +68,7 @@ describe('Client', function () {
                 requestId: settings.PER_REQUEST_SETTINGS_REQUEST_ID,
                 evaluationTimeout: 1234,
                 batchSize: 12,
-                userAgent: "helloWorld"
+                userAgent: 'helloWorld'
             })
             const expectedResult = `requestId=${settings.PER_REQUEST_SETTINGS_REQUEST_ID} evaluationTimeout=1234, batchSize=12, userAgent=helloWorld`;
             assert.equal(expectedResult, resultSet.first());

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-tests.js
@@ -75,6 +75,68 @@ describe('Client', function () {
         });
     });
 
+    it('should handle properties for bytecode request', function () {
+      return client.submit(new Bytecode().addStep('V', [1]))
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.length, 1);
+          const vertex = result.first().object;
+          assert.ok(vertex instanceof graphModule.Vertex);
+          let age, name
+          if (vertex.properties instanceof Array) {
+            age = vertex.properties[1]
+            name = vertex.properties[0]
+          } else {
+            age = vertex.properties.age[0]
+            name = vertex.properties.name[0]
+          }
+          assert.strictEqual(age.value, 29);
+          assert.strictEqual(name.value, 'marko');
+        });
+    });
+
+    it('should skip properties for bytecode request with tokens', function () {
+      return client.submit(new Bytecode().addStep('V', [1]), null, {'materializeProperties': 'tokens'})
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.length, 1);
+          const vertex = result.first().object;
+          assert.ok(vertex instanceof graphModule.Vertex);
+          assert.ok(vertex.properties === undefined || vertex.properties.length === 0);
+        });
+    });
+
+    it('should handle properties for gremlin request', function () {
+      return client.submit('g.V(1)')
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.length, 1);
+          const vertex = result.first();
+          assert.ok(vertex instanceof graphModule.Vertex);
+          let age, name
+          if (vertex.properties instanceof Array) {
+            age = vertex.properties[1]
+            name = vertex.properties[0]
+          } else {
+            age = vertex.properties.age[0]
+            name = vertex.properties.name[0]
+          }
+          assert.strictEqual(age.value, 29);
+          assert.strictEqual(name.value, 'marko');
+        });
+    });
+
+    it('should skip properties for gremlin request with tokens', function () {
+      return client.submit('g.with("materializeProperties", "tokens").V(1)')
+        .then(function (result) {
+          assert.ok(result);
+          assert.strictEqual(result.length, 1);
+          const vertex = result.first();
+          assert.ok(vertex instanceof graphModule.Vertex);
+          assert.ok(vertex.properties === undefined || vertex.properties.length === 0);
+        });
+    });
+
     it('should be able to stream results from the gremlin server', (done) => {
       const output = [];
       let calls = 0;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/client-test.js
@@ -61,6 +61,7 @@ describe('Client', function () {
       submit: function (processor, op, args, requestId) {
         assert.strictEqual(args.gremlin, query);
         assert.strictEqual(args.evaluationTimeout, 123);
+        assert.strictEqual(args.materializeProperties, 'tokens');
         assert.strictEqual(processor, customOpProcessor);
 
         return Promise.resolve();
@@ -69,6 +70,6 @@ describe('Client', function () {
 
     const customClient = new Client('ws://localhost:9321', {traversalSource: 'g', processor: customOpProcessor, connectOnStartup: false});
     customClient._connection = connectionMock;
-    customClient.submit(query, null, {"evaluationTimeout": 123})
+    customClient.submit(query, null, {'evaluationTimeout': 123, 'materializeProperties': 'tokens'})
   });
 });

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -171,7 +171,7 @@ class DriverRemoteConnection(RemoteConnection):
                                  if x[0] == "withStrategies" and type(x[1]) is OptionsStrategy), None)
         request_options = None
         if options_strategy:
-            allowed_keys = ['evaluationTimeout', 'scriptEvaluationTimeout', 'batchSize', 'requestId', 'userAgent']
+            allowed_keys = ['evaluationTimeout', 'scriptEvaluationTimeout', 'batchSize', 'requestId', 'userAgent', 'materializeProperties']
             request_options = {allowed: options_strategy[1].configuration[allowed] for allowed in allowed_keys
                                if allowed in options_strategy[1].configuration}
         return request_options

--- a/gremlin-python/src/main/python/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/graph.py
@@ -43,9 +43,10 @@ class Graph(object):
 
 
 class Element(object):
-    def __init__(self, id, label):
+    def __init__(self, id, label, properties=None):
         self.id = id
         self.label = label
+        self.properties = properties
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.id == other.id
@@ -55,16 +56,16 @@ class Element(object):
 
 
 class Vertex(Element):
-    def __init__(self, id, label="vertex"):
-        Element.__init__(self, id, label)
+    def __init__(self, id, label="vertex", properties=None):
+        Element.__init__(self, id, label, properties)
 
     def __repr__(self):
         return "v[" + str(self.id) + "]"
 
 
 class Edge(Element):
-    def __init__(self, id, outV, label, inV):
-        Element.__init__(self, id, label)
+    def __init__(self, id, outV, label, inV, properties=None):
+        Element.__init__(self, id, label, properties)
         self.outV = outV
         self.inV = inV
 

--- a/gremlin-python/src/main/python/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/graph.py
@@ -74,8 +74,8 @@ class Edge(Element):
 
 
 class VertexProperty(Element):
-    def __init__(self, id, label, value, vertex):
-        Element.__init__(self, id, label)
+    def __init__(self, id, label, value, vertex, properties=None):
+        Element.__init__(self, id, label, properties)
         self.value = value
         self.key = self.label
         self.vertex = vertex

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
@@ -601,8 +601,9 @@ class EdgeIO(_GraphBinaryTypeIO):
         edgelbl = r.to_object(b, DataType.string, False)
         inv = Vertex(r.read_object(b), r.to_object(b, DataType.string, False))
         outv = Vertex(r.read_object(b), r.to_object(b, DataType.string, False))
-        edge = Edge(edgeid, outv, edgelbl, inv)
-        b.read(4)
+        b.read(2)
+        properties = r.read_object(b)
+        edge = Edge(edgeid, outv, edgelbl, inv, properties)
         return edge
 
 
@@ -680,8 +681,7 @@ class VertexIO(_GraphBinaryTypeIO):
 
     @classmethod
     def _read_vertex(cls, b, r):
-        vertex = Vertex(r.read_object(b), r.to_object(b, DataType.string, False))
-        b.read(2)
+        vertex = Vertex(r.read_object(b), r.to_object(b, DataType.string, False), r.read_object(b))
         return vertex
 
 
@@ -707,7 +707,8 @@ class VertexPropertyIO(_GraphBinaryTypeIO):
     @classmethod
     def _read_vertexproperty(cls, b, r):
         vp = VertexProperty(r.read_object(b), r.to_object(b, DataType.string, False), r.read_object(b), None)
-        b.read(4)
+        b.read(2)
+        vp.vertex = r.read_object(b)
         return vp
 
 

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
@@ -708,7 +708,7 @@ class VertexPropertyIO(_GraphBinaryTypeIO):
     def _read_vertexproperty(cls, b, r):
         vp = VertexProperty(r.read_object(b), r.to_object(b, DataType.string, False), r.read_object(b), None)
         b.read(2)
-        vp.vertex = r.read_object(b)
+        vp.properties = r.read_object(b)
         return vp
 
 

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV2d0.py
@@ -591,11 +591,17 @@ class VertexPropertyDeserializer(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, d, reader):
+        properties = None
+        if "properties" in d:
+            properties = reader.to_object(d["properties"])
+            if properties is not None:
+                properties = list(map(lambda x: Property(x[0], x[1], None), properties.items()))
         vertex = Vertex(reader.to_object(d.get("vertex"))) if "vertex" in d else None
         return VertexProperty(reader.to_object(d["id"]),
                               d["label"],
                               reader.to_object(d["value"]),
-                              vertex)
+                              vertex,
+                              properties)
 
 
 class PropertyDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV2d0.py
@@ -561,7 +561,12 @@ class VertexDeserializer(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, d, reader):
-        return Vertex(reader.to_object(d["id"]), d.get("label", "vertex"))
+        properties = None
+        if "properties" in d:
+            properties = reader.to_object(d["properties"])
+            if properties is not None:
+                properties = [item for sublist in properties.values() for item in sublist]
+        return Vertex(reader.to_object(d["id"]), d.get("label", "vertex"), properties)
 
 
 class EdgeDeserializer(_GraphSONTypeIO):
@@ -569,10 +574,16 @@ class EdgeDeserializer(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, d, reader):
+        properties = None
+        if "properties" in d:
+            properties = reader.to_object(d["properties"])
+            if properties is not None:
+                properties = list(properties.values())
         return Edge(reader.to_object(d["id"]),
                     Vertex(reader.to_object(d["outV"]), d.get("outVLabel", "vertex")),
                     d.get("label", "edge"),
-                    Vertex(reader.to_object(d["inV"]), d.get("inVLabel", "vertex")))
+                    Vertex(reader.to_object(d["inV"]), d.get("inVLabel", "vertex")),
+                    properties)
 
 
 class VertexPropertyDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV3d0.py
@@ -659,7 +659,12 @@ class VertexDeserializer(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, d, reader):
-        return Vertex(reader.to_object(d["id"]), d.get("label", "vertex"))
+        properties = None
+        if "properties" in d:
+            properties = reader.to_object(d["properties"])
+            if properties is not None:
+                properties = [item for sublist in properties.values() for item in sublist]
+        return Vertex(reader.to_object(d["id"]), d.get("label", "vertex"), properties)
 
 
 class EdgeDeserializer(_GraphSONTypeIO):
@@ -667,10 +672,16 @@ class EdgeDeserializer(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, d, reader):
+        properties = None
+        if "properties" in d:
+            properties = reader.to_object(d["properties"])
+            if properties is not None:
+                properties = list(properties.values())
         return Edge(reader.to_object(d["id"]),
                     Vertex(reader.to_object(d["outV"]), d.get("outVLabel", "vertex")),
                     d.get("label", "edge"),
-                    Vertex(reader.to_object(d["inV"]), d.get("inVLabel", "vertex")))
+                    Vertex(reader.to_object(d["inV"]), d.get("inVLabel", "vertex")),
+                    properties)
 
 
 class VertexPropertyDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV3d0.py
@@ -689,11 +689,17 @@ class VertexPropertyDeserializer(_GraphSONTypeIO):
 
     @classmethod
     def objectify(cls, d, reader):
+        properties = None
+        if "properties" in d:
+            properties = reader.to_object(d["properties"])
+            if properties is not None:
+                properties = list(map(lambda x: Property(x[0], x[1], None), properties.items()))
         vertex = Vertex(reader.to_object(d.get("vertex"))) if "vertex" in d else None
         return VertexProperty(reader.to_object(d["id"]),
                               d["label"],
                               reader.to_object(d["value"]),
-                              vertex)
+                              vertex,
+                              properties)
 
 
 class PropertyDeserializer(_GraphSONTypeIO):

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -189,6 +189,30 @@ def remote_connection(request):
 
 
 @pytest.fixture(params=['graphsonv2', 'graphsonv3', 'graphbinaryv1'])
+def remote_connection_crew(request):
+    try:
+        if request.param == 'graphbinaryv1':
+            remote_conn = DriverRemoteConnection(anonymous_url, 'gcrew',
+                                                 message_serializer=serializer.GraphBinarySerializersV1())
+        elif request.param == 'graphsonv2':
+            remote_conn = DriverRemoteConnection(anonymous_url, 'gcrew',
+                                                 message_serializer=serializer.GraphSONSerializersV2d0())
+        elif request.param == 'graphsonv3':
+            remote_conn = DriverRemoteConnection(anonymous_url, 'gcrew',
+                                                 message_serializer=serializer.GraphSONSerializersV3d0())
+        else:
+            raise ValueError("Invalid serializer option - " + request.param)
+    except OSError:
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            remote_conn.close()
+
+        request.addfinalizer(fin)
+        return remote_conn
+
+
+@pytest.fixture(params=['graphsonv2', 'graphsonv3', 'graphbinaryv1'])
 def remote_transaction_connection(request):
     try:
         if request.param == 'graphbinaryv1':

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -26,7 +26,7 @@ from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.driver.request import RequestMessage
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.strategies import OptionsStrategy
-from gremlin_python.structure.graph import Graph
+from gremlin_python.structure.graph import Graph, Vertex
 from gremlin_python.driver.aiohttp.transport import AiohttpTransport
 from gremlin_python.statics import *
 from asyncio import TimeoutError
@@ -137,6 +137,25 @@ async def async_connect(enable):
 def test_from_event_loop():
     assert not asyncio.get_event_loop().run_until_complete(async_connect(False))
     assert asyncio.get_event_loop().run_until_complete(async_connect(True))
+
+
+def test_client_gremlin(client):
+    result_set = client.submit('g.V(1)')
+    result = result_set.all().result()
+    assert 1 == len(result)
+    vertex = result[0]
+    assert type(vertex) is Vertex
+    assert 1 == vertex.id
+    assert 2 == len(vertex.properties)
+    assert 'name' == vertex.properties[0].key
+    assert 'marko' == vertex.properties[0].value
+    ##
+    result_set = client.submit('g.with("materializeProperties", "tokens").V(1)')
+    result = result_set.all().result()
+    assert 1 == len(result)
+    vertex = result[0]
+    assert 1 == vertex.id
+    assert 0 == len(vertex.properties)
 
 
 def test_client_bytecode(client):

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -26,9 +26,10 @@ from gremlin_python.statics import *
 
 
 def test_vertex(remote_connection):
-    g = Graph().traversal().withRemote(remote_connection)
+    g = Graph().traversal().with_remote(remote_connection)
     vertex = g.V(1).next()
     assert vertex.id == 1
+    assert vertex.label == 'person'
     assert len(vertex.properties) == 2
     assert vertex.properties[0].key == 'name'
     assert vertex.properties[0].value == 'marko'
@@ -37,28 +38,46 @@ def test_vertex(remote_connection):
 
 
 def test_vertex_without_properties(remote_connection):
-    g = Graph().traversal().withRemote(remote_connection)
+    g = Graph().traversal().with_remote(remote_connection)
     vertex = g.with_('materializeProperties', 'tokens').V(1).next()
     assert vertex.id == 1
+    assert vertex.label == 'person'
     # empty array for GraphBinary and missing field for GraphSON
     assert vertex.properties is None or len(vertex.properties) == 0
 
 
 def test_edge(remote_connection):
-    g = Graph().traversal().withRemote(remote_connection)
+    g = Graph().traversal().with_remote(remote_connection)
     edge = g.E(7).next()
     assert edge.id == 7
+    assert edge.label == 'knows'
     assert len(edge.properties) == 1
     assert edge.properties[0].key == 'weight'
     assert edge.properties[0].value == 0.5
 
 
 def test_edge_without_properties(remote_connection):
-    g = Graph().traversal().withRemote(remote_connection)
+    g = Graph().traversal().with_remote(remote_connection)
     edge = g.with_('materializeProperties', 'tokens').E(7).next()
     assert edge.id == 7
+    assert edge.label == 'knows'
     # empty array for GraphBinary and missing field for GraphSON
     assert edge.properties is None or len(edge.properties) == 0
+
+
+def test_vertex_vertex_properties(remote_connection_crew):
+    g = Graph().traversal().withRemote(remote_connection_crew)
+    vertex = g.V(7).next()
+    assert vertex.id == 7
+    assert vertex.label == 'person'
+    assert len(vertex.properties) == 4
+    assert vertex.properties[1].key == 'location'
+    assert vertex.properties[1].value == 'centreville'
+    assert len(vertex.properties[1].properties) == 2
+    assert vertex.properties[1].properties[0].key == 'startTime'
+    assert vertex.properties[1].properties[0].value == 1990
+    assert vertex.properties[1].properties[1].key == 'endTime'
+    assert vertex.properties[1].properties[1].value == 2000
 
 
 def test_timestamp(remote_connection):

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -25,6 +25,42 @@ from gremlin_python.structure.graph import Graph
 from gremlin_python.statics import *
 
 
+def test_vertex(remote_connection):
+    g = Graph().traversal().withRemote(remote_connection)
+    vertex = g.V(1).next()
+    assert vertex.id == 1
+    assert len(vertex.properties) == 2
+    assert vertex.properties[0].key == 'name'
+    assert vertex.properties[0].value == 'marko'
+    assert vertex.properties[1].key == 'age'
+    assert vertex.properties[1].value == 29
+
+
+def test_vertex_without_properties(remote_connection):
+    g = Graph().traversal().withRemote(remote_connection)
+    vertex = g.with_('materializeProperties', 'tokens').V(1).next()
+    assert vertex.id == 1
+    # empty array for GraphBinary and missing field for GraphSON
+    assert vertex.properties is None or len(vertex.properties) == 0
+
+
+def test_edge(remote_connection):
+    g = Graph().traversal().withRemote(remote_connection)
+    edge = g.E(7).next()
+    assert edge.id == 7
+    assert len(edge.properties) == 1
+    assert edge.properties[0].key == 'weight'
+    assert edge.properties[0].value == 0.5
+
+
+def test_edge_without_properties(remote_connection):
+    g = Graph().traversal().withRemote(remote_connection)
+    edge = g.with_('materializeProperties', 'tokens').E(7).next()
+    assert edge.id == 7
+    # empty array for GraphBinary and missing field for GraphSON
+    assert edge.properties is None or len(edge.properties) == 0
+
+
 def test_timestamp(remote_connection):
     g = Graph().traversal().withRemote(remote_connection)
     ts = timestamp(1481750076295 / 1000)

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
@@ -155,6 +155,7 @@ class TestGraphSONReader(object):
         assert 1 == vertex.id
         assert isinstance(vertex.id, int)
         assert vertex == Vertex(1)
+        assert 2 == len(vertex.properties)
         ##
         vertex = self.graphson_reader.read_object("""
         {"@type":"g:Vertex", "@value":{"id":{"@type":"g:Float","@value":45.23}}}""")

--- a/gremlin-server/scripts/empty-sample.groovy
+++ b/gremlin-server/scripts/empty-sample.groovy
@@ -37,9 +37,4 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
-// to "references" (i.e. just id and label without properties). this strategy was added
-// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
-// serialization formats aligning it with TinkerPop recommended practices for writing
-// Gremlin.
-globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
+globals << [g : traversal().withEmbedded(graph)]

--- a/gremlin-server/scripts/generate-classic.groovy
+++ b/gremlin-server/scripts/generate-classic.groovy
@@ -30,9 +30,4 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
-// to "references" (i.e. just id and label without properties). this strategy was added
-// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
-// serialization formats aligning it with TinkerPop recommended practices for writing
-// Gremlin.
-globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
+globals << [g : traversal().withEmbedded(graph)]

--- a/gremlin-server/scripts/generate-modern-readonly.groovy
+++ b/gremlin-server/scripts/generate-modern-readonly.groovy
@@ -30,9 +30,4 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
-// to "references" (i.e. just id and label without properties). this strategy was added
-// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
-// serialization formats aligning it with TinkerPop recommended practices for writing
-// Gremlin.
-globals << [g : traversal().withEmbedded(graph).withStrategies(ReadOnlyStrategy, ReferenceElementStrategy)]
+globals << [g : traversal().withEmbedded(graph).withStrategies(ReadOnlyStrategy)]

--- a/gremlin-server/scripts/generate-modern.groovy
+++ b/gremlin-server/scripts/generate-modern.groovy
@@ -30,9 +30,4 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
-// to "references" (i.e. just id and label without properties). this strategy was added
-// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
-// serialization formats aligning it with TinkerPop recommended practices for writing
-// Gremlin.
-globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
+globals << [g : traversal().withEmbedded(graph)]

--- a/gremlin-server/scripts/load-sample.groovy
+++ b/gremlin-server/scripts/load-sample.groovy
@@ -36,9 +36,4 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // define the default TraversalSource to bind queries to - this one will be named "g".
-// ReferenceElementStrategy converts all graph elements (vertices/edges/vertex properties)
-// to "references" (i.e. just id and label without properties). this strategy was added
-// in 3.4.0 to make all Gremlin Server results consistent across all protocols and
-// serialization formats aligning it with TinkerPop recommended practices for writing
-// Gremlin.
-globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
+globals << [g : traversal().withEmbedded(graph)]

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.AbstractTraverser;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
 import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
@@ -32,6 +35,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
@@ -52,6 +56,7 @@ public class Context {
     private final ScheduledExecutorService scheduledExecutorService;
     private final AtomicBoolean finalResponseWritten = new AtomicBoolean();
     private final long requestTimeout;
+    private final String materializeProperties;
     private final RequestContentType requestContentType;
     private final Object gremlinArgument;
     private final AtomicBoolean startedResponse = new AtomicBoolean(false);
@@ -90,6 +95,7 @@ public class Context {
         this.gremlinArgument = requestMessage.getArgs().get(Tokens.ARGS_GREMLIN);
         this.requestContentType = determineRequestContents();
         this.requestTimeout = determineTimeout();
+        this.materializeProperties = determineMaterializeProperties();
     }
 
     /**
@@ -100,6 +106,10 @@ public class Context {
      */
     public long getRequestTimeout() {
         return requestTimeout;
+    }
+
+    public String getMaterializeProperties() {
+        return materializeProperties;
     }
 
     public boolean isFinalResponseWritten() {
@@ -269,5 +279,37 @@ public class Context {
                 GremlinScriptChecker.parse(gremlinArgument.toString()).getTimeout() : Optional.empty();
 
         return timeoutDefinedInScript.orElse(seto);
+    }
+
+    private String determineMaterializeProperties() {
+        // with() in Script request has the highest priority
+        if (requestContentType == RequestContentType.SCRIPT) {
+            final Optional<String> mp = GremlinScriptChecker.parse(gremlinArgument.toString()).getMaterializeProperties();
+            if (mp.isPresent())
+                return mp.get().equals(Tokens.MATERIALIZE_PROPERTIES_TOKENS)
+                        ? Tokens.MATERIALIZE_PROPERTIES_TOKENS
+                        : Tokens.MATERIALIZE_PROPERTIES_ALL;
+        }
+
+        final Map<String, Object> args = requestMessage.getArgs();
+        // all options except MATERIALIZE_PROPERTIES_TOKENS treated as MATERIALIZE_PROPERTIES_ALL
+        return args.containsKey(Tokens.ARGS_MATERIALIZE_PROPERTIES)
+                && args.get(Tokens.ARGS_MATERIALIZE_PROPERTIES).equals(Tokens.MATERIALIZE_PROPERTIES_TOKENS)
+                ? Tokens.MATERIALIZE_PROPERTIES_TOKENS
+                : Tokens.MATERIALIZE_PROPERTIES_ALL;
+    }
+
+    public void handleDetachment(final List<Object> aggregate) {
+        if (!aggregate.isEmpty() && !this.getMaterializeProperties().equals(Tokens.MATERIALIZE_PROPERTIES_ALL)) {
+            final Object firstElement = aggregate.get(0);
+
+            if (firstElement instanceof Element) {
+                for (int i = 0; i < aggregate.size(); i++)
+                    aggregate.set(i, ReferenceFactory.detach((Element) aggregate.get(i)));
+            } else if (firstElement instanceof AbstractTraverser) {
+                for (final Object item : aggregate)
+                    ((AbstractTraverser) item).detach();
+            }
+        }
     }
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
@@ -736,6 +736,8 @@ public abstract class AbstractSession implements Session, AutoCloseable {
         final Map<String, Object> responseMetaData = generateResponseMetaData(sessionTask, code, itty);
         final Map<String, Object> statusAttributes = generateStatusAttributes(sessionTask, code, itty);
         try {
+            sessionTask.handleDetachment(aggregate);
+
             if (useBinary) {
                 return new Frame(serializer.serializeResponseAsBinary(ResponseMessage.build(msg)
                         .code(code)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -19,6 +19,11 @@
 package org.apache.tinkerpop.gremlin.server.handler;
 
 import com.codahale.metrics.Timer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptChecker;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.AbstractTraverser;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
+import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
 import org.javatuples.Pair;
 import org.javatuples.Quartet;
@@ -212,9 +217,25 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
 
                             logger.debug("Transforming result of request with script [{}] and bindings of [{}] with result of [{}] on [{}]",
                                     requestArguments.getValue0(), requestArguments.getValue1(), o, Thread.currentThread().getName());
+
+                            final Optional<String> mp = GremlinScriptChecker.parse(requestArguments.getValue0()).getMaterializeProperties();
+                            final List asList = IteratorUtils.asList(o);
+
+                            if (mp.isPresent() && mp.get().equals(Tokens.MATERIALIZE_PROPERTIES_TOKENS)) {
+                                final Object firstElement = asList.get(0);
+
+                                if (firstElement instanceof Element) {
+                                    for (int i = 0; i < asList.size(); i++)
+                                        asList.set(i, ReferenceFactory.detach((Element) asList.get(i)));
+                                } else if (firstElement instanceof AbstractTraverser) {
+                                    for (final Object item : asList)
+                                        ((AbstractTraverser) item).detach();
+                                }
+                            }
+
                             final ResponseMessage responseMessage = ResponseMessage.build(UUID.randomUUID())
                                     .code(ResponseStatusCode.SUCCESS)
-                                    .result(IteratorUtils.asList(o)).create();
+                                    .result(asList).create();
 
                             // http server is sessionless and must handle commit on transactions. the commit occurs
                             // before serialization to be consistent with how things work for websocket based

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractOpProcessor.java
@@ -283,6 +283,8 @@ public abstract class AbstractOpProcessor implements OpProcessor {
         try {
             final ChannelHandlerContext nettyContext = ctx.getChannelHandlerContext();
 
+            ctx.handleDetachment(aggregate);
+
             if (useBinary) {
                 return new Frame(serializer.serializeResponseAsBinary(ResponseMessage.build(msg)
                         .code(code)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/TraverserIterator.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/TraverserIterator.java
@@ -21,7 +21,6 @@ package org.apache.tinkerpop.gremlin.server.util;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
 
@@ -33,17 +32,12 @@ import java.util.Iterator;
 public class TraverserIterator implements Iterator<Object> {
 
     private final Traversal.Admin traversal;
-    private final HaltedTraverserStrategy haltedTraverserStrategy;
     private final TraverserSet bulker = new TraverserSet();
     private final int barrierSize;
 
     public TraverserIterator(final Traversal.Admin traversal) {
         this.traversal = traversal;
         this.barrierSize = traversal.getTraverserRequirements().contains(TraverserRequirement.ONE_BULK) ? 1 : 1000;
-        this.haltedTraverserStrategy = traversal.getStrategies().getStrategy(HaltedTraverserStrategy.class).orElse(
-                Boolean.valueOf(System.getProperty("is.testing", "false")) ?
-                        HaltedTraverserStrategy.detached() :
-                        HaltedTraverserStrategy.reference());
     }
 
     public Traversal.Admin getTraversal() {
@@ -61,7 +55,7 @@ public class TraverserIterator implements Iterator<Object> {
     public Object next() {
         if (this.bulker.isEmpty())
             this.fillBulker();
-        final Traverser.Admin t = this.haltedTraverserStrategy.halt(this.bulker.remove());
+        final Traverser.Admin t = this.bulker.remove();
         return new DefaultRemoteTraverser<>(t.get(), t.bulk());
     }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ContextTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ContextTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.server;
 
 import io.netty.channel.ChannelHandlerContext;
 import nl.altindag.log.LogCaptor;
+import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.util.message.ResponseStatusCode;
@@ -38,6 +39,7 @@ import java.util.function.BiFunction;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class ContextTest {
@@ -174,5 +176,35 @@ public class ContextTest {
         // ensure the frame was released
         Mockito.verify(frame, Mockito.times(1)).tryRelease();
         Mockito.verify(ctx, Mockito.times(1)).flush();
+    }
+
+    @Test
+    public void shouldParseParametersFromScriptRequest()
+    {
+        final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                .addArg(Tokens.ARGS_GREMLIN, "g.with('evaluationTimeout', 1000).with(true).with('materializeProperties', 'tokens').V().out('knows')")
+                .create();
+        final Settings settings = new Settings();
+        final Context context = new Context(request, ctx, settings, null, null, null);
+
+        assertEquals(1000, context.getRequestTimeout());
+        assertEquals("tokens", context.getMaterializeProperties());
+    }
+
+    @Test
+    public void shouldSkipInvalidMaterializePropertiesParameterFromScriptRequest()
+    {
+        final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        final RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                .addArg(Tokens.ARGS_GREMLIN,
+                        "g.with('evaluationTimeout', 1000).with(true).with('materializeProperties', 'some-invalid-value').V().out('knows')")
+                .create();
+        final Settings settings = new Settings();
+        final Context context = new Context(request, ctx, settings, null, null, null);
+
+        assertEquals(1000, context.getRequestTimeout());
+        // "all" is default value
+        assertEquals("all", context.getMaterializeProperties());
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -45,7 +45,6 @@ import org.apache.tinkerpop.gremlin.server.handler.OpExecutorHandler;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.Storage;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.apache.tinkerpop.gremlin.util.TimeUtil;
 import org.apache.tinkerpop.gremlin.util.function.FunctionUtils;
@@ -54,7 +53,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -1000,7 +998,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             final List<Result> r = client.submit("TinkerFactory.createModern().traversal().V(1)").all().join();
             assertEquals(1, r.size());
 
-            final Vertex v = r.get(0).get(ReferenceVertex.class);
+            final Vertex v = r.get(0).get(DetachedVertex.class);
             assertEquals(1, v.id());
             assertEquals("person", v.label());
         } finally {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -20,12 +20,8 @@ package org.apache.tinkerpop.gremlin.server;
 
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
-import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
-import org.apache.tinkerpop.gremlin.util.Tokens;
-import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
-import org.apache.tinkerpop.gremlin.util.ser.Serializers;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -36,14 +32,16 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.IoTest;
 import org.apache.tinkerpop.gremlin.structure.io.binary.GraphBinaryMapper;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceEdge;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferencePath;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceProperty;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0;
-import org.apache.tinkerpop.shaded.kryo.Kryo;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
+import org.apache.tinkerpop.gremlin.util.ser.Serializers;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -52,7 +50,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,21 +144,21 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
     public void shouldHandleVertexResult() throws Exception {
         final ResultSet results = client.submit("gmodern.V(1).next()");
         final Vertex v = results.all().get().get(0).getVertex();
-        assertThat(v, instanceOf(ReferenceVertex.class));
+        assertThat(v, instanceOf(DetachedVertex.class));
     }
 
     @Test
     public void shouldHandleVertexPropertyResult() throws Exception {
         final ResultSet results = client.submit("gmodern.V().properties('name').next()");
         final VertexProperty<String> v = results.all().get().get(0).getVertexProperty();
-        assertThat(v, instanceOf(ReferenceVertexProperty.class));
+        assertThat(v, instanceOf(DetachedVertexProperty.class));
     }
 
     @Test
     public void shouldHandleEdgeResult() throws Exception {
         final ResultSet results = client.submit("gmodern.E().next()");
         final Edge e = results.all().get().get(0).getEdge();
-        assertThat(e, instanceOf(ReferenceEdge.class));
+        assertThat(e, instanceOf(DetachedEdge.class));
     }
 
     @Test

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSerializationIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerSerializationIntegrateTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server;
+
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.apache.tinkerpop.gremlin.util.ser.AbstractMessageSerializer;
+import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
+import org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2d0;
+import org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3d0;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class GremlinServerSerializationIntegrateTest extends AbstractGremlinServerIntegrationTest {
+
+    private AbstractMessageSerializer serializer;
+    private Cluster cluster = null;
+    private Client client = null;
+    private GraphTraversalSource g = null;
+
+    public GremlinServerSerializationIntegrateTest(AbstractMessageSerializer serializer) {
+        this.serializer = serializer;
+    }
+
+    @Parameterized.Parameters
+    public static Collection serializers() {
+        return Arrays.asList(new Object[][]{
+                {new GraphBinaryMessageSerializerV1()},
+                {new GraphSONMessageSerializerV3d0()},
+                {new GraphSONMessageSerializerV2d0()}
+        });
+    }
+
+    @Before
+    public void openConnection() {
+        cluster = TestClientFactory.build().serializer(serializer).create();
+        client = cluster.connect();
+
+        // VertexProperty related test tun on crew graph
+        final String remoteTraversalSourceName = name.getMethodName().contains("VertexProperty") ? "gcrew" : "gmodern";
+
+        g = AnonymousTraversalSource.traversal().withRemote(
+                DriverRemoteConnection.using(cluster, remoteTraversalSourceName));
+    }
+
+    @After
+    public void closeConnection() {
+        if (cluster != null) cluster.close();
+    }
+
+    @Test
+    public void shouldDeserializeVertexPropertiesForScripts() {
+        final Vertex vertex = client.submit("gmodern.V(1)").one().getVertex();
+
+        assertVertexWithProperties(vertex);
+    }
+
+    @Test
+    public void shouldSkipVertexPropertiesForScripts() {
+        final Vertex vertex = client.submit("gmodern.with('materializeProperties', 'tokens').V(1)").one().getVertex();
+
+        assertVertexWithoutProperties(vertex);
+    }
+
+    @Test
+    public void shouldDeserializeVertexPropertiesForBytecode() {
+        final Vertex vertex = g.V(1).next();
+
+        assertVertexWithProperties(vertex);
+    }
+
+    @Test
+    public void shouldSkipVertexPropertiesForBytecode() {
+        final Vertex vertex = g.with("materializeProperties", "tokens").V(1).next();
+
+        assertVertexWithoutProperties(vertex);
+    }
+
+    @Test
+    public void shouldDeserializeEdgePropertiesForScripts() {
+        final Edge edge = client.submit("gmodern.E(7)").one().getEdge();
+
+        assertEdgeWithProperties(edge);
+    }
+
+    @Test
+    public void shouldSkipEdgePropertiesForScripts() {
+        final Edge edge = client.submit("gmodern.with('materializeProperties', 'tokens').E(7)").one().getEdge();
+
+        assertEdgeWithoutProperties(edge);
+    }
+
+    @Test
+    public void shouldDeserializeEdgePropertiesForBytecode() {
+        final Edge edge = g.E(7).next();
+
+        assertEdgeWithProperties(edge);
+    }
+
+    @Test
+    public void shouldSkipEdgePropertiesForBytecode() {
+        final Edge edge = g.with("materializeProperties", "tokens").E(7).next();
+
+        assertEdgeWithoutProperties(edge);
+    }
+
+    @Test
+    public void shouldDeserializeVertexPropertyPropertiesForScripts() {
+        final Vertex vertex = client.submit("gcrew.V(7)").one().getVertex();
+
+        assertVertexWithVertexProperties(vertex);
+    }
+
+    @Test
+    public void shouldSkipVertexPropertyPropertiesForScripts() {
+        final Vertex vertex = client.submit("gcrew.with('materializeProperties', 'tokens').V(7)").one().getVertex();
+
+        assertVertexWithoutVertexProperties(vertex);
+    }
+
+    @Test
+    public void shouldDeserializeVertexPropertyPropertiesForBytecode() {
+        final Vertex vertex = g.V(7).next();
+
+        assertVertexWithVertexProperties(vertex);
+    }
+
+    @Test
+    public void shouldSkipVertexPropertyPropertiesForBytecode() {
+        final Vertex vertex = g.with("materializeProperties", "tokens").V(7).next();
+
+        assertVertexWithoutVertexProperties(vertex);
+    }
+
+    // asserted vertex 7 from crew graph
+    private void assertVertexWithVertexProperties(final Vertex vertex) {
+        assertEquals(7, vertex.id());
+        assertEquals("person", vertex.label());
+
+        assertEquals(4, IteratorUtils.count(vertex.properties()));
+        assertEquals(3, IteratorUtils.count(vertex.properties("location")));
+        final VertexProperty vertexProperty = vertex.properties("location").next();
+        assertEquals("centreville", vertexProperty.value());
+        assertEquals(2, IteratorUtils.count(vertexProperty.properties()));
+        final Property vertexPropertyPropertyStartTime = vertexProperty.property("startTime");
+        assertEquals(1990, vertexPropertyPropertyStartTime.value());
+        final Property vertexPropertyPropertyEndTime = vertexProperty.property("endTime");
+        assertEquals(2000, vertexPropertyPropertyEndTime.value());
+    }
+
+    // asserted vertex 7 from crew graph
+    private void assertVertexWithoutVertexProperties(final Vertex vertex) {
+        assertEquals(7, vertex.id());
+        assertEquals("person", vertex.label());
+
+        assertEquals(0, IteratorUtils.count(vertex.properties()));
+    }
+
+    // asserted vertex 1 from modern graph
+    private void assertVertexWithoutProperties(final Vertex vertex) {
+        assertEquals(1, vertex.id());
+        assertEquals("person", vertex.label());
+
+        assertEquals(Collections.emptyIterator(), vertex.properties());
+    }
+
+    // asserted vertex 1 from modern graph
+    private void assertVertexWithProperties(final Vertex vertex) {
+        assertEquals(1, vertex.id());
+        assertEquals("person", vertex.label());
+
+        assertEquals(2, IteratorUtils.count(vertex.properties()));
+        assertEquals("marko", vertex.property("name").value());
+        assertEquals(29, vertex.property("age").value());
+    }
+
+    // asserted edge 7 from modern graph
+    private void assertEdgeWithoutProperties(final Edge edge) {
+        assertEquals(7, edge.id());
+        assertEquals("knows", edge.label());
+
+        assertEquals(Collections.emptyIterator(), edge.properties());
+    }
+
+    // asserted edge 7 from modern graph
+    private void assertEdgeWithProperties(final Edge edge) {
+        assertEquals(7, edge.id());
+        assertEquals("knows", edge.label());
+
+        assertEquals(1, IteratorUtils.count(edge.properties()));
+        assertEquals(0.5, edge.property("weight").value());
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
@@ -38,7 +38,7 @@ public final class TestClientFactory {
     }
 
     public static Cluster.Builder build(final String address) {
-        return Cluster.build(address).port(45940);
+        return Cluster.build(address).port(PORT);
     }
 
     public static Cluster open() {

--- a/gremlin-server/src/test/scripts/generate-all.groovy
+++ b/gremlin-server/src/test/scripts/generate-all.groovy
@@ -60,24 +60,24 @@ globals << [hook : [
 ] as LifeCycleHook]
 
 // add default TraversalSource instances for each graph instance
-globals << [gclassic : traversal().withEmbedded(classic).withStrategies(ReferenceElementStrategy)]
-globals << [gmodern : traversal().withEmbedded(modern).withStrategies(ReferenceElementStrategy)]
-globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
-globals << [gcrew : traversal().withEmbedded(crew).withStrategies(ReferenceElementStrategy)]
-globals << [ggraph : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
-globals << [ggrateful : traversal().withEmbedded(grateful).withStrategies(ReferenceElementStrategy)]
-globals << [gsink : traversal().withEmbedded(sink).withStrategies(ReferenceElementStrategy)]
+globals << [gclassic : traversal().withEmbedded(classic)]
+globals << [gmodern : traversal().withEmbedded(modern)]
+globals << [g : traversal().withEmbedded(graph)]
+globals << [gcrew : traversal().withEmbedded(crew)]
+globals << [ggraph : traversal().withEmbedded(graph)]
+globals << [ggrateful : traversal().withEmbedded(grateful)]
+globals << [gsink : traversal().withEmbedded(sink)]
 
 // dynamically detect existence of gtx as it may or may not be present depending on the -DincludeNeo4j
 // and the configuration of the particular server instance. with docker/gremlin-server.sh the neo4j
 // "tx" configuration is already present and will therefore be enabled.
 def dynamicGtx = context.getBindings(javax.script.ScriptContext.GLOBAL_SCOPE)["tx"]
 if (dynamicGtx != null)
-    globals << [gtx : traversal().withEmbedded(dynamicGtx).withStrategies(ReferenceElementStrategy)]
+    globals << [gtx : traversal().withEmbedded(dynamicGtx)]
 
 // dynamically detect existence of gimmutable as it is only used in gremlin-go testing suite
 def dynamicGimmutable = context.getBindings(javax.script.ScriptContext.GLOBAL_SCOPE)["immutable"]
 if (dynamicGimmutable != null)
-    globals << [gimmutable : traversal().withEmbedded(dynamicGimmutable).withStrategies(ReferenceElementStrategy)]
+    globals << [gimmutable : traversal().withEmbedded(dynamicGimmutable)]
 
 globals

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinScriptCheckerBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinScriptCheckerBenchmark.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.jsr223;
+
+import org.apache.tinkerpop.benchmark.util.AbstractBenchmarkBase;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptChecker;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.Optional;
+
+/**
+ * @author Valentyn Kahamlyk
+ */
+@State(Scope.Thread)
+public class GremlinScriptCheckerBenchmark extends AbstractBenchmarkBase {
+
+    @Benchmark
+    public Optional<String> testParseRequestId() {
+        return GremlinScriptChecker.parse("g.with('requestId', '4F53FB59-CFC9-4984-B477-452073A352FD').with(true).V().out('knows')").getRequestId();
+    }
+
+    @Benchmark
+    public Optional<String> testParseMaterializeProperties() {
+        return GremlinScriptChecker.parse("g.with('materializeProperties', 'all').with(true).V().out('knows')").getMaterializeProperties();
+    }
+
+    @Benchmark
+    public GremlinScriptChecker.Result testParseAll() {
+        return GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).with('materializeProperties', 'all').with('requestId', '4F53FB59-CFC9-4984-B477-452073A352FD').with(true).V().out('knows')");
+    }
+}

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
@@ -79,6 +79,22 @@ public final class Tokens {
     public static final String ARGS_HOST = "host";
     public static final String ARGS_SESSION = "session";
     public static final String ARGS_MANAGE_TRANSACTION = "manageTransaction";
+    /**
+     * The name of the argument that allows to control the serialization of properties on the server.
+     */
+    public static final String ARGS_MATERIALIZE_PROPERTIES = "materializeProperties";
+
+    /**
+     * The name of the value denoting that all properties of Element should be returned.
+     * Should be used with {@code ARGS_MATERIALIZE_PROPERTIES}
+     */
+
+    public static final String MATERIALIZE_PROPERTIES_ALL = "all";
+    /**
+     * The name of the value denoting that only `ID` and `Label` of Element should be returned.
+     * Should be used with {@code ARGS_MATERIALIZE_PROPERTIES}
+     */
+    public static final String MATERIALIZE_PROPERTIES_TOKENS = "tokens";
 
     /**
      * Argument name that is intended to be used with a session which when its value is {@code true} makes it so

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/GraphBinaryReaderWriterRoundTripTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/GraphBinaryReaderWriterRoundTripTest.java
@@ -55,7 +55,7 @@ import org.apache.tinkerpop.gremlin.structure.io.binary.GraphBinaryWriter;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceEdge;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceProperty;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.junit.Test;
@@ -244,10 +244,10 @@ public class GraphBinaryReaderWriterRoundTripTest {
                 }},
                 new Object[] {"ReferenceVertex", new ReferenceVertex(123, "person"), null},
                 new Object[] {"TinkerVertex", g.V().hasLabel("person").next(), null},
-                new Object[] {"ReferenceVertexProperty", new ReferenceVertexProperty<>(123, "name", "john"), (Consumer<ReferenceVertexProperty>) referenceProperty -> {
-                    assertEquals("name", referenceProperty.key());
-                    assertEquals("john", referenceProperty.value());
-                    assertEquals(123, referenceProperty.id());
+                new Object[] {"DetachedVertexProperty", new DetachedVertexProperty<>(123, "name", "john", null), (Consumer<DetachedVertexProperty>) vertexProperty -> {
+                    assertEquals("name", vertexProperty.key());
+                    assertEquals("john", vertexProperty.value());
+                    assertEquals(123, vertexProperty.id());
                 }},
                 new Object[] {"PathLabelled", g.V().as("a", "b").out().as("c").path().next(), null},
                 new Object[] {"PathNotLabelled", g.V().out().inE().values().path().next(), null},

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertexProperty.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertexProperty.java
@@ -93,7 +93,7 @@ public final class Neo4jVertexProperty<V> implements VertexProperty<V> {
 
     @Override
     public <U> Iterator<Property<U>> properties(final String... propertyKeys) {
-        throw VertexProperty.Exceptions.metaPropertiesNotSupported();
+        return Collections.emptyIterator();
     }
 
     @Override


### PR DESCRIPTION
- Changed default behavior for returning properties on Elements for OLTP queries. Properties now returned.
- Detachment is no longer performed in `TraverserIterator`.
- Added `materializeProperties` request option to control properties serialization.
- Modified serializers in to handle serialization and deserialization of properties.
- Added functional properties to the graph structure components for .NET, GO and Python.
- Modified the GremlinScriptChecker to extract the `materializeProperties` request option.
- Neo4jVertexProperty no longer throw Exception for `properties()`, but return empty iterable.

Jira ticket: https://issues.apache.org/jira/browse/TINKERPOP-2824
