### PR TITLE
TINKERPOP-3030 Update to .NET 8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -264,10 +264,10 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Set up .NET 6.0.x
+      - name: Set up .NET 8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - name: Get Cached Server Base Image
         uses: actions/cache@v3
         id: gremlin-server-test-docker-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,24 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 LABEL maintainer="Daniel Kuppitz <me@gremlin.guru>"
 
 RUN apt-get update
 RUN apt-get -y install software-properties-common python3-software-properties apt-transport-https curl dpkg netcat net-tools iproute2
 RUN add-apt-repository ppa:openjdk-r/ppa
-RUN sh -c 'curl -s https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb'
+RUN sh -c 'curl -s https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb'
 RUN sh -c 'dpkg -i packages-microsoft-prod.deb'
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN apt-get install apt-transport-https gnupg ca-certificates
-RUN sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list'
+RUN sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list'
 RUN apt-get update
 
 # include both java 8/11 so that we can use the same docker image for future builds on that version of the jdk as we do
 # for the older release branches. the java version to use is just controlled by JAVA_HOME hardcoded below
 RUN apt-get install -y openjdk-8-jdk openjdk-11-jdk gawk git maven openssh-server subversion zip
-RUN apt-get install -y --force-yes dotnet-sdk-6.0 mono-devel
+RUN apt-get install -y --force-yes dotnet-sdk-8.0 mono-devel
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y python3 python3.8 python3-dev python3.8-dev python3-pip build-essential checkinstall zlib1g-dev libreadline-gplv2-dev \

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -57,7 +57,7 @@ NOTE: For those using Windows, efforts have been made to keep the build OS indep
 that TinkerPop's build system will only allow for a minimum build at best. +
  +
  Refer to <<building-on-windows>> section for more details.
- 
+
 [[groovy-environment]]
 === Groovy Environment
 
@@ -267,7 +267,7 @@ See the <<release-environment,Release Environment>> section for more information
 [[dotnet-environment]]
 === DotNet Environment
 
-The build optionally requires link:https://dotnet.microsoft.com/download[.NET SDK] (>=6.0) to work with the
+The build optionally requires link:https://dotnet.microsoft.com/download[.NET SDK] (>=8.0) to work with the
 `gremlin-dotnet` module. If .NET SDK is not installed, TinkerPop will still build with Maven, but .NET projects
 will be skipped.
 

--- a/gremlin-dotnet/Examples/BasicGremlin/BasicGremlin.csproj
+++ b/gremlin-dotnet/Examples/BasicGremlin/BasicGremlin.csproj
@@ -19,7 +19,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gremlin-dotnet/Examples/Connections/Connections.cs
+++ b/gremlin-dotnet/Examples/Connections/Connections.cs
@@ -26,13 +26,13 @@ public class ConnectionExample
 {
     static void Main()
     {
-        withRemote();
-        withConf();
-        withSerializer();
+        WithRemote();
+        WithConf();
+        WithSerializer();
     }
 
     // Connecting to the server
-    static void withRemote()
+    static void WithRemote()
     {
         var server = new GremlinServer("localhost", 8182);
         using var remoteConnection = new DriverRemoteConnection(new GremlinClient(server), "g");
@@ -48,7 +48,7 @@ public class ConnectionExample
     }
 
     // Connecting to the server with customized configurations
-    static void withConf()
+    static void WithConf()
     {
         using var remoteConnection = new DriverRemoteConnection(new GremlinClient(
         new GremlinServer(hostname: "localhost", port: 8182, enableSsl: false, username: "", password: "")), "g");
@@ -60,7 +60,7 @@ public class ConnectionExample
     }
 
     // Specifying a serializer
-    static void withSerializer()
+    static void WithSerializer()
     {
         var server = new GremlinServer("localhost", 8182);
         var client = new GremlinClient(server, new GraphSON3MessageSerializer());

--- a/gremlin-dotnet/Examples/Connections/Connections.csproj
+++ b/gremlin-dotnet/Examples/Connections/Connections.csproj
@@ -19,7 +19,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gremlin-dotnet/Examples/ModernTraversals/ModernTraversals.csproj
+++ b/gremlin-dotnet/Examples/ModernTraversals/ModernTraversals.csproj
@@ -19,7 +19,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   gremlin-dotnet-integration-tests:
     container_name: gremlin-dotnet-integration-tests
-    image: mcr.microsoft.com/dotnet/sdk:6.0
+    image: mcr.microsoft.com/dotnet/sdk:8.0
     volumes:
       - .:/gremlin-dotnet
       - ../gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features:/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
@@ -19,7 +19,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>    

--- a/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Gremlin.Net.Benchmarks.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.Benchmarks/Gremlin.Net.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gremlin.Net.IntegrationTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/Gremlin.Net.Template.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Gremlin.Net.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyOriginatorKeyFile>../../build/tinkerpop.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3030

I've also noticed that the examples used camel casing for some method names which I switched to pascal casing to stay idiomatic in C#.

I had to update the Docker image to Ubuntu 20.04 because .NET 8 is not available for Ubuntu 18.04. Since 18.04 is out of support since June already, this update makes sense in general [1].
I verified that the Docker build is still working with:
```sh
./docker/build.sh --dotnet
```

VOTE +1

[1]: https://wiki.ubuntu.com/Releases