### PR TITLE
[TINKERPOP-2934] Shrink the content of ObjectWritable.toString()

### DIFF
--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritable.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritable.java
@@ -32,7 +32,9 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.ConcurrentModificationException;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -61,6 +63,29 @@ public final class ObjectWritable<T> implements WritableComparable<ObjectWritabl
         this.t = t;
     }
 
+    /**
+     * Shrink the content to display for both Collection and Map
+     * @return
+     */
+    private String shrinkedToString() {
+        int s = 0;
+        // handle Collection and Map
+        if (this.t instanceof Collection) {
+            Collection c = (Collection)t;
+            s = c.size();
+        } else if (this.t instanceof Map) {
+            Map m = (Map)t;
+            s = m.size();
+        }
+        if (s > 0) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(this.t.getClass().toString()).append("@size=").append(s);
+            return sb.toString();
+        }
+        // fallback
+        return Objects.toString(this.t);
+    }
+
     @Override
     public String toString() {
         // Spark's background logging apparently tries to log a `toString()` of certain objects while they're being
@@ -69,7 +94,7 @@ public final class ObjectWritable<T> implements WritableComparable<ObjectWritabl
         final int maxAttempts = 5;
         for (int i = maxAttempts; ;) {
             try {
-                return Objects.toString(this.t);
+                return shrinkedToString();
             }
             catch (ConcurrentModificationException cme) {
                 if (--i > 0) {

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritableTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritableTest.java
@@ -21,6 +21,9 @@ package org.apache.tinkerpop.gremlin.hadoop.structure.io;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -45,5 +48,16 @@ public class ObjectWritableTest {
         assertEquals(0, ObjectWritable.empty().compareTo(object));
         assertEquals(0, object.compareTo(ObjectWritable.empty()));
         assertEquals(0, object.compareTo(object));
+    }
+
+    @Test
+    public void shouldDumpStringSize() {
+        Map<String, String> content = new HashMap();
+        content.put("a", "123456");
+        content.put("b", "567890");
+        final ObjectWritable object = new ObjectWritable(content);
+        String f = object.toString();
+        assertTrue(f.startsWith(content.getClass().toString()));
+        assertTrue(f.endsWith(content.size()+""));
     }
 }


### PR DESCRIPTION
Reduce the toString() of ObjectWritable to avoid OOM for running OLAP queries on Spark.