### PR TITLE
Remove final declaration for RepeatStep

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-5-6, 3.5.6>>.
 
 * Fixed bug in `element()` when traversing from edges where bulking was enabled.
-* Refactored `PropertyMapStep` to improve extensibility by providers. Removed `final` class declaration for `ProjectStep` and `CoalesceStep`.
+* Refactored `PropertyMapStep` to improve extensibility by providers. Removed `final` class declaration for `ProjectStep`, `CoalesceStep`, and `RepeatStep`.
 * Fixed bug in grammar that prevented declaration of a `Map` key named `new` without quotes.
 * Fixed bug in grammar that prevented parsing of `Map` key surrounded by parenthesis which is allowable in Groovy.
 * Fixed bug in `GroovyTranslator` that surrounded `String` keys with parenthesis for `Map` when not necessary.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
@@ -38,7 +38,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements TraversalParent {
+public class RepeatStep<S> extends ComputerAwareStep<S, S> implements TraversalParent {
 
     private Traversal.Admin<S, S> repeatTraversal = null;
     private Traversal.Admin<S, ?> untilTraversal = null;
@@ -336,4 +336,7 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
         }
     }
 
+    public String getLoopName() {
+        return loopName;
+    }
 }


### PR DESCRIPTION
This PR will make possible to extend RepeatStep which might be potentially needed for https://github.com/JanusGraph/janusgraph/issues/3733  . This will help creating a replacement step for original RepeatStep with optimizations in place.

Related issue: https://issues.apache.org/jira/browse/TINKERPOP-2927