### PR TITLE
Remove final class declaration for LabelStep

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ This release also includes changes from <<release-3-5-7, 3.5.7>>.
 * Fixed bug with `fail` step not working with a `VertexProgram` running on the server.
 * Introduced mime type `application/vnd.gremlin-v1.0+json;typed=false` to allow direct specification of GraphSON 1.0 without types.
 * Introduced mime type `application/vnd.gremlin-v2.0+json;typed=false` to allow direct specification of GraphSON 2.0 without types.
+* Removed `final` class declaration for `LabelStep`
 
 [[release-3-6-4]]
 === TinkerPop 3.6.4 (Release Date: May 12, 2023)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LabelStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/LabelStep.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LabelStep<S extends Element> extends ScalarMapStep<S, String> {
+public class LabelStep<S extends Element> extends ScalarMapStep<S, String> {
 
     public LabelStep(final Traversal.Admin traversal) {
         super(traversal);


### PR DESCRIPTION
In JanusGraph we would like to make some optimizations to `LabelStep` (https://github.com/JanusGraph/janusgraph/issues/3813).

We need to extend `LabelStep` with additional logic. Even so it's quite simple to implement our own `LabelStep`, it's a little bit dangerous because TinkerPop's `LabelStep` may be used in some optimization strategies (including user-provided optimization strategies). If we replace `LabelStep` with something which doesn't extend `LabelStep` then we may risk breaking some strategies.

For example, here are the places in TinkerPop where `step instanceof LabelStep` is checked:
1) https://github.com/apache/tinkerpop/blob/f00cfe5592ef45e64fb45737a16ec5877a824958/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/ByModulatorOptimizationStrategy.java#L98
2) https://github.com/apache/tinkerpop/blob/f00cfe5592ef45e64fb45737a16ec5877a824958/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/MasterExecutor.java#L149
3) https://github.com/apache/tinkerpop/blob/f00cfe5592ef45e64fb45737a16ec5877a824958/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java#L106

Thus, I propose to remove `final` class declaration for `LabelStep`, so that graph providers could extend this step.
The step looks fairly stable.

Related issue: https://issues.apache.org/jira/browse/TINKERPOP-2927