### PR TITLE
[TINKERPOP-2901] Incorrect result caused by has(key, predicate)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,7 +37,7 @@ This release also includes changes from <<release-3-5-6, 3.5.6>>.
 * Fixed MergeV/MergeE steps to work when onCreate is immutable map.
 * Introduced `Writing` and `Deleting` marker interfaces to identify whether a step can perform write or delete or both on Graph.
 * Added static map capturing possible Traversal steps that shall be added to traversal for a given operator
-
+* Fixed bug which caused some traversals to throw `GremlinTypeErrorException` to users.
 
 [[release-3-6-2]]
 === TinkerPop 3.6.2 (Release Date: January 16, 2023)

--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -145,7 +145,7 @@ When evaluating boolean value expressions, we sometimes encounter situations tha
 other invalid arguments to other boolean value expressions.
 
 Rather than throwing an exception and halting the traversal, we extend normal binary boolean logics and introduce a
-third boolean option option - `ERROR`. How this `ERROR` result is handled is Graph provider dependent. For the reference
+third boolean option - `ERROR`. How this `ERROR` result is handled is Graph provider dependent. For the reference
 implementation, `ERROR` is an internal representation only and will not be propagated back to the client as an
 exception - it will eventually hit a binary reduction operation and be reduced to `FALSE` (thus quietly filters the
 solution that produced the `ERROR`). Before that happens though, it will be treated as its own boolean value with its

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/FilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/FilterStep.java
@@ -41,10 +41,11 @@ public abstract class FilterStep<S> extends AbstractStep<S, S> {
                 if (this.filter(traverser))
                     return traverser;
             } catch (GremlinTypeErrorException ex) {
-                if (this instanceof BinaryReductionStep || getTraversal().isRoot()) {
+                if (this instanceof BinaryReductionStep || getTraversal().isRoot() || !(getTraversal().getParent() instanceof FilterStep)) {
                     /*
-                     * Either we are at a known reduction point (TraversalFilterStep, WhereTraversalStep), or we
-                     * are at the top level of the query. In either of these cases we do a binary reduction from
+                     * Either we are at a known reduction point (TraversalFilterStep, WhereTraversalStep), we
+                     * are at the top level of the query, or our parent query is not a FilterStep and thus cannot handle
+                     * a GremlinTypeErrorException. In any of these cases we do a binary reduction from
                      * ERROR -> FALSE and filter the solution quietly.
                      */
                 } else {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessLimitedStandardSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessLimitedStandardSuite.java
@@ -90,6 +90,8 @@ public class ProcessLimitedStandardSuite extends AbstractGremlinSuite {
             IncidentToAdjacentStrategyProcessTest.class,
             EarlyLimitStrategyProcessTest.class,
 
+            // semantics
+            TernaryBooleanLogicsTest.class,
     };
 
     /**

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TernaryBooleanLogicsTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TernaryBooleanLogicsTest.java
@@ -33,6 +33,8 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.and;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.is;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.not;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.or;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.union;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.where;
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.GraphFeatures;
 
 /**
@@ -318,4 +320,23 @@ public class TernaryBooleanLogicsTest extends AbstractGremlinProcessTest {
         checkHasNext(false, g.inject(1).filter(xor.apply(ERROR, ERROR)));
     }
 
+    /**
+     * Child traversals should propagate error states to their parent traversal if and only if the parent step is a
+     * filter step.
+     */
+    @Test
+    @FeatureRequirement(featureClass = GraphFeatures.class, feature = GraphFeatures.FEATURE_ORDERABILITY_SEMANTICS)
+    public void testErrorPropagation() {
+        final P ERROR = P.lt(Double.NaN);
+
+        // Propagates Error to parent not()
+        checkHasNext(false, g.inject(1).not(not(is(ERROR))));
+        checkHasNext(false, g.inject(1).not(is(ERROR)));
+        // Propagates Error to parent where()
+        checkHasNext(false, g.inject(1).not(where(is(ERROR))));
+        checkHasNext(false, g.inject(1).where(is(ERROR)));
+        // Does not propagate Error through non-filter parent
+        checkHasNext(true, g.inject(1).not(union((is(ERROR)))));
+        checkHasNext(false, g.inject(1).union((is(ERROR))));
+    }
 }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -19,8 +19,11 @@
 package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.step.sideEffect;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
+import org.apache.tinkerpop.gremlin.process.traversal.GremlinTypeErrorException;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.BinaryReductionStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
@@ -132,8 +135,21 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
         try {
             while (iterator.hasNext()) {
                 final E e = iterator.next();
-                if (HasContainer.testAll(e, this.hasContainers))
-                    list.add(e);
+                try {
+                    if (HasContainer.testAll(e, this.hasContainers))
+                        list.add(e);
+                } catch (GremlinTypeErrorException ex) {
+                    if (getTraversal().isRoot() || !(getTraversal().getParent() instanceof FilterStep)) {
+                        /*
+                         * Either we are at the top level of the query, or our parent query is not a FilterStep and thus
+                         * cannot handle a GremlinTypeErrorException. In any of these cases we do a binary reduction
+                         * from ERROR -> FALSE and filter the solution quietly.
+                         */
+                    } else {
+                        // not a ternary -> binary reducer, pass the ERROR on
+                        throw ex;
+                    }
+                }
             }
         } finally {
             // close the old iterator to release resources since we are returning a new iterator (over list)

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStepTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStepTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.step.sideEffect;
+
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.strategy.optimization.TinkerGraphStepStrategy;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+
+public class TinkerGraphStepTest {
+
+    private Graph graph;
+    private GraphTraversalSource g;
+
+    @Before
+    public void setup() {
+        graph = TinkerGraph.open();
+        g = graph.traversal();
+    }
+
+    /**
+     * TinkerGraphStepStrategy pulls `has("age", P.gt(1))` into a HasContainer within the initial TinkerGraphStep.
+     * This requires that TinkerGraphStep handles the reduction from Ternary Boolean logics (TRUE, FALSE, ERROR) to
+     * ordinary boolean logics which normally takes place within FilterStep's.
+     */
+    @Test
+    public void shouldHandleComparisonsWithNaN() {
+        g.addV("v1").property("age", Double.NaN).next();
+        g.addV("v1").property("age", 3).next();
+        int count = g.V().has("age", P.gt(1)).count().next().intValue();
+        assertEquals(1, count);
+    }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2901

One of the optimizations done by TinkerGraphStepStrategy is push down `has()` steps into HasContainer's within TinkerGraphStep. When this occurs, the normal binary reduction of ternary boolean states gets skipped. This PR addresses this by replicating the binary reduction logic within TinkerGraphStep when the filtering is performed.

This PR addresses cases where `GremlinTypeErrorException` is able to leak to the user.

Fixes 2 cases:
1: If has step gets merged into a TinkerGraphStep by TinkerGraphStepStrategy, the evaluation
of the has containers will still be guarded by the same ternary boolean binary reduction logic
as in FilterStep class.

2: If the parent step is not a FilterStep and thus is not equipped to handle a GremlinTypeErrorException,
the error will be reduced to false instead of propagating.