### PR TITLE
Bump gremlin-python dependencies

### DIFF
--- a/gremlin-python/src/main/python/examples/requirements.txt
+++ b/gremlin-python/src/main/python/examples/requirements.txt
@@ -20,10 +20,10 @@ aiohttp==3.8.0
 aiosignal==1.3.1
 async-timeout==4.0.3
 attrs==23.1.0
-charset-normalizer==2.1.1
+charset-normalizer==3.3.2
 frozenlist==1.4.0
-idna==3.4
+idna==3.6
 isodate==0.6.1
-multidict==4.7.6
-six==1.15.0
-yarl==1.9.2
+multidict==6.0.4
+six==1.16.0
+yarl==1.9.4


### PR DESCRIPTION
Merges dependabot PRs #2401 #2402 #2403 #2404 #2405, verified that the upgrades cause no issues.