### PR TITLE
TINKERPOP-3096: improvement: add necessary parameters for logging to fix '%!x(MISSING)' output issue in gremlin-go

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ This release also includes changes from <<release-3-6-8, 3.6.8>>.
 * Fixed so that `TrimGlobalStep` and `TrimLocalStep` have the same character control handling as `Ltrim` and `Rtrim`
 * Fix a bug in `MaxLocalStep`, `MinLocalStep`, `MeanLocalStep` and `SumLocalStep` that it throws `NoSuchElementException` when encounters an empty iterator as input.
 * Fix cases where Map keys of incomparable types could panic in `gremlin-go`.
+* Fixed an issue where missing necessary parameters for logging, resulting in '%!x(MISSING)' output in `gremlin-go`.
 
 [[release-3-7-2]]
 === TinkerPop 3.7.2 (April 8, 2024)

--- a/gremlin-go/driver/graphBinary.go
+++ b/gremlin-go/driver/graphBinary.go
@@ -1009,7 +1009,7 @@ func readMapUnqualified(data *[]byte, i *int) (interface{}, error) {
 	for j := uint32(0); j < sz; j++ {
 		keyDataType := readDataType(data, i)
 		if keyDataType != stringType {
-			return nil, newError(err0703ReadMapNonStringKeyError)
+			return nil, newError(err0703ReadMapNonStringKeyError, keyDataType)
 		}
 
 		// Skip nullable, key must be present

--- a/gremlin-go/driver/graphBinary_test.go
+++ b/gremlin-go/driver/graphBinary_test.go
@@ -320,7 +320,7 @@ func TestGraphBinaryV1(t *testing.T) {
 			buff := []byte{0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01}
 			m, err := readMapUnqualified(&buff, &i)
 			assert.Nil(t, m)
-			assert.Equal(t, newError(err0703ReadMapNonStringKeyError), err)
+			assert.Equal(t, newError(err0703ReadMapNonStringKeyError, intType), err)
 		})
 	})
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->

https://issues.apache.org/jira/browse/TINKERPOP-3096

I encountered a log message missing necessary parameters while using the 'Containing' function. The detailed log information is as follows:


2024/07/14 16:27:28 Error occurred during operation gremlinServerWSProtocol.readLoop(): 'E0703: expected string Key for map, got type='0x%!x(MISSING)''
2024/07/14 16:27:28 Read loop error 'E0703: expected string Key for map, got type='0x%!x(MISSING)'', closing read loop.
2024/07/14 16:27:28 Connection error callback invoked, closing protocol. 



