### PR TITLE
enable bulking for HTTP requests

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -44,8 +44,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.apache.tinkerpop.gremlin.driver.RequestOptions.getRequestOptions;
-
 /**
  * A {@code Client} is constructed from a {@link Cluster} and represents a way to send messages to Gremlin Server.
  * This class itself is a base class as there are different implementations that provide differing kinds of
@@ -240,6 +238,7 @@ public abstract class Client {
         options.getG().ifPresent(g -> request.addG(g));
         options.getLanguage().ifPresent(lang -> request.addLanguage(lang));
         options.getMaterializeProperties().ifPresent(mp -> request.addMaterializeProperties(mp));
+        if (options.isBulking()) request.addBulking(true);
 
         return submitAsync(request.create());
     }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
@@ -48,6 +48,7 @@ public final class RequestOptions {
     private final Long timeout;
     private final String language;
     private final String materializeProperties;
+    private final boolean bulking;
 
     private RequestOptions(final Builder builder) {
         this.graphOrTraversalSource = builder.graphOrTraversalSource;
@@ -56,6 +57,7 @@ public final class RequestOptions {
         this.timeout = builder.timeout;
         this.language = builder.language;
         this.materializeProperties = builder.materializeProperties;
+        this.bulking = builder.bulking;
     }
 
     public Optional<String> getG() {
@@ -80,13 +82,15 @@ public final class RequestOptions {
 
     public Optional<String> getMaterializeProperties() { return Optional.ofNullable(materializeProperties); }
 
+    public boolean isBulking() { return bulking; }
+
     public static Builder build() {
         return new Builder();
     }
 
     public static RequestOptions getRequestOptions(final GremlinLang gremlinLang) {
         final Iterator<OptionsStrategy> itty = gremlinLang.getOptionsStrategies().iterator();
-        final RequestOptions.Builder builder = RequestOptions.build();
+        final RequestOptions.Builder builder = RequestOptions.build().withBulking(true);
         while (itty.hasNext()) {
             final OptionsStrategy optionsStrategy = itty.next();
             final Map<String, Object> options = optionsStrategy.getOptions();
@@ -114,6 +118,7 @@ public final class RequestOptions {
         private Long timeout = null;
         private String materializeProperties = null;
         private String language = null;
+        private boolean bulking = false;
 
         /**
          * The aliases to set on the request.
@@ -149,6 +154,11 @@ public final class RequestOptions {
          */
         public Builder batchSize(final int batchSize) {
             this.batchSize = batchSize;
+            return this;
+        }
+
+        public Builder withBulking(final boolean bulking) {
+            this.bulking = bulking;
             return this;
         }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnection.java
@@ -219,7 +219,7 @@ public class DriverRemoteConnection implements RemoteConnection {
         try {
             gremlinLang.addG(remoteTraversalSourceName);
             return client.submitAsync(gremlinLang.getGremlin(), getRequestOptions(gremlinLang))
-                    .thenApply(rs -> new DriverRemoteTraversal<>(rs, client, attachElements, conf));
+                    .thenApply(rs -> new DriverRemoteTraversal<>(rs, attachElements, conf));
         } catch (Exception ex) {
             throw new RemoteConnectionException(ex);
         }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversal.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversal.java
@@ -19,11 +19,9 @@
 package org.apache.tinkerpop.gremlin.driver.remote;
 
 import org.apache.commons.configuration2.Configuration;
-import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.AbstractRemoteTraversal;
-import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.RemoteTraverser;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.step.map.RemoteStep;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -53,7 +51,7 @@ public class DriverRemoteTraversal<S, E> extends AbstractRemoteTraversal<S, E> {
     private final Iterator<Traverser.Admin<E>> traversers;
     private Traverser.Admin<E> lastTraverser = EmptyTraverser.instance();
 
-    public DriverRemoteTraversal(final ResultSet rs, final Client client, final boolean attach, final Optional<Configuration> conf) {
+    public DriverRemoteTraversal(final ResultSet rs, final boolean attach, final Optional<Configuration> conf) {
         // attaching is really just for testing purposes. it doesn't make sense in any real-world scenario as it would
         // require that the client have access to the Graph instance that produced the result. tests need that
         // attachment process to properly execute in full hence this little hack.
@@ -113,7 +111,7 @@ public class DriverRemoteTraversal<S, E> extends AbstractRemoteTraversal<S, E> {
 
         @Override
         public Traverser.Admin<E> next() {
-            return new DefaultRemoteTraverser<>((E)inner.next().getObject(), 1);
+            return (RemoteTraverser<E>) inner.next().getObject();
         }
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -27,7 +27,6 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -312,7 +311,13 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
         final Bindings mergedBindings = mergeBindingsFromRequest(context, new SimpleBindings(graphManager.getAsBindings()));
         final Object result = scriptEngine.eval(message.getGremlin(), mergedBindings);
 
-        handleIterator(context, IteratorUtils.asIterator(result), serializer);
+        if (args.containsKey(TokensV4.ARGS_BULKING) && (boolean) args.get(TokensV4.ARGS_BULKING)) {
+            // optimization for driver requests
+            ((Traversal.Admin<?, ?>) result).applyStrategies();
+            handleIterator(context, new TraverserIterator((Traversal.Admin<?, ?>) result), serializer);
+        } else {
+            handleIterator(context, IteratorUtils.asIterator(result), serializer);
+        }
     }
 
     @Override
@@ -360,16 +365,6 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
         }
 
         return bindings;
-    }
-
-    private void iterateTraversal(final Context context, MessageSerializerV4<?> serializer, Traversal.Admin<?, ?> traversal)
-            throws InterruptedException {
-        final UUID requestId = context.getChannelHandlerContext().attr(StateKey.REQUEST_ID).get();
-        logger.debug("Traversal request {} for in thread {}", requestId, Thread.currentThread().getName());
-
-        // compile the traversal - without it getEndStep() has nothing in it
-        traversal.applyStrategies();
-        handleIterator(context, new TraverserIterator(traversal), serializer);
     }
 
     private void handleIterator(final Context context, final Iterator itty, final MessageSerializerV4<?> serializer) throws InterruptedException {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/HttpDriverIntegrateTest.java
@@ -122,8 +122,8 @@ public class HttpDriverIntegrateTest extends AbstractGremlinServerIntegrationTes
         final Cluster cluster = TestClientFactory.build().create();
         try {
             final GraphTraversalSource g = traversal().with(DriverRemoteConnection.using(cluster));
-            final String result = g.inject("2").toList().get(0);
-            assertEquals("2", result);
+            final List result = g.inject(1, 2, 3, 2, 1).toList();
+            assertEquals(5, result.size());
         } catch (Exception ex) {
             throw ex;
         } finally {

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/TokensV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/TokensV4.java
@@ -58,6 +58,11 @@ public final class TokensV4 {
     public static final String ARGS_LANGUAGE = "language";
 
     /**
+     * Argument name that allows turning on bulking optimization for driver requests.
+     */
+    public static final String ARGS_BULKING = "bulking";
+
+    /**
      * Argument name that allows the override of the server setting that determines the maximum time to wait for a
      * request to execute on the server.
      */

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageV4.java
@@ -144,6 +144,11 @@ public final class RequestMessageV4 {
             return this;
         }
 
+        public Builder addBulking(final boolean bulking) {
+            this.fields.put(TokensV4.ARGS_BULKING, bulking);
+            return this;
+        }
+
         public Builder addMaterializeProperties(final String materializeProps) {
             Objects.requireNonNull(materializeProps, "materializeProps argument cannot be null.");
             if (!materializeProps.equals(TokensV4.MATERIALIZE_PROPERTIES_TOKENS) && !materializeProps.equals(TokensV4.MATERIALIZE_PROPERTIES_ALL)) {

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/RequestMessageSerializerV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/RequestMessageSerializerV4.java
@@ -70,6 +70,9 @@ public class RequestMessageSerializerV4 {
             if (fields.containsKey(TokensV4.ARGS_BATCH_SIZE)) {
                 builder.addChunkSize((int) fields.get(TokensV4.ARGS_BATCH_SIZE));
             }
+            if (fields.containsKey(TokensV4.ARGS_BULKING)) {
+                builder.addBulking((boolean) fields.get(TokensV4.ARGS_BULKING));
+            }
 
             return builder.create();
         } catch (IOException ex) {


### PR DESCRIPTION
in TP3 bulking works only for Bytecode requests, implemented same functionality for DriverRemoteConnection queries.