### PR TITLE
TINKERPOP-2899 Changed hashCode implementation for LP/P traversers.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bumped to `snakeyaml` 2.0 to fix security vulnerability.
 * Bumped to Apache `commons-configuration` 2.9.0 to fix security vulnerability.
 * Improved `count` step optimization for negative values in input for 'eq' comparison.
+* Fixed performance issue when using SampleGlobalStep with a traverser that has either a LABELED_PATH or PATH requirement.
 
 [[release-3-5-5]]
 === TinkerPop 3.5.5 (Release Date: January 16, 2023)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/B_LP_O_P_S_SE_SL_Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/B_LP_O_P_S_SE_SL_Traverser.java
@@ -80,7 +80,7 @@ public class B_LP_O_P_S_SE_SL_Traverser<T> extends B_O_S_SE_SL_Traverser<T> {
 
     @Override
     public int hashCode() {
-        return carriesUnmergeableSack() ? System.identityHashCode(this) : (super.hashCode() ^ this.path.hashCode());
+        return carriesUnmergeableSack() ? System.identityHashCode(this) : (31 * super.hashCode() + this.path.hashCode());
     }
 
     protected final boolean equals(final B_LP_O_P_S_SE_SL_Traverser other) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/B_LP_O_S_SE_SL_Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/B_LP_O_S_SE_SL_Traverser.java
@@ -112,7 +112,7 @@ public class B_LP_O_S_SE_SL_Traverser<T> extends B_O_S_SE_SL_Traverser<T> {
 
     @Override
     public int hashCode() {
-        return carriesUnmergeableSack() ? System.identityHashCode(this) : (super.hashCode() ^ this.path.hashCode());
+        return carriesUnmergeableSack() ? System.identityHashCode(this) : (31 * super.hashCode() + this.path.hashCode());
     }
 
     protected  final boolean equals(final B_LP_O_S_SE_SL_Traverser other) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/LP_O_OB_P_S_SE_SL_Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/LP_O_OB_P_S_SE_SL_Traverser.java
@@ -106,7 +106,7 @@ public class LP_O_OB_P_S_SE_SL_Traverser<T> extends O_OB_S_SE_SL_Traverser<T> {
 
     @Override
     public int hashCode() {
-        return carriesUnmergeableSack() ? System.identityHashCode(this) : (super.hashCode() ^ this.path.hashCode());
+        return carriesUnmergeableSack() ? System.identityHashCode(this) : (31 * super.hashCode() + this.path.hashCode());
     }
 
     protected final boolean equals(final LP_O_OB_P_S_SE_SL_Traverser other) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/LP_O_OB_S_SE_SL_Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/LP_O_OB_S_SE_SL_Traverser.java
@@ -89,7 +89,7 @@ public class LP_O_OB_S_SE_SL_Traverser<T> extends O_OB_S_SE_SL_Traverser<T> {
 
     @Override
     public int hashCode() {
-        return carriesUnmergeableSack() ? System.identityHashCode(this) : (super.hashCode() ^ this.path.hashCode());
+        return carriesUnmergeableSack() ? System.identityHashCode(this) : (31 * super.hashCode() + this.path.hashCode());
     }
 
     protected final boolean equals(final LP_O_OB_S_SE_SL_Traverser other) {


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TINKERPOP-2899

In some instances, a graph may contain elements whose Ids are sequentially increasing integers. Because the hashCode for Path implementations are calculated based on these same Ids, you run into a situation where both parts of the hashCode calculation are related by some constant. H(A)-H(B)=C where C is a constant. In this case, XOR is a bad candidate for creating the final hashCode because XOR will reduce to some small pool of potential output. This occurs because the most significant bits will be the same for H(A) and H(B) which will cause them to become 0 when XOR'd. This commit changes the algorithm to be a more standard algorithm for this case which is m * H(A) + H(B).

Some quick performance numbers using Kelvin's air-routes data loaded into TinkerGraph via io(graphml()).readGraph()

| Query | Current Implementation time in ms | Proposed Implementation time in ms |
| --- | --- | --- |
| g.E().hasLabel('route').sample(1000).inV().path() | 55403 | 1243 |
| g.E().as('a').hasLabel('route').sample(1000).as('b').dedup('b').inV() | 53653 | 1134 |
| g.withBulk(false).E().as('a').hasLabel('route').sample(1000).as('b').dedup('b').inV() | 53924 | 1357 |
| g.withBulk(false).E().hasLabel('route').sample(1000).inV().path() | 51906 | 1041 |