### PR TITLE
upgrade Go to 1.20

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.20'
       - name: Get Cached Server Base Image
         uses: actions/cache@v3
         id: gremlin-server-test-docker-image

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed a memory leak in the Gremlin.Net driver that only occurred if a CancellationToken was provided.
 * Added `gremlin.spark.dontDeleteNonEmptyOutput` to stop deleting the output folder if it is not empty in `spark-gremlin`.
 * Upgraded `gremlin-javascript` and `gremlint` to Node 16.20.0.
+* Upgraded `gremlin-go` to Go 1.20.
 
 [[release-3-5-6]]
 === TinkerPop 3.5.6 (Release Date: May 1, 2023)

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -277,7 +277,7 @@ See the <<release-environment,Release Environment>> section for more information
 [[go-environment]]
 === Go Environment
 
-The build optionally requires link:https://go.dev/dl/[Go] (>=1.17) to work with the `gremlin-go` module. Creating an
+The build optionally requires link:https://go.dev/dl/[Go] (>=1.20) to work with the `gremlin-go` module. Creating an
 empty `.glv` file will enable running of tests inside of Maven. If `.glv` file does not exist, TinkerPop
 will still build with Maven, but Go projects will be skipped.
 

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -30,6 +30,8 @@ complete list of all the modifications that are part of this release.
 === Upgrading for Users
 
 `gremlin-javascript` and `gremlint` have upgraded from Node 10 to Node 16 as Node 10 has passed end of life.
+`gremlin-go` has upgraded from Go 1.17 to Go 1.20 as Go 1.20 has passed end of life.
+
 
 == TinkerPop 3.5.6
 
@@ -221,7 +223,7 @@ A utility class `SparkIOUtil` is introduces, which allows users to load graph in
 After introducing a number of release candidates over the past several months, the official release of Gremlin-Go is now
 available starting at 3.5.4. There are a few simple prerequisites required to get started:
 
-* A Golang version of `1.17` or greater. Please see link:https://go.dev/dl/[Go Downloads] for more details on installing Golang.
+* A Golang version of `1.20` or greater. Please see link:https://go.dev/dl/[Go Downloads] for more details on installing Golang.
 * A basic understanding of link:https://go.dev/blog/using-go-modules[Go Modules].
 * A project set up using Go Modules where `gremlin-go` will be used as a dependency.
 

--- a/gremlin-go/README.md
+++ b/gremlin-go/README.md
@@ -30,7 +30,7 @@ for early testing purposes only.
 data-flow language that enables users to succinctly express complex traversals on (or queries of) their application's
 property graph.
 
-Gremlin-Go implements Gremlin within the Go language and can be used on any Go runtime greater than v1.17. One
+Gremlin-Go implements Gremlin within the Go language and can be used on any Go runtime greater than v1.20. One
 important difference between Go and Java is that the functions are capitalized, as is required to export functions is Go. 
 
 Gremlin-Go is designed to connect to a "server" that is hosting a TinkerPop-enabled graph system. That "server"

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   gremlin-go-integration-tests:
     container_name: gremlin-go-integration-tests
-    image: golang:1.17
+    image: golang:1.20
     volumes:
       - .:/go_app
       - ../gremlin-test/features:/gremlin-test

--- a/gremlin-go/driver/README.md
+++ b/gremlin-go/driver/README.md
@@ -22,7 +22,7 @@
 
 ## Prerequisites
 
-* `gremlin-go` requires Golang 1.17 or later, please see [Go Download][go] for more details on installing Golang.
+* `gremlin-go` requires Golang 1.20 or later, please see [Go Download][go] for more details on installing Golang.
 * A basic understanding of [Go Modules][gomods]
 * A project set up which uses Go Modules
 
@@ -39,7 +39,7 @@ After running the `go get` command, your `go.mod` file should contain something 
 ```
 module gremlin-go-example
 
-go 1.17
+go 1.20
 
 require github.com/apache/tinkerpop/gremlin-go/v3 v<version>
 ```
@@ -51,7 +51,7 @@ You will need to run `go mod tidy` to import the remaining dependencies of the `
 ```
 module gremlin-go-example
 
-go 1.17
+go 1.20
 
 require github.com/apache/tinkerpop/gremlin-go v0.0.0-20220131225152-54920637bf94
 

--- a/gremlin-go/example/go.mod
+++ b/gremlin-go/example/go.mod
@@ -17,7 +17,7 @@
 
 module example
 
-go 1.17
+go 1.20
 
 require github.com/apache/tinkerpop/gremlin-go/v3 v3.6.1-rc2
 

--- a/gremlin-go/go.mod
+++ b/gremlin-go/go.mod
@@ -17,7 +17,7 @@
 
 module github.com/apache/tinkerpop/gremlin-go/v3
 
-go 1.17
+go 1.20
 
 require (
 	github.com/cucumber/godog v0.12.6


### PR DESCRIPTION
Upgrading go as 1.17 is past end of life. Users have already been notified of this upcoming change here: https://tinkerpop.apache.org/docs/current/upgrade/#_deprecation_warning_for_node_10_and_go_1_17.

There are no breaking changes from this upgrade.

VOTE +1