### PR TITLE
[TINKERPOP-2927] Relax steps extensibility strictness

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/BranchStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/BranchStep.java
@@ -52,8 +52,8 @@ public class BranchStep<S, E, M> extends ComputerAwareStep<S, E> implements Trav
     protected Map<Pick, List<Traversal.Admin<S, E>>> traversalPickOptions = new HashMap<>();
     protected List<Pair<Traversal.Admin<M, ?>, Traversal.Admin<S, E>>> traversalOptions = new ArrayList<>();
 
-    private boolean first = true;
-    private boolean hasBarrier;
+    protected boolean first = true;
+    protected boolean hasBarrier;
 
     public BranchStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -142,7 +142,7 @@ public class BranchStep<S, E, M> extends ComputerAwareStep<S, E> implements Trav
     /**
      * Choose the right traversal option to apply and seed those options with this traverser.
      */
-    private void applyCurrentTraverser(final Traverser.Admin<S> start) {
+    protected void applyCurrentTraverser(final Traverser.Admin<S> start) {
         // first get the value of the choice based on the current traverser and use that to select the right traversal
         // option to which that traverser should be routed
         final M choice = TraversalUtil.apply(start, this.branchTraversal);
@@ -188,7 +188,7 @@ public class BranchStep<S, E, M> extends ComputerAwareStep<S, E> implements Trav
         return ends.iterator();
     }
 
-    private List<Traversal.Admin<S, E>> pickBranches(final M choice) {
+    protected List<Traversal.Admin<S, E>> pickBranches(final M choice) {
         final List<Traversal.Admin<S, E>> branches = new ArrayList<>();
         if (choice instanceof Pick) {
             if (this.traversalPickOptions.containsKey(choice)) {
@@ -258,5 +258,25 @@ public class BranchStep<S, E, M> extends ComputerAwareStep<S, E> implements Trav
         super.reset();
         this.getGlobalChildren().forEach(Traversal.Admin::reset);
         this.first = true;
+    }
+
+    public Traversal.Admin<S, M> getBranchTraversal() {
+        return branchTraversal;
+    }
+
+    public Map<Pick, List<Traversal.Admin<S, E>>> getTraversalPickOptions() {
+        return traversalPickOptions;
+    }
+
+    public List<Pair<Traversal.Admin<M, ?>, Traversal.Admin<S, E>>> getTraversalOptions() {
+        return traversalOptions;
+    }
+
+    public boolean isFirst() {
+        return first;
+    }
+
+    public boolean isHasBarrier() {
+        return hasBarrier;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/ChooseStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/ChooseStep.java
@@ -28,7 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.HasNextStep;
  * @author Joshua Shinavier (http://fortytwo.net)
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class ChooseStep<S, E, M> extends BranchStep<S, E, M> {
+public class ChooseStep<S, E, M> extends BranchStep<S, E, M> {
 
     public ChooseStep(final Traversal.Admin traversal, final Traversal.Admin<S, M> choiceTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/LocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/LocalStep.java
@@ -34,10 +34,10 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LocalStep<S, E> extends AbstractStep<S, E> implements TraversalParent {
+public class LocalStep<S, E> extends AbstractStep<S, E> implements TraversalParent {
 
-    private Traversal.Admin<S, E> localTraversal;
-    private boolean first = true;
+    protected Traversal.Admin<S, E> localTraversal;
+    protected boolean first = true;
 
     public LocalStep(final Traversal.Admin traversal, final Traversal.Admin<S, E> localTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/OptionalStep.java
@@ -34,9 +34,9 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OptionalStep<S> extends AbstractStep<S, S> implements TraversalParent {
+public class OptionalStep<S> extends AbstractStep<S, S> implements TraversalParent {
 
-    private Traversal.Admin<S, S> optionalTraversal;
+    protected Traversal.Admin<S, S> optionalTraversal;
 
     public OptionalStep(final Traversal.Admin traversal, final Traversal.Admin<S, S> optionalTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
@@ -38,12 +38,12 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements TraversalParent {
+public class RepeatStep<S> extends ComputerAwareStep<S, S> implements TraversalParent {
 
-    private Traversal.Admin<S, S> repeatTraversal = null;
-    private Traversal.Admin<S, ?> untilTraversal = null;
-    private Traversal.Admin<S, ?> emitTraversal = null;
-    private String loopName = null;
+    protected Traversal.Admin<S, S> repeatTraversal = null;
+    protected Traversal.Admin<S, ?> untilTraversal = null;
+    protected Traversal.Admin<S, ?> emitTraversal = null;
+    protected String loopName = null;
     public boolean untilFirst = false;
     public boolean emitFirst = false;
 
@@ -113,11 +113,11 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
         return list;
     }
 
-    public final boolean doUntil(final Traverser.Admin<S> traverser, boolean utilFirst) {
+    public boolean doUntil(final Traverser.Admin<S> traverser, boolean utilFirst) {
         return utilFirst == this.untilFirst && null != this.untilTraversal && TraversalUtil.test(traverser, this.untilTraversal);
     }
 
-    public final boolean doEmit(final Traverser.Admin<S> traverser, boolean emitFirst) {
+    public boolean doEmit(final Traverser.Admin<S> traverser, boolean emitFirst) {
         return emitFirst == this.emitFirst && null != this.emitTraversal && TraversalUtil.test(traverser, this.emitTraversal);
     }
 
@@ -144,11 +144,11 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
             this.repeatTraversal.reset();
     }
 
-    private final String untilString() {
+    protected String untilString() {
         return null == this.untilTraversal ? "until(false)" : "until(" + this.untilTraversal + ')';
     }
 
-    private final String emitString() {
+    protected String emitString() {
         return null == this.emitTraversal ? "emit(false)" : "emit(" + this.emitTraversal + ')';
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/UnionStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/UnionStep.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class UnionStep<S, E> extends BranchStep<S, E, Pick> {
+public class UnionStep<S, E> extends BranchStep<S, E, Pick> {
 
     public UnionStep(final Traversal.Admin traversal, final Traversal.Admin<?, E>... unionTraversals) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndStep.java
@@ -26,7 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class AndStep<S> extends ConnectiveStep<S> {
+public class AndStep<S> extends ConnectiveStep<S> {
 
     public AndStep(final Traversal.Admin traversal, final Traversal<S, ?>... traversals) {
         super(traversal, traversals);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ClassFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ClassFilterStep.java
@@ -26,10 +26,10 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class ClassFilterStep<S, T> extends FilterStep<S> {
+public class ClassFilterStep<S, T> extends FilterStep<S> {
 
-    private final Class<T> classFilter;
-    private final boolean allowClasses;
+    protected final Class<T> classFilter;
+    protected final boolean allowClasses;
 
     public ClassFilterStep(final Traversal.Admin traversal, final Class<T> classFilter, final boolean allowClasses) {
         super(traversal);
@@ -47,5 +47,13 @@ public final class ClassFilterStep<S, T> extends FilterStep<S> {
 
     public String toString() {
         return StringFactory.stepString(this, this.classFilter.getSimpleName());
+    }
+
+    public Class<T> getClassFilter() {
+        return classFilter;
+    }
+
+    public boolean isAllowClasses() {
+        return allowClasses;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/CoinStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/CoinStep.java
@@ -31,10 +31,10 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class CoinStep<S> extends FilterStep<S> implements Seedable {
+public class CoinStep<S> extends FilterStep<S> implements Seedable {
 
-    private final Random random = new Random();
-    private final double probability;
+    protected final Random random = new Random();
+    protected final double probability;
 
     public CoinStep(final Traversal.Admin traversal, final double probability) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
@@ -53,16 +53,16 @@ import java.util.function.BinaryOperator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class DedupGlobalStep<S> extends FilterStep<S> implements TraversalParent, Scoping, GraphComputing, Barrier<Map<Object, Traverser.Admin<S>>>, ByModulating, PathProcessor {
+public class DedupGlobalStep<S> extends FilterStep<S> implements TraversalParent, Scoping, GraphComputing, Barrier<Map<Object, Traverser.Admin<S>>>, ByModulating, PathProcessor {
 
-    private Traversal.Admin<S, Object> dedupTraversal = null;
-    private Set<Object> duplicateSet = new HashSet<>();
-    private boolean onGraphComputer = false;
-    private final Set<String> dedupLabels;
-    private Set<String> keepLabels;
-    private boolean executingAtMaster = false;
-    private Map<Object, Traverser.Admin<S>> barrier;
-    private Iterator<Map.Entry<Object, Traverser.Admin<S>>> barrierIterator;
+    protected Traversal.Admin<S, Object> dedupTraversal = null;
+    protected Set<Object> duplicateSet = new HashSet<>();
+    protected boolean onGraphComputer = false;
+    protected final Set<String> dedupLabels;
+    protected Set<String> keepLabels;
+    protected boolean executingAtMaster = false;
+    protected Map<Object, Traverser.Admin<S>> barrier;
+    protected Iterator<Map.Entry<Object, Traverser.Admin<S>>> barrierIterator;
 
     public DedupGlobalStep(final Traversal.Admin traversal, final String... dedupLabels) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DropStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DropStep.java
@@ -39,7 +39,7 @@ import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
  */
 public class DropStep<S> extends FilterStep<S> implements Mutating<Event> {
 
-    private CallbackRegistry<Event> callbackRegistry;
+    protected CallbackRegistry<Event> callbackRegistry;
 
     public DropStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasStep.java
@@ -40,8 +40,8 @@ import java.util.Set;
  */
 public class HasStep<S extends Element> extends FilterStep<S> implements HasContainerHolder, Configuring {
 
-    private final Parameters parameters = new Parameters();
-    private List<HasContainer> hasContainers;
+    protected Parameters parameters = new Parameters();
+    protected List<HasContainer> hasContainers;
 
     public HasStep(final Traversal.Admin traversal, final HasContainer... hasContainers) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/IsStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/IsStep.java
@@ -31,9 +31,9 @@ import java.util.Set;
  * @author Daniel Kuppitz (http://gremlin.guru)
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class IsStep<S> extends FilterStep<S> {
+public class IsStep<S> extends FilterStep<S> {
 
-    private P<S> predicate;
+    protected P<S> predicate;
 
     public IsStep(final Traversal.Admin traversal, final P<S> predicate) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/LambdaFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/LambdaFilterStep.java
@@ -28,9 +28,9 @@ import java.util.function.Predicate;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LambdaFilterStep<S> extends FilterStep<S> implements LambdaHolder {
+public class LambdaFilterStep<S> extends FilterStep<S> implements LambdaHolder {
 
-    private final Predicate<Traverser<S>> predicate;
+    protected final Predicate<Traverser<S>> predicate;
 
     public LambdaFilterStep(final Traversal.Admin traversal, final Predicate<Traverser<S>> predicate) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NoneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NoneStep.java
@@ -26,7 +26,7 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class NoneStep<S> extends FilterStep<S> {
+public class NoneStep<S> extends FilterStep<S> {
 
     public NoneStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/NotStep.java
@@ -32,9 +32,9 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class NotStep<S> extends FilterStep<S> implements TraversalParent{
+public class NotStep<S> extends FilterStep<S> implements TraversalParent{
 
-    private Traversal.Admin<S, ?> notTraversal;
+    protected Traversal.Admin<S, ?> notTraversal;
 
     public NotStep(final Traversal.Admin traversal, final Traversal<S, ?> notTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/OrStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/OrStep.java
@@ -26,7 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OrStep<S> extends ConnectiveStep<S> {
+public class OrStep<S> extends ConnectiveStep<S> {
 
     public OrStep(final Traversal.Admin traversal, final Traversal<S, ?>... traversals) {
         super(traversal, traversals);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
@@ -41,13 +41,13 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class PathFilterStep<S> extends FilterStep<S> implements FromToModulating, ByModulating, TraversalParent, PathProcessor {
+public class PathFilterStep<S> extends FilterStep<S> implements FromToModulating, ByModulating, TraversalParent, PathProcessor {
 
     protected String fromLabel;
     protected String toLabel;
-    private boolean isSimple;
-    private TraversalRing<Object, Object> traversalRing;
-    private Set<String> keepLabels;
+    protected boolean isSimple;
+    protected TraversalRing<Object, Object> traversalRing;
+    protected Set<String> keepLabels;
 
     public PathFilterStep(final Traversal.Admin traversal, final boolean isSimple) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStep.java
@@ -42,12 +42,12 @@ import java.util.function.BinaryOperator;
  * @author Bob Briody (http://bobbriody.com)
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, Bypassing, Barrier<TraverserSet<S>> {
+public class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, Bypassing, Barrier<TraverserSet<S>> {
 
-    private long low;
-    private final long high;
-    private AtomicLong counter = new AtomicLong(0l);
-    private boolean bypass;
+    protected long low;
+    protected final long high;
+    protected AtomicLong counter = new AtomicLong(0l);
+    protected boolean bypass;
 
     public RangeGlobalStep(final Traversal.Admin traversal, final long low, final long high) {
         super(traversal);
@@ -199,5 +199,21 @@ public final class RangeGlobalStep<S> extends FilterStep<S> implements Ranging, 
                 mutatingSeed.addAll(set);
             return mutatingSeed;
         }
+    }
+
+    public long getLow() {
+        return low;
+    }
+
+    public long getHigh() {
+        return high;
+    }
+
+    public AtomicLong getCounter() {
+        return counter;
+    }
+
+    public boolean isBypass() {
+        return bypass;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
@@ -41,11 +41,11 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implements TraversalParent, ByModulating, Seedable {
+public class SampleGlobalStep<S> extends CollectingBarrierStep<S> implements TraversalParent, ByModulating, Seedable {
 
-    private Traversal.Admin<S, Number> probabilityTraversal = new ConstantTraversal<>(1.0d);
-    private final int amountToSample;
-    private final Random random = new Random();
+    protected Traversal.Admin<S, Number> probabilityTraversal = new ConstantTraversal<>(1.0d);
+    protected final int amountToSample;
+    protected final Random random = new Random();
 
     public SampleGlobalStep(final Traversal.Admin traversal, final int amountToSample) {
         super(traversal);
@@ -126,7 +126,7 @@ public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implemen
     }
 
 
-    private Optional<ProjectedTraverser<S, Number>> createProjectedTraverser(final Traverser.Admin<S> traverser) {
+    protected Optional<ProjectedTraverser<S, Number>> createProjectedTraverser(final Traverser.Admin<S> traverser) {
         final TraversalProduct product = TraversalUtil.produce(traverser, this.probabilityTraversal);
         if (product.isProductive()) {
             final Object o = product.get();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStep.java
@@ -39,12 +39,12 @@ import java.util.Set;
 /**
  * @author Matt Frantz (http://github.com/mhfrantz)
  */
-public final class TailGlobalStep<S> extends AbstractStep<S, S> implements Bypassing, Barrier<TraverserSet<S>> {
+public class TailGlobalStep<S> extends AbstractStep<S, S> implements Bypassing, Barrier<TraverserSet<S>> {
 
-    private final long limit;
-    private Deque<Traverser.Admin<S>> tail;
-    private long tailBulk = 0L;
-    private boolean bypass = false;
+    protected final long limit;
+    protected Deque<Traverser.Admin<S>> tail;
+    protected long tailBulk = 0L;
+    protected boolean bypass = false;
 
     public TailGlobalStep(final Traversal.Admin traversal, final long limit) {
         super(traversal);
@@ -111,7 +111,7 @@ public final class TailGlobalStep<S> extends AbstractStep<S, S> implements Bypas
         return Collections.singleton(TraverserRequirement.BULK);
     }
 
-    private void addTail(Traverser.Admin<S> start) {
+    protected void addTail(Traverser.Admin<S> start) {
         // Calculate the tail bulk including this new start.
         this.tailBulk += start.bulk();
         // Evict from the tail buffer until we have enough room.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TimeLimitStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TimeLimitStep.java
@@ -31,11 +31,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public final class TimeLimitStep<S> extends FilterStep<S> {
+public class TimeLimitStep<S> extends FilterStep<S> {
 
-    private AtomicLong startTime = new AtomicLong(-1);
-    private final long timeLimit;
-    private AtomicBoolean timedOut = new AtomicBoolean(false);
+    protected AtomicLong startTime = new AtomicLong(-1);
+    protected final long timeLimit;
+    protected AtomicBoolean timedOut = new AtomicBoolean(false);
 
 
     public TimeLimitStep(final Traversal.Admin traversal, final long timeLimit) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TraversalFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TraversalFilterStep.java
@@ -34,10 +34,10 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TraversalFilterStep<S> extends FilterStep<S> implements TraversalParent, Configuring, BinaryReductionStep {
-    private final Parameters parameters = new Parameters();
+public class TraversalFilterStep<S> extends FilterStep<S> implements TraversalParent, Configuring, BinaryReductionStep {
+    protected Parameters parameters = new Parameters();
 
-    private Traversal.Admin<S, ?> filterTraversal;
+    protected Traversal.Admin<S, ?> filterTraversal;
 
     public TraversalFilterStep(final Traversal.Admin traversal, final Traversal<S, ?> filterTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
@@ -45,7 +45,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class WherePredicateStep<S> extends FilterStep<S> implements Scoping, PathProcessor, ByModulating, TraversalParent {
+public class WherePredicateStep<S> extends FilterStep<S> implements Scoping, PathProcessor, ByModulating, TraversalParent {
 
     protected String startKey;
     protected List<String> selectKeys;
@@ -65,7 +65,7 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
         this.configurePredicates(this.predicate);
     }
 
-    private void configurePredicates(final P<Object> predicate) {
+    protected void configurePredicates(final P<Object> predicate) {
         if (predicate instanceof ConnectiveP)
             ((ConnectiveP<Object>) predicate).getPredicates().forEach(this::configurePredicates);
         else {
@@ -75,7 +75,7 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
         }
     }
 
-    private boolean setPredicateValues(final P<Object> predicate, final Traverser.Admin<S> traverser, final Iterator<String> selectKeysIterator) {
+    protected boolean setPredicateValues(final P<Object> predicate, final Traverser.Admin<S> traverser, final Iterator<String> selectKeysIterator) {
         if (predicate instanceof ConnectiveP) {
             for (P<Object> p : ((ConnectiveP<Object>) predicate).getPredicates()) {
                 if (!this.setPredicateValues(p, traverser, selectKeysIterator))

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTraversalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTraversalStep.java
@@ -42,7 +42,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class WhereTraversalStep<S> extends FilterStep<S> implements TraversalParent, Scoping, PathProcessor, BinaryReductionStep {
+public class WhereTraversalStep<S> extends FilterStep<S> implements TraversalParent, Scoping, PathProcessor, BinaryReductionStep {
 
     protected Traversal.Admin<?, ?> whereTraversal;
     protected final Set<String> scopeKeys = new HashSet<>();
@@ -57,7 +57,7 @@ public final class WhereTraversalStep<S> extends FilterStep<S> implements Traver
         this.whereTraversal = this.integrateChild(this.whereTraversal);
     }
 
-    private void configureStartAndEndSteps(final Traversal.Admin<?, ?> whereTraversal) {
+    protected void configureStartAndEndSteps(final Traversal.Admin<?, ?> whereTraversal) {
         ConnectiveStrategy.instance().apply(whereTraversal);
         //// START STEP to WhereStartStep
         final Step<?, ?> startStep = whereTraversal.getStartStep();
@@ -151,7 +151,7 @@ public final class WhereTraversalStep<S> extends FilterStep<S> implements Traver
 
     public static class WhereStartStep<S> extends ScalarMapStep<S, Object> implements Scoping {
 
-        private String selectKey;
+        protected String selectKey;
 
         public WhereStartStep(final Traversal.Admin traversal, final String selectKey) {
             super(traversal);
@@ -189,8 +189,8 @@ public final class WhereTraversalStep<S> extends FilterStep<S> implements Traver
 
     public static class WhereEndStep extends FilterStep<Object> implements Scoping {
 
-        private final String matchKey;
-        private Object matchValue = null;
+        protected final String matchKey;
+        protected Object matchValue = null;
 
         public WhereEndStep(final Traversal.Admin traversal, final String matchKey) {
             super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
@@ -53,12 +53,12 @@ import java.util.Set;
 public class AddEdgeStartStep extends AbstractStep<Edge, Edge>
         implements Mutating<Event.EdgeAddedEvent>, TraversalParent, Scoping, FromToModulating {
 
-    private static final String FROM = Graph.Hidden.hide("from");
-    private static final String TO = Graph.Hidden.hide("to");
+    protected static final String FROM = Graph.Hidden.hide("from");
+    protected static final String TO = Graph.Hidden.hide("to");
 
-    private boolean first = true;
-    private Parameters parameters = new Parameters();
-    private CallbackRegistry<Event.EdgeAddedEvent> callbackRegistry;
+    protected boolean first = true;
+    protected Parameters parameters = new Parameters();
+    protected CallbackRegistry<Event.EdgeAddedEvent> callbackRegistry;
 
     public AddEdgeStartStep(final Traversal.Admin traversal, final String edgeLabel) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -48,11 +48,11 @@ import java.util.Set;
 public class AddEdgeStep<S> extends ScalarMapStep<S, Edge>
         implements Mutating<Event.EdgeAddedEvent>, TraversalParent, Scoping, FromToModulating {
 
-    private static final String FROM = Graph.Hidden.hide("from");
-    private static final String TO = Graph.Hidden.hide("to");
+    protected static final String FROM = Graph.Hidden.hide("from");
+    protected static final String TO = Graph.Hidden.hide("to");
 
-    private Parameters parameters = new Parameters();
-    private CallbackRegistry<Event.EdgeAddedEvent> callbackRegistry;
+    protected Parameters parameters = new Parameters();
+    protected CallbackRegistry<Event.EdgeAddedEvent> callbackRegistry;
 
     public AddEdgeStep(final Traversal.Admin traversal, final String edgeLabel) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
@@ -47,9 +47,9 @@ import java.util.Set;
 public class AddVertexStartStep extends AbstractStep<Vertex, Vertex>
         implements Mutating<Event.VertexAddedEvent>, TraversalParent, Scoping {
 
-    private Parameters parameters = new Parameters();
-    private boolean first = true;
-    private CallbackRegistry<Event.VertexAddedEvent> callbackRegistry;
+    protected Parameters parameters = new Parameters();
+    protected boolean first = true;
+    protected CallbackRegistry<Event.VertexAddedEvent> callbackRegistry;
 
     public AddVertexStartStep(final Traversal.Admin traversal, final String label) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
@@ -43,8 +43,8 @@ import java.util.Set;
 public class AddVertexStep<S> extends ScalarMapStep<S, Vertex>
         implements Mutating<Event.VertexAddedEvent>, TraversalParent, Scoping {
 
-    private Parameters parameters = new Parameters();
-    private CallbackRegistry<Event.VertexAddedEvent> callbackRegistry;
+    protected Parameters parameters = new Parameters();
+    protected CallbackRegistry<Event.VertexAddedEvent> callbackRegistry;
 
     public AddVertexStep(final Traversal.Admin traversal, final String label) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStep.java
@@ -53,20 +53,20 @@ import static org.apache.tinkerpop.gremlin.structure.service.Service.ServiceCall
  *
  * @author Mike Personick (http://github.com/mikepersonick)
  */
-public final class CallStep<S, E> extends AbstractStep<S, E> implements TraversalParent, AutoCloseable, Configuring {
+public class CallStep<S, E> extends AbstractStep<S, E> implements TraversalParent, AutoCloseable, Configuring {
 
-    private final boolean isStart;
-    private boolean first = true;
+    protected final boolean isStart;
+    protected boolean first = true;
 
-    private ServiceCallContext ctx;
-    private String serviceName;
-    private Service<S, E> service;
-    private Map staticParams;
-    private Traversal.Admin<S,Map> mapTraversal;
-    private Parameters parameters;
+    protected ServiceCallContext ctx;
+    protected String serviceName;
+    protected Service<S, E> service;
+    protected Map staticParams;
+    protected Traversal.Admin<S,Map> mapTraversal;
+    protected Parameters parameters;
 
-    private transient Traverser.Admin<S> head = null;
-    private transient CloseableIterator iterator = EmptyCloseableIterator.instance();
+    protected transient Traverser.Admin<S> head = null;
+    protected transient CloseableIterator iterator = EmptyCloseableIterator.instance();
 
     public CallStep(final Traversal.Admin traversal, final boolean isStart) {
         this(traversal, isStart, null);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
@@ -35,9 +35,9 @@ import java.util.Set;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class CoalesceStep<S, E> extends FlatMapStep<S, E> implements TraversalParent {
+public class CoalesceStep<S, E> extends FlatMapStep<S, E> implements TraversalParent {
 
-    private List<Traversal.Admin<S, E>> coalesceTraversals;
+    protected List<Traversal.Admin<S, E>> coalesceTraversals;
 
     @SafeVarargs
     public CoalesceStep(final Traversal.Admin traversal, final Traversal.Admin<S, E>... coalesceTraversals) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConstantStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConstantStep.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 public class ConstantStep<S, E> extends ScalarMapStep<S, E> {
 
-    private final E constant;
+    protected final E constant;
 
     public ConstantStep(final Traversal.Admin traversal, final E constant) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountGlobalStep.java
@@ -32,9 +32,9 @@ import java.util.function.BinaryOperator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class CountGlobalStep<S> extends ReducingBarrierStep<S, Long> {
+public class CountGlobalStep<S> extends ReducingBarrierStep<S, Long> {
 
-    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.BULK);
+    protected static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.BULK);
 
     public CountGlobalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountLocalStep.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class CountLocalStep<S> extends ScalarMapStep<S, Long> {
+public class CountLocalStep<S> extends ScalarMapStep<S, Long> {
 
     public CountLocalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/DedupLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/DedupLocalStep.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class DedupLocalStep<E, S extends Iterable<E>> extends ScalarMapStep<S, Set<E>> {
+public class DedupLocalStep<E, S extends Iterable<E>> extends ScalarMapStep<S, Set<E>> {
 
     public DedupLocalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ElementMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ElementMapStep.java
@@ -49,7 +49,7 @@ import java.util.Set;
 public class ElementMapStep<K,E> extends ScalarMapStep<Element, Map<K, E>> implements TraversalParent, GraphComputing {
 
     protected final String[] propertyKeys;
-    private boolean onGraphComputer = false;
+    protected boolean onGraphComputer = false;
 
     public ElementMapStep(final Traversal.Admin traversal, final String... propertyKeys) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ElementStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ElementStep.java
@@ -32,7 +32,7 @@ import java.util.Set;
  *
  * @author Mike Personick (http://github.com/mikepersonick)
  */
-public final class ElementStep<P extends Property, E extends Element> extends ScalarMapStep<P, E> {
+public class ElementStep<P extends Property, E extends Element> extends ScalarMapStep<P, E> {
 
     public ElementStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FlatMapStep.java
@@ -31,8 +31,8 @@ import java.util.Iterator;
  */
 public abstract class FlatMapStep<S, E> extends AbstractStep<S, E> {
 
-    private Traverser.Admin<S> head = null;
-    private Iterator<E> iterator = EmptyIterator.instance();
+    protected Traverser.Admin<S> head = null;
+    protected Iterator<E> iterator = EmptyIterator.instance();
 
     public FlatMapStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FoldStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/FoldStep.java
@@ -38,10 +38,10 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class FoldStep<S, E> extends ReducingBarrierStep<S, E> {
+public class FoldStep<S, E> extends ReducingBarrierStep<S, E> {
 
-    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.OBJECT);
-    private final boolean listFold;
+    protected static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.OBJECT);
+    protected final boolean listFold;
 
     public FoldStep(final Traversal.Admin traversal) {
         this(traversal, (Supplier) ArrayListSupplier.instance(), (BiFunction) Operator.addAll);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -57,8 +57,8 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
     protected transient Supplier<Iterator<E>> iteratorSupplier;
     protected boolean isStart;
     protected boolean done = false;
-    private Traverser.Admin<S> head = null;
-    private Iterator<E> iterator = EmptyIterator.instance();
+    protected Traverser.Admin<S> head = null;
+    protected Iterator<E> iterator = EmptyIterator.instance();
 
 
     public GraphStep(final Traversal.Admin traversal, final Class<E> returnClass, final boolean isStart, final Object... ids) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
@@ -43,7 +43,7 @@ import java.util.function.BinaryOperator;
  */
 public class GroupCountStep<S, E> extends ReducingBarrierStep<S, Map<E, Long>> implements TraversalParent, ByModulating {
 
-    private Traversal.Admin<S, E> keyTraversal = null;
+    protected Traversal.Admin<S, E> keyTraversal = null;
 
     public GroupCountStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
@@ -46,14 +46,14 @@ import java.util.function.BinaryOperator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>>
+public class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>>
         implements ByModulating, TraversalParent, ProfilingAware, Grouping<S, K, V> {
 
-    private char state = 'k';
-    private Traversal.Admin<S, K> keyTraversal;
-    private Traversal.Admin<S, V> valueTraversal;
-    private Barrier barrierStep;
-    private boolean resetBarrierForProfiling = false;
+    protected char state = 'k';
+    protected Traversal.Admin<S, K> keyTraversal;
+    protected Traversal.Admin<S, V> valueTraversal;
+    protected Barrier barrierStep;
+    protected boolean resetBarrierForProfiling = false;
 
     public GroupStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -82,7 +82,7 @@ public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>>
         return this.valueTraversal;
     }
 
-    private void setValueTraversal(final Traversal.Admin kvTraversal) {
+    protected void setValueTraversal(final Traversal.Admin kvTraversal) {
         this.valueTraversal = this.integrateChild(convertValueTraversal(kvTraversal));
         this.barrierStep = determineBarrierStep(this.valueTraversal);
         this.setReducingBiOperator(new GroupBiOperator<>(null == this.barrierStep ? Operator.assign : this.barrierStep.getMemoryComputeKey().getReducer()));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/HasNextStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/HasNextStep.java
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class HasNextStep<S> extends AbstractStep<S, Boolean> {
+public class HasNextStep<S> extends AbstractStep<S, Boolean> {
 
     public HasNextStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IdStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IdStep.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class IdStep<S extends Element> extends ScalarMapStep<S, Object> {
+public class IdStep<S extends Element> extends ScalarMapStep<S, Object> {
 
     public IdStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IndexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IndexStep.java
@@ -42,14 +42,14 @@ import java.util.function.Function;
  */
 public class IndexStep<S, E> extends ScalarMapStep<S, E> implements TraversalParent, Configuring {
 
-    private final static IllegalArgumentException INVALID_CONFIGURATION_EXCEPTION =
+    protected final static IllegalArgumentException INVALID_CONFIGURATION_EXCEPTION =
             new IllegalArgumentException("WithOptions.indexer requires a single Integer argument (possible " + "" +
                     "values are: WithOptions.[list|map])");
 
-    private final Parameters parameters = new Parameters();
+    protected Parameters parameters = new Parameters();
 
-    private Function<Iterator<?>, Object> indexer;
-    private IndexerType indexerType;
+    protected Function<Iterator<?>, Object> indexer;
+    protected IndexerType indexerType;
 
     public IndexStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -78,7 +78,7 @@ public class IndexStep<S, E> extends ScalarMapStep<S, E> implements TraversalPar
         return super.hashCode() ^ this.indexer.hashCode();
     }
 
-    private static List<List<Object>> indexedList(final Iterator<?> iterator) {
+    protected static List<List<Object>> indexedList(final Iterator<?> iterator) {
         final List<List<Object>> list = new ArrayList<>();
         int i = 0;
         while (iterator.hasNext()) {
@@ -87,7 +87,7 @@ public class IndexStep<S, E> extends ScalarMapStep<S, E> implements TraversalPar
         return Collections.unmodifiableList(list);
     }
 
-    private static Map<Integer, Object> indexedMap(final Iterator<?> iterator) {
+    protected static Map<Integer, Object> indexedMap(final Iterator<?> iterator) {
         final Map<Integer, Object> map = new LinkedHashMap<>();
         int i = 0;
         while (iterator.hasNext()) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LabelStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LabelStep.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LabelStep<S extends Element> extends ScalarMapStep<S, String> {
+public class LabelStep<S extends Element> extends ScalarMapStep<S, String> {
 
     public LabelStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LambdaCollectingBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LambdaCollectingBarrierStep.java
@@ -30,9 +30,9 @@ import java.util.function.Consumer;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LambdaCollectingBarrierStep<S> extends CollectingBarrierStep<S> implements LambdaHolder {
+public class LambdaCollectingBarrierStep<S> extends CollectingBarrierStep<S> implements LambdaHolder {
 
-    private final Consumer<TraverserSet<S>> barrierConsumer;
+    protected final Consumer<TraverserSet<S>> barrierConsumer;
 
     public LambdaCollectingBarrierStep(final Traversal.Admin traversal, final Consumer<TraverserSet<S>> barrierConsumer, final int maxBarrierSize) {
         super(traversal, maxBarrierSize);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LambdaFlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LambdaFlatMapStep.java
@@ -29,9 +29,9 @@ import java.util.function.Function;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LambdaFlatMapStep<S, E> extends FlatMapStep<S, E> implements LambdaHolder {
+public class LambdaFlatMapStep<S, E> extends FlatMapStep<S, E> implements LambdaHolder {
 
-    private final Function<Traverser<S>, Iterator<E>> function;
+    protected final Function<Traverser<S>, Iterator<E>> function;
 
     public LambdaFlatMapStep(final Traversal.Admin traversal, final Function<Traverser<S>, Iterator<E>> function) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LambdaMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LambdaMapStep.java
@@ -28,9 +28,9 @@ import java.util.function.Function;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LambdaMapStep<S, E> extends ScalarMapStep<S, E> implements LambdaHolder {
+public class LambdaMapStep<S, E> extends ScalarMapStep<S, E> implements LambdaHolder {
 
-    private final Function<Traverser<S>, E> function;
+    protected final Function<Traverser<S>, E> function;
 
     public LambdaMapStep(final Traversal.Admin traversal, final Function<Traverser<S>, E> function) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LoopsStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LoopsStep.java
@@ -24,9 +24,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class LoopsStep<S> extends ScalarMapStep<S, Integer> {
+public class LoopsStep<S> extends ScalarMapStep<S, Integer> {
 
-    private String loopName;
+    protected String loopName;
 
     public LoopsStep(final Traversal.Admin traversal, final String loopName) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MathStep.java
@@ -47,13 +47,13 @@ import java.util.regex.Pattern;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class MathStep<S> extends MapStep<S, Double> implements ByModulating, TraversalParent, Scoping, PathProcessor {
+public class MathStep<S> extends MapStep<S, Double> implements ByModulating, TraversalParent, Scoping, PathProcessor {
 
-    private static final String CURRENT = "_";
-    private final String equation;
-    private final TinkerExpression expression;
-    private TraversalRing<S, Number> traversalRing = new TraversalRing<>();
-    private Set<String> keepLabels;
+    protected static final String CURRENT = "_";
+    protected final String equation;
+    protected final TinkerExpression expression;
+    protected TraversalRing<S, Number> traversalRing = new TraversalRing<>();
+    protected Set<String> keepLabels;
 
     public MathStep(final Traversal.Admin traversal, final String equation) {
         super(traversal);
@@ -177,7 +177,7 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
 
     ///
 
-    private static final String[] FUNCTIONS = new String[]{
+    protected static final String[] FUNCTIONS = new String[]{
             "abs", "acos", "asin", "atan",
             "cbrt", "ceil", "cos", "cosh",
             "exp",
@@ -187,7 +187,7 @@ public final class MathStep<S> extends MapStep<S, Double> implements ByModulatin
             "tan", "tanh"
     };
 
-    private static final Pattern VARIABLE_PATTERN =  Pattern.compile("\\b(?![0-9]+|\\b(?:" +
+    protected static final Pattern VARIABLE_PATTERN =  Pattern.compile("\\b(?![0-9]+|\\b(?:" +
             String.join("|", FUNCTIONS) + ")\\b)([a-zA-Z_][a-zA-Z0-9_]*)\\b");
 
     protected static final Set<String> getVariables(final String equation) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxGlobalStep.java
@@ -32,7 +32,7 @@ import java.util.function.BinaryOperator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class MaxGlobalStep<S extends Comparable> extends ReducingBarrierStep<S, S> {
+public class MaxGlobalStep<S extends Comparable> extends ReducingBarrierStep<S, S> {
 
     public MaxGlobalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxLocalStep.java
@@ -33,7 +33,7 @@ import static org.apache.tinkerpop.gremlin.util.NumberHelper.max;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class MaxLocalStep<E extends Comparable, S extends Iterable<E>> extends ScalarMapStep<S, E> {
+public class MaxLocalStep<E extends Comparable, S extends Iterable<E>> extends ScalarMapStep<S, E> {
 
     public MaxLocalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanGlobalStep.java
@@ -38,9 +38,9 @@ import static org.apache.tinkerpop.gremlin.util.NumberHelper.mul;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class MeanGlobalStep<S extends Number, E extends Number> extends ReducingBarrierStep<S, E> {
+public class MeanGlobalStep<S extends Number, E extends Number> extends ReducingBarrierStep<S, E> {
 
-    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.OBJECT, TraverserRequirement.BULK);
+    protected static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(TraverserRequirement.OBJECT, TraverserRequirement.BULK);
 
     public MeanGlobalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanLocalStep.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class MeanLocalStep<E extends Number, S extends Iterable<E>> extends ScalarMapStep<S, Number> {
+public class MeanLocalStep<E extends Number, S extends Iterable<E>> extends ScalarMapStep<S, Number> {
 
     public MeanLocalStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -57,7 +57,7 @@ public final class MeanLocalStep<E extends Number, S extends Iterable<E>> extend
         throw FastNoSuchElementException.instance();
     }
 
-    private E untilNonNull(final Iterator<E> itty) {
+    protected E untilNonNull(final Iterator<E> itty) {
         E result = null;
         while (itty.hasNext() && null == result) {
             result = itty.next();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStep.java
@@ -54,14 +54,14 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outV;
  */
 public class MergeEdgeStep<S> extends MergeStep<S, Edge, Object> {
 
-    private static final Set allowedTokens = new LinkedHashSet(Arrays.asList(T.id, T.label, Direction.IN, Direction.OUT));
+    protected static final Set allowedTokens = new LinkedHashSet(Arrays.asList(T.id, T.label, Direction.IN, Direction.OUT));
 
     public static void validateMapInput(final Map map, final boolean ignoreTokens) {
         MergeStep.validate(map, ignoreTokens, allowedTokens, "mergeE");
     }
 
-    private Traversal.Admin<S, Object> outVTraversal = null;
-    private Traversal.Admin<S, Object> inVTraversal = null;
+    protected Traversal.Admin<S, Object> outVTraversal = null;
+    protected Traversal.Admin<S, Object> inVTraversal = null;
 
     public MergeEdgeStep(final Traversal.Admin traversal, final boolean isStart) {
         super(traversal, isStart);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeStep.java
@@ -165,7 +165,7 @@ public abstract class MergeStep<S, E, C> extends FlatMapStep<S, E> implements Mu
         return super.processNextStart();
     }
 
-    private void generateTraverser(final Object o) {
+    protected void generateTraverser(final Object o) {
         final TraverserGenerator generator = this.getTraversal().getTraverserGenerator();
         this.addStart(generator.generate(o, (Step) this, 1L));
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStep.java
@@ -44,7 +44,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class MergeVertexStep<S> extends MergeStep<S, Vertex, Map> {
 
-    private static final Set allowedTokens = new LinkedHashSet(Arrays.asList(T.id, T.label));
+    protected static final Set allowedTokens = new LinkedHashSet(Arrays.asList(T.id, T.label));
 
     public static void validateMapInput(final Map map, final boolean ignoreTokens) {
         MergeStep.validate(map, ignoreTokens, allowedTokens, "mergeV");

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinGlobalStep.java
@@ -32,7 +32,7 @@ import java.util.function.BinaryOperator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class MinGlobalStep<S extends Comparable> extends ReducingBarrierStep<S, S> {
+public class MinGlobalStep<S extends Comparable> extends ReducingBarrierStep<S, S> {
 
     public MinGlobalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinLocalStep.java
@@ -33,7 +33,7 @@ import static org.apache.tinkerpop.gremlin.util.NumberHelper.min;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class MinLocalStep<E extends Comparable, S extends Iterable<E>> extends ScalarMapStep<S, E> {
+public class MinLocalStep<E extends Comparable, S extends Iterable<E>> extends ScalarMapStep<S, E> {
 
     public MinLocalStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
@@ -35,10 +35,10 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class NoOpBarrierStep<S> extends AbstractStep<S, S> implements LocalBarrier<S> {
+public class NoOpBarrierStep<S> extends AbstractStep<S, S> implements LocalBarrier<S> {
 
-    private int maxBarrierSize;
-    private TraverserSet<S> barrier;
+    protected int maxBarrierSize;
+    protected TraverserSet<S> barrier;
 
     public NoOpBarrierStep(final Traversal.Admin traversal) {
         this(traversal, Integer.MAX_VALUE);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
@@ -52,12 +52,12 @@ import java.util.stream.Collectors;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OrderGlobalStep<S, C extends Comparable> extends CollectingBarrierStep<S> implements ComparatorHolder<S, C>, TraversalParent, ByModulating, Seedable {
+public class OrderGlobalStep<S, C extends Comparable> extends CollectingBarrierStep<S> implements ComparatorHolder<S, C>, TraversalParent, ByModulating, Seedable {
 
-    private List<Pair<Traversal.Admin<S, C>, Comparator<C>>> comparators = new ArrayList<>();
-    private MultiComparator<C> multiComparator = null;
-    private long limit = Long.MAX_VALUE;
-    private final Random random = new Random();
+    protected List<Pair<Traversal.Admin<S, C>, Comparator<C>>> comparators = new ArrayList<>();
+    protected MultiComparator<C> multiComparator = null;
+    protected long limit = Long.MAX_VALUE;
+    protected final Random random = new Random();
 
     public OrderGlobalStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -173,7 +173,7 @@ public final class OrderGlobalStep<S, C extends Comparable> extends CollectingBa
         return MemoryComputeKey.of(this.getId(), new OrderBiOperator<>(this.limit, this.multiComparator, this.random), false, true);
     }
 
-    private Optional<ProjectedTraverser<S, Object>> createProjectedTraverser(final Traverser.Admin<S> traverser) {
+    protected Optional<ProjectedTraverser<S, Object>> createProjectedTraverser(final Traverser.Admin<S> traverser) {
         // this was ProjectedTraverser<S, C> but the projection may not be C in the case of a lambda where a
         // Comparable may not be expected but rather an object that can be compared in any way given a lambda.
         // not sure why this is suddenly an issue but Intellij would not let certain tests pass without this
@@ -189,7 +189,7 @@ public final class OrderGlobalStep<S, C extends Comparable> extends CollectingBa
         return projections.size() == comparators.size() ? Optional.of(new ProjectedTraverser(traverser, projections)) : Optional.empty();
     }
 
-    private final MultiComparator<C> createMultiComparator() {
+    protected MultiComparator<C> createMultiComparator() {
         final List<Comparator<C>> list = new ArrayList<>(this.comparators.size());
         for (final Pair<Traversal.Admin<S, C>, Comparator<C>> pair : this.comparators) {
             list.add(pair.getValue1());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStep.java
@@ -46,10 +46,10 @@ import java.util.stream.Collectors;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OrderLocalStep<S, C extends Comparable> extends ScalarMapStep<S, S> implements ComparatorHolder<S, C>, ByModulating, TraversalParent, Seedable {
+public class OrderLocalStep<S, C extends Comparable> extends ScalarMapStep<S, S> implements ComparatorHolder<S, C>, ByModulating, TraversalParent, Seedable {
 
-    private List<Pair<Traversal.Admin<S, C>, Comparator<C>>> comparators = new ArrayList<>();
-    private final Random random = new Random();
+    protected List<Pair<Traversal.Admin<S, C>, Comparator<C>>> comparators = new ArrayList<>();
+    protected final Random random = new Random();
 
     public OrderLocalStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -86,7 +86,7 @@ public final class OrderLocalStep<S, C extends Comparable> extends ScalarMapStep
     /**
      * Take the collection and apply modulators removing traversers that have modulators that aren't productive.
      */
-    private List<Pair<S, List<C>>> filterAndModulate(final Collection<S> original) {
+    protected List<Pair<S, List<C>>> filterAndModulate(final Collection<S> original) {
         if (comparators.isEmpty())
             this.comparators.add(new Pair<>(new IdentityTraversal(), (Comparator) Order.asc));
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
@@ -40,12 +40,12 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class PathStep<S> extends MapStep<S, Path> implements TraversalParent, PathProcessor, ByModulating, FromToModulating {
+public class PathStep<S> extends MapStep<S, Path> implements TraversalParent, PathProcessor, ByModulating, FromToModulating {
 
-    private TraversalRing<Object, Object> traversalRing;
-    private Set<String> keepLabels;
-    private String fromLabel;
-    private String toLabel;
+    protected TraversalRing<Object, Object> traversalRing;
+    protected Set<String> keepLabels;
+    protected String fromLabel;
+    protected String toLabel;
 
     public PathStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
@@ -37,15 +37,19 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> implements TraversalParent, ByModulating {
+public class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> implements TraversalParent, ByModulating {
 
-    private final List<String> projectKeys;
-    private TraversalRing<S, E> traversalRing;
+    protected final List<String> projectKeys;
+    protected TraversalRing<S, E> traversalRing;
 
     public ProjectStep(final Traversal.Admin traversal, final String... projectKeys) {
+        this(traversal, new TraversalRing<>(), projectKeys);
+    }
+
+    public ProjectStep(final Traversal.Admin traversal, TraversalRing<S, E> traversalRing, final String... projectKeys) {
         super(traversal);
         this.projectKeys = Arrays.asList(projectKeys);
-        this.traversalRing = new TraversalRing<>();
+        this.traversalRing = traversalRing;
     }
 
     @Override
@@ -111,5 +115,9 @@ public final class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> im
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return this.getSelfAndChildRequirements();
+    }
+
+    public TraversalRing<S, E> getTraversalRing() {
+        return traversalRing;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertiesStep.java
@@ -42,6 +42,13 @@ public class PropertiesStep<E> extends FlatMapStep<Element, E> implements AutoCl
     protected final String[] propertyKeys;
     protected final PropertyType returnType;
 
+    public PropertiesStep(final Traversal.Admin traversal, final PropertyType propertyType, final Parameters parameters, final String... propertyKeys) {
+        super(traversal);
+        this.parameters = parameters;
+        this.returnType = propertyType;
+        this.propertyKeys = propertyKeys;
+    }
+
     public PropertiesStep(final Traversal.Admin traversal, final PropertyType propertyType, final String... propertyKeys) {
         super(traversal);
         this.returnType = propertyType;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyKeyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyKeyStep.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class PropertyKeyStep extends ScalarMapStep<Property, String> {
+public class PropertyKeyStep extends ScalarMapStep<Property, String> {
 
     public PropertyKeyStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
@@ -64,12 +64,16 @@ public class PropertyMapStep<K,E> extends ScalarMapStep<Element, Map<K, E>>
     protected Parameters parameters = new Parameters();
     protected TraversalRing<K, E> traversalRing;
 
-    public PropertyMapStep(final Traversal.Admin traversal, final PropertyType propertyType, final String... propertyKeys) {
+    public PropertyMapStep(final Traversal.Admin traversal, final PropertyType propertyType, TraversalRing<K, E> traversalRing, final String... propertyKeys) {
         super(traversal);
         this.propertyKeys = propertyKeys;
         this.returnType = propertyType;
         this.propertyTraversal = null;
-        this.traversalRing = new TraversalRing<>();
+        this.traversalRing = traversalRing;
+    }
+
+    public PropertyMapStep(final Traversal.Admin traversal, final PropertyType propertyType, final String... propertyKeys) {
+        this(traversal, propertyType, new TraversalRing<>(), propertyKeys);
     }
 
     public PropertyMapStep(final Traversal.Admin traversal, final int options, final PropertyType propertyType, final String... propertyKeys) {
@@ -247,5 +251,17 @@ public class PropertyMapStep<K,E> extends ScalarMapStep<Element, Map<K, E>>
             }
             this.traversalRing.reset();
         }
+    }
+
+    public int getTokens() {
+        return tokens;
+    }
+
+    public Traversal.Admin<Element, ? extends Property> getPropertyTraversal() {
+        return propertyTraversal;
+    }
+
+    public TraversalRing<K, E> getTraversalRing() {
+        return traversalRing;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyValueStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyValueStep.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class PropertyValueStep<E> extends ScalarMapStep<Property<E>, E> {
+public class PropertyValueStep<E> extends ScalarMapStep<Property<E>, E> {
 
     public PropertyValueStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
@@ -36,10 +36,10 @@ import java.util.Set;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class RangeLocalStep<S> extends ScalarMapStep<S, S> {
+public class RangeLocalStep<S> extends ScalarMapStep<S, S> {
 
-    private final long low;
-    private final long high;
+    protected final long low;
+    protected final long high;
 
     public RangeLocalStep(final Traversal.Admin traversal, final long low, final long high) {
         super(traversal);
@@ -92,7 +92,7 @@ public final class RangeLocalStep<S> extends ScalarMapStep<S, S> {
     /**
      * Extracts specified range of elements from a Map.
      */
-    private static Map applyRangeMap(final Map map, final long low, final long high) {
+    protected static Map applyRangeMap(final Map map, final long low, final long high) {
         final long capacity = (high != -1 ? high : map.size()) - low;
         final Map result = new LinkedHashMap((int) Math.min(capacity, map.size()));
         long c = 0L;
@@ -111,7 +111,7 @@ public final class RangeLocalStep<S> extends ScalarMapStep<S, S> {
     /**
      * Extracts specified range of elements from a Collection.
      */
-    private static Object applyRangeIterable(final Iterable<Object> iterable, final long low, final long high) {
+    protected static Object applyRangeIterable(final Iterable<Object> iterable, final long low, final long high) {
         // See if we only want a single item.  It is also possible that we will allow more than one item, but that the
         // incoming container is only capable of producing a single item.  In that case, we will still emit a
         // container.  This allows the result type to be predictable based on the step arguments.  It also allows us to
@@ -154,5 +154,13 @@ public final class RangeLocalStep<S> extends ScalarMapStep<S, S> {
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    public long getLow() {
+        return low;
+    }
+
+    public long getHigh() {
+        return high;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SackStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SackStep.java
@@ -28,7 +28,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SackStep<S, E> extends ScalarMapStep<S, E> {
+public class SackStep<S, E> extends ScalarMapStep<S, E> {
 
     public SackStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SampleLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SampleLocalStep.java
@@ -37,11 +37,11 @@ import java.util.Set;
  * @author Daniel Kuppitz (http://gremlin.guru)
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SampleLocalStep<S> extends ScalarMapStep<S, S> implements Seedable {
+public class SampleLocalStep<S> extends ScalarMapStep<S, S> implements Seedable {
 
-    private final Random random = new Random();
+    protected final Random random = new Random();
 
-    private final int amountToSample;
+    protected final int amountToSample;
 
     public SampleLocalStep(final Traversal.Admin traversal, final int amountToSample) {
         super(traversal);
@@ -65,7 +65,7 @@ public final class SampleLocalStep<S> extends ScalarMapStep<S, S> implements See
         }
     }
 
-    private S mapCollection(final Collection collection) {
+    protected S mapCollection(final Collection collection) {
         if (collection.size() <= this.amountToSample)
             return (S) collection;
 
@@ -77,7 +77,7 @@ public final class SampleLocalStep<S> extends ScalarMapStep<S, S> implements See
         return (S) target;
     }
 
-    private S mapMap(final Map map) {
+    protected S mapMap(final Map map) {
         if (map.size() <= this.amountToSample)
             return (S) map;
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
@@ -40,12 +40,12 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SelectOneStep<S, E> extends MapStep<S, E> implements TraversalParent, Scoping, PathProcessor, ByModulating {
+public class SelectOneStep<S, E> extends MapStep<S, E> implements TraversalParent, Scoping, PathProcessor, ByModulating {
 
-    private final Pop pop;
-    private final String selectKey;
-    private Traversal.Admin<S, E> selectTraversal = null;
-    private Set<String> keepLabels;
+    protected final Pop pop;
+    protected final String selectKey;
+    protected Traversal.Admin<S, E> selectTraversal = null;
+    protected Set<String> keepLabels;
 
     public SelectOneStep(final Traversal.Admin traversal, final Pop pop, final String selectKey) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -46,13 +46,13 @@ import java.util.Set;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implements Scoping, TraversalParent, PathProcessor, ByModulating {
+public class SelectStep<S, E> extends MapStep<S, Map<String, E>> implements Scoping, TraversalParent, PathProcessor, ByModulating {
 
-    private TraversalRing<Object, E> traversalRing = new TraversalRing<>();
-    private final Pop pop;
-    private final List<String> selectKeys;
-    private final Set<String> selectKeysSet;
-    private Set<String> keepLabels;
+    protected TraversalRing<Object, E> traversalRing = new TraversalRing<>();
+    protected final Pop pop;
+    protected final List<String> selectKeys;
+    protected final Set<String> selectKeysSet;
+    protected Set<String> keepLabels;
 
     public SelectStep(final Traversal.Admin traversal, final Pop pop, final String... selectKeys) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumGlobalStep.java
@@ -34,9 +34,9 @@ import static org.apache.tinkerpop.gremlin.util.NumberHelper.mul;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SumGlobalStep<S extends Number> extends ReducingBarrierStep<S, S> {
+public class SumGlobalStep<S extends Number> extends ReducingBarrierStep<S, S> {
 
-    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(
+    protected static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(
             TraverserRequirement.BULK,
             TraverserRequirement.OBJECT
     );

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStep.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class SumLocalStep<E extends Number, S extends Iterable<E>> extends ScalarMapStep<S, E> {
+public class SumLocalStep<E extends Number, S extends Iterable<E>> extends ScalarMapStep<S, E> {
 
     public SumLocalStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -52,7 +52,7 @@ public final class SumLocalStep<E extends Number, S extends Iterable<E>> extends
         throw FastNoSuchElementException.instance();
     }
 
-    private E untilNonNull(final Iterator<E> itty) {
+    protected E untilNonNull(final Iterator<E> itty) {
         E result = null;
         while (itty.hasNext() && null == result) {
             result = itty.next();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStep.java
@@ -34,9 +34,9 @@ import java.util.Set;
 /**
  * @author Matt Frantz (http://github.com/mhfrantz)
  */
-public final class TailLocalStep<S> extends ScalarMapStep<S, S> {
+public class TailLocalStep<S> extends ScalarMapStep<S, S> {
 
-    private final long limit;
+    protected final long limit;
 
     public TailLocalStep(final Traversal.Admin traversal, final long limit) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalFlatMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalFlatMapStep.java
@@ -33,9 +33,9 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TraversalFlatMapStep<S, E> extends FlatMapStep<S, E> implements TraversalParent {
+public class TraversalFlatMapStep<S, E> extends FlatMapStep<S, E> implements TraversalParent {
 
-    private Traversal.Admin<S, E> flatMapTraversal;
+    protected Traversal.Admin<S, E> flatMapTraversal;
 
     public TraversalFlatMapStep(final Traversal.Admin traversal, final Traversal<S, E> flatMapTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalMapStep.java
@@ -36,9 +36,9 @@ import java.util.Set;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public final class TraversalMapStep<S, E> extends MapStep<S, E> implements TraversalParent {
+public class TraversalMapStep<S, E> extends MapStep<S, E> implements TraversalParent {
 
-    private Traversal.Admin<S, E> mapTraversal;
+    protected Traversal.Admin<S, E> mapTraversal;
 
     public TraversalMapStep(final Traversal.Admin traversal, final Traversal<S, E> mapTraversal) {
         super(traversal);
@@ -83,5 +83,9 @@ public final class TraversalMapStep<S, E> extends MapStep<S, E> implements Trave
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return this.getSelfAndChildRequirements();
+    }
+
+    public Traversal.Admin<S, E> getMapTraversal() {
+        return mapTraversal;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalSelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TraversalSelectStep.java
@@ -40,12 +40,12 @@ import java.util.Set;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class TraversalSelectStep<S, E> extends MapStep<S, E> implements TraversalParent, PathProcessor, ByModulating, Scoping {
+public class TraversalSelectStep<S, E> extends MapStep<S, E> implements TraversalParent, PathProcessor, ByModulating, Scoping {
 
-    private final Pop pop;
-    private Traversal.Admin<S, E> keyTraversal;
-    private Traversal.Admin<E, E> selectTraversal = null;
-    private Set<String> keepLabels;
+    protected final Pop pop;
+    protected Traversal.Admin<S, E> keyTraversal;
+    protected Traversal.Admin<E, E> selectTraversal = null;
+    protected Set<String> keepLabels;
 
     public TraversalSelectStep(final Traversal.Admin traversal, final Pop pop, final Traversal<S, E> keyTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -43,10 +43,10 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements TraversalParent, ByModulating, PathProcessor {
+public class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements TraversalParent, ByModulating, PathProcessor {
 
-    private TraversalRing<Object, Object> traversalRing = new TraversalRing<>();
-    private Set<String> keepLabels;
+    protected TraversalRing<Object, Object> traversalRing = new TraversalRing<>();
+    protected Set<String> keepLabels;
 
     public TreeStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -143,7 +143,7 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements T
             return mutatingSeed;
         }
 
-        public static final TreeBiOperator instance() {
+        public static TreeBiOperator instance() {
             return INSTANCE;
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/UnfoldStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/UnfoldStep.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class UnfoldStep<S, E> extends FlatMapStep<S, E> {
+public class UnfoldStep<S, E> extends FlatMapStep<S, E> {
 
     public UnfoldStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -59,7 +59,7 @@ public final class UnfoldStep<S, E> extends FlatMapStep<S, E> {
         return Collections.singleton(TraverserRequirement.OBJECT);
     }
 
-    private final Iterator<E> handleArrays(final Object array) {
+    protected Iterator<E> handleArrays(final Object array) {
         if (array instanceof Object[]) {
             return new ArrayIterator<>((E[]) array);
         } else {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStep.java
@@ -40,9 +40,9 @@ import java.util.Set;
 public class VertexStep<E extends Element> extends FlatMapStep<Vertex, E> implements AutoCloseable, Configuring {
 
     protected Parameters parameters = new Parameters();
-    private final String[] edgeLabels;
-    private Direction direction;
-    private final Class<E> returnClass;
+    protected final String[] edgeLabels;
+    protected Direction direction;
+    protected final Class<E> returnClass;
 
     public VertexStep(final Traversal.Admin traversal, final Class<E> returnClass, final Direction direction, final String... edgeLabels) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStep.java
@@ -52,9 +52,9 @@ import java.util.Set;
 public class AddPropertyStep<S extends Element> extends SideEffectStep<S>
         implements Mutating<Event.ElementPropertyChangedEvent>, TraversalParent, Scoping {
 
-    private Parameters parameters = new Parameters();
-    private final VertexProperty.Cardinality cardinality;
-    private CallbackRegistry<Event.ElementPropertyChangedEvent> callbackRegistry;
+    protected Parameters parameters = new Parameters();
+    protected final VertexProperty.Cardinality cardinality;
+    protected CallbackRegistry<Event.ElementPropertyChangedEvent> callbackRegistry;
 
     public AddPropertyStep(final Traversal.Admin traversal, final VertexProperty.Cardinality cardinality, final Object keyObject, final Object valueObject) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateGlobalStep.java
@@ -45,11 +45,11 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class AggregateGlobalStep<S> extends AbstractStep<S, S> implements SideEffectCapable<Collection, Collection>, TraversalParent, ByModulating, LocalBarrier<S> {
+public class AggregateGlobalStep<S> extends AbstractStep<S, S> implements SideEffectCapable<Collection, Collection>, TraversalParent, ByModulating, LocalBarrier<S> {
 
-    private Traversal.Admin<S, Object> aggregateTraversal = null;
-    private String sideEffectKey;
-    private TraverserSet<S> barrier;
+    protected Traversal.Admin<S, Object> aggregateTraversal = null;
+    protected String sideEffectKey;
+    protected TraverserSet<S> barrier;
 
     public AggregateGlobalStep(final Traversal.Admin traversal, final String sideEffectKey) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateLocalStep.java
@@ -39,10 +39,10 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class AggregateLocalStep<S> extends SideEffectStep<S> implements SideEffectCapable<Collection, Collection>, TraversalParent, ByModulating {
+public class AggregateLocalStep<S> extends SideEffectStep<S> implements SideEffectCapable<Collection, Collection>, TraversalParent, ByModulating {
 
-    private Traversal.Admin<S, Object> storeTraversal = null;
-    private String sideEffectKey;
+    protected Traversal.Admin<S, Object> storeTraversal = null;
+    protected String sideEffectKey;
 
     public AggregateLocalStep(final Traversal.Admin traversal, final String sideEffectKey) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/FailStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/FailStep.java
@@ -57,9 +57,9 @@ public class FailStep<S> extends SideEffectStep<S> {
      * Default {@link Failure} implementation that is thrown by {@link FailStep}.
      */
     public static class FailException extends RuntimeException implements Failure {
-        private final Map<String,Object> metadata;
-        private final Traversal.Admin traversal;
-        private final Traverser.Admin traverser;
+        protected final Map<String,Object> metadata;
+        protected final Traversal.Admin traversal;
+        protected final Traverser.Admin traverser;
 
         public FailException(final Traversal.Admin traversal, final Traverser.Admin traverser,
                              final String message, final Map<String,Object> metadata) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
@@ -40,8 +40,8 @@ import java.util.Set;
  */
 public class GroupCountSideEffectStep<S, E> extends SideEffectStep<S> implements SideEffectCapable<Map<E, Long>, Map<E, Long>>, TraversalParent, ByModulating {
 
-    private Traversal.Admin<S, E> keyTraversal = null;
-    private String sideEffectKey;
+    protected Traversal.Admin<S, E> keyTraversal = null;
+    protected String sideEffectKey;
 
     public GroupCountSideEffectStep(final Traversal.Admin traversal, final String sideEffectKey) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
@@ -44,16 +44,16 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S>
+public class GroupSideEffectStep<S, K, V> extends SideEffectStep<S>
         implements SideEffectCapable<Map<K, ?>, Map<K, V>>, TraversalParent, ByModulating, ProfilingAware, Grouping<S, K, V> {
 
-    private char state = 'k';
-    private Traversal.Admin<S, K> keyTraversal;
-    private Traversal.Admin<S, V> valueTraversal;
-    private Barrier barrierStep;
-    private boolean resetBarrierForProfiling = false;
+    protected char state = 'k';
+    protected Traversal.Admin<S, K> keyTraversal;
+    protected Traversal.Admin<S, V> valueTraversal;
+    protected Barrier barrierStep;
+    protected boolean resetBarrierForProfiling = false;
     ///
-    private String sideEffectKey;
+    protected String sideEffectKey;
 
     public GroupSideEffectStep(final Traversal.Admin traversal, final String sideEffectKey) {
         super(traversal);
@@ -85,7 +85,7 @@ public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S>
         return this.valueTraversal;
     }
 
-    private void setValueTraversal(final Traversal.Admin valueTraversal) {
+    protected void setValueTraversal(final Traversal.Admin valueTraversal) {
         this.valueTraversal = this.integrateChild(convertValueTraversal(valueTraversal));
         this.barrierStep = determineBarrierStep(this.valueTraversal);
         this.getTraversal().getSideEffects().register(this.sideEffectKey, null,

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/IdentityStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/IdentityStep.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class IdentityStep<S> extends AbstractStep<S, S> {
+public class IdentityStep<S> extends AbstractStep<S, S> {
 
     public IdentityStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/InjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/InjectStep.java
@@ -24,9 +24,9 @@ import org.apache.tinkerpop.gremlin.util.iterator.ArrayIterator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class InjectStep<S> extends StartStep<S> {
+public class InjectStep<S> extends StartStep<S> {
 
-    private final S[] injections;
+    protected final S[] injections;
 
     @SafeVarargs
     public InjectStep(final Traversal.Admin traversal, final S... injections) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/IoStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/IoStep.java
@@ -58,10 +58,10 @@ import java.util.stream.Collectors;
  */
 public class IoStep<S> extends AbstractStep<S,S> implements ReadWriting {
 
-    private Parameters parameters = new Parameters();
-    private boolean first = true;
-    private String file;
-    private Mode mode = Mode.UNSET;
+    protected Parameters parameters = new Parameters();
+    protected boolean first = true;
+    protected String file;
+    protected Mode mode = Mode.UNSET;
 
     public IoStep(final Traversal.Admin traversal, final String file) {
         super(traversal);
@@ -141,7 +141,7 @@ public class IoStep<S> extends AbstractStep<S,S> implements ReadWriting {
      * Builds a {@link GraphReader} instance to use. Attempts to detect the file format to be read using the file
      * extension or simply uses configurations provided by the user on the parameters given to the step.
      */
-    private GraphReader constructReader() {
+    protected GraphReader constructReader() {
         final Object objectOrClass = parameters.get(IO.reader, this::detectFileType).get(0);
         if (objectOrClass instanceof GraphReader)
             return (GraphReader) objectOrClass;
@@ -175,7 +175,7 @@ public class IoStep<S> extends AbstractStep<S,S> implements ReadWriting {
      * Builds a {@link GraphWriter} instance to use. Attempts to detect the file format to be write using the file
      * extension or simply uses configurations provided by the user on the parameters given to the step.
      */
-    private GraphWriter constructWriter() {
+    protected GraphWriter constructWriter() {
         final Object objectOrClass = parameters.get(IO.writer, this::detectFileType).get(0);
         if (objectOrClass instanceof GraphWriter)
             return (GraphWriter) objectOrClass;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/LambdaSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/LambdaSideEffectStep.java
@@ -28,9 +28,9 @@ import java.util.function.Consumer;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LambdaSideEffectStep<S> extends SideEffectStep<S> implements LambdaHolder {
+public class LambdaSideEffectStep<S> extends SideEffectStep<S> implements LambdaHolder {
 
-    private final Consumer<Traverser<S>> consumer;
+    protected final Consumer<Traverser<S>> consumer;
 
     public LambdaSideEffectStep(final Traversal.Admin traversal, final Consumer<Traverser<S>> consumer) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileSideEffectStep.java
@@ -32,11 +32,11 @@ import java.util.function.Supplier;
 /**
  * @author Bob Briody (http://bobbriody.com)
  */
-public final class ProfileSideEffectStep<S> extends SideEffectStep<S> implements SideEffectCapable<DefaultTraversalMetrics, DefaultTraversalMetrics>, GraphComputing {
+public class ProfileSideEffectStep<S> extends SideEffectStep<S> implements SideEffectCapable<DefaultTraversalMetrics, DefaultTraversalMetrics>, GraphComputing {
     public static final String DEFAULT_METRICS_KEY = Graph.Hidden.hide("metrics");
 
-    private String sideEffectKey;
-    private boolean onGraphComputer = false;
+    protected String sideEffectKey;
+    protected boolean onGraphComputer = false;
 
     public ProfileSideEffectStep(final Traversal.Admin traversal, final String sideEffectKey) {
         super(traversal);
@@ -77,7 +77,7 @@ public final class ProfileSideEffectStep<S> extends SideEffectStep<S> implements
         return start;
     }
 
-    private DefaultTraversalMetrics getTraversalMetricsFromSideEffects() {
+    protected DefaultTraversalMetrics getTraversalMetricsFromSideEffects() {
         return (DefaultTraversalMetrics) this.getTraversal().getSideEffects().get(this.sideEffectKey);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
@@ -38,11 +38,11 @@ import java.util.function.BiFunction;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SackValueStep<S, A, B> extends AbstractStep<S, S> implements TraversalParent, ByModulating, LambdaHolder {
+public class SackValueStep<S, A, B> extends AbstractStep<S, S> implements TraversalParent, ByModulating, LambdaHolder {
 
-    private Traversal.Admin<S, B> sackTraversal = null;
+    protected Traversal.Admin<S, B> sackTraversal = null;
 
-    private BiFunction<A, B, A> sackFunction;
+    protected BiFunction<A, B, A> sackFunction;
 
     public SackValueStep(final Traversal.Admin traversal, final BiFunction<A, B, A> sackFunction) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SideEffectCapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SideEffectCapStep.java
@@ -37,9 +37,9 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SideEffectCapStep<S, E> extends SupplyingBarrierStep<S, E> {
+public class SideEffectCapStep<S, E> extends SupplyingBarrierStep<S, E> {
 
-    private List<String> sideEffectKeys;
+    protected List<String> sideEffectKeys;
     public transient Map<String, SideEffectCapable<Object, E>> sideEffectCapableSteps;
 
     public SideEffectCapStep(final Traversal.Admin traversal, final String sideEffectKey, final String... sideEffectKeys) {
@@ -99,7 +99,7 @@ public final class SideEffectCapStep<S, E> extends SupplyingBarrierStep<S, E> {
             return (E) this.getMapOfSideEffects();
     }
 
-    private Map<String, Object> getMapOfSideEffects() {
+    protected Map<String, Object> getMapOfSideEffects() {
         final TraversalSideEffects temp = this.getTraversal().getSideEffects();
         final Map<String, Object> sideEffects = new HashMap<>();
         for (final String sideEffectKey : this.sideEffectKeys) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphStep.java
@@ -45,19 +45,19 @@ import java.util.Set;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SubgraphStep extends SideEffectStep<Edge> implements SideEffectCapable {
+public class SubgraphStep extends SideEffectStep<Edge> implements SideEffectCapable {
 
-    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(
+    protected static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(
             TraverserRequirement.OBJECT,
             TraverserRequirement.SIDE_EFFECTS
     );
 
-    private Graph subgraph;
-    private String sideEffectKey;
-    private Graph.Features.VertexFeatures parentGraphFeatures;
-    private boolean subgraphSupportsMetaProperties = false;
+    protected Graph subgraph;
+    protected String sideEffectKey;
+    protected Graph.Features.VertexFeatures parentGraphFeatures;
+    protected boolean subgraphSupportsMetaProperties = false;
 
-    private static final Map<String, Object> DEFAULT_CONFIGURATION = new HashMap<String, Object>() {{
+    protected static final Map<String, Object> DEFAULT_CONFIGURATION = new HashMap<String, Object>() {{
         put(Graph.GRAPH, "org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph"); // hard coded because TinkerGraph is not part of gremlin-core
     }};
 
@@ -110,7 +110,7 @@ public final class SubgraphStep extends SideEffectStep<Edge> implements SideEffe
 
     ///
 
-    private Vertex getOrCreate(final Vertex vertex) {
+    protected Vertex getOrCreate(final Vertex vertex) {
         final Iterator<Vertex> vertexIterator = subgraph.vertices(vertex.id());
 
         try {
@@ -135,7 +135,7 @@ public final class SubgraphStep extends SideEffectStep<Edge> implements SideEffe
         return subgraphVertex;
     }
 
-    private void addEdgeToSubgraph(final Edge edge) {
+    protected void addEdgeToSubgraph(final Edge edge) {
         final Iterator<Edge> edgeIterator = subgraph.edges(edge.id());
 
         try {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TraversalSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TraversalSideEffectStep.java
@@ -33,9 +33,9 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TraversalSideEffectStep<S> extends SideEffectStep<S> implements TraversalParent {
+public class TraversalSideEffectStep<S> extends SideEffectStep<S> implements TraversalParent {
 
-    private Traversal.Admin<S, ?> sideEffectTraversal;
+    protected Traversal.Admin<S, ?> sideEffectTraversal;
 
     public TraversalSideEffectStep(final Traversal.Admin traversal, final Traversal<S, ?> sideEffectTraversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
@@ -41,11 +41,11 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements SideEffectCapable<Tree, Tree>, TraversalParent, ByModulating, PathProcessor {
+public class TreeSideEffectStep<S> extends SideEffectStep<S> implements SideEffectCapable<Tree, Tree>, TraversalParent, ByModulating, PathProcessor {
 
-    private TraversalRing<Object, Object> traversalRing;
-    private String sideEffectKey;
-    private Set<String> keepLabels;
+    protected TraversalRing<Object, Object> traversalRing;
+    protected String sideEffectKey;
+    protected Set<String> keepLabels;
 
     public TreeSideEffectStep(final Traversal.Admin traversal, final String sideEffectKey) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/CollectingBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/CollectingBarrierStep.java
@@ -42,8 +42,8 @@ import java.util.function.BinaryOperator;
 public abstract class CollectingBarrierStep<S> extends AbstractStep<S, S> implements Barrier<TraverserSet<S>> {
 
     protected TraverserSet<S> traverserSet;
-    private int maxBarrierSize;
-    private boolean barrierConsumed = false;
+    protected int maxBarrierSize;
+    protected boolean barrierConsumed = false;
 
     public CollectingBarrierStep(final Traversal.Admin traversal) {
         this(traversal, Integer.MAX_VALUE);
@@ -144,5 +144,9 @@ public abstract class CollectingBarrierStep<S> extends AbstractStep<S, S> implem
     @Override
     public MemoryComputeKey<TraverserSet<S>> getMemoryComputeKey() {
         return MemoryComputeKey.of(this.getId(), (BinaryOperator) Operator.addAll, false, true);
+    }
+
+    public int getMaxBarrierSize() {
+        return maxBarrierSize;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
@@ -32,7 +32,7 @@ import java.util.NoSuchElementException;
  */
 public abstract class ComputerAwareStep<S, E> extends AbstractStep<S, E> implements GraphComputing {
 
-    private Iterator<Traverser.Admin<E>> previousIterator = EmptyIterator.instance();
+    protected Iterator<Traverser.Admin<E>> previousIterator = EmptyIterator.instance();
 
     public ComputerAwareStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ProfileStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ProfileStep.java
@@ -35,9 +35,9 @@ import java.util.function.BinaryOperator;
 /**
  * @author Bob Briody (http://bobbriody.com)
  */
-public final class ProfileStep<S> extends AbstractStep<S, S> implements MemoryComputing<MutableMetrics> {  // pseudo GraphComputing but local traversals are "GraphComputing"
-    private MutableMetrics metrics;
-    private boolean onGraphComputer = false;
+public class ProfileStep<S> extends AbstractStep<S, S> implements MemoryComputing<MutableMetrics> {  // pseudo GraphComputing but local traversals are "GraphComputing"
+    protected MutableMetrics metrics;
+    protected boolean onGraphComputer = false;
 
     public ProfileStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -90,7 +90,7 @@ public final class ProfileStep<S> extends AbstractStep<S, S> implements MemoryCo
         return this.starts.next();
     }
 
-    private void initializeIfNeeded() {
+    protected void initializeIfNeeded() {
         if (null == this.metrics) {
             this.onGraphComputer = TraversalHelper.onGraphComputer(this.getTraversal());
             this.metrics = new MutableMetrics(this.getPreviousStep().getId(), this.getPreviousStep().toString());
@@ -142,7 +142,7 @@ public final class ProfileStep<S> extends AbstractStep<S, S> implements MemoryCo
             return metricsA;
         }
 
-        public static final ProfileBiOperator instance() {
+        public static ProfileBiOperator instance() {
             return INSTANCE;
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ReducingBarrierStep.java
@@ -51,7 +51,7 @@ public abstract class ReducingBarrierStep<S, E> extends AbstractStep<S, E> imple
     protected BinaryOperator<E> reducingBiOperator;
     protected boolean hasProcessedOnce = false;
 
-    private E seed = (E) NON_EMITTING_SEED;
+    protected E seed = (E) NON_EMITTING_SEED;
 
     public ReducingBarrierStep(final Traversal.Admin traversal) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/RequirementsStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/RequirementsStep.java
@@ -31,9 +31,9 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class RequirementsStep<S> extends AbstractStep<S, S> {
+public class RequirementsStep<S> extends AbstractStep<S, S> {
 
-    private final Set<TraverserRequirement> requirements;
+    protected final Set<TraverserRequirement> requirements;
 
     public RequirementsStep(final Traversal.Admin traversal, final Set<TraverserRequirement> requirements) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/SupplyingBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/SupplyingBarrierStep.java
@@ -35,7 +35,7 @@ import java.util.function.BinaryOperator;
  */
 public abstract class SupplyingBarrierStep<S, E> extends AbstractStep<S, E> implements Barrier<Boolean> {
 
-    private boolean done = false;
+    protected boolean done = false;
 
     public SupplyingBarrierStep(final Traversal.Admin traversal) {
         super(traversal);


### PR DESCRIPTION
In this commit the next changes are done for the Step classes:
- Make private fields as protected
- Allow to overwride any method by removing `final` keyword
- Allow to extend any Step class by removing `final` keyword
- Add getter methods for some fields which might be useful for Step information retrieval

Issue: https://issues.apache.org/jira/browse/TINKERPOP-2927
Discussion: https://lists.apache.org/thread/vjbjh29kwjhd5lcmkqqqqrhw7rw2ynh9
