### PR TITLE
[TINKERPOP-2972] ProjectStep and SelectStep do not allow a duplicate key

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,7 +25,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-5-8, 3.5.8>>.
 
+==== Improvements
 
+* TINKERPOP-2972 Throw an Exception when a duplicate key is supplied for ProjectStep and SelectStep
 
 [[release-3-6-5]]
 === TinkerPop 3.6.5 (Release Date: July 31, 2023)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
@@ -29,10 +29,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -48,6 +50,11 @@ public class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> implemen
 
     public ProjectStep(final Traversal.Admin traversal, final TraversalRing<S, E> traversalRing, final String... projectKeys) {
         super(traversal);
+
+        if (Arrays.stream(projectKeys).collect(Collectors.toSet()).size() != projectKeys.length) {
+            throw new IllegalArgumentException("keys must be unique in ProjectStep");
+        }
+
         this.projectKeys = Arrays.asList(projectKeys);
         this.traversalRing = traversalRing;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -59,6 +59,9 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
         this.pop = pop;
         this.selectKeys = Arrays.asList(selectKeys);
         this.selectKeysSet = Collections.unmodifiableSet(new HashSet<>(this.selectKeys));
+        if (this.selectKeysSet.size() != this.selectKeys.size()) {
+            throw new IllegalArgumentException("keys must be unique in SelectStep");
+        }
         if (this.selectKeys.size() < 2)
             throw new IllegalArgumentException("At least two select keys must be provided: " + this);
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStepTest.java
@@ -22,9 +22,15 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -43,5 +49,16 @@ public class ProjectStepTest extends StepTest {
                 __.project("x").by(__.outE().count()),
                 __.project("y").by("name")
         );
+    }
+
+    @Test
+    public void shouldThrowWhenDuplicateKeySupplied() {
+        try {
+            __.project("x", "x");
+            fail("Should throw an exception.");
+        } catch (final Exception re) {
+            assertThat(re, instanceOf(IllegalArgumentException.class));
+            assertThat(re.getMessage(), is("keys must be unique in ProjectStep"));
+        }
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStepTest.java
@@ -28,7 +28,11 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -61,6 +65,17 @@ public class SelectStepTest extends StepTest {
         };
         for (final Object[] traversalPath : traversalPaths) {
             assertEquals(traversalPath[0], ((Traversal.Admin<?, ?>) traversalPath[1]).getTraverserRequirements().contains(TraverserRequirement.LABELED_PATH));
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenDuplicateKeySupplied() {
+        try {
+            __.select("x", "x");
+            fail("Should throw an exception.");
+        } catch (final Exception re) {
+            assertThat(re, instanceOf(IllegalArgumentException.class));
+            assertThat(re.getMessage(), is("keys must be unique in SelectStep"));
         }
     }
 }


### PR DESCRIPTION
Having duplicate keys does not make sense and a user won't use this feature (correct me otherwise). But due to the round-robin nature, determining which traversal should be mapped to the key is complicated in terms of implementation.

So we should throw fast so that we don't have to deal with duplicate keys.