### PR TITLE
Open NoOpBarrierStep for extensibility

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from <<release-3-6-8, 3.6.8>>.
 
 * Refactored mutation events registration by moving reusable code from relevant steps to `EventUtil`
+* Open `NoOpBarrierStep` for extensibility (removed `final` keyword)
 
 [[release-3-7-2]]
 === TinkerPop 3.7.2 (April 8, 2024)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/NoOpBarrierStep.java
@@ -35,19 +35,23 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class NoOpBarrierStep<S> extends AbstractStep<S, S> implements LocalBarrier<S> {
+public class NoOpBarrierStep<S> extends AbstractStep<S, S> implements LocalBarrier<S> {
 
-    private int maxBarrierSize;
-    private TraverserSet<S> barrier;
+    protected int maxBarrierSize;
+    protected TraverserSet<S> barrier;
 
     public NoOpBarrierStep(final Traversal.Admin traversal) {
         this(traversal, Integer.MAX_VALUE);
     }
 
     public NoOpBarrierStep(final Traversal.Admin traversal, final int maxBarrierSize) {
+        this(traversal, maxBarrierSize, (TraverserSet<S>) traversal.getTraverserSetSupplier().get());
+    }
+
+    public NoOpBarrierStep(final Traversal.Admin traversal, final int maxBarrierSize, TraverserSet<S> barrier) {
         super(traversal);
         this.maxBarrierSize = maxBarrierSize;
-        this.barrier = (TraverserSet<S>) this.traversal.getTraverserSetSupplier().get();
+        this.barrier = barrier;
     }
 
     @Override


### PR DESCRIPTION
This will make it possible to extend and overwrite `NoOpBarrierStep`.

Reason for this change: https://github.com/JanusGraph/janusgraph/pull/4456#issuecomment-2118854247

Related discussion (Discord thread about `barrier` + `drop` step usage): https://discord.com/channels/838910279550238720/1241219665376706603

Related discussion where the conclusion was made to relax individual steps based on necessity: https://lists.apache.org/thread/vjbjh29kwjhd5lcmkqqqqrhw7rw2ynh9