### PR TITLE
3.6: fixing licenses/NOTICE for console and server distributions

### DIFF
--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -244,6 +244,10 @@ limitations under the License.
                                         <resource>NOTICE.txt</resource>
                                         <resource>NOTICE</resource>
                                         <resource>licenses</resource>
+                                        <!--Exclude kryo and minilog licenses to avoid conflict as they are included in
+                                            both gremlin-shaded and gremlin-driver-->
+                                        <resource>META-INF/licenses/kryo</resource>
+                                        <resource>META-INF/licenses/minilog</resource>
                                     </resources>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
@@ -289,6 +293,14 @@ limitations under the License.
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/licenses/slf4j</resource>
                                     <file>src/main/static/licenses/slf4j</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/logback</resource>
+                                    <file>src/main/static/licenses/logback</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/antlr4</resource>
+                                    <file>src/main/static/licenses/antlr4</file>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/gremlin-console/src/main/static/LICENSE
+++ b/gremlin-console/src/main/static/LICENSE
@@ -207,6 +207,7 @@ BSD-style Licenses
 
 The Apache TinkerPop project bundles the following components under the BSD License:
 
+     Antlr4 (org.antlr:antlr4-runtime:4.9.1 - https://www.antlr.org) - for details, see licenses/antlr4
      jcabi-log (com.jcabi:jcabi-log:0.14 - http://www.jcabi.com/jcabi-log) - for details, see licenses/jcabi-log
      jcabi-manifests 1.1 (com.jcabi:jcabi-manifests:1.1 - http://www.jcabi.com/jcabi-manifests) - for details, see licenses/jcabi-manifests
      JLine (jline:jline:2.14.6 - https://github.com/jline/jline2) - for details, see licenses/jline2

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -43,11 +43,6 @@ The original software and related information is available
 at http://www.jcraft.com/jsch/.
 
 ------------------------------------------------------------------------
-JavaTuples 1.2
-------------------------------------------------------------------------
-Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
-
-------------------------------------------------------------------------
 HPPC 0.7.1
 ------------------------------------------------------------------------
 HPPC borrowed code, ideas or both from:
@@ -60,7 +55,23 @@ HPPC borrowed code, ideas or both from:
    (Apache license)
 
 ------------------------------------------------------------------------
+Jackson-Databind and Jackson-Core 2.14.0 (Included through gremlin-shaded)
+------------------------------------------------------------------------
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+------------------------------------------------------------------------
+JavaTuples 1.2
+------------------------------------------------------------------------
+Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
+
+------------------------------------------------------------------------
 Netty 4.1.86
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
 
+------------------------------------------------------------------------
+Objenesis 2.4 (Included through gremlin-shaded)
+------------------------------------------------------------------------
+Copyright 2006-2016 Joe Walnes, Henri Tremblay, Leonardo Mesquita

--- a/gremlin-console/src/main/static/licenses/antlr4
+++ b/gremlin-console/src/main/static/licenses/antlr4
@@ -1,0 +1,28 @@
+Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither name of copyright holders nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -196,6 +196,10 @@ limitations under the License.
                                         <resource>NOTICE.txt</resource>
                                         <resource>NOTICE</resource>
                                         <resource>licenses</resource>
+                                        <!--Exclude kryo and minilog licenses to avoid conflict as they are included in
+                                            both gremlin-shaded and gremlin-driver-->
+                                        <resource>META-INF/licenses/kryo</resource>
+                                        <resource>META-INF/licenses/minilog</resource>
                                     </resources>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
@@ -222,7 +226,19 @@ limitations under the License.
                                     <resource>META-INF/licenses/minlog</resource>
                                     <file>src/main/static/licenses/minlog</file>
                                 </transformer>
-                            </transformers>>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/logback</resource>
+                                    <file>src/main/static/licenses/logback</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/slf4j</resource>
+                                    <file>src/main/static/licenses/slf4j</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/antlr4</resource>
+                                    <file>src/main/static/licenses/antlr4</file>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/gremlin-driver/src/main/static/NOTICE
+++ b/gremlin-driver/src/main/static/NOTICE
@@ -17,6 +17,13 @@ HPPC borrowed code, ideas or both from:
    (Apache license)
 
 ------------------------------------------------------------------------
+Jackson-Databind and Jackson-Core 2.14.0 (Included through gremlin-shaded)
+------------------------------------------------------------------------
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+------------------------------------------------------------------------
 JavaTuples 1.2
 ------------------------------------------------------------------------
 Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
@@ -26,3 +33,7 @@ Netty 4.1.62
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
 
+------------------------------------------------------------------------
+Objenesis 2.4 (Included through gremlin-shaded)
+------------------------------------------------------------------------
+Copyright 2006-2016 Joe Walnes, Henri Tremblay, Leonardo Mesquita

--- a/gremlin-driver/src/main/static/licenses/antlr4
+++ b/gremlin-driver/src/main/static/licenses/antlr4
@@ -1,0 +1,28 @@
+Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither name of copyright holders nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gremlin-server/src/main/static/LICENSE
+++ b/gremlin-server/src/main/static/LICENSE
@@ -207,6 +207,7 @@ BSD-style Licenses
 
 The Apache TinkerPop project bundles the following components under the BSD License:
 
+     Antlr4 (org.antlr:antlr4-runtime:4.9.1 - https://www.antlr.org) - for details, see licenses/antlr4
      jcabi-log (com.jcabi:jcabi-log:0.14 - http://www.jcabi.com/jcabi-log) - for details, see licenses/jcabi-log
      jcabi-manifests 1.1 (com.jcabi:jcabi-manifests:1.1 - http://www.jcabi.com/jcabi-manifests) - for details, see licenses/jcabi-manifests
      JLine (jline:jline:2.14.6 - https://github.com/jline/jline2) - for details, see licenses/jline2

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -30,6 +30,25 @@ The original software and related information is available
 at http://www.jcraft.com/jsch/.
 
 ------------------------------------------------------------------------
+HPPC 0.7.1
+------------------------------------------------------------------------
+HPPC borrowed code, ideas or both from:
+
+ * Apache Lucene, http://lucene.apache.org/
+   (Apache license)
+ * Fastutil, http://fastutil.di.unimi.it/
+   (Apache license)
+ * Koloboke, https://github.com/OpenHFT/Koloboke
+   (Apache license)
+
+------------------------------------------------------------------------
+Jackson-Databind 2.14.0 and Jackson-Core (Included through gremlin-shaded)
+------------------------------------------------------------------------
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+------------------------------------------------------------------------
 JavaTuples 1.2
 ------------------------------------------------------------------------
 Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
@@ -49,18 +68,11 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------
-HPPC 0.7.1
-------------------------------------------------------------------------
-HPPC borrowed code, ideas or both from:
-
- * Apache Lucene, http://lucene.apache.org/
-   (Apache license)
- * Fastutil, http://fastutil.di.unimi.it/
-   (Apache license)
- * Koloboke, https://github.com/OpenHFT/Koloboke
-   (Apache license)
-
-------------------------------------------------------------------------
 Netty 4.1.86
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
+
+------------------------------------------------------------------------
+Objenesis 2.4 (Included through gremlin-shaded)
+------------------------------------------------------------------------
+Copyright 2006-2016 Joe Walnes, Henri Tremblay, Leonardo Mesquita

--- a/gremlin-server/src/main/static/licenses/antlr4
+++ b/gremlin-server/src/main/static/licenses/antlr4
@@ -1,0 +1,28 @@
+Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither name of copyright holders nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -111,6 +111,34 @@ limitations under the License.
                                  the option name suggests. -->
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <minimizeJar>false</minimizeJar>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/kryo</resource>
+                                    <file>src/main/static/licenses/kryo</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/licenses/minilog</resource>
+                                    <file>src/main/static/licenses/minilog</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                    <resources>
+                                        <resource>NOTICE</resource>
+                                    </resources>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/NOTICE</resource>
+                                    <file>src/main/static/NOTICE</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                    <resources>
+                                        <resource>LICENSE</resource>
+                                    </resources>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/LICENSE</resource>
+                                    <file>src/main/static/LICENSE</file>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/gremlin-shaded/src/main/static/LICENSE
+++ b/gremlin-shaded/src/main/static/LICENSE
@@ -207,35 +207,9 @@ BSD-style Licenses
 
 The Apache TinkerPop project bundles the following components under the BSD License:
 
-     Antlr4 (org.antlr:antlr4-runtime:4.9.1 - https://www.antlr.org) - for details, see licenses/antlr4
-     jcabi-log (com.jcabi:jcabi-log:0.14 - http://www.jcabi.com/jcabi-log) - for details, see
-       - shaded to com.shaded.jcabi.log
-       - for details, see licenses/jcabi-log
-     jcabi-manifests 1.1 (com.jcabi:jcabi-manifests:1.1 - http://www.jcabi.com/jcabi-manifests)
-       - shaded to com.shaded.jcabi.manifests
-       - for details, see licenses/jcabi-manifests
      Kryo (com.esotericsoftware:kryo-shaded:3.0.3 - https://github.com/EsotericSoftware/kryo)
-       - shaded to org.apache.tinkerpop.shaded.kryo
+       - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.kryo
        - for details, see licenses/kryo
      minlog (com.esotericsoftware:minlog:1.3.0 - https://github.com/EsotericSoftware/minlog)
-       - shaded to org.apache.tinkerpop.shaded.minlog
+       - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.minlog
        - for details, see licenses/minlog
-
-========================================================================
-MIT Licenses
-========================================================================
-
-The Apache TinkerPop project bundles the following components under the MIT License:
-
-     SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org)
-       - shaded to org.shaded.slf4j
-       - for details, see licenses/slf4j
-
-========================================================================
-Other Licenses
-========================================================================
-
-The Apache TinkerPop project bundles the following components under the Eclipse Public License 1.0:
-
-     logback-core (ch.qos.logback:logback-core:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback
-     logback-classic (ch.qos.logback:logback-classic:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback

--- a/gremlin-shaded/src/main/static/NOTICE
+++ b/gremlin-shaded/src/main/static/NOTICE
@@ -1,0 +1,31 @@
+Apache TinkerPop :: Gremlin Shaded
+Copyright 2013-2023 Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+------------------------------------------------------------------------
+Jackson-Databind 2.14.0 and Jackson-Core
+------------------------------------------------------------------------
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+------------------------------------------------------------------------
+Objenesis 2.4
+------------------------------------------------------------------------
+Copyright 2006-2016 Joe Walnes, Henri Tremblay, Leonardo Mesquita

--- a/gremlin-shaded/src/main/static/licenses/kryo
+++ b/gremlin-shaded/src/main/static/licenses/kryo
@@ -1,0 +1,9 @@
+Copyright (c) 2008-2023, Nathan Sweet All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gremlin-shaded/src/main/static/licenses/minilog
+++ b/gremlin-shaded/src/main/static/licenses/minilog
@@ -1,0 +1,10 @@
+Copyright (c) 2008, Nathan Sweet
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Fixing some issues found during the release of 3.5.6/3.6.4.

Additionally adding static NOTICE and licenses files for gremlin-shaded for inclusion in the shaded jar. Also updates notices for console and server as their distributions include gremlin-shaded.
