### PR TITLE
Adding Getter for fields of IntersectStep and DisjunctStep.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/DisjunctStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/DisjunctStep.java
@@ -46,6 +46,14 @@ public final class DisjunctStep<S, E> extends ScalarMapStep<S, Set<?>> implement
         }
     }
 
+    public Traversal.Admin<S,E> getValueTraversal() {
+        return this.valueTraversal;
+    }
+
+    public Object getParameterItems() {
+        return this.parameterItems;
+    }
+
     @Override
     public String getStepName() { return "disjunct"; }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IntersectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IntersectStep.java
@@ -48,6 +48,14 @@ public final class IntersectStep<S, E> extends ScalarMapStep<S, Set<?>> implemen
         }
     }
 
+    public Traversal.Admin<S,E> getValueTraversal() {
+        return this.valueTraversal;
+    }
+
+    public Object getParameterItems() {
+        return this.parameterItems;
+    }
+
     @Override
     public String getStepName() { return "intersect"; }
 


### PR DESCRIPTION
For Vendors implementing these steps, the members of these step classes need to be accessible. Thus adding getters over their members. 