### PR TITLE
TINKERPOP-3079 Fixed non-idempotent unit test `TraversalStrategiesTest#shouldAllowUserManipulationOfGlobalCache`

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -59,6 +60,14 @@ import static org.junit.Assert.fail;
  */
 public class TraversalStrategiesTest {
 
+    @Before
+    public void setup() {
+        TraversalStrategies.GlobalCache.registerStrategies(TestGraph.class,
+                TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone().addStrategies(new StrategyA(), new StrategyB()));
+        TraversalStrategies.GlobalCache.registerStrategies(TestGraphComputer.class,
+                TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class).clone().addStrategies(new StrategyC()));
+    }
+    
     @Test
     public void shouldAllowUserManipulationOfGlobalCache() {
         ///////////
@@ -129,11 +138,6 @@ public class TraversalStrategiesTest {
 
     public static class TestGraphComputer implements GraphComputer {
 
-        static {
-            TraversalStrategies.GlobalCache.registerStrategies(TestGraphComputer.class,
-                    TraversalStrategies.GlobalCache.getStrategies(GraphComputer.class).clone().addStrategies(new StrategyC()));
-        }
-
         @Override
         public GraphComputer result(ResultGraph resultGraph) {
             return this;
@@ -181,11 +185,6 @@ public class TraversalStrategiesTest {
     }
 
     public static class TestGraph implements Graph {
-
-        static {
-            TraversalStrategies.GlobalCache.registerStrategies(TestGraph.class,
-                    TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone().addStrategies(new StrategyA(), new StrategyB()));
-        }
 
         @Override
         public Vertex addVertex(Object... keyValues) {


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TINKERPOP-3079

### Brief Description of the Bug

The test `TraversalStrategiesTest#shouldAllowUserManipulationOfGlobalCache` is non-idempotent, as it passes in the first run but fails in the second run in the same environment. The source of the problem is that the initial strategies registration (`StrategyA`, `StrategyB` and `StrategyC`) for the `TestGraph` and `TestGraphComputer` classes are static: https://github.com/apache/tinkerpop/blob/66e5a47ffd3976d29bc7797c399b8e11c5ba810e/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java#L132 and https://github.com/apache/tinkerpop/blob/66e5a47ffd3976d29bc7797c399b8e11c5ba810e/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java#L185 
These static blocks will only be called once during class loading. 
In the first execution of the test `TraversalStrategiesTest#shouldAllowUserManipulationOfGlobalCache`, `StrategyA` is removed from global strategies:https://github.com/apache/tinkerpop/blob/66e5a47ffd3976d29bc7797c399b8e11c5ba810e/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java#L82 
And the test does not restore it after execution. 
Therefore, in the second execution of the test, `StrategyA` is not present in the global strategies, so assertions like `assertTrue(strategies.getStrategy(StrategyA.class).isPresent())` would fail: https://github.com/apache/tinkerpop/blob/66e5a47ffd3976d29bc7797c399b8e11c5ba810e/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/TraversalStrategiesTest.java#L77

A fix is necessary since unit tests shall be self-contained. Idempotent tests help maintain this isolation by ensuring that the state of the system under test is consistent at the beginning of each test, regardless of previous test runs. For example, fixing non-idempotent tests can help proactively avoid state pollution that results in test order dependency (which could hurt regression testing with the use of test selection / prioritization / parallelism.

### Failure Message in the 2nd Test Run:
```
java.lang.AssertionError:
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.tinkerpop.gremlin.process.TraversalStrategiesTest.shouldAllowUserManipulationOfGlobalCache(TraversalStrategiesTest.java:77)
```

### Reproduce

Use the `NIOInspector` plugin that supports rerunning individual tests in the same environment:
```
cd gremlin-core
mvn edu.illinois:NIOInspector:rerun -Dtest=org.apache.tinkerpop.gremlin.process.TraversalStrategiesTest#shouldAllowUserManipulationOfGlobalCache
```

### Proposed Fix
Handle initial strategies registration in a `setup()` method rather than in static blocks of test classes.

### Verify the Change
After the patch, all tests pass idempotently.