### PR TITLE
Python driver basic connectivity to HTTP server

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -195,8 +195,8 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
         async def async_write():
             basic_auth = None
             # basic password authentication for https connections
-            if message['auth']:
-                basic_auth = aiohttp.BasicAuth(message['auth']['username'], message['auth']['password'])
+            # if message['auth']:
+            #     basic_auth = aiohttp.BasicAuth(message['auth']['username'], message['auth']['password'])
             async with async_timeout.timeout(self._write_timeout):
                 self._http_req_resp = await self._client_session.post(url="/gremlin",
                                                                       auth=basic_auth,
@@ -210,8 +210,15 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
     def read(self):
         # Inner function to perform async read.
         async def async_read():
+            buffer = b""
+            # async for data, end_of_http_chunk in self._http_req_resp.content.iter_chunks():
+            #     buffer += data
+            #     if end_of_http_chunk:
+            #         print('ended')
+            #     print(buffer)
             async with async_timeout.timeout(self._read_timeout):
-                return {"content": await self._http_req_resp.read(),
+                data = await self._http_req_resp.read()
+                return {"content": data,
                         "ok": self._http_req_resp.ok,
                         "status": self._http_req_resp.status}
 

--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -26,6 +26,7 @@ from gremlin_python.driver.transport import AbstractBaseTransport
 __author__ = 'Lyndon Bauto (lyndonb@bitquilltech.com)'
 
 
+# TODO: remove WS transport & refactor
 class AiohttpTransport(AbstractBaseTransport):
     nest_asyncio_applied = False
 
@@ -195,8 +196,8 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
         async def async_write():
             basic_auth = None
             # basic password authentication for https connections
-            # if message['auth']:
-            #     basic_auth = aiohttp.BasicAuth(message['auth']['username'], message['auth']['password'])
+            if message['auth']:
+                basic_auth = aiohttp.BasicAuth(message['auth']['username'], message['auth']['password'])
             async with async_timeout.timeout(self._write_timeout):
                 self._http_req_resp = await self._client_session.post(url="/gremlin",
                                                                       auth=basic_auth,
@@ -210,6 +211,7 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
     def read(self):
         # Inner function to perform async read.
         async def async_read():
+            # TODO: set-up chunked reading
             buffer = b""
             # async for data, end_of_http_chunk in self._http_req_resp.content.iter_chunks():
             #     buffer += data

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -180,23 +180,19 @@ class Client:
             raise Exception("Client is closed")
 
         log.debug("message '%s'", str(message))
-        args = {'gremlin': message, 'aliases': {'g': self._traversal_source}}
-        processor = ''
-        op = 'eval'
+        # args = {'gremlin': message, 'fields': {'g': self._traversal_source}}
+        fields = {'g': self._traversal_source}
         if isinstance(message, traversal.Bytecode):
-            op = 'bytecode'
-            processor = 'traversal'
+            fields['gremlinType'] = 'bytecode'
+        elif isinstance(message, str):
+            fields['gremlinType'] = 'eval'
 
         if isinstance(message, str) and bindings:
-            args['bindings'] = bindings
-
-        if self._session_enabled:
-            args['session'] = str(self._session)
-            processor = 'session'
+            fields['bindings'] = bindings
 
         if isinstance(message, traversal.Bytecode) or isinstance(message, str):
-            log.debug("processor='%s', op='%s', args='%s'", str(processor), str(op), str(args))
-            message = request.RequestMessage(processor=processor, op=op, args=args)
+            log.debug("fields='%s', gremlin='%s'", str(fields), str(message))
+            message = request.RequestMessageV4(fields=fields, gremlin=message)
 
         conn = self._pool.get(True)
         if request_options:

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -38,6 +38,7 @@ except ImportError:
 __author__ = 'David M. Brown (davebshow@gmail.com), Lyndon Bauto (lyndonb@bitquilltech.com)'
 
 
+# TODO: remove session, update connection pooling, etc.
 class Client:
 
     def __init__(self, url, traversal_source, protocol_factory=None,
@@ -58,7 +59,7 @@ class Client:
         if not self._use_http and "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
         if message_serializer is None:
-            message_serializer = serializer.GraphBinarySerializersV1()
+            message_serializer = serializer.GraphBinarySerializersV4()
 
         self._message_serializer = message_serializer
         self._username = username
@@ -180,7 +181,6 @@ class Client:
             raise Exception("Client is closed")
 
         log.debug("message '%s'", str(message))
-        # args = {'gremlin': message, 'fields': {'g': self._traversal_source}}
         fields = {'g': self._traversal_source}
         if isinstance(message, traversal.Bytecode):
             fields['gremlinType'] = 'bytecode'
@@ -196,5 +196,6 @@ class Client:
 
         conn = self._pool.get(True)
         if request_options:
-            message.args.update(request_options)
+            message.fields.update(request_options)
+
         return conn.write(message)

--- a/gremlin-python/src/main/python/gremlin_python/driver/connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/connection.py
@@ -56,8 +56,6 @@ class Connection:
             self._transport.close()
 
     def write(self, request_message):
-        print('\n===conn===')
-        print(request_message)
         if not self._inited:
             self.connect()
         self._result_set = resultset.ResultSet(queue.Queue())

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -61,7 +61,7 @@ class AbstractBaseProtocol(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def write(self, request_id, request_message):
+    def write(self, request_message):
         pass
 
 
@@ -206,7 +206,7 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
     def connection_made(self, transport):
         super(GremlinServerHTTPProtocol, self).connection_made(transport)
 
-    def write(self, request_id, request_message):
+    def write(self, request_message):
 
         basic_auth = {}
         if self._username and self._password:
@@ -217,13 +217,13 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
         message = {
             'headers': {'CONTENT-TYPE': content_type,
                         'ACCEPT': content_type},
-            'payload': self._message_serializer.serialize_message(request_id, request_message),
+            'payload': self._message_serializer.serialize_message(request_message),
             'auth': basic_auth
         }
 
         self._transport.write(message)
 
-    def data_received(self, response, results_dict):
+    def data_received(self, response, result_set):
         # if Gremlin Server cuts off then we get a None for the message
         if response is None:
             log.error("Received empty message from server.")
@@ -232,8 +232,6 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
 
         if response['ok']:
             message = self._message_serializer.deserialize_message(response['content'])
-            request_id = message['requestId']
-            result_set = results_dict[request_id] if request_id in results_dict else ResultSet(None, None)
             status_code = message['status']['code']
             aggregate_to = message['result']['meta'].get('aggregateTo', 'list')
             data = message['result']['data']
@@ -241,19 +239,20 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
 
             if status_code == 204:
                 result_set.stream.put_nowait([])
-                del results_dict[request_id]
                 return status_code
             elif status_code in [200, 206]:
                 result_set.stream.put_nowait(data)
-                if status_code == 200:
-                    result_set.status_attributes = message['status']['attributes']
-                    del results_dict[request_id]
+                # if status_code == 200:
+                #     result_set.status_attributes = message['status']['attributes']
                 return status_code
+            else:
+                log.error("\r\nReceived error message '%s'\r\n\r\nWith result set '%s'",
+                          str(message), str(result_set))
+                raise GremlinServerError({'code': status_code,
+                                          'message': message['status']['message'],
+                                          'attributes': {}})
         else:
-            # This message is going to be huge and kind of hard to read, but in the event of an error,
-            # it can provide invaluable info, so space it out appropriately.
-            log.error("\r\nReceived error message '%s'\r\n\r\nWith results dictionary '%s'",
-                      str(response['content']), str(results_dict))
+            log.error("\r\nReceived error message '%s'\r\n\r\nWith result set '%s'",
+                      str(response['content']), str(result_set))
             body = json.loads(response['content'])
-            del results_dict[body['requestId']]
             raise GremlinServerError({'code': response['status'], 'message': body['message'], 'attributes': {}})

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -251,6 +251,7 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
                                           'message': message['status']['message'],
                                           'attributes': {}})
         else:
+            # TODO check error deserialization after chunking implementation
             log.error("\r\nReceived error message '%s'\r\n\r\nWith result set '%s'",
                       str(response['content']), str(result_set))
             body = json.loads(response['content'])

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -243,8 +243,6 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
                 return status_code
             elif status_code in [200, 206]:
                 result_set.stream.put_nowait(data)
-                # if status_code == 200:
-                #     result_set.status_attributes = message['status']['attributes']
                 return status_code
             else:
                 log.error("\r\nReceived error message '%s'\r\n\r\nWith result set '%s'",

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -65,6 +65,7 @@ class AbstractBaseProtocol(metaclass=abc.ABCMeta):
         pass
 
 
+# TODO: remove WS protocol & refactor
 class GremlinServerWSProtocol(AbstractBaseProtocol):
     QOP_AUTH_BIT = 1
     _kerberos_context = None

--- a/gremlin-python/src/main/python/gremlin_python/driver/request.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/request.py
@@ -20,6 +20,5 @@ import collections
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
-
-RequestMessage = collections.namedtuple(
-    'RequestMessage', ['processor', 'op', 'args'])
+RequestMessageV4 = collections.namedtuple(
+    'RequestMessageV4', ['fields', 'gremlin'])

--- a/gremlin-python/src/main/python/gremlin_python/driver/resultset.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/resultset.py
@@ -27,7 +27,6 @@ class ResultSet:
         self._stream = stream
         self._done = None
         self._aggregate_to = None
-        self._status_attributes = {}
 
     @property
     def aggregate_to(self):
@@ -36,14 +35,6 @@ class ResultSet:
     @aggregate_to.setter
     def aggregate_to(self, val):
         self._aggregate_to = val
-
-    @property
-    def status_attributes(self):
-        return self._status_attributes
-
-    @status_attributes.setter
-    def status_attributes(self, val):
-        self._status_attributes = val
 
     @property
     def stream(self):

--- a/gremlin-python/src/main/python/gremlin_python/driver/resultset.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/resultset.py
@@ -23,9 +23,8 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 class ResultSet:
 
-    def __init__(self, stream, request_id):
+    def __init__(self, stream):
         self._stream = stream
-        self._request_id = request_id
         self._done = None
         self._aggregate_to = None
         self._status_attributes = {}
@@ -45,10 +44,6 @@ class ResultSet:
     @status_attributes.setter
     def status_attributes(self, val):
         self._status_attributes = val
-
-    @property
-    def request_id(self):
-        return self._request_id
 
     @property
     def stream(self):

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -75,10 +75,10 @@ class Session(Processor):
     def bytecode(self, args):
         gremlin = args['gremlin']
         args['gremlin'] = self._writer.to_dict(gremlin)
-        bindings = args.get('bindings', '')
-        if not bindings:
-            bindings = {'g': 'g'}
-        args['bindings'] = bindings
+        aliases = args.get('aliases', '')
+        if not aliases:
+            aliases = {'g': 'g'}
+        args['aliases'] = aliases
         return args
 
 
@@ -336,9 +336,9 @@ class GraphBinarySerializersV4(object):
             'fields': fields,
             'gremlin': gremlin
         }
-        return self.finalize_message(message, 0x20, self.version)
+        return self.finalize_message(message)
 
-    def finalize_message(self, message, mime_len, mime_type):
+    def finalize_message(self, message):
         ba = bytearray()
 
         ba.extend(graphbinaryV4.uint8_pack(0x81))
@@ -358,6 +358,11 @@ class GraphBinarySerializersV4(object):
         return bytes(ba)
 
     def deserialize_message(self, message):
+        if len(message) == 0:
+            return {'status': {'code': 204},
+                    'result': {'meta': {},
+                               'data': []}}
+
         # for parsing string message via HTTP connections
         b = io.BytesIO(base64.b64decode(message) if isinstance(message, str) else message)
 

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
@@ -49,6 +49,7 @@ _serializers = OrderedDict()
 _deserializers = {}
 
 
+# TODO: to be removed
 class DataType(Enum):
     null = 0xfe
     int = 0x01

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV4.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV4.py
@@ -1,0 +1,1178 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+"""
+
+import datetime
+import calendar
+import uuid
+import math
+import io
+import struct
+from collections import OrderedDict
+import logging
+
+from struct import pack, unpack
+from aenum import Enum
+from datetime import timedelta
+from gremlin_python import statics
+from gremlin_python.statics import FloatType, BigDecimal, FunctionType, ShortType, IntType, LongType, BigIntType, \
+                                   TypeType, DictType, ListType, SetType, SingleByte, ByteBufferType, GremlinType, \
+                                   SingleChar
+from gremlin_python.process.traversal import Barrier, Binding, Bytecode, Cardinality, Column, Direction, DT, Merge, \
+                                             Operator, Order, Pick, Pop, P, Scope, TextP, Traversal, Traverser, \
+                                             TraversalStrategy, T
+from gremlin_python.process.graph_traversal import GraphTraversal
+from gremlin_python.structure.graph import Graph, Edge, Property, Vertex, VertexProperty, Path
+from gremlin_python.structure.io.util import HashableDict, SymbolUtil
+
+log = logging.getLogger(__name__)
+
+# When we fall back to a superclass's serializer, we iterate over this map.
+# We want that iteration order to be consistent, so we use an OrderedDict,
+# not a dict.
+_serializers = OrderedDict()
+_deserializers = {}
+
+
+class DataType(Enum):
+    null = 0xfe
+    int = 0x01
+    long = 0x02
+    string = 0x03
+    date = 0x04
+    timestamp = 0x05
+    clazz = 0x06
+    double = 0x07
+    float = 0x08
+    list = 0x09
+    map = 0x0a
+    set = 0x0b
+    uuid = 0x0c
+    edge = 0x0d
+    path = 0x0e
+    property = 0x0f
+    graph = 0x10                  # not supported - no graph object in python yet
+    vertex = 0x11
+    vertexproperty = 0x12
+    barrier = 0x13
+    binding = 0x14
+    bytecode = 0x15
+    cardinality = 0x16
+    column = 0x17
+    direction = 0x18
+    operator = 0x19
+    order = 0x1a
+    pick = 0x1b
+    pop = 0x1c
+    lambda_ = 0x1d
+    p = 0x1e
+    scope = 0x1f
+    t = 0x20
+    traverser = 0x21
+    bigdecimal = 0x22
+    biginteger = 0x23
+    byte = 0x24
+    bytebuffer = 0x25
+    short = 0x26
+    boolean = 0x27
+    textp = 0x28
+    traversalstrategy = 0x29
+    bulkset = 0x2a
+    tree = 0x2b                   # not supported - no tree object in Python yet
+    metrics = 0x2c
+    traversalmetrics = 0x2d
+    merge = 0x2e
+    dt = 0x2f
+    char = 0x80
+    duration = 0x81
+    marker = 0xfd
+    inetaddress = 0x82            # todo
+    instant = 0x83                # todo
+    localdate = 0x84              # todo
+    localdatetime = 0x85          # todo
+    localtime = 0x86              # todo
+    monthday = 0x87               # todo
+    offsetdatetime = 0x88         # todo
+    offsettime = 0x89             # todo
+    period = 0x8a                 # todo
+    year = 0x8b                   # todo
+    yearmonth = 0x8c              # todo
+    zonedatetime = 0x8d           # todo
+    zoneoffset = 0x8e             # todo
+    custom = 0x00                 # todo
+
+
+NULL_BYTES = [DataType.null.value, 0x01]
+
+
+def _make_packer(format_string):
+    packer = struct.Struct(format_string)
+    pack = packer.pack
+    unpack = lambda s: packer.unpack(s)[0]
+    return pack, unpack
+
+
+int64_pack, int64_unpack = _make_packer('>q')
+int32_pack, int32_unpack = _make_packer('>i')
+int16_pack, int16_unpack = _make_packer('>h')
+int8_pack, int8_unpack = _make_packer('>b')
+uint64_pack, uint64_unpack = _make_packer('>Q')
+uint8_pack, uint8_unpack = _make_packer('>B')
+float_pack, float_unpack = _make_packer('>f')
+double_pack, double_unpack = _make_packer('>d')
+
+
+class GraphBinaryTypeType(type):
+    def __new__(mcs, name, bases, dct):
+        cls = super(GraphBinaryTypeType, mcs).__new__(mcs, name, bases, dct)
+        if not name.startswith('_'):
+            if cls.python_type:
+                _serializers[cls.python_type] = cls
+            if cls.graphbinary_type:
+                _deserializers[cls.graphbinary_type] = cls
+        return cls
+
+
+class GraphBinaryWriter(object):
+    def __init__(self, serializer_map=None):
+        self.serializers = _serializers.copy()
+        if serializer_map:
+            self.serializers.update(serializer_map)
+
+    def write_object(self, object_data):
+        return self.to_dict(object_data)
+
+    def to_dict(self, obj, to_extend=None):
+        if to_extend is None:
+            to_extend = bytearray()
+
+        if obj is None:
+            to_extend.extend(NULL_BYTES)
+            return
+
+        try:
+            t = type(obj)
+            return self.serializers[t].dictify(obj, self, to_extend)
+        except KeyError:
+            for key, serializer in self.serializers.items():
+                if isinstance(obj, key):
+                    return serializer.dictify(obj, self, to_extend)
+
+        if isinstance(obj, dict):
+            return dict((self.to_dict(k, to_extend), self.to_dict(v, to_extend)) for k, v in obj.items())
+        elif isinstance(obj, set):
+            return set([self.to_dict(o, to_extend) for o in obj])
+        elif isinstance(obj, list):
+            return [self.to_dict(o, to_extend) for o in obj]
+        else:
+            return obj
+
+
+class GraphBinaryReader(object):
+    def __init__(self, deserializer_map=None):
+        self.deserializers = _deserializers.copy()
+        if deserializer_map:
+            self.deserializers.update(deserializer_map)
+
+    def read_object(self, b):
+        if isinstance(b, bytearray):
+            return self.to_object(io.BytesIO(b))
+        elif isinstance(b, io.BufferedIOBase):
+            return self.to_object(b)
+
+    def to_object(self, buff, data_type=None, nullable=True):
+        if data_type is None:
+            bt = uint8_unpack(buff.read(1))
+            if bt == DataType.null.value:
+                if nullable:
+                    buff.read(1)
+                return None
+            return self.deserializers[DataType(bt)].objectify(buff, self, nullable)
+        else:
+            return self.deserializers[data_type].objectify(buff, self, nullable)
+
+
+class _GraphBinaryTypeIO(object, metaclass=GraphBinaryTypeType):
+    python_type = None
+    graphbinary_type = None
+
+    @classmethod
+    def prefix_bytes(cls, graphbin_type, as_value=False, nullable=True, to_extend=None):
+        if to_extend is None:
+            to_extend = bytearray()
+
+        if not as_value:
+            to_extend += uint8_pack(graphbin_type.value)
+
+        if nullable:
+            to_extend += int8_pack(0)
+
+        return to_extend
+
+    @classmethod
+    def read_int(cls, buff):
+        return int32_unpack(buff.read(4))
+
+    @classmethod
+    def is_null(cls, buff, reader, else_opt, nullable=True):
+        return None if nullable and buff.read(1)[0] == 0x01 else else_opt(buff, reader)
+
+    def dictify(self, obj, writer, to_extend, as_value=False, nullable=True):
+        raise NotImplementedError()
+
+    def objectify(self, d, reader, nullable=True):
+        raise NotImplementedError()
+        
+
+class LongIO(_GraphBinaryTypeIO):
+
+    python_type = LongType
+    graphbinary_type = DataType.long
+    byte_format_pack = int64_pack
+    byte_format_unpack = int64_unpack
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        if obj < -9223372036854775808 or obj > 9223372036854775807:
+            raise Exception("Value too big, please use bigint Gremlin type")
+        else:
+            cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+            to_extend.extend(cls.byte_format_pack(obj))
+            return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: int64_unpack(buff.read(8)), nullable)
+
+
+class IntIO(LongIO):
+
+    python_type = IntType
+    graphbinary_type = DataType.int
+    byte_format_pack = int32_pack
+    byte_format_unpack = int32_unpack
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: cls.read_int(b), nullable)
+
+
+class ShortIO(LongIO):
+
+    python_type = ShortType
+    graphbinary_type = DataType.short
+    byte_format_pack = int16_pack
+    byte_format_unpack = int16_unpack
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: int16_unpack(buff.read(2)), nullable)
+
+
+class BigIntIO(_GraphBinaryTypeIO):
+
+    python_type = BigIntType
+    graphbinary_type = DataType.biginteger
+
+    @classmethod
+    def write_bigint(cls, obj, to_extend):
+        length = (obj.bit_length() + 7) // 8
+        if obj > 0:
+            b = obj.to_bytes(length, byteorder='big')
+            to_extend.extend(int32_pack(length + 1))
+            to_extend.extend(int8_pack(0))
+            to_extend.extend(b)
+        else:
+            # handle negative
+            b = obj.to_bytes(length, byteorder='big', signed=True)
+            to_extend.extend(int32_pack(length))
+            to_extend.extend(b)
+        return to_extend
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        return cls.write_bigint(obj, to_extend)
+
+    @classmethod
+    def read_bigint(cls, buff):
+        size = cls.read_int(buff)
+        return int.from_bytes(buff.read(size), byteorder='big', signed=True)
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=False):
+        return cls.is_null(buff, reader, lambda b, r: cls.read_bigint(b), nullable)
+
+
+class DateIO(_GraphBinaryTypeIO):
+
+    python_type = datetime.datetime
+    graphbinary_type = DataType.date
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        try:
+            timestamp_seconds = calendar.timegm(obj.utctimetuple())
+            pts = timestamp_seconds * 1e3 + getattr(obj, 'microsecond', 0) / 1e3
+        except AttributeError:
+            pts = calendar.timegm(obj.timetuple()) * 1e3
+
+        ts = int(round(pts))
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int64_pack(ts))
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader,
+                           lambda b, r: datetime.datetime.utcfromtimestamp(int64_unpack(b.read(8)) / 1000.0),
+                           nullable)
+
+
+# Based on current implementation, this class must always be declared before FloatIO.
+# Seems pretty fragile for future maintainers. Maybe look into this.
+class TimestampIO(_GraphBinaryTypeIO):
+    python_type = statics.timestamp
+    graphbinary_type = DataType.timestamp
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        # Java timestamp expects milliseconds integer - Have to use int because of legacy Python
+        ts = int(round(obj * 1000))
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int64_pack(ts))
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        # Python timestamp expects seconds
+        return cls.is_null(buff, reader, lambda b, r: statics.timestamp(int64_unpack(b.read(8)) / 1000.0),
+                           nullable)
+    
+
+def _long_bits_to_double(bits):
+    return unpack('d', pack('Q', bits))[0]
+
+
+NAN = _long_bits_to_double(0x7ff8000000000000)
+POSITIVE_INFINITY = _long_bits_to_double(0x7ff0000000000000)
+NEGATIVE_INFINITY = _long_bits_to_double(0xFff0000000000000)
+
+
+class FloatIO(LongIO):
+
+    python_type = FloatType
+    graphbinary_type = DataType.float
+    graphbinary_base_type = DataType.float
+    byte_format_pack = float_pack
+    byte_format_unpack = float_unpack
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        if math.isnan(obj):
+            cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+            to_extend.extend(cls.byte_format_pack(NAN))
+        elif math.isinf(obj) and obj > 0:
+            cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+            to_extend.extend(cls.byte_format_pack(POSITIVE_INFINITY))
+        elif math.isinf(obj) and obj < 0:
+            cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+            to_extend.extend(cls.byte_format_pack(NEGATIVE_INFINITY))
+        else:
+            cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+            to_extend.extend(cls.byte_format_pack(obj))
+
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: float_unpack(b.read(4)), nullable)
+
+
+class DoubleIO(FloatIO):
+    """
+    Floats basically just fall through to double serialization.
+    """
+
+    graphbinary_type = DataType.double
+    graphbinary_base_type = DataType.double
+    byte_format_pack = double_pack
+    byte_format_unpack = double_unpack
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: double_unpack(b.read(8)), nullable)
+
+
+class BigDecimalIO(_GraphBinaryTypeIO):
+
+    python_type = BigDecimal
+    graphbinary_type = DataType.bigdecimal
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int32_pack(obj.scale))
+        return BigIntIO.write_bigint(obj.unscaled_value, to_extend)
+
+    @classmethod
+    def _read(cls, buff):
+        scale = int32_unpack(buff.read(4))
+        unscaled_value = BigIntIO.read_bigint(buff)
+        return BigDecimal(scale, unscaled_value)
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=False):
+        return cls.is_null(buff, reader, lambda b, r: cls._read(b), nullable)
+
+
+class CharIO(_GraphBinaryTypeIO):
+    python_type = SingleChar
+    graphbinary_type = DataType.char
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(obj.encode("utf-8"))
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_char, nullable)
+
+    @classmethod
+    def _read_char(cls, b, r):
+        max_bytes = 4
+        x = b.read(1)
+        while max_bytes > 0:
+            max_bytes = max_bytes - 1
+            try:
+                return x.decode("utf-8")
+            except UnicodeDecodeError:
+                x += b.read(1)
+
+
+class StringIO(_GraphBinaryTypeIO):
+
+    python_type = str
+    graphbinary_type = DataType.string
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        str_bytes = obj.encode("utf-8")
+        to_extend += int32_pack(len(str_bytes))
+        to_extend += str_bytes
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: b.read(cls.read_int(b)).decode("utf-8"), nullable)
+
+
+class ListIO(_GraphBinaryTypeIO):
+
+    python_type = list
+    graphbinary_type = DataType.list
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int32_pack(len(obj)))
+        for item in obj:
+            writer.to_dict(item, to_extend)
+
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_list, nullable)
+
+    @classmethod
+    def _read_list(cls, b, r):
+        size = cls.read_int(b)
+        the_list = []
+        while size > 0:
+            the_list.append(r.read_object(b))
+            size = size - 1
+
+        return the_list
+
+
+class SetDeserializer(ListIO):
+
+    python_type = SetType
+    graphbinary_type = DataType.set
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return set(ListIO.objectify(buff, reader, nullable))
+
+
+class MapIO(_GraphBinaryTypeIO):
+
+    python_type = DictType
+    graphbinary_type = DataType.map
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+
+        to_extend.extend(int32_pack(len(obj)))
+        for k, v in obj.items():
+            writer.to_dict(k, to_extend)
+            writer.to_dict(v, to_extend)
+
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_map, nullable)
+
+    @classmethod
+    def _read_map(cls, b, r):
+        size = cls.read_int(b)
+        the_dict = {}
+        while size > 0:
+            k = HashableDict.of(r.read_object(b))
+            v = r.read_object(b)
+            the_dict[k] = v
+            size = size - 1
+
+        return the_dict
+
+
+class UuidIO(_GraphBinaryTypeIO):
+
+    python_type = uuid.UUID
+    graphbinary_type = DataType.uuid
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(obj.bytes)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: uuid.UUID(bytes=b.read(16)), nullable)
+
+
+class EdgeIO(_GraphBinaryTypeIO):
+
+    python_type = Edge
+    graphbinary_type = DataType.edge
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+
+        writer.to_dict(obj.id, to_extend)
+        StringIO.dictify(obj.label, writer, to_extend, True, False)
+        writer.to_dict(obj.inV.id, to_extend)
+        StringIO.dictify(obj.inV.label, writer, to_extend, True, False)
+        writer.to_dict(obj.outV.id, to_extend)
+        StringIO.dictify(obj.outV.label, writer, to_extend, True, False)
+        to_extend.extend(NULL_BYTES)
+        to_extend.extend(NULL_BYTES)
+
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_edge, nullable)
+
+    @classmethod
+    def _read_edge(cls, b, r):
+        edgeid = r.read_object(b)
+        edgelbl = r.to_object(b, DataType.string, False)
+        inv = Vertex(r.read_object(b), r.to_object(b, DataType.string, False))
+        outv = Vertex(r.read_object(b), r.to_object(b, DataType.string, False))
+        b.read(2)
+        properties = r.read_object(b)
+        edge = Edge(edgeid, outv, edgelbl, inv, properties)
+        return edge
+
+
+class PathIO(_GraphBinaryTypeIO):
+
+    python_type = Path
+    graphbinary_type = DataType.path
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        writer.to_dict(obj.labels, to_extend)
+        writer.to_dict(obj.objects, to_extend)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: Path(r.read_object(b), r.read_object(b)), nullable)
+
+
+class PropertyIO(_GraphBinaryTypeIO):
+
+    python_type = Property
+    graphbinary_type = DataType.property
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        StringIO.dictify(obj.key, writer, to_extend, True, False)
+        writer.to_dict(obj.value, to_extend)
+        to_extend.extend(NULL_BYTES)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_property, nullable)
+
+    @classmethod
+    def _read_property(cls, b, r):
+        p = Property(r.to_object(b, DataType.string, False), r.read_object(b), None)
+        b.read(2)
+        return p
+
+
+class TinkerGraphIO(_GraphBinaryTypeIO):
+
+    python_type = Graph
+    graphbinary_type = DataType.graph
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        raise AttributeError("TinkerGraph serialization is not currently supported by gremlin-python")
+
+    @classmethod
+    def objectify(cls, b, reader, as_value=False):
+        raise AttributeError("TinkerGraph deserialization is not currently supported by gremlin-python")
+
+
+class VertexIO(_GraphBinaryTypeIO):
+
+    python_type = Vertex
+    graphbinary_type = DataType.vertex
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        writer.to_dict(obj.id, to_extend)
+        StringIO.dictify(obj.label, writer, to_extend, True, False)
+        to_extend.extend(NULL_BYTES)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_vertex, nullable)
+
+    @classmethod
+    def _read_vertex(cls, b, r):
+        vertex = Vertex(r.read_object(b), r.to_object(b, DataType.string, False), r.read_object(b))
+        return vertex
+
+
+class VertexPropertyIO(_GraphBinaryTypeIO):
+
+    python_type = VertexProperty
+    graphbinary_type = DataType.vertexproperty
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        writer.to_dict(obj.id, to_extend)
+        StringIO.dictify(obj.label, writer, to_extend, True, False)
+        writer.to_dict(obj.value, to_extend)
+        to_extend.extend(NULL_BYTES)
+        to_extend.extend(NULL_BYTES)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_vertexproperty, nullable)
+
+    @classmethod
+    def _read_vertexproperty(cls, b, r):
+        vp = VertexProperty(r.read_object(b), r.to_object(b, DataType.string, False), r.read_object(b), None)
+        b.read(2)
+        vp.properties = r.read_object(b)
+        return vp
+
+
+class _EnumIO(_GraphBinaryTypeIO):
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        StringIO.dictify(SymbolUtil.to_camel_case(str(obj.name)), writer, to_extend)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_enumval, nullable)
+
+    @classmethod
+    def _read_enumval(cls, b, r):
+        enum_name = r.to_object(b)
+        return cls.python_type[SymbolUtil.to_snake_case(enum_name)]
+
+
+class BarrierIO(_EnumIO):
+    graphbinary_type = DataType.barrier
+    python_type = Barrier
+
+
+class CardinalityIO(_EnumIO):
+    graphbinary_type = DataType.cardinality
+    python_type = Cardinality
+
+
+class ColumnIO(_EnumIO):
+    graphbinary_type = DataType.column
+    python_type = Column
+
+
+class DirectionIO(_EnumIO):
+    graphbinary_type = DataType.direction
+    python_type = Direction
+
+    @classmethod
+    def _read_enumval(cls, b, r):
+        # Direction needs to retain all CAPS. note that to_/from_ are really just aliases of IN/OUT
+        # so they don't need to be accounted for in serialization
+        enum_name = r.to_object(b)
+        return cls.python_type[enum_name]
+
+
+class OperatorIO(_EnumIO):
+    graphbinary_type = DataType.operator
+    python_type = Operator
+
+
+class OrderIO(_EnumIO):
+    graphbinary_type = DataType.order
+    python_type = Order
+
+
+class PickIO(_EnumIO):
+    graphbinary_type = DataType.pick
+    python_type = Pick
+
+
+class PopIO(_EnumIO):
+    graphbinary_type = DataType.pop
+    python_type = Pop
+
+
+class BindingIO(_GraphBinaryTypeIO):
+
+    python_type = Binding
+    graphbinary_type = DataType.binding
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        StringIO.dictify(obj.key, writer, to_extend, True, False)
+        writer.to_dict(obj.value, to_extend)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, lambda b, r: Binding(r.to_object(b, DataType.string, False),
+                                                              reader.read_object(b)), nullable)
+
+
+class BytecodeIO(_GraphBinaryTypeIO):
+    python_type = Bytecode
+    graphbinary_type = DataType.bytecode
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        # cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        bc = obj.bytecode if isinstance(obj, Traversal) else obj
+        to_extend.extend(int32_pack(len(bc.step_instructions)))
+        for inst in bc.step_instructions:
+            inst_name, inst_args = inst[0], inst[1:] if len(inst) > 1 else []
+            StringIO.dictify(inst_name, writer, to_extend, True, False)
+            to_extend.extend(int32_pack(len(inst_args)))
+            for arg in inst_args:
+                writer.to_dict(arg, to_extend)
+
+        to_extend.extend(int32_pack(len(bc.source_instructions)))
+        for inst in bc.source_instructions:
+            inst_name, inst_args = inst[0], inst[1:] if len(inst) > 1 else []
+            StringIO.dictify(inst_name, writer, to_extend, True, False)
+            to_extend.extend(int32_pack(len(inst_args)))
+            for arg in inst_args:
+                if isinstance(arg, TypeType):
+                    writer.to_dict(GremlinType(arg().fqcn), to_extend)
+                else:
+                    writer.to_dict(arg, to_extend)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_bytecode, nullable)
+
+    @classmethod
+    def _read_bytecode(cls, b, r):
+        bytecode = Bytecode()
+
+        step_count = cls.read_int(b)
+        ix = 0
+        while ix < step_count:
+            inst = [r.to_object(b, DataType.string, False)]
+            inst_ct = cls.read_int(b)
+            iy = 0
+            while iy < inst_ct:
+                inst.append(r.read_object(b))
+                iy += 1
+            bytecode.step_instructions.append(inst)
+            ix += 1
+
+        source_count = cls.read_int(b)
+        ix = 0
+        while ix < source_count:
+            inst = [r.to_object(b, DataType.string, False)]
+            inst_ct = cls.read_int(b)
+            iy = 0
+            while iy < inst_ct:
+                inst.append(r.read_object(b))
+                iy += 1
+            bytecode.source_instructions.append(inst)
+            ix += 1
+
+        return bytecode
+
+
+class TraversalIO(BytecodeIO):
+    python_type = GraphTraversal
+
+
+class LambdaSerializer(_GraphBinaryTypeIO):
+
+    python_type = FunctionType
+    graphbinary_type = DataType.lambda_
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+
+        lambda_result = obj()
+        script = lambda_result if isinstance(lambda_result, str) else lambda_result[0]
+        language = statics.default_lambda_language if isinstance(lambda_result, str) else lambda_result[1]
+
+        StringIO.dictify(language, writer, to_extend, True, False)
+
+        script_cleaned = script
+        script_args = -1
+
+        if language == "gremlin-groovy" and "->" in script:
+            # if the user has explicitly added parameters to the groovy closure then we can easily detect one or two
+            # arg lambdas - if we can't detect 1 or 2 then we just go with "unknown"
+            args = script[0:script.find("->")]
+            script_args = 2 if "," in args else 1
+
+        StringIO.dictify(script_cleaned, writer, to_extend, True, False)
+        to_extend.extend(int32_pack(script_args))
+
+        return to_extend
+
+
+class PSerializer(_GraphBinaryTypeIO):
+    graphbinary_type = DataType.p
+    python_type = P
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+
+        StringIO.dictify(obj.operator, writer, to_extend, True, False)
+
+        args = []
+        if obj.other is None:
+            if isinstance(obj.value, ListType):
+                args = obj.value
+            else:
+                args.append(obj.value)
+        else:
+            args.append(obj.value)
+            args.append(obj.other)
+
+        to_extend.extend(int32_pack(len(args)))
+        for a in args:
+            writer.to_dict(a, to_extend)
+
+        return to_extend
+
+
+class DTIO(_EnumIO):
+    graphbinary_type = DataType.dt
+    python_type = DT
+
+
+class MergeIO(_EnumIO):
+    graphbinary_type = DataType.merge
+    python_type = Merge
+
+
+class ScopeIO(_EnumIO):
+    graphbinary_type = DataType.scope
+    python_type = Scope
+
+
+class TIO(_EnumIO):
+    graphbinary_type = DataType.t
+    python_type = T
+
+
+class TraverserIO(_GraphBinaryTypeIO):
+    graphbinary_type = DataType.traverser
+    python_type = Traverser
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int64_pack(obj.bulk))
+        writer.to_dict(obj.object, to_extend)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_traverser, nullable)
+
+    @classmethod
+    def _read_traverser(cls, b, r):
+        bulk = int64_unpack(b.read(8))
+        obj = r.read_object(b)
+        return Traverser(obj, bulk=bulk)
+
+
+class ByteIO(_GraphBinaryTypeIO):
+    python_type = SingleByte
+    graphbinary_type = DataType.byte
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int8_pack(obj))
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader,
+                           lambda b, r: int.__new__(SingleByte, int8_unpack(b.read(1))),
+                           nullable)
+
+
+class ByteBufferIO(_GraphBinaryTypeIO):
+    python_type = ByteBufferType
+    graphbinary_type = DataType.bytebuffer
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int32_pack(len(obj)))
+        to_extend.extend(obj)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_bytebuffer, nullable)
+
+    @classmethod
+    def _read_bytebuffer(cls, b, r):
+        size = cls.read_int(b)
+        return ByteBufferType(b.read(size))
+
+
+class BooleanIO(_GraphBinaryTypeIO):
+    python_type = bool
+    graphbinary_type = DataType.boolean
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        to_extend.extend(int8_pack(0x01 if obj else 0x00))
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader,
+                           lambda b, r: True if int8_unpack(b.read(1)) == 0x01 else False,
+                           nullable)
+
+
+class TextPSerializer(_GraphBinaryTypeIO):
+    graphbinary_type = DataType.textp
+    python_type = TextP
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+
+        StringIO.dictify(obj.operator, writer, to_extend, True, False)
+
+        args = []
+        if obj.other is None:
+            if isinstance(obj.value, ListType):
+                args = obj.value
+            else:
+                args.append(obj.value)
+        else:
+            args.append(obj.value)
+            args.append(obj.other)
+
+        to_extend.extend(int32_pack(len(args)))
+        for a in args:
+            writer.to_dict(a, to_extend)
+
+        return to_extend
+
+
+class BulkSetDeserializer(_GraphBinaryTypeIO):
+
+    graphbinary_type = DataType.bulkset
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_bulkset, nullable)
+
+    @classmethod
+    def _read_bulkset(cls, b, r):
+        size = cls.read_int(b)
+        the_list = []
+        while size > 0:
+            itm = r.read_object(b)
+            bulk = int64_unpack(b.read(8))
+            for y in range(bulk):
+                the_list.append(itm)            
+            size = size - 1
+
+        return the_list
+
+
+class MetricsDeserializer(_GraphBinaryTypeIO):
+
+    graphbinary_type = DataType.metrics
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_metrics, nullable)
+
+    @classmethod
+    def _read_metrics(cls, b, r):
+        metricid = r.to_object(b, DataType.string, False)
+        name = r.to_object(b, DataType.string, False)
+        duration = r.to_object(b, DataType.long, nullable=False)
+        counts = r.to_object(b, DataType.map, nullable=False)
+        annotations = r.to_object(b, DataType.map, nullable=False)
+        metrics = r.to_object(b, DataType.list, nullable=False)
+
+        return {"id": metricid,
+                "name": name,
+                "dur": duration,
+                "counts": counts,
+                "annotations": annotations,
+                "metrics": metrics}
+
+
+class TraversalMetricsDeserializer(_GraphBinaryTypeIO):
+
+    graphbinary_type = DataType.traversalmetrics
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_traversalmetrics, nullable)
+
+    @classmethod
+    def _read_traversalmetrics(cls, b, r):
+        duration = r.to_object(b, DataType.long, nullable=False)
+        metrics = r.to_object(b, DataType.list, nullable=False)
+
+        return {"dur": duration,
+                "metrics": metrics}
+
+
+class ClassSerializer(_GraphBinaryTypeIO):
+    graphbinary_type = DataType.clazz
+    python_type = GremlinType
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        StringIO.dictify(obj.gremlin_type, writer, to_extend, True, False)
+        return to_extend
+
+
+class TraversalStrategySerializer(_GraphBinaryTypeIO):
+    graphbinary_type = DataType.traversalstrategy
+    python_type = TraversalStrategy
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+
+        ClassSerializer.dictify(GremlinType(obj.fqcn), writer, to_extend, True, False)
+        conf = {k: cls._convert(v) for k, v in obj.configuration.items()}
+        MapIO.dictify(conf, writer, to_extend, True, False)
+
+        return to_extend
+
+    @classmethod
+    def _convert(cls, v):
+        return v.bytecode if isinstance(v, Traversal) else v
+
+
+class DurationIO(_GraphBinaryTypeIO):
+    python_type = timedelta
+    graphbinary_type = DataType.duration
+
+    @classmethod
+    def dictify(cls, obj, writer, to_extend, as_value=False, nullable=True):
+        cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+        LongIO.dictify(obj.seconds, writer, to_extend, True, False)
+        IntIO.dictify(obj.microseconds * 1000, writer, to_extend, True, False)
+        return to_extend
+
+    @classmethod
+    def objectify(cls, buff, reader, nullable=True):
+        return cls.is_null(buff, reader, cls._read_duration, nullable)
+    
+    @classmethod
+    def _read_duration(cls, b, r):
+        seconds = r.to_object(b, DataType.long, False)
+        nanos = r.to_object(b, DataType.int, False)
+        return timedelta(seconds=seconds, microseconds=nanos / 1000)
+
+
+# class MarkerIO(_GraphBinaryTypeIO):
+#     python_type = SingleByte
+#     graphbinary_type = DataType.marker
+#
+#     @classmethod
+#     def dictify(cls, obj, writer, to_extend, as_value=True, nullable=True):
+#         cls.prefix_bytes(cls.graphbinary_type, as_value, nullable, to_extend)
+#         to_extend.extend(int8_pack(obj))
+#         return to_extend
+#
+#     @classmethod
+#     def objectify(cls, buff, reader, nullable=True):
+#         return cls.is_null(buff, reader,
+#                            lambda b, r: int.__new__(SingleByte, int8_unpack(b.read(1))),
+#                            nullable)

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV2d0.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV2d0.py
@@ -42,6 +42,7 @@ _serializers = OrderedDict()
 _deserializers = {}
 
 
+# TODO: to be removed
 class GraphSONTypeType(type):
     def __new__(mcs, name, bases, dct):
         cls = super(GraphSONTypeType, mcs).__new__(mcs, name, bases, dct)

--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV3d0.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphsonV3d0.py
@@ -43,6 +43,7 @@ _serializers = OrderedDict()
 _deserializers = {}
 
 
+# TODO: to be removed
 class GraphSONTypeType(type):
     def __new__(mcs, name, bases, dct):
         cls = super(GraphSONTypeType, mcs).__new__(mcs, name, bases, dct)

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -35,7 +35,7 @@ from gremlin_python.driver.driver_remote_connection import (
 from gremlin_python.driver.protocol import GremlinServerWSProtocol
 from gremlin_python.driver.serializer import (
     GraphSONMessageSerializer, GraphSONSerializersV2d0, GraphSONSerializersV3d0,
-    GraphBinarySerializersV1)
+    GraphBinarySerializersV1, GraphBinarySerializersV4)
 from gremlin_python.driver.aiohttp.transport import AiohttpTransport, AiohttpHTTPTransport
 
 gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
@@ -279,6 +279,11 @@ def remote_connection_graphsonV2(request):
 
         request.addfinalizer(fin)
         return remote_conn
+
+
+@pytest.fixture
+def graphbinary_serializer_v4(request):
+    return GraphBinarySerializersV4()
 
 
 @pytest.fixture

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -52,7 +52,7 @@ basic_url = gremlin_basic_auth_url.format(45941)
 kerberos_url = gremlin_server_url.format(45942)
 kerberized_service = 'test-service@{}'.format(kerberos_hostname)
 
-"""HTTP server testing"""
+"""HTTP server testing variables"""
 gremlin_server_url_http = os.environ.get('GREMLIN_SERVER_URL_HTTP', 'http://localhost:{}/')
 gremlin_basic_auth_url_http = os.environ.get('GREMLIN_SERVER_BASIC_AUTH_URL_HTTP', 'https://localhost:{}/')
 anonymous_url_http = gremlin_server_url_http.format(45940)
@@ -176,7 +176,7 @@ def authenticated_client(request):
 def remote_connection(request):
     try:
         if request.param == 'graphbinaryv1':
-            remote_conn = DriverRemoteConnection(anonymos_url, 'gmodern',
+            remote_conn = DriverRemoteConnection(anonymous_url, 'gmodern',
                                                  message_serializer=serializer.GraphBinarySerializersV1())
         elif request.param == 'graphsonv2':
             remote_conn = DriverRemoteConnection(anonymous_url, 'gmodern',

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -32,12 +32,14 @@ from gremlin_python.driver.connection import Connection
 from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import (
     DriverRemoteConnection)
-from gremlin_python.driver.protocol import GremlinServerWSProtocol
+from gremlin_python.driver.protocol import GremlinServerWSProtocol, GremlinServerHTTPProtocol
 from gremlin_python.driver.serializer import (
     GraphSONMessageSerializer, GraphSONSerializersV2d0, GraphSONSerializersV3d0,
     GraphBinarySerializersV1, GraphBinarySerializersV4)
 from gremlin_python.driver.aiohttp.transport import AiohttpTransport, AiohttpHTTPTransport
 
+
+# TODO: update or remove once all implementations are finalized
 gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
 gremlin_basic_auth_url = os.environ.get('GREMLIN_SERVER_BASIC_AUTH_URL', 'wss://localhost:{}/gremlin')
 gremlin_socket_server_url = os.environ.get('GREMLIN_SOCKET_SERVER_URL', 'ws://localhost:{}/gremlin')
@@ -48,12 +50,14 @@ kerberos_hostname = os.environ.get('KRB_HOSTNAME', socket.gethostname())
 anonymous_url = gremlin_server_url.format(45940)
 basic_url = gremlin_basic_auth_url.format(45941)
 kerberos_url = gremlin_server_url.format(45942)
-
 kerberized_service = 'test-service@{}'.format(kerberos_hostname)
+
+"""HTTP server testing"""
 gremlin_server_url_http = os.environ.get('GREMLIN_SERVER_URL_HTTP', 'http://localhost:{}/')
 gremlin_basic_auth_url_http = os.environ.get('GREMLIN_SERVER_BASIC_AUTH_URL_HTTP', 'https://localhost:{}/')
 anonymous_url_http = gremlin_server_url_http.format(45940)
 basic_url_http = gremlin_basic_auth_url_http.format(45941)
+
 verbose_logging = False
 
 logging.basicConfig(format='%(asctime)s [%(levelname)8s] [%(filename)15s:%(lineno)d - %(funcName)10s()] - %(message)s',
@@ -172,7 +176,7 @@ def authenticated_client(request):
 def remote_connection(request):
     try:
         if request.param == 'graphbinaryv1':
-            remote_conn = DriverRemoteConnection(anonymous_url, 'gmodern',
+            remote_conn = DriverRemoteConnection(anonymos_url, 'gmodern',
                                                  message_serializer=serializer.GraphBinarySerializersV1())
         elif request.param == 'graphsonv2':
             remote_conn = DriverRemoteConnection(anonymous_url, 'gmodern',
@@ -282,11 +286,6 @@ def remote_connection_graphsonV2(request):
 
 
 @pytest.fixture
-def graphbinary_serializer_v4(request):
-    return GraphBinarySerializersV4()
-
-
-@pytest.fixture
 def graphson_serializer_v2(request):
     return GraphSONSerializersV2d0()
 
@@ -301,18 +300,76 @@ def graphbinary_serializer_v1(request):
     return GraphBinarySerializersV1()
 
 
-@pytest.fixture(params=['graphsonv2', 'graphsonv3', 'graphbinaryv1'])
+"""
+Tests below are for the HTTP server with GraphBinaryV4
+"""
+@pytest.fixture
+def connection_http(request):
+    protocol = GremlinServerHTTPProtocol(
+        GraphBinarySerializersV4(),
+        username='stephen', password='password')
+    executor = concurrent.futures.ThreadPoolExecutor(5)
+    pool = queue.Queue()
+    try:
+        conn = Connection(anonymous_url_http, 'gmodern', protocol,
+                          lambda: AiohttpHTTPTransport(), executor, pool)
+    except OSError:
+        executor.shutdown()
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            executor.shutdown()
+            conn.close()
+
+        request.addfinalizer(fin)
+        return conn
+
+
+@pytest.fixture
+def client_http(request):
+    try:
+        client = Client(anonymous_url_http, 'gmodern')
+    except OSError:
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            client.close()
+
+        request.addfinalizer(fin)
+        return client
+
+
+@pytest.fixture(params=['basic'])
+def authenticated_client_http(request):
+    try:
+        if request.param == 'basic':
+            # turn off certificate verification for testing purposes only
+            ssl_opts = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            ssl_opts.verify_mode = ssl.CERT_NONE
+            client = Client(basic_url_http, 'gmodern', username='stephen', password='password',
+                            transport_factory=lambda: AiohttpHTTPTransport(ssl_options=ssl_opts))
+        else:
+            raise ValueError("Invalid authentication option - " + request.param)
+    except OSError:
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            client.close()
+
+        request.addfinalizer(fin)
+        return client
+
+
+@pytest.fixture
+def graphbinary_serializer_v4(request):
+    return GraphBinarySerializersV4()
+
+
+@pytest.fixture(params=['graphbinaryv4'])
 def remote_connection_http(request):
     try:
-        if request.param == 'graphbinaryv1':
-            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gmodern',
-                                                 message_serializer=serializer.GraphBinarySerializersV1())
-        elif request.param == 'graphsonv2':
-            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gmodern',
-                                                 message_serializer=serializer.GraphSONSerializersV2d0())
-        elif request.param == 'graphsonv3':
-            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gmodern',
-                                                 message_serializer=serializer.GraphSONSerializersV3d0())
+        if request.param == 'graphbinaryv4':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gmodern')
         else:
             raise ValueError("Invalid serializer option - " + request.param)
     except OSError:
@@ -325,10 +382,24 @@ def remote_connection_http(request):
         return remote_conn
 
 
-"""
-# The WsAndHttpChannelizer somehow does not distinguish the ssl handlers so authenticated https remote connection will
-# only work with HttpChannelizer that is currently not in the testing set up, thus this is commented out for now
+@pytest.fixture(params=['graphbinaryv4'])
+def remote_connection_http_crew(request):
+    try:
+        if request.param == 'graphbinaryv4':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'gcrew')
+        else:
+            raise ValueError("Invalid serializer option - " + request.param)
+    except OSError:
+        pytest.skip('Gremlin Server is not running')
+    else:
+        def fin():
+            remote_conn.close()
 
+        request.addfinalizer(fin)
+        return remote_conn
+
+
+# TODO: revisit once auth is updated
 @pytest.fixture(params=['basic'])
 def remote_connection_http_authenticated(request):
     try:
@@ -338,7 +409,6 @@ def remote_connection_http_authenticated(request):
             ssl_opts.verify_mode = ssl.CERT_NONE
             remote_conn = DriverRemoteConnection(basic_url_http, 'gmodern',
                                                  username='stephen', password='password',
-                                                 message_serializer=serializer.GraphSONSerializersV2d0(),
                                                  transport_factory=lambda: AiohttpHTTPTransport(ssl_options=ssl_opts))
         else:
             raise ValueError("Invalid authentication option - " + request.param)
@@ -350,18 +420,13 @@ def remote_connection_http_authenticated(request):
 
         request.addfinalizer(fin)
         return remote_conn
-"""
 
 
-@pytest.fixture(params=['graphsonv3', 'graphbinaryv1'])
+@pytest.fixture(params=['graphbinaryv4'])
 def invalid_alias_remote_connection_http(request):
     try:
-        if request.param == 'graphbinaryv1':
-            remote_conn = DriverRemoteConnection(anonymous_url_http, 'does_not_exist',
-                                                 message_serializer=serializer.GraphBinarySerializersV1())
-        elif request.param == 'graphsonv3':
-            remote_conn = DriverRemoteConnection(anonymous_url_http, 'does_not_exist',
-                                                 message_serializer=serializer.GraphSONSerializersV3d0())
+        if request.param == 'graphbinaryv4':
+            remote_conn = DriverRemoteConnection(anonymous_url_http, 'does_not_exist')
         else:
             raise ValueError("Invalid serializer option - " + request.param)
     except OSError:

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -351,7 +351,7 @@ def test_client_bytecode_with_bigint(client_http):
 
 def test_big_result_set(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
-    t = g.inject(1).repeat(__.add_V('person').property('name', __.loops())).times(20000).count()
+    t = g.inject(1).repeat(__.add_v('person').property('name', __.loops())).times(20000).count()
     message = create_basic_request_message(t, source='g')
     result_set = client_http.submit(message)
     results = []

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -74,6 +74,14 @@ def test_client_message_too_big(client_http):
         client_http.close()
 
 
+def test_client_script_submission(client_http):
+    assert len(client_http.submit("new int[100]").all().result()) == 100
+
+
+def test_client_script_submission_inject(client_http):
+    assert len(client_http.submit("g.inject(new int[100])").all().result()) == 100
+
+
 def test_client_simple_eval(client_http):
     assert client_http.submit('1 + 1').all().result()[0] == 2
 

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -21,29 +21,35 @@ import os
 import threading
 import uuid
 
+import pytest
 from gremlin_python.driver import serializer
 from gremlin_python.driver.client import Client
 from gremlin_python.driver.protocol import GremlinServerError
-from gremlin_python.driver.request import RequestMessage
+from gremlin_python.driver.request import RequestMessageV4
 from gremlin_python.process.graph_traversal import __, GraphTraversalSource
 from gremlin_python.process.traversal import TraversalStrategies
 from gremlin_python.process.strategies import OptionsStrategy
 from gremlin_python.structure.graph import Graph, Vertex
-from gremlin_python.driver.aiohttp.transport import AiohttpTransport
+from gremlin_python.driver.aiohttp.transport import AiohttpTransport, AiohttpHTTPTransport
 from gremlin_python.statics import *
 from asyncio import TimeoutError
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
-gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
-test_no_auth_url = gremlin_server_url.format(45940)
+gremlin_server_url_http = os.environ.get('GREMLIN_SERVER_URL_HTTP', 'http://localhost:{}/')
+test_no_auth_http_url = gremlin_server_url_http.format(45940)
 
 
-def test_connection(connection):
+def create_basic_request_message(traversal, source='gmodern', type='bytecode'):
+    return RequestMessageV4(fields={'g': source, 'gremlinType': type}, gremlin=traversal.bytecode)
+
+
+@pytest.mark.skip(reason="needs additional updates")
+def test_connection(connection_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    results_set = connection.write(message).result()
+    message = create_basic_request_message(t)
+    results_set = connection_http.write(message).result()
     future = results_set.all()
     results = future.result()
     assert len(results) == 6
@@ -52,37 +58,39 @@ def test_connection(connection):
     assert 'host' in results_set.status_attributes
 
 
-def test_client_message_too_big(client):
+@pytest.mark.skip(reason="needs additional updates")
+def test_client_message_too_big(client_http):
     try:
-        client = Client(test_no_auth_url, 'g', max_content_length=4096)
-        client.submit("\" \"*8000").all().result()
+        client_http = Client(test_no_auth_http_url, 'g', max_content_length=4096)
+        client_http.submit("\" \"*8000").all().result()
         assert False
     except Exception as ex:
         assert ex.args[0].startswith("Received error on read: 'Message size") \
                and ex.args[0].endswith("exceeds limit 4096'")
 
         # confirm the client instance is still usable and not closed
-        assert ["test"] == client.submit("'test'").all().result()
+        assert ["test"] == client_http.submit("'test'").all().result()
     finally:
-        client.close()
+        client_http.close()
 
 
-def test_client_simple_eval(client):
-    assert client.submit('1 + 1').all().result()[0] == 2
+def test_client_simple_eval(client_http):
+    assert client_http.submit('1 + 1').all().result()[0] == 2
 
 
-def test_client_simple_eval_bindings(client):
-    assert client.submit('x + x', {'x': 2}).all().result()[0] == 4
+def test_client_simple_eval_bindings(client_http):
+    assert client_http.submit('x + x', {'x': 2}).all().result()[0] == 4
 
 
-def test_client_eval_traversal(client):
-    assert len(client.submit('g.V()').all().result()) == 6
+def test_client_eval_traversal(client_http):
+    assert len(client_http.submit('g.V()').all().result()) == 6
 
 
-def test_client_error(client):
+@pytest.mark.skip(reason="needs additional updates")
+def test_client_error(client_http):
     try:
         # should fire an exception
-        client.submit('1/0').all().result()
+        client_http.submit('1/0').all().result()
         assert False
     except GremlinServerError as ex:
         assert 'exceptions' in ex.status_attributes
@@ -90,65 +98,66 @@ def test_client_error(client):
         assert str(ex) == f"{ex.status_code}: {ex.status_message}"
 
     # still can submit after failure
-    assert client.submit('x + x', {'x': 2}).all().result()[0] == 4
+    assert client_http.submit('x + x', {'x': 2}).all().result()[0] == 4
 
 
-def test_client_connection_pool_after_error(client):
+@pytest.mark.skip(reason="needs additional updates")
+def test_client_connection_pool_after_error(client_http):
     # Overwrite fixture with pool_size=1 client
-    client = Client(test_no_auth_url, 'gmodern', pool_size=1)
+    client_http = Client(test_no_auth_http_url, 'gmodern', pool_size=1)
 
     try:
         # should fire an exception
-        client.submit('1/0').all().result()
+        client_http.submit('1/0').all().result()
         assert False
     except GremlinServerError as gse:
         # expecting the pool size to be 1 again after query returned
         assert gse.status_code == 597
-        assert client.available_pool_size == 1
+        assert client_http.available_pool_size == 1
 
     # still can submit after failure
-    assert client.submit('x + x', {'x': 2}).all().result()[0] == 4
+    assert client_http.submit('x + x', {'x': 2}).all().result()[0] == 4
 
 
-def test_client_no_hang_if_submit_on_closed(client):
-    assert client.submit('1 + 1').all().result()[0] == 2
-    client.close()
+def test_client_no_hang_if_submit_on_closed(client_http):
+    assert client_http.submit('1 + 1').all().result()[0] == 2
+    client_http.close()
     try:
         # should fail since not hang if closed
-        client.submit('1 + 1').all().result()
+        client_http.submit('1 + 1').all().result()
         assert False
     except Exception as ex:
         assert True
 
 
-def test_client_close_all_connection_in_pool(client):
-    client = Client(test_no_auth_url, 'g', pool_size=1, session="75e9620e-da98-41e3-9378-0336db803de0")
-    assert client.available_pool_size == 1
-    client.submit('2+2').all().result()
-    client.close()
-    assert client.available_pool_size == 0
+def test_client_close_all_connection_in_pool(client_http):
+    client_http = Client(test_no_auth_http_url, 'g', pool_size=1)
+    assert client_http.available_pool_size == 1
+    client_http.submit('2+2').all().result()
+    client_http.close()
+    assert client_http.available_pool_size == 0
 
 
-def test_client_side_timeout_set_for_aiohttp(client):
-    client = Client(test_no_auth_url, 'gmodern',
-                    transport_factory=lambda: AiohttpTransport(read_timeout=1, write_timeout=1))
+def test_client_side_timeout_set_for_aiohttp(client_http):
+    client_http = Client(test_no_auth_http_url, 'gmodern',
+                         transport_factory=lambda: AiohttpHTTPTransport(read_timeout=1, write_timeout=1))
 
     try:
         # should fire an exception
-        client.submit('Thread.sleep(2000);1').all().result()
+        client_http.submit('Thread.sleep(2000);1').all().result()
         assert False
     except TimeoutError as err:
         # asyncio TimeoutError has no message.
         assert str(err) == ""
 
     # still can submit after failure
-    assert client.submit('x + x', {'x': 2}).all().result()[0] == 4
+    assert client_http.submit('x + x', {'x': 2}).all().result()[0] == 4
 
 
 async def async_connect(enable):
     try:
-        transport = AiohttpTransport(call_from_event_loop=enable)
-        transport.connect(test_no_auth_url)
+        transport = AiohttpHTTPTransport(call_from_event_loop=enable)
+        transport.connect(test_no_auth_http_url)
         transport.close()
         return True
     except RuntimeError:
@@ -160,8 +169,8 @@ def test_from_event_loop():
     assert asyncio.get_event_loop().run_until_complete(async_connect(True))
 
 
-def test_client_gremlin(client):
-    result_set = client.submit('g.V(1)')
+def test_client_gremlin(client_http):
+    result_set = client_http.submit('g.V(1)')
     result = result_set.all().result()
     assert 1 == len(result)
     vertex = result[0]
@@ -171,7 +180,7 @@ def test_client_gremlin(client):
     assert 'name' == vertex.properties[0].key
     assert 'marko' == vertex.properties[0].value
     ##
-    result_set = client.submit('g.with("materializeProperties", "tokens").V(1)')
+    result_set = client_http.submit('g.with("materializeProperties", "tokens").V(1)')
     result = result_set.all().result()
     assert 1 == len(result)
     vertex = result[0]
@@ -179,58 +188,58 @@ def test_client_gremlin(client):
     assert 0 == len(vertex.properties)
 
 
-def test_client_bytecode(client):
+def test_client_bytecode(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t)
+    result_set = client_http.submit(message)
     assert len(result_set.all().result()) == 6
 
 
-def test_client_bytecode_options(client):
+def test_client_bytecode_options(client_http):
     # smoke test to validate serialization of OptionsStrategy. no way to really validate this from an integration
     # test perspective because there's no way to access the internals of the strategy via bytecode
     g = GraphTraversalSource(Graph(), TraversalStrategies())
-    t = g.withStrategies(OptionsStrategy(options={"x": "test", "y": True})).V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    result_set = client.submit(message)
+    t = g.with_strategies(OptionsStrategy(options={"x": "test", "y": True})).V()
+    message = create_basic_request_message(t)
+    result_set = client_http.submit(message)
     assert len(result_set.all().result()) == 6
     ##
     t = g.with_("x", "test").with_("y", True).V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t)
+    result_set = client_http.submit(message)
     assert len(result_set.all().result()) == 6
 
 
-def test_iterate_result_set(client):
+def test_iterate_result_set(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t)
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 6
 
 
-def test_client_async(client):
+def test_client_async(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    future = client.submit_async(message)
+    message = create_basic_request_message(t)
+    future = client_http.submit_async(message)
     result_set = future.result()
     assert len(result_set.all().result()) == 6
 
 
-def test_connection_share(client):
+def test_connection_share(client_http):
     # Overwrite fixture with pool_size=1 client
-    client = Client(test_no_auth_url, 'gmodern', pool_size=1)
+    client_http = Client(test_no_auth_http_url, 'gmodern', pool_size=1)
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    message2 = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    future = client.submit_async(message)
-    future2 = client.submit_async(message2)
+    message = create_basic_request_message(t)
+    message2 = create_basic_request_message(t)
+    future = client_http.submit_async(message)
+    future2 = client_http.submit_async(message2)
 
     result_set2 = future2.result()
     assert len(result_set2.all().result()) == 6
@@ -241,14 +250,14 @@ def test_connection_share(client):
     assert len(result_set.all().result()) == 6
 
 
-def test_multi_conn_pool(client):
+def test_multi_conn_pool(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    message2 = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    client = Client(test_no_auth_url, 'g', pool_size=1)
-    future = client.submit_async(message)
-    future2 = client.submit_async(message2)
+    message = create_basic_request_message(t)
+    message2 = create_basic_request_message(t)
+    client_http = Client(test_no_auth_http_url, 'g', pool_size=1)
+    future = client_http.submit_async(message)
+    future2 = client_http.submit_async(message2)
 
     result_set2 = future2.result()
     assert len(result_set2.all().result()) == 6
@@ -258,7 +267,7 @@ def test_multi_conn_pool(client):
     assert len(result_set.all().result()) == 6
 
 
-def test_multi_thread_pool(client):
+def test_multi_thread_pool(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     traversals = [g.V(),
                   g.V().count(),
@@ -272,10 +281,10 @@ def test_multi_thread_pool(client):
     condition = threading.Condition()
 
     def thread_run(tr, result_list):
-        message = RequestMessage('traversal', 'bytecode', {'gremlin': tr.bytecode, 'aliases': {'g': 'gmodern'}})
+        message = create_basic_request_message(tr)
         with condition:
             condition.wait(5)
-        result_set = client.submit(message)
+        result_set = client_http.submit(message)
         for result in result_set:
             result_list.append(result)
 
@@ -298,207 +307,184 @@ def test_multi_thread_pool(client):
     assert len(results[2][0]) == 6
     assert results[3][0][0].object == 6
 
-def test_client_bytecode_with_short(client):
+
+def test_client_bytecode_with_short(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V().has('age', short(16)).count()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t)
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 1
 
-def test_client_bytecode_with_long(client):
+
+def test_client_bytecode_with_long(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V().has('age', long(851401972585122)).count()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t)
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 1
 
 
-def test_client_bytecode_with_bigint(client):
+def test_client_bytecode_with_bigint(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V().has('age', bigint(0x1000_0000_0000_0000_0000)).count()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t)
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 1
 
 
-def test_multi_request_in_session(client):
-    # Overwrite fixture with session client
-    session_id = str(uuid.uuid4())
-    client = Client(test_no_auth_url, 'g', session=session_id)
-
-    assert client.submit('x = 1').all().result()[0] == 1
-    assert client.submit('x + 2').all().result()[0] == 3
-
-    client.close()
-
-    # attempt reconnect to session and make sure "x" is no longer a thing
-    client = Client(test_no_auth_url, 'g', session=session_id)
-    try:
-        # should fire an exception
-        client.submit('x').all().result()
-        assert False
-    except Exception:
-        assert True
-
-
-def test_client_pool_in_session(client):
-    # Overwrite fixture with pool_size=2 client
-    try:
-        # should fire an exception
-        client = Client(test_no_auth_url, 'g', session=str(uuid.uuid4()), pool_size=2)
-        assert False
-    except Exception:
-        assert True
-
-
-def test_big_result_set(client):
+def test_big_result_set(client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
-    t = g.inject(1).repeat(__.addV('person').property('name', __.loops())).times(20000).count()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = client.submit(message)
+    t = g.inject(1).repeat(__.add_V('person').property('name', __.loops())).times(20000).count()
+    message = create_basic_request_message(t, source='g')
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 1
 
     t = g.V().limit(10)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t, source='g')
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 10
 
     t = g.V().limit(100)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t, source='g')
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 100
 
     t = g.V().limit(1000)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = client.submit(message)
+    message = create_basic_request_message(t, source='g')
+    result_set = client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 1000
 
-    t = g.V().limit(10000)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = client.submit(message)
-    results = []
-    for result in result_set:
-        results += result
-    assert len(results) == 10000
+    # TODO: enable after setting up docker for GitHub or cleaning up server-side locally
+    # t = g.V().limit(10000)
+    # message = create_basic_request_message(t, source='g')
+    # result_set = client_http.submit(message)
+    # results = []
+    # for result in result_set:
+    #     results += result
+    # assert len(results) == 10000
 
 
-def test_big_result_set_secure(authenticated_client):
+@pytest.mark.skip(reason="enable after making sure authenticated testing server is set up in docker")
+def test_big_result_set_secure(authenticated_client_http):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
-    t = g.inject(1).repeat(__.addV('person').property('name', __.loops())).times(20000).count()
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = authenticated_client.submit(message)
+    t = g.inject(1).repeat(__.add_v('person').property('name', __.loops())).times(20000).count()
+    message = create_basic_request_message(t, source='g')
+    result_set = authenticated_client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 1
 
     t = g.V().limit(10)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = authenticated_client.submit(message)
+    message = create_basic_request_message(t, source='g')
+    result_set = authenticated_client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 10
 
     t = g.V().limit(100)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = authenticated_client.submit(message)
+    message = create_basic_request_message(t, source='g')
+    result_set = authenticated_client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 100
 
     t = g.V().limit(1000)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = authenticated_client.submit(message)
+    message = create_basic_request_message(t, source='g')
+    result_set = authenticated_client_http.submit(message)
     results = []
     for result in result_set:
         results += result
     assert len(results) == 1000
 
-    t = g.V().limit(10000)
-    message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
-    result_set = authenticated_client.submit(message)
-    results = []
-    for result in result_set:
-        results += result
-    assert len(results) == 10000
+    # TODO: enable after setting up docker for GitHub or cleaning up server-side locally
+    # t = g.V().limit(10000)
+    # message = create_basic_request_message(t, source='g')
+    # result_set = authenticated_client_http.submit(message)
+    # results = []
+    # for result in result_set:
+    #     results += result
+    # assert len(results) == 10000
 
 
 async def asyncio_func():
     return 1
 
 
-def test_asyncio(client):
+def test_asyncio(client_http):
     try:
         asyncio.get_event_loop().run_until_complete(asyncio_func())
     except RuntimeError:
         assert False
 
 
-def test_client_custom_invalid_request_id_graphson_script(client):
-    client = Client(test_no_auth_url, 'gmodern', message_serializer=serializer.GraphSONSerializersV3d0())
+# TODO: tests pass because requestID is now generated on HTTP server and this option gets ignored, tests to be removed
+#  or updated depending on if we still want to use requestID or not
+def test_client_custom_invalid_request_id_graphson_script(client_http):
+    client = Client(test_no_auth_http_url, 'gmodern')
     try:
-        client.submit('g.V()', request_options={"requestId":"malformed"}).all().result()
+        client.submit('g.V()', request_options={"requestId": "malformed"}).all().result()
     except Exception as ex:
         assert "badly formed hexadecimal UUID string" in str(ex)
 
 
-def test_client_custom_invalid_request_id_graphbinary_script(client):
-    client = Client(test_no_auth_url, 'gmodern', message_serializer=serializer.GraphBinarySerializersV1())
+def test_client_custom_invalid_request_id_graphbinary_script(client_http):
+    client_http = Client(test_no_auth_http_url, 'gmodern')
     try:
-        client.submit('g.V()', request_options={"requestId":"malformed"}).all().result()
+        client_http.submit('g.V()', request_options={"requestId": "malformed"}).all().result()
     except Exception as ex:
         assert "badly formed hexadecimal UUID string" in str(ex)
 
 
-def test_client_custom_valid_request_id_script_uuid(client):
-    assert len(client.submit('g.V()', request_options={"requestId":uuid.uuid4()}).all().result()) == 6
+def test_client_custom_valid_request_id_script_uuid(client_http):
+    assert len(client_http.submit('g.V()', request_options={"requestId": uuid.uuid4()}).all().result()) == 6
 
 
-def test_client_custom_valid_request_id_script_string(client):
-    assert len(client.submit('g.V()', request_options={"requestId":str(uuid.uuid4())}).all().result()) == 6
+def test_client_custom_valid_request_id_script_string(client_http):
+    assert len(client_http.submit('g.V()', request_options={"requestId": str(uuid.uuid4())}).all().result()) == 6
 
 
-def test_client_custom_invalid_request_id_graphson_bytecode(client):
-    client = Client(test_no_auth_url, 'gmodern', message_serializer=serializer.GraphSONSerializersV3d0())
+def test_client_custom_invalid_request_id_graphson_bytecode(client_http):
+    client_http = Client(test_no_auth_http_url, 'gmodern')
     query = GraphTraversalSource(Graph(), TraversalStrategies()).V().bytecode
     try:
-        client.submit(query, request_options={"requestId":"malformed"}).all().result()
+        client_http.submit(query, request_options={"requestId": "malformed"}).all().result()
     except Exception as ex:
         assert "badly formed hexadecimal UUID string" in str(ex)
 
 
-def test_client_custom_invalid_request_id_graphbinary_bytecode(client):
-    client = Client(test_no_auth_url, 'gmodern', message_serializer=serializer.GraphBinarySerializersV1())
+def test_client_custom_invalid_request_id_graphbinary_bytecode(client_http):
+    client_http = Client(test_no_auth_http_url, 'gmodern')
     query = GraphTraversalSource(Graph(), TraversalStrategies()).V().bytecode
     try:
-        client.submit(query, request_options={"requestId":"malformed"}).all().result()
+        client_http.submit(query, request_options={"requestId": "malformed"}).all().result()
     except Exception as ex:
         assert "badly formed hexadecimal UUID string" in str(ex)
 
 
-def test_client_custom_valid_request_id_bytecode(client):
+def test_client_custom_valid_request_id_bytecode(client_http):
     query = GraphTraversalSource(Graph(), TraversalStrategies()).V().bytecode
-    assert len(client.submit(query).all().result()) == 6
+    assert len(client_http.submit(query).all().result()) == 6

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -18,6 +18,7 @@
 #
 import os
 
+import pytest
 from gremlin_python import statics
 from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.statics import long
@@ -37,6 +38,9 @@ __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
 test_no_auth_url = gremlin_server_url.format(45940)
 
+
+# TODO: WS tests to be removed
+@pytest.mark.skip(reason="disabling all WS tests as we move to HTTP")
 class TestDriverRemoteConnection(object):
     def test_traversals(self, remote_connection):
         statics.load_statics(globals())

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_threaded.py
@@ -17,7 +17,6 @@
 # under the License.
 #
 import concurrent.futures
-import os
 import sys
 import queue
 from threading import Thread
@@ -28,10 +27,11 @@ from gremlin_python.process.anonymous_traversal import traversal
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
-gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
-test_no_auth_url = gremlin_server_url.format(45940)
+gremlin_server_url_http = 'http://localhost:{}'
+test_no_auth_http_url = gremlin_server_url_http.format(45940)
 
-def test_conns_in_threads(remote_connection):
+
+def test_conns_in_threads(remote_connection_http):
     q = queue.Queue()
     child = Thread(target=_executor, args=(q, None))
     child2 = Thread(target=_executor, args=(q, None))
@@ -44,10 +44,10 @@ def test_conns_in_threads(remote_connection):
     child2.join()
 
 
-def test_conn_in_threads(remote_connection):
+def test_conn_in_threads(remote_connection_http):
     q = queue.Queue()
-    child = Thread(target=_executor, args=(q, remote_connection))
-    child2 = Thread(target=_executor, args=(q, remote_connection))
+    child = Thread(target=_executor, args=(q, remote_connection_http))
+    child2 = Thread(target=_executor, args=(q, remote_connection_http))
     child.start()
     child2.start()
     for x in range(2):
@@ -62,7 +62,7 @@ def _executor(q, conn):
     if not conn:
         # This isn't a fixture so close manually
         close = True
-        conn = DriverRemoteConnection(test_no_auth_url, 'gmodern', pool_size=4)
+        conn = DriverRemoteConnection(test_no_auth_http_url, 'gmodern', pool_size=4)
     try:
         g = traversal().with_(conn)
         future = g.V().promise()
@@ -79,7 +79,7 @@ def _executor(q, conn):
 
 def handle_request():
     try:
-        remote_connection = DriverRemoteConnection(test_no_auth_url, "g")
+        remote_connection = DriverRemoteConnection(test_no_auth_http_url, "gmodern")
         g = traversal().with_(remote_connection)
         g.V().limit(1).toList()
         remote_connection.close()

--- a/gremlin-python/src/main/python/tests/driver/test_serializer.py
+++ b/gremlin-python/src/main/python/tests/driver/test_serializer.py
@@ -19,6 +19,7 @@
 from gremlin_python.structure.io import graphsonV2d0
 from gremlin_python.structure.io import graphsonV3d0
 from gremlin_python.structure.io import graphbinaryV1
+from gremlin_python.structure.io import graphbinaryV4
 
 
 __author__ = 'David M. Brown'
@@ -43,3 +44,10 @@ def test_graphbinary_serializer_v1(graphbinary_serializer_v1):
     assert isinstance(graphbinary_serializer_v1._graphbinary_reader, graphbinaryV1.GraphBinaryReader)
     assert isinstance(graphbinary_serializer_v1.standard._writer, graphbinaryV1.GraphBinaryWriter)
     assert isinstance(graphbinary_serializer_v1.traversal._writer, graphbinaryV1.GraphBinaryWriter)
+
+
+def test_graphbinary_serializer_v4(graphbinary_serializer_v4):
+    assert graphbinary_serializer_v4.version == b"application/vnd.graphbinary-v4.0"
+    assert isinstance(graphbinary_serializer_v4._graphbinary_reader, graphbinaryV4.GraphBinaryReader)
+    assert isinstance(graphbinary_serializer_v4.standard._writer, graphbinaryV4.GraphBinaryWriter)
+    assert isinstance(graphbinary_serializer_v4.traversal._writer, graphbinaryV4.GraphBinaryWriter)

--- a/gremlin-python/src/main/python/tests/driver/test_serializer.py
+++ b/gremlin-python/src/main/python/tests/driver/test_serializer.py
@@ -16,34 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from gremlin_python.structure.io import graphsonV2d0
-from gremlin_python.structure.io import graphsonV3d0
-from gremlin_python.structure.io import graphbinaryV1
 from gremlin_python.structure.io import graphbinaryV4
 
 
 __author__ = 'David M. Brown'
-
-
-def test_graphson_serializer_v2(graphson_serializer_v2):
-    assert graphson_serializer_v2.version == b"application/vnd.gremlin-v2.0+json"
-    assert isinstance(graphson_serializer_v2._graphson_reader, graphsonV2d0.GraphSONReader)
-    assert isinstance(graphson_serializer_v2.standard._writer, graphsonV2d0.GraphSONWriter)
-    assert isinstance(graphson_serializer_v2.traversal._writer, graphsonV2d0.GraphSONWriter)
-
-
-def test_graphson_serializer_v3(graphson_serializer_v3):
-    assert graphson_serializer_v3.version == b"application/vnd.gremlin-v3.0+json"
-    assert isinstance(graphson_serializer_v3._graphson_reader, graphsonV3d0.GraphSONReader)
-    assert isinstance(graphson_serializer_v3.standard._writer, graphsonV3d0.GraphSONWriter)
-    assert isinstance(graphson_serializer_v3.traversal._writer, graphsonV3d0.GraphSONWriter)
-
-
-def test_graphbinary_serializer_v1(graphbinary_serializer_v1):
-    assert graphbinary_serializer_v1.version == b"application/vnd.graphbinary-v1.0"
-    assert isinstance(graphbinary_serializer_v1._graphbinary_reader, graphbinaryV1.GraphBinaryReader)
-    assert isinstance(graphbinary_serializer_v1.standard._writer, graphbinaryV1.GraphBinaryWriter)
-    assert isinstance(graphbinary_serializer_v1.traversal._writer, graphbinaryV1.GraphBinaryWriter)
 
 
 def test_graphbinary_serializer_v4(graphbinary_serializer_v4):

--- a/gremlin-python/src/main/python/tests/driver/test_web_socket_client_behavior.py
+++ b/gremlin-python/src/main/python/tests/driver/test_web_socket_client_behavior.py
@@ -23,14 +23,18 @@ __author__ = 'Cole Greer (cole@colegreer.ca)'
 import re
 import operator
 from functools import reduce
+
+import pytest
 from gremlin_python.driver import useragent
 
 
+# TODO: remove or modify after implementing equivalent support in HTTP server
 # Note: This test demonstrates different behavior in response to a server sending a close frame than the other GLV's.
 # Other GLV's will respond to this by trying to reconnect. This test is also demonstrating incorrect behavior of
 # client.is_closed() as it appears unaware that the event loop is dead.
 # These differences from other GLV's are being tracked in [TINKERPOP-2846]. If this behavior is changed to resemble
 # other GLV's, this test should be updated to show a vertex is being received by the second request.
+@pytest.mark.skip(reason="not implemented in HTTP & need to check on server side")
 def test_does_not_create_new_connection_if_closed_by_server(socket_server_client, socket_server_settings):
     try:
         socket_server_client.submit(

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -20,13 +20,13 @@ under the License.
 import datetime
 import uuid
 
-from gremlin_python.driver.serializer import GraphSONSerializersV2d0, GraphBinarySerializersV1
+from gremlin_python.driver.serializer import GraphBinarySerializersV4
 from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.statics import *
 
 
-def test_vertex(remote_connection):
-    g = traversal().with_(remote_connection)
+def test_vertex(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
     vertex = g.V(1).next()
     assert vertex.id == 1
     assert vertex.label == 'person'
@@ -37,8 +37,8 @@ def test_vertex(remote_connection):
     assert vertex.properties[1].value == 29
 
 
-def test_vertex_without_properties(remote_connection):
-    g = traversal().with_(remote_connection)
+def test_vertex_without_properties(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
     vertex = g.with_('materializeProperties', 'tokens').V(1).next()
     assert vertex.id == 1
     assert vertex.label == 'person'
@@ -46,8 +46,8 @@ def test_vertex_without_properties(remote_connection):
     assert vertex.properties is None or len(vertex.properties) == 0
 
 
-def test_edge(remote_connection):
-    g = traversal().with_(remote_connection)
+def test_edge(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
     edge = g.E(7).next()
     assert edge.id == 7
     assert edge.label == 'knows'
@@ -56,8 +56,8 @@ def test_edge(remote_connection):
     assert edge.properties[0].value == 0.5
 
 
-def test_edge_without_properties(remote_connection):
-    g = traversal().with_(remote_connection)
+def test_edge_without_properties(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
     edge = g.with_('materializeProperties', 'tokens').E(7).next()
     assert edge.id == 7
     assert edge.label == 'knows'
@@ -65,8 +65,8 @@ def test_edge_without_properties(remote_connection):
     assert edge.properties is None or len(edge.properties) == 0
 
 
-def test_vertex_vertex_properties(remote_connection_crew):
-    g = traversal().with_(remote_connection_crew)
+def test_vertex_vertex_properties(remote_connection_http_crew):
+    g = traversal().with_(remote_connection_http_crew)
     vertex = g.V(7).next()
     assert vertex.id == 7
     assert vertex.label == 'person'
@@ -80,8 +80,8 @@ def test_vertex_vertex_properties(remote_connection_crew):
     assert vertex.properties[1].properties[1].value == 2000
 
 
-def test_timestamp(remote_connection):
-    g = traversal().with_(remote_connection)
+def test_timestamp(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
     ts = timestamp(1481750076295 / 1000)
     resp = g.addV('test_vertex').property('ts', ts)
     resp = resp.toList()
@@ -94,8 +94,8 @@ def test_timestamp(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_datetime(remote_connection):
-    g = traversal().with_(remote_connection)
+def test_datetime(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
     dt = datetime.datetime.utcfromtimestamp(1481750076295 / 1000)
     resp = g.addV('test_vertex').property('dt', dt).toList()
     vid = resp[0].id
@@ -107,8 +107,8 @@ def test_datetime(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_uuid(remote_connection):
-    g = traversal().with_(remote_connection)
+def test_uuid(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
     uid = uuid.UUID("41d2e28a-20a4-4ab0-b379-d810dede3786")
     resp = g.addV('test_vertex').property('uuid', uid).toList()
     vid = resp[0].id
@@ -120,11 +120,11 @@ def test_uuid(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_short(remote_connection):
-    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+def test_short(remote_connection_http):
+    if not isinstance(remote_connection_http._client._message_serializer, GraphBinarySerializersV4):
         return
 
-    g = traversal().with_(remote_connection)
+    g = traversal().with_(remote_connection_http)
     num = short(1111)
     resp = g.addV('test_vertex').property('short', num).toList()
     vid = resp[0].id
@@ -136,11 +136,11 @@ def test_short(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_bigint_positive(remote_connection):
-    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+def test_bigint_positive(remote_connection_http):
+    if not isinstance(remote_connection_http._client._message_serializer, GraphBinarySerializersV4):
         return
 
-    g = traversal().with_(remote_connection)
+    g = traversal().with_(remote_connection_http)
     big = bigint(0x1000_0000_0000_0000_0000)
     resp = g.addV('test_vertex').property('bigint', big).toList()
     vid = resp[0].id
@@ -152,11 +152,11 @@ def test_bigint_positive(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_bigint_negative(remote_connection):
-    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+def test_bigint_negative(remote_connection_http):
+    if not isinstance(remote_connection_http._client._message_serializer, GraphBinarySerializersV4):
         return
 
-    g = traversal().with_(remote_connection)
+    g = traversal().with_(remote_connection_http)
     big = bigint(-0x1000_0000_0000_0000_0000)
     resp = g.addV('test_vertex').property('bigint', big).toList()
     vid = resp[0].id
@@ -168,11 +168,11 @@ def test_bigint_negative(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_bigdecimal(remote_connection):
-    if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
+def test_bigdecimal(remote_connection_http):
+    if not isinstance(remote_connection_http._client._message_serializer, GraphBinarySerializersV4):
         return
 
-    g = traversal().with_(remote_connection)
+    g = traversal().with_(remote_connection_http)
     bigdecimal = BigDecimal(101, 235)
     resp = g.addV('test_vertex').property('bigdecimal', bigdecimal).toList()
     vid = resp[0].id
@@ -185,32 +185,31 @@ def test_bigdecimal(remote_connection):
         g.V(vid).drop().iterate()
 
 
-def test_odd_bits(remote_connection):
-    if not isinstance(remote_connection._client._message_serializer, GraphSONSerializersV2d0):
-        g = traversal().with_(remote_connection)
-        char_lower = str.__new__(SingleChar, chr(78))
-        resp = g.addV('test_vertex').property('char_lower', char_lower).toList()
-        vid = resp[0].id
-        try:
-            v = g.V(vid).values('char_lower').toList()[0]
-            assert v == char_lower
-        finally:
-            g.V(vid).drop().iterate()
+def test_odd_bits(remote_connection_http):
+    g = traversal().with_(remote_connection_http)
+    char_lower = str.__new__(SingleChar, chr(78))
+    resp = g.addV('test_vertex').property('char_lower', char_lower).toList()
+    vid = resp[0].id
+    try:
+        v = g.V(vid).values('char_lower').toList()[0]
+        assert v == char_lower
+    finally:
+        g.V(vid).drop().iterate()
 
-        char_upper = str.__new__(SingleChar, chr(57344))
-        resp = g.addV('test_vertex').property('char_upper', char_upper).toList()
-        vid = resp[0].id
-        try:
-            v = g.V(vid).values('char_upper').toList()[0]
-            assert v == char_upper
-        finally:
-            g.V(vid).drop().iterate()
+    char_upper = str.__new__(SingleChar, chr(57344))
+    resp = g.addV('test_vertex').property('char_upper', char_upper).toList()
+    vid = resp[0].id
+    try:
+        v = g.V(vid).values('char_upper').toList()[0]
+        assert v == char_upper
+    finally:
+        g.V(vid).drop().iterate()
 
-        dur = datetime.timedelta(seconds=1000, microseconds=1000)
-        resp = g.addV('test_vertex').property('dur', dur).toList()
-        vid = resp[0].id
-        try:
-            v = g.V(vid).values('dur').toList()[0]
-            assert v == dur
-        finally:
-            g.V(vid).drop().iterate()
+    dur = datetime.timedelta(seconds=1000, microseconds=1000)
+    resp = g.addV('test_vertex').property('dur', dur).toList()
+    vid = resp[0].id
+    try:
+        v = g.V(vid).values('dur').toList()[0]
+        assert v == dur
+    finally:
+        g.V(vid).drop().iterate()

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV4.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV4.py
@@ -23,12 +23,12 @@ import math
 
 from gremlin_python.statics import timestamp, long, bigint, BigDecimal, SingleByte, SingleChar, ByteBufferType
 from gremlin_python.structure.graph import Vertex, Edge, Property, VertexProperty, Path
-from gremlin_python.structure.io.graphbinaryV1 import GraphBinaryWriter, GraphBinaryReader
+from gremlin_python.structure.io.graphbinaryV4 import GraphBinaryWriter, GraphBinaryReader
 from gremlin_python.process.traversal import Barrier, Binding, Bytecode, Merge, Direction
+from gremlin_python.structure.io.util import Marker
 
 
-# TODO: to be removed
-class TestGraphBinaryV1(object):
+class TestGraphBinaryV4(object):
     graphbinary_writer = GraphBinaryWriter()
     graphbinary_reader = GraphBinaryReader()
 
@@ -231,5 +231,10 @@ class TestGraphBinaryV1(object):
 
     def test_duration(self):
         x = datetime.timedelta(seconds=1000, microseconds=1000)
+        output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
+        assert x == output
+
+    def test_marker(self):
+        x = Marker.end_of_stream()
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
         assert x == output

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
@@ -38,6 +38,7 @@ from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.anonymous_traversal import traversal
 
 
+# TODO: to be removed
 class TestGraphSONReader(object):
     graphson_reader = GraphSONReader()
 

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV3d0.py
@@ -37,6 +37,7 @@ from gremlin_python.process.strategies import SubgraphStrategy
 from gremlin_python.process.graph_traversal import __
 
 
+# TODO: to be removed
 class TestGraphSONReader(object):
     graphson_reader = GraphSONReader()
 

--- a/gremlin-server/conf/gremlin-server-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-modern.yaml
@@ -30,8 +30,7 @@ scriptEngines: {
                org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/generate-modern.groovy]}}}}
 serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV4, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/json
-  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4 }                                                                                                           # application/vnd.graphbinary-v1.0
-  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4}                                                                                                            # application/vnd.graphbinary-v4.0
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
 strictTransactionManagement: false

--- a/gremlin-server/conf/gremlin-server-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-modern.yaml
@@ -18,6 +18,7 @@
 host: localhost
 port: 8182
 evaluationTimeout: 30000
+channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 scriptEngines: {
@@ -28,9 +29,9 @@ scriptEngines: {
                org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]},
                org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/generate-modern.groovy]}}}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/json
-  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
-  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV4, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/json
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4 }                                                                                                           # application/vnd.graphbinary-v1.0
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
 strictTransactionManagement: false
@@ -42,3 +43,7 @@ maxChunkSize: 8192
 maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
+writeBufferLowWaterMark: 32768
+writeBufferHighWaterMark: 65536
+ssl: {
+  enabled: false}


### PR DESCRIPTION
Updated python HTTP connection to use the new 4.0 request/response message formats. Reformatted existing tests to use HTTP server (tests passed with local HTTP server), but will need to further modify docker set up for GH actions. There remains a couple of client tests that need investigation. All old WS sockets are currently disabled, and will be removed at a later point along with related implementations. 

Next step is to enable chunked transfer, tests for new message formats will be added then. 