### PR TITLE
Make ProjectStep extensible

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
@@ -37,15 +37,19 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> implements TraversalParent, ByModulating {
+public class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> implements TraversalParent, ByModulating {
 
     private final List<String> projectKeys;
     private TraversalRing<S, E> traversalRing;
 
     public ProjectStep(final Traversal.Admin traversal, final String... projectKeys) {
+        this(traversal, new TraversalRing<>(), projectKeys);
+    }
+
+    public ProjectStep(final Traversal.Admin traversal, final TraversalRing<S, E> traversalRing, final String... projectKeys) {
         super(traversal);
         this.projectKeys = Arrays.asList(projectKeys);
-        this.traversalRing = new TraversalRing<>();
+        this.traversalRing = traversalRing;
     }
 
     @Override
@@ -111,5 +115,9 @@ public final class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> im
     @Override
     public Set<TraverserRequirement> getRequirements() {
         return this.getSelfAndChildRequirements();
+    }
+
+    public TraversalRing<S, E> getTraversalRing() {
+        return traversalRing;
     }
 }


### PR DESCRIPTION
_This PR implements part of https://github.com/apache/tinkerpop/pull/2027 . Close this PR without merging in case https://github.com/apache/tinkerpop/pull/2027 is merged._

The intention of this PR is to provide getter methods to ProjectStep along with a constructor which accepts TraversalRing which is needed for https://github.com/JanusGraph/janusgraph/issues/3559 . This will help creating a replacement step for original ProjectStep with optimizations in place.

Related issue: https://issues.apache.org/jira/browse/TINKERPOP-2927