### PR TITLE
[TINKERPOP-2973] Enable vertex properties filtering for GraphComputer

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.computer.util.DefaultComputerResult;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.concurrent.Future;
@@ -134,6 +135,16 @@ public interface GraphComputer {
      * @throws IllegalArgumentException if the provided traversal attempts to access adjacent vertices
      */
     public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) throws IllegalArgumentException;
+
+    /**
+     * Add a filter that will limit which vertex properties are loaded from the graph source. The loaded vertices
+     * will only have those properties that pass through the provided filter. To drop all vertex properties,
+     * provide a traversal like __.properties("dummy") where "dummy" is not a valid vertex property.
+     *
+     * @param vertexPropertyFilter the traversal that determines which vertex properties are loaded for each vertex
+     * @return the updated GraphComputer with newly set vertex property filter
+     */
+    public GraphComputer vertexProperties(final Traversal<Vertex, ? extends Property<?>> vertexPropertyFilter);
 
     /**
      * Set an arbitrary configuration key/value for the underlying {@code Configuration} in the {@link GraphComputer}.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -574,6 +575,13 @@ public final class StarGraph implements Graph, Serializable {
                         else
                             this.inEdges = inEdges;
                     }
+                }
+                if (graphFilter.hasVertexPropertyFilter()) {
+                    Set<String> retainSet = new HashSet<>();
+                    graphFilter.legalVertexProperties(this).forEachRemaining(property -> {
+                        retainSet.add(property.key());
+                    });
+                    this.vertexProperties.keySet().removeIf(key -> !retainSet.contains(key));
                 }
                 return Optional.of(this);
             } else {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
@@ -165,6 +166,11 @@ public class TraversalStrategiesTest {
 
         @Override
         public GraphComputer edges(Traversal<Vertex, Edge> edgeFilter) throws IllegalArgumentException {
+            return this;
+        }
+
+        @Override
+        public GraphComputer vertexProperties(Traversal<Vertex, ? extends Property<?>> vertexPropertyFilter) {
             return this;
         }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -155,6 +155,12 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
             } catch (final UnsupportedOperationException e) {
                 assertEquals(GraphComputer.Exceptions.graphFilterNotSupported().getMessage(), e.getMessage());
             }
+            try {
+                new BadGraphComputer().vertexProperties(__.properties("type"));
+                fail("Should throw an unsupported operation exception");
+            } catch (final UnsupportedOperationException e) {
+                assertEquals(GraphComputer.Exceptions.graphFilterNotSupported().getMessage(), e.getMessage());
+            }
         } else {
             fail("Should not support graph filter: " + BadGraphComputer.class);
         }
@@ -194,6 +200,11 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
 
         @Override
         public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
+            throw GraphComputer.Exceptions.graphFilterNotSupported();
+        }
+
+        @Override
+        public GraphComputer vertexProperties(Traversal<Vertex, ? extends Property<?>> vertexPropertyFilter) {
             throw GraphComputer.Exceptions.graphFilterNotSupported();
         }
 
@@ -1756,13 +1767,19 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
             } catch (final UnsupportedOperationException e) {
                 assertEquals(GraphComputer.Exceptions.graphFilterNotSupported().getMessage(), e.getMessage());
             }
+            try {
+                graphProvider.getGraphComputer(graph).vertexProperties(__.properties("prop1", "prop2"));
+                fail("Should throw an unsupported operation exception");
+            } catch (final UnsupportedOperationException e) {
+                assertEquals(GraphComputer.Exceptions.graphFilterNotSupported().getMessage(), e.getMessage());
+            }
             return;
         }
         /// VERTEX PROGRAM
-        graphProvider.getGraphComputer(graph).vertices(__.hasLabel("software")).program(new VertexProgramM(VertexProgramM.SOFTWARE_ONLY)).submit().get();
+        graphProvider.getGraphComputer(graph).vertices(__.hasLabel("software")).vertexProperties(__.properties("dummy")).program(new VertexProgramM(VertexProgramM.SOFTWARE_ONLY)).submit().get();
         graphProvider.getGraphComputer(graph).vertices(__.hasLabel("person")).program(new VertexProgramM(VertexProgramM.PEOPLE_ONLY)).submit().get();
         graphProvider.getGraphComputer(graph).edges(__.bothE("knows")).program(new VertexProgramM(VertexProgramM.KNOWS_ONLY)).submit().get();
-        graphProvider.getGraphComputer(graph).vertices(__.hasLabel("person")).edges(__.bothE("knows")).program(new VertexProgramM(VertexProgramM.PEOPLE_KNOWS_ONLY)).submit().get();
+        graphProvider.getGraphComputer(graph).vertices(__.hasLabel("person")).vertexProperties(__.properties("name")).edges(__.bothE("knows")).program(new VertexProgramM(VertexProgramM.PEOPLE_KNOWS_ONLY)).submit().get();
         graphProvider.getGraphComputer(graph).vertices(__.hasLabel("person")).edges(__.<Vertex>bothE("knows").has("weight", P.gt(0.5f))).program(new VertexProgramM(VertexProgramM.PEOPLE_KNOWS_WELL_ONLY)).submit().get();
         graphProvider.getGraphComputer(graph).edges(__.<Vertex>bothE().limit(0)).program(new VertexProgramM(VertexProgramM.VERTICES_ONLY)).submit().get();
         graphProvider.getGraphComputer(graph).edges(__.<Vertex>outE().limit(1)).program(new VertexProgramM(VertexProgramM.ONE_OUT_EDGE_ONLY)).submit().get();
@@ -1800,6 +1817,14 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
             fail();
         } catch (final IllegalArgumentException e) {
             assertEquals(e.getMessage(), GraphComputer.Exceptions.edgeFilterAccessesAdjacentVertices(__.<Vertex>out().outE()).getMessage());
+        }
+        try {
+            // VertexProgramM.PEOPLE_KNOWS_ONLY needs name property
+            graphProvider.getGraphComputer(graph)
+                .vertices(__.hasLabel("person")).edges(__.bothE("knows")).vertexProperties(__.properties("dummy"))
+                .program(new VertexProgramM(VertexProgramM.PEOPLE_KNOWS_ONLY)).submit().get();
+        } catch (final ExecutionException e) {
+            assertTrue(e.getMessage().contains("The property does not exist as the key has no associated value for the provided element"));
         }
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgramTest.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 
@@ -73,8 +74,9 @@ public class PageRankVertexProgramTest extends AbstractGremlinProcessTest {
     @LoadGraphWith(MODERN)
     public void shouldExecutePageRankWithEpsilonBreak() throws Exception {
         if (graphProvider.getGraphComputer(graph).features().supportsResultGraphPersistCombination(GraphComputer.ResultGraph.NEW, GraphComputer.Persist.VERTEX_PROPERTIES)) {
-            final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass()).
-                    program(PageRankVertexProgram.build().epsilon(0.00001d).iterations(30).create(graph)).submit().get(); // by using epsilon 0.00001, we should get iterations 11
+            final ComputerResult result = graph.compute(graphProvider.getGraphComputer(graph).getClass())
+                .vertexProperties(__.properties("name", "age", "lang"))
+                .program(PageRankVertexProgram.build().epsilon(0.00001d).iterations(30).create(graph)).submit().get(); // by using epsilon 0.00001, we should get iterations 11
             result.graph().traversal().V().forEachRemaining(v -> {
                 assertEquals(3, v.keys().size()); // name, age/lang, pageRank
                 assertTrue(v.keys().contains("name"));

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
@@ -34,8 +34,8 @@ import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.util.GraphComputerHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.io.Storage;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.Gremlin;
 import org.slf4j.Logger;
@@ -85,6 +85,12 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
     @Override
     public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
         this.graphFilter.setEdgeFilter(edgeFilter);
+        return this;
+    }
+
+    @Override
+    public GraphComputer vertexProperties(final Traversal<Vertex, ? extends Property<?>> vertexPropertyFilter) {
+        this.graphFilter.setVertexPropertyFilter(vertexPropertyFilter);
         return this;
     }
 

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.gryo.GryoInputFormat;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.spark.AbstractSparkTest;
 import org.apache.tinkerpop.gremlin.spark.process.computer.SparkGraphComputer;
 import org.apache.tinkerpop.gremlin.spark.process.computer.SparkHadoopGraphProvider;
@@ -70,7 +71,10 @@ public class SparkTest extends AbstractSparkTest {
             assertEquals(i, Spark.getRDDs().size());
             configuration.setProperty(Constants.GREMLIN_HADOOP_OUTPUT_LOCATION, prefix + i);
             Graph graph = GraphFactory.open(configuration);
-            graph.compute(SparkGraphComputer.class).persist(GraphComputer.Persist.VERTEX_PROPERTIES).program(PageRankVertexProgram.build().iterations(1).create(graph)).submit().get();
+            graph.compute(SparkGraphComputer.class)
+                .persist(GraphComputer.Persist.VERTEX_PROPERTIES)
+                .vertexProperties(__.properties("dummy"))
+                .program(PageRankVertexProgram.build().iterations(1).create(graph)).submit().get();
             assertNotNull(Spark.getRDD(graphRDDName));
             assertEquals(i + 1, Spark.getRDDs().size());
         }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalInterruptedException;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
@@ -125,6 +126,12 @@ public final class TinkerGraphComputer implements GraphComputer {
     @Override
     public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
         this.graphFilter.setEdgeFilter(edgeFilter);
+        return this;
+    }
+
+    @Override
+    public GraphComputer vertexProperties(Traversal<Vertex, ? extends Property<?>> vertexPropertyFilter) {
+        this.graphFilter.setVertexPropertyFilter(vertexPropertyFilter);
         return this;
     }
 

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
@@ -21,6 +21,8 @@ package org.apache.tinkerpop.gremlin.tinkergraph.process.computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.process.computer.VertexComputeKey;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -36,9 +38,11 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerVertex;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerVertexProperty;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,6 +59,7 @@ public final class TinkerGraphComputerView {
     private final Set<Object> legalVertices = new HashSet<>();
     private final Map<Object, Set<Object>> legalEdges = new HashMap<>();
     private final GraphFilter graphFilter;
+    private final Set<String> retainVertexProperties;
 
     public TinkerGraphComputerView(final TinkerGraph graph, final GraphFilter graphFilter, final Set<VertexComputeKey> computeKeys) {
         this.graph = graph;
@@ -75,6 +80,11 @@ public final class TinkerGraphComputerView {
                     this.graphFilter.legalEdges(vertex).forEachRemaining(edge -> edges.add(edge.id()));
                 }
             });
+        }
+        if (this.graphFilter.hasVertexPropertyFilter()) {
+            retainVertexProperties = new HashSet<>(Arrays.asList(((PropertiesStep) graphFilter.getVertexPropertyFilter().getStartStep()).getPropertyKeys()));
+        } else {
+            retainVertexProperties = null;
         }
     }
 
@@ -97,19 +107,26 @@ public final class TinkerGraphComputerView {
     public List<VertexProperty<?>> getProperty(final TinkerVertex vertex, final String key) {
         // if the vertex property is already on the vertex, use that.
         final List<VertexProperty<?>> vertexProperty = this.getValue(vertex, key);
-        return vertexProperty.isEmpty() ? (List) TinkerHelper.getProperties(vertex).getOrDefault(key, Collections.emptyList()) : vertexProperty;
-        //return isComputeKey(key) ? this.getValue(vertex, key) : (List) TinkerHelper.getProperties(vertex).getOrDefault(key, Collections.emptyList());
+        return vertexProperty.isEmpty() ? (List) getPropertiesMap(vertex).getOrDefault(key, Collections.emptyList()) : vertexProperty;
     }
 
     public List<Property> getProperties(final TinkerVertex vertex) {
         final List<Property> list = new ArrayList<>();
-        for (final List<VertexProperty> properties : TinkerHelper.getProperties(vertex).values()) {
+        for (final List<VertexProperty> properties : getPropertiesMap(vertex).values()) {
             list.addAll(properties);
         }
         for (final List<VertexProperty<?>> properties : this.computeProperties.getOrDefault(vertex, Collections.emptyMap()).values()) {
             list.addAll(properties);
         }
         return list;
+    }
+
+    private Map<String, List<VertexProperty>> getPropertiesMap(final TinkerVertex vertex) {
+        Map<String, List<VertexProperty>> propertiesMap = TinkerHelper.getProperties(vertex);
+        if (retainVertexProperties != null) {
+            propertiesMap.keySet().retainAll(retainVertexProperties);
+        }
+        return propertiesMap;
     }
 
     public void removeProperty(final TinkerVertex vertex, final String key, final VertexProperty property) {


### PR DESCRIPTION
GraphComputer has vertexFilter and edgeFilter, but not yet a filter for vertex properties. Many vertex programs don't need many if not all vertex properties. PageRank, for example, does not need any vertex properties at all. Having a vertex property filter can greatly reduce memory/disk usage.