### PR TITLE
[TINKERPOP-3025] Add missing l_trim() and r_trim() to python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-7-2]]
 === TinkerPop 3.7.2 (NOT OFFICIALLY RELEASED YET)
 
-
+* Deprecated `ltrim()` and `rTrim()` in favor of `l_trim()` and `r_trim` in Python.
 
 [[release-3-7-1]]
 === TinkerPop 3.7.1 (November 20, 2023)

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -1468,10 +1468,6 @@ class __(object, metaclass=MagicType):
         return cls.graph_traversal(None, None, Bytecode()).min_(*args)
 
     @classmethod
-    def none(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).none(*args)
-
-    @classmethod
     def not_(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).not_(*args)
 
@@ -2496,8 +2492,6 @@ statics.add_static('identity', identity)
 statics.add_static('inE', inE)
 
 statics.add_static('in_e', in_e)
-
-statics.add_static('inV', inV)
 
 statics.add_static('in_v', in_v)
 

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -2461,6 +2461,8 @@ statics.add_static('inE', inE)
 
 statics.add_static('in_e', in_e)
 
+statics.add_static('inV', inV)
+
 statics.add_static('in_v', in_v)
 
 statics.add_static('in_', in_)

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -1452,6 +1452,10 @@ class __(object, metaclass=MagicType):
         return cls.graph_traversal(None, None, Bytecode()).min_(*args)
 
     @classmethod
+    def none(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).none(*args)
+
+    @classmethod
     def not_(cls, *args):
         return cls.graph_traversal(None, None, Bytecode()).not_(*args)
 

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -659,6 +659,10 @@ class GraphTraversal(Traversal):
         self.bytecode.add_step("lTrim", *args)
         return self
 
+    def l_trim(self, *args):
+        self.bytecode.add_step("lTrim", *args)
+        return self
+
     def map(self, *args):
         self.bytecode.add_step("map", *args)
         return self
@@ -838,6 +842,10 @@ class GraphTraversal(Traversal):
         return self
 
     def rTrim(self, *args):
+        self.bytecode.add_step("rTrim", *args)
+        return self
+
+    def r_trim(self, *args):
         self.bytecode.add_step("rTrim", *args)
         return self
 
@@ -1413,7 +1421,15 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def ltrim(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).ltrim(*args)
+        warnings.warn(
+            "gremlin_python.process.__.ltrim will be replaced by "
+            "gremlin_python.process.__.l_trim.",
+            DeprecationWarning)
+        return cls.l_trim(*args)
+    
+    @classmethod
+    def l_trim(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).l_trim(*args)
 
     @classmethod
     def map(cls, *args):
@@ -1561,7 +1577,15 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def rTrim(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).rTrim(*args)
+        warnings.warn(
+            "gremlin_python.process.__.rTrim will be replaced by "
+            "gremlin_python.process.__.r_trim.",
+            DeprecationWarning)
+        return cls.r_trim(*args)
+
+    @classmethod
+    def r_trim(cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).r_trim(*args)
 
     @classmethod
     def sack(cls, *args):
@@ -2088,7 +2112,11 @@ def loops(*args):
 
 
 def ltrim(*args):
-    return __.ltrim(*args)
+    return __.l_trim(*args)
+
+
+def l_trim(*args):
+    return __.l_trim(*args)
 
 
 def map(*args):
@@ -2208,7 +2236,11 @@ def reverse(*args):
 
 
 def rTrim(*args):
-    return __.rTrim(*args)
+    return __.r_trim(*args)
+
+
+def r_trim(*args):
+    return __.r_trim(*args)
 
 
 def sack(*args):
@@ -2491,6 +2523,8 @@ statics.add_static('loops', loops)
 
 statics.add_static('ltrim', ltrim)
 
+statics.add_static('l_trim', l_trim)
+
 statics.add_static('map', map)
 
 statics.add_static('match', match)
@@ -2550,6 +2584,8 @@ statics.add_static('replace', replace)
 statics.add_static('reverse', reverse)
 
 statics.add_static('rTrim', rTrim)
+
+statics.add_static('r_trim', r_trim)
 
 statics.add_static('sack', sack)
 


### PR DESCRIPTION
https://issues.apache.org/jira/projects/TINKERPOP/issues/TINKERPOP-3025?filter=allopenissues Added missing l_trim/r_trim, deprecated ltrim/rTrim, and minor consistency fixes to python.