### PR TITLE
 Fixing connection cleanup in case of mass connection breaking.

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -129,9 +129,17 @@ final class Connection {
                 // close did not come from the client side. it means the server closed the channel for some reason.
                 // it's important to distinguish that difference in debugging
                 if (thisConnection.closeFuture.get() == null) {
+
+                    String poolInfo = "";
+                    try {
+                        poolInfo = thisConnection.pool.getPoolInfo(thisConnection);
+                    } catch (final Exception ex) {
+                        // Don't do anything if any exception was caught during the creation of poolInfo.
+                        // Yes swallow this exception
+                    }
                     logger.error(String.format(
                             "Server closed the Connection on channel %s - scheduling removal from %s",
-                            channel.id().asShortText(), thisConnection.pool.getPoolInfo(thisConnection)));
+                            channel.id().asShortText(), poolInfo));
 
                     // delegate the task to scheduler thread and free up the event loop
                     thisConnection.cluster.connectionScheduler().submit(() -> thisConnection.pool.definitelyDestroyConnection(thisConnection));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -665,13 +665,22 @@ final class ConnectionPool {
                                    final List<Connection> connections) {
         final int connectionCount = connections.size();
         for (int ix = 0; ix < connectionCount; ix++) {
+            try {
             final Connection c = connections.get(ix);
-            if (c.equals(connectionToCallout))
+                if (c.equals(connectionToCallout)) {
                 sb.append("==> ");
-            else
+                }
+                else {
                 sb.append("> ");
-
+                }
             sb.append(c.getConnectionInfo(false));
+            } catch (final ArrayIndexOutOfBoundsException ex) {
+                // Connections object is a concurrent list being modified by multiple threads.
+                // Can not rely on the size of the list collected at the start of this method.
+                // So in case if the index being sought doesn't exists, then provide the poolInfo
+                // best effort basis.
+                break;
+            }
 
             if (ix < connectionCount - 1)
                 sb.append(System.lineSeparator());


### PR DESCRIPTION
 CAUSE:
 In some cases when credentials expire, or servers encounters a
 blip and closes all connections. The driver gets close message on all
 connections. While processing those close messages, the driver was
 getting into race conditions, where in multiple threads were trying to
 close connections and trying to update the connections object i.e. list
 of connections in the pool. This was leading to uncaught exceptions and
 stale connections in the pool. These connections are never cleanedup
 post this.

 FIX:
 Ignore the ArrayOutOfBoundException in trying to get an object from
 connections object in case of creating a poolInfo message. This way,
 the code tries to provide the accurate poolInfo best efforts basis.