### PR TITLE
Add deprecation notice for Neo4j-Gremlin

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed a bug in `gremlin-server` where timeout tasks were not cancelled and could cause very large memory usage when timeout is large.
 * Removed `jcabi-manifests` dependency from `gremlin-core`, `gremlin-driver`, and `gremlin-server`.
 * Fixed a bug that caused the `GremlinGroovyScriptEngine` to throw a `MissingMethodException` when calling a static method in __ with the same name as an enum.
+* Deprecated Neo4j-Gremlin
 
 [[release-3-5-6]]
 === TinkerPop 3.5.6 (Release Date: May 1, 2023)

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -15,7 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ////
 [[neo4j-gremlin]]
-== Neo4j-Gremlin
+== Neo4j-Gremlin (Deprecated)
+
+WARNING: Deprecated: Neo4j-Gremlin is not compatible with versions of Neo4j beyond 3.4 (Reached End of Life March 31, 2020).
+For this reason, use of Neo4j-Gremlin is not recommended for production environments. Neo4j-Gremlin is expected to
+remain compatible with upcoming releases of TinkerPop, however long term support is not guaranteed. Neo4j-Gremlin may
+be dropped from future versions of TinkerPop if compatibility cannot reasonably be maintained. Alternative TinkerPop
+enabled graph providers can be found on the link:https://tinkerpop.apache.org/providers.html[TinkerPop site].
 
 [source,xml]
 ----

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -29,8 +29,12 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
+==== Runtime Version Upgrades
+
 `gremlin-javascript` and `gremlint` have upgraded from Node 10 to Node 16 as Node 10 has passed end of life.
 `gremlin-go` has upgraded from Go 1.17 to Go 1.20 as Go 1.20 has passed end of life.
+
+==== GraphSON max token lengths
 
 Introduced max number length (10000 chars), string length (20 000 000 chars), and nesting depth (1000)
 constraints for GraphSON deserialization due to security vulnerabilities with earlier versions of Jackson Databind.
@@ -46,6 +50,11 @@ serializers:
       }
   }
 ```
+
+==== Deprecation of Neo4j-Gremlin
+
+Neo4j-Gremlin has been deprecated due to incompatibility with current versions of Neo4j.
+See link:https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin[reference docs] for more information.
 
 == TinkerPop 3.5.6
 

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/jsr223/Neo4jGremlinPlugin.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/jsr223/Neo4jGremlinPlugin.java
@@ -33,7 +33,9 @@ import org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jVertexProperty;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jGremlinPlugin extends AbstractGremlinPlugin {
 
     private static final String NAME = "tinkerpop.neo4j";

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/LabelP.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/LabelP.java
@@ -26,7 +26,9 @@ import java.util.function.BiPredicate;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class LabelP extends P<String> {
 
     private LabelP(final String label) {
@@ -37,6 +39,10 @@ public final class LabelP extends P<String> {
         return new LabelP(label);
     }
 
+    /**
+     * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
+     */
+    @Deprecated
     public static final class LabelBiPredicate implements BiPredicate<String, String>, Serializable {
 
         private static final LabelBiPredicate INSTANCE = new LabelBiPredicate();

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/CypherStartStep.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/CypherStartStep.java
@@ -27,7 +27,9 @@ import java.util.Map;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class CypherStartStep extends StartStep<Map<String, Object>> {
 
     private final String query;

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/Neo4jGraphStep.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/Neo4jGraphStep.java
@@ -50,7 +50,9 @@ import java.util.function.BiPredicate;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Stephen Mallette (http://stephen.genoprime.com)
  * @author Pieter Martin
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jGraphStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder {
 
     private final List<HasContainer> hasContainers = new ArrayList<>();

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/strategy/optimization/Neo4jGraphStepStrategy.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/strategy/optimization/Neo4jGraphStepStrategy.java
@@ -33,7 +33,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 /**
  * @author Pieter Martin
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jGraphStepStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
 
     private static final Neo4jGraphStepStrategy INSTANCE = new Neo4jGraphStepStrategy();

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/util/Neo4jCypherIterator.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/util/Neo4jCypherIterator.java
@@ -30,7 +30,9 @@ import java.util.stream.Collectors;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jCypherIterator<T> implements Iterator<Map<String, T>> {
 
     private final Iterator<Map<String, T>> iterator;

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jEdge.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jEdge.java
@@ -33,7 +33,9 @@ import java.util.Iterator;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jEdge extends Neo4jElement implements Edge, WrappedEdge<Neo4jRelationship> {
 
     public Neo4jEdge(final Neo4jRelationship relationship, final Neo4jGraph graph) {

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jElement.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jElement.java
@@ -30,7 +30,9 @@ import java.util.Set;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public abstract class Neo4jElement implements Element, WrappedElement<Neo4jEntity> {
     protected final Neo4jGraph graph;
     protected final Neo4jEntity baseElement;

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
@@ -52,11 +52,13 @@ import java.util.stream.Stream;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Pieter Martin
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
 @Graph.OptIn(Graph.OptIn.SUITE_STRUCTURE_STANDARD)
 @Graph.OptIn(Graph.OptIn.SUITE_STRUCTURE_INTEGRATE)
 @Graph.OptIn(Graph.OptIn.SUITE_PROCESS_STANDARD)
 @Graph.OptIn("org.apache.tinkerpop.gremlin.neo4j.NativeNeo4jSuite")
+@Deprecated
 public final class Neo4jGraph implements Graph, WrappedGraph<Neo4jGraphAPI> {
 
     static {

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraphVariables.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraphVariables.java
@@ -29,7 +29,9 @@ import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jGraphVariables implements Graph.Variables {
 
     private final Neo4jGraph graph;

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jHelper.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jHelper.java
@@ -23,7 +23,9 @@ import org.neo4j.tinkerpop.api.Neo4jNode;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jHelper {
 
     private static final String NOT_FOUND_EXCEPTION = "NotFoundException";

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jProperty.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jProperty.java
@@ -26,7 +26,9 @@ import org.neo4j.tinkerpop.api.Neo4jEntity;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jProperty<V> implements Property<V> {
 
     protected final Element element;

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertex.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertex.java
@@ -43,7 +43,9 @@ import static org.apache.tinkerpop.gremlin.structure.Direction.OUT;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jVertex extends Neo4jElement implements Vertex, WrappedVertex<Neo4jNode> {
 
     public static final String LABEL_DELIMINATOR = "::";

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertexProperty.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jVertexProperty.java
@@ -36,7 +36,9 @@ import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated See: https://tinkerpop.apache.org/docs/3.5.7/reference/#neo4j-gremlin
  */
+@Deprecated
 public final class Neo4jVertexProperty<V> implements VertexProperty<V> {
 
     protected final Neo4jVertex vertex;


### PR DESCRIPTION
Based on dev list discussion, a decision was made to deprecate neo4j-gremlin. It will remain in the repo for foreseeable future and we will continue to maintain compatibility when possible. If the effort to maintain neo4j-gremlin becomes unreasonable in the future, a decision to remove it may be made at that time.

See DISCUSS thread on the dev list for more details: (https://lists.apache.org/thread/lxn4s9fs8rzggm0jlnffnphfpqnpn3h8)

VOTE +1