### PR TITLE
Refactor mutation events registration by moving reusable code from relevant steps to EventUti

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,7 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-6-8, 3.6.8>>.
 
-
+* Refactored mutation events registration by moving reusable code from relevant steps to `EventUtil`
 
 [[release-3-7-2]]
 === TinkerPop 3.7.2 (April 8, 2024)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DropStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DropStep.java
@@ -24,13 +24,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Deleting;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.EventUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ListCallbackRegistry;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
-import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -38,7 +35,7 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
  */
 public class DropStep<S> extends FilterStep<S> implements Deleting<Event> {
 
-    private CallbackRegistry<Event> callbackRegistry;
+    protected CallbackRegistry<Event> callbackRegistry;
 
     public DropStep(final Traversal.Admin traversal) {
         super(traversal);
@@ -49,36 +46,11 @@ public class DropStep<S> extends FilterStep<S> implements Deleting<Event> {
         final S s = traverser.get();
         if (s instanceof Element) {
             final Element toRemove = (Element) s;
-            if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-                final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-                final Event removeEvent;
-                if (s instanceof Vertex)
-                    removeEvent = new Event.VertexRemovedEvent(eventStrategy.detach((Vertex) s));
-                else if (s instanceof Edge)
-                    removeEvent = new Event.EdgeRemovedEvent(eventStrategy.detach((Edge) s));
-                else if (s instanceof VertexProperty)
-                    removeEvent = new Event.VertexPropertyRemovedEvent(eventStrategy.detach((VertexProperty) s));
-                else
-                    throw new IllegalStateException("The incoming object is not removable: " + s);
-
-                callbackRegistry.getCallbacks().forEach(c -> c.accept(removeEvent));
-            }
-
+            EventUtil.registerElementRemoval(callbackRegistry, getTraversal(), toRemove);
             toRemove.remove();
         } else if (s instanceof Property) {
             final Property toRemove = (Property) s;
-            if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-                final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-                final Event.ElementPropertyEvent removeEvent;
-                if (toRemove.element() instanceof Edge)
-                    removeEvent = new Event.EdgePropertyRemovedEvent(eventStrategy.detach((Edge) toRemove.element()), eventStrategy.detach(toRemove));
-                else if (toRemove.element() instanceof VertexProperty)
-                    removeEvent = new Event.VertexPropertyPropertyRemovedEvent(eventStrategy.detach((VertexProperty) toRemove.element()), eventStrategy.detach(toRemove));
-                else
-                    throw new IllegalStateException("The incoming object is not removable: " + s);
-
-                callbackRegistry.getCallbacks().forEach(c -> c.accept(removeEvent));
-            }
+            EventUtil.registerPropertyRemoval(callbackRegistry, getTraversal(), toRemove);
             toRemove.remove();
         } else
             throw new IllegalStateException("The incoming object is not removable: " + s);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStep.java
@@ -31,8 +31,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.EventUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ListCallbackRegistry;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -133,11 +133,7 @@ public class AddEdgeStartStep extends AbstractStep<Edge, Edge>
                         .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
 
             final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));
-            if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-                final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-                final Event.EdgeAddedEvent vae = new Event.EdgeAddedEvent(eventStrategy.detach(edge));
-                callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
-            }
+            EventUtil.registerEdgeCreation(callbackRegistry, getTraversal(), edge);
             return generator.generate(edge, this, 1L);
         } else
             throw FastNoSuchElementException.instance();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStep.java
@@ -27,8 +27,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Writing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.EventUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ListCallbackRegistry;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -137,11 +137,7 @@ public class AddEdgeStep<S> extends ScalarMapStep<S, Edge>
                     .attach(Attachable.Method.get(this.getTraversal().getGraph().orElse(EmptyGraph.instance())));
 
         final Edge edge = fromVertex.addEdge(edgeLabel, toVertex, this.parameters.getKeyValues(traverser, TO, FROM, T.label));
-        if (callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-            final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-            final Event.EdgeAddedEvent vae = new Event.EdgeAddedEvent(eventStrategy.detach(edge));
-            callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
-        }
+        EventUtil.registerEdgeCreation(callbackRegistry, getTraversal(), edge);
         return edge;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStep.java
@@ -29,8 +29,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.EventUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ListCallbackRegistry;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -100,11 +100,7 @@ public class AddVertexStartStep extends AbstractStep<Vertex, Vertex>
             this.first = false;
             final TraverserGenerator generator = this.getTraversal().getTraverserGenerator();
             final Vertex vertex = this.getTraversal().getGraph().get().addVertex(this.parameters.getKeyValues(generator.generate(false, (Step) this, 1L)));
-            if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-                final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-                final Event.VertexAddedEvent vae = new Event.VertexAddedEvent(eventStrategy.detach(vertex));
-                this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
-            }
+            EventUtil.registerVertexCreation(callbackRegistry, getTraversal(), vertex);
             return generator.generate(vertex, this, 1L);
         } else
             throw FastNoSuchElementException.instance();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStep.java
@@ -26,8 +26,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Writing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.EventUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ListCallbackRegistry;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -92,11 +92,7 @@ public class AddVertexStep<S> extends ScalarMapStep<S, Vertex>
     @Override
     protected Vertex map(final Traverser.Admin<S> traverser) {
         final Vertex vertex = this.getTraversal().getGraph().get().addVertex(this.parameters.getKeyValues(traverser));
-        if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-            final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-            final Event.VertexAddedEvent vae = new Event.VertexAddedEvent(eventStrategy.detach(vertex));
-            this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
-        }
+        EventUtil.registerVertexCreation(callbackRegistry, getTraversal(), vertex);
         return vertex;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStep.java
@@ -34,14 +34,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.LambdaFilterStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.EventUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
@@ -288,15 +285,7 @@ public class MergeEdgeStep<S> extends MergeStep<S, Edge, Object> {
                 onMatchMap.forEach((key, value) -> {
                     // trigger callbacks for eventing - in this case, it's a EdgePropertyChangedEvent. if there's no
                     // registry/callbacks then just set the property
-                    if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-                        final EventStrategy eventStrategy =
-                                getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-                        final Property<?> p = e.property(key);
-                        final Property<Object> oldValue =
-                                p.isPresent() ? eventStrategy.detach(e.property(key)) : null;
-                        final Event.EdgePropertyChangedEvent vpce = new Event.EdgePropertyChangedEvent(eventStrategy.detach(e), oldValue, value);
-                        this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vpce));
-                    }
+                    EventUtil.registerEdgePropertyChange(callbackRegistry, getTraversal(), e, key, value);
                     e.property(key, value);
                 });
 
@@ -343,11 +332,7 @@ public class MergeEdgeStep<S> extends MergeStep<S, Edge, Object> {
         final Edge edge = fromV.addEdge(label, toV, properties.toArray());
 
         // trigger callbacks for eventing - in this case, it's a VertexAddedEvent
-        if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-            final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-            final Event.EdgeAddedEvent vae = new Event.EdgeAddedEvent(eventStrategy.detach(edge));
-            this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
-        }
+        EventUtil.registerEdgeCreationWithGenericEventRegistry(callbackRegistry, getTraversal(), edge);
 
         return IteratorUtils.of(edge);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStep.java
@@ -30,10 +30,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.CardinalityValueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.EventUtil;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
@@ -118,13 +116,7 @@ public class MergeVertexStep<S> extends MergeStep<S, Vertex, Map> {
 
                     // trigger callbacks for eventing - in this case, it's a VertexPropertyChangedEvent. if there's no
                     // registry/callbacks then just set the property
-                    if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-                        final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-                        final Property<?> p = v.property(key);
-                        final Property<Object> oldValue = p.isPresent() ? eventStrategy.detach(v.property(key)) : null;
-                        final Event.VertexPropertyChangedEvent vpce = new Event.VertexPropertyChangedEvent(eventStrategy.detach(v), oldValue, val);
-                        this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vpce));
-                    }
+                    EventUtil.registerVertexPropertyChange(callbackRegistry, getTraversal(), v, key, val);
 
                     // try to detect proper cardinality for the key according to the graph
                     v.property(card, key, val);
@@ -167,11 +159,7 @@ public class MergeVertexStep<S> extends MergeStep<S, Vertex, Map> {
                 });
 
         // trigger callbacks for eventing - in this case, it's a VertexAddedEvent
-        if (this.callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty()) {
-            final EventStrategy eventStrategy = getTraversal().getStrategies().getStrategy(EventStrategy.class).get();
-            final Event.VertexAddedEvent vae = new Event.VertexAddedEvent(eventStrategy.detach(vertex));
-            this.callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
-        }
+        EventUtil.registerVertexCreationWithGenericEventRegistry(callbackRegistry, getTraversal(), vertex);
 
         return IteratorUtils.of(vertex);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/EventUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/event/EventUtil.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.util.event;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+
+public class EventUtil {
+
+    public static void registerVertexPropertyChange(CallbackRegistry<Event> callbackRegistry,
+                                                    Traversal.Admin<Object, Object> traversal,
+                                                    Vertex vertex,
+                                                    String key,
+                                                    Object value){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final EventStrategy eventStrategy = forceGetEventStrategy(traversal);
+            final Property<?> p = vertex.property(key);
+            final Property<Object> oldValue = p.isPresent() ? eventStrategy.detach(vertex.property(key)) : null;
+            final Event.VertexPropertyChangedEvent vpce = new Event.VertexPropertyChangedEvent(eventStrategy.detach(vertex), oldValue, value);
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(vpce));
+        }
+    }
+
+    public static void registerEdgePropertyChange(CallbackRegistry<Event> callbackRegistry,
+                                                  Traversal.Admin<Object, Object> traversal,
+                                                  Edge edge,
+                                                  String key,
+                                                  Object value){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final EventStrategy eventStrategy = forceGetEventStrategy(traversal);
+            final Property<?> p = edge.property(key);
+            final Property<Object> oldValue =
+                    p.isPresent() ? eventStrategy.detach(edge.property(key)) : null;
+            final Event.EdgePropertyChangedEvent vpce = new Event.EdgePropertyChangedEvent(eventStrategy.detach(edge), oldValue, value);
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(vpce));
+        }
+    }
+
+    public static void registerEdgeCreation(CallbackRegistry<Event.EdgeAddedEvent> callbackRegistry,
+                                            Traversal.Admin<Object, Object> traversal,
+                                            Edge addedEdge){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final Event.EdgeAddedEvent vae = createEdgeAddedEvent(traversal, addedEdge);
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
+        }
+    }
+
+    public static void registerEdgeCreationWithGenericEventRegistry(CallbackRegistry<Event> callbackRegistry,
+                                                                    Traversal.Admin<Object, Object> traversal,
+                                                                    Edge addedEdge){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final Event.EdgeAddedEvent vae = createEdgeAddedEvent(traversal, addedEdge);
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
+        }
+    }
+
+    private static Event.EdgeAddedEvent createEdgeAddedEvent(Traversal.Admin<Object, Object> traversal, Edge addedEdge){
+        final EventStrategy eventStrategy = forceGetEventStrategy(traversal);
+        return new Event.EdgeAddedEvent(eventStrategy.detach(addedEdge));
+    }
+
+    public static void registerVertexCreation(CallbackRegistry<Event.VertexAddedEvent> callbackRegistry,
+                                              Traversal.Admin<Object, Object> traversal,
+                                              Vertex addedVertex){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final Event.VertexAddedEvent vae = createVertexAddedEvent(traversal, addedVertex);
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
+        }
+    }
+
+    public static void registerVertexCreationWithGenericEventRegistry(CallbackRegistry<Event> callbackRegistry,
+                                                                      Traversal.Admin<Object, Object> traversal,
+                                                                      Vertex addedVertex){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final Event.VertexAddedEvent vae = createVertexAddedEvent(traversal, addedVertex);
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(vae));
+        }
+    }
+
+    private static Event.VertexAddedEvent createVertexAddedEvent(Traversal.Admin<Object, Object> traversal, Vertex addedVertex){
+        final EventStrategy eventStrategy = forceGetEventStrategy(traversal);
+        return new Event.VertexAddedEvent(eventStrategy.detach(addedVertex));
+    }
+
+    public static void registerElementRemoval(CallbackRegistry<Event> callbackRegistry,
+                                              Traversal.Admin<Object, Object> traversal,
+                                              Element elementForRemoval){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final EventStrategy eventStrategy = forceGetEventStrategy(traversal);
+            final Event removeEvent;
+            if (elementForRemoval instanceof Vertex)
+                removeEvent = new Event.VertexRemovedEvent(eventStrategy.detach((Vertex) elementForRemoval));
+            else if (elementForRemoval instanceof Edge)
+                removeEvent = new Event.EdgeRemovedEvent(eventStrategy.detach((Edge) elementForRemoval));
+            else if (elementForRemoval instanceof VertexProperty)
+                removeEvent = new Event.VertexPropertyRemovedEvent(eventStrategy.detach((VertexProperty) elementForRemoval));
+            else
+                throw new IllegalStateException("The incoming object is not removable: " + elementForRemoval);
+
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(removeEvent));
+        }
+    }
+
+    public static void registerPropertyRemoval(CallbackRegistry<Event> callbackRegistry,
+                                               Traversal.Admin<Object, Object> traversal,
+                                               Property elementForRemoval){
+        if (hasAnyCallbacks(callbackRegistry)) {
+            final EventStrategy eventStrategy = forceGetEventStrategy(traversal);
+            final Event.ElementPropertyEvent removeEvent;
+            if (elementForRemoval.element() instanceof Edge)
+                removeEvent = new Event.EdgePropertyRemovedEvent(eventStrategy.detach((Edge) elementForRemoval.element()), eventStrategy.detach(elementForRemoval));
+            else if (elementForRemoval.element() instanceof VertexProperty)
+                removeEvent = new Event.VertexPropertyPropertyRemovedEvent(eventStrategy.detach((VertexProperty) elementForRemoval.element()), eventStrategy.detach(elementForRemoval));
+            else
+                throw new IllegalStateException("The incoming object is not removable: " + elementForRemoval);
+
+            callbackRegistry.getCallbacks().forEach(c -> c.accept(removeEvent));
+        }
+    }
+
+    public static void registerPropertyChange(CallbackRegistry<Event.ElementPropertyChangedEvent> callbackRegistry,
+                                              EventStrategy es,
+                                              Element affectedElement,
+                                              Property removedProperty,
+                                              Object value,
+                                              Object[] vertexPropertyKeyValues){
+        final Event.ElementPropertyChangedEvent event;
+        if (affectedElement instanceof Vertex) {
+            event = new Event.VertexPropertyChangedEvent(es.detach((Vertex) affectedElement), removedProperty, value, vertexPropertyKeyValues);
+        } else if (affectedElement instanceof Edge) {
+            event = new Event.EdgePropertyChangedEvent(es.detach((Edge) affectedElement), removedProperty, value);
+        } else if (affectedElement instanceof VertexProperty) {
+            event = new Event.VertexPropertyPropertyChangedEvent(es.detach((VertexProperty) affectedElement), removedProperty, value);
+        } else {
+            throw new IllegalStateException(String.format("The incoming object cannot be processed by change eventing in %s:  %s", AddPropertyStep.class.getName(), affectedElement));
+        }
+        for (EventCallback<Event.ElementPropertyChangedEvent> c : callbackRegistry.getCallbacks()) {
+            c.accept(event);
+        }
+    }
+
+    public static boolean hasAnyCallbacks(CallbackRegistry<? extends Event> callbackRegistry){
+        return callbackRegistry != null && !callbackRegistry.getCallbacks().isEmpty();
+    }
+
+    public static EventStrategy forceGetEventStrategy(Traversal.Admin<Object, Object> traversal){
+        return traversal.getStrategies().getStrategy(EventStrategy.class).get();
+    }
+}


### PR DESCRIPTION
This will allow to reuse callback registration logic for extended classes of mutation steps.

Related discussion where the conclusion was made to relax individual steps based on necessity: https://lists.apache.org/thread/vjbjh29kwjhd5lcmkqqqqrhw7rw2ynh9