### PR TITLE
[TINKERPOP-3006] Enable remote connection over HTTP for gremlin python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,8 @@ This release also includes changes from <<release-3-5-8, 3.5.8>>.
 * Fixed a javadoc comment in `GraphTraversal.not()` method.
 * Allowed `gremlin-driver` to be used over HTTP for experimental purposes.
 * Deprecated the `HandshakeInterceptor` in favor of a more generic `RequestInterceptor`.
+* Allowed `gremlin-python` to be used over HTTP for experimental purposes.
+* Updated `gremlin-python` translator to enable additional traversals over HTTP.
 * Fixed a bug in `StarGraph` where `EdgeFilter` did not remove associated Edge Properties.
 * Added translator to the Go GLV.
 * Fixed bug with filtering for `group()` when the side-effect label was defined for it.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslator.java
@@ -186,7 +186,7 @@ public final class GroovyTranslator implements Translator.ScriptTranslator {
                 if (NumberHelper.isPositiveInfinity(o))
                     return (o instanceof Double ? "Double" : "Float") + ".POSITIVE_INFINITY";
                 if (NumberHelper.isNegativeInfinity(o))
-                    return (o instanceof Double ? "Double" : "Float") + ".POSITIVE_INFINITY";
+                    return (o instanceof Double ? "Double" : "Float") + ".NEGATIVE_INFINITY";
 
                 return o + (o instanceof Double ? "d" : "f");
             }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslatorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/GroovyTranslatorTest.java
@@ -213,6 +213,21 @@ public class GroovyTranslatorTest {
     }
 
     @Test
+    public void shouldTranslateNaN() {
+        assertTranslation("Double.NaN", Double.NaN);
+    }
+
+    @Test
+    public void shouldTranslatePosInf() {
+        assertTranslation("Double.POSITIVE_INFINITY", Double.POSITIVE_INFINITY);
+    }
+
+    @Test
+    public void shouldTranslateNegInf() {
+        assertTranslation("Double.NEGATIVE_INFINITY", Double.NEGATIVE_INFINITY);
+    }
+
+    @Test
     public void shouldIncludeCustomTypeTranslationForSomethingSilly() throws Exception {
         final SillyClass notSillyEnough = SillyClass.from("not silly enough", 100);
 

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       - KRB5CCNAME=./test-tkt.cc
       - GREMLIN_SERVER_URL=ws://gremlin-server-test-python:{}/gremlin
       - GREMLIN_SERVER_BASIC_AUTH_URL=wss://gremlin-server-test-python:{}/gremlin
+      - GREMLIN_SERVER_URL_HTTP=http://gremlin-server-test-python:{}/
+      - GREMLIN_SERVER_BASIC_AUTH_URL_HTTP=https://gremlin-server-test-python:{}/
       - KRB_HOSTNAME=${KRB_HOSTNAME:-gremlin-server-test}
       - VERSION=${VERSION}
     working_dir: /python_app

--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -169,9 +169,6 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
             self._ssl_context = self._aiohttp_kwargs.pop("ssl_options")
             self._enable_ssl = True
 
-        # if "ssl_options" in self._aiohttp_kwargs:
-        #     self._aiohttp_kwargs["ssl_context"] = self._aiohttp_kwargs.pop("ssl_options")
-
     def __del__(self):
         # Close will only actually close if things are left open, so this is safe to call.
         # Clean up any connection resources and close the event loop.

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -19,6 +19,7 @@
 import logging
 import warnings
 import queue
+import re
 from concurrent.futures import ThreadPoolExecutor
 
 from gremlin_python.driver import connection, protocol, request, serializer
@@ -45,15 +46,20 @@ class Client:
                  kerberized_service="", headers=None, session=None,
                  enable_user_agent_on_connect=True, **transport_kwargs):
         log.info("Creating Client with url '%s'", url)
+
+        # check via url that we are using http protocol
+        self._use_http = re.search('^http', url)
+
         self._closed = False
         self._url = url
         self._headers = headers
         self._enable_user_agent_on_connect = enable_user_agent_on_connect
         self._traversal_source = traversal_source
-        if "max_content_length" not in transport_kwargs:
+        if not self._use_http and "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
             message_serializer = serializer.GraphBinarySerializersV1()
+            # message_serializer = serializer.GraphSONMessageSerializer()
 
         self._message_serializer = message_serializer
         self._username = username
@@ -63,21 +69,31 @@ class Client:
         if transport_factory is None:
             try:
                 from gremlin_python.driver.aiohttp.transport import (
-                    AiohttpTransport)
+                    AiohttpTransport, AiohttpHTTPTransport)
             except ImportError:
                 raise Exception("Please install AIOHTTP or pass "
                                 "custom transport factory")
             else:
                 def transport_factory():
-                    return AiohttpTransport(**transport_kwargs)
+                    if self._use_http:
+                        return AiohttpHTTPTransport(**transport_kwargs)
+                    else:
+                        return AiohttpTransport(**transport_kwargs)
         self._transport_factory = transport_factory
         if protocol_factory is None:
-            def protocol_factory(): return protocol.GremlinServerWSProtocol(
-                self._message_serializer,
-                username=self._username,
-                password=self._password,
-                kerberized_service=kerberized_service,
-                max_content_length=transport_kwargs["max_content_length"])
+            def protocol_factory():
+                if self._use_http:
+                    return protocol.GremlinServerHTTPProtocol(
+                        self._message_serializer,
+                        username=self._username,
+                        password=self._password)
+                else:
+                    return protocol.GremlinServerWSProtocol(
+                        self._message_serializer,
+                        username=self._username,
+                        password=self._password,
+                        kerberized_service=kerberized_service,
+                        max_content_length=transport_kwargs["max_content_length"])
         self._protocol_factory = protocol_factory
         if self._session_enabled:
             if pool_size is None:

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -59,7 +59,6 @@ class Client:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
             message_serializer = serializer.GraphBinarySerializersV1()
-            # message_serializer = serializer.GraphSONMessageSerializer()
 
         self._message_serializer = message_serializer
         self._username = username

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+import base64
 import logging
 import struct
 import uuid
@@ -156,7 +157,8 @@ class GraphSONMessageSerializer(object):
         return message
 
     def deserialize_message(self, message):
-        msg = json.loads(message.decode('utf-8'))
+        # for parsing string message via HTTP connections
+        msg = json.loads(message if isinstance(message, str) else message.decode('utf-8'))
         return self._graphson_reader.to_object(msg)
 
 
@@ -268,7 +270,8 @@ class GraphBinarySerializersV1(object):
         return bytes(ba)
 
     def deserialize_message(self, message):
-        b = io.BytesIO(message)
+        # for parsing string message via HTTP connections
+        b = io.BytesIO(base64.b64decode(message) if isinstance(message, str) else message)
 
         b.read(1)  # version
 

--- a/gremlin-python/src/main/python/gremlin_python/process/translator.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/translator.py
@@ -24,11 +24,11 @@ sent to any TinkerPop compliant HTTP endpoint.
 """
 __author__ = 'Kelvin R. Lawrence (gfxman)'
 
-from gremlin_python.process.graph_traversal import __
-from gremlin_python.process.anonymous_traversal import traversal
+import re
+
 from gremlin_python.process.traversal import *
-from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.strategies import *
+from gremlin_python.structure.graph import Vertex, Edge, VertexProperty
 from datetime import datetime
 
 
@@ -39,16 +39,16 @@ class Translator:
 
     # Dictionary used to reverse-map token IDs to strings
     options = {
-      WithOptions.tokens: 'tokens',
-      WithOptions.none: 'none',
-      WithOptions.ids: 'ids',
-      WithOptions.labels: 'labels',
-      WithOptions.keys: 'keys',
-      WithOptions.values: 'values',
-      WithOptions.all: 'all',
-      WithOptions.indexer: 'indexer',
-      WithOptions.list: 'list',
-      WithOptions.map: 'map'                           
+        WithOptions.tokens: 'tokens',
+        WithOptions.none: 'none',
+        WithOptions.ids: 'ids',
+        WithOptions.labels: 'labels',
+        WithOptions.keys: 'keys',
+        WithOptions.values: 'values',
+        WithOptions.all: 'all',
+        WithOptions.indexer: 'indexer',
+        WithOptions.list: 'list',
+        WithOptions.map: 'map'
     }
 
     def __init__(self, traversal_source=None):
@@ -60,20 +60,22 @@ class Translator:
     def get_target_language(self):
         return "gremlin-groovy"
 
-    def of(self,traversal_source):
+    def of(self, traversal_source):
         self.traversal_source = traversal_source
         return self
 
     # Do any needed special processing for the representation
-    # of strings and dates.
+    # of strings and dates and boolean.
     def fixup(self, v):
         if isinstance(v, str):
             return f'\'{v}\''
         elif type(v) == datetime:
             return self.process_date(v)
+        elif type(v) == bool:
+            return 'true' if v else 'false'
         else:
             return str(v)
-    
+
     # Turn a Python datetime into the equivalent new Date(...)
     def process_date(self, date):
         y = date.year - 1900
@@ -97,26 +99,55 @@ class Translator:
         else:
             res += self.fixup(p.value)
             if p.other is not None:
-                res+= ',' + self.fixup(p.other)
+                res += ',' + self.fixup(p.other)
         res += ')'
         return res
 
     # Special processing to handle strategies
     def process_strategy(self, s):
         c = 0
-        res = f'new {str(s)}('
-        for key in s.configuration:
-            res += ',' if c > 0 else ''
-            res += key + ':'
-            val = s.configuration[key]
-            if isinstance(val, Traversal):
-                res += self.translate(val.bytecode, child=True)
-            else:
-                res += self.fixup(val)
-            c += 1
-        res += ')'
+        res = ''
+        # if parameter is empty, only pass class name (referenced GroovyTranslator.java)
+        if not s.configuration:
+            res += s.__class__.__name__
+        else:
+            res = f'new {str(s)}('
+            for key in s.configuration:
+                res += ',' if c > 0 else ''
+                res += key + ':'
+                val = s.configuration[key]
+                if isinstance(val, Traversal):
+                    res += self.translate(val.bytecode, child=True)
+                else:
+                    res += self.fixup(val)
+                c += 1
+            res += ')'
         return res
         pass
+
+    # Special processing to handle vertices
+    def process_vertex(self, vertex):
+        return f'new ReferenceVertex({str(vertex.id)},\'{vertex.label}\')'
+
+    # Special processing to handle edges
+    def process_edge(self, edge):
+        return f'new ReferenceEdge({str(edge.id)},\'{edge.label}\',' \
+               f'new ReferenceVertex({str(edge.inV.id)},\'{edge.inV.label}\'),' \
+               f'new ReferenceVertex({str(edge.outV.id)},\'{edge.outV.label}\'))'
+
+    # Special processing to handle vertex property
+    def process_vertex_property(self, vp):
+        return f'new ReferenceVertexProperty({str(vp.id)},\'{vp.label}\',{self.fixup(vp.value)})'
+
+    # Special processing to handle lambda
+    def process_lambda(self, lam):
+        lambda_result = lam()
+        script = lambda_result if isinstance(lambda_result, str) else lambda_result[0]
+        return f'{script}' if re.match(r"^\{.*\}$", script) else f'{{{script}}}'
+
+    # Special processing to handle bindings inside of traversals
+    def process_binding(self, binding):
+        return f'Bindings.instance().of(\'{binding.key}\', {str(binding.value)})'
 
     # Main driver of the translation. Different parts of
     # a Traversal are handled appropriately.
@@ -130,16 +161,21 @@ class Translator:
             for p in params:
                 script += ',' if c > 0 else ''
                 if with_opts:
-                  script += f'WithOptions.{self.options[p]}'
+                    script += f'WithOptions.{self.options[p]}'
                 elif type(p) == Bytecode:
                     script += self.translate(p, True)
                 elif isinstance(p, P):
                     script += self.process_predicate(p)
+                elif type(p) == Vertex:
+                    script += self.process_vertex(p)
+                elif type(p) == Edge:
+                    script += self.process_edge(p)
+                elif type(p) == VertexProperty:
+                    script += self.process_vertex_property(p)
                 elif type(p) in [Cardinality, Pop, Operator]:
                     tmp = str(p)
-                    script += tmp[0:-1] if tmp.endswith('_') else tmp 
-                elif type(p) in [ReadOnlyStrategy, SubgraphStrategy, VertexProgramStrategy,
-                                 OptionsStrategy, PartitionStrategy]:
+                    script += tmp[0:-1] if tmp.endswith('_') else tmp
+                elif isinstance(p, TraversalStrategy):  # this will capture all strategies
                     script += self.process_strategy(p)
                 elif type(p) == datetime:
                     script += self.process_date(p)
@@ -150,8 +186,14 @@ class Translator:
                     script += f'\'{p}\''
                 elif type(p) == bool:
                     script += 'true' if p else 'false'
+                elif isinstance(p, type(lambda: None)) and p.__name__ == (lambda: None).__name__:
+                    script += self.process_lambda(p)
+                elif type(p) == Binding:
+                    script += self.process_binding(p)
                 elif p is None:
                     script += 'null'
+                elif isinstance(p, type):
+                    script += p.__name__
                 else:
                     script += str(p)
                 c += 1
@@ -165,11 +207,11 @@ class Translator:
     # anonymous traversal style syntax.
     def translate(self, bytecode, child=False):
         script = '__' if child else self.traversal_source
-        
+
         for step in bytecode.source_instructions:
             script += self.do_translation(step)
 
         for step in bytecode.step_instructions:
             script += self.do_translation(step)
-       
+
         return script

--- a/gremlin-python/src/main/python/gremlin_python/process/translator.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/translator.py
@@ -24,6 +24,8 @@ sent to any TinkerPop compliant HTTP endpoint.
 """
 __author__ = 'Kelvin R. Lawrence (gfxman)'
 
+import math
+import numbers
 import re
 
 from gremlin_python.process.traversal import *
@@ -51,6 +53,8 @@ class Translator:
         WithOptions.map: 'map'
     }
 
+    conn_p = ['and', 'or']
+
     def __init__(self, traversal_source=None):
         self.traversal_source = traversal_source
 
@@ -68,11 +72,26 @@ class Translator:
     # of strings and dates and boolean.
     def fixup(self, v):
         if isinstance(v, str):
-            return f'\'{v}\''
+            return f'{v!r}'  # use repr() format for canonical string rep
         elif type(v) == datetime:
             return self.process_date(v)
         elif type(v) == bool:
             return 'true' if v else 'false'
+        elif isinstance(v, numbers.Number):
+            return self.process_number(v)
+        elif isinstance(v, set):
+            return f'[{str(v)[1:-1]}]'
+        elif isinstance(v, P):
+            return self.process_predicate(v)
+        elif type(v) == Vertex:
+            return self.process_vertex(v)
+        elif type(v) == Edge:
+            return self.process_edge(v)
+        elif type(v) in [Merge]:  # on_create on_match out_v in_v
+            tmp = str(v)
+            return f'{tmp.split("_")[0]}{tmp.split("_")[1].capitalize()}' if tmp.find('_') else tmp
+        elif v is None:
+            return 'null'
         else:
             return str(v)
 
@@ -89,17 +108,25 @@ class Translator:
     # Do special processing needed to format predicates that come in
     # such as "gt(a)" correctly.
     def process_predicate(self, p):
-        res = str(p).split('(')[0] + '('
+        res = ''
+        if p.operator in self.conn_p:
+            res += f'{self.process_predicate(p.value)}.{p.operator}({self.process_predicate(p.other)})'
+        else:
+            res += f'{self.process_p_value(p)}'
+        return res
 
+    # process the value of the predicates
+    def process_p_value(self, p):
+        res = str(p).split('(')[0] + '('
         if type(p.value) == list:
             res += '['
             for v in p.value:
                 res += self.fixup(v) + ','
-            res = res[0:-1] + ']'
+            res = (res[0:-1] + ']') if len(p.value) > 0 else (res + ']')
         else:
             res += self.fixup(p.value)
             if p.other is not None:
-                res += ',' + self.fixup(p.other)
+                res += f',{self.fixup(p.other)}'
         res += ')'
         return res
 
@@ -109,7 +136,7 @@ class Translator:
         res = ''
         # if parameter is empty, only pass class name (referenced GroovyTranslator.java)
         if not s.configuration:
-            res += s.__class__.__name__
+            res += s.strategy_name
         else:
             res = f'new {str(s)}('
             for key in s.configuration:
@@ -127,7 +154,7 @@ class Translator:
 
     # Special processing to handle vertices
     def process_vertex(self, vertex):
-        return f'new ReferenceVertex({str(vertex.id)},\'{vertex.label}\')'
+        return f'new ReferenceVertex({self.fixup(vertex.id)},\'{vertex.label}\')'
 
     # Special processing to handle edges
     def process_edge(self, edge):
@@ -143,7 +170,47 @@ class Translator:
     def process_lambda(self, lam):
         lambda_result = lam()
         script = lambda_result if isinstance(lambda_result, str) else lambda_result[0]
-        return f'{script}' if re.match(r"^\{.*\}$", script) else f'{{{script}}}'
+        return f'{script}' if re.match(r"^\{.*\}$", script, flags=re.DOTALL) else f'{{{script}}}'
+
+    def process_dict(self, d):
+        c = 0
+        res = '['
+        if len(d) == 0:
+            res += ':'
+        else:
+            for k, v in d.items():
+                wrap = not isinstance(k, str)
+                res += ',' if c > 0 else ''
+                res += '(' if wrap else ''
+                res += self.fixup(k)
+                res += ')' if wrap else ''
+                res += f':{self.fixup(v)}'
+                c += 1
+        res += ']'
+        return res
+
+    def process_number(self, n):
+        if isinstance(n, float):
+            # converting floats into doubles for script since python doesn't distinguish and java defaults to double
+            if math.isnan(n):
+                return "Double.NaN"
+            elif math.isinf(n) and n > 0:
+                return "Double.POSITIVE_INFINITY"
+            elif math.isinf(n) and n < 0:
+                return "Double.NEGATIVE_INFINITY"
+            else:
+                return f'{n}d'
+        return f'{n}'
+
+    def process_list(self, l):
+        c = 0
+        res = '['
+        for i in l:
+            res += ',' if c > 0 else ''
+            res += self.fixup(i)
+            c += 1
+        res += ']'
+        return res
 
     # Special processing to handle bindings inside of traversals
     def process_binding(self, binding):
@@ -158,6 +225,7 @@ class Translator:
         if len(params) > 0:
             c = 0
             with_opts = False
+            is_merge_op = (step[0] == 'mergeV') or (step[0] == 'mergeE')
             for p in params:
                 script += ',' if c > 0 else ''
                 if with_opts:
@@ -172,9 +240,13 @@ class Translator:
                     script += self.process_edge(p)
                 elif type(p) == VertexProperty:
                     script += self.process_vertex_property(p)
-                elif type(p) in [Cardinality, Pop, Operator]:
+                elif type(p) in [Cardinality, Pop, Operator, Scope, T]:
                     tmp = str(p)
                     script += tmp[0:-1] if tmp.endswith('_') else tmp
+                elif type(p) in [Merge]:  # on_create on_match out_v in_v
+                    is_merge_op = True
+                    tmp = str(p)
+                    script += f'{tmp.split("_")[0]}{tmp.split("_")[1].capitalize()}' if tmp.find('_') else tmp
                 elif isinstance(p, TraversalStrategy):  # this will capture all strategies
                     script += self.process_strategy(p)
                 elif type(p) == datetime:
@@ -183,7 +255,7 @@ class Translator:
                     script += 'WithOptions.tokens'
                     with_opts = True
                 elif isinstance(p, str):
-                    script += f'\'{p}\''
+                    script += f'{p!r}'  # use repr() format for canonical string rep
                 elif type(p) == bool:
                     script += 'true' if p else 'false'
                 elif isinstance(p, type(lambda: None)) and p.__name__ == (lambda: None).__name__:
@@ -191,9 +263,17 @@ class Translator:
                 elif type(p) == Binding:
                     script += self.process_binding(p)
                 elif p is None:
-                    script += 'null'
+                    script += '(Traversal) null' if is_merge_op else 'null'
                 elif isinstance(p, type):
                     script += p.__name__
+                elif isinstance(p, dict):
+                    script += self.process_dict(p)
+                elif isinstance(p, numbers.Number):
+                    script += self.process_number(p)
+                elif isinstance(p, set):
+                    script += f'[{str(p)[1:-1]}] as Set' if len(p) > 0 else '[] as Set'
+                elif isinstance(p, list):
+                    script += self.process_list(p)
                 else:
                     script += str(p)
                 c += 1

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -34,7 +34,7 @@ from gremlin_python.driver.protocol import GremlinServerWSProtocol
 from gremlin_python.driver.serializer import (
     GraphSONMessageSerializer, GraphSONSerializersV2d0, GraphSONSerializersV3d0,
     GraphBinarySerializersV1)
-from gremlin_python.driver.aiohttp.transport import AiohttpTransport
+from gremlin_python.driver.aiohttp.transport import AiohttpTransport, AiohttpHTTPTransport
 
 gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
 gremlin_basic_auth_url = os.environ.get('GREMLIN_SERVER_BASIC_AUTH_URL', 'wss://localhost:{}/gremlin')
@@ -43,6 +43,10 @@ anonymous_url = gremlin_server_url.format(45940)
 basic_url = gremlin_basic_auth_url.format(45941)
 kerberos_url = gremlin_server_url.format(45942)
 kerberized_service = 'test-service@{}'.format(kerberos_hostname)
+gremlin_server_url_http = os.environ.get('GREMLIN_SERVER_URL_HTTP', 'http://localhost:{}/')
+gremlin_basic_auth_url_http = os.environ.get('GREMLIN_SERVER_BASIC_AUTH_URL_HTTP', 'https://localhost:{}/')
+anonymous_url_http = gremlin_server_url_http.format(45940)
+basic_url_http = gremlin_basic_auth_url_http.format(45941)
 verbose_logging = False
 
 logging.basicConfig(format='%(asctime)s [%(levelname)8s] [%(filename)15s:%(lineno)d - %(funcName)10s()] - %(message)s',
@@ -209,3 +213,55 @@ def graphson_serializer_v3(request):
 @pytest.fixture
 def graphbinary_serializer_v1(request):
     return GraphBinarySerializersV1()
+
+
+@pytest.fixture(params=['graphsonv2', 'graphsonv3', 'graphbinaryv1'])
+def remote_connection_http(request):
+    try:
+        if request.param == 'graphbinaryv1':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gmodern',
+                                                 message_serializer=serializer.GraphBinarySerializersV1())
+        elif request.param == 'graphsonv2':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gmodern',
+                                                 message_serializer=serializer.GraphSONSerializersV2d0())
+        elif request.param == 'graphsonv3':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gmodern',
+                                                 message_serializer=serializer.GraphSONSerializersV3d0())
+        else:
+            raise ValueError("Invalid serializer option - " + request.param)
+    except OSError:
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            remote_conn.close()
+
+        request.addfinalizer(fin)
+        return remote_conn
+
+
+"""
+# The WsAndHttpChannelizer somehow does not distinguish the ssl handlers so authenticated https remote connection will
+# only work with HttpChannelizer that is currently not in the testing set up, thus this is commented out for now
+
+@pytest.fixture(params=['basic'])
+def remote_connection_http_authenticated(request):
+    try:
+        if request.param == 'basic':
+            # turn off certificate verification for testing purposes only
+            ssl_opts = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            ssl_opts.verify_mode = ssl.CERT_NONE
+            remote_conn = DriverRemoteConnection(basic_url_http, 'gmodern',
+                                                 username='stephen', password='password',
+                                                 message_serializer=serializer.GraphSONSerializersV2d0(),
+                                                 transport_factory=lambda: AiohttpHTTPTransport(ssl_options=ssl_opts))
+        else:
+            raise ValueError("Invalid authentication option - " + request.param)
+    except OSError:
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            remote_conn.close()
+
+        request.addfinalizer(fin)
+        return remote_conn
+"""

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
@@ -1,0 +1,212 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import os
+
+from gremlin_python import statics
+from gremlin_python.driver.protocol import GremlinServerError
+from gremlin_python.statics import long
+from gremlin_python.process.traversal import Traverser
+from gremlin_python.process.traversal import TraversalStrategy
+from gremlin_python.process.traversal import Bindings
+from gremlin_python.process.traversal import P, Order, T
+from gremlin_python.process.graph_traversal import __
+from gremlin_python.process.anonymous_traversal import traversal
+from gremlin_python.structure.graph import Vertex
+from gremlin_python.process.strategies import SubgraphStrategy, ReservedKeysVerificationStrategy, SeedStrategy
+from gremlin_python.structure.io.util import HashableDict
+from gremlin_python.driver.serializer import GraphSONSerializersV2d0
+
+gremlin_server_url_http = os.environ.get('GREMLIN_SERVER_URL_HTTP', 'http://localhost:{}/')
+test_no_auth_http_url = gremlin_server_url_http.format(45940)
+
+# due to the limitation of relying on python translator for sending scripts over HTTP, certain tests are omitted
+class TestDriverRemoteConnectionHttp(object):
+    def test_traversals(self, remote_connection_http):
+        statics.load_statics(globals())
+        g = traversal().withRemote(remote_connection_http)
+
+        assert long(6) == g.V().count().toList()[0]
+        # #
+        assert Vertex(1) == g.V(1).next()
+        assert Vertex(1) == g.V(Vertex(1)).next()
+        assert 1 == g.V(1).id_().next()
+        assert Traverser(Vertex(1)) == g.V(1).nextTraverser()
+        assert 1 == len(g.V(1).toList())
+        assert isinstance(g.V(1).toList(), list)
+        results = g.V().repeat(__.out()).times(2).name
+        results = results.toList()
+        assert 2 == len(results)
+        assert "lop" in results
+        assert "ripple" in results
+        # #
+        assert 10 == g.V().repeat(__.both()).times(5)[0:10].count().next()
+        assert 1 == g.V().repeat(__.both()).times(5)[0:1].count().next()
+        assert 0 == g.V().repeat(__.both()).times(5)[0:0].count().next()
+        assert 4 == g.V()[2:].count().next()
+        assert 2 == g.V()[:2].count().next()
+        # #
+        results = g.withSideEffect('a', ['josh', 'peter']).V(1).out('created').in_('created').values('name').where(
+            P.within('a')).toList()
+        assert 2 == len(results)
+        assert 'josh' in results
+        assert 'peter' in results
+        # #
+        results = g.V().out().profile().toList()
+        assert 1 == len(results)
+        assert 'metrics' in results[0]
+        assert 'dur' in results[0]
+        # #
+        results = g.V().has('name', 'peter').as_('a').out('created').as_('b').select('a', 'b').by(
+            __.valueMap()).toList()
+        assert 1 == len(results)
+        assert 'peter' == results[0]['a']['name'][0]
+        assert 35 == results[0]['a']['age'][0]
+        assert 'lop' == results[0]['b']['name'][0]
+        assert 'java' == results[0]['b']['lang'][0]
+        assert 2 == len(results[0]['a'])
+        assert 2 == len(results[0]['b'])
+        # #
+        results = g.V(1).inject(g.V(2).next()).values('name').toList()
+        assert 2 == len(results)
+        assert 'marko' in results
+        assert 'vadas' in results
+        # #
+        results = g.V().has('person', 'name', 'marko').map(
+            lambda: ("it.get().value('name')", "gremlin-groovy")).toList()
+        assert 1 == len(results)
+        assert 'marko' in results
+        # #
+        # this test just validates that the underscored versions of steps conflicting with Gremlin work
+        # properly and can be removed when the old steps are removed - TINKERPOP-2272
+        results = g.V().filter_(__.values('age').sum_().and_(
+            __.max_().is_(P.gt(0)), __.min_().is_(P.gt(0)))).range_(0, 1).id_().next()
+        assert 1 == results
+        # #
+        # test binding in P
+        results = g.V().has('person', 'age', Bindings.of('x', P.lt(30))).count().next()
+        assert 2 == results
+        # #
+        # test dict keys which can only work on GraphBinary and GraphSON3 which include specific serialization
+        # types for dict
+        if not isinstance(remote_connection_http._client._message_serializer, GraphSONSerializersV2d0):
+            results = g.V().has('person', 'name', 'marko').elementMap("name").groupCount().next()
+            assert {HashableDict.of({T.id: 1, T.label: 'person', 'name': 'marko'}): 1} == results
+        if not isinstance(remote_connection_http._client._message_serializer, GraphSONSerializersV2d0):
+            results = g.V().has('person', 'name', 'marko').both('knows').groupCount().by(
+                __.values('name').fold()).next()
+            assert {tuple(['vadas']): 1, tuple(['josh']): 1} == results
+
+    def test_iteration(self, remote_connection_http):
+        statics.load_statics(globals())
+        g = traversal().withRemote(remote_connection_http)
+
+        t = g.V().count()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert 6 == t.next()
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+
+        t = g.V().has('name', P.within('marko', 'peter')).values('name').order()
+        assert "marko" == t.next()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert t.hasNext()
+        assert "peter" == t.next()
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+        assert not (t.hasNext())
+
+        try:
+            t.next()
+            assert False
+        except StopIteration:
+            assert True
+
+    def test_strategies(self, remote_connection_http):
+        statics.load_statics(globals())
+        g = traversal().withRemote(remote_connection_http). \
+            withStrategies(TraversalStrategy("SubgraphStrategy",
+                                             {"vertices": __.hasLabel("person"),
+                                              "edges": __.hasLabel("created")},
+                                             "org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy"))
+        assert 4 == g.V().count().next()
+        assert 0 == g.E().count().next()
+        assert 1 == g.V().label().dedup().count().next()
+        assert 4 == g.V().filter_(lambda: ("x -> true", "gremlin-groovy")).count().next()
+        assert "person" == g.V().label().dedup().next()
+        #
+        g = traversal().withRemote(remote_connection_http). \
+            withStrategies(SubgraphStrategy(vertices=__.hasLabel("person"), edges=__.hasLabel("created")))
+        assert 4 == g.V().count().next()
+        assert 0 == g.E().count().next()
+        assert 1 == g.V().label().dedup().count().next()
+        assert "person" == g.V().label().dedup().next()
+        #
+        g = traversal().withRemote(remote_connection_http). \
+            withStrategies(SubgraphStrategy(edges=__.hasLabel("created")))
+        assert 6 == g.V().count().next()
+        assert 4 == g.E().count().next()
+        assert 1 == g.E().label().dedup().count().next()
+        assert "created" == g.E().label().dedup().next()
+        #
+        g = g.withoutStrategies(SubgraphStrategy). \
+            withComputer(vertices=__.has("name", "marko"), edges=__.limit(0))
+        assert 1 == g.V().count().next()
+        assert 0 == g.E().count().next()
+        assert "person" == g.V().label().next()
+        assert "marko" == g.V().name.next()
+        #
+        g = traversal().withRemote(remote_connection_http).withComputer()
+        assert 6 == g.V().count().next()
+        assert 6 == g.E().count().next()
+        #
+        g = traversal().withRemote(remote_connection_http).withStrategies(SeedStrategy(12345))
+        shuffledResult = g.V().values("name").order().by(Order.shuffle).toList()
+        assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
+        assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
+        assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
+
+    def test_clone(self, remote_connection_http):
+        g = traversal().withRemote(remote_connection_http)
+        t = g.V().both()
+        assert 12 == len(t.toList())
+        assert 5 == t.clone().limit(5).count().next()
+        assert 10 == t.clone().limit(10).count().next()
+
+    """
+    # The WsAndHttpChannelizer somehow does not distinguish the ssl handlers so authenticated https remote connection
+    # only work with HttpChannelizer that is currently not in the testing set up, thus this is commented out for now
+    
+    def test_authenticated(self, remote_connection_http_authenticated):
+        statics.load_statics(globals())
+        g = traversal().withRemote(remote_connection_http_authenticated)
+
+        assert long(6) == g.V().count().toList()[0]
+    """

--- a/gremlin-python/src/main/python/tests/process/test_translator.py
+++ b/gremlin-python/src/main/python/tests/process/test_translator.py
@@ -36,293 +36,298 @@ class TestTranslator(object):
         tests = list()
         # 0
         tests.append([g.V(),
-                     "g.V()"])
+                      "g.V()"])
         # 1
         tests.append([g.V('1', '2', '3', '4'),
-                     "g.V('1','2','3','4')"])
+                      "g.V('1','2','3','4')"])
         # 2
         tests.append([g.V('3').valueMap(True),
-                     "g.V('3').valueMap(true)"])
+                      "g.V('3').valueMap(true)"])
         # 3
         tests.append([g.V().constant(5),
-                     "g.V().constant(5)"])
+                      "g.V().constant(5)"])
         # 4
         tests.append([g.V().constant(1.5),
-                     "g.V().constant(1.5)"])
+                      "g.V().constant(1.5d)"])
         # 5
         tests.append([g.V().constant('Hello'),
-                     "g.V().constant('Hello')"])
+                      "g.V().constant('Hello')"])
         # 6
         tests.append([g.V().hasLabel('airport').limit(5),
-                     "g.V().hasLabel('airport').limit(5)"])
+                      "g.V().hasLabel('airport').limit(5)"])
         # 7
         tests.append([g.V().hasLabel(within('a', 'b', 'c')),
-                     "g.V().hasLabel(within(['a','b','c']))"])
+                      "g.V().hasLabel(within(['a','b','c']))"])
         # 8
         tests.append([g.V().hasLabel('airport', 'continent').out().limit(5),
-                     "g.V().hasLabel('airport','continent').out().limit(5)"])
+                      "g.V().hasLabel('airport','continent').out().limit(5)"])
         # 9
         tests.append([g.V().hasLabel('airport').out().values('code').limit(5),
-                     "g.V().hasLabel('airport').out().values('code').limit(5)"])
+                      "g.V().hasLabel('airport').out().values('code').limit(5)"])
         # 10
         tests.append([g.V('3').as_('a').out('route').limit(10).where(eq('a')).by('region'),
-                     "g.V('3').as('a').out('route').limit(10).where(eq('a')).by('region')"])
+                      "g.V('3').as('a').out('route').limit(10).where(eq('a')).by('region')"])
         # 11
         tests.append([g.V('3').repeat(__.out('route').simplePath()).times(2).path().by('code'),
-                     "g.V('3').repeat(__.out('route').simplePath()).times(2).path().by('code')"])
+                      "g.V('3').repeat(__.out('route').simplePath()).times(2).path().by('code')"])
         # 12
         tests.append([g.V().hasLabel('airport').out().has('region', 'US-TX').values('code').limit(5),
-                     "g.V().hasLabel('airport').out().has('region','US-TX').values('code').limit(5)"])
+                      "g.V().hasLabel('airport').out().has('region','US-TX').values('code').limit(5)"])
         # 13
         tests.append([g.V().hasLabel('airport').union(__.values('city'), __.values('region')).limit(5),
-                     "g.V().hasLabel('airport').union(__.values('city'),__.values('region')).limit(5)"])
+                      "g.V().hasLabel('airport').union(__.values('city'),__.values('region')).limit(5)"])
         # 14
         tests.append([g.V('3').as_('a').out('route', 'routes'),
-                     "g.V('3').as('a').out('route','routes')"])
+                      "g.V('3').as('a').out('route','routes')"])
         # 15
         tests.append([g.V().where(__.values('runways').is_(5)),
-                    "g.V().where(__.values('runways').is(5))"])
+                      "g.V().where(__.values('runways').is(5))"])
         # 16
         tests.append([g.V('3').repeat(__.out().simplePath()).until(__.has('code', 'AGR')).path().by('code').limit(5),
-                     "g.V('3').repeat(__.out().simplePath()).until(__.has('code','AGR')).path().by('code').limit(5)"])
+                      "g.V('3').repeat(__.out().simplePath()).until(__.has('code','AGR')).path().by('code').limit(5)"])
         # 17
         tests.append([g.V().hasLabel('airport').order().by(__.id_()),
-                     "g.V().hasLabel('airport').order().by(__.id())"])
+                      "g.V().hasLabel('airport').order().by(__.id())"])
         # 18
         tests.append([g.V().hasLabel('airport').order().by(T.id),
-                     "g.V().hasLabel('airport').order().by(T.id)"])
+                      "g.V().hasLabel('airport').order().by(T.id)"])
         # 19
-        tests.append([g.V().hasLabel('airport').order().by(__.id_(),Order.desc),
-                     "g.V().hasLabel('airport').order().by(__.id(),Order.desc)"])
+        tests.append([g.V().hasLabel('airport').order().by(__.id_(), Order.desc),
+                      "g.V().hasLabel('airport').order().by(__.id(),Order.desc)"])
         # 20
-        tests.append([g.V().hasLabel('airport').order().by('code',Order.desc),
-                     "g.V().hasLabel('airport').order().by('code',Order.desc)"])
+        tests.append([g.V().hasLabel('airport').order().by('code', Order.desc),
+                      "g.V().hasLabel('airport').order().by('code',Order.desc)"])
         # 21
         tests.append([g.V('1', '2', '3').local(__.out().out().dedup().fold()),
-                     "g.V('1','2','3').local(__.out().out().dedup().fold())"])
+                      "g.V('1','2','3').local(__.out().out().dedup().fold())"])
         # 22
         tests.append([g.V('3').out().path().count(Scope.local),
-                     "g.V('3').out().path().count(Scope.local)"])
+                      "g.V('3').out().path().count(Scope.local)"])
         # 23
         tests.append([g.E().count(),
-                     "g.E().count()"])
+                      "g.E().count()"])
         # 24
         tests.append([g.V('5').outE('route').inV().path().limit(10),
-                     "g.V('5').outE('route').inV().path().limit(10)"])
+                      "g.V('5').outE('route').inV().path().limit(10)"])
         # 25
         tests.append([g.V('5').propertyMap().select(Column.keys),
-                     "g.V('5').propertyMap().select(Column.keys)"])
+                      "g.V('5').propertyMap().select(Column.keys)"])
         # 26
         tests.append([g.V('5').propertyMap().select(Column.values),
-                     "g.V('5').propertyMap().select(Column.values)"])
+                      "g.V('5').propertyMap().select(Column.values)"])
         # 27
         tests.append([g.V('3').values('runways').math('_ + 1'),
-                     "g.V('3').values('runways').math('_ + 1')"])
+                      "g.V('3').values('runways').math('_ + 1')"])
         # 28
         tests.append([g.V('3').emit().repeat(__.out().simplePath()).times(3).limit(5).path(),
-                     "g.V('3').emit().repeat(__.out().simplePath()).times(3).limit(5).path()"])
+                      "g.V('3').emit().repeat(__.out().simplePath()).times(3).limit(5).path()"])
         # 29
         tests.append([g.V().match(__.as_('a').has('code', 'LHR').as_('b')).select('b').by('code'),
-                     "g.V().match(__.as('a').has('code','LHR').as('b')).select('b').by('code')"])
+                      "g.V().match(__.as('a').has('code','LHR').as('b')).select('b').by('code')"])
         # 30
         tests.append([g.V().has('test-using-keyword-as-property', 'repeat'),
-                     "g.V().has('test-using-keyword-as-property','repeat')"])
+                      "g.V().has('test-using-keyword-as-property','repeat')"])
         # 31
         tests.append([g.V('1').addE('test').to(__.V('4')),
-                     "g.V('1').addE('test').to(__.V('4'))"])
+                      "g.V('1').addE('test').to(__.V('4'))"])
         # 32
         tests.append([g.V().values('runways').max_(),
-                     "g.V().values('runways').max()"])
+                      "g.V().values('runways').max()"])
         # 33
         tests.append([g.V().values('runways').min_(),
-                     "g.V().values('runways').min()"])
+                      "g.V().values('runways').min()"])
         # 34
         tests.append([g.V().values('runways').sum_(),
-                     "g.V().values('runways').sum()"])
+                      "g.V().values('runways').sum()"])
         # 35
         tests.append([g.V().values('runways').mean(),
-                     "g.V().values('runways').mean()"])
+                      "g.V().values('runways').mean()"])
         # 36
         tests.append([g.withSack(0).V('3', '5').sack(Operator.sum_).by('runways').sack(),
-                     "g.withSack(0).V('3','5').sack(Operator.sum).by('runways').sack()"])
+                      "g.withSack(0).V('3','5').sack(Operator.sum).by('runways').sack()"])
         # 37
-        tests.append([g.V('3').values('runways').store('x').V('4').values('runways').store('x').by(__.constant(1)).V('6').store('x').by(__.constant(1)).select('x').unfold().sum_(),
-                     "g.V('3').values('runways').store('x').V('4').values('runways').store('x').by(__.constant(1)).V('6').store('x').by(__.constant(1)).select('x').unfold().sum()"])
+        tests.append([g.V('3').values('runways').store('x').V('4').values('runways').store('x').by(__.constant(1)).V(
+            '6').store('x').by(__.constant(1)).select('x').unfold().sum_(),
+                      "g.V('3').values('runways').store('x').V('4').values('runways').store('x').by(__.constant(1)).V('6').store('x').by(__.constant(1)).select('x').unfold().sum()"])
         # 38
         tests.append([g.inject(3, 4, 5),
-                     "g.inject(3,4,5)"])
+                      "g.inject(3,4,5)"])
         # 39
         tests.append([g.inject([3, 4, 5]),
-                     "g.inject([3, 4, 5])"])
+                      "g.inject([3,4,5])"])
         # 40
         tests.append([g.inject(3, 4, 5).count(),
-                     "g.inject(3,4,5).count()"])
+                      "g.inject(3,4,5).count()"])
         # 41
         tests.append([g.V().has('runways', gt(5)).count(),
-                     "g.V().has('runways',gt(5)).count()"])
+                      "g.V().has('runways',gt(5)).count()"])
         # 42
         tests.append([g.V().has('runways', lte(5.3)).count(),
-                     "g.V().has('runways',lte(5.3)).count()"])
+                      "g.V().has('runways',lte(5.3d)).count()"])
         # 43
-        tests.append([g.V().has('code', within(123,124)),
-                     "g.V().has('code',within([123,124]))"])
+        tests.append([g.V().has('code', within(123, 124)),
+                      "g.V().has('code',within([123,124]))"])
         # 44
         tests.append([g.V().has('code', within(123, 'abc')),
-                     "g.V().has('code',within([123,'abc']))"])
+                      "g.V().has('code',within([123,'abc']))"])
         # 45
         tests.append([g.V().has('code', within('abc', 123)),
-                     "g.V().has('code',within(['abc',123]))"])
+                      "g.V().has('code',within(['abc',123]))"])
         # 46
         tests.append([g.V().has('code', within('abc', 'xyz')),
-                     "g.V().has('code',within(['abc','xyz']))"])
+                      "g.V().has('code',within(['abc','xyz']))"])
         # 47
-        tests.append([g.V('1', '2').has('region', P.within('US-TX','US-GA')),
-                     "g.V('1','2').has('region',within(['US-TX','US-GA']))"])
+        tests.append([g.V('1', '2').has('region', P.within('US-TX', 'US-GA')),
+                      "g.V('1','2').has('region',within(['US-TX','US-GA']))"])
         # 48
         tests.append([g.V().and_(__.has('runways', P.gt(5)), __.has('region', 'US-TX')),
-                     "g.V().and(__.has('runways',gt(5)),__.has('region','US-TX'))"])
+                      "g.V().and(__.has('runways',gt(5)),__.has('region','US-TX'))"])
         # 49
         tests.append([g.V().union(__.has('runways', gt(5)), __.has('region', 'US-TX')),
-                     "g.V().union(__.has('runways',gt(5)),__.has('region','US-TX'))"])
+                      "g.V().union(__.has('runways',gt(5)),__.has('region','US-TX'))"])
         # 50
-        tests.append([g.V('3').choose(__.values('runways').is_(3), __.constant('three'),__.constant('not three')),
-                     "g.V('3').choose(__.values('runways').is(3),__.constant('three'),__.constant('not three'))"])
+        tests.append([g.V('3').choose(__.values('runways').is_(3), __.constant('three'), __.constant('not three')),
+                      "g.V('3').choose(__.values('runways').is(3),__.constant('three'),__.constant('not three'))"])
         # 51
-        tests.append([g.V('3').choose(__.values('runways')).option(1, __.constant('three')).option(2,__.constant('not three')),
-                     "g.V('3').choose(__.values('runways')).option(1,__.constant('three')).option(2,__.constant('not three'))"])
+        tests.append(
+            [g.V('3').choose(__.values('runways')).option(1, __.constant('three')).option(2, __.constant('not three')),
+             "g.V('3').choose(__.values('runways')).option(1,__.constant('three')).option(2,__.constant('not three'))"])
         # 52
-        tests.append([g.V('3').choose(__.values('runways')).option(1.5, __.constant('one and a half')).option(2,__.constant('not three')),
-                     "g.V('3').choose(__.values('runways')).option(1.5,__.constant('one and a half')).option(2,__.constant('not three'))"])
+        tests.append([g.V('3').choose(__.values('runways')).option(1.5, __.constant('one and a half')).option(2,
+                                                                                                              __.constant(
+                                                                                                                  'not three')),
+                      "g.V('3').choose(__.values('runways')).option(1.5d,__.constant('one and a half')).option(2,__.constant('not three'))"])
         # 53
         tests.append([g.V('3').repeat(__.out().simplePath()).until(__.loops().is_(1)).count(),
-                     "g.V('3').repeat(__.out().simplePath()).until(__.loops().is(1)).count()"])
+                      "g.V('3').repeat(__.out().simplePath()).until(__.loops().is(1)).count()"])
         # 54
-        tests.append([g.V().hasLabel('airport').limit(20).group().by('region').by('code').order(Scope.local).by(Column.keys),
-                     "g.V().hasLabel('airport').limit(20).group().by('region').by('code').order(Scope.local).by(Column.keys)"])
+        tests.append(
+            [g.V().hasLabel('airport').limit(20).group().by('region').by('code').order(Scope.local).by(Column.keys),
+             "g.V().hasLabel('airport').limit(20).group().by('region').by('code').order(Scope.local).by(Column.keys)"])
         # 55
         tests.append([g.V('1').as_('a').V('2').as_('a').select(Pop.all_, 'a'),
-                     "g.V('1').as('a').V('2').as('a').select(Pop.all,'a')"])
+                      "g.V('1').as('a').V('2').as('a').select(Pop.all,'a')"])
         # 56
         tests.append([g.addV('test').property(Cardinality.set_, 'p1', 10),
-                     "g.addV('test').property(Cardinality.set,'p1',10)"])
+                      "g.addV('test').property(Cardinality.set,'p1',10)"])
         # 57
         tests.append([g.addV('test').property(Cardinality.list_, 'p1', 10),
-                     "g.addV('test').property(Cardinality.list,'p1',10)"])
+                      "g.addV('test').property(Cardinality.list,'p1',10)"])
 
         # 58
         tests.append([g.addV('test').property(Cardinality.single, 'p1', 10),
-                     "g.addV('test').property(Cardinality.single,'p1',10)"])
+                      "g.addV('test').property(Cardinality.single,'p1',10)"])
         # 59
         tests.append([g.V().limit(5).order().by(T.label),
-                     "g.V().limit(5).order().by(T.label)"])
+                      "g.V().limit(5).order().by(T.label)"])
 
         # 60
         tests.append([g.V().range_(1, 5),
-                     "g.V().range(1,5)"])
+                      "g.V().range(1,5)"])
 
         # 61
         tests.append([g.addV('test').property('p1', 123),
-                     "g.addV('test').property('p1',123)"])
+                      "g.addV('test').property('p1',123)"])
 
         # 62
-        tests.append([g.addV('test').property('date',datetime(2021, 2, 1, 9, 30)),
-                     "g.addV('test').property('date',new Date(121,2,1,9,30,0))"])
+        tests.append([g.addV('test').property('date', datetime(2021, 2, 1, 9, 30)),
+                      "g.addV('test').property('date',new Date(121,2,1,9,30,0))"])
         # 63
-        tests.append([g.addV('test').property('date',datetime(2021, 2, 1)),
-                     "g.addV('test').property('date',new Date(121,2,1,0,0,0))"])
+        tests.append([g.addV('test').property('date', datetime(2021, 2, 1)),
+                      "g.addV('test').property('date',new Date(121,2,1,0,0,0))"])
         # 64
         tests.append([g.addE('route').from_(__.V('1')).to(__.V('2')),
-                     "g.addE('route').from(__.V('1')).to(__.V('2'))"])
+                      "g.addE('route').from(__.V('1')).to(__.V('2'))"])
         # 65
         tests.append([g.withSideEffect('a', [1, 2]).V('3').select('a'),
-                     "g.withSideEffect('a',[1, 2]).V('3').select('a')"])
+                      "g.withSideEffect('a',[1,2]).V('3').select('a')"])
         # 66
         tests.append([g.withSideEffect('a', 1).V('3').select('a'),
-                     "g.withSideEffect('a',1).V('3').select('a')"])
+                      "g.withSideEffect('a',1).V('3').select('a')"])
         # 67
         tests.append([g.withSideEffect('a', 'abc').V('3').select('a'),
-                     "g.withSideEffect('a','abc').V('3').select('a')"])
+                      "g.withSideEffect('a','abc').V('3').select('a')"])
         # 68
         tests.append([g.V().has('airport', 'region', 'US-NM').limit(3).values('elev').fold().index(),
-                     "g.V().has('airport','region','US-NM').limit(3).values('elev').fold().index()"])
+                      "g.V().has('airport','region','US-NM').limit(3).values('elev').fold().index()"])
         # 69
         tests.append([g.V('3').repeat(__.timeLimit(1000).out().simplePath()).until(__.has('code', 'AGR')).path(),
-                     "g.V('3').repeat(__.timeLimit(1000).out().simplePath()).until(__.has('code','AGR')).path()"])
+                      "g.V('3').repeat(__.timeLimit(1000).out().simplePath()).until(__.has('code','AGR')).path()"])
 
         # 70
         tests.append([g.V().hasLabel('airport').where(__.values('elev').is_(gt(14000))),
-                     "g.V().hasLabel('airport').where(__.values('elev').is(gt(14000)))"])
+                      "g.V().hasLabel('airport').where(__.values('elev').is(gt(14000)))"])
 
         # 71
         tests.append([g.V().hasLabel('airport').where(__.out().count().is_(gt(250))).values('code'),
-                     "g.V().hasLabel('airport').where(__.out().count().is(gt(250))).values('code')"])
+                      "g.V().hasLabel('airport').where(__.out().count().is(gt(250))).values('code')"])
 
         # 72
         tests.append([g.V().hasLabel('airport').filter_(__.out().count().is_(gt(250))).values('code'),
-                     "g.V().hasLabel('airport').filter(__.out().count().is(gt(250))).values('code')"])
+                      "g.V().hasLabel('airport').filter(__.out().count().is(gt(250))).values('code')"])
         # 73
         tests.append([g.withSack(0).
-                        V('3').
-                        repeat(__.outE('route').sack(Operator.sum_).by('dist').inV()).
-                        until(__.has('code', 'AGR').or_().loops().is_(4)).
-                        has('code', 'AGR').
-                        local(__.union(__.path().by('code').by('dist'),__.sack()).fold()).
-                        limit(10),
-                     "g.withSack(0).V('3').repeat(__.outE('route').sack(Operator.sum).by('dist').inV()).until(__.has('code','AGR').or().loops().is(4)).has('code','AGR').local(__.union(__.path().by('code').by('dist'),__.sack()).fold()).limit(10)"])
+                     V('3').
+                     repeat(__.outE('route').sack(Operator.sum_).by('dist').inV()).
+                     until(__.has('code', 'AGR').or_().loops().is_(4)).
+                     has('code', 'AGR').
+                     local(__.union(__.path().by('code').by('dist'), __.sack()).fold()).
+                     limit(10),
+                      "g.withSack(0).V('3').repeat(__.outE('route').sack(Operator.sum).by('dist').inV()).until(__.has('code','AGR').or().loops().is(4)).has('code','AGR').local(__.union(__.path().by('code').by('dist'),__.sack()).fold()).limit(10)"])
 
         # 74
         tests.append([g.addV().as_('a').addV().as_('b').addE('knows').from_('a').to('b'),
-                     "g.addV().as('a').addV().as('b').addE('knows').from('a').to('b')"])
+                      "g.addV().as('a').addV().as('b').addE('knows').from('a').to('b')"])
 
         # 75
         tests.append([g.addV('Person').as_('a').addV('Person').as_('b').addE('knows').from_('a').to('b'),
-                     "g.addV('Person').as('a').addV('Person').as('b').addE('knows').from('a').to('b')"])
+                      "g.addV('Person').as('a').addV('Person').as('b').addE('knows').from('a').to('b')"])
         # 76
-        tests.append([g.V('3').project('Out','In').by(__.out().count()).by(__.in_().count()),
-                     "g.V('3').project('Out','In').by(__.out().count()).by(__.in().count())"])
+        tests.append([g.V('3').project('Out', 'In').by(__.out().count()).by(__.in_().count()),
+                      "g.V('3').project('Out','In').by(__.out().count()).by(__.in().count())"])
         # 77
         tests.append([g.V('44').out().aggregate('a').out().where(within('a')).path(),
-                     "g.V('44').out().aggregate('a').out().where(within(['a'])).path()"])
+                      "g.V('44').out().aggregate('a').out().where(within(['a'])).path()"])
         # 78
         tests.append([g.V().has('date', datetime(2021, 2, 22)),
-                     "g.V().has('date',new Date(121,2,22,0,0,0))"])
+                      "g.V().has('date',new Date(121,2,22,0,0,0))"])
         # 79
         tests.append([g.V().has('date', within(datetime(2021, 2, 22), datetime(2021, 1, 1))),
                       "g.V().has('date',within([new Date(121,2,22,0,0,0),new Date(121,1,1,0,0,0)]))"])
         # 80
         tests.append([g.V().has('date', between(datetime(2021, 1, 1), datetime(2021, 2, 22))),
-                                "g.V().has('date',between(new Date(121,1,1,0,0,0),new Date(121,2,22,0,0,0)))"])
+                      "g.V().has('date',between(new Date(121,1,1,0,0,0),new Date(121,2,22,0,0,0)))"])
         # 81
-        tests.append([g.V().has('date', inside(datetime(2021, 1, 1),datetime(2021, 2, 22))),
-                                "g.V().has('date',inside(new Date(121,1,1,0,0,0),new Date(121,2,22,0,0,0)))"])
+        tests.append([g.V().has('date', inside(datetime(2021, 1, 1), datetime(2021, 2, 22))),
+                      "g.V().has('date',inside(new Date(121,1,1,0,0,0),new Date(121,2,22,0,0,0)))"])
         # 82
         tests.append([g.V().has('date', P.gt(datetime(2021, 1, 1, 9, 30))),
-                     "g.V().has('date',gt(new Date(121,1,1,9,30,0)))"])
+                      "g.V().has('date',gt(new Date(121,1,1,9,30,0)))"])
         # 83
-        tests.append([g.V().has('runways', between(3,5)),
-                     "g.V().has('runways',between(3,5))"])
+        tests.append([g.V().has('runways', between(3, 5)),
+                      "g.V().has('runways',between(3,5))"])
         # 84
-        tests.append([g.V().has('runways', inside(3,5)),
-                     "g.V().has('runways',inside(3,5))"])
+        tests.append([g.V().has('runways', inside(3, 5)),
+                      "g.V().has('runways',inside(3,5))"])
         # 85
         tests.append([g.V('44').outE().elementMap(),
-                     "g.V('44').outE().elementMap()"])
+                      "g.V('44').outE().elementMap()"])
         # 86
         tests.append([g.V('44').valueMap().by(__.unfold()),
-                     "g.V('44').valueMap().by(__.unfold())"])
+                      "g.V('44').valueMap().by(__.unfold())"])
         # 87
-        tests.append([g.V('44').valueMap().with_(WithOptions.tokens,WithOptions.labels),
-                     "g.V('44').valueMap().with(WithOptions.tokens,WithOptions.labels)"])
+        tests.append([g.V('44').valueMap().with_(WithOptions.tokens, WithOptions.labels),
+                      "g.V('44').valueMap().with(WithOptions.tokens,WithOptions.labels)"])
         # 88
         tests.append([g.V('44').valueMap().with_(WithOptions.tokens),
-                     "g.V('44').valueMap().with(WithOptions.tokens)"])
+                      "g.V('44').valueMap().with(WithOptions.tokens)"])
         # 89
         tests.append([g.withStrategies(ReadOnlyStrategy()).addV('test'),
                       "g.withStrategies(ReadOnlyStrategy).addV('test')"])
         # 90
         strategy = SubgraphStrategy(vertices=__.has('region', 'US-TX'), edges=__.hasLabel('route'))
         tests.append([g.withStrategies(strategy).V().count(),
-                    "g.withStrategies(new SubgraphStrategy(vertices:__.has('region','US-TX'),edges:__.hasLabel('route'))).V().count()"])
+                      "g.withStrategies(new SubgraphStrategy(vertices:__.has('region','US-TX'),edges:__.hasLabel('route'))).V().count()"])
         # 91
         strategy = SubgraphStrategy(vertex_properties=__.hasNot('runways'))
         tests.append([g.withStrategies(strategy).V().count(),
@@ -333,7 +338,7 @@ class TestTranslator(object):
                       "g.withStrategies(new SubgraphStrategy(vertices:__.has('region','US-TX'),vertexProperties:__.hasNot('runways'))).V().count()"])
         # 93
         strategy = SubgraphStrategy(vertices=__.has('region', 'US-TX'), edges=__.hasLabel('route'))
-        tests.append([g.withStrategies(ReadOnlyStrategy(),strategy).V().count(),
+        tests.append([g.withStrategies(ReadOnlyStrategy(), strategy).V().count(),
                       "g.withStrategies(ReadOnlyStrategy,new SubgraphStrategy(vertices:__.has('region','US-TX'),edges:__.hasLabel('route'))).V().count()"])
         # 94
         strategy = SubgraphStrategy(vertices=__.has('region', 'US-TX'))
@@ -344,35 +349,37 @@ class TestTranslator(object):
                       "g.withStrategies(new OptionsStrategy(evaluationTimeout:500)).V().count()"])
         # 96
         tests.append([g.withStrategies(OptionsStrategy({'evaluationTimeout': 500})).V().count(),
-                     "g.withStrategies(new OptionsStrategy(evaluationTimeout:500)).V().count()"])
+                      "g.withStrategies(new OptionsStrategy(evaluationTimeout:500)).V().count()"])
         # 97
-        tests.append([g.withStrategies(PartitionStrategy(partition_key="partition", write_partition="a", read_partitions=["a"])).addV('test'),
-                     "g.withStrategies(new PartitionStrategy(partitionKey:'partition',writePartition:'a',readPartitions:['a'])).addV('test')"])
+        tests.append([g.withStrategies(
+            PartitionStrategy(partition_key="partition", write_partition="a", read_partitions=["a"])).addV('test'),
+                      "g.withStrategies(new PartitionStrategy(partitionKey:'partition',writePartition:'a',readPartitions:['a'])).addV('test')"])
         # 98
-        tests.append([g.withComputer().V().shortestPath().with_(ShortestPath.target, __.has('name','peter')),
-                     "g.withStrategies(VertexProgramStrategy).V().shortestPath().with('~tinkerpop.shortestPath.target',__.has('name','peter'))"])
+        tests.append([g.withComputer().V().shortestPath().with_(ShortestPath.target, __.has('name', 'peter')),
+                      "g.withStrategies(VertexProgramStrategy).V().shortestPath().with('~tinkerpop.shortestPath.target',__.has('name','peter'))"])
 
         # 99
         tests.append([g.V().has("p1", starting_with("foo")),
-                     "g.V().has('p1',startingWith('foo'))"])
+                      "g.V().has('p1',startingWith('foo'))"])
 
         # 100
         tests.append([g.V().has("p1", ending_with("foo")),
-                     "g.V().has('p1',endingWith('foo'))"])
+                      "g.V().has('p1',endingWith('foo'))"])
 
         # 101
         class SuperStr(str):
             pass
+
         tests.append([g.V(SuperStr("foo_id")),
-                     "g.V('foo_id')"])
+                      "g.V('foo_id')"])
 
         # 102
         tests.append([g.V().has("p1", containing(SuperStr("foo"))),
-                     "g.V().has('p1',containing('foo'))"])
+                      "g.V().has('p1',containing('foo'))"])
 
         # 103
         tests.append([g.V().has("p1", None),
-                     "g.V().has('p1',null)"])
+                      "g.V().has('p1',null)"])
 
         # 104
         vertex = Vertex(0, "person")
@@ -398,6 +405,31 @@ class TestTranslator(object):
         # 108
         tests.append([g.V().has('person', 'age', Bindings.of('x', P.lt(30))).count(),
                       "g.V().has('person','age',Bindings.instance().of('x', lt(30))).count()"])
+
+        # 109
+        tests.append([g.inject({'name': 'java'}, {T.id: 0}, {},
+                               {'age': float(10), 'pos_inf': float("inf"), 'neg_inf': float("-inf"), 'nan': float("nan")}),
+                      "g.inject(['name':'java'],[(T.id):0],[:],['age':10.0d,'pos_inf':Double.POSITIVE_INFINITY,'neg_inf':Double.NEGATIVE_INFINITY,'nan':Double.NaN])"])
+
+        # 110
+        tests.append([g.inject(float(1)).is_(P.eq(1).or_(P.gt(2)).or_(P.lte(3)).or_(P.gte(4))),
+                      "g.inject(1.0d).is(eq(1).or(gt(2)).or(lte(3)).or(gte(4)))"])
+
+        # 111
+        tests.append([g.V().hasLabel('person').has('age',P.gt(10).or_(P.gte(11).and_(P.lt(20))).and_(P.lt(29).or_(P.eq(35)))).name,
+                      "g.V().hasLabel('person').has('age',gt(10).or(gte(11).and(lt(20))).and(lt(29).or(eq(35)))).values('name')"])
+
+        # 112
+        tests.append([g.inject(set(('a'))),
+                      "g.inject(['a'] as Set)"])
+
+        # 113
+        tests.append([g.merge_v(None),
+                      "g.mergeV((Traversal) null)"])
+
+        # 114
+        tests.append([g.merge_e(None),
+                      "g.mergeE((Traversal) null)"])
 
         tlr = Translator().of('g')
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3006

Adding experimental feature for python to connect via HTTP. This is relying on the python translator, for which additional types were added. There shouldn't be any breaking changes.

Connecting to remote can be done via
`remote_conn = DriverRemoteConnection('http://localhost':8182/, 'g')`
and for traversals
`g = traversal().with_remote(remote_conn)`

One note, in addition to the integration test, I ran the feature test suite (radish tests) locally with the HTTP endpoint for 3.6 and all tests passed. One exception is that `g.inject(null, null)` test will fail due to combination of Groovy script issue that throws NPE with 2nd nulls and server HTTP handler hanging upon NPEs. 

VOTE +1