### PR TITLE
TINKERPOP-2939 Fixed MergeE/MergeV steps to always throw exception for invalid `onMatch` option.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,7 +30,8 @@ This release also includes changes from <<release-3-5-7, 3.5.7>>.
 * Fixed bug with `fail` step not working with a `VertexProgram` running on the server.
 * Introduced mime type `application/vnd.gremlin-v1.0+json;typed=false` to allow direct specification of GraphSON 1.0 without types.
 * Introduced mime type `application/vnd.gremlin-v2.0+json;typed=false` to allow direct specification of GraphSON 2.0 without types.
-* Removed `final` class declaration for `LabelStep`
+* Removed `final` class declaration for `LabelStep`.
+* Fixed MergeE/MergeV steps to always throw exception for invalid `onMatch` option.
 
 [[release-3-6-4]]
 === TinkerPop 3.6.4 (Release Date: May 12, 2023)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStep.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Merge;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
@@ -265,6 +266,10 @@ public class MergeEdgeStep<S> extends MergeStep<S, Edge, Object> {
         Iterator<Edge> edges = searchEdges(mergeMap);
 
         if (onMatchTraversal != null) {
+            if (onMatchTraversal instanceof ConstantTraversal) {
+                final Map matchMap = onMatchTraversal.next();
+                validateMapInput(matchMap, true);
+            }
 
             edges = IteratorUtils.peek(edges, e -> {
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStep.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -84,6 +85,11 @@ public class MergeVertexStep<S> extends MergeStep<S, Vertex, Map> {
         Iterator<Vertex> vertices = searchVertices(mergeMap);
 
         if (onMatchTraversal != null) {
+            if (onMatchTraversal instanceof ConstantTraversal) {
+                final Map matchMap = onMatchTraversal.next();
+                validateMapInput(matchMap, true);
+            }
+
             // attach the onMatch properties
             vertices = IteratorUtils.peek(vertices, v -> {
 

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/MergeEdge.feature
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/MergeEdge.feature
@@ -853,3 +853,18 @@ Feature: Step - mergeE()
     And the graph should return 1 for count of "g.E()"
     And the graph should return 1 for count of "g.V(1).out(\"knows\").hasId(2)"
 
+  # cannot use hidden namespace for label key for onMatch
+  Scenario: g_mergeEXnullX
+    Given the empty graph
+    And the graph initializer of
+      """
+      g.addV("person").property("name", "marko").property("age", 29)
+      """
+    And using the parameter xx1 defined as "m[{\"t[label]\": \"self\", \"D[OUT]\":\"M[outV]\", \"D[IN]\":\"M[inV]\"}]"
+    And using the parameter xx2 defined as "m[{\"~label\":\"vertex\"}]"
+    And the traversal of
+      """
+      g.V().as("v").mergeE(xx1).option(Merge.onMatch,xx2).option(Merge.outV,select("v")).option(Merge.inV,select("v"))
+      """
+    When iterated to list
+    Then the traversal will raise an error with message containing text of "Property key can not be a hidden key: ~label"

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/MergeEdge.feature
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/MergeEdge.feature
@@ -854,7 +854,7 @@ Feature: Step - mergeE()
     And the graph should return 1 for count of "g.V(1).out(\"knows\").hasId(2)"
 
   # cannot use hidden namespace for label key for onMatch
-  Scenario: g_mergeEXnullX
+  Scenario: g_V_asXvX_mergeEXxx1X_optionXMerge_onMatch_xx2X_optionXMerge_outV_selectXvXX_optionXMerge_inV_selectXvXX
     Given the empty graph
     And the graph initializer of
       """

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/MergeVertex.feature
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/MergeVertex.feature
@@ -827,3 +827,14 @@ Feature: Step - mergeV()
       """
     When iterated to list
     Then the traversal will raise an error with message containing text of "Property key can not be a hidden key: ~label"
+
+  # cannot use hidden namespace for label key for onMatch
+  Scenario: g_mergeV_hidden_label_key_onMatch_matched_prohibited
+    Given the empty graph
+    And using the parameter xx1 defined as "m[{\"~label\":\"vertex\"}]"
+    And the traversal of
+      """
+      g.mergeV([:]).option(Merge.onMatch, xx1)
+      """
+    When iterated to list
+    Then the traversal will raise an error with message containing text of "Property key can not be a hidden key: ~label"


### PR DESCRIPTION
Fixed MergeE/MergeV steps to always throw exception for invalid `onMatch` option.
Now exception is thrown only if the element is not present.

Jira https://issues.apache.org/jira/browse/TINKERPOP-2939