### PR TITLE
Improved contains check for bulkset with elements

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Introduced multi-architecture AMD64/ARM64 docker images for gremlin-console.
 * Fixed bug in `JavaTranslator` where `has(String, null)` could call `has(String, Traversal)` to generate an error.
 * Fixed issue where server errors weren't being properly parsed when sending bytecode over HTTP.
+* Improved bulkset contains check for elements if all elements in bulkset are of the same type
 
 [[release-3-6-6]]
 === TinkerPop 3.6.6 (November 20, 2023)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Contains.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Contains.java
@@ -54,9 +54,6 @@ public enum Contains implements BiPredicate<Object, Collection> {
         public boolean test(final Object first, final Collection second) {
             if (first instanceof Element &&
                     second instanceof BulkSet<?> &&
-                    ((BulkSet<?>)second).allContainedElementsSameClass() &&
-                    ((BulkSet<?>)second).getAllContainedElementsClass() != null &&
-                    Element.class.isAssignableFrom(((BulkSet<?>)second).getAllContainedElementsClass()) &&
                     first.getClass() == ((BulkSet<?>)second).getAllContainedElementsClass()) {
                 /*
                  * For elements (i.e., vertices, edges, vertex properties) it is safe to use the contains check

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Contains.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Contains.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.structure.Element;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.function.BiPredicate;
 
 /**
@@ -52,6 +52,21 @@ public enum Contains implements BiPredicate<Object, Collection> {
     within {
         @Override
         public boolean test(final Object first, final Collection second) {
+            if (first instanceof Element &&
+                    second instanceof BulkSet<?> &&
+                    ((BulkSet<?>)second).allContainedElementsSameClass() &&
+                    ((BulkSet<?>)second).getAllContainedElementsClass() != null &&
+                    Element.class.isAssignableFrom(((BulkSet<?>)second).getAllContainedElementsClass()) &&
+                    first.getClass() == ((BulkSet<?>)second).getAllContainedElementsClass()) {
+                /*
+                 * For elements (i.e., vertices, edges, vertex properties) it is safe to use the contains check
+                 * since the hash code computation and equals comparison give the same result as the Gremlin equality comparison
+                 * (using GremlinValueComparator.COMPARABILITY.equals) based on the Gremlin comparison semantics
+                 * (cf. <a href="https://tinkerpop.apache.org/docs/3.7.0/dev/provider/#gremlin-semantics-concepts">...</a>).
+                 * In both cases, we just compare the ids of the elements. Therefore, it is safe to use the contains check.
+                 */
+                return second.contains(first);
+            }
             GremlinTypeErrorException typeError = null;
             for (final Object o : second) {
                 try {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSet.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSet.java
@@ -85,13 +85,8 @@ public final class BulkSet<S> extends AbstractSet<S> implements Set<S>, Serializ
             allContainedElementsClassChecked = true;
             boolean hadNull = false;
             for (final S key : this.map.keySet()) {
-                if ((key == null || key.getClass() == null)) {
-                    if (allContainedElementsClass != null) {
-                        allContainedElementsClass = null;
-                        break;
-                    }
-                    hadNull = true;
-                } else if (hadNull) {
+                if (key == null) {
+                    allContainedElementsClass = null;
                     break;
                 } else if (allContainedElementsClass != null && !key.getClass().equals(allContainedElementsClass)) {
                     allContainedElementsClass = null;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSet.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSet.java
@@ -42,6 +42,68 @@ import java.util.stream.Collectors;
 public final class BulkSet<S> extends AbstractSet<S> implements Set<S>, Serializable {
     private final Map<S, Long> map = new LinkedHashMap<>();
 
+
+    /**
+     * Represents the class/type of all added elements/objects in the bulk set if they are of the same class/type.
+     * If elements/objects of different types/classes are added, then the class is set to null (within the add) method.
+     * Note that it is not guaranteed that there some elements/objects are of different types/classes if the value is null.
+     *
+     * This is mainly used as an optimization in some cases. In fact, the contains within check can use this to improve
+     * the lookup whether vertices or edges are contained in the bulk set (see
+     * {@link org.apache.tinkerpop.gremlin.process.traversal.Contains#within Contains.within}).
+     * This works for elements (i.e., vertices, edges, vertex properties) since the
+     * hash code computation and equals comparison give the same result as the Gremlin equality comparison (using
+     * GremlinValueComparator.COMPARABILITY.equals) based on the Gremlin comparison semantics
+     * (cf. <a href="https://tinkerpop.apache.org/docs/3.7.0/dev/provider/#gremlin-semantics-concepts">...</a>).
+     * For other types of objects, it is not completely clear, whether this would also result in the same results.
+     *
+     * The field is marked as transient such that it is not considered for serialization.
+     */
+    private transient Class<?> allContainedElementsClass = null;
+    private transient boolean allContainedElementsClassChecked = true;
+
+    /**
+     * @return the class of all contained elements/objects if it is guaranteed that all are of the same type/class (but not
+     * necessarily, i.e., they can have the same type/class, but we may return null here if it was not analysed/identified).
+     * If no common class was identified, then null is returned.
+     */
+    public Class<?> getAllContainedElementsClass() {
+        if (allContainedElementsSameClass()) {
+            return allContainedElementsClass;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @return true if it is guaranteed that all contained elements/objects are of the same type/class and not null (but not
+     * necessarily, i.e., they can have the same type/class, but we may return false here if it was not analysed/identified)
+     */
+    public boolean allContainedElementsSameClass() {
+        if (!allContainedElementsClassChecked) {
+            allContainedElementsClass = null;
+            allContainedElementsClassChecked = true;
+            boolean hadNull = false;
+            for (final S key : this.map.keySet()) {
+                if ((key == null || key.getClass() == null)) {
+                    if (allContainedElementsClass != null) {
+                        allContainedElementsClass = null;
+                        break;
+                    }
+                    hadNull = true;
+                } else if (hadNull) {
+                    break;
+                } else if (allContainedElementsClass != null && !key.getClass().equals(allContainedElementsClass)) {
+                    allContainedElementsClass = null;
+                    break;
+                } else if (allContainedElementsClass == null) {
+                    allContainedElementsClass = key.getClass();
+                }
+            }
+        }
+        return allContainedElementsClass != null;
+    }
+
     @Override
     public int size() {
         return (int) this.longSize();
@@ -89,6 +151,7 @@ public final class BulkSet<S> extends AbstractSet<S> implements Set<S>, Serializ
     }
 
     public boolean add(final S s, final long bulk) {
+        allContainedElementsClassChecked = false;
         final Long current = this.map.get(s);
         if (current != null) {
             this.map.put(s, current + bulk);

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/ContainsBulkSetTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/ContainsBulkSetTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal;
+
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertexProperty;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Enclosed.class)
+public class ContainsBulkSetTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void bulkSetElements() {
+        final BulkSet<Object> bulkSet = Mockito.spy(new BulkSet<>());
+        bulkSet.add(new ReferenceVertex("1"), 1);
+        bulkSet.add(new ReferenceVertex("2"), 1);
+        bulkSet.add(new ReferenceVertex("3"), 1);
+
+        // If bulkset contains only one type of element, we should use contains
+        assertEquals(true, Contains.within.test(new ReferenceVertex("3"), bulkSet));
+        assertEquals(false, Contains.within.test(new ReferenceVertex("4"), bulkSet));
+        verify(bulkSet, times(2)).contains(anyObject());
+        // we should also not use contains if we test for different type
+        assertEquals(false, Contains.within.test(new ReferenceVertexProperty<>("2", "label", "value"), bulkSet));
+        verify(bulkSet, times(2)).contains(anyObject());
+
+        // If bulkset contains different types of elements, we can no longer use contains
+        bulkSet.add("test string", 1);
+        assertEquals(true, Contains.within.test(new ReferenceVertex("3"), bulkSet));
+        assertEquals(false, Contains.within.test(new ReferenceVertex("4"), bulkSet));
+        assertEquals(false, Contains.within.test(new ReferenceVertexProperty<>("2", "label", "value"), bulkSet));
+        verify(bulkSet, times(2)).contains(anyObject());
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSetTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSetTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.util;
 
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -28,6 +28,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -65,6 +66,56 @@ public class BulkSetTest {
             list.add(random.nextBoolean());
         }
         assertEquals(10000000, list.size());
+    }
+
+    @Test
+    public void shouldHaveSameClassAsLongAsSameTypesAreAdded() {
+        final BulkSet<Object> bulkSet = new BulkSet<>();
+        bulkSet.add(new ReferenceVertex("1"), 1);
+        bulkSet.add(new ReferenceVertex("2"), 1);
+        bulkSet.add(new ReferenceVertex("3"), 3);
+        assertTrue(bulkSet.allContainedElementsSameClass());
+        assertEquals(bulkSet.getAllContainedElementsClass(), ReferenceVertex.class);
+        bulkSet.add(new ReferenceVertex("4"), 5);
+        assertEquals(bulkSet.getAllContainedElementsClass(), ReferenceVertex.class);
+        bulkSet.add(new Long(2), 5);
+        assertFalse(bulkSet.allContainedElementsSameClass());
+        assertNull(bulkSet.getAllContainedElementsClass());
+    }
+
+    @Test
+    public void shouldNotHaveSameClassForDifferentTypes() {
+        final BulkSet<Object> bulkSet = new BulkSet<>();
+        bulkSet.add(new ReferenceVertex("1"), 1);
+        bulkSet.add(new Long(2), 5);
+        bulkSet.add(new ReferenceVertex("3"), 3);
+        assertNull(bulkSet.getAllContainedElementsClass());
+        assertFalse(bulkSet.allContainedElementsSameClass());
+        bulkSet.add(new ReferenceVertex("4"), 5);
+        assertNull(bulkSet.getAllContainedElementsClass());
+        assertFalse(bulkSet.allContainedElementsSameClass());
+    }
+
+    @Test
+    public void shouldNotHaveSameClassWhenEmpty() {
+        final BulkSet<Object> bulkSet = new BulkSet<>();
+        assertNull(bulkSet.getAllContainedElementsClass());
+        assertFalse(bulkSet.allContainedElementsSameClass());
+    }
+
+    @Test
+    public void shouldNotHaveSameClassForNull() {
+        final BulkSet<Object> bulkSet = new BulkSet<>();
+        bulkSet.add(null, 5);
+        assertNull(bulkSet.getAllContainedElementsClass());
+        assertFalse(bulkSet.allContainedElementsSameClass());
+        assertFalse(bulkSet.isEmpty());
+        bulkSet.add(new Long(2), 5);
+        assertNull(bulkSet.getAllContainedElementsClass());
+        assertFalse(bulkSet.allContainedElementsSameClass());
+        bulkSet.add(null, 3);
+        assertNull(bulkSet.getAllContainedElementsClass());
+        assertFalse(bulkSet.allContainedElementsSameClass());
     }
 
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSetTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/BulkSetTest.java
@@ -116,6 +116,19 @@ public class BulkSetTest {
         bulkSet.add(null, 3);
         assertNull(bulkSet.getAllContainedElementsClass());
         assertFalse(bulkSet.allContainedElementsSameClass());
+
+        // adding null in the middle
+        final BulkSet<Object> bulkSet2 = new BulkSet<>();
+        bulkSet2.add(new ReferenceVertex("4"), 5);
+        assertEquals(bulkSet2.getAllContainedElementsClass(), ReferenceVertex.class);
+        assertTrue(bulkSet2.allContainedElementsSameClass());
+        assertFalse(bulkSet2.isEmpty());
+        bulkSet2.add(null, 5);
+        assertNull(bulkSet2.getAllContainedElementsClass());
+        assertFalse(bulkSet2.allContainedElementsSameClass());
+        bulkSet2.add(new ReferenceVertex("3"), 5);
+        assertNull(bulkSet2.getAllContainedElementsClass());
+        assertFalse(bulkSet2.allContainedElementsSameClass());
     }
 
     @Test


### PR DESCRIPTION
Improved within test check for bulkset with elements (i.e., Vertex, Edge, VertexProperty) by using contains method. Due to changes w.r.t. Gremlin comparison semantics (cf. https://tinkerpop.apache.org/docs/3.7.0/dev/provider/#gremlin-semantics-concepts) this check was no longer done efficiently, which led to some regressions (see query/example below). In some cases, we can however ensure that the contains of the bulkset (using hash code and Object.equals) leads to the same results as the GremlinValueComparator.COMPARABILITY.equals. In fact, for elements, both checks are only be done with the ids of these elements.

This change re-enables an efficient check for elements (if the bulkset also contains these elements and only contains these kind of elements). This is realized via a transient attribute (allContainedElementsSameClass) in the bulkset class that represents whether all elements are of same type/class, which is checked by the within test method. Tje attribute is computed lazily when accessed to avoid overhead if the information is not required.

Pseudo code for sample data:
```
final Vertex x1 = G.addVertex(T.id, "x1", T.label, "person", "age", 27, "name", "x1");
// many friends for x1
for (int i = 1; i < 10000; ++i) {
    final Vertex x1fi = G.addVertex(T.id, "f"+i, T.label, "person", "age", 27, "name", "f"+i);
    x1.addEdge("knows", x1fi, T.id, "e-x1-f"+i, "weight", 0.5);
}
// one special friend that also has many other friends
final Vertex x1f0 = G.addVertex(T.id, "f0", T.label, "person", "age", 27, "name", "f0");
x1.addEdge("knows", x1f0, T.id, "e-x1-f0", "weight", 0.5);

// adding these many other friends, so friends of friends for x1
for (int i = 1; i < 10000; ++i) {
    final Vertex x1f0ofi = G.addVertex(T.id, "fof"+i, T.label, "person", "age", 27, "name", "fof"+i);
    x1f0.addEdge("knows", x1f0ofi, T.id, "e-f0-f"+i, "weight", 0.5);
}
```

Sample query (which is very inefficiently executed without this change):
```
g.V("x1").as("root").aggregate("directFriends")
                                .select("root").out().aggregate("directFriends")
                                .select("directFriends").limit(1).unfold().out().where(without("directFriends"))
```
The query is obviously not optimally formulated, but reproduces the issue