### PR TITLE
TINKERPOP-2976 Fix modification while iterating

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-5-8]]
 === TinkerPop 3.5.8 (NOT OFFICIALLY RELEASED YET)
 
+* Fixed a bug in Gremlin.Net that can lead to an `InvalidOperationException` due to modifying a collection while iterating over it in the serializers.
 
 
 [[release-3-5-7]]

--- a/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Structure/IO/GraphSON/GraphSONWriter.cs
@@ -134,11 +134,11 @@ namespace Gremlin.Net.Structure.IO.GraphSON
 
         private IGraphSONSerializer TryGetSerializerFor(Type type)
         {
-            if (Serializers.ContainsKey(type))
+            if (Serializers.TryGetValue(type, out var serializer))
             {
-                return Serializers[type];
+                return serializer;
             }
-            foreach (var supportedType in Serializers.Keys)
+            foreach (var supportedType in new List<Type>(Serializers.Keys))
                 if (supportedType.IsAssignableFrom(type))
                 {
                     return Serializers[supportedType];


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2976

In rare cases users could get an `InvalidOperationException` if the dictionary of `_serializerByType` was modified while another thread in parallel iterated over the keys of this dictionary. Just creating a copy of the supported types and then iterating over that should fix this.
The problem was reported for GraphBinary, but the GraphSONWriter had the same problem so I also fixed it there.

VOTE +1

Since we are currently in code freeze, we can simply merge this after that has been lifted.