### PR TITLE
[TINKERPOP-2891] Improved handling for negative values in CountStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `AuthInfoProvider` interface and `NewDynamicAuth()` to gremlin-go for dynamic authentication support.
 * Bumped to `snakeyaml` 2.0 to fix security vulnerability.
 * Bumped to Apache `commons-configuration` 2.9.0 to fix security vulnerability.
+* Improved `count` step optimization for negative values in input for 'eq' comparison.
 
 [[release-3-5-5]]
 === TinkerPop 3.5.5 (Release Date: January 16, 2023)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategy.java
@@ -178,7 +178,7 @@ public final class CountStrategy extends AbstractTraversalStrategy<TraversalStra
                             }
                         }
                     } else {
-                        TraversalHelper.insertBeforeStep(new RangeGlobalStep<>(traversal, 0L, highRange), curr, traversal);
+                        TraversalHelper.insertBeforeStep(new RangeGlobalStep<>(traversal, 0L, highRange < 0 ? 0 : highRange), curr, traversal);
                     }
                     i++;
                 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategyTest.java
@@ -63,6 +63,7 @@ public class CountStrategyTest {
                 {__.count().is(1), __.limit(2).count().is(1)},
                 {__.count().is(-1), __.limit(0).count().is(-1)}, // -1 for RangeGlobalStep means no upper limit
                 {__.count().is(-2), __.limit(0).count().is(-2)},
+                {__.count().is(-2023), __.limit(0).count().is(-2023)},
                 {__.out().count().is(0), __.out().limit(1).count().is(0)},
                 {__.outE().count().is(lt(1)), __.outE().limit(1).count().is(lt(1))},
                 {__.both().count().is(lte(0)), __.both().limit(1).count().is(lte(0))},

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategyTest.java
@@ -61,6 +61,8 @@ public class CountStrategyTest {
         return Arrays.asList(new Traversal[][]{
                 {__.count().is(0), __.limit(1).count().is(0)},
                 {__.count().is(1), __.limit(2).count().is(1)},
+                {__.count().is(-1), __.limit(0).count().is(-1)}, // -1 for RangeGlobalStep means no upper limit
+                {__.count().is(-2), __.limit(0).count().is(-2)},
                 {__.out().count().is(0), __.out().limit(1).count().is(0)},
                 {__.outE().count().is(lt(1)), __.outE().limit(1).count().is(lt(1))},
                 {__.both().count().is(lte(0)), __.both().limit(1).count().is(lte(0))},


### PR DESCRIPTION
Fixed optimization of `count` step inside `CountStrategy`.

queries like
` g.V().where(__.in().count().is(eq(-3)))` and  `g.V().where(__.in().count().is(eq(-2)))` are now correctly optimized as `g.V().where(__.in().limit(0).count().is(eq(-2)))`

https://issues.apache.org/jira/browse/TINKERPOP-2891