### PR TITLE
[TINKERPOP-2963] Introduce new mimeType to use Graphson-1.0 text serializer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -83,6 +83,7 @@ This release also includes changes from <<release-3-5-6, 3.5.6>>.
 * TINKERPOP-2925 mergeE() in javascript producing an error
 * TINKERPOP-2926 Gremlin-Java > An UnsupportedOperationException occurs on calling next() after a merge step with the option step modulator if the element does not exist
 * TINKERPOP-2928 element() not working in conjunction with edge properties
+* TINKERPOP-2963 Introduced new mime-type application/vnd.gremlin-v1.0+json;sparse=true to use GraphSON-1.0 in text format
 
 ==== Improvements
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1190,7 +1190,7 @@ $ curl -H "Accept:application/vnd.gremlin-v3.0+json" -X POST -d "{\"gremlin\":\"
 IMPORTANT: `GraphSONMessageSerializerGremlinV1d0` configures `application/vnd.gremlin-v1.0+json`, but this mime type does
 not support text serialization (i.e. `MessageTextSerializer`) which means that it cannot be used for the serializing
 results to the HTTP endpoint in Gremlin Server. GraphSON 1.0 must be configured with `application/json` using the
-`GraphSONMessageSerializerV1d0` as demonstrated above.
+`GraphSONMessageSerializerV1d0` as demonstrated above or use mimeType `application/vnd.gremlin-v1.0+json;sparse=true`.
 
 [[server-graphbinary]]
 ===== GraphBinary

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0.java
@@ -40,7 +40,7 @@ import java.util.UUID;
  */
 public final class GraphSONMessageSerializerV1d0 extends AbstractGraphSONMessageSerializerV1d0 implements MessageTextSerializer<ObjectMapper> {
     private static final Logger logger = LoggerFactory.getLogger(GraphSONMessageSerializerV1d0.class);
-    private static final String MIME_TYPE = SerTokens.MIME_JSON;
+    private static final String MIME_TYPE = SerTokens.MIME_GRAPHSON_V1D0_SPARSE;
 
     private static byte[] header;
 
@@ -61,7 +61,7 @@ public final class GraphSONMessageSerializerV1d0 extends AbstractGraphSONMessage
 
     @Override
     public String[] mimeTypesSupported() {
-        return new String[]{MIME_TYPE};
+        return new String[]{MIME_TYPE, SerTokens.MIME_JSON};
     }
 
     @Override

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/SerTokens.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/SerTokens.java
@@ -40,6 +40,7 @@ public final class SerTokens {
 
     public static final String MIME_JSON = "application/json";
     public static final String MIME_GRAPHSON_V1D0 = "application/vnd.gremlin-v1.0+json";
+    public static final String MIME_GRAPHSON_V1D0_SPARSE = "application/vnd.gremlin-v1.0+json;sparse=true";
     public static final String MIME_GRAPHSON_V2D0 = "application/vnd.gremlin-v2.0+json";
     public static final String MIME_GRAPHSON_V3D0 = "application/vnd.gremlin-v3.0+json";
     public static final String MIME_GRAPHBINARY_V1D0 = "application/vnd.graphbinary-v1.0";

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/Serializers.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/Serializers.java
@@ -33,6 +33,7 @@ public enum Serializers {
      */
     GRAPHSON(SerTokens.MIME_JSON),
     GRAPHSON_V1D0(SerTokens.MIME_GRAPHSON_V1D0),
+    GRAPHSON_V1D0_SPARSE(SerTokens.MIME_GRAPHSON_V1D0_SPARSE),
     GRAPHSON_V2D0(SerTokens.MIME_GRAPHSON_V2D0),
     GRAPHSON_V3D0(SerTokens.MIME_GRAPHSON_V3D0),
     GRAPHBINARY_V1D0(SerTokens.MIME_GRAPHBINARY_V1D0);
@@ -54,6 +55,8 @@ public enum Serializers {
                 return new GraphSONMessageSerializerV3d0();
             case SerTokens.MIME_GRAPHSON_V1D0:
                 return new GraphSONMessageSerializerGremlinV1d0();
+            case SerTokens.MIME_GRAPHSON_V1D0_SPARSE:
+                return new GraphSONMessageSerializerV1d0();
             case SerTokens.MIME_GRAPHSON_V2D0:
                 return new GraphSONMessageSerializerV2d0();
             case SerTokens.MIME_GRAPHBINARY_V1D0:

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
@@ -929,6 +929,19 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
             assertEquals(0, node.get("result").get("data").get(0).asInt());
         }
 
+        final HttpPost httppost1Sparse = new HttpPost(TestClientFactory.createURLString());
+        httppost1Sparse.setHeader(HttpHeaders.CONTENT_TYPE, SerTokens.MIME_JSON);
+        httppost1Sparse.setHeader(HttpHeaders.ACCEPT, SerTokens.MIME_GRAPHSON_V1D0_SPARSE);
+        httppost1Sparse.setEntity(new StringEntity("{\"gremlin\":\"1-1\"}", Consts.UTF_8));
+
+        try (final CloseableHttpResponse response = httpclient.execute(httppost1Sparse)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertEquals(SerTokens.MIME_GRAPHSON_V1D0_SPARSE, response.getEntity().getContentType().getValue());
+            final String json = EntityUtils.toString(response.getEntity());
+            final JsonNode node = mapper.readTree(json);
+            assertEquals(0, node.get("result").get("data").get(0).asInt());
+        }
+
         final HttpPost httppost2 = new HttpPost(TestClientFactory.createURLString());
         httppost2.setHeader(HttpHeaders.CONTENT_TYPE, SerTokens.MIME_JSON);
         httppost2.setHeader(HttpHeaders.ACCEPT, SerTokens.MIME_GRAPHSON_V2D0);


### PR DESCRIPTION
Users/Providers who wish to use GraphSON-1.0 in text format should make serializer 
`GraphSONMessageSerializerV1d0` default serializer. Alternatively introduce new mimeType `application/vnd.gremlin-v1.0+json;sparse=true` to let users/providers use GraphSON-1.0 in text format without changing defaults.