### PR TITLE
TINKERPOP-2948 bump jackson databind to 2.15.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-5-7]]
 === TinkerPop 3.5.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Bumped `jackson-databind` to 2.15.0 to fix security vulnerability.
 * Fixed a memory leak in the Gremlin.Net driver that only occurred if a CancellationToken was provided.
 * Fixed gremlin-python `Client` problem where calling `submit()` after` `close()` would hang the system.
 * Added `gremlin.spark.dontDeleteNonEmptyOutput` to stop deleting the output folder if it is not empty in `spark-gremlin`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-5-7]]
 === TinkerPop 3.5.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
-* Bumped `jackson-databind` to 2.15.0 to fix security vulnerability.
+* Bumped `jackson-databind` to 2.15.2 to fix security vulnerability.
+* Introduced `maxNumberLength`, `maxStringLength`, and `maxNestingDepth` configs for `GraphSON` serializers.
 * Fixed a memory leak in the Gremlin.Net driver that only occurred if a CancellationToken was provided.
 * Fixed gremlin-python `Client` problem where calling `submit()` after` `close()` would hang the system.
 * Added `gremlin.spark.dontDeleteNonEmptyOutput` to stop deleting the output folder if it is not empty in `spark-gremlin`.

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -32,6 +32,20 @@ complete list of all the modifications that are part of this release.
 `gremlin-javascript` and `gremlint` have upgraded from Node 10 to Node 16 as Node 10 has passed end of life.
 `gremlin-go` has upgraded from Go 1.17 to Go 1.20 as Go 1.20 has passed end of life.
 
+Introduced max number length (10000 chars), string length (20 000 000 chars), and nesting depth (1000)
+constraints for GraphSON deserialization due to security vulnerabilities with earlier versions of Jackson Databind.
+New constraints are not expected to impact most users but can be overriden via GraphSONMapper.Builder or through serializer configuration.
+Example:
+```
+serializers:
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+      config: {
+        maxNumberLength: 500,
+        maxStringLength: 500,
+        maxNestingDepth: 500
+      }
+  }
+```
 
 == TinkerPop 3.5.6
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONStreamConstraintsTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONStreamConstraintsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.structure.io.graphson;
+
+import org.apache.tinkerpop.shaded.jackson.core.exc.StreamConstraintsException;
+import org.apache.tinkerpop.shaded.jackson.databind.JsonMappingException;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GraphSONStreamConstraintsTest extends AbstractGraphSONTest{
+
+    final ObjectMapper defaultMapper = GraphSONMapper.build().create().createMapper();
+
+    @Test
+    public void testMaxNumberLengthConfig() throws Exception {
+        final int serializedData = 1000;
+
+        final ObjectMapper mapper = GraphSONMapper.build().maxNumberLength(2).create().createMapper();
+
+        // should pass with default serializer config
+        assertEquals((Integer)serializedData, serializeDeserializeAuto(defaultMapper, serializedData));
+
+        // should fail with small limit config
+        final Exception exception = assertThrows(JsonMappingException.class, () -> {
+            serializeDeserializeAuto(mapper, serializedData);
+        });
+        assertTrue("Expected StreamConstraintsException for exceeding max number length, found: "+exception.getMessage(),
+                exception.getMessage().contains("org.apache.tinkerpop.shaded.jackson.core.exc.StreamConstraintsException: Number length")
+                && exception.getMessage().contains("exceeds the maximum length (2)"));
+    }
+
+    @Test
+    public void testMaxStringLengthConfig() throws Exception {
+        final String serializedData = "This string is more than 20 chars long";
+
+        final ObjectMapper mapper = GraphSONMapper.build().maxStringLength(20).create().createMapper();
+
+        // should pass with default serializer config
+        assertEquals(serializedData, serializeDeserializeAuto(defaultMapper, serializedData));
+
+        // should fail with small limit config
+        final Exception exception = assertThrows(StreamConstraintsException.class, () -> {
+            serializeDeserializeAuto(mapper, serializedData);
+        });
+        assertTrue("Expected StreamConstraintsException for exceeding max String length, found: "+exception.getMessage(),
+                exception.getMessage().contains("String length")
+                        && exception.getMessage().contains("exceeds the maximum length (20)"));
+    }
+
+    @Test
+    public void testMaxNestingDepthConfig() throws Exception {
+        final Map<String, Object> serializedData = new HashMap<>();
+        serializedData.put(
+                "key1", new HashMap<>().put(
+                        "key2", new HashMap<>().put(
+                                "key3", "val1")));
+        final ObjectMapper mapper = GraphSONMapper.build().maxNestingDepth(1).create().createMapper();
+
+        // should pass with default serializer config
+        assertEquals(serializedData, serializeDeserializeAuto(defaultMapper, serializedData));
+
+        // should fail with small limit config
+        final Exception exception = assertThrows(JsonMappingException.class, () -> {
+            serializeDeserializeAuto(mapper, serializedData);
+        });
+        assertTrue("Expected StreamConstraintsException for exceeding max nesting depth,  found: "+exception.getMessage(),
+                exception.getMessage().contains("org.apache.tinkerpop.shaded.jackson.core.exc.StreamConstraintsException: Depth")
+                        && exception.getMessage().contains("exceeds the maximum allowed nesting depth (1)"));
+    }
+}

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0.java
@@ -75,6 +75,7 @@ public abstract class AbstractGraphSONMessageSerializerV1d0 extends AbstractMess
     public void configure(final Map<String, Object> config, final Map<String, Graph> graphs) {
         final GraphSONMapper.Builder initialBuilder = initBuilder(null);
         addIoRegistries(config, initialBuilder);
+        applyMaxTokenLimits(initialBuilder, config);
         mapper = configureBuilder(initialBuilder).create().createMapper();
     }
 
@@ -152,6 +153,21 @@ public abstract class AbstractGraphSONMessageSerializerV1d0 extends AbstractMess
         final GraphSONMapper.Builder b = null == builder ? GraphSONMapper.build() : builder;
         return b.addCustomModule(new AbstractGraphSONMessageSerializerV1d0.GremlinServerModule())
                 .version(GraphSONVersion.V1_0);
+    }
+
+    private GraphSONMapper.Builder applyMaxTokenLimits(final GraphSONMapper.Builder builder, final Map<String, Object> config) {
+        if(config != null) {
+            if(config.containsKey("maxNumberLength")) {
+                builder.maxNumberLength((int)config.get("maxNumberLength"));
+            }
+            if(config.containsKey("maxStringLength")) {
+                builder.maxStringLength((int)config.get("maxStringLength"));
+            }
+            if(config.containsKey("maxNestingDepth")) {
+                builder.maxNestingDepth((int)config.get("maxNestingDepth"));
+            }
+        }
+        return builder;
     }
 
     @Override

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0.java
@@ -75,6 +75,7 @@ public abstract class AbstractGraphSONMessageSerializerV2d0 extends AbstractMess
     public void configure(final Map<String, Object> config, final Map<String, Graph> graphs) {
         final GraphSONMapper.Builder initialBuilder = initBuilder(null);
         addIoRegistries(config, initialBuilder);
+        applyMaxTokenLimits(initialBuilder, config);
         mapper = configureBuilder(initialBuilder).create().createMapper();
     }
 
@@ -143,6 +144,21 @@ public abstract class AbstractGraphSONMessageSerializerV2d0 extends AbstractMess
         final GraphSONMapper.Builder b = null == builder ? GraphSONMapper.build() : builder;
         return b.addCustomModule(GraphSONXModuleV2d0.build().create(false))
                 .version(GraphSONVersion.V2_0);
+    }
+
+    private GraphSONMapper.Builder applyMaxTokenLimits(final GraphSONMapper.Builder builder, final Map<String, Object> config) {
+        if(config != null) {
+            if(config.containsKey("maxNumberLength")) {
+                builder.maxNumberLength((int)config.get("maxNumberLength"));
+            }
+            if(config.containsKey("maxStringLength")) {
+                builder.maxStringLength((int)config.get("maxStringLength"));
+            }
+            if(config.containsKey("maxNestingDepth")) {
+                builder.maxNestingDepth((int)config.get("maxNestingDepth"));
+            }
+        }
+        return builder;
     }
 
     @Override

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterConfigTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterConfigTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0;
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0;
+import org.apache.tinkerpop.shaded.jackson.core.StreamReadConstraints;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClusterConfigTest {
+
+    @Test
+    public void shouldPropagateSerializerConstraintsForGraphSON3() {
+        final Configuration config = new BaseConfiguration();
+        config.setProperty("serializer.config.maxNumberLength", 999);
+        config.setProperty("serializer.config.maxStringLength", 123456);
+        config.setProperty("serializer.config.maxNestingDepth", 55);
+        config.setProperty("hosts", Arrays.asList("localhost"));
+
+        config.setProperty("serializer.className", GraphSONMessageSerializerV3d0.class.getCanonicalName());
+        final Cluster cluster = Cluster.open(config);
+        assertTrue(cluster.getSerializer() instanceof GraphSONMessageSerializerV3d0);
+        final GraphSONMessageSerializerV3d0 serV3 = (GraphSONMessageSerializerV3d0) cluster.getSerializer();
+        final StreamReadConstraints constraints = serV3.getMapper().getFactory().streamReadConstraints();
+
+        assertEquals(999, constraints.getMaxNumberLength());
+        assertEquals(123456, constraints.getMaxStringLength());
+        assertEquals(55, constraints.getMaxNestingDepth());
+    }
+
+    @Test
+    public void shouldPropagateSerializerConstraintsForGraphSON2() {
+        final Configuration config = new BaseConfiguration();
+        config.setProperty("serializer.config.maxNumberLength", 999);
+        config.setProperty("serializer.config.maxStringLength", 123456);
+        config.setProperty("serializer.config.maxNestingDepth", 55);
+        config.setProperty("hosts", Arrays.asList("localhost"));
+
+        config.setProperty("serializer.className", GraphSONMessageSerializerV2d0.class.getCanonicalName());
+        final Cluster cluster = Cluster.open(config);
+        assertTrue(cluster.getSerializer() instanceof GraphSONMessageSerializerV2d0);
+        final GraphSONMessageSerializerV2d0 serV2 = (GraphSONMessageSerializerV2d0) cluster.getSerializer();
+        final StreamReadConstraints constraints = serV2.getMapper().getFactory().streamReadConstraints();
+
+        assertEquals(999, constraints.getMaxNumberLength());
+        assertEquals(123456, constraints.getMaxStringLength());
+        assertEquals(55, constraints.getMaxNestingDepth());
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV1d0Test.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.ser;
+
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapper;
+import org.apache.tinkerpop.shaded.jackson.core.StreamReadConstraints;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractGraphSONMessageSerializerV1d0Test {
+    @Test
+    public void shouldApplyMaxTokenLengthsOnConfigure() {
+        // Initialize bare-bones AbstractGraphSONMessageSerializerV1d0
+        final AbstractGraphSONMessageSerializerV1d0 serializer = new AbstractGraphSONMessageSerializerV1d0() {
+            @Override byte[] obtainHeader() { return new byte[0]; }
+            @Override GraphSONMapper.Builder configureBuilder(GraphSONMapper.Builder builder) { return builder;}
+            @Override public String[] mimeTypesSupported() {return new String[0]; }
+        };
+
+        final Map<String, Object> config = new HashMap<>();
+        config.put("maxNumberLength", 999);
+        config.put("maxStringLength", 12345);
+        config.put("maxNestingDepth", 55);
+
+        serializer.configure(config, null);
+
+        final StreamReadConstraints constraints = serializer.getMapper().getFactory().streamReadConstraints();
+
+        assertEquals(999, constraints.getMaxNumberLength());
+        assertEquals(12345, constraints.getMaxStringLength());
+        assertEquals(55, constraints.getMaxNestingDepth());
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/AbstractGraphSONMessageSerializerV2d0Test.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.ser;
+
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapper;
+import org.apache.tinkerpop.shaded.jackson.core.StreamReadConstraints;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractGraphSONMessageSerializerV2d0Test {
+    @Test
+    public void shouldApplyMaxTokenLengthsOnConfigure() {
+        // Initialize bare-bones AbstractGraphSONMessageSerializerV1d0
+        final AbstractGraphSONMessageSerializerV2d0 serializer = new AbstractGraphSONMessageSerializerV2d0() {
+            @Override byte[] obtainHeader() { return new byte[0]; }
+            @Override GraphSONMapper.Builder configureBuilder(GraphSONMapper.Builder builder) { return builder;}
+            @Override public String[] mimeTypesSupported() {return new String[0]; }
+        };
+
+        final Map<String, Object> config = new HashMap<>();
+        config.put("maxNumberLength", 999);
+        config.put("maxStringLength", 12345);
+        config.put("maxNestingDepth", 55);
+
+        serializer.configure(config, null);
+
+        final StreamReadConstraints constraints = serializer.getMapper().getFactory().streamReadConstraints();
+
+        assertEquals(999, constraints.getMaxNumberLength());
+        assertEquals(12345, constraints.getMaxStringLength());
+        assertEquals(55, constraints.getMaxNestingDepth());
+    }
+}

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -48,7 +48,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.0</version>
+            <version>2.15.2</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -48,7 +48,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.0</version>
+            <version>2.15.0</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,9 @@ limitations under the License.
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>3.4.1</version>
+                    <configuration>
+                        <createDependencyReducedPom>false</createDependencyReducedPom>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -653,7 +653,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.4</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2948

This PR is meant to supersede https://github.com/apache/tinkerpop/pull/2061.

This PR includes a version bump for jackson, a bump for the shade plugin (required due to jackson 2.15.0 being a multi-release jar containing some java 17 and java 20 classes), as well as additional configuration options for graphSON serializers.

Jackson 2.15.0 adds new StreamReadConstraints which set a max length for numbers, strings, and a max nesting depth. These have been configured to 10 000, 20 000 000, and 1000 by default in TinkerPop. New serializer configs for `maxNumberLength`, `maxStringLength`, and `maxNestingDepth` have been added to graphSON serializers to adjust these values if needed.

VOTE +1