### PR TITLE
TINKERPOP-2852 Deploying multi-arch docker images

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Improved `addE()` error messaging when traverser is not a `Vertex`.
 * Added `SubmitWithOptions()` methods to `Client` and `DriverRemoteConnection` in Go GLV to pass `RequestOptions` to the server.
 * Fixed bug in which `gremlin-server` would not respond to clients if an `Error` was thrown during bytecode traversals.
+* Added ability to deploy multi-arch Docker images for server and console. Server image now supports AMD64 and ARM64.
 * Changed `with()` configuration for `ARGS_BATCH_SIZE` and `ARGS_EVAL_TIMEOUT` to be more forgiving on the type of `Number` used for the value.
 * Changed `gremlin-console` to add imports via an ImportCustomizer to reduce time spent resolving imports.
 * Bumped to Groovy 2.5.22.

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -381,7 +381,7 @@ organization. So if you don't already have an account on Docker Hub then create 
 a PMC member adds your account to the TinkerPop organization. Afterwards, authentication information needs to be added to
 the `~/.docker/config.json` file. This information can simply be added with the `docker login` command which will ask for
 credentials. This must be done only once. Finally, `docker push` can be used to push images to Docker Hub which will
-be done automatically on `mvn deploy` or it can be triggered manually with `mvn dockerfile:push`.
+be done automatically on `mvn deploy` or it can be triggered manually with `mvn docker:push`.
 
 [[building-testing]]
 == Building and Testing

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -30,24 +30,10 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
-=== Upgrading for Providers
+==== ARM64 Support for Gremlin Server Docker Image
 
-==== Local steps should handle non-Iterables
-
-`index` steps and local steps `count`, `dedup`, `max`, `mean`, `min`, `order`, `range`, `sample`, `sum`, `tail` should
-work correctly with not only `Iterable` input, but also with arrays and single values.
-
-Examples of queries that should be supported:
-
-[source,groovy]
-----
-g.inject(1).max(local)
-----
-
-[source,java]
-----
-g.inject(new Integer[] {1,2},3).max(Scope.local).toList()
-----
+Gremlin server docker image now supports both AMD64 and ARM64. Multi-architecture image can now be found at
+https://hub.docker.com/r/tinkerpop/gremlin-server
 
 === Upgrading for Providers
 
@@ -66,6 +52,23 @@ expensive step to propagate that data throughout the traversal in between each s
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2855[TINKERPOP-2855],
 link:https://issues.apache.org/jira/browse/TINKERPOP-2888[TINKERPOP-2888]
+
+===== Local steps should handle non-Iterables
+
+`index` steps and local steps `count`, `dedup`, `max`, `mean`, `min`, `order`, `range`, `sample`, `sum`, `tail` should
+work correctly with not only `Iterable` input, but also with arrays and single values.
+
+Examples of queries that should be supported:
+
+[source,groovy]
+----
+g.inject(1).max(local)
+----
+
+[source,java]
+----
+g.inject(new Integer[] {1,2},3).max(Scope.local).toList()
+----
 
 == TinkerPop 3.5.5
 

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -25,6 +25,14 @@ limitations under the License.
     </parent>
     <artifactId>gremlin-console</artifactId>
     <name>Apache TinkerPop :: Gremlin Console</name>
+    <properties>
+    <!--Testing in macOs on ARM reveals that the linux/arm64/v8 console
+        container is quite unstable at this time and results in frequent freezes.
+        It is believed the issue lies with the ARM docker engine. The stability of ARM
+        images is likely to improve overtime and this omition should be intermittently
+        re-evaluated.-->
+        <docker.platforms>linux/amd64<!--,linux/arm64/v8--></docker.platforms>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
@@ -293,6 +301,38 @@ limitations under the License.
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <configuration>
+                        <images>
+                            <image>
+                                <name>tinkerpop/gremlin-console:${project.version}</name>
+                                <build>
+                                    <dockerFile>${project.build.directory}/../Dockerfile</dockerFile>
+                                    <args>
+                                        <GREMLIN_CONSOLE_DIR>target/apache-tinkerpop-${project.artifactId}-${project.version}-standalone</GREMLIN_CONSOLE_DIR>
+                                    </args>
+                                    <tags>
+                                        <!-- docker.tags.* properties are empty if project.version is a pre-release
+                                            resulting in no additional tags -->
+                                        <tag>${docker.tags.majorVersion.minorVersion}</tag>
+                                        <tag>${docker.tags.latest}</tag>
+                                    </tags>
+                                    <buildx>
+                                        <platforms>
+                                            <platform>${docker.platforms}</platform>
+                                        </platforms>
+                                    </buildx>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>
@@ -365,59 +405,28 @@ limitations under the License.
                             <skip>true</skip>
                         </configuration>
                     </plugin>
+
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>docker-image-build</id>
+                                <id>docker:build</id>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                                <configuration>
-                                    <tag>${project.version}</tag>
-                                    <buildArgs>
-                                        <GREMLIN_CONSOLE_DIR>target/apache-tinkerpop-${project.artifactId}-${project.version}-standalone</GREMLIN_CONSOLE_DIR>
-                                    </buildArgs>
-                                </configuration>
+                                <phase>package</phase>
                             </execution>
                             <execution>
-                                <id>docker-image-tag-minor-version</id>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>docker-image-push</id>
-                                <phase>deploy</phase>
+                                <id>docker:push</id>
                                 <goals>
                                     <goal>push</goal>
                                 </goals>
-                                <configuration>
-                                    <tag>${project.version}</tag>
-                                    <skip>${only.when.is.snapshot.used}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>docker-image-push-minor-version</id>
                                 <phase>deploy</phase>
-                                <goals>
-                                    <goal>push</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <repository>tinkerpop/gremlin-console</repository>
-                        </configuration>
                     </plugin>
+
                 </plugins>                
             </build>
         </profile>

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -32,6 +32,7 @@ limitations under the License.
         -->
         <maven.exec.skip>false</maven.exec.skip> <!-- default -->
         <skipImageBuild>${maven.exec.skip}</skipImageBuild>
+        <docker.platforms>linux/amd64,linux/arm64/v8</docker.platforms>
     </properties>
     <dependencies>
         <dependency>
@@ -207,6 +208,38 @@ limitations under the License.
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <configuration>
+                        <images>
+                            <image>
+                                <name>tinkerpop/gremlin-server:${project.version}</name>
+                                <build>
+                                    <dockerFile>${project.build.directory}/../Dockerfile</dockerFile>
+                                    <args>
+                                        <GREMLIN_SERVER_DIR>target/apache-tinkerpop-${project.artifactId}-${project.version}-standalone</GREMLIN_SERVER_DIR>
+                                    </args>
+                                    <tags>
+                                        <!-- docker.tags.* properties are empty if project.version is a pre-release
+                                            resulting in no additional tags -->
+                                        <tag>${docker.tags.majorVersion.minorVersion}</tag>
+                                        <tag>${docker.tags.latest}</tag>
+                                    </tags>
+                                    <buildx>
+                                        <platforms>
+                                            <platform>${docker.platforms}</platform>
+                                        </platforms>
+                                    </buildx>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>
@@ -233,7 +266,6 @@ limitations under the License.
                 </plugins>
             </build>
         </profile>
-
 
         <profile>
             <!--
@@ -378,57 +410,24 @@ limitations under the License.
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>docker-image-build</id>
+                                <id>docker:build</id>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                                <configuration>
-                                    <tag>${project.version}</tag>
-                                    <buildArgs>
-                                        <GREMLIN_SERVER_DIR>target/apache-tinkerpop-${project.artifactId}-${project.version}-standalone</GREMLIN_SERVER_DIR>
-                                    </buildArgs>
-                                </configuration>
+                                <phase>package</phase>
                             </execution>
                             <execution>
-                                <id>docker-image-tag-minor-version</id>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>docker-image-push</id>
-                                <phase>deploy</phase>
+                                <id>docker:push</id>
                                 <goals>
                                     <goal>push</goal>
                                 </goals>
-                                <configuration>
-                                    <tag>${project.version}</tag>
-                                    <skip>${only.when.is.snapshot.used}</skip>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>docker-image-push-minor-version</id>
                                 <phase>deploy</phase>
-                                <goals>
-                                    <goal>push</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</tag>
-                                    <skip>${only.when.is.prerelease.version}</skip>
-                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <repository>tinkerpop/gremlin-server</repository>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,57 @@ limitations under the License.
                         </configuration>
                     </execution>
                     <execution>
+                        <!-- sets the true.when.is.prerelease.version property to true if a prerelease version was used,
+                            empty string otherwise -->
+                        <id>build-helper-regex-is-prerelease-version2</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>true.when.is.prerelease.version</name>
+                            <value>${only.when.is.prerelease.version}</value>
+                            <regex>${project.version}</regex>
+                            <replacement></replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- sets the docker.tags.majorVersion.minorVersion property to
+                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion} unless a prerelease version was,
+                            used. If a prerelease is used, an empty string is assigned instead. -->
+                        <id>build-helper-regex-set-docker-version-tag</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>docker.tags.majorVersion.minorVersion</name>
+                            <value>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}${true.when.is.prerelease.version}</value>
+                            <regex>.*true</regex>
+                            <replacement></replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+
+<!--                    <execution>-->
+<!--                    Excluded as latest tag is currently only updated for the 3.6.x branch    -->
+                        <!-- sets the docker.tags.latest property to "latest" unless a prerelease version was,
+                            used. If a prerelease is used, an empty string is assigned instead. -->
+<!--                    <id>build-helper-regex-set-docker-latest-tag</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>docker.tags.latest</name>
+                            <value>latest${true.when.is.prerelease.version}</value>
+                            <regex>.*true</regex>
+                            <replacement></replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution> -->
+                    <execution>
                         <id>parse-version</id>
                         <goals>
                             <goal>parse-version</goal>
@@ -598,12 +649,10 @@ limitations under the License.
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.0.2</version>
                 </plugin>
-                <!-- can't upgrade past 1.4.6 until we enforce maven 3.5.2 or better
-                     https://github.com/spotify/dockerfile-maven/issues/252 -->
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>1.4.13</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.42.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -857,7 +906,6 @@ limitations under the License.
     </dependencyManagement>
 
     <profiles>
-
         <profile>
             <id>jdk11</id>
             <activation>


### PR DESCRIPTION
Replaces spotify plugin with io.fabric8 docker-maven-plugin. The new plugin has the benefit of supporting multi-arch images through buildx for deployments and it is an actively maintained plugin as opposed to the spotify plugin.

The new plugin continues to fetch auth credentials from the same location so no changes to the release environment will be necessary.

I have tested the full set of .Net gherkin and integration tests against the new server image with no issues. I have also used [container-diff](https://github.com/GoogleContainerTools/container-diff) to compare the new image to the one that we currently build using the mvn exec plugin and docker compose. These are the results:

```
-----File-----

These entries have been added to colegreer/tinkerpop:server-3.5.6-SNAPSHOT: None

These entries have been deleted from colegreer/tinkerpop:server-3.5.6-SNAPSHOT: None

These entries have been changed between colegreer/tinkerpop:server-3.5.6-SNAPSHOT and tinkerpop/gremlin-server:3.5.6-SNAPSHOT:
FILE                                                             SIZE1         SIZE2
/opt/gremlin-server/lib/gremlin-server-3.5.6-SNAPSHOT.jar        243K          242.8K
/etc/ssl/certs/java/cacerts                                      155.3K        155.3K


-----Apt-----

Packages found only in colegreer/tinkerpop:server-3.5.6-SNAPSHOT: None

Packages found only in tinkerpop/gremlin-server:3.5.6-SNAPSHOT: None

Version differences: None
```
I haven't yet identified the minute difference in the jar file between the two images. I can investigate this further if anyone views it as a potential concern.

Unfortunately the ARM64 console image has been unstable in my tests and I've opted to exclude it for now. The configuration for multi-arch console images is still included in this PR so an ARM console image can be added to the deployment in the future with a one liner update.

Additional architectures such as `ppc64le` could be added to the deployment simply by listing them in the `docker.platforms` property in the console and server poms. I would expect all architectures supported by the [alpine](https://hub.docker.com/_/alpine) base image should work although I lack the resources to test this.