### PR TITLE
TINKERPOP-2986: [StarGraph] Drop edge properties when dropping edges

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -360,12 +360,20 @@ public final class StarGraph implements Graph, Serializable {
             super(id, label);
         }
 
+        private void dropEdgeProperty(Object id) {
+            if (edgeProperties != null) {
+                edgeProperties.remove(id);
+            }
+        }
+
         public void dropEdges(final Direction direction) {
             if ((direction.equals(Direction.OUT) || direction.equals(Direction.BOTH)) && null != this.outEdges) {
+                this.outEdges.values().forEach(edges -> edges.forEach(edge -> dropEdgeProperty(edge.id())));
                 this.outEdges.clear();
                 this.outEdges = null;
             }
             if ((direction.equals(Direction.IN) || direction.equals(Direction.BOTH)) && null != this.inEdges) {
+                this.inEdges.values().forEach(edges -> edges.forEach(edge -> dropEdgeProperty(edge.id())));
                 this.inEdges.clear();
                 this.inEdges = null;
             }
@@ -373,12 +381,14 @@ public final class StarGraph implements Graph, Serializable {
 
         public void dropEdges(final Direction direction, final String edgeLabel) {
             if (null != this.outEdges && (direction.equals(Direction.OUT) || direction.equals(Direction.BOTH))) {
+                this.outEdges.get(edgeLabel).forEach(edge -> dropEdgeProperty(edge.id()));
                 this.outEdges.remove(edgeLabel);
 
                 if (this.outEdges.isEmpty())
                     this.outEdges = null;
             }
             if (null != this.inEdges && (direction.equals(Direction.IN) || direction.equals(Direction.BOTH))) {
+                this.inEdges.get(edgeLabel).forEach(edge -> dropEdgeProperty(edge.id()));
                 this.inEdges.remove(edgeLabel);
 
                 if (this.inEdges.isEmpty())


### PR DESCRIPTION
SparkGraphComputer uses StarGraph to represent an in-memory graph. EdgeFilter can be configured by users to drop unneeded edges, but the edge properties aren't dropped. This fixes this bug and greatly reduces memory footprint.