### PR TITLE
fixed broken link in the-traversal.asciidoc

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -357,7 +357,7 @@ configuration step more closely.
 === WithStrategies Configuration
 
 The `withStrategies()` configuration allows inclusion of additional `TraversalStrategy` instances to be applied to
-any traversals spawned from the configured source. Please see the <<traversal-strategy,Traversal Strategy Section>>
+any traversals spawned from the configured source. Please see the <<traversalstrategy,Traversal Strategy Section>>
 for more details on how this configuration works.
 
 [[configuration-steps-withoutstrategies]]


### PR DESCRIPTION
When I clicked the old broken link, it just reloaded the document which confused me. Removing the hyphen here should point it to the right place.