### PR TITLE
Getters for internal fields of SubstringLocalStep, SubstringGlobalStep

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SubstringGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SubstringGlobalStep.java
@@ -52,6 +52,14 @@ public final class SubstringGlobalStep<S, E> extends ScalarMapStep<S, E> {
         this(traversal, startIndex, null);
     }
 
+    public Integer getStart() {
+        return this.start;
+    }
+
+    public Integer getEnd() {
+        return this.end;
+    }
+
     @Override
     protected E map(final Traverser.Admin<S> traverser) {
         final S item = traverser.get();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SubstringLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SubstringLocalStep.java
@@ -53,6 +53,14 @@ public final class SubstringLocalStep<S, E> extends StringLocalStep<S, E> {
         this(traversal, startIndex, null);
     }
 
+    public Integer getStart() {
+        return this.start;
+    }
+
+    public Integer getEnd() {
+        return this.end;
+    }
+
     @Override
     protected E applyStringOperation(String item) {
         final int newStart = processStringIndex(item.length(), this.start);


### PR DESCRIPTION
For external vendor implementation of these steps, the internal fields of these steps need to be accessible. Thats why added the getters here. 