### PR TITLE
TINKERPOP-2731 Bump Spark to 3.3.2.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ This release also includes changes from <<release-3-6-XXX, 3.6.XXX>>.
 * Removed deprecated `getInstance()` method for grammar `Visitor` implementations.
 * Bumped Groovy to 4.0.9.
 * Bumped GMavenPlus to 2.1.0.
+* Bumped Spark to 3.3.2.
 
 == TinkerPop 3.6.0 (Tinkerheart)
 

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@ limitations under the License.
         <netty.version>4.1.86.Final</netty.version>
         <slf4j.version>1.7.25</slf4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <spark.version>3.2.1</spark.version>
+        <spark.version>3.3.2</spark.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -74,6 +74,11 @@ limitations under the License.
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <!-- Spark requires a specific range of jackson-databind. See dependency section below. -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-math3</artifactId>
@@ -156,6 +161,16 @@ limitations under the License.
                     <groupId>org.apache.ivy</groupId>
                     <artifactId>ivy</artifactId>
                 </exclusion>
+                <!-- Spark 3.3.2 includes self-conflicting versions of snappy -->
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+                <!-- Excluding this log4j binding as it leads to NoSuchMethodErrors -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- resolve spark-gremlin conflicts -->
@@ -206,23 +221,23 @@ limitations under the License.
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.12.10</version>
+            <version>2.12.15</version>
         </dependency>
-        <!-- use jackson 2.12.7 to fit better with spark where Scala module 2.12.3 requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
+        <!-- use jackson 2.13.5 to fit better with spark 2.3.3 where Scala module 2.13.4 requires Jackson Databind version >= 2.13.0 and < 2.14.0 -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.12.7</version>
+            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.12.7</version>
+            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7</version>
+            <version>2.13.5</version>
         </dependency>
         <!-- TEST -->
         <dependency>
@@ -259,6 +274,12 @@ limitations under the License.
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- Spark contains conflicting versions of snappy so it is excluded above. Include the newer version here. -->
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.8.4</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This upgrade is necessary for TINKERPOP-2703 (Build on JDK17).

Fixes https://issues.apache.org/jira/browse/TINKERPOP-2731