### PR TITLE
Introduce Netty handler for managing request IDs.

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -359,7 +359,7 @@ public abstract class Client {
 //        options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_EVAL_TIMEOUT, timeout));
         options.getParameters().ifPresent(params -> request.addBindings(params));
         options.getAliases().ifPresent(aliases -> {if (aliases.get("g") != null) request.addG(aliases.get("g")); });
-        options.getOverrideRequestId().ifPresent(request::overrideRequestId);
+//        options.getOverrideRequestId().ifPresent(request::overrideRequestId);
 //        options.getUserAgent().ifPresent(userAgent -> request.addArg(Tokens.ARGS_USER_AGENT, userAgent));
         options.getLanguage().ifPresent(lang -> request.addLanguage(lang));
 //        options.getMaterializeProperties().ifPresent(mp -> request.addArg(Tokens.ARGS_MATERIALIZE_PROPERTIES, mp));
@@ -656,7 +656,7 @@ public abstract class Client {
                 // apply settings if they were made available
                 options.getBatchSize().ifPresent(batchSize -> request.addChunkSize(batchSize));
 //                options.getTimeout().ifPresent(timeout -> request.add(Tokens.ARGS_EVAL_TIMEOUT, timeout));
-                options.getOverrideRequestId().ifPresent(request::overrideRequestId);
+//                options.getOverrideRequestId().ifPresent(request::overrideRequestId);
 //                options.getUserAgent().ifPresent(userAgent -> request.add(Tokens.ARGS_USER_AGENT, userAgent));
 //                options.getMaterializeProperties().ifPresent(mp -> request.addArg(Tokens.ARGS_MATERIALIZE_PROPERTIES, mp));
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler
 import org.apache.tinkerpop.gremlin.server.handler.HttpBasicAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpBasicAuthorizationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpRequestCheckingHandler;
+import org.apache.tinkerpop.gremlin.server.handler.HttpRequestIdHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpRequestMessageDecoder;
 import org.apache.tinkerpop.gremlin.server.handler.HttpUserAgentHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
@@ -55,6 +56,8 @@ public class HttpChannelizer extends AbstractChannelizer {
     private HttpRequestCheckingHandler httpRequestCheckingHandler = new HttpRequestCheckingHandler();
     private HttpRequestMessageDecoder httpRequestMessageDecoder = new HttpRequestMessageDecoder(serializers);
 
+    private HttpRequestIdHandler httpRequestIdHandler = new HttpRequestIdHandler();
+
     @Override
     public void init(final ServerGremlinExecutor serverGremlinExecutor) {
         super.init(serverGremlinExecutor);
@@ -71,6 +74,7 @@ public class HttpChannelizer extends AbstractChannelizer {
         if (logger.isDebugEnabled())
             pipeline.addLast(new LoggingHandler("http-io", LogLevel.DEBUG));
 
+        pipeline.addLast("http-requestid-handler", httpRequestIdHandler);
         pipeline.addLast("http-keepalive-handler", new HttpServerKeepAliveHandler());
         pipeline.addLast("http-cors-handler", new CorsHandler(CorsConfigBuilder.forAnyOrigin().build()));
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtil.java
@@ -80,8 +80,7 @@ import static io.netty.handler.codec.http.LastHttpContent.EMPTY_LAST_CONTENT;
 public class HttpHandlerUtil {
     private static final Logger logger = LoggerFactory.getLogger(HttpHandlerUtil.class);
     static final Meter errorMeter = MetricManager.INSTANCE.getMeter(name(GremlinServer.class, "errors"));
-    private static final String ARGS_BINDINGS_DOT = Tokens.ARGS_BINDINGS + ".";
-    private static final String ARGS_ALIASES_DOT = Tokens.ARGS_ALIASES + ".";
+
     /**
      * A generic mapper to return JSON errors in specific cases.
      */

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestIdHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestIdHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpResponse;
+
+import java.util.UUID;
+
+/**
+ * A handler that generates a Request ID for the incoming HTTP request and injects the same ID into the response header.
+ */
+@ChannelHandler.Sharable
+public class HttpRequestIdHandler extends ChannelDuplexHandler {
+    public static String REQUEST_ID_HEADER_NAME = "Gremlin-RequestId";
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        ctx.attr(StateKey.REQUEST_ID).set(UUID.randomUUID());
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse) msg;
+            response.headers().add(REQUEST_ID_HEADER_NAME, ctx.attr(StateKey.REQUEST_ID).get());
+        }
+        ctx.write(msg, promise);
+    }
+}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoder.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoder.java
@@ -218,13 +218,10 @@ public class HttpRequestMessageDecoder extends MessageToMessageDecoder<FullHttpR
         final JsonNode languageNode = body.get(Tokens.ARGS_LANGUAGE);
         final String language = null == languageNode ? "gremlin-groovy" : languageNode.asText();
 
-        final JsonNode requestIdNode = body.get(Tokens.REQUEST_ID);
-        final UUID requestId = null == requestIdNode ? UUID.randomUUID() : UUID.fromString(requestIdNode.asText());
-
         final JsonNode chunkSizeNode = body.get(Tokens.ARGS_BATCH_SIZE);
         final Integer chunkSize = null == chunkSizeNode ? null : chunkSizeNode.asInt();
 
-        final RequestMessageV4.Builder builder = RequestMessageV4.build(scriptNode.asText()).overrideRequestId(requestId)
+        final RequestMessageV4.Builder builder = RequestMessageV4.build(scriptNode.asText())
                 .addBindings(bindings).addLanguage(language);
         if (null != g) builder.addG(g);
         if (null != chunkSize) builder.addChunkSize(chunkSize);

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/StateKey.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/StateKey.java
@@ -25,6 +25,8 @@ import org.apache.tinkerpop.gremlin.server.auth.Authenticator;
 import org.apache.tinkerpop.gremlin.util.ser.MessageTextSerializerV4;
 import org.javatuples.Pair;
 
+import java.util.UUID;
+
 /**
  * Keys used in the various handlers to store state in the pipeline.
  *
@@ -53,6 +55,11 @@ public final class StateKey {
      * The key for the current request.
      */
     public static final AttributeKey<RequestMessage> REQUEST_MESSAGE = AttributeKey.valueOf("request");
+
+    /**
+     * The key for the current request ID.
+     */
+    public static final AttributeKey<UUID> REQUEST_ID = AttributeKey.valueOf("requestId");
 
     /**
      * The key for the current {@link AuthenticatedUser}.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestIdHandlerTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestIdHandlerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.apache.tinkerpop.gremlin.server.handler.HttpRequestIdHandler.REQUEST_ID_HEADER_NAME;
+import static org.junit.Assert.assertTrue;
+
+public class HttpRequestIdHandlerTest {
+    @Test
+    public void shouldProvideRequestIdToFollowingHandlers() {
+        final HttpRequestIdHandler httpRequestIdHandler = new HttpRequestIdHandler();
+        final EmbeddedChannel testChannel = new EmbeddedChannel(new HttpServerCodec(), httpRequestIdHandler);
+
+        final ByteBuf buffer = testChannel.alloc().buffer();
+        buffer.writeCharSequence("abc", CharsetUtil.UTF_8);
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/gremlin", buffer);
+
+        testChannel.writeInbound(httpRequest);
+        testChannel.finish();
+
+        assertTrue(testChannel.readInbound() instanceof HttpRequest);
+        assertTrue(testChannel.attr(StateKey.REQUEST_ID) != null);
+
+        buffer.release();
+    }
+
+    @Test
+    public void shouldInjectRequestIdHeaderToOutgoingWrites() {
+        final HttpRequestIdHandler httpRequestIdHandler = new HttpRequestIdHandler();
+        final EmbeddedChannel testServerChannel = new EmbeddedChannel(httpRequestIdHandler);
+
+        final ByteBuf buffer = testServerChannel.alloc().buffer();
+        buffer.writeCharSequence("abc", CharsetUtil.UTF_8);
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/gremlin", buffer);
+
+        final FullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+
+        testServerChannel.writeInbound(httpRequest);
+        testServerChannel.writeOutbound(httpResponse);
+        final HttpResponse updatedResponse = testServerChannel.readOutbound();
+
+        testServerChannel.finish();
+        assertTrue(updatedResponse.headers().contains(REQUEST_ID_HEADER_NAME));
+        UUID.fromString(updatedResponse.headers().get(REQUEST_ID_HEADER_NAME));
+
+        httpRequest.release();
+        httpResponse.release();
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoderTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoderTest.java
@@ -72,9 +72,7 @@ public class HttpRequestMessageDecoderTest {
         final HttpRequestMessageDecoder requestMessageDecoder = new HttpRequestMessageDecoder(serializers);
         final EmbeddedChannel testChannel = new EmbeddedChannel(new HttpServerCodec(), new HttpObjectAggregator(Integer.MAX_VALUE), requestMessageDecoder);
 
-        final RequestMessageV4 request = RequestMessageV4.build("g.V()")
-                .overrideRequestId(UUID.randomUUID())
-                .create();
+        final RequestMessageV4 request = RequestMessageV4.build("g.V()").create();
 
         final ByteBuf buffer = graphSONSerializer.serializeRequestMessageV4(request, allocator);
 
@@ -98,9 +96,7 @@ public class HttpRequestMessageDecoderTest {
         final HttpRequestMessageDecoder requestMessageDecoder = new HttpRequestMessageDecoder(serializers);
         final EmbeddedChannel testChannel = new EmbeddedChannel(new HttpServerCodec(), new HttpObjectAggregator(Integer.MAX_VALUE), requestMessageDecoder);
 
-        final RequestMessageV4 request = RequestMessageV4.build("g.V()")
-                .overrideRequestId(UUID.randomUUID())
-                .create();
+        final RequestMessageV4 request = RequestMessageV4.build("g.V()").addLanguage("gremlin-lang").create();
 
         final ByteBuf buffer = graphBinarySerializer.serializeRequestMessageV4(request, allocator);
 

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
@@ -55,8 +55,7 @@ public final class Tokens {
     public static final String ARGS_BINDINGS = "bindings";
 
     /**
-     * Argument name that allows definition of alias names for {@link Graph} and {@link TraversalSource} objects on
-     * the remote system.
+     * @Deprecated
      */
     public static final String ARGS_ALIASES = "aliases";
 

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageV4.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- * The model for a request message in the HTTP body that is sent to the server.
+ * The model for a request message in the HTTP body that is sent to the server beginning in 4.0.0.
  */
 public final class RequestMessageV4 {
     /**
@@ -150,16 +150,6 @@ public final class RequestMessageV4 {
         private Builder(final Object gremlin) {
             this.gremlin = gremlin;
             this.fields.put(Tokens.REQUEST_ID, UUID.randomUUID());
-        }
-
-        /**
-         * Override the request identifier with a specified one, otherwise the {@link Builder} will randomly generate
-         * a {@link UUID}.
-         */
-        public Builder overrideRequestId(final UUID requestId) {
-            Objects.requireNonNull(requestId, "requestId argument cannot be null.");
-            this.fields.put(Tokens.REQUEST_ID, requestId);
-            return this;
         }
 
         public Builder addLanguage(final String language) {

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/ResponseMessage.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/ResponseMessage.java
@@ -111,10 +111,6 @@ public final class ResponseMessage {
         return new Builder(requestMessage);
     }
 
-    public static Builder build(final RequestMessageV4 requestMessage) {
-        return new Builder(requestMessage);
-    }
-
     public static Builder build(final UUID requestId) {
         return new Builder(requestId);
     }

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/AbstractGraphSONMessageSerializerV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/AbstractGraphSONMessageSerializerV4.java
@@ -286,9 +286,6 @@ public abstract class AbstractGraphSONMessageSerializerV4 extends AbstractGraphS
         public RequestMessageV4 createObject(final Map<String, Object> data) {
             RequestMessageV4.Builder builder = RequestMessageV4.build(data.get(SerTokens.TOKEN_GREMLIN));
 
-            if (data.containsKey(SerTokens.TOKEN_REQUEST)) {
-                builder.overrideRequestId(UUID.fromString(data.get(SerTokens.TOKEN_REQUEST).toString()));
-            }
             if (data.containsKey(SerTokens.TOKEN_LANGUAGE)) {
                 builder.addLanguage(data.get(SerTokens.TOKEN_LANGUAGE).toString());
             }

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/RequestMessageSerializerV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/RequestMessageSerializerV4.java
@@ -63,9 +63,6 @@ public class RequestMessageSerializerV4 {
             }
 
             final RequestMessageV4.Builder builder = RequestMessageV4.build(gremlin);
-            if (fields.containsKey(SerTokens.TOKEN_REQUEST)) {
-                builder.overrideRequestId(UUID.fromString(fields.get(SerTokens.TOKEN_REQUEST).toString()));
-            }
             if (fields.containsKey(SerTokens.TOKEN_LANGUAGE)) {
                 builder.addLanguage(fields.get(SerTokens.TOKEN_LANGUAGE).toString());
             }

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageV4Test.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageV4Test.java
@@ -31,13 +31,6 @@ import static org.junit.Assert.fail;
 
 public class RequestMessageV4Test {
     @Test
-    public void shouldOverrideRequest() {
-        final UUID request = UUID.randomUUID();
-        final RequestMessageV4 msg = RequestMessageV4.build("x").overrideRequestId(request).create();
-        assertEquals(request, msg.getRequestId());
-    }
-
-    @Test
     public void shouldSetScriptGremlin() {
         final String script = "g.V().both()";
         final RequestMessageV4 msg = RequestMessageV4.build(script).create();
@@ -93,17 +86,15 @@ public class RequestMessageV4Test {
     @Test
     public void shouldGetFields() {
         final String g = "gmodern";
-        final UUID rId = UUID.randomUUID();
         final String lang = "lang";
         final String query = "g.V()";
         final Map<String, Object> bindings = new HashMap<>();
         bindings.put("b", "c");
         bindings.put("g", "gmodern");
 
-        final RequestMessageV4 msg = RequestMessageV4.build(query).addG(g).addBindings(bindings).addLanguage(lang).overrideRequestId(rId).create();
+        final RequestMessageV4 msg = RequestMessageV4.build(query).addG(g).addBindings(bindings).addLanguage(lang).create();
         final Map<String, Object> fields = msg.getFields();
         assertEquals(g, fields.get(Tokens.ARGS_G));
-        assertEquals(rId, fields.get(Tokens.REQUEST_ID));
         assertEquals(lang, fields.get(Tokens.ARGS_LANGUAGE));
         assertEquals(bindings, fields.get(Tokens.ARGS_BINDINGS));
         assertEquals(query, msg.getGremlin());


### PR DESCRIPTION
Request IDs are now generated by the server and returned as a header. This handler handles both of these operations to centralize the implementation.