### PR TITLE
TINKERPOP-2958 Added cancel for query timeout task when query completes.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Upgraded `gremlin-go` to Go 1.20.
 * Improved the python Translator class
 * Added `gremlin-java8.bat` file as a workaround to allow loading the console using Java 8 on Windows.
+* Fixed a bug in `gremlin-server` where timeout tasks were not cancelled and could cause very large memory usage when timeout is large.
 
 [[release-3-5-6]]
 === TinkerPop 3.5.6 (Release Date: May 1, 2023)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -269,7 +269,9 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                 timerContext.stop();
 
                 // There is a race condition that this query may have finished before the timeoutFuture was created,
-                // though this is very unlikely. Either way we don't want a NPE.
+                // though this is very unlikely. This is handled in the settor, if this has already been grabbed.
+                // If we passed this point and the setter hasn't been called, it will cancel the timeoutFuture inside
+                // the setter to compensate.
                 final ScheduledFuture<?> timeoutFuture = context.getTimeoutExecutor();
                 if (null != timeoutFuture)
                     timeoutFuture.cancel(true);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/traversal/TraversalOpProcessor.java
@@ -63,6 +63,7 @@ import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -266,6 +267,12 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
                 }
             } finally {
                 timerContext.stop();
+
+                // There is a race condition that this query may have finished before the timeoutFuture was created,
+                // though this is very unlikely. Either way we don't want a NPE.
+                final ScheduledFuture<?> timeoutFuture = context.getTimeoutExecutor();
+                if (null != timeoutFuture)
+                    timeoutFuture.cancel(true);
             }
 
             return null;
@@ -275,12 +282,12 @@ public class TraversalOpProcessor extends AbstractOpProcessor {
             final Future<?> executionFuture = context.getGremlinExecutor().getExecutorService().submit(evalFuture);
             if (seto > 0) {
                 // Schedule a timeout in the thread pool for future execution
-                context.getScheduledExecutorService().schedule(() -> {
+                context.setTimeoutExecutor(context.getScheduledExecutorService().schedule(() -> {
                     executionFuture.cancel(true);
                     if (!context.getStartedResponse()) {
                         context.sendTimeoutResponse();
                     }
-                }, seto, TimeUnit.MILLISECONDS);
+                }, seto, TimeUnit.MILLISECONDS));
             }
         } catch (RejectedExecutionException ree) {
             context.writeAndFlush(ResponseMessage.build(msg).code(ResponseStatusCode.TOO_MANY_REQUESTS)


### PR DESCRIPTION
I noticed extreme memory usage in recent versions of TinkerPop. After some investigation I found that this was because the task that is scheduled to cancel the query if it doesn't complete in time is not cancelled when the query completes.

This means that if the timeout is large and you have high throughput on the graph, memory starts adding up. On my laptop with Aerospike Graph, I was seeing ~1 GB per second growth in memory until it hit about 10 GB and then my system would slow down and eventually OOME.

I added a cancel for this in this PR to fix this issue and tested it and the memory growth does not happen. (I tested with changes on 3.6-dev but then brought those to 3.5-dev since the problem is rooted there).