### PR TITLE
[TINKERPOP-3098] added configuration for logging level for Gremlin Console in Windows

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed a bug in GremlinServer not properly propagating arguments when authentication is enabled.
 * Fixed bug in Java driver where connection pool was not removing dead connections under certain error conditions.
 * Raised handshake exceptions for Java driver for `NoHostAvailableException` situations.
+* The default logging level for Gremlin Console in Windows is set to the same WARN level as for Linux.
+* Add command line option `-l` to change logging level for Gremlin Console in Windows.
 
 [[release-3-6-7]]
 === TinkerPop 3.6.7 (April 8, 2024)

--- a/gremlin-console/src/main/bin/gremlin-java8.bat
+++ b/gremlin-console/src/main/bin/gremlin-java8.bat
@@ -40,9 +40,20 @@ FOR /r %%j in (*.jar *.JAR) do (
 )
 cd ..
 
+set GREMLIN_LOG_LEVEL=WARN
+
+:: Process options
+
+:parse
+IF "%~1"=="" GOTO endparse
+IF "%~1"=="-l" set GREMLIN_LOG_LEVEL=%~2
+SHIFT
+GOTO parse
+:endparse
+
 :: workaround for https://issues.apache.org/jira/browse/GROOVY-6453
 set JAVA_OPTIONS=-Xms32m -Xmx512m -Djline.terminal=none
 
 :: Launch the application
 
-java %JAVA_OPTIONS% %JAVA_ARGS% -cp "%CONSOLE_JARS%" org.apache.tinkerpop.gremlin.console.Console %*
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp "%CONSOLE_JARS%" "-Dlogback.configurationFile=conf/logback.xml" "-Dgremlin.logback.level=%GREMLIN_LOG_LEVEL%" org.apache.tinkerpop.gremlin.console.Console %*

--- a/gremlin-console/src/main/bin/gremlin.bat
+++ b/gremlin-console/src/main/bin/gremlin.bat
@@ -34,11 +34,22 @@ FOR /D /r %%i in (*) do (
 
 cd ..
 
+set GREMLIN_LOG_LEVEL=WARN
+
+:: Process options
+
+:parse
+IF "%~1"=="" GOTO endparse
+IF "%~1"=="-l" set GREMLIN_LOG_LEVEL=%~2
+SHIFT
+GOTO parse
+:endparse
+
 :: workaround for https://issues.apache.org/jira/browse/GROOVY-6453
 set JAVA_OPTIONS=-Xms32m -Xmx512m -Djline.terminal=none
 
 :: Launch the application
 
-java %JAVA_OPTIONS% %JAVA_ARGS% -cp "%LIBDIR%\*;%EXTDIR%;" org.apache.tinkerpop.gremlin.console.Console %*
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp "%LIBDIR%\*;%EXTDIR%;" "-Dlogback.configurationFile=conf/logback.xml" "-Dgremlin.logback.level=%GREMLIN_LOG_LEVEL%" org.apache.tinkerpop.gremlin.console.Console %*
 
 set CLASSPATH=%OLD_CLASSPATH%


### PR DESCRIPTION
Default logging level for Gremlin Console in Windows is set to the same WARN level as for Linux.
Add command line option `-l` to change logging level for Gremlin Console in Windows.

https://issues.apache.org/jira/browse/TINKERPOP-3098
