### PR TITLE
[TINKERPOP-2964] Fixed bug in `replaceLocalChild`.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ This release also includes changes from <<release-3-5-8, 3.5.8>>.
 * Added translator to the Go GLV.
 * Fixed bug with filtering for `group()` when the side-effect label was defined for it.
 * ProjectStep now throws exception when a duplicate key is provided in a query.
+* Fixed bug in `replaceLocalChild` where child traversal was not correctly integrated.
 * Fixed bug in `ElementIdStrategy` where the order of `hasId` was impacting proper filters.
 * Fixed bug in the Java driver configuration for serialization when reading settings from an `InputStream`.
 * Fixed bug in `DotNetTranslator` where `PartitionStrategy` usage was not translating properly when specifying the `readPartitions`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/PathFilterStep.java
@@ -125,7 +125,7 @@ public final class PathFilterStep<S> extends FilterStep<S> implements FromToModu
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
         this.traversalRing.replaceTraversal(
                 (Traversal.Admin<Object, Object>) oldTraversal,
-                (Traversal.Admin<Object, Object>) newTraversal);
+                this.integrateChild(newTraversal));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
@@ -185,6 +185,6 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
         this.traversalRing.replaceTraversal(
                 (Traversal.Admin) oldTraversal,
-                (Traversal.Admin) newTraversal);
+                this.integrateChild(newTraversal));
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
@@ -90,7 +90,7 @@ public final class PathStep<S> extends MapStep<S, Path> implements TraversalPare
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
         this.traversalRing.replaceTraversal(
                 (Traversal.Admin<Object, Object>) oldTraversal,
-                (Traversal.Admin<Object, Object>) newTraversal);
+                this.integrateChild(newTraversal));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProjectStep.java
@@ -112,7 +112,7 @@ public class ProjectStep<S, E> extends ScalarMapStep<S, Map<String, E>> implemen
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
         this.traversalRing.replaceTraversal(
                 (Traversal.Admin<S, E>) oldTraversal,
-                (Traversal.Admin<S, E>) newTraversal);
+                this.integrateChild(newTraversal));
     }
 
     public List<String> getProjectKeys() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -136,7 +136,7 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
         this.traversalRing.replaceTraversal(
                 (Traversal.Admin<Object, E>) oldTraversal,
-                (Traversal.Admin<Object, E>) newTraversal);
+                this.integrateChild(newTraversal));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -68,7 +68,7 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements T
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
         this.traversalRing.replaceTraversal(
                 (Traversal.Admin<Object, Object>) oldTraversal,
-                (Traversal.Admin<Object, Object>) newTraversal);
+                this.integrateChild(newTraversal));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
@@ -122,7 +122,7 @@ public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements Si
     public void replaceLocalChild(final Traversal.Admin<?, ?> oldTraversal, final Traversal.Admin<?, ?> newTraversal) {
         this.traversalRing.replaceTraversal(
                 (Traversal.Admin<Object, Object>) oldTraversal,
-                (Traversal.Admin<Object, Object>) newTraversal);
+                this.integrateChild(newTraversal));
     }
 
     @Override


### PR DESCRIPTION
 Fixed bug in `replaceLocalChild` where child traversal was not correctly integrated.

https://issues.apache.org/jira/browse/TINKERPOP-2964