### PR TITLE
[TINKERPOP-3021] Add ARM64 console docker images

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Improved error message from `JavaTranslator` by including exception source.
 * Added tests for error handling for GLV's if tx.commit() is called remotely for graphs without transactions support.
+* Introduced multi-architecture AMD64/ARM64 docker images for gremlin-console.
 
 [[release-3-6-6]]
 === TinkerPop 3.6.6 (November 20, 2023)

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -26,12 +26,7 @@ limitations under the License.
     <artifactId>gremlin-console</artifactId>
     <name>Apache TinkerPop :: Gremlin Console</name>
     <properties>
-    <!--Testing in macOs on ARM reveals that the linux/arm64/v8 console
-        container is quite unstable at this time and results in frequent freezes.
-        It is believed the issue lies with the ARM docker engine. The stability of ARM
-        images is likely to improve overtime and this omition should be intermittently
-        re-evaluated.-->
-        <docker.platforms>linux/amd64<!--,linux/arm64/v8--></docker.platforms>
+        <docker.platforms>linux/amd64,linux/arm64/v8</docker.platforms>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3021

Enables multi-architecture AMD64/ARM64 docker images in gremlin-console deployment. This was previously disabled due to observed instabilities in the image. Previously the ARM image was plagued by severe latency and widespread freezing and crashing. These issues were stemming from the docker engine as the console has run natively on arm flawlessly for several releases now. With recent improvements to docker, I am unable to find any issues with the console images. The arm console container is now snappy, responsive, and stable in my testing.

VOTE +1