### PR TITLE
[TINKERPOP-3016] Fix for reading value from different read operation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ This release also includes changes from <<release-3-6-6, 3.6.6>> and <<release-3
 * Fixed deserialization of element properties for GraphBinary.
 * Fixed bug in `union()` as a start step where the `Path` was including the starting dummy traverser.
 * Moved some TinkerGraph specific transaction tests from `TransactionMultiThreadedTest` to `TinkerTransactionGraphTest`
+* Fixed incorrect read operations in some cases for `TinkerTransactionGraph`.
 * Improved performance for Element comparison by comparing hashCode() prior to doing more expensive checks.
 
 [[release-3-7.0]]

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
@@ -94,10 +94,13 @@ final class TinkerElementContainer<T extends TinkerElement> {
 
         final T cloned = (T) element.clone();
         transactionUpdatedValue.set(cloned);
-        isReadInTx.set(true);
-        usesInTransactions.incrementAndGet();
 
-        tx.markRead(this);
+        if (!isReadInTx.get()) {
+            isReadInTx.set(true);
+            usesInTransactions.incrementAndGet();
+            tx.markRead(this);
+        }
+
         return cloned;
     }
 
@@ -164,10 +167,11 @@ final class TinkerElementContainer<T extends TinkerElement> {
      */
     public void setDraft(final T transactionElement, final TinkerTransaction tx) {
         elementId = transactionElement.id();
-        if (!isModifiedInTx.get())
+        if (!isModifiedInTx.get()) {
             usesInTransactions.incrementAndGet();
+            isModifiedInTx.set(true);
+        }
         transactionUpdatedValue.set(transactionElement);
-        isModifiedInTx.set(true);
         tx.markChanged(this);
     }
 

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
@@ -235,7 +235,7 @@ final class TinkerElementContainer<T extends TinkerElement> {
     /**
      * Cleanup changes made in the current transaction.
      */
-    void reset() {
+    public void reset() {
         transactionUpdatedValue.remove();
         isDeletedInTx.set(false);
         isModifiedInTx.set(false);

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
@@ -42,22 +42,27 @@ final class TinkerElementContainer<T extends TinkerElement> {
     /**
      * Value of elements updated in current transaction.
      */
-    private ThreadLocal<T> transactionUpdatedValue = ThreadLocal.withInitial(() -> null);
+    private final ThreadLocal<T> transactionUpdatedValue = ThreadLocal.withInitial(() -> null);
     /**
      * Marker for element deleted in current transaction.
      */
-    private ThreadLocal<Boolean> isDeletedInTx = ThreadLocal.withInitial(() -> false);
+    private final ThreadLocal<Boolean> isDeletedInTx = ThreadLocal.withInitial(() -> false);
 
     /**
      * Marker for element modified in current transaction.
      */
-    private ThreadLocal<Boolean> isModifiedInTx = ThreadLocal.withInitial(() -> false);
+    private final ThreadLocal<Boolean> isModifiedInTx = ThreadLocal.withInitial(() -> false);
+
+    /**
+     * Marker for element read in current transaction.
+     */
+    private final ThreadLocal<Boolean> isReadInTx = ThreadLocal.withInitial(() -> false);
 
     /**
      * Count of usages of container in different transactions.
      * Needed to understand whether this element is used in other transactions or it can be deleted during rollback.
      */
-    private AtomicInteger usesInTransactions = new AtomicInteger(0);
+    private final AtomicInteger usesInTransactions = new AtomicInteger(0);
 
     /**
      * Used to protect container from simultaneous modification in different transactions.
@@ -82,13 +87,17 @@ final class TinkerElementContainer<T extends TinkerElement> {
         return element;
     }
 
-    public T getWithClone() {
+    public T getWithClone(final TinkerTransaction tx) {
         if (isDeletedInTx.get()) return null;
         if (transactionUpdatedValue.get() != null) return transactionUpdatedValue.get();
         if (isDeleted || null == element) return null;
 
         final T cloned = (T) element.clone();
         transactionUpdatedValue.set(cloned);
+        isReadInTx.set(true);
+        usesInTransactions.incrementAndGet();
+
+        tx.markRead(this);
         return cloned;
     }
 
@@ -143,7 +152,6 @@ final class TinkerElementContainer<T extends TinkerElement> {
      * @param tx current transaction
      */
     public void touch(final T transactionElement, final TinkerTransaction tx) {
-        elementId = transactionElement.id();
         if (transactionUpdatedValue.get() == transactionElement && isModifiedInTx.get()) return;
 
         setDraft(transactionElement, tx);
@@ -208,6 +216,8 @@ final class TinkerElementContainer<T extends TinkerElement> {
             usesInTransactions.decrementAndGet();
         if (isModifiedInTx.get())
             usesInTransactions.decrementAndGet();
+        if (isReadInTx.get())
+            usesInTransactions.decrementAndGet();
     }
 
     /**
@@ -221,10 +231,11 @@ final class TinkerElementContainer<T extends TinkerElement> {
     /**
      * Cleanup changes made in the current transaction.
      */
-    private void reset() {
+    void reset() {
         transactionUpdatedValue.remove();
         isDeletedInTx.set(false);
         isModifiedInTx.set(false);
+        isReadInTx.set(false);
     }
 
     /**

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
@@ -198,8 +198,8 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
             throw ex;
         } finally {
             // remove elements from graph if not used in other tx's
-            changedVertices.stream().filter(v -> v.canBeRemoved()).forEach(v -> graph.vertices.remove(v.getElementId()));
-            changedEdges.stream().filter(e -> e.canBeRemoved()).forEach(e -> graph.edges.remove(e.getElementId()));
+            changedVertices.stream().filter(v -> v.canBeRemoved()).forEach(v -> graph.getVertices().remove(v.getElementId()));
+            changedEdges.stream().filter(e -> e.canBeRemoved()).forEach(e -> graph.getEdges().remove(e.getElementId()));
 
             final Set<TinkerElementContainer> readElements = txReadElements.get();
             if (readElements != null)
@@ -241,9 +241,9 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
 
         // cleanup unused containers
         if (null != changedVertices)
-            changedVertices.stream().filter(v -> v.canBeRemoved()).forEach(v -> graph.vertices.remove(v.getElementId()));
+            changedVertices.stream().filter(v -> v.canBeRemoved()).forEach(v -> graph.getVertices().remove(v.getElementId()));
         if (null != changedEdges)
-            changedEdges.stream().filter(e -> e.canBeRemoved()).forEach(e -> graph.edges.remove(e.getElementId()));
+            changedEdges.stream().filter(e -> e.canBeRemoved()).forEach(e -> graph.getEdges().remove(e.getElementId()));
 
         final Set<TinkerElementContainer> readElements = txReadElements.get();
         if (readElements != null)

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
@@ -60,6 +60,11 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
      */
     private final ThreadLocal<Set<TinkerElementContainer<TinkerEdge>>> txChangedEdges = new ThreadLocal<>();
 
+    /**
+     * Set of references to element containers read in current transaction.
+     */
+    private final ThreadLocal<Set<TinkerElementContainer>> txReadElements = new ThreadLocal<>();
+
     private final TinkerTransactionGraph graph;
 
     static {
@@ -84,9 +89,6 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
 
     @Override
     protected void doOpen() {
-        if (isOpen())
-            Transaction.Exceptions.transactionAlreadyOpen();
-
         txNumber.set(openedTx.getAndIncrement());
     }
 
@@ -112,6 +114,18 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
                 txChangedEdges.set(new HashSet<>());
             txChangedEdges.get().add((TinkerElementContainer<TinkerEdge>) container);
         }
+    }
+
+    /**
+     * Adds element to list of read in current transaction.
+     */
+    protected <T extends TinkerElement> void markRead(TinkerElementContainer container) {
+        if (!isOpen()) txNumber.set(openedTx.getAndIncrement());
+
+        if (null == txReadElements.get())
+            txReadElements.set(new HashSet<>());
+
+        txReadElements.get().add(container);
     }
 
     /**
@@ -148,10 +162,12 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
 
             // try to lock all element containers, throw exception if any element already locked by other tx
             changedVertices.forEach(v -> {
-                if (!v.tryLock()) throw new TransactionException(TX_CONFLICT);
+                if (!v.tryLock())
+                    throw new TransactionException(TX_CONFLICT);
             });
             changedEdges.forEach(e -> {
-                if (!e.tryLock()) throw new TransactionException(TX_CONFLICT);
+                if (!e.tryLock())
+                    throw new TransactionException(TX_CONFLICT);
             });
 
             // verify versions of all elements to be sure no element changes during setting lock
@@ -185,8 +201,13 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
             changedVertices.stream().filter(v -> v.canBeRemoved()).forEach(v -> graph.vertices.remove(v.getElementId()));
             changedEdges.stream().filter(e -> e.canBeRemoved()).forEach(e -> graph.edges.remove(e.getElementId()));
 
+            final Set<TinkerElementContainer> readElements = txReadElements.get();
+            if (readElements != null)
+                readElements.stream().forEach(e -> e.reset());
+
             txChangedVertices.remove();
             txChangedEdges.remove();
+            txReadElements.remove();
 
             changedVertices.forEach(v -> v.releaseLock());
             changedEdges.forEach(e -> e.releaseLock());

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
@@ -245,8 +245,13 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
         if (null != changedEdges)
             changedEdges.stream().filter(e -> e.canBeRemoved()).forEach(e -> graph.edges.remove(e.getElementId()));
 
+        final Set<TinkerElementContainer> readElements = txReadElements.get();
+        if (readElements != null)
+            readElements.stream().forEach(e -> e.reset());
+
         txChangedVertices.remove();
         txChangedEdges.remove();
+        txReadElements.remove();
 
         txNumber.set(NOT_STARTED);
     }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraph.java
@@ -72,8 +72,8 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
 
     private final TinkerTransaction transaction = new TinkerTransaction(this);
 
-    final Map<Object, TinkerElementContainer<TinkerVertex>> vertices = new ConcurrentHashMap<>();
-    final Map<Object, TinkerElementContainer<TinkerEdge>> edges = new ConcurrentHashMap<>();
+    private final Map<Object, TinkerElementContainer<TinkerVertex>> vertices = new ConcurrentHashMap<>();
+    private final Map<Object, TinkerElementContainer<TinkerEdge>> edges = new ConcurrentHashMap<>();
 
     /**
      * An empty private constructor that initializes {@link TinkerTransactionGraph}.

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraph.java
@@ -72,8 +72,8 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
 
     private final TinkerTransaction transaction = new TinkerTransaction(this);
 
-    protected Map<Object, TinkerElementContainer<TinkerVertex>> vertices = new ConcurrentHashMap<>();
-    protected Map<Object, TinkerElementContainer<TinkerEdge>> edges = new ConcurrentHashMap<>();
+    final Map<Object, TinkerElementContainer<TinkerVertex>> vertices = new ConcurrentHashMap<>();
+    final Map<Object, TinkerElementContainer<TinkerEdge>> edges = new ConcurrentHashMap<>();
 
     /**
      * An empty private constructor that initializes {@link TinkerTransactionGraph}.
@@ -184,7 +184,7 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
             this.tx().readWrite();
             container.touch(vertex, (TinkerTransaction) tx());
         }
-    };
+    }
 
     @Override
     public void touch(final TinkerEdge edge) {
@@ -197,7 +197,7 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
             this.tx().readWrite();
             container.touch(edge, (TinkerTransaction) tx());
         }
-    };
+    }
 
     @Override
     public Edge addEdge(final TinkerVertex outVertex, final TinkerVertex inVertex, final String label, final Object... keyValues) {
@@ -310,7 +310,7 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
     @Override
     public Vertex vertex(final Object vertexId) {
         final TinkerElementContainer<TinkerVertex> container = vertices.get(vertexIdManager.convert(vertexId));
-        return container == null ? null : container.getWithClone();
+        return container == null ? null : container.getWithClone((TinkerTransaction) tx());
     }
 
     @Override
@@ -321,7 +321,7 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
     @Override
     public Edge edge(final Object edgeId) {
         final TinkerElementContainer<TinkerEdge> container = edges.get(edgeIdManager.convert(edgeId));
-        return container == null ? null : container.getWithClone();
+        return container == null ? null : container.getWithClone((TinkerTransaction) tx());
     }
 
     @Override
@@ -340,7 +340,7 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
         if (0 == ids.length) {
             iterator = new TinkerGraphIterator<>(
                     // todo: clone only if traversal contains mutating steps
-                    elements.values().stream().map(c -> (T) c.getWithClone()).filter(e -> e != null).iterator());
+                    elements.values().stream().map(c -> (T) c.getWithClone((TinkerTransaction) tx())).filter(e -> e != null).iterator());
         } else {
             final List<Object> idList = Arrays.asList(ids);
 
@@ -353,7 +353,7 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
                 if (null == id) return null;
                 final Object iid = clazz.isAssignableFrom(id.getClass()) ? clazz.cast(id).id() : idManager.convert(id);
                 final TinkerElementContainer<C> container = elements.get(iid);
-                return container == null ? null : (T) container.getWithClone();
+                return container == null ? null : (T) container.getWithClone((TinkerTransaction) tx());
             }).iterator(), Objects::nonNull));
         }
         return TinkerHelper.inComputerMode(this) ?
@@ -380,7 +380,7 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
         if (null == vertex.inEdgesId) vertex.inEdgesId = new ConcurrentHashMap<>();
         Set<Object> edges = vertex.inEdgesId.get(label);
         if (null == edges) {
-            edges = ConcurrentHashMap.newKeySet();;
+            edges = ConcurrentHashMap.newKeySet();
             vertex.inEdgesId.put(label, edges);
         }
         edges.add(edge.id());
@@ -491,23 +491,6 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
             if (null != this.vertexIndex) this.vertexIndex.dropKeyIndex(key);
         } else if (Edge.class.isAssignableFrom(elementClass)) {
             if (null != this.edgeIndex) this.edgeIndex.dropKeyIndex(key);
-        } else {
-            throw new IllegalArgumentException("Class is not indexable: " + elementClass);
-        }
-    }
-
-    /**
-     * Return all the keys currently being index for said element class  ({@link Vertex} or {@link Edge}).
-     *
-     * @param elementClass the element class to get the indexed keys for
-     * @param <E>          The type of the element class
-     * @return the set of keys currently being indexed
-     */
-    public <E extends Element> Set<String> getIndexedKeys(final Class<E> elementClass) {
-        if (Vertex.class.isAssignableFrom(elementClass)) {
-            return null == this.vertexIndex ? Collections.emptySet() : this.vertexIndex.getIndexedKeys();
-        } else if (Edge.class.isAssignableFrom(elementClass)) {
-            return null == this.edgeIndex ? Collections.emptySet() : this.edgeIndex.getIndexedKeys();
         } else {
             throw new IllegalArgumentException("Class is not indexable: " + elementClass);
         }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionalIndex.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionalIndex.java
@@ -183,8 +183,8 @@ final class TinkerTransactionalIndex<T extends TinkerElement> extends AbstractTi
 
         final Map elements =
                 Vertex.class.isAssignableFrom(indexClass) ?
-                        ((TinkerTransactionGraph) graph).vertices :
-                        ((TinkerTransactionGraph) graph).edges;
+                        ((TinkerTransactionGraph) graph).getVertices() :
+                        ((TinkerTransactionGraph) graph).getEdges();
 
         for (Object element : elements.values()) {
             addContainer((TinkerElementContainer<T>) element);

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraphTest.java
@@ -102,6 +102,27 @@ public class TinkerTransactionGraphTest {
         assertEquals(0, g.getVertices().size());
     }
 
+    @Test
+    public void shouldCleanUpVertexContainerOnCommit() {
+        final TinkerTransactionGraph g = TinkerTransactionGraph.open();
+
+        final GraphTraversalSource gtx = g.tx().begin();
+
+        gtx.addV().property(T.id, vid).iterate();
+        gtx.tx().commit();
+
+        // read vertex in new TX
+        final GraphTraversalSource gtx2 = g.tx().begin();
+        final Vertex v = gtx.V(vid).next();
+        // should be the same instance
+        assertEquals(v, g.getVertices().get(vid).getModified());
+        // commit without modifications
+        gtx.tx().commit();
+
+        // should clean up unused value in container
+        assertEquals(1, g.getVertices().size());
+        assertNull(g.getVertices().get(vid).getModified());
+    }
 
     @Test
     public void shouldDeleteUnusedVertexContainerOnCommit() {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraphTest.java
@@ -114,6 +114,7 @@ public class TinkerTransactionGraphTest {
         // read vertex in new TX
         final GraphTraversalSource gtx2 = g.tx().begin();
         final Vertex v = gtx.V(vid).next();
+        gtx.V(vid).iterate();
         // should be the same instance
         assertEquals(v, g.getVertices().get(vid).getModified());
         // commit without modifications
@@ -136,6 +137,7 @@ public class TinkerTransactionGraphTest {
         // read vertex in new TX
         final GraphTraversalSource gtx2 = g.tx().begin();
         final Vertex v = gtx.V(vid).next();
+        gtx.V(vid).iterate();
         // should be the same instance
         assertEquals(v, g.getVertices().get(vid).getModified());
         // rollback without modifications


### PR DESCRIPTION
Fix for issue when `TinkerTransactionGraph` used without transaction. A situation is possible when the value read before by another client in the same thread is returned.

Something like
Client1 in Thread1 read Vertex1, value cashed for consistent read.
Tx created for this request commit all changes, but for read operation it's nothing to do.

Client2 in Thread2 modify Vertex1 and commit changes.

Client3 got same Thread1 for his request, but cashed Vertex1 still used.

https://issues.apache.org/jira/browse/TINKERPOP-3016