### PR TITLE
TINKERPOP-2925 mergeE() in javascript producing an error

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ This release also includes changes from <<release-3-5-6, 3.5.6>>.
 * Fixed bug in `GroovyTranslator` that surrounded `String` keys with parenthesis for `Map` when not necessary.
 * Added support to the grammar allowing `List` and `Map` key declarations for `Map` entries.
 * Fixed `Direction` enum bug in `gremlin-javascript` where `Direction.from_` and `Direction.to` was not properly aliased to `Direction.OUT` and `Direction.IN`
+* Fixed `Direction` enum in `gremlin-python` where `Direction.from_` and `Direction.to` were not added, and they can now be used instead of defining `from_=Direction.OUT` and `to=Direction.IN`
 * Improved performance of comparison (equals) between not compatible types and nulls.
 
 [[release-3-6-2]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ This release also includes changes from <<release-3-5-6, 3.5.6>>.
 * Fixed bug in grammar that prevented parsing of `Map` key surrounded by parenthesis which is allowable in Groovy.
 * Fixed bug in `GroovyTranslator` that surrounded `String` keys with parenthesis for `Map` when not necessary.
 * Added support to the grammar allowing `List` and `Map` key declarations for `Map` entries.
+* Fixed `Direction` enum bug in `gremlin-javascript` where `Direction.from_` and `Direction.to` was not properly aliased to `Direction.OUT` and `Direction.IN`
 * Improved performance of comparison (equals) between not compatible types and nulls.
 
 [[release-3-6-2]]

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -2076,8 +2076,6 @@ from gremlin_python.process.traversal import Scope
 from gremlin_python.process.traversal import Barrier
 from gremlin_python.process.traversal import Bindings
 from gremlin_python.process.traversal import WithOptions
-from_ = Direction.OUT
-to = Direction.IN
 ----
 
 These can be used analogously to how they are used in Gremlin-Java.

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -473,6 +473,22 @@ function toEnum(typeName, keys) {
   return result;
 }
 
+const directionAlias = {
+  from_: 'out',
+  to: 'in',
+};
+
+// for direction enums, maps the same EnumValue object to the enum aliases after creating them
+function toDirectionEnum(typeName, keys) {
+  const result = toEnum(typeName, keys);
+  Object.keys(directionAlias).forEach((k) => {
+    if (directionAlias.hasOwnProperty(k)) {
+      result[k] = result[directionAlias[k]];
+    }
+  });
+  return result;
+}
+
 class EnumValue {
   constructor(typeName, elementName) {
     this.typeName = typeName;
@@ -496,7 +512,7 @@ module.exports = {
   barrier: toEnum('Barrier', 'normSack'),
   cardinality: toEnum('Cardinality', 'list set single'),
   column: toEnum('Column', 'keys values'),
-  direction: toEnum('Direction', 'BOTH IN OUT from_ to'),
+  direction: toDirectionEnum('Direction', 'BOTH IN OUT from_ to'),
   graphSONVersion: toEnum('GraphSONVersion', 'V1_0 V2_0 V3_0'),
   gryoVersion: toEnum('GryoVersion', 'V1_0 V3_0'),
   merge: toEnum('Merge', 'onCreate onMatch outV inV'),

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -482,9 +482,7 @@ const directionAlias = {
 function toDirectionEnum(typeName, keys) {
   const result = toEnum(typeName, keys);
   Object.keys(directionAlias).forEach((k) => {
-    if (directionAlias.hasOwnProperty(k)) {
-      result[k] = result[directionAlias[k]];
-    }
+    result[k] = result[directionAlias[k]];
   });
   return result;
 }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -348,9 +348,7 @@ function toT(value) {
 function toDirection(value) {
   // swap Direction.from alias
   if (value === 'from')
-    return direction["out"];
-  else if (value === 'to')
-    return direction["in"];
+    return direction["from_"];
   else
     return direction[value.toLowerCase()];
 }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
@@ -63,6 +63,23 @@ describe('Traversal', function () {
       assert.strictEqual(bytecode.stepInstructions[2][2].elementName, 'desc');
     });
 
+    it('should add steps with Direction aliases from_ and to properly mapped to OUT and IN', function () {
+      const g = anon.traversal().withGraph(new graph.Graph());
+      const bytecode = g.V().to(t.direction.from_, 'knows').to(t.direction.in, 'created').getBytecode();
+      assert.ok(bytecode);
+      assert.strictEqual(bytecode.sourceInstructions.length, 0);
+      assert.strictEqual(bytecode.stepInstructions.length, 3);
+      assert.strictEqual(bytecode.stepInstructions[0][0], 'V');
+      assert.strictEqual(bytecode.stepInstructions[1][0], 'to');
+      assert.strictEqual(typeof bytecode.stepInstructions[1][1], 'object');
+      assert.strictEqual(bytecode.stepInstructions[1][1].typeName, 'Direction');
+      assert.strictEqual(bytecode.stepInstructions[1][1].elementName, 'OUT');
+      assert.strictEqual(bytecode.stepInstructions[1][2], 'knows');
+      assert.strictEqual(bytecode.stepInstructions[2][1].typeName, 'Direction');
+      assert.strictEqual(bytecode.stepInstructions[2][1].elementName, 'IN');
+      assert.strictEqual(bytecode.stepInstructions[2][2], 'created');
+    });
+
     it('should configure OptionStrategy for with_()', function () {
       const g = new graph.Graph().traversal();
       const bytecode = g.with_('x','test').with_('y').V().getBytecode();

--- a/gremlin-python/src/main/python/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/traversal.py
@@ -165,13 +165,23 @@ Column = Enum('Column', ' keys values')
 statics.add_static('keys', Column.keys)
 statics.add_static('values', Column.values)
 
-Direction = Enum('Direction', ' BOTH IN OUT')
+# alias from_ and to
+Direction = Enum(
+    value='Direction',
+    names=[
+        ('BOTH', 'BOTH'),
+        ('IN', 'IN'),
+        ('OUT', 'OUT'),
+        ('from_', "OUT"),
+        ('to', 'IN'),
+    ],
+)
 
 statics.add_static('OUT', Direction.OUT)
 statics.add_static('IN', Direction.IN)
 statics.add_static('BOTH', Direction.BOTH)
-statics.add_static('from_', Direction.IN)
-statics.add_static('to', Direction.BOTH)
+statics.add_static('from_', Direction.OUT)
+statics.add_static('to', Direction.IN)
 
 GraphSONVersion = Enum('GraphSONVersion', ' V1_0 V2_0 V3_0')
 

--- a/gremlin-python/src/main/python/radish/feature_steps.py
+++ b/gremlin-python/src/main/python/radish/feature_steps.py
@@ -33,13 +33,6 @@ label = __.label
 inV = __.inV
 project = __.project
 tail = __.tail
-direction = {
-    "OUT": Direction.OUT,
-    "IN": Direction.IN,
-    "BOTH": Direction.BOTH,
-    "from_": Direction.OUT,
-    "to": Direction.IN,
-}
 
 ignores = []
 
@@ -237,7 +230,7 @@ def _convert(val, ctx):
     elif isinstance(val, str) and re.match(r"^t\[.*\]$", val):  # parse instance of T enum
         return T[val[2:-1]]
     elif isinstance(val, str) and re.match(r"^D\[.*\]$", val):  # parse instance of Direction enum
-        return direction[__alias_direction(val[2:-1])]
+        return Direction[__alias_direction(val[2:-1])]
     elif isinstance(val, str) and re.match(r"^M\[.*\]$", val):  # parse instance of Merge enum
         return Merge[__alias_merge(val[2:-1])]
     elif isinstance(val, str) and re.match(r"^null$", val):  # parse null to None

--- a/gremlin-python/src/main/python/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/python/tests/process/test_traversal.py
@@ -27,7 +27,7 @@ from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.structure.graph import Graph
 from gremlin_python.process.anonymous_traversal import traversal
-from gremlin_python.process.traversal import P
+from gremlin_python.process.traversal import P, Direction
 from gremlin_python.process.traversal import Binding, Bindings
 from gremlin_python.process.graph_traversal import __
 
@@ -79,6 +79,20 @@ class TestTraversal(object):
         assert Binding('b', 'created') == bytecode.step_instructions[1][1]
         assert 'binding[b=created]' == str(bytecode.step_instructions[1][1])
         assert isinstance(hash(bytecode.step_instructions[1][1]), int)
+        ###
+        bytecode = g.V().to(Direction.from_, 'knows').to(Direction.to, 'created').bytecode
+        assert 0 == len(bytecode.bindings.keys())
+        assert 0 == len(bytecode.source_instructions)
+        assert 3 == len(bytecode.step_instructions)
+        assert "V" == bytecode.step_instructions[0][0]
+        assert "to" == bytecode.step_instructions[1][0]
+        assert Direction.OUT == bytecode.step_instructions[1][1]
+        assert "knows" == bytecode.step_instructions[1][2]
+        assert Direction.IN == bytecode.step_instructions[2][1]
+        assert "created" == bytecode.step_instructions[2][2]
+        assert 1 == len(bytecode.step_instructions[0])
+        assert 3 == len(bytecode.step_instructions[1])
+        assert 3 == len(bytecode.step_instructions[2])
 
     def test_P(self):
         # verify that the order of operations is respected

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV1.py
@@ -26,8 +26,6 @@ from gremlin_python.structure.graph import Vertex, Edge, Property, VertexPropert
 from gremlin_python.structure.io.graphbinaryV1 import GraphBinaryWriter, GraphBinaryReader
 from gremlin_python.process.traversal import Barrier, Binding, Bytecode, Merge, Direction
 
-from_ = Direction.OUT
-
 
 class TestGraphBinaryReader(object):
     graphbinary_reader = GraphBinaryReader()
@@ -189,7 +187,7 @@ class TestGraphSONWriter(object):
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
         assert x == output
 
-        x = from_
+        x = Direction.from_
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
         assert x == output
 

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
@@ -36,8 +36,6 @@ from gremlin_python.process.traversal import P, Merge, Operator, Order, Barrier,
 from gremlin_python.process.strategies import SubgraphStrategy
 from gremlin_python.process.graph_traversal import __
 
-from_ = Direction.OUT
-
 
 class TestGraphSONReader(object):
     graphson_reader = GraphSONReader()
@@ -325,7 +323,7 @@ class TestGraphSONWriter(object):
         assert {"@type": "g:Operator", "@value": "sum"} == json.loads(self.graphson_writer.write_object(Operator.sum_))
         assert {"@type": "g:Operator", "@value": "sumLong"} == json.loads(self.graphson_writer.write_object(Operator.sum_long))
         assert {"@type": "g:Direction", "@value": "OUT"} == json.loads(self.graphson_writer.write_object(Direction.OUT))
-        assert {"@type": "g:Direction", "@value": "OUT"} == json.loads(self.graphson_writer.write_object(from_))
+        assert {"@type": "g:Direction", "@value": "OUT"} == json.loads(self.graphson_writer.write_object(Direction.from_))
 
     def test_P(self):
         result = {'@type': 'g:P',

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV3d0.py
@@ -36,8 +36,6 @@ from gremlin_python.process.traversal import P, Merge, Barrier, Order, Operator,
 from gremlin_python.process.strategies import SubgraphStrategy
 from gremlin_python.process.graph_traversal import __
 
-from_ = Direction.OUT
-
 
 class TestGraphSONReader(object):
     graphson_reader = GraphSONReader()
@@ -385,7 +383,7 @@ class TestGraphSONWriter(object):
         assert {"@type": "g:Operator", "@value": "sum"} == json.loads(self.graphson_writer.write_object(Operator.sum_))
         assert {"@type": "g:Operator", "@value": "sumLong"} == json.loads(self.graphson_writer.write_object(Operator.sum_long))
         assert {"@type": "g:Direction", "@value": "OUT"} == json.loads(self.graphson_writer.write_object(Direction.OUT))
-        assert {"@type": "g:Direction", "@value": "OUT"} == json.loads(self.graphson_writer.write_object(from_))
+        assert {"@type": "g:Direction", "@value": "OUT"} == json.loads(self.graphson_writer.write_object(Direction.from_))
 
     def test_P(self):
         result = {'@type': 'g:P',


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2925

Issue in gremlin-javascript arose due to Direction aliases `from_` and `to` not properly returning `Direction.OUT` and `Direction.IN`.

Also found similar issue in gremlin-python, where `Direction.from_` and `Direction.to` were not added to the `Direction` enum. They can now be used directly without the need to declare `from_ = Direction.OUT` and `to = Direction.IN`.

The existing Gherkin test as `g_mergeEXlabel_knows_out_marko_in_vadasX_aliased_direction` covers the case, although customized alias maps in feature-steps masked the issue in python and javascript, which are now removed.

This issue doesn't seem to appear in gremlin-go and gremlin-dotnet. 
