### PR TITLE
TINKERPOP-2950 Add docker shutdown handling to close containers gracefully

### DIFF
--- a/gremlin-server/src/main/docker/docker-entrypoint.sh
+++ b/gremlin-server/src/main/docker/docker-entrypoint.sh
@@ -35,6 +35,6 @@ handler()
 }
 
 exec $GREMLIN_SERVER "$@" &
-PID=$(ps aux | grep -w $GREMLIN_SERVER | grep -v grep | awk '{print $1}')
+PID=$(ps aux | grep -w $GREMLIN_SERVER | grep -v grep | awk 'NR==1 {print $1}')
 trap 'handler $PID' SIGTERM
 wait "$PID"

--- a/gremlin-server/src/main/docker/docker-entrypoint.sh
+++ b/gremlin-server/src/main/docker/docker-entrypoint.sh
@@ -35,6 +35,6 @@ handler()
 }
 
 exec $GREMLIN_SERVER "$@" &
-PID=$(ps aux | grep -w $GREMLIN_SERVER | grep -v grep | awk 'NR==1 {print $1}')
+PID=$(ps | grep -w $GREMLIN_SERVER | grep -v grep | awk 'NR==1 {print $1}')
 trap 'handler $PID' SIGTERM
 wait "$PID"

--- a/gremlin-server/src/main/docker/docker-entrypoint.sh
+++ b/gremlin-server/src/main/docker/docker-entrypoint.sh
@@ -22,10 +22,19 @@
 set -e
 
 CONF_FILE=$1
+GREMLIN_SERVER=/opt/gremlin-server/bin/gremlin-server.sh
 
 # IP substitution hack borrowed from:
 # https://github.com/htaox/NEAT/blob/94a004831cf89767e116d955192fc14ac82e5069/docker-scripts/gremlin-server-3.0.0/files/default_cmd#L5
 IP=$(ip -o -4 addr list eth0 | perl -n -e 'if (m{inet\s([\d\.]+)\/\d+\s}xms) { print $1 }')
 sed -i "s|^host:.*|host: $IP|" $CONF_FILE
 
-exec /opt/gremlin-server/bin/gremlin-server.sh "$@"
+handler()
+{
+  kill -s SIGINT "$PID"
+}
+
+exec $GREMLIN_SERVER "$@" &
+PID=$(ps aux | grep -w $GREMLIN_SERVER | grep -v grep | awk '{print $1}')
+trap 'handler $PID' SIGTERM
+wait "$PID"


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/TINKERPOP-2950.  Handles SIGTERM when shutting down docker container by sending SIGINT to server processes.