### PR TITLE
 Fixing connection cleanup in case of mass connection breaking.

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.TimeUtil;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -663,18 +664,19 @@ final class ConnectionPool {
 
     private void appendConnections(final StringBuilder sb, final Connection connectionToCallout,
                                    final List<Connection> connections) {
-        final int connectionCount = connections.size();
-        for (int ix = 0; ix < connectionCount; ix++) {
-            final Connection c = connections.get(ix);
-            if (c.equals(connectionToCallout))
+        final Iterator<Connection> it = connections.iterator();
+        while(it.hasNext()) {
+            final Connection c = it.next();
+            if (c.equals(connectionToCallout)) {
                 sb.append("==> ");
-            else
+            }
+            else {
                 sb.append("> ");
-
+            }
             sb.append(c.getConnectionInfo(false));
-
-            if (ix < connectionCount - 1)
+            if (it.hasNext()) {
                 sb.append(System.lineSeparator());
+            }
         }
     }
 


### PR DESCRIPTION
 CAUSE:
 In some cases when credentials expire, or servers encounters a
 blip and closes all connections. The driver gets close message on all
 connections. While processing those close messages, the driver was
 getting into race conditions, where in multiple threads were trying to
 close connections and trying to update the connections object i.e. list
 of connections in the pool. This was leading to uncaught exceptions and
 stale connections in the pool. These connections are never cleanedup
 post this.

 FIX:
 Iterate the connections list while creating the connectionPool Info.
 Since the list used is copyOnWrite, the iterator API creates a clone
 and uses that clone for referring the element. Thus providing thread
 safe interface.

 However the information provided by this iteration is a bit stale, but
 this doesn't matter.