### PR TITLE
Bytecode support for HTTP requests

### DIFF
--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -978,6 +978,9 @@ with a custom sub-protocol.  Under this configuration, Gremlin Server accepts re
 evaluates that script and then streams back the results.  The notion of "streaming" is depicted in the diagram to the
 right.
 
+There is also an experimental possibility to use link:http://en.wikipedia.org/wiki/HTTP[HTTP]. Currently this is only
+supported by Java and Python GLV's.
+
 The diagram shows an incoming request to process the Gremlin script of `g.V()`.  Gremlin Server evaluates that script,
 getting an `Iterator` of vertices as a result, and steps through each `Vertex` within it.  The vertices are batched
 together given the `resultIterationBatchSize` configuration.  In this case, that value must be `2` given that each
@@ -1032,6 +1035,21 @@ The above JSON represents the "body" of the request to send to Gremlin Server. W
 WebSocket, Gremlin Server can accept a packet frame using a "text" (1) or a "binary" (2) opcode. Using "text"
 is a bit more limited in that Gremlin Server will always process the body of that request as JSON.  Generally speaking
 "text" is just for testing purposes.
+
+For HTTP can be used following serializers distinguished by `Content-Type` HTTP header
+[width="100%",cols="3,10, 10",options="header"]
+|=========================================================
+|Serializer | Content-Type| Description
+|GraphBinaryMessageSerializerV1 | application/vnd.graphbinary-v1.0 | Efficient binary format recommended for default use.
+|GraphSONMessageSerializerV3 | application/vnd.gremlin-v3.0+json | Json-compatible format containing types of all data.
+|GraphSONUntypedMessageSerializerV3 | application/vnd.gremlin-v3.0+json;types=false | Json-compatible format without metadata. For this reason it cannot be used for transmission of ByteCode requests.
+|=========================================================
+
+Same options can be used for `Accept` Header. By default, same serializer will handle both request and response.
+Only HTTP Post requests are supported.
+Both Gremlin strings and Gremlin bytecode requests may be supported.
+
+NOTE: All this HTTP options designed for GLV's. For usage with browsers, curl, Postman and other tools see link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-via-http[Connecting via HTTP section].
 
 The preferred method for sending requests to Gremlin Server is to use the "binary" opcode.  In this case, a "header"
 will need be sent in addition to to the "body".  The "header" basically consists of a "mime type" so that Gremlin

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -152,11 +152,11 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#hadoop-gremlin[HadoopGra
 implementations for ideas and patterns.
 
 . Online Transactional Processing Graph Systems (*OLTP*)
-.. Structure API: `Graph`, `Element`, `Vertex`, `Edge`, `Property` and `Transaction` (if transactions are supported).
-.. Process API: `TraversalStrategy` instances for optimizing Gremlin traversals to the provider's graph system (i.e. `TinkerGraphStepStrategy`).
+ .. Structure API: `Graph`, `Element`, `Vertex`, `Edge`, `Property` and `Transaction` (if transactions are supported).
+ .. Process API: `TraversalStrategy` instances for optimizing Gremlin traversals to the provider's graph system (i.e. `TinkerGraphStepStrategy`).
 . Online Analytics Processing Graph Systems (*OLAP*)
-.. Everything required of OLTP is required of OLAP (but not vice versa).
-.. GraphComputer API: `GraphComputer`, `Messenger`, `Memory`.
+ .. Everything required of OLTP is required of OLAP (but not vice versa).
+ .. GraphComputer API: `GraphComputer`, `Messenger`, `Memory`.
 
 Please consider the following implementation notes:
 

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -152,11 +152,11 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#hadoop-gremlin[HadoopGra
 implementations for ideas and patterns.
 
 . Online Transactional Processing Graph Systems (*OLTP*)
- .. Structure API: `Graph`, `Element`, `Vertex`, `Edge`, `Property` and `Transaction` (if transactions are supported).
- .. Process API: `TraversalStrategy` instances for optimizing Gremlin traversals to the provider's graph system (i.e. `TinkerGraphStepStrategy`).
+.. Structure API: `Graph`, `Element`, `Vertex`, `Edge`, `Property` and `Transaction` (if transactions are supported).
+.. Process API: `TraversalStrategy` instances for optimizing Gremlin traversals to the provider's graph system (i.e. `TinkerGraphStepStrategy`).
 . Online Analytics Processing Graph Systems (*OLAP*)
- .. Everything required of OLTP is required of OLAP (but not vice versa).
- .. GraphComputer API: `GraphComputer`, `Messenger`, `Memory`.
+.. Everything required of OLTP is required of OLAP (but not vice versa).
+.. GraphComputer API: `GraphComputer`, `Messenger`, `Memory`.
 
 Please consider the following implementation notes:
 
@@ -978,9 +978,6 @@ with a custom sub-protocol.  Under this configuration, Gremlin Server accepts re
 evaluates that script and then streams back the results.  The notion of "streaming" is depicted in the diagram to the
 right.
 
-There is also an experimental possibility to use link:http://en.wikipedia.org/wiki/HTTP[HTTP]. Currently this is only
-supported by Java and Python GLV's.
-
 The diagram shows an incoming request to process the Gremlin script of `g.V()`.  Gremlin Server evaluates that script,
 getting an `Iterator` of vertices as a result, and steps through each `Vertex` within it.  The vertices are batched
 together given the `resultIterationBatchSize` configuration.  In this case, that value must be `2` given that each
@@ -1035,21 +1032,6 @@ The above JSON represents the "body" of the request to send to Gremlin Server. W
 WebSocket, Gremlin Server can accept a packet frame using a "text" (1) or a "binary" (2) opcode. Using "text"
 is a bit more limited in that Gremlin Server will always process the body of that request as JSON.  Generally speaking
 "text" is just for testing purposes.
-
-For HTTP the following serializers can be used, distinguished by `Content-Type` HTTP header
-[width="100%",cols="3,10, 10",options="header"]
-|=========================================================
-|Serializer | Content-Type| Description
-|GraphBinaryMessageSerializerV1 | application/vnd.graphbinary-v1.0 | Efficient binary format recommended for default use.
-|GraphSONMessageSerializerV3 | application/vnd.gremlin-v3.0+json | Json-compatible format containing types of all data.
-|GraphSONUntypedMessageSerializerV3 | application/vnd.gremlin-v3.0+json;types=false | Json-compatible format without metadata. For this reason it cannot be used for transmission of ByteCode requests.
-|=========================================================
-
-Same options can be used for `Accept` Header. By default, same serializer will handle both request and response.
-Only HTTP Post requests are supported.
-Both Gremlin scripts and Gremlin `Bytecode` requests are supported.
-
-NOTE: All of the above HTTP options are designed for use with GLV's. For usage with browsers, cURL, Postman and other tools see link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-via-http[Connecting via HTTP section].
 
 The preferred method for sending requests to Gremlin Server is to use the "binary" opcode.  In this case, a "header"
 will need be sent in addition to to the "body".  The "header" basically consists of a "mime type" so that Gremlin

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -1036,7 +1036,7 @@ WebSocket, Gremlin Server can accept a packet frame using a "text" (1) or a "bin
 is a bit more limited in that Gremlin Server will always process the body of that request as JSON.  Generally speaking
 "text" is just for testing purposes.
 
-For HTTP can be used following serializers distinguished by `Content-Type` HTTP header
+For HTTP the following serializers can be used, distinguished by `Content-Type` HTTP header
 [width="100%",cols="3,10, 10",options="header"]
 |=========================================================
 |Serializer | Content-Type| Description
@@ -1047,9 +1047,9 @@ For HTTP can be used following serializers distinguished by `Content-Type` HTTP 
 
 Same options can be used for `Accept` Header. By default, same serializer will handle both request and response.
 Only HTTP Post requests are supported.
-Both Gremlin strings and Gremlin bytecode requests may be supported.
+Both Gremlin scripts and Gremlin `Bytecode` requests are supported.
 
-NOTE: All this HTTP options designed for GLV's. For usage with browsers, curl, Postman and other tools see link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-via-http[Connecting via HTTP section].
+NOTE: All of the above HTTP options are designed for use with GLV's. For usage with browsers, cURL, Postman and other tools see link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-via-http[Connecting via HTTP section].
 
 The preferred method for sending requests to Gremlin Server is to use the "binary" opcode.  In this case, a "header"
 will need be sent in addition to to the "body".  The "header" basically consists of a "mime type" so that Gremlin

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoder.java
@@ -42,13 +42,6 @@ public final class HttpGremlinResponseDecoder extends MessageToMessageDecoder<Fu
 
     @Override
     protected void decode(final ChannelHandlerContext channelHandlerContext, final FullHttpResponse httpResponse, final List<Object> objects) throws Exception {
-        // !!! Why we need to convert all to string?
-        final String content = httpResponse.content().toString(CharsetUtil.UTF_8);
-
-        if (!(serializer instanceof MessageTextSerializer))
-            throw new IllegalStateException(String.format("%s must be of type %s to decode responses from HTTP endpoints",
-                    serializer.getClass().getSimpleName(), HttpGremlinResponseDecoder.class.getSimpleName()));
-
-        objects.add(((MessageTextSerializer) serializer).deserializeResponse(content));
+        objects.add(serializer.deserializeResponse(httpResponse.content()));
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoder.java
@@ -42,6 +42,7 @@ public final class HttpGremlinResponseDecoder extends MessageToMessageDecoder<Fu
 
     @Override
     protected void decode(final ChannelHandlerContext channelHandlerContext, final FullHttpResponse httpResponse, final List<Object> objects) throws Exception {
+        // !!! Why we need to convert all to string?
         final String content = httpResponse.content().toString(CharsetUtil.UTF_8);
 
         if (!(serializer instanceof MessageTextSerializer))

--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -187,7 +187,6 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
             else:
                 self._client_session = aiohttp.ClientSession(base_url=url, headers=headers, loop=self._loop)
 
-
         # Execute the async connect synchronously.
         self._loop.run_until_complete(async_connect())
 
@@ -212,8 +211,7 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
         # Inner function to perform async read.
         async def async_read():
             async with async_timeout.timeout(self._read_timeout):
-                # using http request read()
-                return await self._http_req_resp.text()
+                return await self._http_req_resp.read()
 
         return self._loop.run_until_complete(async_read())
 

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -206,7 +206,6 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
     def connection_made(self, transport):
         super(GremlinServerHTTPProtocol, self).connection_made(transport)
 
-    # Transforms request message into string
     def write(self, request_id, request_message):
 
         basic_auth = {}
@@ -230,13 +229,6 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
             log.error("Received empty message from server.")
             raise GremlinServerError({'code': 500,
                                       'message': 'Server disconnected - please try to reconnect', 'attributes': {}})
-
-        # if a request query cannot be compiled by Gremlin Server, the HTTP handler will send back the exception in
-        # json string without a requestId
-        if 'message' in message and 'requestId' not in message:
-            log.error("\r\nReceived error message from server '%s'", str(message))
-            raise GremlinServerError({'code': 400,
-                                      'message': message, 'attributes': {}})
 
         message = self._message_serializer.deserialize_message(message)
         request_id = message['requestId']

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -208,33 +208,17 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
 
     # Transforms request message into string
     def write(self, request_id, request_message):
-        payload = {
-            'requestId': request_id
-        }
-
-        gremlinArgs = request_message.args['gremlin']
-        useBytecode = isinstance(gremlinArgs, Bytecode)
-
-        # translate bytecode into scripts
-        if useBytecode:
-            request_message.args['gremlin'] = Translator().of('g').translate(gremlinArgs)
-            payload['op'] = 'bytecode'
-
-        # add all args into the payload
-        for k, v in request_message.args.items():
-            payload[k] = v
-
-        json_data = json.dumps(payload)
 
         basic_auth = {}
         if self._username and self._password:
             basic_auth['username'] = self._username
             basic_auth['password'] = self._password
 
+        content_type = str(self._message_serializer.version, encoding='utf-8')
         message = {
-            'headers': {'CONTENT-TYPE': 'application/json',
-                        'ACCEPT': str(self._message_serializer.version, encoding='utf-8')},
-            'payload': json_data,
+            'headers': {'CONTENT-TYPE': content_type,
+                        'ACCEPT': content_type},
+            'payload': self._message_serializer.serialize_message(request_id, request_message),
             'auth': basic_auth
         }
 

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
@@ -31,19 +31,9 @@ from gremlin_python.process.strategies import SubgraphStrategy, SeedStrategy
 from gremlin_python.structure.io.util import HashableDict
 from gremlin_python.driver.serializer import GraphSONSerializersV2d0
 
-"""
-Due to the limitation of relying on python translator for sending groovy scripts over HTTP, certain tests are omitted.
-
-Some known limitation with current HTTP via groovy script translator:
-- Any known limitation with groovy script will be inherited, such as injection of 2 items with the second null, 
-    e.g. g.inject(null, null), will lead to NPE
-- Any server side NPE will cause hanging with no response, need to check server HTTP handlers
-- HTTPS only works with HttpChannelizer, need to check how WsAndHttpChannelizer handles SSL
-- No transaction support
-"""
-
 gremlin_server_url_http = os.environ.get('GREMLIN_SERVER_URL_HTTP', 'http://localhost:{}/')
 test_no_auth_http_url = gremlin_server_url_http.format(45940)
+
 
 class TestDriverRemoteConnectionHttp(object):
     def test_traversals(self, remote_connection_http):
@@ -164,10 +154,12 @@ class TestDriverRemoteConnectionHttp(object):
         g = traversal().withRemote(remote_connection_http)
 
         assert 24.0 == g.withSack(1.0, lambda: ("x -> x + 1", "gremlin-groovy")).V().both().sack().sum_().next()
-        assert 24.0 == g.withSack(lambda: ("{1.0d}", "gremlin-groovy"), lambda: ("x -> x + 1", "gremlin-groovy")).V().both().sack().sum_().next()
+        assert 24.0 == g.withSack(lambda: ("{1.0d}", "gremlin-groovy"),
+                                  lambda: ("x -> x + 1", "gremlin-groovy")).V().both().sack().sum_().next()
 
         assert 48.0 == g.withSack(1.0, lambda: ("x, y ->  x + y + 1", "gremlin-groovy")).V().both().sack().sum_().next()
-        assert 48.0 == g.withSack(lambda: ("{1.0d}", "gremlin-groovy"), lambda: ("x, y ->  x + y + 1", "gremlin-groovy")).V().both().sack().sum_().next()
+        assert 48.0 == g.withSack(lambda: ("{1.0d}", "gremlin-groovy"),
+                                  lambda: ("x, y ->  x + y + 1", "gremlin-groovy")).V().both().sack().sum_().next()
 
     def test_strategies(self, remote_connection_http):
         statics.load_statics(globals())
@@ -219,6 +211,7 @@ class TestDriverRemoteConnectionHttp(object):
         assert 12 == len(t.toList())
         assert 5 == t.clone().limit(5).count().next()
         assert 10 == t.clone().limit(10).count().next()
+
 
     """
     # The WsAndHttpChannelizer somehow does not distinguish the ssl handlers so authenticated https remote connection

--- a/gremlin-server/conf/gremlin-server-rest-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-modern.yaml
@@ -28,7 +28,11 @@ scriptEngines: {
                org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]},
                org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/generate-modern.groovy]}}}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/json
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONUntypedMessageSerializerV3, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}     # application/vnd.gremlin-v3.0+json;types=false
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/vnd.gremlin-v3.0+json
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
+
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
 strictTransactionManagement: false

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -151,9 +151,9 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
 
             final RequestMessage requestMessage;
             try {
-                requestMessage = HttpHandlerUtil.getRequestMessageFromHttpRequest(req);
-            } catch (IllegalArgumentException iae) {
-                HttpHandlerUtil.sendError(ctx, BAD_REQUEST, iae.getMessage(), keepAlive);
+                requestMessage = HttpHandlerUtil.getRequestMessageFromHttpRequest(req, serializers);
+            } catch (IllegalArgumentException|SerializationException ex) {
+                HttpHandlerUtil.sendError(ctx, BAD_REQUEST, ex.getMessage(), keepAlive);
                 ReferenceCountUtil.release(msg);
                 return;
             }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -241,7 +241,6 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
                             // results to Traverser so that GLVs can handle the results. don't quite get the same
                             // benefit here because the bulk has to be 1 since we've already resolved the result,
                             // but at least http is compatible
-                            // !!! not friendly for console users?
                             final List<Object> results = requestMessage.getOp().equals(Tokens.OPS_BYTECODE) ?
                                     (List<Object>) IteratorUtils.asList(o).stream().map(r -> new DefaultRemoteTraverser<Object>(r, 1)).collect(Collectors.toList()) :
                                     IteratorUtils.asList(o);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -269,7 +269,7 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
                             attemptCommit(requestMessage.getArg(Tokens.ARGS_ALIASES), graphManager, settings.strictTransactionManagement);
 
                             try {
-                                return Unpooled.wrappedBuffer(serializer.getValue1().serializeResponseAsString(responseMessage, ctx.alloc()).getBytes(UTF8));
+                                return Unpooled.wrappedBuffer(serializer.getValue1().serializeResponseAsBinary(responseMessage, ctx.alloc()));
                             } catch (Exception ex) {
                                 logger.warn(String.format("Error during serialization for %s", responseMessage), ex);
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
@@ -92,7 +92,7 @@ public class HttpHandlerUtil {
                 buffer.readBytes(bytes);
                 final String mimeType = new String(bytes, StandardCharsets.UTF_8);
 
-                if (Arrays.stream(serializer.mimeTypesSupported()).anyMatch(t -> !t.equals(mimeType)))
+                if (Arrays.stream(serializer.mimeTypesSupported()).noneMatch(t -> t.equals(mimeType)))
                     throw new IllegalArgumentException("Mime type mismatch. Value in content-type header not equal payload header.");
             } else
                 buffer.resetReaderIndex();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
@@ -55,6 +55,7 @@ import java.util.UUID;
 import static com.codahale.metrics.MetricRegistry.name;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 /**
@@ -80,7 +81,7 @@ public class HttpHandlerUtil {
                                                                   Map<String, MessageSerializer<?>> serializers) throws SerializationException {
         final String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
 
-        if (contentType != null && !contentType.equals("application/json") && serializers.containsKey(contentType)) {
+        if (request.method() == POST && contentType != null && !contentType.equals("application/json") && serializers.containsKey(contentType)) {
             final MessageSerializer<?> serializer = serializers.get(contentType);
 
             final ByteBuf buffer = request.content();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
@@ -76,6 +76,21 @@ public class HttpHandlerUtil {
 
     /**
      * Convert a http request into a {@link RequestMessage}.
+     * There are 2 payload types options here.
+     * 1.
+     *     existing https://tinkerpop.apache.org/docs/current/reference/#connecting-via-http
+     *     intended to use with curl, postman, etc. by users
+     *     both GET and POST
+     *     Content-Type header can be empty or application/json
+     *     Accept header can be any, most useful can be application/json, text/plain, application/vnd.gremlin-v3.0+json and application/vnd.gremlin-v3.0+json;types=false
+     *     Request body example: { "gremlin": "g.V()" }
+     * 2.
+     *     experimental payload with serialized RequestMessage
+     *     intended for drivers/GLV's. Support both gremlin and bytecode queries.
+     *     only POST
+     *     Content-Type is defined by used serializer, expected type GraphSON application/vnd.gremlin-v3.0+json or GraphBinary application/vnd.graphbinary-v1.0. Untyped GraphSON is not supported, it can't deserialize bytecode
+     *     Accept header can be any.
+     *     Request body contains serialized RequestMessage
      */
     public static RequestMessage getRequestMessageFromHttpRequest(final FullHttpRequest request,
                                                                   Map<String, MessageSerializer<?>> serializers) throws SerializationException {
@@ -94,7 +109,7 @@ public class HttpHandlerUtil {
                 final String mimeType = new String(bytes, StandardCharsets.UTF_8);
 
                 if (Arrays.stream(serializer.mimeTypesSupported()).noneMatch(t -> t.equals(mimeType)))
-                    throw new IllegalArgumentException("Mime type mismatch. Value in content-type header not equal payload header.");
+                    throw new IllegalArgumentException("Mime type mismatch. Value in content-type header is not equal payload header.");
             } else
                 buffer.resetReaderIndex();
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
@@ -103,6 +103,8 @@ public class HttpHandlerUtil {
 
             // additional validation for header
             final int first = buffer.readByte();
+            // payload can be plain json or can start with additional header with content type.
+            // if first character is not "{" (0x7b) then need to verify is correct serializer selected.
             if (first != 0x7b) {
                 final byte[] bytes = new byte[first];
                 buffer.readBytes(bytes);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/TextPlainMessageSerializer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/TextPlainMessageSerializer.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.server.util;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.CharsetUtil;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.util.ser.MessageTextSerializer;
@@ -42,7 +43,11 @@ public class TextPlainMessageSerializer implements MessageTextSerializer<Functio
 
     @Override
     public ByteBuf serializeResponseAsBinary(final ResponseMessage responseMessage, final ByteBufAllocator allocator) throws SerializationException {
-        throw new UnsupportedOperationException("text/plain does not produce binary");
+        final String payload = serializeResponseAsString(responseMessage, allocator);
+        final ByteBuf encodedMessage = allocator.buffer(payload.length());
+        encodedMessage.writeCharSequence(payload, CharsetUtil.UTF_8);
+
+        return encodedMessage;
     }
 
     @Override

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
@@ -48,6 +51,7 @@ import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
@@ -393,9 +397,9 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
             assertEquals(mime, response.getEntity().getContentType().getValue());
-            final String base64 = EntityUtils.toString(response.getEntity());
+
             final GraphBinaryMessageSerializerV1 serializer = new GraphBinaryMessageSerializerV1(TypeSerializerRegistry.INSTANCE);
-            final ResponseMessage msg = serializer.deserializeResponse(base64);
+            final ResponseMessage msg = serializer.deserializeResponse(toByteBuf(response.getEntity()));
             final List<Object> data = (List<Object>) msg.getResult().getData();
             assertEquals(6, data.size());
             for (Object o : data) {
@@ -414,9 +418,9 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         try (final CloseableHttpResponse response = httpclient.execute(httpget)) {
             assertEquals(200, response.getStatusLine().getStatusCode());
             assertEquals(mime, response.getEntity().getContentType().getValue());
-            final String base64 = EntityUtils.toString(response.getEntity());
+
             final GraphBinaryMessageSerializerV1 serializer = new GraphBinaryMessageSerializerV1(TypeSerializerRegistry.INSTANCE);
-            final ResponseMessage msg = serializer.deserializeResponse(base64);
+            final ResponseMessage msg = serializer.deserializeResponse(toByteBuf(response.getEntity()));
             final List<Object> data = (List<Object>) msg.getResult().getData();
             assertEquals(6, data.size());
             for (Object o : data) {
@@ -1072,5 +1076,13 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
         assertEquals(500, secondGetResult.get().intValue());
 
         threadPool.shutdown();
+    }
+
+    private static ByteBuf toByteBuf(final HttpEntity httpEntity) throws IOException {
+        final byte[] asArray = new byte[(int)httpEntity.getContentLength()];
+
+        httpEntity.getContent().read(asArray);
+
+        return Unpooled.wrappedBuffer(asArray);
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
@@ -81,7 +81,8 @@ public class HttpDriverIntegrateTest extends AbstractGremlinServerIntegrationTes
                 .create();
         try {
             final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));
-            assertEquals("2", g.inject("2").toList().get(0));
+            final String result = g.inject("2").toList().get(0);
+            assertEquals("2", result);
         } catch (Exception ex) {
             throw ex;
         } finally {
@@ -97,7 +98,8 @@ public class HttpDriverIntegrateTest extends AbstractGremlinServerIntegrationTes
                 .create();
         try {
             final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));
-            assertEquals("2", g.inject("2").toList().get(0));
+            final String result = g.inject("2").toList().get(0);
+            assertEquals("2", result);
         } catch (Exception ex) {
             throw ex;
         } finally {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtilTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtilTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.QueryStringEncoder;
+import io.netty.util.CharsetUtil;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
+import org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3;
+import org.apache.tinkerpop.gremlin.util.ser.SerTokens;
+import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class HttpHandlerUtilTest {
+
+    private final ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+    private final GraphBinaryMessageSerializerV1 graphBinarySerializer = new GraphBinaryMessageSerializerV1();
+    public final GraphSONMessageSerializerV3 graphSONSerializer = new GraphSONMessageSerializerV3();
+
+    @Test
+    public void shouldFailWhenIncorrectSerializerUsed() throws SerializationException {
+        final RequestMessage request = RequestMessage.build(Tokens.OPS_BYTECODE)
+                .processor("traversal")
+                .overrideRequestId(UUID.randomUUID())
+                .addArg(Tokens.ARGS_GREMLIN, "g.V()")
+                .create();
+
+        final ByteBuf buffer = graphSONSerializer.serializeRequestAsBinary(request, allocator);
+
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.CONTENT_TYPE, SerTokens.MIME_GRAPHBINARY_V1);
+
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some uri",
+                buffer, headers, new DefaultHttpHeaders());
+
+        final Map<String, MessageSerializer<?>> serializers = new HashMap<>();
+        serializers.put(SerTokens.MIME_GRAPHBINARY_V1, graphBinarySerializer);
+
+        try {
+            HttpHandlerUtil.getRequestMessageFromHttpRequest(httpRequest, serializers);
+            fail("SerializationException expected");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Mime type mismatch. Value in content-type header not equal payload header.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldCorrectlyDeserializeRequestMessage() throws SerializationException {
+        final RequestMessage request = RequestMessage.build(Tokens.OPS_BYTECODE)
+                .processor("traversal")
+                .overrideRequestId(UUID.randomUUID())
+                .addArg(Tokens.ARGS_GREMLIN, "g.V()")
+                .create();
+
+        final ByteBuf buffer = graphBinarySerializer.serializeRequestAsBinary(request, allocator);
+
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.CONTENT_TYPE, SerTokens.MIME_GRAPHBINARY_V1);
+
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some uri",
+                buffer, headers, new DefaultHttpHeaders());
+
+        final Map<String, MessageSerializer<?>> serializers = new HashMap<>();
+        serializers.put(SerTokens.MIME_GRAPHBINARY_V1, graphBinarySerializer);
+
+        final RequestMessage deserialized = HttpHandlerUtil.getRequestMessageFromHttpRequest(httpRequest, serializers);
+        assertThat(request, samePropertyValuesAs(deserialized));
+    }
+
+    @Test
+    public void shouldCorrectlyDeserializeGremlinFromPostRequest() throws SerializationException {
+        final String gremlin = "g.V().hasLabel('person')";
+        final UUID requestId = UUID.randomUUID();
+        final ByteBuf buffer = allocator.buffer();
+        buffer.writeCharSequence("{ \"gremlin\": \"" + gremlin +
+                        "\", \"requestId\": \"" + requestId +
+                        "\", \"language\":  \"gremlin-groovy\"}",
+                CharsetUtil.UTF_8);
+
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.CONTENT_TYPE, SerTokens.MIME_JSON);
+
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some uri",
+                buffer, headers, new DefaultHttpHeaders());
+
+        final Map<String, MessageSerializer<?>> serializers = new HashMap<>();
+        serializers.put(SerTokens.MIME_GRAPHBINARY_V1, graphBinarySerializer);
+
+        final RequestMessage deserialized = HttpHandlerUtil.getRequestMessageFromHttpRequest(httpRequest, serializers);
+        assertEquals(gremlin, deserialized.getArgs().get(Tokens.ARGS_GREMLIN));
+        assertEquals(requestId, deserialized.getRequestId());
+        assertEquals("gremlin-groovy", deserialized.getArg(Tokens.ARGS_LANGUAGE));
+    }
+
+    @Test
+    public void shouldCorrectlyDeserializeGremlinFromGetRequest() throws SerializationException {
+        final String gremlin = "g.V().hasLabel('person')";
+        final UUID requestId = UUID.randomUUID();
+        final ByteBuf buffer = allocator.buffer();
+
+        final List<String> headerOptions = Arrays.asList("", null, SerTokens.MIME_JSON, "some invalid value");
+
+        for (final String contentTypeValue : headerOptions) {
+            final HttpHeaders headers = new DefaultHttpHeaders();
+            if (contentTypeValue != null) {
+                headers.add(HttpHeaderNames.CONTENT_TYPE, contentTypeValue);
+            }
+
+            final QueryStringEncoder encoder = new QueryStringEncoder("/");
+            encoder.addParam("gremlin", gremlin);
+            encoder.addParam("requestId", requestId.toString());
+            encoder.addParam("language", "gremlin-groovy");
+
+            final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                    encoder.toString(), buffer, headers, new DefaultHttpHeaders());
+
+            final Map<String, MessageSerializer<?>> serializers = new HashMap<>();
+            serializers.put(SerTokens.MIME_GRAPHBINARY_V1, graphBinarySerializer);
+
+            final RequestMessage deserialized = HttpHandlerUtil.getRequestMessageFromHttpRequest(httpRequest, serializers);
+            assertEquals(gremlin, deserialized.getArgs().get(Tokens.ARGS_GREMLIN));
+            assertEquals(requestId, deserialized.getRequestId());
+            assertEquals("gremlin-groovy", deserialized.getArg(Tokens.ARGS_LANGUAGE));
+        }
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtilTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtilTest.java
@@ -79,7 +79,7 @@ public class HttpHandlerUtilTest {
             HttpHandlerUtil.getRequestMessageFromHttpRequest(httpRequest, serializers);
             fail("SerializationException expected");
         } catch (IllegalArgumentException ex) {
-            assertEquals("Mime type mismatch. Value in content-type header not equal payload header.", ex.getMessage());
+            assertEquals("Mime type mismatch. Value in content-type header is not equal payload header.", ex.getMessage());
         }
     }
 

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/GraphBinaryMessageSerializerV1Test.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/GraphBinaryMessageSerializerV1Test.java
@@ -20,6 +20,13 @@ package org.apache.tinkerpop.gremlin.util.ser.binary;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.util.message.ResponseStatusCode;
@@ -42,12 +49,17 @@ public class GraphBinaryMessageSerializerV1Test {
     private final ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
     private final GraphBinaryMessageSerializerV1 serializer = new GraphBinaryMessageSerializerV1();
 
+    // !!!
     @Test
     public void shouldSerializeAndDeserializeRequest() throws SerializationException {
-        final RequestMessage request = RequestMessage.build("op1")
-                .processor("proc1")
+        final GraphTraversalSource g = EmptyGraph.instance().traversal();
+        final Traversal.Admin t = g.V().asAdmin();
+
+        final RequestMessage request = RequestMessage.build(Tokens.OPS_BYTECODE)
+                .processor("traversal")
                 .overrideRequestId(UUID.randomUUID())
                 .addArg("arg1", "value1")
+                .addArg(Tokens.ARGS_GREMLIN, t.getBytecode())
                 .create();
 
         final ByteBuf buffer = serializer.serializeRequestAsBinary(request, allocator);


### PR DESCRIPTION
Added Gremlin bytecode support for HTTP requests for Java and Python GLV's without translation to Gremlin script.
Added serialization for entire `RequestMessage`.
Payload type distinguished by `Content-Type` header .
