### PR TITLE
Temporary fix to failing JDK8 test

### DIFF
--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/Select.feature
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/Select.feature
@@ -906,7 +906,7 @@ Feature: Step - select()
     Given the modern graph
     And the traversal of
       """
-      g.V().as("label").aggregate(local,"x").select("x").select("label")
+      g.V().as("label").aggregate(local,"x").barrier().select("x").select("label")
       """
     When iterated to list
     Then the result should be unordered


### PR DESCRIPTION
A new SelectStep test is failing in JDK8 tests due to a difference in hashing between Java 8 and 11.  In Java 8, the hash used to identify the traverser to be removed from the no-op barrier is recomputed at removal, and can't find a match due to other traversal branches having added vertices to the bulkset, thus changing its potential hash value.  Java 11 simply uses the hash field stored at creation instead of recomputing it which avoids this problem.  

This additional barrier step is a temporary fix that helps the query wait until all the vertices have been added to the bulkset before adding traversals to the no-op barrier so that hashing stays consistent.