### PR TITLE
Make CoalesceStep extensible

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
@@ -35,7 +35,7 @@ import java.util.Set;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class CoalesceStep<S, E> extends FlatMapStep<S, E> implements TraversalParent {
+public class CoalesceStep<S, E> extends FlatMapStep<S, E> implements TraversalParent {
 
     private List<Traversal.Admin<S, E>> coalesceTraversals;
 


### PR DESCRIPTION
_This PR implements part of https://github.com/apache/tinkerpop/pull/2027 . Close this PR without merging in case https://github.com/apache/tinkerpop/pull/2027 is merged._

This PR will make possible to extend `CoalesceStep` which is needed for https://github.com/JanusGraph/janusgraph/issues/2996 . This will help creating a replacement step for original CoalesceStep with optimizations in place.

Related issue: https://issues.apache.org/jira/browse/TINKERPOP-2927