### PR TITLE
Rename RangeByIsCountStrategy to CountStrategy in Gremlin.NET.

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Optimization/CountStrategy.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/Strategy/Optimization/CountStrategy.cs
@@ -26,14 +26,14 @@ namespace Gremlin.Net.Process.Traversal.Strategy.Optimization
     /// <summary>
     ///     Optimizes any occurrence of <c>Count()</c>-step followed by an <c>Is()</c>-step.
     /// </summary>
-    public class RangeByIsCountStrategy : AbstractTraversalStrategy
+    public class CountStrategy : AbstractTraversalStrategy
     {
-        private const string JavaFqcn = OptimizationNamespace + nameof(RangeByIsCountStrategy);
+        private const string JavaFqcn = OptimizationNamespace + nameof(CountStrategy);
         
         /// <summary>
-        ///     Initializes a new instance of the <see cref="RangeByIsCountStrategy" /> class.
+        ///     Initializes a new instance of the <see cref="CountStrategy" /> class.
         /// </summary>
-        public RangeByIsCountStrategy() : base(JavaFqcn)
+        public CountStrategy() : base(JavaFqcn)
         {
         }
     }


### PR DESCRIPTION
This change has originally been done in f08d44fc5c8649658fd775289f0a49ec1816306d.