### PR TITLE
TINKERPOP-2999 3.7.0 Remote Console Sends Incomplete Queries

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ This release also includes changes from <<release-3-6-5, 3.6.6>> and <<release-3
 * Added the `trim()`, `lTrim()`, `rTrim()`, and `reverse()` steps to perform `String` manipulations.
 * Added `replace()`, `split()` and `substring()` steps to perform `String` manipulations.
 * Checked graph features for meta-property support before trying to serialize them in `VertexPropertySerializer` for GraphBinary.
+* Fixed multiline query bug in console caused by upgrade to Groovy 4.
 * Added date manipulation steps `asDate`, `dateAdd` and `dateDiff`.
 * Added new data type `DT` to represent periods of time.
 * Added Gherkin support for Date.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/GremlinGroovysh.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/GremlinGroovysh.groovy
@@ -24,8 +24,10 @@ import org.apache.groovy.groovysh.Groovysh
 import org.apache.groovy.groovysh.ParseCode
 import org.apache.groovy.groovysh.Parser
 import org.apache.groovy.groovysh.util.CommandArgumentParser
+import org.apache.groovy.groovysh.util.ScriptVariableAnalyzer
 import org.apache.tinkerpop.gremlin.console.commands.GremlinSetCommand
 import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer
 import org.codehaus.groovy.tools.shell.IO
 
@@ -102,11 +104,40 @@ class GremlinGroovysh extends Groovysh {
                 List<String> current = new ArrayList<String>(buffers.current())
                 current << line
 
+                String importsSpec = this.getImportStatements()
+
                 // determine if this script is complete or not - if not it's a multiline script
-                def status = parser.parse(current)
+                def status = parser.parse([importsSpec] + current)
 
                 switch (status.code) {
                     case ParseCode.COMPLETE:
+                        if (!Boolean.valueOf(getPreference(INTERPRETER_MODE_PREFERENCE_KEY, 'false')) || isTypeOrMethodDeclaration(current)) {
+                            // Evaluate the current buffer w/imports and dummy statement
+                            List buff = [importsSpec] + [ 'true' ] + current
+                            try {
+                                interp.evaluate(buff)
+                            } catch(MultipleCompilationErrorsException t) {
+                                if (isIncompleteCaseOfAntlr4(t)) {
+                                    // treat like INCOMPLETE case
+                                    buffers.updateSelected(current)
+                                    break
+                                }
+                                throw t
+                            }
+                        } else {
+                            // Evaluate Buffer wrapped with code storing bounded vars
+                            try {
+                                evaluateWithStoredBoundVars(importsSpec, current)
+                            } catch(MultipleCompilationErrorsException t) {
+                                if (isIncompleteCaseOfAntlr4(t)) {
+                                    // treat like INCOMPLETE case
+                                    buffers.updateSelected(current)
+                                    break
+                                }
+                                throw t
+                            }
+                        }
+
                         // concat script here because commands don't support multi-line
                         def script = String.join(Parser.getNEWLINE(), current)
                         setLastResult(mediator.currentRemote().submit([script]))
@@ -139,5 +170,49 @@ class GremlinGroovysh extends Groovysh {
         interp.context['_'] = result
 
         maybeRecordResult(result)
+    }
+
+    private Object evaluateWithStoredBoundVars(String importsSpec, List<String> current) {
+        Object result
+        String variableBlocks = null
+        // To make groovysh behave more like an interpreter, we need to retrieve all bound
+        // vars at the end of script execution, and then update them into the groovysh Binding context.
+        Set<String> boundVars = ScriptVariableAnalyzer.getBoundVars(importsSpec + Parser.NEWLINE + current.join(Parser.NEWLINE), interp.classLoader)
+        if (boundVars) {
+            variableBlocks = "$COLLECTED_BOUND_VARS_MAP_VARNAME = new HashMap();"
+            boundVars.each({ String varname ->
+                // bound vars can be in global or some local scope.
+                // We discard locally scoped vars by ignoring MissingPropertyException
+                variableBlocks += """
+try {$COLLECTED_BOUND_VARS_MAP_VARNAME[\"$varname\"] = $varname;
+} catch (MissingPropertyException e){}"""
+            })
+        }
+        // Evaluate the current buffer w/imports and dummy statement
+        List<String> buff
+        if (variableBlocks) {
+            buff = [importsSpec] + ['try {', 'true'] + current + ['} finally {' + variableBlocks + '}']
+        } else {
+            buff = [importsSpec] + ['true'] + current
+        }
+        setLastResult(result = interp.evaluate(buff))
+
+        if (variableBlocks) {
+            def boundVarValues = (Map<String, Object>) interp.context.getVariable(COLLECTED_BOUND_VARS_MAP_VARNAME)
+            boundVarValues.each({ String name, Object value -> interp.context.setVariable(name, value) })
+        }
+
+        return result
+    }
+
+    private boolean isIncompleteCaseOfAntlr4(MultipleCompilationErrorsException t) {
+        // TODO antlr4 parser errors pop out here - can we rework to be like antlr2?
+        (
+            (t.message.contains('Unexpected input: ') || t.message.contains('Unexpected character: ')) && !(
+                t.message.contains("Unexpected input: '}'")
+                    || t.message.contains("Unexpected input: ')'")
+                    || t.message.contains("Unexpected input: ']'")
+            )
+        )
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2999
Fixes issue where multiline commands would throw error on the first line, caused by upgrade to Groovy 4.  Handling pulled from Groovysh.groovy