### PR TITLE
Fix Java driver HTTP connection request not encoding all args

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoder.java
@@ -71,6 +71,7 @@ public final class HttpGremlinRequestEncoder extends MessageToMessageEncoder<Req
                 gremlin = gremlinStringOrBytecode.toString();
             }
             final byte[] payload = mapper.writeValueAsBytes(new HashMap<String,Object>() {{
+                this.putAll(requestMessage.getArgs());
                 put(Tokens.ARGS_GREMLIN, gremlin);
                 put(Tokens.REQUEST_ID, requestMessage.getRequestId());
                 if (usesBytecode) put("op", Tokens.OPS_BYTECODE);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
@@ -144,6 +144,23 @@ public class HttpDriverIntegrateTest extends AbstractGremlinServerIntegrationTes
     }
 
     @Test
+    public void shouldSubmitAliasRemoteTraversalSource() throws Exception {
+        final Cluster cluster = TestClientFactory.build()
+                .channelizer(Channelizer.HttpChannelizer.class)
+                .serializer(Serializers.GRAPHSON_V3D0)
+                .create();
+        try {
+            final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "gmodern"));
+            assertEquals("2", g.inject("2").toList().get(0));
+            assertEquals(Long.valueOf(6), g.V().count().toList().get(0));
+        } catch (Exception ex) {
+            throw ex;
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
     public void shouldFailToUseSession() throws Exception {
         final Cluster cluster = TestClientFactory.build()
                 .channelizer(Channelizer.HttpChannelizer.class)


### PR DESCRIPTION
I noticed that the Java driver wasn't encoding the remaining args into the payload, such as aliases for traversal source were not registered. Not sure if it was intentional, or if the type of args encoded should be limited instead of having all of them, so I'm adding this quick fix as a PR.