### PR TITLE
Remove TEST_TRANSACTIONS flag from GLVs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,8 @@ This release also includes changes from <<release-3-6-XXX, 3.6.XXX>>.
 * Added warning on vertex property cardinality mismatch when reading GraphML.
 * Added a `union()` start step.
 * Added the `concat()` step to perform `String` concatenations.
+* Added `TinkerTransactionGraph`, a reference implementation of transactional `TinkerGraph`
+* Replaced instances of Neo4j transaction graph with `TinkerTransactionGraph` for server, driver, and GLV integration tests
 * Bumped to `ws` 8.x for `gremlin-javascript`.
 * Added support for mid-traversal `E()`-steps to Gremlin core and GLV's.
 * Added nullable annotations to Gremlin.NET.
@@ -48,7 +50,7 @@ This release also includes changes from <<release-3-6-XXX, 3.6.XXX>>.
 * Added `materializeProperties` request option to control properties serialization.
 * Modified serializers in to handle serialization and deserialization of properties.
 * Added functional properties to the graph structure components for .NET, GO and Python.
-* Modified the 1GremlinScriptChecker1 to extract the `materializeProperties` request option.
+* Modified the `GremlinScriptChecker` to extract the `materializeProperties` request option.
 * `Neo4jVertexProperty` no longer throw Exception for `properties()`, but return empty `Iterable`.
 * Modified the grammar to allow for parameters to be specified in Gremlin.
 * Modified `GremlinLangScriptEngine` to take bindings.

--- a/docs/src/reference/implementations-tinkergraph.asciidoc
+++ b/docs/src/reference/implementations-tinkergraph.asciidoc
@@ -268,15 +268,15 @@ To use the embedded TinkerTransactionGraph in Gremlin Console:
 
 [gremlin-groovy]
 ----
-gremlin> graph = TinkerTransactionGraph.open() <1>
-gremlin> g = traversal().withEmbedded(graph) <2>
-gremlin> g.addV('test').property('name','one')
-gremlin> g.tx().commit() <3>
-gremlin> g.V().valueMap()
-gremlin> g.addV('test').property('name','two') <4>
-gremlin> g.V().valueMap()
-gremlin> g.tx().rollback() <5>
-gremlin> g.V().valueMap()
+graph = TinkerTransactionGraph.open() <1>
+g = traversal().withEmbedded(graph) <2>
+g.addV('test').property('name','one')
+g.tx().commit() <3>
+g.V().valueMap()
+g.addV('test').property('name','two') <4>
+g.V().valueMap()
+g.tx().rollback() <5>
+g.V().valueMap()
 ----
 
 <1> Open transactional graph.

--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -55,7 +55,6 @@ services:
       - ../gremlin-tools/gremlin-socket-server/conf:/gremlin-dotnet/gremlin-socket-server/conf/
     environment:
       - DOCKER_ENVIRONMENT=true
-      - TEST_TRANSACTIONS=true
     working_dir: /gremlin-dotnet
     command: >
       bash -c "dotnet test ./Gremlin.Net.sln -c Release;

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -60,7 +60,6 @@ services:
       - RUN_INTEGRATION_TESTS=true
       - RUN_INTEGRATION_WITH_ALIAS_TESTS=true
       - RUN_BASIC_AUTH_INTEGRATION_TESTS=true
-      - TEST_TRANSACTIONS=true
       - GREMLIN_SOCKET_SERVER_URL=ws://gremlin-socket-server-go
       - GREMLIN_SOCKET_SERVER_CONFIG_PATH=/go_app/gremlin-socket-server/conf/test-ws-gremlin.yaml
     working_dir: /go_app

--- a/gremlin-go/driver/traversal_test.go
+++ b/gremlin-go/driver/traversal_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestTraversal(t *testing.T) {
-	testTransactionEnable := getEnvOrDefaultBool("TEST_TRANSACTIONS", true)
 
 	t.Run("Test clone traversal", func(t *testing.T) {
 		g := cloneGraphTraversalSource(&Graph{}, NewBytecode(nil), nil)
@@ -75,7 +74,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test Transaction commit", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)
@@ -105,7 +103,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test Transaction rollback", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)
@@ -135,7 +132,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test Transaction flows", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)
@@ -182,7 +178,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test multi commit Transaction", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)
@@ -217,7 +212,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test multi rollback Transaction", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)
@@ -252,7 +246,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test multi commit and rollback Transaction", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)
@@ -287,7 +280,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test Transaction close", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)
@@ -323,7 +315,6 @@ func TestTraversal(t *testing.T) {
 	})
 
 	t.Run("Test Transaction close tx from parent", func(t *testing.T) {
-		skipTestsIfNotEnabled(t, integrationTestSuiteName, testTransactionEnable)
 		// Start a transaction traversal.
 		remote := newConnection(t)
 		g := Traversal_().WithRemote(remote)

--- a/gremlin-go/pom.xml
+++ b/gremlin-go/pom.xml
@@ -29,7 +29,6 @@ limitations under the License.
         <!-- provides a way to convert maven.test.skip value to skipTests for use in skipping go tests -->
         <maven.test.skip>false</maven.test.skip>
         <skipTests>${maven.test.skip}</skipTests>
-        <TEST_TRANSACTIONS>false</TEST_TRANSACTIONS>
         <gremlin.server.dir>${project.parent.basedir}/gremlin-server</gremlin.server.dir>
     </properties>
     <build>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
@@ -53,7 +53,6 @@ services:
       - ../../../../../gremlin-tools/gremlin-socket-server/conf:/js_app/gremlin-socket-server/conf/
     environment:
       - DOCKER_ENVIRONMENT=true
-      - TEST_TRANSACTIONS=true
     working_dir: /js_app
     command: >
       bash -c "npm config set cache /tmp --global

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
@@ -220,19 +220,14 @@ describe('Traversal', function () {
   });
   describe('support remote transactions - commit', function() {
     before(function () {
-      if (process.env.TEST_TRANSACTIONS !== "true") return this.skip();
-
       txConnection = helper.getConnection('gtx');
       return txConnection.open();
     });
     after(function () {
-      if (process.env.TEST_TRANSACTIONS === "true") {
-        // neo4j gets re-used and has to be cleaned up per test that uses it
-        const g = traversal().withRemote(txConnection);
-        return g.V().drop().iterate().then(() => {
-          return txConnection.close()
-        });
-      }
+      const g = traversal().withRemote(txConnection);
+      return g.V().drop().iterate().then(() => {
+        return txConnection.close()
+      });
     });
     it('should commit a simple transaction', async function () {
       const g = traversal().withRemote(txConnection);
@@ -263,19 +258,15 @@ describe('Traversal', function () {
   });
   describe('support remote transactions - rollback', function() {
     before(function () {
-      if (process.env.TEST_TRANSACTIONS !== "true") return this.skip();
 
       txConnection = helper.getConnection('gtx');
       return txConnection.open();
     });
     after(function () {
-      if (process.env.TEST_TRANSACTIONS === "true") {
-        // neo4j gets re-used and has to be cleaned up per test that uses it
-        const g = traversal().withRemote(txConnection);
-        return g.V().drop().iterate().then(() => {
-          return txConnection.close()
-        });
-      }
+      const g = traversal().withRemote(txConnection);
+      return g.V().drop().iterate().then(() => {
+        return txConnection.close()
+      });
     });
     it('should rollback a simple transaction', async function() {
       const g = traversal().withRemote(txConnection);

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -56,7 +56,6 @@ services:
       - ../gremlin-tools/gremlin-socket-server/conf:/python_app/gremlin-socket-server/conf/
 
     environment:
-      - TEST_TRANSACTIONS=${TEST_TRANSACTIONS:-true}
       - DEBIAN_FRONTEND=noninteractive
       - KRB5_CONFIG=./gremlin-test-server/krb5.conf
       - KRB5CCNAME=./test-tkt.cc

--- a/gremlin-python/pom.xml
+++ b/gremlin-python/pom.xml
@@ -29,7 +29,6 @@ limitations under the License.
         <!-- provides a way to convert maven.test.skip value to skipTests for use in skipping python tests -->
         <maven.test.skip>false</maven.test.skip>
         <skipTests>${maven.test.skip}</skipTests>
-        <TEST_TRANSACTIONS>false</TEST_TRANSACTIONS>
         <gremlin.server.dir>${project.parent.basedir}/gremlin-server</gremlin.server.dir>
         <tinkerpop.root.dir>${project.parent.basedir}</tinkerpop.root.dir>
     </properties>

--- a/gremlin-python/src/main/python/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/python/tests/process/test_traversal.py
@@ -35,10 +35,6 @@ gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gre
 anonymous_url = gremlin_server_url.format(45940)
 
 
-def transactions_disabled():
-    return (os.environ['TEST_TRANSACTIONS'] != 'true') if 'TEST_TRANSACTIONS' in os.environ else False
-
-
 class TestTraversal(object):
     def test_bytecode(self):
         g = traversal().withGraph(Graph())
@@ -154,7 +150,6 @@ class TestTraversal(object):
         except TypeError:
             pass
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_transaction_commit(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().withRemote(remote_transaction_connection)
@@ -178,7 +173,6 @@ class TestTraversal(object):
         drop_graph_check_count(g)
         verify_gtx_closed(gtx)
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_transaction_rollback(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().withRemote(remote_transaction_connection)
@@ -202,7 +196,6 @@ class TestTraversal(object):
         drop_graph_check_count(g)
         verify_gtx_closed(gtx)
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_transaction_no_begin(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().withRemote(remote_transaction_connection)
@@ -254,7 +247,6 @@ class TestTraversal(object):
         tx.rollback()
         assert not tx.isOpen()
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_multi_commit_transaction(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().withRemote(remote_transaction_connection)
@@ -285,7 +277,6 @@ class TestTraversal(object):
         verify_tx_state([tx1, tx2], False)
         assert g.V().count().next() == start_count + 3
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_multi_rollback_transaction(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().withRemote(remote_transaction_connection)
@@ -316,7 +307,6 @@ class TestTraversal(object):
         verify_tx_state([tx1, tx2], False)
         assert g.V().count().next() == start_count
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_multi_commit_and_rollback(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().withRemote(remote_transaction_connection)
@@ -347,7 +337,6 @@ class TestTraversal(object):
         verify_tx_state([tx1, tx2], False)
         assert g.V().count().next() == start_count + 2
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_transaction_close_tx(self):
         remote_conn = create_connection_to_gtx()
         g = traversal().withRemote(remote_conn)
@@ -383,7 +372,6 @@ class TestTraversal(object):
 
         drop_graph_check_count(g)
 
-    @pytest.mark.skipif(transactions_disabled(), reason="Transactions are not enabled.")
     def test_transaction_close_tx_from_parent(self):
         remote_conn = create_connection_to_gtx()
         g = traversal().withRemote(remote_conn)


### PR DESCRIPTION
As we are switching to TinkerTransactionGraph, we can run transaction tests by default and no longer need the environment flag `TEST_TRANSACTIONS` to run tests only when Neo4j plugin is installed. This flag and its usage is now removed from all GLVs. 