### PR TITLE
Remove redundant six dependency

### DIFF
--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       bash -c "apt-get update && apt-get -y install libkrb5-dev krb5-user
       && echo 'password' | kinit stephen
       && klist
-      && pip install wheel radish-bdd PyHamcrest aenum isodate kerberos six
+      && pip install wheel radish-bdd PyHamcrest aenum isodate kerberos
       && python3 ./setup.py build
       && python3 ./setup.py test
       && python3 ./setup.py install

--- a/gremlin-python/src/main/python/examples/requirements.txt
+++ b/gremlin-python/src/main/python/examples/requirements.txt
@@ -25,5 +25,4 @@ frozenlist==1.4.1
 idna==3.6
 isodate==0.6.1
 multidict==6.0.5
-six==1.16.0
 yarl==1.9.4

--- a/gremlin-python/src/main/python/setup.cfg
+++ b/gremlin-python/src/main/python/setup.cfg
@@ -14,9 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-[bdist_wheel]
-universal=1
-
 [aliases]
 test=pytest
 

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -70,7 +70,6 @@ setup(
     ],
     tests_require=[
         'pytest>=4.6.4,<7.2.0',
-        'mock>=3.0.5,<5.0.0',
         'radish-bdd==0.13.4',
         'PyHamcrest>=1.9.0,<3.0.0'
     ],

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -51,9 +51,6 @@ install_requires = [
     'isodate>=0.6.0,<1.0.0'
 ]
 
-if sys.version_info < (3, 5):
-    install_requires += ['pyparsing>=2.4.7,<3.0.0']
-
 setup(
     name='gremlinpython',
     version=version,

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -61,7 +61,7 @@ setup(
               'gremlin_python.driver.aiohttp', 'gremlin_python.process',
               'gremlin_python.structure', 'gremlin_python.structure.io'],
     license='Apache 2',
-    url='http://tinkerpop.apache.org',
+    url='https://tinkerpop.apache.org',
     description='Gremlin-Python for Apache TinkerPop',
     long_description=codecs.open("README.rst", "r", "UTF-8").read(),
     long_description_content_type='text/x-rst',

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -48,7 +48,6 @@ install_requires = [
     'nest_asyncio',
     'aiohttp>=3.8.0,<4.0.0',
     'aenum>=1.4.5,<4.0.0',
-    'six>=1.10.0,<2.0.0',
     'isodate>=0.6.0,<1.0.0'
 ]
 

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
@@ -26,7 +26,7 @@ import uuid
 import math
 from decimal import *
 
-from mock import Mock
+from unittest.mock import Mock
 
 from gremlin_python.statics import *
 from gremlin_python.structure.graph import Vertex, Edge, Property, VertexProperty, Graph, Path
@@ -37,7 +37,7 @@ from gremlin_python.process.strategies import SubgraphStrategy
 from gremlin_python.process.graph_traversal import __
 
 
-class TestGraphSONReader(object):
+class TestGraphSONReader:
     graphson_reader = GraphSONReader()
 
     def test_number_input(self):
@@ -215,7 +215,7 @@ class TestGraphSONReader(object):
     def test_custom_mapping(self):
 
         # extended mapping
-        class X(object):
+        class X:
             pass
 
         type_string = "test:Xtype"
@@ -297,7 +297,7 @@ class TestGraphSONReader(object):
         assert c is None
 
 
-class TestGraphSONWriter(object):
+class TestGraphSONWriter:
     graphson_writer = GraphSONWriter()
     graphson_reader = GraphSONReader()
 
@@ -417,7 +417,7 @@ class TestGraphSONWriter(object):
 
     def test_custom_mapping(self):
         # extended mapping
-        class X(object):
+        class X:
             pass
 
         serdes = Mock()
@@ -488,7 +488,7 @@ class TestGraphSONWriter(object):
         assert expected == output
 
 
-class TestFunctionalGraphSONIO(object):
+class TestFunctionalGraphSONIO:
     """Functional IO tests"""
 
     def test_timestamp(self, remote_connection_graphsonV2):

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV3d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV3d0.py
@@ -26,7 +26,7 @@ import uuid
 import math
 from decimal import *
 
-from mock import Mock
+from unittest.mock import Mock
 
 from gremlin_python.statics import *
 from gremlin_python.structure.graph import Vertex, Edge, Property, VertexProperty, Path
@@ -37,7 +37,7 @@ from gremlin_python.process.strategies import SubgraphStrategy
 from gremlin_python.process.graph_traversal import __
 
 
-class TestGraphSONReader(object):
+class TestGraphSONReader:
     graphson_reader = GraphSONReader()
 
     def test_collections(self):
@@ -57,7 +57,7 @@ class TestGraphSONReader(object):
                                                      "3"]}))
         # return a set as normal
         assert isinstance(x, set)
-        assert x == set([1, 2, "3"])
+        assert x == {1, 2, "3"}
 
         x = self.graphson_reader.read_object(
             json.dumps({"@type": "g:Set", "@value": [{"@type": "g:Int32", "@value": 1},
@@ -261,7 +261,7 @@ class TestGraphSONReader(object):
     def test_custom_mapping(self):
 
         # extended mapping
-        class X(object):
+        class X:
             pass
 
         type_string = "test:Xtype"
@@ -344,7 +344,7 @@ class TestGraphSONReader(object):
         assert c is None
 
 
-class TestGraphSONWriter(object):
+class TestGraphSONWriter:
     graphson_writer = GraphSONWriter()
     graphson_reader = GraphSONReader()
 
@@ -356,7 +356,7 @@ class TestGraphSONWriter(object):
         assert {"@type": "g:Set", "@value": [{"@type": "g:Int32", "@value": 1},
                                              {"@type": "g:Int32", "@value": 2},
                                              {"@type": "g:Int32", "@value": 3}]} == json.loads(
-            self.graphson_writer.write_object(set([1, 2, 3, 3])))
+            self.graphson_writer.write_object({1, 2, 3, 3}))
         assert {"@type": "g:Map",
                 "@value": ['a', {"@type": "g:Int32", "@value": 1}]} == json.loads(
             self.graphson_writer.write_object({'a': 1}))
@@ -484,7 +484,7 @@ class TestGraphSONWriter(object):
 
     def test_custom_mapping(self):
         # extended mapping
-        class X(object):
+        class X:
             pass
 
         serdes = Mock()


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->

The Python package no longer uses the six library, but still installs it as a dependency. Let's remove it to make installs a bit quicker and smaller.

Also universal wheels are for supporting both Python 2 and 3, so is no longer needed.

Do you still support Python 3.4? I don't think so, but couldn't find the min version documented. Well, this can be also removed if not:

```python
if sys.version_info < (3, 5):
    install_requires += ['pyparsing>=2.4.7,<3.0.0']
```

