### PR TITLE
TINKERPOP-3063 Fix bug in Gremlin.Net authentication for parallel requests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.6.7 (NOT OFFICIALLY RELEASED YET)
 
 * Fixed a bug in Gremlin.Net for .NET 8 that led to exceptions: `InvalidOperationException: Enumeration has not started. Call MoveNext.`
+* Fixed a bug in the Gremlin.Net driver that could lead to failed authentication if multiple requests are executed in parallel.
 * Fixed message requestId serialization in `gremlin-python`.
 * Improved performance of `PathRetractionStrategy` for traversals that carry many children, but don't hold many labels to propogate.
 * Fixed bug in bytecode translation of `g.tx().commit()` and `g.tx().rollback()` in all languages.

--- a/docs/src/upgrade/release-3.6.x.asciidoc
+++ b/docs/src/upgrade/release-3.6.x.asciidoc
@@ -43,6 +43,22 @@ Gremlin.Net driver expected.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-3029[TINKERPOP-3029]
 
+==== Gremlin.Net: Fixed a bug related to authentication for multiple requests in parallel
+
+Executing multiple queries in parallel could lead to authentication failures if `MaxInProcessPerConnection` is set to a
+value higher than `1` as the second request could then be sent to the server while the server was still waiting for
+the authentication challenge response from the driver for the first query.
+
+This is now fixed by simply executing a validation request on each connection right after establishing the connection.
+That validation request will already handle authentication if necessary so user requests can afterwards directly be
+executed in parallel without needing to authenticate again.
+
+This is strictly speaking a breaking change since exceptions caused by authentication failures (no/wrong credentials
+configured) now occur directly when the `GremlinClient` is instantiated.
+In previous versions, the exceptions would only occur when the first request is executed.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-3063[TINKERPOP-3063]
+
 === Upgrading for Providers
 
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -140,7 +140,7 @@ namespace Gremlin.Net.Driver
             }
             catch (Exception e)
             {
-                if (receivedMsg!.RequestId != null)
+                if (receivedMsg.RequestId != null)
                 {
                     if(_callbackByRequestId.TryRemove(receivedMsg.RequestId.Value, out var responseHandler))
                     {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3063

Executing multiple queries in parallel could lead to authentication failures if `MaxInProcessPerConnection` is set to a value higher than `1` as the second request could then be sent to the server while the server was still waiting for the authentication challenge response from the driver for the first query.

This made it necessary to set `MaxInProcessPerConnection=1` as a workaround for such scenarios which of course means that connection pooling is less efficient.

Simply sending a validation request on each connection right after establishing the connection and therefore before it can be used to submit queries from the user should fix this issue. The downside of this is of course that connection establishment takes slightly longer. I think this is an acceptable trade-off even for scenarios where authentication is not used since this also validates the connection irrespective of authentication and also because this delay only occurs once right at the start of an application.

VOTE +1