### PR TITLE
[TINKERPOP-3060] Manage the versions of snappy-java and jackson-* centrally to avoid version conflict.

### DIFF
--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -123,7 +123,7 @@ limitations under the License.
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.8.2</version>
+            <version>${snappy-java.version}</version>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>
@@ -144,17 +144,17 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- TEST -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@ limitations under the License.
         <guice.version>4.2.3</guice.version>
         <hadoop.version>3.3.3</hadoop.version>
         <hamcrest.version>2.2</hamcrest.version>
+        <jackson.version>2.13.5</jackson.version>
         <java.tuples.version>1.2</java.tuples.version>
         <javadoc-plugin.version>3.3.1</javadoc-plugin.version>
         <javapoet.version>1.13.0</javapoet.version>
@@ -177,6 +178,7 @@ limitations under the License.
         <netty.version>4.1.101.Final</netty.version>
         <slf4j.version>1.7.25</slf4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
+        <snappy-java.version>1.1.8.4</snappy-java.version>
         <spark.version>3.3.2</spark.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -227,17 +227,17 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- TEST -->
         <dependency>
@@ -279,7 +279,7 @@ limitations under the License.
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.8.4</version>
+            <version>${snappy-java.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Currently some modules of Tinkerpop are using the same dependency. However, some of these dependencies' versions are not centrally managed and therefore cause discrepancy. This pr defines version in parent pom.xml centrally to avoid version conflict.