### PR TITLE
Replace ResponseResult with ResponseResultV4.

### DIFF
--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverGremlinPlugin.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/jsr223/DriverGremlinPlugin.java
@@ -39,7 +39,7 @@ import org.apache.tinkerpop.gremlin.util.MessageSerializerV4;
 import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessageV4;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessageV4;
-import org.apache.tinkerpop.gremlin.util.message.ResponseResult;
+import org.apache.tinkerpop.gremlin.util.message.ResponseResultV4;
 import org.apache.tinkerpop.gremlin.util.message.ResponseStatusV4;
 import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4;
 import org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV4;
@@ -69,7 +69,7 @@ public class DriverGremlinPlugin extends AbstractGremlinPlugin {
                     ResponseException.class,
                     RequestMessageV4.class,
                     ResponseMessageV4.class,
-                    ResponseResult.class,
+                    ResponseResultV4.class,
                     ResponseStatusV4.class,
                     GraphSONMessageSerializerV4.class,
                     GraphSONUntypedMessageSerializerV4.class,

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Result.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Result.java
@@ -18,13 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
-import org.apache.tinkerpop.gremlin.util.message.ResponseResult;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.util.message.ResponseResultV4;
 
 import java.util.Iterator;
 
@@ -39,7 +39,7 @@ public final class Result {
     final Object resultObject;
 
     /**
-     * Constructs a "result" from data found in {@link ResponseResult#getData()}.
+     * Constructs a "result" from data found in {@link ResponseResultV4#getData()}.
      */
     public Result(final Object responseData) {
         this.resultObject = responseData;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -708,7 +708,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             assertTrue(responses.get(0).getStatus().getMessage().contains("timeout occurred"));
 
             // validate that we can still send messages to the server
-            assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());
+            assertEquals(2, ((Integer) (client.submit("1+1").get(0).getResult().getData()).get(0)).intValue());
         }
     }
 
@@ -723,7 +723,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             assertThat(responses.get(0).getStatus().getMessage(), allOf(startsWith("Evaluation exceeded"), containsString("100 ms")));
 
             // validate that we can still send messages to the server
-            assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());
+            assertEquals(2, ((Integer) (client.submit("1+1").get(0).getResult().getData()).get(0)).intValue());
         }
     }
 
@@ -736,7 +736,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             assertThat(responses.get(0).getStatus().getMessage(), startsWith("Timeout during script evaluation triggered by TimedInterruptCustomizerProvider"));
 
             // validate that we can still send messages to the server
-            assertEquals(2, ((List<Integer>) client.submit("1+1").get(0).getResult().getData()).get(0).intValue());
+            assertEquals(2, ((Integer) (client.submit("1+1").get(0).getResult().getData()).get(0)).intValue());
         }
     }
 
@@ -744,7 +744,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     @SuppressWarnings("unchecked")
     public void shouldLoadInitScript() throws Exception {
         try (SimpleClient client = TestClientFactory.createSimpleHttpClient()){
-            assertEquals(2, ((List<Integer>) client.submit("addItUp(1,1)").get(0).getResult().getData()).get(0).intValue());
+            assertEquals(2, ((Integer) (client.submit("addItUp(1,1)").get(0).getResult().getData()).get(0)).intValue());
         }
     }
 

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/SerializationBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/driver/SerializationBenchmark.java
@@ -36,6 +36,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.UUID;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -103,7 +104,7 @@ public class SerializationBenchmark extends AbstractBenchmarkBase {
     private static final UUID id = UUID.randomUUID();
 
     private static final ResponseMessageV4 response = ResponseMessageV4
-            .build().code(HttpResponseStatus.OK).result(new ReferenceVertex(1, "person"))
+            .build().code(HttpResponseStatus.OK).result(Collections.singletonList(new ReferenceVertex(1, "person")))
             .create();
 
     private static final Bytecode bytecode = new Bytecode();

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/ResponseMessageV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/ResponseMessageV4.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,10 +34,10 @@ import java.util.Map;
  */
 public final class ResponseMessageV4 {
     private final ResponseStatusV4 responseStatus;
-    private final ResponseResult responseResult;
+    private final ResponseResultV4 responseResult;
 
     private ResponseMessageV4(final ResponseStatusV4 responseStatus,
-                            final ResponseResult responseResult) {
+                            final ResponseResultV4 responseResult) {
         this.responseResult = responseResult;
         this.responseStatus = responseStatus;
     }
@@ -45,7 +46,7 @@ public final class ResponseMessageV4 {
         return responseStatus;
     }
 
-    public ResponseResult getResult() {
+    public ResponseResultV4 getResult() {
         return responseResult;
     }
 
@@ -99,7 +100,7 @@ public final class ResponseMessageV4 {
 
     public final static class Builder {
         private HttpResponseStatus code = null;
-        private Object result = Collections.emptyList();
+        private List<Object> result = Collections.emptyList();
         private String statusMessage = null;
         private String exception = null;
         private Map<String, Object> attributes = Collections.emptyMap();
@@ -127,7 +128,7 @@ public final class ResponseMessageV4 {
             return this;
         }
 
-        public Builder result(final Object result) {
+        public Builder result(final List<Object> result) {
             this.result = result;
             return this;
         }
@@ -138,7 +139,7 @@ public final class ResponseMessageV4 {
         }
 
         public ResponseMessageV4 create() {
-            final ResponseResult responseResult = new ResponseResult(result, metaData);
+            final ResponseResultV4 responseResult = new ResponseResultV4(result, metaData);
             // skip null values
             if (code == null && statusMessage == null) {
                 return new ResponseMessageV4(null, responseResult);

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/ResponseResultV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/ResponseResultV4.java
@@ -18,21 +18,22 @@
  */
 package org.apache.tinkerpop.gremlin.util.message;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- * @author Stephen Mallette (http://stephen.genoprime.com)
+ * Data model for the "result" portion of a {@link ResponseMessageV4}.
  */
-public final class ResponseResult {
-    private final Object data;
+public final class ResponseResultV4 {
+    private final List<Object> data;
     private final Map<String, Object> meta;
 
-    public ResponseResult(final Object data, final Map<String, Object> meta) {
+    public ResponseResultV4(final List<Object> data, final Map<String, Object> meta) {
         this.data = data;
         this.meta = meta;
     }
 
-    public Object getData() {
+    public List<Object> getData() {
         return data;
     }
 

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/AbstractGraphSONMessageSerializerV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/AbstractGraphSONMessageSerializerV4.java
@@ -374,7 +374,7 @@ public abstract class AbstractGraphSONMessageSerializerV4 extends AbstractMessag
             GraphSONUtil.writeEndObject(responseMessage, jsonGenerator, typeSerializer);
 
             jsonGenerator.writeFieldName(SerTokens.TOKEN_RESULT);
-            final Object result = responseMessage.getResult().getData();
+            final List<Object> result = responseMessage.getResult().getData();
             if (result != null) {
                 serializerProvider.findTypedValueSerializer(result.getClass(), true, null).serialize(result, jsonGenerator, serializerProvider);
             } else {
@@ -472,7 +472,7 @@ public abstract class AbstractGraphSONMessageSerializerV4 extends AbstractMessag
             final Map<String, Object> status = (Map<String, Object>) data.get(SerTokens.TOKEN_STATUS);
             ResponseMessageV4.Builder response = ResponseMessageV4.build()
                     .code(HttpResponseStatus.valueOf((Integer) status.get(SerTokens.TOKEN_CODE)))
-                    .result(data.get(SerTokens.TOKEN_RESULT));
+                    .result((List) data.get(SerTokens.TOKEN_RESULT));
 
             if (null != status.get(SerTokens.TOKEN_EXCEPTION)) {
                 response.exception(String.valueOf(status.get(SerTokens.TOKEN_EXCEPTION)));

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/ResponseMessageSerializerV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/ResponseMessageSerializerV4.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.structure.io.Buffer;
 import org.apache.tinkerpop.gremlin.structure.io.binary.GraphBinaryReader;
 import org.apache.tinkerpop.gremlin.structure.io.binary.GraphBinaryWriter;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessageV4;
-import org.apache.tinkerpop.gremlin.util.message.ResponseResult;
+import org.apache.tinkerpop.gremlin.util.message.ResponseResultV4;
 import org.apache.tinkerpop.gremlin.util.message.ResponseStatusV4;
 import org.apache.tinkerpop.gremlin.util.ser.NettyBufferFactory;
 import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
@@ -63,7 +63,7 @@ public class ResponseMessageSerializerV4 {
         // Wrap netty's buffer
         final Buffer buffer = bufferFactory.create(byteBuf);
 
-        final ResponseResult result = value.getResult();
+        final ResponseResultV4 result = value.getResult();
         final ResponseStatusV4 status = value.getStatus();
 
         try {

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/GraphSONMessageSerializerV4Test.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/GraphSONMessageSerializerV4Test.java
@@ -31,7 +31,7 @@ import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONXModuleV3;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.TinkerPopJacksonModule;
 import org.apache.tinkerpop.gremlin.util.MessageSerializerV4;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessageV4;
-import org.apache.tinkerpop.gremlin.util.message.ResponseResult;
+import org.apache.tinkerpop.gremlin.util.message.ResponseResultV4;
 import org.apache.tinkerpop.shaded.jackson.core.JsonGenerator;
 import org.apache.tinkerpop.shaded.jackson.core.JsonParser;
 import org.apache.tinkerpop.shaded.jackson.core.JsonProcessingException;
@@ -197,9 +197,9 @@ public class GraphSONMessageSerializerV4Test {
 
         final ResponseMessageV4 toSerialize = ResponseMessageV4.build().result(Collections.singletonList(Color.RED)).code(HttpResponseStatus.OK).create();
         final ByteBuf buffer = serializer.serializeResponseAsBinary(toSerialize, allocator);
-        ResponseResult results = serializer.deserializeBinaryResponse(buffer).getResult();
+        ResponseResultV4 results = serializer.deserializeBinaryResponse(buffer).getResult();
 
-        assertEquals(Color.RED, ((List) results.getData()).get(0));
+        assertEquals(Color.RED, results.getData().get(0));
     }
 
     public static class ColorIoRegistry extends AbstractIoRegistry {
@@ -266,11 +266,11 @@ public class GraphSONMessageSerializerV4Test {
         GraphSONMessageSerializerV4 graphSONMessageSerializerV4 = new GraphSONMessageSerializerV4(builder);
 
         ResponseMessageV4 rm = convert("hello", graphSONMessageSerializerV4);
-        assertEquals(rm.getResult().getData(), "hello");
+        assertEquals(rm.getResult().getData().get(0), "hello");
     }
 
     private ResponseMessageV4 convert(final Object toSerialize, MessageSerializerV4<?> serializer) throws SerializationException {
-        final ByteBuf bb = serializer.serializeResponseAsBinary(responseMessageBuilder.result(toSerialize).create(), allocator);
+        final ByteBuf bb = serializer.serializeResponseAsBinary(responseMessageBuilder.result(Collections.singletonList(toSerialize)).create(), allocator);
         return serializer.deserializeBinaryResponse(bb);
     }
 }

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/types/sample/SamplePersonSerializerTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/types/sample/SamplePersonSerializerTest.java
@@ -102,7 +102,7 @@ public class SamplePersonSerializerTest {
         final SamplePerson person = new SamplePerson("Olivia", birthDate);
 
         final ByteBuf serialized = serializer.serializeResponseAsBinary(
-                ResponseMessageV4.build().result(person).create(), allocator);
+                ResponseMessageV4.build().result(Collections.singletonList(person)).create(), allocator);
 
         final ResponseMessageV4 deserialized = serializer.deserializeBinaryResponse(serialized);
 


### PR DESCRIPTION
The V4 version changes the data to be List<Object> rather than just a plain Object since the server will always wrap the result in a List anyway. The GraphSON representation will now contain an empty array instead of a null when there are no results.