### PR TITLE
Let JavaTranslator.translateObject() throw clearer ISE

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/JavaTranslator.java
@@ -137,7 +137,7 @@ public final class JavaTranslator<S extends TraversalSource, T extends Traversal
                     }
                     return traversal;
                 } catch (final Throwable e) {
-                    throw new IllegalStateException(e.getMessage());
+                    throw new IllegalStateException(e.getMessage(), e);
                 }
             }
         } else if (object instanceof TraversalStrategyProxy) {


### PR DESCRIPTION
Wrap the full original exception, because its message might not be enough to pinpoint the issue.