### PR TITLE
Add gremlin-java8.bat for Java 8 Windows Console users.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Upgraded `gremlin-javascript` and `gremlint` to Node 16.20.0.
 * Upgraded `gremlin-go` to Go 1.20.
 * Improved the python Translator class
+* Added `gremlin-java8.bat` file as a workaround to allow loading the console using Java 8 on Windows.
 
 [[release-3-5-6]]
 === TinkerPop 3.5.6 (Release Date: May 1, 2023)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -70,7 +70,7 @@ analysis, small to medium sized data loading projects and other exploratory func
 highly extensible, featuring a rich plugin system that allows new tools, commands,
 link:http://en.wikipedia.org/wiki/Domain-specific_language[DSLs], etc. to be exposed to users.
 
-To start the Gremlin Console, run `gremlin.sh` or `gremlin.bat`:
+To start the Gremlin Console, run `gremlin.sh` or `gremlin.bat` (`gremlin-java8.bat` for Java 8):
 
 [source,text]
 ----

--- a/docs/src/tutorials/getting-started/index.asciidoc
+++ b/docs/src/tutorials/getting-started/index.asciidoc
@@ -69,7 +69,8 @@ plugin activated: tinkerpop.tinkergraph
 gremlin>
 ----
 
-TIP: Windows users may use the included `bin/gremlin.bat` file to start the Gremlin Console.
+TIP: Windows users may use the included `bin/gremlin.bat` (`bin/gremlin-java8.bat` for Java 8) file to start the Gremlin
+Console.
 
 The Gremlin Console is a link:http://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop[REPL environment],
 which provides a nice way to learn Gremlin as you get immediate feedback for the code that you enter. This eliminates

--- a/gremlin-console/src/main/bin/gremlin-java8.bat
+++ b/gremlin-console/src/main/bin/gremlin-java8.bat
@@ -1,0 +1,48 @@
+:: Licensed to the Apache Software Foundation (ASF) under one
+:: or more contributor license agreements.  See the NOTICE file
+:: distributed with this work for additional information
+:: regarding copyright ownership.  The ASF licenses this file
+:: to you under the Apache License, Version 2.0 (the
+:: "License"); you may not use this file except in compliance
+:: with the License.  You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing,
+:: software distributed under the License is distributed on an
+:: "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+:: KIND, either express or implied.  See the License for the
+:: specific language governing permissions and limitations
+:: under the License.
+
+:: Windows launcher script for Gremlin Console
+:: Use this with Java8 as it contains a workaround for Windows Path Loading for Java8
+
+@echo off
+SETLOCAL EnableDelayedExpansion
+
+set work=%CD%
+if [%work:~-3%]==[bin] cd ..
+set work=%CD%
+
+set CONSOLE_JARS=
+
+FOR %%i in (.\lib\*.jar .\lib\*.JAR) do (
+    :: get lib jars with a relative path as there is a hard limit to length of a variable
+    set CONSOLE_JARS=!CONSOLE_JARS!;%%i
+)
+
+cd ext
+FOR /r %%j in (*.jar *.JAR) do (
+    :: get all ext jars with a relative path as there is a hard limit to length of a variable
+    SET FULL_PATH=%%j
+    set CONSOLE_JARS=!CONSOLE_JARS!;.!FULL_PATH:%work%=!
+)
+cd ..
+
+:: workaround for https://issues.apache.org/jira/browse/GROOVY-6453
+set JAVA_OPTIONS=-Xms32m -Xmx512m -Djline.terminal=none
+
+:: Launch the application
+
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp "%CONSOLE_JARS%" org.apache.tinkerpop.gremlin.console.Console %*


### PR DESCRIPTION
The gremlin.bat file no longer works for users of Java 8 due to some changes in how pathing is determined in Groovy. This bat file finds all jars in lib and ext rather than using the * wildcard as that no longer works in Groovy. Because of the hard limit on the length of a variable for commands, relative paths had to be used instead of absolute paths. Although the use of relative paths for the -cp option is discouraged by Java, it is necessary in this case.