### PR TITLE
Add PropertyMapStep getters and a constructor with TraversalRing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,7 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-5-6, 3.5.6>>.
 
-* Refactored `PropertyMapStep` to improve extensibility by providers.
+* Refactored `PropertyMapStep` to improve extensibility by providers. Removed `final` class declaration for `ProjectStep` and `CoalesceStep`.
 * Fixed bug in grammar that prevented declaration of a `Map` key named `new` without quotes.
 * Fixed bug in grammar that prevented parsing of `Map` key surrounded by parenthesis which is allowable in Groovy.
 * Fixed bug in `GroovyTranslator` that surrounded `String` keys with parenthesis for `Map` when not necessary.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PropertyMapStep.java
@@ -40,7 +40,6 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -64,12 +63,16 @@ public class PropertyMapStep<K,E> extends ScalarMapStep<Element, Map<K, E>>
     protected Parameters parameters = new Parameters();
     protected TraversalRing<K, E> traversalRing;
 
-    public PropertyMapStep(final Traversal.Admin traversal, final PropertyType propertyType, final String... propertyKeys) {
+    public PropertyMapStep(final Traversal.Admin traversal, final PropertyType propertyType, TraversalRing<K, E> traversalRing, final String... propertyKeys) {
         super(traversal);
         this.propertyKeys = propertyKeys;
         this.returnType = propertyType;
         this.propertyTraversal = null;
-        this.traversalRing = new TraversalRing<>();
+        this.traversalRing = traversalRing;
+    }
+
+    public PropertyMapStep(final Traversal.Admin traversal, final PropertyType propertyType, final String... propertyKeys) {
+        this(traversal, propertyType, new TraversalRing<>(), propertyKeys);
     }
 
     public PropertyMapStep(final Traversal.Admin traversal, final int options, final PropertyType propertyType, final String... propertyKeys) {
@@ -247,5 +250,13 @@ public class PropertyMapStep<K,E> extends ScalarMapStep<Element, Map<K, E>>
             }
             this.traversalRing.reset();
         }
+    }
+
+    public Traversal.Admin<Element, ? extends Property> getPropertyTraversal() {
+        return propertyTraversal;
+    }
+
+    public TraversalRing<K, E> getTraversalRing() {
+        return traversalRing;
     }
 }


### PR DESCRIPTION
_This PR implements part of #2027 . Close this PR without merging in case #2027 is merged._

The intention of this PR is to provide getter methods to `PropertyMapStep` along with a constructor which accepts `TraversalRing` which is needed for https://github.com/JanusGraph/janusgraph/issues/2444 . This will help creating a replacement step for original PropertyMapStep with optimizations in place. 

Related issue: https://issues.apache.org/jira/browse/TINKERPOP-2927