### PR TITLE
Update nullability for AsString(), Conjoin() in Gremlin.Net

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversal.cs
@@ -226,19 +226,19 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the asString step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal<TStart, string> AsString ()
+        public GraphTraversal<TStart, string?> AsString ()
         {
             Bytecode.AddStep("asString");
-            return Wrap<TStart, string>(this);
+            return Wrap<TStart, string?>(this);
         }
         
         /// <summary>
         ///     Adds the asString step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal<TStart, TNewEnd> AsString<TNewEnd> (Scope scope)
+        public GraphTraversal<TStart, TNewEnd?> AsString<TNewEnd> (Scope scope)
         {
             Bytecode.AddStep("asString", scope);
-            return Wrap<TStart, TNewEnd>(this);
+            return Wrap<TStart, TNewEnd?>(this);
         }
 
         /// <summary>
@@ -591,10 +591,10 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Adds the conjoin step to this <see cref="GraphTraversal{SType, EType}" />.
         /// </summary>
-        public GraphTraversal<TStart, TEnd> Conjoin (string delimiter)
+        public GraphTraversal<TStart, TEnd?> Conjoin (string delimiter)
         {
             Bytecode.AddStep("conjoin", delimiter);
-            return Wrap<TStart, TEnd>(this);
+            return Wrap<TStart, TEnd?>(this);
         }
 
         /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/__.cs
@@ -155,7 +155,7 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the asString step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, string> AsString()
+        public static GraphTraversal<object, string?> AsString()
         {
             return new GraphTraversal<object, string>().AsString();            
         }
@@ -163,7 +163,7 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the asString step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, E2> AsString<E2>(Scope scope)
+        public static GraphTraversal<object, E2?> AsString<E2>(Scope scope)
         {
             return new GraphTraversal<object, E2>().AsString<E2>(scope);            
         }
@@ -381,7 +381,7 @@ namespace Gremlin.Net.Process.Traversal
         /// <summary>
         ///     Spawns a <see cref="GraphTraversal{SType, EType}" /> and adds the conjoin step to that traversal.
         /// </summary>
-        public static GraphTraversal<object, object> Conjoin(string delimiter)
+        public static GraphTraversal<object, object?> Conjoin(string delimiter)
         {
             return new GraphTraversal<object, object>().Conjoin(delimiter);
         }


### PR DESCRIPTION
Handling of null values has been changed in #2351 for `asString()` and `conjoin()` to return `null` for `null` values instead of the string `"null"`.

Just to clarify: I don't consider this change important enough to stop the current release process. This can just be included in the next line of releases.