### PR TITLE
(fix) (gremlin-python) don't use deprecated methods

### DIFF
--- a/gremlin-python/src/main/python/README.rst
+++ b/gremlin-python/src/main/python/README.rst
@@ -42,16 +42,16 @@ from the Python shell looks like this:
 
     >>> from gremlin_python.process.anonymous_traversal import traversal
     >>> from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
-    >>> g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
+    >>> g = traversal().with_remote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 
 Once "g" has been created using a connection, it is then possible to start writing Gremlin traversals to query the
 remote graph:
 
-    >>> g.V().both()[1:3].toList()
+    >>> g.V().both()[1:3].to_list()
     [v[2], v[4]]
-    >>> g.V().both()[1].toList()
+    >>> g.V().both()[1].to_list()
     [v[2]]
-    >>> g.V().both().name.toList()
+    >>> g.V().both().name.to_list()
     [lop, vadas, josh, marko, marko, josh, peter, ripple, lop, marko, josh, lop]
 
 -----------------
@@ -84,7 +84,7 @@ Create Vertex
 
     def create_vertex(self, vid, vlabel):
         # default database cardinality is used when Cardinality argument is not specified
-        g.addV(vlabel).property(id, vid). \
+        g.add_v(vlabel).property(id, vid). \
           property(single, 'name', 'Apache'). \
           property('lastname', 'Tinkerpop'). \
           next()
@@ -95,13 +95,13 @@ Find Vertices
 .. code:: python
 
     def list_all(self, limit=500):
-        g.V().limit(limit).elementMap().toList()
+        g.V().limit(limit).element_map().to_list()
 
     def find_vertex(self, vid):
-        g.V(vid).elementMap().next()
+        g.V(vid).element_map().next()
 
     def list_by_label_name(self, vlabel, name):
-        g.V().has(vlabel, 'name', name).elementMap().toList()
+        g.V().has(vlabel, 'name', name).element_map().to_list()
 
 Update Vertex
 ^^^^^^^^^^^^^

--- a/gremlin-python/src/main/python/example.py
+++ b/gremlin-python/src/main/python/example.py
@@ -32,7 +32,7 @@ def main():
     #
     # which starts it in "console" mode with an empty in-memory TinkerGraph ready to go bound to a
     # variable named "g" as referenced in the following line.
-    g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin', 'g'))
+    g = traversal().with_remote(DriverRemoteConnection('ws://localhost:8182/gremlin', 'g'))
 
     # add some data - be sure to use a terminating step like iterate() so that the traversal
     # "executes". iterate() does not return any data and is used to just generate side-effects

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -1587,7 +1587,7 @@ def V(*args):
 
 
 def addE(*args):
-    return __.addE(*args)
+    return __.add_e(*args)
 
 
 def add_e(*args):
@@ -1595,7 +1595,7 @@ def add_e(*args):
 
 
 def addV(*args):
-    return __.addV(*args)
+    return __.add_v(*args)
 
 
 def add_v(*args):
@@ -1623,7 +1623,7 @@ def both(*args):
 
 
 def bothE(*args):
-    return __.bothE(*args)
+    return __.both_e(*args)
 
 
 def both_e(*args):
@@ -1631,7 +1631,7 @@ def both_e(*args):
 
 
 def bothV(*args):
-    return __.bothV(*args)
+    return __.both_v(*args)
 
 
 def both_v(*args):
@@ -1671,7 +1671,7 @@ def count(*args):
 
 
 def cyclicPath(*args):
-    return __.cyclicPath(*args)
+    return __.cyclic_path(*args)
 
 
 def cyclic_path(*args):
@@ -1691,7 +1691,7 @@ def element(*args):
 
 
 def elementMap(*args):
-    return __.elementMap(*args)
+    return __.element_map(*args)
 
 
 def element_map(*args):
@@ -1711,7 +1711,7 @@ def filter_(*args):
 
 
 def flatMap(*args):
-    return __.flatMap(*args)
+    return __.flat_map(*args)
 
 
 def flat_map(*args):
@@ -1727,7 +1727,7 @@ def group(*args):
 
 
 def groupCount(*args):
-    return __.groupCount(*args)
+    return __.group_count(*args)
 
 
 def group_count(*args):
@@ -1739,7 +1739,7 @@ def has(*args):
 
 
 def hasId(*args):
-    return __.hasId(*args)
+    return __.has_id(*args)
 
 
 def has_id(*args):
@@ -1747,7 +1747,7 @@ def has_id(*args):
 
 
 def hasKey(*args):
-    return __.hasKey(*args)
+    return __.has_key_(*args)
 
 
 def has_key_(*args):
@@ -1755,7 +1755,7 @@ def has_key_(*args):
 
 
 def hasLabel(*args):
-    return __.hasLabel(*args)
+    return __.has_label(*args)
 
 
 def has_label(*args):
@@ -1763,7 +1763,7 @@ def has_label(*args):
 
 
 def hasNot(*args):
-    return __.hasNot(*args)
+    return __.has_not(*args)
 
 
 def has_not(*args):
@@ -1771,7 +1771,7 @@ def has_not(*args):
 
 
 def hasValue(*args):
-    return __.hasValue(*args)
+    return __.has_value(*args)
 
 
 def has_value(*args):
@@ -1787,7 +1787,7 @@ def identity(*args):
 
 
 def inE(*args):
-    return __.inE(*args)
+    return __.in_e(*args)
 
 
 def in_e(*args):
@@ -1795,7 +1795,7 @@ def in_e(*args):
 
 
 def inV(*args):
-    return __.inV(*args)
+    return __.in_v(*args)
 
 
 def in_v(*args):
@@ -1887,7 +1887,7 @@ def order(*args):
 
 
 def otherV(*args):
-    return __.otherV(*args)
+    return __.other_v(*args)
 
 
 def other_v(*args):
@@ -1899,7 +1899,7 @@ def out(*args):
 
 
 def outE(*args):
-    return __.outE(*args)
+    return __.out_e(*args)
 
 
 def out_e(*args):
@@ -1907,7 +1907,7 @@ def out_e(*args):
 
 
 def outV(*args):
-    return __.outV(*args)
+    return __.out_v(*args)
 
 
 def out_v(*args):
@@ -1931,7 +1931,7 @@ def property(*args):
 
 
 def propertyMap(*args):
-    return __.propertyMap(*args)
+    return __.property_map(*args)
 
 
 def property_map(*args):
@@ -1959,7 +1959,7 @@ def select(*args):
 
 
 def sideEffect(*args):
-    return __.sideEffect(*args)
+    return __.side_effect(*args)
 
 
 def side_effect(*args):
@@ -1967,7 +1967,7 @@ def side_effect(*args):
 
 
 def simplePath(*args):
-    return __.simplePath(*args)
+    return __.simple_path(*args)
 
 
 def simple_path(*args):
@@ -1995,7 +1995,7 @@ def tail(*args):
 
 
 def timeLimit(*args):
-    return __.timeLimit(*args)
+    return __.time_limit(*args)
 
 
 def time_limit(*args):
@@ -2011,7 +2011,7 @@ def to(*args):
 
 
 def toE(*args):
-    return __.toE(*args)
+    return __.to_e(*args)
 
 
 def to_e(*args):
@@ -2019,7 +2019,7 @@ def to_e(*args):
 
 
 def toV(*args):
-    return __.toV(*args)
+    return __.to_v(*args)
 
 
 def to_v(*args):
@@ -2047,7 +2047,7 @@ def value(*args):
 
 
 def valueMap(*args):
-    return __.valueMap(*args)
+    return __.value_map(*args)
 
 
 def value_map(*args):

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -134,7 +134,7 @@ class GraphTraversalSource(object):
         val = True if v is None else v
         if options_strategy is None:
             options_strategy = OptionsStrategy({k: val})
-            source = self.withStrategies(options_strategy)
+            source = self.with_strategies(options_strategy)
         else:
             options_strategy[1].configuration[k] = val
 

--- a/gremlin-python/src/main/python/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/traversal.py
@@ -77,7 +77,7 @@ class Traversal(object):
     def iterate(self):
         self.bytecode.add_step("none")
         while True:
-            try: self.nextTraverser()
+            try: self.next_traverser()
             except StopIteration: return self
 
     def nextTraverser(self):


### PR DESCRIPTION
`gremlin-python` internally calls deprecated methods. This PR fixes that.