### PR TITLE
TINKERPOP-2953 Update how enums are imported in ImportGroovyCustomizer.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `gremlin-java8.bat` file as a workaround to allow loading the console using Java 8 on Windows.
 * Fixed a bug in `gremlin-server` where timeout tasks were not cancelled and could cause very large memory usage when timeout is large.
 * Removed `jcabi-manifests` dependency from `gremlin-core`, `gremlin-driver`, and `gremlin-server`.
+* Fixed a bug that caused the `GremlinGroovyScriptEngine` to throw a `MissingMethodException` when calling a static method in __ with the same name as an enum.
 
 [[release-3-5-6]]
 === TinkerPop 3.5.6 (Release Date: May 1, 2023)

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ImportGroovyCustomizer.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ImportGroovyCustomizer.java
@@ -58,7 +58,7 @@ class ImportGroovyCustomizer implements GroovyCustomizer {
             customizer.getMethodImports().stream()
                     .filter(m -> !m.getDeclaringClass().equals(__.class))
                     .forEach(m -> ic.addStaticImport(m.getDeclaringClass().getCanonicalName(), m.getName()));
-            customizer.getEnumImports().forEach(m -> ic.addStaticImport(m.getDeclaringClass().getCanonicalName(), m.name()));
+            customizer.getEnumClasses().forEach(m -> ic.addStaticStars(m.getCanonicalName())); // TINKERPOP-2953
             customizer.getFieldImports().forEach(f -> ic.addStaticImport(f.getDeclaringClass().getCanonicalName(), f.getName()));
         }
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TINKERPOP-2953

The latest Groovy upgrade to 2.5.22 seems to have changed how enums are imported which led to the __ static methods which have the same name to not be found.

Thanks to bmsq on Discord who suggested this fix.

VOTE+1