### PR TITLE
Add requestIds to server HTTP error response.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added tests for error handling for GLV's if tx.commit() is called remotely for graphs without transactions support.
 * Introduced multi-architecture AMD64/ARM64 docker images for gremlin-console.
 * Fixed bug in `JavaTranslator` where `has(String, null)` could call `has(String, Traversal)` to generate an error.
+* Fixed issue where server errors weren't being properly parsed when sending bytecode over HTTP.
 
 [[release-3-6-6]]
 === TinkerPop 3.6.6 (November 20, 2023)

--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -211,7 +211,9 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
         # Inner function to perform async read.
         async def async_read():
             async with async_timeout.timeout(self._read_timeout):
-                return await self._http_req_resp.read()
+                return {"content": await self._http_req_resp.read(),
+                        "ok": self._http_req_resp.ok,
+                        "status": self._http_req_resp.status}
 
         return self._loop.run_until_complete(async_read())
 

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -265,3 +265,24 @@ def remote_connection_http_authenticated(request):
         request.addfinalizer(fin)
         return remote_conn
 """
+
+
+@pytest.fixture(params=['graphsonv3', 'graphbinaryv1'])
+def invalid_alias_remote_connection_http(request):
+    try:
+        if request.param == 'graphbinaryv1':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'does_not_exist',
+                                                 message_serializer=serializer.GraphBinarySerializersV1())
+        elif request.param == 'graphsonv3':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'does_not_exist',
+                                                 message_serializer=serializer.GraphSONSerializersV3d0())
+        else:
+            raise ValueError("Invalid serializer option - " + request.param)
+    except OSError:
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            remote_conn.close()
+
+        request.addfinalizer(fin)
+        return remote_conn

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
@@ -30,6 +30,7 @@ from gremlin_python.structure.graph import Vertex
 from gremlin_python.process.strategies import SubgraphStrategy, SeedStrategy
 from gremlin_python.structure.io.util import HashableDict
 from gremlin_python.driver.serializer import GraphSONSerializersV2d0
+from gremlin_python.driver.protocol import GremlinServerError
 
 gremlin_server_url_http = os.environ.get('GREMLIN_SERVER_URL_HTTP', 'http://localhost:{}/')
 test_no_auth_http_url = gremlin_server_url_http.format(45940)
@@ -212,6 +213,15 @@ class TestDriverRemoteConnectionHttp(object):
         assert 5 == t.clone().limit(5).count().next()
         assert 10 == t.clone().limit(10).count().next()
 
+    def test_receive_error(self, invalid_alias_remote_connection_http):
+        g = traversal().withRemote(invalid_alias_remote_connection_http)
+
+        try:
+            g.V().next()
+            assert False
+        except GremlinServerError as err:
+            assert err.status_code == 400
+            assert 'Could not rebind' in err.status_message
 
     """
     # The WsAndHttpChannelizer somehow does not distinguish the ssl handlers so authenticated https remote connection

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
@@ -230,10 +230,15 @@ public class HttpHandlerUtil {
 
     static void sendError(final ChannelHandlerContext ctx, final HttpResponseStatus status,
                           final String message, final boolean keepAlive) {
-        sendError(ctx, status, message, Optional.empty(), keepAlive);
+        sendError(ctx, status, null, message, Optional.empty(), keepAlive);
     }
 
-    static void sendError(final ChannelHandlerContext ctx, final HttpResponseStatus status,
+    static void sendError(final ChannelHandlerContext ctx, final HttpResponseStatus status, final UUID requestId,
+                          final String message, final boolean keepAlive) {
+        sendError(ctx, status, requestId, message, Optional.empty(), keepAlive);
+    }
+
+    static void sendError(final ChannelHandlerContext ctx, final HttpResponseStatus status, final UUID requestId,
                           final String message, final Optional<Throwable> t, final boolean keepAlive) {
         if (t.isPresent())
             logger.warn(String.format("Invalid request - responding with %s and %s", status, message), t.get());
@@ -250,6 +255,9 @@ public class HttpHandlerUtil {
             final ArrayNode exceptionList = node.putArray(Tokens.STATUS_ATTRIBUTE_EXCEPTIONS);
             ExceptionUtils.getThrowableList(t.get()).forEach(throwable -> exceptionList.add(throwable.getClass().getName()));
             node.put(Tokens.STATUS_ATTRIBUTE_STACK_TRACE, ExceptionUtils.getStackTrace(t.get()));
+        }
+        if (requestId != null) {
+            node.put("requestId", requestId.toString());
         }
 
         final FullHttpResponse response = new DefaultFullHttpResponse(

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
@@ -205,4 +205,38 @@ public class HttpDriverIntegrateTest extends AbstractGremlinServerIntegrationTes
             cluster.close();
         }
     }
+
+    @Test
+    public void shouldDeserializeErrorWithGraphBinary() throws Exception {
+        final Cluster cluster = TestClientFactory.build()
+                .channelizer(Channelizer.HttpChannelizer.class)
+                .serializer(Serializers.GRAPHBINARY_V1D0)
+                .create();
+        try {
+            final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "doesNotExist"));
+            g.V().next();
+            fail("Expected exception to be thrown.");
+        } catch (Exception ex) {
+            assert ex.getMessage().contains("Could not rebind");
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void shouldDeserializeErrorWithGraphSON() throws Exception {
+        final Cluster cluster = TestClientFactory.build()
+                .channelizer(Channelizer.HttpChannelizer.class)
+                .serializer(Serializers.GRAPHSON_V3D0)
+                .create();
+        try {
+            final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "doesNotExist"));
+            g.V().next();
+            fail("Expected exception to be thrown.");
+        } catch (Exception ex) {
+            assert ex.getMessage().contains("Could not rebind");
+        } finally {
+            cluster.close();
+        }
+    }
 }


### PR DESCRIPTION
HTTP errors are returned as JSON without requestId. The requestId is required in order to form a ResponseMessage that can be properly deserialized by the Java driver.

Not release blocking.