### PR TITLE
TINKERPOP-3081 Fix traversal argument propagation under authentication

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-6-8]]
 === TinkerPop 3.6.8 (NOT OFFICIALLY RELEASED YET)
 
+* Fixed a bug in GremlinServer not properly propagating arguments when authentication is enabled.
 
 [[release-3-6-7]]
 === TinkerPop 3.6.7 (April 8, 2024)

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WebSocketAuthorizationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WebSocketAuthorizationHandler.java
@@ -68,19 +68,9 @@ public class WebSocketAuthorizationHandler extends ChannelInboundHandlerAdapter 
                         final Bytecode bytecode = (Bytecode) requestMessage.getArgs().get(Tokens.ARGS_GREMLIN);
                         final Map<String, String> aliases = (Map<String, String>) requestMessage.getArgs().get(Tokens.ARGS_ALIASES);
                         final Bytecode restrictedBytecode = authorizer.authorize(user, bytecode, aliases);
-                        final RequestMessage.Builder restrictedMsgBuilder = RequestMessage.build(Tokens.OPS_BYTECODE).
-                                overrideRequestId(requestMessage.getRequestId()).
-                                processor("traversal").
-                                addArg(Tokens.ARGS_GREMLIN, restrictedBytecode).
-                                addArg(Tokens.ARGS_ALIASES, aliases);
-
-                        // Apply all other arguments except the bytecode and aliases.
-                        for (Map.Entry<String, Object> entry : requestMessage.getArgs().entrySet()) {
-                            if (!Tokens.ARGS_GREMLIN.equals(entry.getKey()) && !Tokens.ARGS_ALIASES.equals(entry.getKey())) {
-                                restrictedMsgBuilder.addArg(entry.getKey(), entry.getValue());
-                            }
-                        }
-                        final RequestMessage restrictedMsg = restrictedMsgBuilder.create();
+                        final RequestMessage restrictedMsg = RequestMessage.from(requestMessage)
+                                .addArg(Tokens.ARGS_GREMLIN, restrictedBytecode)
+                                .addArg(Tokens.ARGS_ALIASES, aliases).create();
                         ctx.fireChannelRead(restrictedMsg);
                         break;
                     case Tokens.OPS_EVAL:

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WebSocketAuthorizationHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WebSocketAuthorizationHandler.java
@@ -68,11 +68,19 @@ public class WebSocketAuthorizationHandler extends ChannelInboundHandlerAdapter 
                         final Bytecode bytecode = (Bytecode) requestMessage.getArgs().get(Tokens.ARGS_GREMLIN);
                         final Map<String, String> aliases = (Map<String, String>) requestMessage.getArgs().get(Tokens.ARGS_ALIASES);
                         final Bytecode restrictedBytecode = authorizer.authorize(user, bytecode, aliases);
-                        final RequestMessage restrictedMsg = RequestMessage.build(Tokens.OPS_BYTECODE).
+                        final RequestMessage.Builder restrictedMsgBuilder = RequestMessage.build(Tokens.OPS_BYTECODE).
                                 overrideRequestId(requestMessage.getRequestId()).
                                 processor("traversal").
                                 addArg(Tokens.ARGS_GREMLIN, restrictedBytecode).
-                                addArg(Tokens.ARGS_ALIASES, aliases).create();
+                                addArg(Tokens.ARGS_ALIASES, aliases);
+
+                        // Apply all other arguments except the bytecode and aliases.
+                        for (Map.Entry<String, Object> entry : requestMessage.getArgs().entrySet()) {
+                            if (!Tokens.ARGS_GREMLIN.equals(entry.getKey()) && !Tokens.ARGS_ALIASES.equals(entry.getKey())) {
+                                restrictedMsgBuilder.addArg(entry.getKey(), entry.getValue());
+                            }
+                        }
+                        final RequestMessage restrictedMsg = restrictedMsgBuilder.create();
                         ctx.fireChannelRead(restrictedMsg);
                         break;
                     case Tokens.OPS_EVAL:

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
@@ -31,6 +31,7 @@ import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.AbstractWarningVerificationStrategy;
 import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
 import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
@@ -41,14 +42,18 @@ import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONTokens;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.codehaus.groovy.tools.shell.CommandException;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Objects;
+import java.util.concurrent.CompletionException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -62,7 +67,7 @@ import static org.junit.Assert.fail;
  * @author Marc de Lignie
  */
 public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegrationTest {
-    private static final Long DEFAULT_EVALUATION_TIMEOUT = 1000L;
+    private static final Long DEFAULT_EVALUATION_TIMEOUT = 2000L;
     private static LogCaptor logCaptor;
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -395,14 +400,15 @@ public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegr
         final Cluster cluster = TestClientFactory.build().credentials("stephen", "password").create();
         final GraphTraversalSource g = AnonymousTraversalSource.traversal().withRemote(
                 DriverRemoteConnection.using(cluster, "gmodern"));
+        final Instant instant = Instant.now();
         try {
-            final String lambdaFunction = String.format("{ n, i -> sleep(%d); return i; }", DEFAULT_EVALUATION_TIMEOUT + 1000);
-            g.with("evaluationTimeout", DEFAULT_EVALUATION_TIMEOUT + 2000).
+            g.with("evaluationTimeout", DEFAULT_EVALUATION_TIMEOUT / 20).
                     V().
-                    limit(1).
-                    sack(
-                        Lambda.biFunction(lambdaFunction, "gremlin-groovy")).
-                    next();
+                    repeat(__.both()).
+                    until(__.count().is(0)).
+                    toList();
+        } catch (final CompletionException e) {
+            Assert.assertTrue(Instant.now().toEpochMilli() - instant.toEpochMilli() < DEFAULT_EVALUATION_TIMEOUT / 2);
         } finally {
             cluster.close();
         }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
@@ -396,7 +396,7 @@ public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegr
         final GraphTraversalSource g = AnonymousTraversalSource.traversal().withRemote(
                 DriverRemoteConnection.using(cluster, "gmodern"));
         try {
-            final String lambdaFunction = String.format("{ n, i -> sleep(%d); return i; }", DEFAULT_EVALUATION_TIMEOUT + 1000);
+            final String lambdaFunction = String.format("{ n, i -> sleep(%d); return i; }", (DEFAULT_EVALUATION_TIMEOUT + 1000) / 1000);
             g.with("evaluationTimeout", DEFAULT_EVALUATION_TIMEOUT + 2000).
                     V().
                     limit(1).

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
@@ -396,14 +396,13 @@ public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegr
         final GraphTraversalSource g = AnonymousTraversalSource.traversal().withRemote(
                 DriverRemoteConnection.using(cluster, "gmodern"));
         try {
-            g.with("evaluationTimeout", DEFAULT_EVALUATION_TIMEOUT + 1000).V().limit(1).map(t -> {
-                try {
-                    Thread.sleep(DEFAULT_EVALUATION_TIMEOUT + 500);
-                } catch (InterruptedException ie) {
-                    // do nothing
-                }
-                return t;
-            }).next();
+            final String lambdaFunction = String.format("{ n, i -> sleep(%d); return i; }", DEFAULT_EVALUATION_TIMEOUT + 1000);
+            g.with("evaluationTimeout", DEFAULT_EVALUATION_TIMEOUT + 2000).
+                    V().
+                    limit(1).
+                    sack(
+                        Lambda.biFunction(lambdaFunction, "gremlin-groovy")).
+                    next();
         } finally {
             cluster.close();
         }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
@@ -62,6 +62,7 @@ import static org.junit.Assert.fail;
  * @author Marc de Lignie
  */
 public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegrationTest {
+    private static final Long DEFAULT_EVALUATION_TIMEOUT = 1000L;
     private static LogCaptor logCaptor;
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -107,6 +108,7 @@ public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegr
         settings.authentication = authSettings;
         settings.authorization = authzSettings;
         settings.enableAuditLog = true;
+        settings.evaluationTimeout = DEFAULT_EVALUATION_TIMEOUT;
 
         final String nameOfTest = name.getMethodName();
         switch (nameOfTest) {
@@ -385,6 +387,25 @@ public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegr
             final String json = EntityUtils.toString(response.getEntity());
             final JsonNode node = mapper.readTree(json);
             assertEquals(6, node.get("result").get("data").get(GraphSONTokens.VALUEPROP).get(0).get(GraphSONTokens.VALUEPROP).intValue());
+        }
+    }
+
+    @Test
+    public void shouldRespectTimeoutWithAuth() {
+        final Cluster cluster = TestClientFactory.build().credentials("stephen", "password").create();
+        final GraphTraversalSource g = AnonymousTraversalSource.traversal().withRemote(
+                DriverRemoteConnection.using(cluster, "gmodern"));
+        try {
+            g.with("evaluationTimeout", DEFAULT_EVALUATION_TIMEOUT + 1000).V().limit(1).map(t -> {
+                try {
+                    Thread.sleep(DEFAULT_EVALUATION_TIMEOUT + 500);
+                } catch (InterruptedException ie) {
+                    // do nothing
+                }
+                return t;
+            }).next();
+        } finally {
+            cluster.close();
         }
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthzIntegrateTest.java
@@ -396,7 +396,7 @@ public class GremlinServerAuthzIntegrateTest extends AbstractGremlinServerIntegr
         final GraphTraversalSource g = AnonymousTraversalSource.traversal().withRemote(
                 DriverRemoteConnection.using(cluster, "gmodern"));
         try {
-            final String lambdaFunction = String.format("{ n, i -> sleep(%d); return i; }", (DEFAULT_EVALUATION_TIMEOUT + 1000) / 1000);
+            final String lambdaFunction = String.format("{ n, i -> sleep(%d); return i; }", DEFAULT_EVALUATION_TIMEOUT + 1000);
             g.with("evaluationTimeout", DEFAULT_EVALUATION_TIMEOUT + 2000).
                     V().
                     limit(1).


### PR DESCRIPTION
Issue is that when using authentication traversal arguments  (for example evaluationTimeout do not propagate, leading to failures in the traversal and unexpected behavior. This fixes that problem