### PR TITLE
Update log lever from error to warn when server closes connection

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -129,7 +129,7 @@ final class Connection {
                 // close did not come from the client side. it means the server closed the channel for some reason.
                 // it's important to distinguish that difference in debugging
                 if (thisConnection.closeFuture.get() == null) {
-                    logger.error(String.format(
+                    logger.warn(String.format(
                             "Server closed the Connection on channel %s - scheduling removal from %s",
                             channel.id().asShortText(), thisConnection.pool.getPoolInfo(thisConnection)));
 


### PR DESCRIPTION
- AWS Neptune closes connections after 10 days when IAM is enabled.
  - Refer https://docs.aws.amazon.com/neptune/latest/userguide/limits.html#limits-websockets 
  `When IAM authentication is enabled, a WebSocket connection is always disconnected a few minutes more than 10 days after it was established, if it hasn't already been closed by then.`
  - This creates lot of error logs when using connection pools.
- Unless server closing connection is an error, logging the respective log as WARN may be ideal to prevent noise in logs.
