### PR TITLE
Improve Java CodeQl Reliability

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'java', 'javascript', 'python' ]
+        language: [ 'go', 'javascript', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
@@ -97,3 +97,34 @@ jobs:
         uses: github/codeql-action/analyze@v2
         with:
           category: "/language:csharp"
+
+  # Java is run as a separate job as the autobuild for Java is prone to random timeout failures
+  analyze_java:
+    name: Analyze Java
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: 'java'
+
+      - run: |
+          echo "Build Java"
+          mvn clean package -B -V -e \
+          -pl -:gremlin-javascript,-:gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlin-go,-:gremlin-python,-:gremlin-language,-:gremlint \
+          -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Dspotbugs.skip -Denforcer.skip -Dmaven.javadoc.skip \
+          -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true -Dspotless.check.skip=true
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:java"


### PR DESCRIPTION
I think many of us have observed many random CI failures stemming from Java CodeQL. In my observations these failures have always been during the autobuild phase (typically when trying to load the antlr runtime as part of gremlin-language). This PR switches Java codeQL to use a manual build instruction instead and restricts it to only building gremlin-core, gremlin-groovy, gremlin-driver, gremlin-server, and tinkergraph-gremlin.

I believe this will resolve the unreliable build failures while retaining the existing vulnerability scanning.