### PR TITLE
[TINKERPOP-2877] Added integer overflow checks

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -244,6 +244,7 @@ This release also includes changes from <<release-3-5-3, 3.5.3>>.
 * Added `TextP.regex` and `TextP.notRegex`.
 * Changed TinkerGraph to allow identifiers to be heterogeneous when filtering.
 * Prevented values of `T` to `property()` from being `null`.
+* Added throwing `ArithmeticException` when arithmetic operations overflow for byte, short, int and long arguments.
 * Added `element()` step.
 * Added `call()` step.
 * Added `fail()` step.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
@@ -202,7 +202,7 @@ public enum Operator implements BinaryOperator<Object> {
      */
     sumLong {
         public Object apply(final Object a, final Object b) {
-            return (long) a + (long) b;
+            return NumberHelper.add((long) a, (long) b);
         }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/NumberHelper.java
@@ -28,10 +28,22 @@ import java.util.function.BiFunction;
  */
 public final class NumberHelper {
 
+    private static byte asByte(int arg) {
+        if (arg > Byte.MAX_VALUE || arg < Byte.MIN_VALUE)
+            throw new ArithmeticException("byte overflow");
+        return (byte) arg;
+    }
+
+    private static short asShort(int arg) {
+        if (arg > Short.MAX_VALUE || arg < Short.MIN_VALUE)
+            throw new ArithmeticException("short overflow");
+        return (short) arg;
+    }
+
     static final NumberHelper BYTE_NUMBER_HELPER = new NumberHelper(
-            (a, b) -> (byte) (a.byteValue() + b.byteValue()),
-            (a, b) -> (byte) (a.byteValue() - b.byteValue()),
-            (a, b) -> (byte) (a.byteValue() * b.byteValue()),
+            (a, b) -> asByte(a.byteValue() + b.byteValue()),
+            (a, b) -> asByte(a.byteValue() - b.byteValue()),
+            (a, b) -> asByte(a.byteValue() * b.byteValue()),
             (a, b) -> (byte) (a.byteValue() / b.byteValue()),
             (a, b) -> {
                 if (isNumber(a)) {
@@ -56,9 +68,9 @@ public final class NumberHelper {
             (a, b) -> Byte.compare(a.byteValue(), b.byteValue()));
 
     static final NumberHelper SHORT_NUMBER_HELPER = new NumberHelper(
-            (a, b) -> (short) (a.shortValue() + b.shortValue()),
-            (a, b) -> (short) (a.shortValue() - b.shortValue()),
-            (a, b) -> (short) (a.shortValue() * b.shortValue()),
+            (a, b) -> asShort(a.shortValue() + b.shortValue()),
+            (a, b) -> asShort(a.shortValue() - b.shortValue()),
+            (a, b) -> asShort(a.shortValue() * b.shortValue()),
             (a, b) -> (short) (a.shortValue() / b.shortValue()),
             (a, b) -> {
                 if (isNumber(a)) {
@@ -83,9 +95,9 @@ public final class NumberHelper {
             (a, b) -> Short.compare(a.shortValue(), b.shortValue()));
 
     static final NumberHelper INTEGER_NUMBER_HELPER = new NumberHelper(
-            (a, b) -> a.intValue() + b.intValue(),
-            (a, b) -> a.intValue() - b.intValue(),
-            (a, b) -> a.intValue() * b.intValue(),
+            (a, b) -> Math.addExact(a.intValue(), b.intValue()),
+            (a, b) -> Math.subtractExact(a.intValue(), b.intValue()),
+            (a, b) -> Math.multiplyExact(a.intValue(), b.intValue()),
             (a, b) -> a.intValue() / b.intValue(),
             (a, b) -> {
                 if (isNumber(a)) {
@@ -110,9 +122,9 @@ public final class NumberHelper {
             (a, b) -> Integer.compare(a.intValue(), b.intValue()));
 
     static final NumberHelper LONG_NUMBER_HELPER = new NumberHelper(
-            (a, b) -> a.longValue() + b.longValue(),
-            (a, b) -> a.longValue() - b.longValue(),
-            (a, b) -> a.longValue() * b.longValue(),
+            (a, b) -> Math.addExact(a.longValue(), b.longValue()),
+            (a, b) -> Math.subtractExact(a.longValue(), b.longValue()),
+            (a, b) -> Math.multiplyExact(a.longValue(), b.longValue()),
             (a, b) -> a.longValue() / b.longValue(),
             (a, b) -> {
                 if (isNumber(a)) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/NumberHelperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/NumberHelperTest.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.util;
 
 import org.javatuples.Quartet;
+import org.javatuples.Triplet;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -38,6 +39,7 @@ import static org.apache.tinkerpop.gremlin.util.NumberHelper.sub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -95,6 +97,21 @@ public class NumberHelperTest {
                     // BIG DECIMAL
                     new Quartet<>(BigDecimal.ONE, BigDecimal.ONE, BigDecimal.class, BigDecimal.class)
             );
+
+    private final static List<Triplet<Number, Number, String>> OVERFLOW_CASES = Arrays.asList(
+            new Triplet<>(Integer.MAX_VALUE, 1, "add"),
+            new Triplet<>(Integer.MIN_VALUE, 1, "sub"),
+            new Triplet<>(Integer.MAX_VALUE, Integer.MAX_VALUE, "mul"),
+            new Triplet<>(Long.MAX_VALUE, 1L, "add"),
+            new Triplet<>(Long.MIN_VALUE, 1L, "sub"),
+            new Triplet<>(Long.MAX_VALUE,  Integer.MAX_VALUE, "mul"),
+            new Triplet<>(Byte.MAX_VALUE, (byte)100, "add"),
+            new Triplet<>(Byte.MIN_VALUE, (byte)100, "sub"),
+            new Triplet<>((byte)100, (byte)100, "mul"),
+            new Triplet<>(Short.MAX_VALUE, (short)100, "add"),
+            new Triplet<>(Short.MIN_VALUE, (short)100, "sub"),
+            new Triplet<>(Short.MAX_VALUE, (short)100, "mul")
+    );
 
     @Test
     public void shouldReturnHighestCommonNumberClass() {
@@ -440,6 +457,26 @@ public class NumberHelperTest {
 
             assertEquals(-1, compare(null, one).intValue());
             assertEquals(1, compare(one, null).intValue());
+        }
+    }
+
+    @Test
+    public void shouldThrowArithmeticExceptionOnOverflow() {
+        for (final Triplet<Number, Number, String> q : OVERFLOW_CASES) {
+            try {
+                switch (q.getValue2()) {
+                    case "add":
+                        add(q.getValue0(), q.getValue1());
+                    case "sub":
+                        sub(q.getValue0(), q.getValue1());
+                    case "mul":
+                        mul(q.getValue0(), q.getValue1());
+                }
+                fail("ArithmeticException expected");
+            }
+            catch (ArithmeticException ex) {
+                // expected
+            }
         }
     }
 }


### PR DESCRIPTION
For some integer operations the result is not checked for overflow, which can lead to unexpected results.
For example
```
gremlin> __.inject(Long.MAX_VALUE,Long.MAX_VALUE,2).sum()
==>0
```

In this PR I added throwing `ArithmeticException` for overflow cases. 

More details in https://issues.apache.org/jira/browse/TINKERPOP-2877