### PR TITLE
GremlinServer: Restrict the thread pool size to 1 when serving a TinkerTransactionGraph

### DIFF
--- a/gremlin-server/conf/gremlin-server-transaction.yaml
+++ b/gremlin-server/conf/gremlin-server-transaction.yaml
@@ -39,6 +39,7 @@ metrics: {
   csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
   jmxReporter: {enabled: true},
   slf4jReporter: {enabled: true, interval: 180000}}
+gremlinPool: 1
 strictTransactionManagement: false
 idleConnectionTimeout: 0
 keepAliveInterval: 0


### PR DESCRIPTION
For sessionless requests, executing requests on different threads leads to unpredictable behaviour, even if requests are serialized on the client side (even with some reasonable wait time between requests). Wrapping each request in a transaction on the client side works just fine however, so this change might be a bit to broad for explicit transaction processing. Maybe there is a way to only restrict the sessionless processor and leave the session-processor multi-threaded?