### PR TITLE
TINKERPOP-2944 Dispose Cancellation callbacks to fix memory leak

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-5-7]]
 === TinkerPop 3.5.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-
+* Fixed a memory leak in the Gremlin.Net driver that only occurred if a CancellationToken was provided.
 
 [[release-3-5-6]]
 === TinkerPop 3.5.6 (Release Date: May 1, 2023)

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -50,14 +50,12 @@ namespace Gremlin.Net.Driver
         private readonly string _sessionId;
         private readonly bool _sessionEnabled;
 
-        private readonly ConcurrentQueue<(RequestMessage msg, CancellationToken cancellationToken)> _writeQueue =
-            new ConcurrentQueue<(RequestMessage, CancellationToken)>();
+        private readonly ConcurrentQueue<(RequestMessage msg, CancellationToken cancellationToken)> _writeQueue = new();
 
         private readonly ConcurrentDictionary<Guid, IResponseHandlerForSingleRequestMessage> _callbackByRequestId =
-            new ConcurrentDictionary<Guid, IResponseHandlerForSingleRequestMessage>();
-        
-        private readonly List<CancellationTokenRegistration> _cancellationTokenRegistrations =
-            new List<CancellationTokenRegistration>();
+            new();
+
+        private readonly ConcurrentDictionary<Guid, CancellationTokenRegistration> _cancellationByRequestId = new();
         private int _connectionState = 0;
         private int _writeInProgress = 0;
         private const int Closed = 1;
@@ -91,7 +89,8 @@ namespace Gremlin.Net.Driver
         {
             var receiver = new ResponseHandlerForSingleRequestMessage<T>();
             _callbackByRequestId.GetOrAdd(requestMessage.RequestId, receiver);
-            _cancellationTokenRegistrations.Add(cancellationToken.Register(() =>
+
+            _cancellationByRequestId.GetOrAdd(requestMessage.RequestId, cancellationToken.Register(() =>
             {
                 if (_callbackByRequestId.TryRemove(requestMessage.RequestId, out var responseHandler))
                 {
@@ -141,10 +140,17 @@ namespace Gremlin.Net.Driver
             }
             catch (Exception e)
             {
-                if (receivedMsg.RequestId != null &&
-                    _callbackByRequestId.TryRemove(receivedMsg.RequestId.Value, out var responseHandler))
+                if (receivedMsg!.RequestId != null)
                 {
-                    responseHandler?.HandleFailure(e);
+                    if(_callbackByRequestId.TryRemove(receivedMsg.RequestId.Value, out var responseHandler))
+                    {
+                        responseHandler?.HandleFailure(e);
+                        
+                    }
+                    if (_cancellationByRequestId.TryRemove(receivedMsg.RequestId.Value, out var cancellation))
+                    {
+                        cancellation.Dispose();
+                    }
                 }
             }
         }
@@ -173,6 +179,10 @@ namespace Gremlin.Net.Driver
 
             if (status.Code == ResponseStatusCode.Success || status.Code == ResponseStatusCode.NoContent)
             {
+                if (_cancellationByRequestId.TryRemove(receivedMsg.RequestId.Value, out var cancellation))
+                {
+                    cancellation.Dispose();
+                }
                 responseHandler?.Finalize(status.Attributes);
                 _callbackByRequestId.TryRemove(receivedMsg.RequestId.Value, out _);
             }
@@ -256,6 +266,7 @@ namespace Gremlin.Net.Driver
                 cb.HandleFailure(exception);
             }
             _callbackByRequestId.Clear();
+            DisposeCancellationRegistrations();
         }
 
         private async Task SendMessageAsync(RequestMessage message, CancellationToken cancellationToken)
@@ -332,13 +343,19 @@ namespace Gremlin.Net.Driver
                 if (disposing)
                 {
                     _webSocketConnection?.Dispose();
-                    foreach (var registration in _cancellationTokenRegistrations)
-                    {
-                        registration.Dispose();
-                    }
+                    DisposeCancellationRegistrations();
                 }
                 _disposed = true;
             }
+        }
+
+        private void DisposeCancellationRegistrations()
+        {
+            foreach (var cancellation in _cancellationByRequestId.Values)
+            {
+                cancellation.Dispose();
+            }
+            _cancellationByRequestId.Clear();
         }
 
         #endregion


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2944

This should fix the memory leak described in TINKERPOP-2944 caused by not cleaning up the cancellation token registrations which contain a reference to the `RequestMessage`.

VOTE +1