### PR TITLE
TINKERPOP-3029 Fix enumeration for .NET 8

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-6-7]]
 === TinkerPop 3.6.7 (NOT OFFICIALLY RELEASED YET)
 
+* Fixed a bug in Gremlin.Net for .NET 8 that led to exceptions: `InvalidOperationException: Enumeration has not started. Call MoveNext.`
 * Improved error message from `JavaTranslator` by including exception source.
 * Added missing `short` serialization (`gx:Int16`) to GraphSONV2 and GraphSONV3 in `gremlin-python`
 * Added tests for error handling for GLV's if tx.commit() is called remotely for graphs without transactions support.

--- a/docs/src/upgrade/release-3.6.x.asciidoc
+++ b/docs/src/upgrade/release-3.6.x.asciidoc
@@ -30,6 +30,18 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
+==== Gremlin.Net: Fixed a bug in traversal enumeration on .NET 8
+
+The behavior of `IEnumerable` was changed in .NET 8 when `Current` was accessed on it before starting the enumeration
+via `MoveNext()`.
+The Gremlin.Net driver unfortunately did exactly that in some cases which led to exceptions
+(`InvalidOperationException: Enumeration has not started. Call MoveNext.`) on .NET 8 for some traversals.
+Traversal enumeration has been changed for this version of Gremlin.Net to avoid this problem.
+
+Older platforms than .NET 8 are not affected as `IEnumerable.Current` returned `null` there which is what the
+Gremlin.Net driver expected.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-3029[TINKERPOP-3029]
 
 === Upgrading for Providers
 

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
@@ -82,21 +82,22 @@ namespace Gremlin.Net.Process.Traversal
         }
         
         private bool MoveNextInternal()
-        {                   
+        {
             if (_fetchedNext) return _nextAvailable;
-            
-            var currentTraverser = TraverserEnumerator.Current;
-            if (currentTraverser?.Bulk > 1)
-            {
-                currentTraverser.Bulk--;
-                _nextAvailable = true;
-            }
-            else
+
+            if (!_nextAvailable || TraverserEnumerator.Current?.Bulk == 0)
             {
                 _nextAvailable = TraverserEnumerator.MoveNext();
             }
+            if (!_nextAvailable) return false;
+            
+            var currentTraverser = TraverserEnumerator.Current;
+            if (currentTraverser?.Bulk >= 1)
+            {
+                currentTraverser.Bulk--;
+            }
 
-            return _nextAvailable;
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3029

`IEnumerable<T>.Current` has been changed in .NET 8. Before .NET 8, it simply returned `null` if `MoveNext()` wasn't called first. With .NET 8 however it throws an exception.
Since this has apparently already been undefined behavior before, we should fix this irrespective of .NET 8:
https://github.com/dotnet/runtime/issues/85243#issuecomment-1521085177

The problem can be reproduced by executing the Gherkin tests with .NET without the change in `DefaultTraversal` (by changing the `TargetFramework` in `Gremlin.Net.IntegrationTest.csproj` to `net8.0`). .NET 8 needs to be installed for this of course.

VOTE +1