### PR TITLE
Notice for renaming `none()` to `discard()`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -82,7 +82,7 @@ This release also includes changes from <<release-3-6-6, 3.6.6>> and <<release-3
 * TINKERPOP-2830 Handle User-Agent from HTTP Requests to server
 * TINKERPOP-2946 Resolve ordering issues in gherkin tests
 * TINKERPOP-2951 Add translator to the Go GLV
-* TINKERPOP-2964  Many TraversalParent's steps have a replaceLocalChild logic that can result in a new ChildTraversal having an ID that already exists.
+* TINKERPOP-2964 Many TraversalParent's steps have a replaceLocalChild logic that can result in a new ChildTraversal having an ID that already exists.
 * TINKERPOP-2978 Add List Manipulation Steps to Gremlin
 * TINKERPOP-2979 Add Date Manipulation Steps to Gremlin
 * TINKERPOP-2982 Allow gremlin-driver usage over HTTP

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3148,12 +3148,14 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 [[none-step]]
 === None Step
 
-The `none()`-step (*filter*) filters all objects from a traversal stream. It is especially useful for to traversals
+The `none()`-step (*filter*) filters all objects from a traversal stream. It is especially useful for traversals
 that are executed remotely where returning results is not useful and the traversal is only meant to generate
 side-effects. Choosing not to return results saves in serialization and network costs as the objects are filtered on
 the remote end and not returned to the client side. Typically, this step does not need to be used directly and is
 quietly used by the `iterate()` terminal step which appends `none()` to the traversal before actually cycling through
 results.
+
+NOTE: As of release 4.0.0, `none()` will be renamed to `discard()`.
 
 *Additional References*
 

--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -30,7 +30,7 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
-==== Renaming `none()` Step to `discard()`
+==== Notice: Renaming `none()` step to `discard()` in 4.0.0
 `none()`, which is primarily used by `iterate()` to discard traversal results in remote contexts, will be renamed to
 `discard()` in release 4.0.0.
 

--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -36,7 +36,7 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Providers
 
-==== Renaming NoneStep to DiscardStep
+==== Notice: Renaming NoneStep to DiscardStep in 4.0.0
 NoneStep, which is primarily used by `iterate()` to discard traversal results in remote contexts, will be renamed to
 DiscardStep in release 4.0.0 to make room for a list filtering NoneStep.
 

--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -30,9 +30,15 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
+==== Renaming `none()` Step to `discard()`
+`none()`, which is primarily used by `iterate()` to discard traversal results in remote contexts, will be renamed to
+`discard()` in release 4.0.0.
 
 === Upgrading for Providers
 
+==== Renaming NoneStep to DiscardStep
+NoneStep, which is primarily used by `iterate()` to discard traversal results in remote contexts, will be renamed to
+DiscardStep in release 4.0.0 to make room for a list filtering NoneStep.
 
 == TinkerPop 3.7.1
 *Release Date: November 20, 2023*


### PR DESCRIPTION
Provides notice in release notes that none() will be renamed to discard() in https://github.com/apache/tinkerpop/pull/2377.