### PR TITLE
[TINKERPOP-3082] Allow specifying a customized Spark AppName

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ This release also includes changes from <<release-3-6-8, 3.6.8>>.
 * Refactored mutation events registration by moving reusable code from relevant steps to `EventUtil`
 * Open `NoOpBarrierStep` for extensibility (removed `final` keyword)
 * Deprecated public constructor for `SeedStrategy` in favor of builder pattern to be consistent with other strategies.
+* Allow specifying a customized Spark app name
 
 [[release-3-7-2]]
 === TinkerPop 3.7.2 (April 8, 2024)

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/Spark.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/Spark.java
@@ -43,12 +43,17 @@ public class Spark {
     private static SparkContext CONTEXT;
     private static final Map<String, RDD<?>> NAME_TO_RDD = new ConcurrentHashMap<>();
 
+    public static final String DEFAULT_APP_NAME = "Apache TinkerPop's Spark-Gremlin";
+
     private Spark() {
     }
 
     public static SparkContext create(final SparkConf sparkConf) {
         if (isContextNullOrStopped()) {
-            sparkConf.setAppName("Apache TinkerPop's Spark-Gremlin");
+            // Set the default app name if it is not specified
+            if (sparkConf.get("spark.app.name", DEFAULT_APP_NAME).equals(DEFAULT_APP_NAME)) {
+                sparkConf.setAppName(DEFAULT_APP_NAME);
+            }
             CONTEXT = SparkContext.getOrCreate(sparkConf);
         }
         return CONTEXT;

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
@@ -51,6 +51,23 @@ import static org.junit.Assert.assertTrue;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class SparkTest extends AbstractSparkTest {
+    @Test
+    public void testCustomizedSparkAppName() {
+	final String appName = "SparkAppNameTest";
+	final org.apache.spark.SparkConf sparkConfiguration = new org.apache.spark.SparkConf();
+	sparkConfiguration.set("spark.app.name", appName);
+	sparkConfiguration.set("spark.master", "local[4]");
+	final org.apache.spark.SparkContext sparkContext = Spark.create(sparkConfiguration);
+	assertEquals(appName, sparkContext.getConf().get("spark.app.name"));
+    }
+
+    @Test
+    public void testDefaultSparkAppName() {
+	final org.apache.spark.SparkConf sparkConfiguration = new org.apache.spark.SparkConf();
+	sparkConfiguration.set("spark.master", "local[4]");
+	final org.apache.spark.SparkContext sparkContext = Spark.create(sparkConfiguration);
+	assertEquals(Spark.DEFAULT_APP_NAME, sparkContext.getConf().get("spark.app.name"));
+    }
 
     @Test
     public void testSparkRDDPersistence() throws Exception {


### PR DESCRIPTION
It should allow overriding the Spark App name if user wants to. If user does not specify the Spark app name, we will provide the default one. This is useful for user to see different Spark App if there are many Gremlin Servers sharing the same Spark cluster.