### PR TITLE
Attempt to fix TINKERPOP-2918.

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
@@ -77,9 +77,9 @@ namespace Gremlin.Net.Process
         /// </summary>
         private static string GenerateUserAgent()
         {
-            var applicationName = Assembly.GetExecutingAssembly().GetName().Name?
+            var applicationName = Assembly.GetEntryAssembly()?.GetName().Name?
                                                         .Replace(' ', '_') ?? "NotAvailable";
-            var driverVersion = AssemblyName.GetAssemblyName("Gremlin.Net.dll").Version?.ToString()
+            var driverVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString()
                                                         .Replace(' ', '_')  ?? "NotAvailable";
             var languageVersion = Environment.Version.ToString().Replace(' ', '_');
             var osName = Environment.OSVersion.Platform.ToString().Replace(' ', '_');


### PR DESCRIPTION
I can only assume the first call to GetExecutingAssembly should have been GetEntryAssembly, whereas for the driverVersion, GetExecutingAssembly should be used (for reasons described in the ticket).