### PR TITLE
Update ProfilingApplication default options to align with HTTP.

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ProfilingApplication.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ProfilingApplication.java
@@ -184,17 +184,18 @@ public class ProfilingApplication {
         final int executions = Integer.parseInt(options.getOrDefault("executions", "10").toString());
         final int nioPoolSize = Integer.parseInt(options.getOrDefault("nioPoolSize", "1").toString());
         final int requests = Integer.parseInt(options.getOrDefault("requests", "10000").toString());
-        final int minConnectionPoolSize = Integer.parseInt(options.getOrDefault("minConnectionPoolSize", "256").toString());
-        final int maxConnectionPoolSize = Integer.parseInt(options.getOrDefault("maxConnectionPoolSize", "256").toString());
-        final int maxWaitForConnection = Integer.parseInt(options.getOrDefault("maxWaitForConnection", "3000").toString());
+        final int minConnectionPoolSize = Integer.parseInt(options.getOrDefault("minConnectionPoolSize", "128").toString());
+        final int maxConnectionPoolSize = Integer.parseInt(options.getOrDefault("maxConnectionPoolSize", "1024").toString());
+        final int maxWaitForConnection = Integer.parseInt(options.getOrDefault("maxWaitForConnection", "300000").toString());
         final int workerPoolSize = Integer.parseInt(options.getOrDefault("workerPoolSize", Runtime.getRuntime().availableProcessors() * 2).toString());
         final int tooSlowThreshold = Integer.parseInt(options.getOrDefault("tooSlowThreshold", "125").toString());
         final String serializer = options.getOrDefault("serializer", Serializers.GRAPHBINARY_V4.name()).toString();
 
         final boolean exercise = Boolean.parseBoolean(options.getOrDefault("exercise", "false").toString());
-        final String script = options.getOrDefault("script", "1+1").toString();
+        final String script = options.getOrDefault("script", "g.inject(1)").toString();
 
         final Cluster cluster = Cluster.build(host)
+                .maxContentLength(Integer.MAX_VALUE)
                 .minConnectionPoolSize(minConnectionPoolSize)
                 .maxConnectionPoolSize(maxConnectionPoolSize)
                 .nioPoolSize(nioPoolSize)


### PR DESCRIPTION
Some performance numbers to compare the current master-http branch against 3.7-dev using ProfilingApplication.

## ProfilingApplication Information

The **ProfilingApplication** has two modes: latency and throughput.

The latency test will run a particular query one at a time for several runs. It then reports the average latency of the query. The chosen query for this test was `g.V().both().repeat()` as the server is able to quickly respond to this request but it also generates a lot of data to be returned over the wire.

The throughput test will issue *requests (an application argument)* number of queries to the server and see how long it takes to complete them. It will then report the results as number or queries completed per second. The throughput tests can be either **exercise** or **1+1**. When the application argument *exercise* is set to true, there are a number of preset queries that will be used, if it is false, then "1+1" is the query used. See https://github.com/apache/tinkerpop/blob/master/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ProfilingApplication.java#L54 for the list of queries

## Performance Metrics

### Test System
**Server**
EC2 m7a.8xlarge US EAST 2

**Server Config**
```
maxWorkQueueSize: 65536
threadPoolWorker: 8
gremlinPool: 16
evaluationTimeout: 30000000
```

**Driver**
EC2 m7a.4xlarge US WEST 2

| Branch | Test Type | Arguments | Query | Result |
| :---: | :---: | :---: | :---: | :---: |
| 3.7-dev | Latency | minConnectionPoolSize 1 | `g.V()` *6 vertices* | 0.05625982837 sec |
| 3.7-dev | Latency | minConnectionPoolSize 1 | `g.V().repeat(both()).times(15)` *2 824 992 vertices* | 3.844317 sec |
| 3.7-dev | Latency | minConnectionPoolSize 1 | `g.V().repeat(both()).times(18)` *39 750 654 vertices* | 53.4815487 sec |
| master-http | Latency | minConnectionPoolSize 1 | `g.V()` *6 vertices* | 0.05744388 sec |
| master-http | Latency | minConnectionPoolSize 1 | `g.V().repeat(both()).times(15)` *2 824 992 vertices* | 3.915586 sec |
| master-http | Latency | minConnectionPoolSize 1 | `g.V().repeat(both()).times(18)` *39 750 654 vertices* | 54.892998565 sec |
| 3.7-dev | Throughput | parallelism 16 requests 10000000 | `1 + 1` | 35458 req/sec |
| 3.7-dev | Throughput | parallelism 16 requests 10000000  exercise true | `N/A` | 30159 req/sec |
| 3.7-dev | Throughput | parallelism 16 requests 100000000  exercise true | `N/A` | 30488 req/sec |
| master-http | Throughput | parallelism 16  requests 10000000 | `1 + 1` | 19758 req/sec NOTE: the pool size is small so the performance is lowered |
| master-http | Throughput | parallelism 16  requests 10000000  exercise true | `N/A` | 19690 req/sec NOTE: the pool size is small so the performance is lowered |
| master-http | Throughput | parallelism 16  requests 10000000  minConnectionPoolSize 1500  maxConnectionPoolSize 5000 | `1 + 1` | 34450 req/sec |
| master-http | Throughput | parallelism 16  requests 10000000  minConnectionPoolSize 1500  maxConnectionPoolSize 5000 exercise true | `N/A` | 32138 req/sec |
| master-http | Throughput | parallelism 16  requests 100000000  maxConnectionPoolSize 5000  exercise true | `N/A` | 30063 req/sec |
