### PR TITLE
Bytecode removal in gremlin-python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Serialization support removed for `Bindings` and `Bytecode`.
 * `EmbeddedRemoteConnection` will use `Gremlinlang`, not `JavaTranslator`.
 * Java `Client` will no longer support submitting traversals. `DriverRemoteConnection` should be used instead.
+* Removed usage of `Bytecode` from `gremlin-python`.
 * Fixed `GremlinLangScriptEngine` handling for some strategies.
 
 == TinkerPop 3.7.0 (Gremfir Master of the Pan Flute)

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -156,7 +156,8 @@ class Client:
         log.debug("message '%s'", str(message))
         fields = {'g': self._traversal_source}
 
-        # TODO: binding is part of request_options, evaluate the need to keep it separate in python
+        # TODO: bindings is now part of request_options, evaluate the need to keep it separate in python.
+        #  Note this bindings parameter only applies to string script submissions
         if isinstance(message, str) and bindings:
             fields['bindings'] = bindings
 
@@ -169,8 +170,9 @@ class Client:
             message.fields.update({token: request_options[token] for token in TokensV4
                                    if token in request_options})
             if 'params' in request_options:
-                if 'bindings' not in message.fields:
-                    message.fields['bindings'] = bindings if bindings else {}
-                message.fields['bindings'].update(request_options['params'])
+                if 'bindings' in message.fields:
+                    message.fields['bindings'].update(request_options['params'])
+                else:
+                    message.fields['bindings'] = request_options['params']
 
         return conn.write(message)

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -24,6 +24,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from gremlin_python.driver import connection, protocol, request, serializer
 from gremlin_python.process import traversal
+from gremlin_python.driver.request import TokensV4
 
 log = logging.getLogger("gremlinpython")
 
@@ -154,20 +155,22 @@ class Client:
 
         log.debug("message '%s'", str(message))
         fields = {'g': self._traversal_source}
-        if isinstance(message, traversal.Bytecode):
-            fields['gremlinType'] = 'bytecode'
-        elif isinstance(message, str):
-            fields['gremlinType'] = 'eval'
 
+        # TODO: binding is part of request_options, evaluate the need to keep it separate in python
         if isinstance(message, str) and bindings:
             fields['bindings'] = bindings
 
-        if isinstance(message, traversal.Bytecode) or isinstance(message, str):
+        if isinstance(message, str):
             log.debug("fields='%s', gremlin='%s'", str(fields), str(message))
             message = request.RequestMessageV4(fields=fields, gremlin=message)
 
         conn = self._pool.get(True)
         if request_options:
-            message.fields.update(request_options)
+            message.fields.update({token: request_options[token] for token in TokensV4
+                                   if token in request_options})
+            if 'params' in request_options:
+                if 'bindings' not in message.fields:
+                    message.fields['bindings'] = bindings if bindings else {}
+                message.fields['bindings'].update(request_options['params'])
 
         return conn.write(message)

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -168,7 +168,12 @@ class Client:
         conn = self._pool.get(True)
         if request_options:
             message.fields.update({token: request_options[token] for token in TokensV4
-                                   if token in request_options})
+                                   if token in request_options and token != 'bindings'})
+            if 'bindings' in request_options:
+                if 'bindings' in message.fields:
+                    message.fields['bindings'].update(request_options['bindings'])
+                else:
+                    message.fields['bindings'] = request_options['bindings']
             if 'params' in request_options:
                 if 'bindings' in message.fields:
                     message.fields['bindings'].update(request_options['params'])

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -124,9 +124,6 @@ class DriverRemoteConnection(RemoteConnection):
             request_options.update({token: os.configuration[token] for token in TokensV4
                                     if token in os.configuration})
         if gremlin_lang.parameters is not None and len(gremlin_lang.parameters) > 0:
-            if request_options is None:
-                request_options = gremlin_lang.parameters
-            else:
-                request_options["params"] = gremlin_lang.parameters
+            request_options["params"] = gremlin_lang.parameters
 
         return request_options

--- a/gremlin-python/src/main/python/gremlin_python/driver/remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/remote_connection.py
@@ -37,7 +37,7 @@ class RemoteConnection(object, metaclass=abc.ABCMeta):
         return self._traversal_source
 
     @abc.abstractmethod
-    def submit(self, bytecode):
+    def submit(self, gremlin_lang):
         pass
 
     def is_closed(self):
@@ -69,10 +69,10 @@ class RemoteStrategy(traversal.TraversalStrategy):
 
     def apply(self, traversal):
         if traversal.traversers is None:
-            remote_traversal = self.remote_connection.submit(traversal.bytecode)
+            remote_traversal = self.remote_connection.submit(traversal.gremlin_lang)
             traversal.remote_results = remote_traversal
             traversal.traversers = remote_traversal.traversers
 
     def apply_async(self, traversal):
         if traversal.traversers is None:
-            traversal.remote_results = self.remote_connection.submit_async(traversal.bytecode)
+            traversal.remote_results = self.remote_connection.submit_async(traversal.gremlin_lang)

--- a/gremlin-python/src/main/python/gremlin_python/driver/request.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/request.py
@@ -22,3 +22,6 @@ __author__ = 'David M. Brown (davebshow@gmail.com)'
 
 RequestMessageV4 = collections.namedtuple(
     'RequestMessageV4', ['fields', 'gremlin'])
+
+TokensV4 = ['batchSize', 'bindings', 'g', 'gremlin', 'language',
+            'evaluationTimeout', 'materializeProperties', 'timeoutMs', 'userAgent']

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -24,7 +24,7 @@ from threading import Lock
 from .traversal import Traversal
 from .traversal import TraversalStrategies
 from .strategies import VertexProgramStrategy, OptionsStrategy
-from .traversal import Bytecode
+from .traversal import GremlinLang
 from ..driver.remote_connection import RemoteStrategy
 from .. import statics
 from ..statics import long
@@ -35,13 +35,13 @@ __author__ = 'Stephen Mallette (http://stephen.genoprime.com), Lyndon Bauto (lyn
 
 
 class GraphTraversalSource(object):
-    def __init__(self, graph, traversal_strategies, bytecode=None, remote_connection=None):
+    def __init__(self, graph, traversal_strategies, gremlin_lang=None, remote_connection=None):
         log.info("Creating GraphTraversalSource.")
         self.graph = graph
         self.traversal_strategies = traversal_strategies
-        if bytecode is None:
-            bytecode = Bytecode()
-        self.bytecode = bytecode
+        if gremlin_lang is None:
+            gremlin_lang = GremlinLang()
+        self.gremlin_lang = gremlin_lang
         self.graph_traversal = GraphTraversal
         if remote_connection:
             self.traversal_strategies.add_strategies([RemoteStrategy(remote_connection)])
@@ -51,10 +51,10 @@ class GraphTraversalSource(object):
         return "graphtraversalsource[" + str(self.graph) + "]"
 
     def get_graph_traversal_source(self):
-        return self.__class__(self.graph, TraversalStrategies(self.traversal_strategies), Bytecode(self.bytecode))
+        return self.__class__(self.graph, TraversalStrategies(self.traversal_strategies), GremlinLang(self.gremlin_lang))
 
     def get_graph_traversal(self):
-        return self.graph_traversal(self.graph, self.traversal_strategies, Bytecode(self.bytecode))
+        return self.graph_traversal(self.graph, self.traversal_strategies, GremlinLang(self.gremlin_lang))
 
     def withBulk(self, *args):
         warnings.warn(
@@ -65,7 +65,7 @@ class GraphTraversalSource(object):
 
     def with_bulk(self, *args):
         source = self.get_graph_traversal_source()
-        source.bytecode.add_source("withBulk", *args)
+        source.gremlin_lang.add_source("withBulk", *args)
         return source
 
     def withPath(self, *args):
@@ -77,7 +77,7 @@ class GraphTraversalSource(object):
 
     def with_path(self, *args):
         source = self.get_graph_traversal_source()
-        source.bytecode.add_source("withPath", *args)
+        source.gremlin_lang.add_source("withPath", *args)
         return source
 
     def withSack(self, *args):
@@ -89,7 +89,7 @@ class GraphTraversalSource(object):
 
     def with_sack(self, *args):
         source = self.get_graph_traversal_source()
-        source.bytecode.add_source("withSack", *args)
+        source.gremlin_lang.add_source("withSack", *args)
         return source
 
     def withSideEffect(self, *args):
@@ -101,7 +101,7 @@ class GraphTraversalSource(object):
 
     def with_side_effect(self, *args):
         source = self.get_graph_traversal_source()
-        source.bytecode.add_source("withSideEffect", *args)
+        source.gremlin_lang.add_source("withSideEffect", *args)
         return source
 
     def withStrategies(self, *args):
@@ -113,7 +113,7 @@ class GraphTraversalSource(object):
 
     def with_strategies(self, *args):
         source = self.get_graph_traversal_source()
-        source.bytecode.add_source("withStrategies", *args)
+        source.gremlin_lang.add_source("withStrategies", *args)
         return source
 
     def withoutStrategies(self, *args):
@@ -125,12 +125,12 @@ class GraphTraversalSource(object):
 
     def without_strategies(self, *args):
         source = self.get_graph_traversal_source()
-        source.bytecode.add_source("withoutStrategies", *args)
+        source.gremlin_lang.add_source("withoutStrategies", *args)
         return source
 
     def with_(self, k, v=None):
         source = self.get_graph_traversal_source()
-        options_strategy = next((x for x in source.bytecode.source_instructions
+        options_strategy = next((x for x in source.gremlin_lang.gremlin
                                  if x[0] == "withStrategies" and type(x[1]) is OptionsStrategy), None)
 
         val = True if v is None else v
@@ -142,23 +142,24 @@ class GraphTraversalSource(object):
 
         return source
 
-    def tx(self):
-        # In order to keep the constructor unchanged within 3.5.x we can try to pop the RemoteConnection out of the
-        # TraversalStrategies. keeping this unchanged will allow user DSLs to not take a break.
-        # This is the same strategy as gremlin-javascript.
-        # TODO https://issues.apache.org/jira/browse/TINKERPOP-2664: refactor this to be nicer in 3.6.0 when
-        #  we can take a breaking change
-        remote_connection = next((x.remote_connection for x in self.traversal_strategies.traversal_strategies if
-                                  x.fqcn == "py:RemoteStrategy"), None)
-
-        if remote_connection is None:
-            raise Exception("Error, remote connection is required for transaction.")
-
-        # You can't do g.tx().begin().tx() i.e child transactions are not supported.
-        if remote_connection and remote_connection.is_session_bound():
-            raise Exception("This TraversalSource is already bound to a transaction - child transactions are not "
-                            "supported")
-        return Transaction(self, remote_connection)
+    # TODO remove or update once HTTP transaction is implemented
+    # def tx(self):
+    #     # In order to keep the constructor unchanged within 3.5.x we can try to pop the RemoteConnection out of the
+    #     # TraversalStrategies. keeping this unchanged will allow user DSLs to not take a break.
+    #     # This is the same strategy as gremlin-javascript.
+    #     # TODO https://issues.apache.org/jira/browse/TINKERPOP-2664: refactor this to be nicer in 3.6.0 when
+    #     #  we can take a breaking change
+    #     remote_connection = next((x.remote_connection for x in self.traversal_strategies.traversal_strategies if
+    #                               x.fqcn == "py:RemoteStrategy"), None)
+    #
+    #     if remote_connection is None:
+    #         raise Exception("Error, remote connection is required for transaction.")
+    #
+    #     # You can't do g.tx().begin().tx() i.e child transactions are not supported.
+    #     if remote_connection and remote_connection.is_session_bound():
+    #         raise Exception("This TraversalSource is already bound to a transaction - child transactions are not "
+    #                         "supported")
+    #     return Transaction(self, remote_connection)
 
     def withComputer(self, graph_computer=None, workers=None, result=None, persist=None, vertices=None,
                      edges=None, configuration=None):
@@ -175,12 +176,12 @@ class GraphTraversalSource(object):
 
     def E(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("E", *args)
+        traversal.gremlin_lang.add_step("E", *args)
         return traversal
 
     def V(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("V", *args)
+        traversal.gremlin_lang.add_step("V", *args)
         return traversal
 
     def addE(self, *args):
@@ -192,7 +193,7 @@ class GraphTraversalSource(object):
 
     def add_e(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("addE", *args)
+        traversal.gremlin_lang.add_step("addE", *args)
         return traversal
 
     def addV(self, *args):
@@ -204,43 +205,43 @@ class GraphTraversalSource(object):
 
     def add_v(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("addV", *args)
+        traversal.gremlin_lang.add_step("addV", *args)
         return traversal
 
     def merge_v(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("mergeV", *args)
+        traversal.gremlin_lang.add_step("mergeV", *args)
         return traversal
 
     def merge_e(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("mergeE", *args)
+        traversal.gremlin_lang.add_step("mergeE", *args)
         return traversal
 
     def inject(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("inject", *args)
+        traversal.gremlin_lang.add_step("inject", *args)
         return traversal
 
     def io(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("io", *args)
+        traversal.gremlin_lang.add_step("io", *args)
         return traversal
 
     def call(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("call", *args)
+        traversal.gremlin_lang.add_step("call", *args)
         return traversal
 
     def union(self, *args):
         traversal = self.get_graph_traversal()
-        traversal.bytecode.add_step("union", *args)
+        traversal.gremlin_lang.add_step("union", *args)
         return traversal
 
 
 class GraphTraversal(Traversal):
-    def __init__(self, graph, traversal_strategies, bytecode):
-        super(GraphTraversal, self).__init__(graph, traversal_strategies, bytecode)
+    def __init__(self, graph, traversal_strategies, gremlin_lang):
+        super(GraphTraversal, self).__init__(graph, traversal_strategies, gremlin_lang)
 
     def __getitem__(self, index):
         if isinstance(index, int):
@@ -262,14 +263,14 @@ class GraphTraversal(Traversal):
         return self.values(key)
 
     def clone(self):
-        return GraphTraversal(self.graph, self.traversal_strategies, copy.deepcopy(self.bytecode))
+        return GraphTraversal(self.graph, self.traversal_strategies, copy.deepcopy(self.gremlin_lang))
 
     def V(self, *args):
-        self.bytecode.add_step("V", *args)
+        self.gremlin_lang.add_step("V", *args)
         return self
 
     def E(self, *args):
-        self.bytecode.add_step("E", *args)
+        self.gremlin_lang.add_step("E", *args)
         return self
 
     def addE(self, *args):
@@ -280,7 +281,7 @@ class GraphTraversal(Traversal):
         return self.add_e(*args)
 
     def add_e(self, *args):
-        self.bytecode.add_step("addE", *args)
+        self.gremlin_lang.add_step("addE", *args)
         return self
 
     def addV(self, *args):
@@ -291,43 +292,43 @@ class GraphTraversal(Traversal):
         return self.add_v(*args)
 
     def add_v(self, *args):
-        self.bytecode.add_step("addV", *args)
+        self.gremlin_lang.add_step("addV", *args)
         return self
 
     def aggregate(self, *args):
-        self.bytecode.add_step("aggregate", *args)
+        self.gremlin_lang.add_step("aggregate", *args)
         return self
 
     def all_(self, *args):
-        self.bytecode.add_step("all", *args)
+        self.gremlin_lang.add_step("all", *args)
         return self
 
     def and_(self, *args):
-        self.bytecode.add_step("and", *args)
+        self.gremlin_lang.add_step("and", *args)
         return self
 
     def any_(self, *args):
-        self.bytecode.add_step("any", *args)
+        self.gremlin_lang.add_step("any", *args)
         return self
 
     def as_(self, *args):
-        self.bytecode.add_step("as", *args)
+        self.gremlin_lang.add_step("as", *args)
         return self
 
     def as_date(self, *args):
-        self.bytecode.add_step("asDate", *args)
+        self.gremlin_lang.add_step("asDate", *args)
         return self
 
     def as_string(self, *args):
-        self.bytecode.add_step("asString", *args)
+        self.gremlin_lang.add_step("asString", *args)
         return self
 
     def barrier(self, *args):
-        self.bytecode.add_step("barrier", *args)
+        self.gremlin_lang.add_step("barrier", *args)
         return self
 
     def both(self, *args):
-        self.bytecode.add_step("both", *args)
+        self.gremlin_lang.add_step("both", *args)
         return self
 
     def bothE(self, *args):
@@ -338,7 +339,7 @@ class GraphTraversal(Traversal):
         return self.both_e(*args)
 
     def both_e(self, *args):
-        self.bytecode.add_step("bothE", *args)
+        self.gremlin_lang.add_step("bothE", *args)
         return self
 
     def bothV(self, *args):
@@ -349,47 +350,47 @@ class GraphTraversal(Traversal):
         return self.both_v(*args)
 
     def both_v(self, *args):
-        self.bytecode.add_step("bothV", *args)
+        self.gremlin_lang.add_step("bothV", *args)
         return self
 
     def branch(self, *args):
-        self.bytecode.add_step("branch", *args)
+        self.gremlin_lang.add_step("branch", *args)
         return self
 
     def by(self, *args):
-        self.bytecode.add_step("by", *args)
+        self.gremlin_lang.add_step("by", *args)
         return self
 
     def call(self, *args):
-        self.bytecode.add_step("call", *args)
+        self.gremlin_lang.add_step("call", *args)
         return self
 
     def cap(self, *args):
-        self.bytecode.add_step("cap", *args)
+        self.gremlin_lang.add_step("cap", *args)
         return self
 
     def choose(self, *args):
-        self.bytecode.add_step("choose", *args)
+        self.gremlin_lang.add_step("choose", *args)
         return self
 
     def coalesce(self, *args):
-        self.bytecode.add_step("coalesce", *args)
+        self.gremlin_lang.add_step("coalesce", *args)
         return self
 
     def coin(self, *args):
-        self.bytecode.add_step("coin", *args)
+        self.gremlin_lang.add_step("coin", *args)
         return self
 
     def combine(self, *args):
-        self.bytecode.add_step("combine", *args)
+        self.gremlin_lang.add_step("combine", *args)
         return self
 
     def concat(self, *args):
-        self.bytecode.add_step("concat", *args)
+        self.gremlin_lang.add_step("concat", *args)
         return self
 
     def conjoin(self, *args):
-        self.bytecode.add_step("conjoin", *args)
+        self.gremlin_lang.add_step("conjoin", *args)
         return self
 
     def connectedComponent(self, *args):
@@ -400,15 +401,15 @@ class GraphTraversal(Traversal):
         return self.connected_component(*args)
 
     def connected_component(self, *args):
-        self.bytecode.add_step("connectedComponent", *args)
+        self.gremlin_lang.add_step("connectedComponent", *args)
         return self
 
     def constant(self, *args):
-        self.bytecode.add_step("constant", *args)
+        self.gremlin_lang.add_step("constant", *args)
         return self
 
     def count(self, *args):
-        self.bytecode.add_step("count", *args)
+        self.gremlin_lang.add_step("count", *args)
         return self
 
     def cyclicPath(self, *args):
@@ -419,39 +420,39 @@ class GraphTraversal(Traversal):
         return self.cyclic_path(*args)
 
     def cyclic_path(self, *args):
-        self.bytecode.add_step("cyclicPath", *args)
+        self.gremlin_lang.add_step("cyclicPath", *args)
         return self
 
     def date_add(self, *args):
-        self.bytecode.add_step("dateAdd", *args)
+        self.gremlin_lang.add_step("dateAdd", *args)
         return self
 
     def date_diff(self, *args):
-        self.bytecode.add_step("dateDiff", *args)
+        self.gremlin_lang.add_step("dateDiff", *args)
         return self
 
     def dedup(self, *args):
-        self.bytecode.add_step("dedup", *args)
+        self.gremlin_lang.add_step("dedup", *args)
         return self
 
     def difference(self, *args):
-        self.bytecode.add_step("difference", *args)
+        self.gremlin_lang.add_step("difference", *args)
         return self
 
     def discard(self, *args):
-        self.bytecode.add_step("discard", *args)
+        self.gremlin_lang.add_step("discard", *args)
         return self
 
     def disjunct(self, *args):
-        self.bytecode.add_step("disjunct", *args)
+        self.gremlin_lang.add_step("disjunct", *args)
         return self
 
     def drop(self, *args):
-        self.bytecode.add_step("drop", *args)
+        self.gremlin_lang.add_step("drop", *args)
         return self
 
     def element(self, *args):
-        self.bytecode.add_step("element", *args)
+        self.gremlin_lang.add_step("element", *args)
         return self
 
     def elementMap(self, *args):
@@ -462,19 +463,19 @@ class GraphTraversal(Traversal):
         return self.element_map(*args)
 
     def element_map(self, *args):
-        self.bytecode.add_step("elementMap", *args)
+        self.gremlin_lang.add_step("elementMap", *args)
         return self
 
     def emit(self, *args):
-        self.bytecode.add_step("emit", *args)
+        self.gremlin_lang.add_step("emit", *args)
         return self
 
     def fail(self, *args):
-        self.bytecode.add_step("fail", *args)
+        self.gremlin_lang.add_step("fail", *args)
         return self
 
     def filter_(self, *args):
-        self.bytecode.add_step("filter", *args)
+        self.gremlin_lang.add_step("filter", *args)
         return self
 
     def flatMap(self, *args):
@@ -485,23 +486,23 @@ class GraphTraversal(Traversal):
         return self.flat_map(*args)
 
     def flat_map(self, *args):
-        self.bytecode.add_step("flatMap", *args)
+        self.gremlin_lang.add_step("flatMap", *args)
         return self
 
     def fold(self, *args):
-        self.bytecode.add_step("fold", *args)
+        self.gremlin_lang.add_step("fold", *args)
         return self
 
     def format_(self, *args):
-        self.bytecode.add_step("format", *args)
+        self.gremlin_lang.add_step("format", *args)
         return self
 
     def from_(self, *args):
-        self.bytecode.add_step("from", *args)
+        self.gremlin_lang.add_step("from", *args)
         return self
 
     def group(self, *args):
-        self.bytecode.add_step("group", *args)
+        self.gremlin_lang.add_step("group", *args)
         return self
 
     def groupCount(self, *args):
@@ -512,11 +513,11 @@ class GraphTraversal(Traversal):
         return self.group_count(*args)
 
     def group_count(self, *args):
-        self.bytecode.add_step("groupCount", *args)
+        self.gremlin_lang.add_step("groupCount", *args)
         return self
 
     def has(self, *args):
-        self.bytecode.add_step("has", *args)
+        self.gremlin_lang.add_step("has", *args)
         return self
 
     def hasId(self, *args):
@@ -527,7 +528,7 @@ class GraphTraversal(Traversal):
         return self.has_id(*args)
 
     def has_id(self, *args):
-        self.bytecode.add_step("hasId", *args)
+        self.gremlin_lang.add_step("hasId", *args)
         return self
 
     def hasKey(self, *args):
@@ -538,11 +539,11 @@ class GraphTraversal(Traversal):
         return self.has_key_(*args)
 
     def has_key_(self, *args):
-        self.bytecode.add_step("hasKey", *args)
+        self.gremlin_lang.add_step("hasKey", *args)
         return self
 
     def has_key(self, *args):
-        self.bytecode.add_step("hasKey", *args)
+        self.gremlin_lang.add_step("hasKey", *args)
         return self
 
     def hasLabel(self, *args):
@@ -553,7 +554,7 @@ class GraphTraversal(Traversal):
         return self.has_label(*args)
 
     def has_label(self, *args):
-        self.bytecode.add_step("hasLabel", *args)
+        self.gremlin_lang.add_step("hasLabel", *args)
         return self
 
     def hasNot(self, *args):
@@ -564,7 +565,7 @@ class GraphTraversal(Traversal):
         return self.has_not(*args)
 
     def has_not(self, *args):
-        self.bytecode.add_step("hasNot", *args)
+        self.gremlin_lang.add_step("hasNot", *args)
         return self
 
     def hasValue(self, *args):
@@ -575,15 +576,15 @@ class GraphTraversal(Traversal):
         return self.has_value(*args)
 
     def has_value(self, *args):
-        self.bytecode.add_step("hasValue", *args)
+        self.gremlin_lang.add_step("hasValue", *args)
         return self
 
     def id_(self, *args):
-        self.bytecode.add_step("id", *args)
+        self.gremlin_lang.add_step("id", *args)
         return self
 
     def identity(self, *args):
-        self.bytecode.add_step("identity", *args)
+        self.gremlin_lang.add_step("identity", *args)
         return self
 
     def inE(self, *args):
@@ -594,7 +595,7 @@ class GraphTraversal(Traversal):
         return self.in_e(*args)
 
     def in_e(self, *args):
-        self.bytecode.add_step("inE", *args)
+        self.gremlin_lang.add_step("inE", *args)
         return self
 
     def inV(self, *args):
@@ -605,119 +606,119 @@ class GraphTraversal(Traversal):
         return self.in_v(*args)
 
     def in_v(self, *args):
-        self.bytecode.add_step("inV", *args)
+        self.gremlin_lang.add_step("inV", *args)
         return self
 
     def in_(self, *args):
-        self.bytecode.add_step("in", *args)
+        self.gremlin_lang.add_step("in", *args)
         return self
 
     def index(self, *args):
-        self.bytecode.add_step("index", *args)
+        self.gremlin_lang.add_step("index", *args)
         return self
 
     def inject(self, *args):
-        self.bytecode.add_step("inject", *args)
+        self.gremlin_lang.add_step("inject", *args)
         return self
 
     def intersect(self, *args):
-        self.bytecode.add_step("intersect", *args)
+        self.gremlin_lang.add_step("intersect", *args)
         return self
 
     def is_(self, *args):
-        self.bytecode.add_step("is", *args)
+        self.gremlin_lang.add_step("is", *args)
         return self
 
     def key(self, *args):
-        self.bytecode.add_step("key", *args)
+        self.gremlin_lang.add_step("key", *args)
         return self
 
     def label(self, *args):
-        self.bytecode.add_step("label", *args)
+        self.gremlin_lang.add_step("label", *args)
         return self
 
     def length(self, *args):
-        self.bytecode.add_step("length", *args)
+        self.gremlin_lang.add_step("length", *args)
         return self
 
     def limit(self, *args):
-        self.bytecode.add_step("limit", *args)
+        self.gremlin_lang.add_step("limit", *args)
         return self
 
     def local(self, *args):
-        self.bytecode.add_step("local", *args)
+        self.gremlin_lang.add_step("local", *args)
         return self
 
     def loops(self, *args):
-        self.bytecode.add_step("loops", *args)
+        self.gremlin_lang.add_step("loops", *args)
         return self
 
     def lTrim(self, *args):
-        self.bytecode.add_step("lTrim", *args)
+        self.gremlin_lang.add_step("lTrim", *args)
         return self
 
     def l_trim(self, *args):
-        self.bytecode.add_step("lTrim", *args)
+        self.gremlin_lang.add_step("lTrim", *args)
         return self
 
     def map(self, *args):
-        self.bytecode.add_step("map", *args)
+        self.gremlin_lang.add_step("map", *args)
         return self
 
     def match(self, *args):
-        self.bytecode.add_step("match", *args)
+        self.gremlin_lang.add_step("match", *args)
         return self
 
     def math(self, *args):
-        self.bytecode.add_step("math", *args)
+        self.gremlin_lang.add_step("math", *args)
         return self
 
     def max_(self, *args):
-        self.bytecode.add_step("max", *args)
+        self.gremlin_lang.add_step("max", *args)
         return self
 
     def mean(self, *args):
-        self.bytecode.add_step("mean", *args)
+        self.gremlin_lang.add_step("mean", *args)
         return self
 
     def merge(self, *args):
-        self.bytecode.add_step("merge", *args)
+        self.gremlin_lang.add_step("merge", *args)
         return self
 
     def merge_e(self, *args):
-        self.bytecode.add_step("mergeE", *args)
+        self.gremlin_lang.add_step("mergeE", *args)
         return self
 
     def merge_v(self, *args):
-        self.bytecode.add_step("mergeV", *args)
+        self.gremlin_lang.add_step("mergeV", *args)
         return self
 
     def min_(self, *args):
-        self.bytecode.add_step("min", *args)
+        self.gremlin_lang.add_step("min", *args)
         return self
 
     def none(self, *args):
-        self.bytecode.add_step("none", *args)
+        self.gremlin_lang.add_step("none", *args)
         return self
 
     def not_(self, *args):
-        self.bytecode.add_step("not", *args)
+        self.gremlin_lang.add_step("not", *args)
         return self
 
     def option(self, *args):
-        self.bytecode.add_step("option", *args)
+        self.gremlin_lang.add_step("option", *args)
         return self
 
     def optional(self, *args):
-        self.bytecode.add_step("optional", *args)
+        self.gremlin_lang.add_step("optional", *args)
         return self
 
     def or_(self, *args):
-        self.bytecode.add_step("or", *args)
+        self.gremlin_lang.add_step("or", *args)
         return self
 
     def order(self, *args):
-        self.bytecode.add_step("order", *args)
+        self.gremlin_lang.add_step("order", *args)
         return self
 
     def otherV(self, *args):
@@ -728,11 +729,11 @@ class GraphTraversal(Traversal):
         return self.other_v(*args)
 
     def other_v(self, *args):
-        self.bytecode.add_step("otherV", *args)
+        self.gremlin_lang.add_step("otherV", *args)
         return self
 
     def out(self, *args):
-        self.bytecode.add_step("out", *args)
+        self.gremlin_lang.add_step("out", *args)
         return self
 
     def outE(self, *args):
@@ -743,7 +744,7 @@ class GraphTraversal(Traversal):
         return self.out_e(*args)
 
     def out_e(self, *args):
-        self.bytecode.add_step("outE", *args)
+        self.gremlin_lang.add_step("outE", *args)
         return self
 
     def outV(self, *args):
@@ -754,7 +755,7 @@ class GraphTraversal(Traversal):
         return self.out_v(*args)
 
     def out_v(self, *args):
-        self.bytecode.add_step("outV", *args)
+        self.gremlin_lang.add_step("outV", *args)
         return self
 
     def pageRank(self, *args):
@@ -765,11 +766,11 @@ class GraphTraversal(Traversal):
         return self.page_rank(*args)
 
     def page_rank(self, *args):
-        self.bytecode.add_step("pageRank", *args)
+        self.gremlin_lang.add_step("pageRank", *args)
         return self
 
     def path(self, *args):
-        self.bytecode.add_step("path", *args)
+        self.gremlin_lang.add_step("path", *args)
         return self
 
     def peerPressure(self, *args):
@@ -780,31 +781,31 @@ class GraphTraversal(Traversal):
         return self.peer_pressure(*args)
 
     def peer_pressure(self, *args):
-        self.bytecode.add_step("peerPressure", *args)
+        self.gremlin_lang.add_step("peerPressure", *args)
         return self
 
     def product(self, *args):
-        self.bytecode.add_step("product", *args)
+        self.gremlin_lang.add_step("product", *args)
         return self
 
     def profile(self, *args):
-        self.bytecode.add_step("profile", *args)
+        self.gremlin_lang.add_step("profile", *args)
         return self
 
     def program(self, *args):
-        self.bytecode.add_step("program", *args)
+        self.gremlin_lang.add_step("program", *args)
         return self
 
     def project(self, *args):
-        self.bytecode.add_step("project", *args)
+        self.gremlin_lang.add_step("project", *args)
         return self
 
     def properties(self, *args):
-        self.bytecode.add_step("properties", *args)
+        self.gremlin_lang.add_step("properties", *args)
         return self
 
     def property(self, *args):
-        self.bytecode.add_step("property", *args)
+        self.gremlin_lang.add_step("property", *args)
         return self
 
     def propertyMap(self, *args):
@@ -815,47 +816,47 @@ class GraphTraversal(Traversal):
         return self.property_map(*args)
 
     def property_map(self, *args):
-        self.bytecode.add_step("propertyMap", *args)
+        self.gremlin_lang.add_step("propertyMap", *args)
         return self
 
     def range_(self, *args):
-        self.bytecode.add_step("range", *args)
+        self.gremlin_lang.add_step("range", *args)
         return self
 
     def read(self, *args):
-        self.bytecode.add_step("read", *args)
+        self.gremlin_lang.add_step("read", *args)
         return self
 
     def repeat(self, *args):
-        self.bytecode.add_step("repeat", *args)
+        self.gremlin_lang.add_step("repeat", *args)
         return self
 
     def replace(self, *args):
-        self.bytecode.add_step("replace", *args)
+        self.gremlin_lang.add_step("replace", *args)
         return self
 
     def reverse(self, *args):
-        self.bytecode.add_step("reverse", *args)
+        self.gremlin_lang.add_step("reverse", *args)
         return self
 
     def rTrim(self, *args):
-        self.bytecode.add_step("rTrim", *args)
+        self.gremlin_lang.add_step("rTrim", *args)
         return self
 
     def r_trim(self, *args):
-        self.bytecode.add_step("rTrim", *args)
+        self.gremlin_lang.add_step("rTrim", *args)
         return self
 
     def sack(self, *args):
-        self.bytecode.add_step("sack", *args)
+        self.gremlin_lang.add_step("sack", *args)
         return self
 
     def sample(self, *args):
-        self.bytecode.add_step("sample", *args)
+        self.gremlin_lang.add_step("sample", *args)
         return self
 
     def select(self, *args):
-        self.bytecode.add_step("select", *args)
+        self.gremlin_lang.add_step("select", *args)
         return self
 
     def shortestPath(self, *args):
@@ -866,7 +867,7 @@ class GraphTraversal(Traversal):
         return self.shortest_path(*args)
 
     def shortest_path(self, *args):
-        self.bytecode.add_step("shortestPath", *args)
+        self.gremlin_lang.add_step("shortestPath", *args)
         return self
 
     def sideEffect(self, *args):
@@ -877,7 +878,7 @@ class GraphTraversal(Traversal):
         return self.side_effect(*args)
 
     def side_effect(self, *args):
-        self.bytecode.add_step("sideEffect", *args)
+        self.gremlin_lang.add_step("sideEffect", *args)
         return self
 
     def simplePath(self, *args):
@@ -888,35 +889,35 @@ class GraphTraversal(Traversal):
         return self.simple_path(*args)
 
     def simple_path(self, *args):
-        self.bytecode.add_step("simplePath", *args)
+        self.gremlin_lang.add_step("simplePath", *args)
         return self
 
     def skip(self, *args):
-        self.bytecode.add_step("skip", *args)
+        self.gremlin_lang.add_step("skip", *args)
         return self
 
     def split(self, *args):
-        self.bytecode.add_step("split", *args)
+        self.gremlin_lang.add_step("split", *args)
         return self
 
     def store(self, *args):
-        self.bytecode.add_step("store", *args)
+        self.gremlin_lang.add_step("store", *args)
         return self
 
     def subgraph(self, *args):
-        self.bytecode.add_step("subgraph", *args)
+        self.gremlin_lang.add_step("subgraph", *args)
         return self
 
     def substring(self, *args):
-        self.bytecode.add_step("substring", *args)
+        self.gremlin_lang.add_step("substring", *args)
         return self
 
     def sum_(self, *args):
-        self.bytecode.add_step("sum", *args)
+        self.gremlin_lang.add_step("sum", *args)
         return self
 
     def tail(self, *args):
-        self.bytecode.add_step("tail", *args)
+        self.gremlin_lang.add_step("tail", *args)
         return self
 
     def timeLimit(self, *args):
@@ -927,15 +928,15 @@ class GraphTraversal(Traversal):
         return self.time_limit(*args)
 
     def time_limit(self, *args):
-        self.bytecode.add_step("timeLimit", *args)
+        self.gremlin_lang.add_step("timeLimit", *args)
         return self
 
     def times(self, *args):
-        self.bytecode.add_step("times", *args)
+        self.gremlin_lang.add_step("times", *args)
         return self
 
     def to(self, *args):
-        self.bytecode.add_step("to", *args)
+        self.gremlin_lang.add_step("to", *args)
         return self
 
     def toE(self, *args):
@@ -946,15 +947,15 @@ class GraphTraversal(Traversal):
         return self.to_e(*args)
 
     def to_e(self, *args):
-        self.bytecode.add_step("toE", *args)
+        self.gremlin_lang.add_step("toE", *args)
         return self
 
     def to_lower(self, *args):
-        self.bytecode.add_step("toLower", *args)
+        self.gremlin_lang.add_step("toLower", *args)
         return self
 
     def to_upper(self, *args):
-        self.bytecode.add_step("toUpper", *args)
+        self.gremlin_lang.add_step("toUpper", *args)
         return self
 
     def toV(self, *args):
@@ -965,31 +966,31 @@ class GraphTraversal(Traversal):
         return self.to_v(*args)
 
     def to_v(self, *args):
-        self.bytecode.add_step("toV", *args)
+        self.gremlin_lang.add_step("toV", *args)
         return self
 
     def tree(self, *args):
-        self.bytecode.add_step("tree", *args)
+        self.gremlin_lang.add_step("tree", *args)
         return self
 
     def trim(self, *args):
-        self.bytecode.add_step("trim", *args)
+        self.gremlin_lang.add_step("trim", *args)
         return self
 
     def unfold(self, *args):
-        self.bytecode.add_step("unfold", *args)
+        self.gremlin_lang.add_step("unfold", *args)
         return self
 
     def union(self, *args):
-        self.bytecode.add_step("union", *args)
+        self.gremlin_lang.add_step("union", *args)
         return self
 
     def until(self, *args):
-        self.bytecode.add_step("until", *args)
+        self.gremlin_lang.add_step("until", *args)
         return self
 
     def value(self, *args):
-        self.bytecode.add_step("value", *args)
+        self.gremlin_lang.add_step("value", *args)
         return self
 
     def valueMap(self, *args):
@@ -1000,23 +1001,23 @@ class GraphTraversal(Traversal):
         return self.value_map(*args)
 
     def value_map(self, *args):
-        self.bytecode.add_step("valueMap", *args)
+        self.gremlin_lang.add_step("valueMap", *args)
         return self
 
     def values(self, *args):
-        self.bytecode.add_step("values", *args)
+        self.gremlin_lang.add_step("values", *args)
         return self
 
     def where(self, *args):
-        self.bytecode.add_step("where", *args)
+        self.gremlin_lang.add_step("where", *args)
         return self
 
     def with_(self, *args):
-        self.bytecode.add_step("with", *args)
+        self.gremlin_lang.add_step("with", *args)
         return self
 
     def write(self, *args):
-        self.bytecode.add_step("write", *args)
+        self.gremlin_lang.add_step("write", *args)
         return self
 
 
@@ -1034,7 +1035,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def start(cls):
-        return GraphTraversal(None, None, Bytecode())
+        return GraphTraversal(None, None, GremlinLang())
 
     @classmethod
     def __(cls, *args):
@@ -1042,11 +1043,11 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def E(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).E(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).E(*args)
 
     @classmethod
     def V(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).V(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).V(*args)
 
     @classmethod
     def addE(cls, *args):
@@ -1058,7 +1059,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def add_e(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).add_e(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).add_e(*args)
 
     @classmethod
     def addV(cls, *args):
@@ -1070,43 +1071,43 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def add_v(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).add_v(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).add_v(*args)
 
     @classmethod
     def aggregate(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).aggregate(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).aggregate(*args)
 
     @classmethod
     def all_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).all_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).all_(*args)
 
     @classmethod
     def and_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).and_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).and_(*args)
 
     @classmethod
     def any_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).any_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).any_(*args)
 
     @classmethod
     def as_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).as_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).as_(*args)
 
     @classmethod
     def as_date(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).as_date(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).as_date(*args)
 
     @classmethod
     def as_string(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).as_string(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).as_string(*args)
 
     @classmethod
     def barrier(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).barrier(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).barrier(*args)
 
     @classmethod
     def both(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).both(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).both(*args)
 
     @classmethod
     def bothE(cls, *args):
@@ -1118,7 +1119,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def both_e(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).both_e(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).both_e(*args)
 
     @classmethod
     def bothV(cls, *args):
@@ -1130,51 +1131,51 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def both_v(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).both_v(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).both_v(*args)
 
     @classmethod
     def branch(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).branch(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).branch(*args)
 
     @classmethod
     def call(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).call(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).call(*args)
 
     @classmethod
     def cap(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).cap(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).cap(*args)
 
     @classmethod
     def choose(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).choose(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).choose(*args)
 
     @classmethod
     def coalesce(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).coalesce(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).coalesce(*args)
 
     @classmethod
     def coin(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).coin(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).coin(*args)
 
     @classmethod
     def combine(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).combine(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).combine(*args)
 
     @classmethod
     def concat(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).concat(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).concat(*args)
 
     @classmethod
     def conjoin(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).conjoin(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).conjoin(*args)
 
     @classmethod
     def constant(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).constant(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).constant(*args)
 
     @classmethod
     def count(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).count(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).count(*args)
 
     @classmethod
     def cyclicPath(cls, *args):
@@ -1186,35 +1187,35 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def cyclic_path(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).cyclic_path(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).cyclic_path(*args)
 
     @classmethod
     def date_add(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).date_add(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).date_add(*args)
 
     @classmethod
     def date_diff(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).date_diff(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).date_diff(*args)
 
     @classmethod
     def dedup(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).dedup(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).dedup(*args)
 
     @classmethod
     def difference(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).difference(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).difference(*args)
 
     @classmethod
     def disjunct(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).disjunct(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).disjunct(*args)
 
     @classmethod
     def drop(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).drop(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).drop(*args)
 
     @classmethod
     def element(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).element(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).element(*args)
 
     @classmethod
     def elementMap(cls, *args):
@@ -1226,19 +1227,19 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def element_map(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).element_map(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).element_map(*args)
 
     @classmethod
     def emit(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).emit(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).emit(*args)
 
     @classmethod
     def fail(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).fail(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).fail(*args)
 
     @classmethod
     def filter_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).filter_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).filter_(*args)
 
     @classmethod
     def flatMap(cls, *args):
@@ -1250,19 +1251,19 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def flat_map(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).flat_map(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).flat_map(*args)
 
     @classmethod
     def fold(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).fold(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).fold(*args)
 
     @classmethod
     def format_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).format_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).format_(*args)
 
     @classmethod
     def group(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).group(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).group(*args)
 
     @classmethod
     def groupCount(cls, *args):
@@ -1274,11 +1275,11 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def group_count(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).group_count(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).group_count(*args)
 
     @classmethod
     def has(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).has(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).has(*args)
 
     @classmethod
     def hasId(cls, *args):
@@ -1290,7 +1291,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def has_id(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).has_id(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).has_id(*args)
 
     @classmethod
     def hasKey(cls, *args):
@@ -1302,7 +1303,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def has_key_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).has_key_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).has_key_(*args)
 
     @classmethod
     def hasLabel(cls, *args):
@@ -1314,7 +1315,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def has_label(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).has_label(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).has_label(*args)
 
     @classmethod
     def hasNot(cls, *args):
@@ -1326,7 +1327,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def has_not(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).has_not(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).has_not(*args)
 
     @classmethod
     def hasValue(cls, *args):
@@ -1338,15 +1339,15 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def has_value(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).has_value(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).has_value(*args)
 
     @classmethod
     def id_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).id_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).id_(*args)
 
     @classmethod
     def identity(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).identity(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).identity(*args)
 
     @classmethod
     def inE(cls, *args):
@@ -1358,7 +1359,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def in_e(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).in_e(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).in_e(*args)
 
     @classmethod
     def inV(cls, *args):
@@ -1370,51 +1371,51 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def in_v(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).in_v(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).in_v(*args)
 
     @classmethod
     def in_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).in_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).in_(*args)
 
     @classmethod
     def index(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).index(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).index(*args)
 
     @classmethod
     def inject(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).inject(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).inject(*args)
 
     @classmethod
     def intersect(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).intersect(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).intersect(*args)
 
     @classmethod
     def is_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).is_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).is_(*args)
 
     @classmethod
     def key(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).key(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).key(*args)
 
     @classmethod
     def label(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).label(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).label(*args)
 
     @classmethod
     def length(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).length(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).length(*args)
 
     @classmethod
     def limit(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).limit(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).limit(*args)
 
     @classmethod
     def local(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).local(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).local(*args)
 
     @classmethod
     def loops(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).loops(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).loops(*args)
 
     @classmethod
     def ltrim(cls, *args):
@@ -1426,63 +1427,63 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def l_trim(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).l_trim(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).l_trim(*args)
 
     @classmethod
     def map(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).map(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).map(*args)
 
     @classmethod
     def match(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).match(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).match(*args)
 
     @classmethod
     def math(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).math(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).math(*args)
 
     @classmethod
     def max_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).max_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).max_(*args)
 
     @classmethod
     def mean(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).mean(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).mean(*args)
 
     @classmethod
     def merge(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).merge(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).merge(*args)
 
     @classmethod
     def merge_e(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).merge_e(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).merge_e(*args)
 
     @classmethod
     def merge_v(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).merge_v(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).merge_v(*args)
 
     @classmethod
     def min_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).min_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).min_(*args)
 
     @classmethod
     def none(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).none(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).none(*args)
 
     @classmethod
     def not_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).not_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).not_(*args)
 
     @classmethod
     def optional(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).optional(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).optional(*args)
 
     @classmethod
     def or_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).or_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).or_(*args)
 
     @classmethod
     def order(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).order(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).order(*args)
 
     @classmethod
     def otherV(cls, *args):
@@ -1494,11 +1495,11 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def other_v(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).other_v(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).other_v(*args)
 
     @classmethod
     def out(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).out(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).out(*args)
 
     @classmethod
     def outE(cls, *args):
@@ -1510,7 +1511,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def out_e(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).out_e(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).out_e(*args)
 
     @classmethod
     def outV(cls, *args):
@@ -1522,27 +1523,27 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def out_v(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).out_v(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).out_v(*args)
 
     @classmethod
     def path(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).path(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).path(*args)
 
     @classmethod
     def product(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).product(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).product(*args)
 
     @classmethod
     def project(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).project(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).project(*args)
 
     @classmethod
     def properties(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).properties(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).properties(*args)
 
     @classmethod
     def property(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).property(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).property(*args)
 
     @classmethod
     def propertyMap(cls, *args):
@@ -1554,23 +1555,23 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def property_map(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).property_map(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).property_map(*args)
 
     @classmethod
     def range_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).range_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).range_(*args)
 
     @classmethod
     def repeat(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).repeat(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).repeat(*args)
 
     @classmethod
     def replace(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).replace(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).replace(*args)
 
     @classmethod
     def reverse(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).reverse(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).reverse(*args)
 
     @classmethod
     def rTrim(cls, *args):
@@ -1582,19 +1583,19 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def r_trim(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).r_trim(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).r_trim(*args)
 
     @classmethod
     def sack(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).sack(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).sack(*args)
 
     @classmethod
     def sample(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).sample(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).sample(*args)
 
     @classmethod
     def select(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).select(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).select(*args)
 
     @classmethod
     def sideEffect(cls, *args):
@@ -1606,7 +1607,7 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def side_effect(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).side_effect(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).side_effect(*args)
 
     @classmethod
     def simplePath(cls, *args):
@@ -1618,35 +1619,35 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def simple_path(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).simple_path(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).simple_path(*args)
 
     @classmethod
     def skip(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).skip(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).skip(*args)
 
     @classmethod
     def split(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).split(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).split(*args)
 
     @classmethod
     def store(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).store(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).store(*args)
 
     @classmethod
     def subgraph(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).subgraph(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).subgraph(*args)
 
     @classmethod
     def substring(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).substring(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).substring(*args)
 
     @classmethod
     def sum_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).sum_(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).sum_(*args)
 
     @classmethod
     def tail(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).tail(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).tail(*args)
 
     @classmethod
     def timeLimit(cls, *args):
@@ -1658,15 +1659,15 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def time_limit(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).time_limit(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).time_limit(*args)
 
     @classmethod
     def times(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).times(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).times(*args)
 
     @classmethod
     def to(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).to(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).to(*args)
 
     @classmethod
     def toE(cls, *args):
@@ -1678,15 +1679,15 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def to_e(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).to_e(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).to_e(*args)
 
     @classmethod
     def to_lower(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).to_lower(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).to_lower(*args)
 
     @classmethod
     def to_upper(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).to_upper(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).to_upper(*args)
 
     @classmethod
     def toV(cls, *args):
@@ -1698,31 +1699,31 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def to_v(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).to_v(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).to_v(*args)
 
     @classmethod
     def tree(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).tree(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).tree(*args)
 
     @classmethod
     def trim(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).trim(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).trim(*args)
 
     @classmethod
     def unfold(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).unfold(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).unfold(*args)
 
     @classmethod
     def union(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).union(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).union(*args)
 
     @classmethod
     def until(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).until(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).until(*args)
 
     @classmethod
     def value(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).value(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).value(*args)
 
     @classmethod
     def valueMap(cls, *args):
@@ -1734,90 +1735,90 @@ class __(object, metaclass=MagicType):
 
     @classmethod
     def value_map(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).value_map(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).value_map(*args)
 
     @classmethod
     def values(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).values(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).values(*args)
 
     @classmethod
     def where(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).where(*args)
+        return cls.graph_traversal(None, None, GremlinLang()).where(*args)
 
 
 # Class to handle transactions.
-class Transaction:
-
-    def __init__(self, g, remote_connection):
-        self._g = g
-        self._session_based_connection = None
-        self._remote_connection = remote_connection
-        self.__is_open = False
-        self.__mutex = Lock()
-
-    # Begins transaction.
-    def begin(self):
-        with self.__mutex:
-            # Verify transaction is not open.
-            self.__verify_transaction_state(False, "Transaction already started on this object")
-
-            # Create new session using the remote connection.
-            self._session_based_connection = self._remote_connection.create_session()
-            self.__is_open = True
-
-            # Set the session as a remote strategy within the traversal strategy.
-            traversal_strategy = TraversalStrategies()
-            traversal_strategy.add_strategies([RemoteStrategy(self._session_based_connection)])
-
-            # Return new GraphTraversalSource.
-            return GraphTraversalSource(self._g.graph, traversal_strategy, self._g.bytecode)
-
-    # Rolls transaction back.
-    def rollback(self):
-        with self.__mutex:
-            # Verify transaction is open, close session and return result of transaction's rollback.
-            self.__verify_transaction_state(True, "Cannot rollback a transaction that is not started.")
-            return self.__close_session(self._session_based_connection.rollback())
-
-    # Commits the current transaction.
-    def commit(self):
-        with self.__mutex:
-            # Verify transaction is open, close session and return result of transaction's commit.
-            self.__verify_transaction_state(True, "Cannot commit a transaction that is not started.")
-            return self.__close_session(self._session_based_connection.commit())
-
-    # Closes session.
-    def close(self):
-        with self.__mutex:
-            # Verify transaction is open.
-            self.__verify_transaction_state(True, "Cannot close a transaction that has previously been closed.")
-            self.__close_session(None)
-
-    # Return whether or not transaction is open.
-    # Allow camelcase function here to keep api consistent with other languages.
-    def isOpen(self):
-        warnings.warn(
-            "gremlin_python.process.Transaction.isOpen will be replaced by "
-            "gremlin_python.process.Transaction.is_open.",
-            DeprecationWarning)
-        return self.is_open()
-
-    def is_open(self):
-        # if the underlying DriverRemoteConnection is closed then the Transaction can't be open
-        if (self._session_based_connection and self._session_based_connection.is_closed()) or \
-                self._remote_connection.is_closed():
-            self.__is_open = False
-
-        return self.__is_open
-
-    def __verify_transaction_state(self, state, error_message):
-        if self.__is_open != state:
-            raise Exception(error_message)
-
-    def __close_session(self, session):
-        self.__is_open = False
-        self._remote_connection.remove_session(self._session_based_connection)
-        return session
+# class Transaction:
+#
+#     def __init__(self, g, remote_connection):
+#         self._g = g
+#         self._session_based_connection = None
+#         self._remote_connection = remote_connection
+#         self.__is_open = False
+#         self.__mutex = Lock()
+#
+#     # Begins transaction.
+#     def begin(self):
+#         with self.__mutex:
+#             # Verify transaction is not open.
+#             self.__verify_transaction_state(False, "Transaction already started on this object")
+#
+#             # Create new session using the remote connection.
+#             self._session_based_connection = self._remote_connection.create_session()
+#             self.__is_open = True
+#
+#             # Set the session as a remote strategy within the traversal strategy.
+#             traversal_strategy.py = TraversalStrategies()
+#             traversal_strategy.py.add_strategies([RemoteStrategy(self._session_based_connection)])
+#
+#             # Return new GraphTraversalSource.
+#             return GraphTraversalSource(self._g.graph, traversal_strategy.py, self._g.bytecode)
+#
+#     # Rolls transaction back.
+#     def rollback(self):
+#         with self.__mutex:
+#             # Verify transaction is open, close session and return result of transaction's rollback.
+#             self.__verify_transaction_state(True, "Cannot rollback a transaction that is not started.")
+#             return self.__close_session(self._session_based_connection.rollback())
+#
+#     # Commits the current transaction.
+#     def commit(self):
+#         with self.__mutex:
+#             # Verify transaction is open, close session and return result of transaction's commit.
+#             self.__verify_transaction_state(True, "Cannot commit a transaction that is not started.")
+#             return self.__close_session(self._session_based_connection.commit())
+#
+#     # Closes session.
+#     def close(self):
+#         with self.__mutex:
+#             # Verify transaction is open.
+#             self.__verify_transaction_state(True, "Cannot close a transaction that has previously been closed.")
+#             self.__close_session(None)
+#
+#     # Return whether or not transaction is open.
+#     # Allow camelcase function here to keep api consistent with other languages.
+#     def isOpen(self):
+#         warnings.warn(
+#             "gremlin_python.process.Transaction.isOpen will be replaced by "
+#             "gremlin_python.process.Transaction.is_open.",
+#             DeprecationWarning)
+#         return self.is_open()
+#
+#     def is_open(self):
+#         # if the underlying DriverRemoteConnection is closed then the Transaction can't be open
+#         if (self._session_based_connection and self._session_based_connection.is_closed()) or \
+#                 self._remote_connection.is_closed():
+#             self.__is_open = False
+#
+#         return self.__is_open
+#
+#     def __verify_transaction_state(self, state, error_message):
+#         if self.__is_open != state:
+#             raise Exception(error_message)
+#
+#     def __close_session(self, session):
+#         self.__is_open = False
+#         self._remote_connection.remove_session(self._session_based_connection)
+#         return session
 
 
 def E(*args):

--- a/gremlin-python/src/main/python/gremlin_python/process/translator.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/translator.py
@@ -34,6 +34,7 @@ from gremlin_python.structure.graph import Vertex, Edge, VertexProperty
 from datetime import datetime
 
 
+# TODO to be removed as bytecode and groovy are replaced by gremlin lang scripts
 class Translator:
     """
     Turn a bytecode object back into a textual query (Gremlin Groovy script).

--- a/gremlin-python/src/main/python/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/traversal.py
@@ -18,25 +18,37 @@
 #
 
 import copy
+import math
+import numbers
+import re
+import threading
 import warnings
+from io import StringIO
+
 from aenum import Enum
+# from gremlin_python.process.strategies import OptionsStrategy
+from gremlin_python.structure.graph import Vertex
+# from gremlin_python.process.gremlin_lang import GremlinLang
+
 from .. import statics
-from ..statics import long
+from ..statics import long, SingleByte, short, bigint, BigDecimal
+from datetime import datetime
+
 
 class Traversal(object):
-    def __init__(self, graph, traversal_strategies, bytecode):
+    def __init__(self, graph, traversal_strategies, gremlin_lang):
         self.graph = graph
         self.traversal_strategies = traversal_strategies
-        self.bytecode = bytecode
+        self.gremlin_lang = gremlin_lang
         self.traversers = None
         self.last_traverser = None
 
     def __repr__(self):
-        return str(self.bytecode)
+        return self.gremlin_lang.get_gremlin()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return self.bytecode == other.bytecode
+            return self.gremlin_lang.get_gremlin() == other.gremlin_lang.get_gremlin()
         else:
             return False
 
@@ -48,11 +60,15 @@ class Traversal(object):
             self.traversal_strategies.apply_strategies(self)
         if self.last_traverser is None:
             self.last_traverser = next(self.traversers)
-        object = self.last_traverser.object
-        self.last_traverser.bulk = self.last_traverser.bulk - 1
-        if self.last_traverser.bulk <= 0:
-            self.last_traverser = None
-        return object
+        # TODO affected by bulking, revisit after bulking is added back
+        # object = self.last_traverser.object
+        # self.last_traverser.bulk = self.last_traverser.bulk - 1
+        # if self.last_traverser.bulk <= 0:
+        #     self.last_traverser = None
+        # return object
+        res = self.last_traverser
+        self.last_traverser = None
+        return res
 
     def toList(self):
         warnings.warn(
@@ -75,10 +91,12 @@ class Traversal(object):
         return set(iter(self))
 
     def iterate(self):
-        self.bytecode.add_step("discard")
+        self.gremlin_lang.add_step("discard")
         while True:
-            try: self.next_traverser()
-            except StopIteration: return self
+            try:
+                self.next_traverser()
+            except StopIteration:
+                return self
 
     def nextTraverser(self):
         warnings.warn(
@@ -87,6 +105,7 @@ class Traversal(object):
             DeprecationWarning)
         return self.next_traverser()
 
+    # TODO: affected by bulking, revisit after bulking is added back
     def next_traverser(self):
         if self.traversers is None:
             self.traversal_strategies.apply_strategies(self)
@@ -104,13 +123,16 @@ class Traversal(object):
             DeprecationWarning)
         return self.has_next()
 
+    # TODO: revisit after bulking is added back
     def has_next(self):
         if self.traversers is None:
             self.traversal_strategies.apply_strategies(self)
         if self.last_traverser is None:
-            try: self.last_traverser = next(self.traversers)
-            except StopIteration: return False
-        return not(self.last_traverser is None) and self.last_traverser.bulk > 0
+            try:
+                self.last_traverser = next(self.traversers)
+            except StopIteration:
+                return False
+        return not (self.last_traverser is None)  # and self.last_traverser.bulk > 0
 
     def next(self, amount=None):
         if amount is None:
@@ -120,8 +142,10 @@ class Traversal(object):
             tempList = []
             while count < amount:
                 count = count + 1
-                try: temp = self.__next__()
-                except StopIteration: return tempList
+                try:
+                    temp = self.__next__()
+                except StopIteration:
+                    return tempList
                 tempList.append(temp)
             return tempList
 
@@ -129,6 +153,7 @@ class Traversal(object):
         self.traversal_strategies.apply_async_strategies(self)
         future_traversal = self.remote_results
         future = type(future_traversal)()
+
         def process(f):
             try:
                 traversal = f.result()
@@ -145,6 +170,7 @@ class Traversal(object):
                         future.set_result(result)
                 else:
                     future.set_result(self)
+
         future_traversal.add_done_callback(process)
         return future
 
@@ -183,12 +209,14 @@ statics.add_static('BOTH', Direction.BOTH)
 statics.add_static('from_', Direction.OUT)
 statics.add_static('to', Direction.IN)
 
+# TODO to be removed
 GraphSONVersion = Enum('GraphSONVersion', ' V1_0 V2_0 V3_0')
 
 statics.add_static('V1_0', GraphSONVersion.V1_0)
 statics.add_static('V2_0', GraphSONVersion.V2_0)
 statics.add_static('V3_0', GraphSONVersion.V3_0)
 
+# TODO to be removed
 GryoVersion = Enum('GryoVersion', ' V1_0 V3_0')
 
 statics.add_static('V1_0', GryoVersion.V1_0)
@@ -231,7 +259,6 @@ Scope = Enum('Scope', ' global_ local')
 statics.add_static('global_', Scope.global_)
 statics.add_static('local', Scope.local)
 
-
 T = Enum('T', ' id id_ key label value')
 
 statics.add_static('id', T.id)
@@ -239,7 +266,6 @@ statics.add_static('label', T.label)
 statics.add_static('id_', T.id_)
 statics.add_static('key', T.key)
 statics.add_static('value', T.value)
-
 
 Operator = Enum('Operator', ' addAll add_all and_ assign div max max_ min min_ minus mult or_ sum_ sumLong sum_long')
 
@@ -316,7 +342,7 @@ class P(object):
             return P("within", list(args[0]))
         else:
             return P("within", list(args))
-        
+
     @staticmethod
     def without(*args):
         if len(args) == 1 and type(args[0]) == list:
@@ -570,16 +596,12 @@ statics.add_static('regex', regex)
 
 statics.add_static('not_regex', not_regex)
 
-
-
-
 '''
 IO
 '''
 
 
 class IO(object):
-
     graphml = "graphml"
 
     graphson = "graphson"
@@ -599,7 +621,6 @@ ConnectedComponent
 
 
 class ConnectedComponent(object):
-
     component = "gremlin.connectedComponentVertexProgram.component"
 
     edges = "~tinkerpop.connectedComponent.edges"
@@ -615,7 +636,6 @@ ShortestPath
 
 
 class ShortestPath(object):
-
     distance = "~tinkerpop.shortestPath.distance"
 
     edges = "~tinkerpop.shortestPath.edges"
@@ -637,7 +657,6 @@ PageRank
 
 
 class PageRank(object):
-
     edges = "~tinkerpop.pageRank.edges"
 
     propertyName = "~tinkerpop.pageRank.propertyName"
@@ -653,7 +672,6 @@ PeerPressure
 
 
 class PeerPressure(object):
-
     edges = "~tinkerpop.peerPressure.edges"
 
     propertyName = "~tinkerpop.peerPressure.propertyName"
@@ -734,6 +752,7 @@ BYTECODE
 '''
 
 
+# TODO to be removed
 class Bytecode(object):
     def __init__(self, bytecode=None):
         self.source_instructions = []
@@ -778,7 +797,8 @@ class Bytecode(object):
     def __convertArgument(self, arg):
         if isinstance(arg, Traversal):
             if arg.graph is not None:
-                raise TypeError("The child traversal of " + str(arg) + " was not spawned anonymously - use the __ class rather than a TraversalSource to construct the child traversal")
+                raise TypeError("The child traversal of " + str(
+                    arg) + " was not spawned anonymously - use the __ class rather than a TraversalSource to construct the child traversal")
             self.bindings.update(arg.bytecode.bindings)
             return arg.bytecode
         elif isinstance(arg, dict):
@@ -804,7 +824,7 @@ class Bytecode(object):
 
     def __repr__(self):
         return (str(self.source_instructions) if len(self.source_instructions) > 0 else "") + \
-               (str(self.step_instructions) if len(self.step_instructions) > 0 else "")
+            (str(self.step_instructions) if len(self.step_instructions) > 0 else "")
 
     @staticmethod
     def _create_graph_op(name, *values):
@@ -846,6 +866,7 @@ BINDINGS
 '''
 
 
+# TODO to be removed
 class Bindings(object):
 
     @staticmethod
@@ -876,7 +897,6 @@ WITH OPTIONS
 
 
 class WithOptions(object):
-
     tokens = "~tinkerpop.valueMap.tokens"
 
     none = 0
@@ -897,3 +917,365 @@ class WithOptions(object):
 
     map = 1
 
+
+'''
+GREMLIN LANGUAGE
+'''
+
+
+class GremlinLang(object):
+    conn_p = ['and', 'or']
+
+    def __init__(self, gremlin_lang=None):
+        self.empty_array = []
+
+        self.gremlin = []
+        self.parameters = {}
+        self.options_strategies = []
+        self.param_count = AtomicInteger()
+
+        if gremlin_lang is not None:
+            self.gremlin = list(gremlin_lang.gremlin)
+            self.parameters = dict(gremlin_lang.parameters)
+            self.options_strategies = list(gremlin_lang.options_strategies)
+            self.param_count = gremlin_lang.param_count
+
+    def _add_to_gremlin(self, string_name, *args):
+
+        if string_name == 'CardinalityValueTraversal':
+            self.gremlin.append(
+                f'Cardinality.{self._convert_argument(args[0][0])}({self._convert_argument(args[0][1])})')
+            return
+
+        self.gremlin.extend(['.', string_name, '('])
+
+        c = 0
+        while len(args[0]) > c:
+            if c != 0:
+                self.gremlin.append(',')
+            self.gremlin.append(self._arg_as_string(self._convert_argument(args[0][c])))
+            c += 1
+
+        self.gremlin.append(')')
+
+    def _arg_as_string(self, arg):
+
+        if arg is None:
+            return 'null'
+
+        if isinstance(arg, str):
+            return f'{arg!r}'  # use repr() format for canonical string rep
+            # return f'"{arg}"'
+        if isinstance(arg, bool):
+            return 'true' if arg else 'false'
+
+        if isinstance(arg, SingleByte):
+            return f'{arg}B'
+        if isinstance(arg, short):
+            return f'{arg}S'
+        if isinstance(arg, long):
+            return f'{arg}L'
+        if isinstance(arg, bigint):
+            return f'{arg}N'
+        if isinstance(arg, int):
+            return f'{arg}'
+        if isinstance(arg, float):
+            # converting floats into doubles for script since python doesn't distinguish and java defaults to double
+            if math.isnan(arg):
+                return "NaN"
+            elif math.isinf(arg) and arg > 0:
+                return "+Infinity"
+            elif math.isinf(arg) and arg < 0:
+                return "-Infinity"
+            else:
+                return f'{arg}D'
+        if isinstance(arg, BigDecimal):
+            # TODO double check implementation when revisiting types definition
+            return f'{arg.unscaled_value}M'
+
+        if isinstance(arg, datetime):
+            return f'datetime("{arg.isoformat()}")'
+
+        if isinstance(arg, Enum):
+            tmp = str(arg)
+            return tmp[0:-1] if tmp.endswith('_') else tmp
+
+        if isinstance(arg, Vertex):
+            return f'new ReferenceVertex({self._arg_as_string(arg.id)},\'{arg.label}\')'
+
+        if isinstance(arg, P):
+            return self._process_predicate(arg)
+
+        if isinstance(arg, GremlinLang) or isinstance(arg, Traversal):
+            gremlin_lang = arg if isinstance(arg, GremlinLang) else arg.gremlin_lang
+            self.parameters.update(gremlin_lang.parameters)
+            return gremlin_lang.get_gremlin('__')
+
+        if isinstance(arg, Parameter):
+            key = arg.key
+            if key is None:
+                key = f'_{self.param_count.get_and_increment()}'
+
+            if not key.isidentifier():
+                raise Exception(f'invalid parameter name {key}.')
+
+            if key in self.parameters:
+                if self.parameters[key] != arg.value:
+                    raise Exception(f'parameter with name {key} already exists.')
+            else:
+                self.parameters[key] = arg.value
+            return key
+
+        if isinstance(arg, dict):
+            return self._process_dict(arg)
+
+        if isinstance(arg, set):
+            return self._process_set(arg)
+
+        if isinstance(arg, list):
+            return self._process_list(arg)
+
+        if hasattr(arg, '__class__'):
+            try:
+                return arg.__name__
+            except AttributeError:
+                pass
+
+        return self._as_parameter(arg)
+
+    def _as_parameter(self, arg):
+        param_name = f'_{self.param_count.get_and_increment()}'
+        self.parameters[param_name] = arg
+        return param_name
+
+    # Do special processing needed to format predicates that come in
+    # such as "gt(a)" correctly.
+    def _process_predicate(self, p):
+        res = []
+        if p.operator in self.conn_p:
+            res.append(f'{self._process_predicate(p.value)}.{p.operator}({self._process_predicate(p.other)})')
+        else:
+            res.append(f'{self._process_p_value(p)}')
+        return ''.join(res)
+
+    # process the value of the predicates
+    def _process_p_value(self, p):
+        c = 0
+        res = [str(p).split('(')[0] + '(']
+        if isinstance(p.value, list):
+            res.append('[')
+            for v in p.value:
+                if c > 0:
+                    res.append(',')
+                res.append(self._arg_as_string(v))
+                c += 1
+            res.append(']')
+        else:
+            res.append(self._arg_as_string(p.value))
+            if p.other is not None:
+                res.append(f',{self._arg_as_string(p.other)}')
+        res.append(')')
+        return ''.join(res)
+
+    def _process_dict(self, d):
+        c = 0
+        res = ['[']
+        if len(d) == 0:
+            res.append(':')
+        else:
+            for k, v in d.items():
+                wrap = not isinstance(k, str)
+                if c > 0:
+                    res.append(',')
+                res.append(f'({self._arg_as_string(k)})') if wrap else res.append(self._arg_as_string(k))
+                res.append(f':{self._arg_as_string(v)}')
+                c += 1
+        res.append(']')
+        return ''.join(res)
+
+    def _process_set(self, s):
+        c = 0
+        res = ['{']
+        for i in s:
+            if c > 0:
+                res.append(',')
+            res.append(self._arg_as_string(i))
+            c += 1
+        res.append('}')
+        return ''.join(res)
+
+    def _process_list(self, lst):
+        c = 0
+        res = ['[']
+        for i in lst:
+            if c > 0:
+                res.append(',')
+            res.append(self._arg_as_string(i))
+            c += 1
+        res.append(']')
+        return ''.join(res)
+
+    def get_gremlin(self, g='g'):
+        # special handling for CardinalityValueTraversal
+        if len(self.gremlin) != 0 and self.gremlin[0] != '.':
+            return ''.join(self.gremlin)
+
+        return g + ''.join(self.gremlin)
+
+    def get_parameters(self):
+        return self.parameters
+
+    def add_g(self, g):
+        self.parameters['g'] = g
+
+    def reset(self):
+        self.param_count.set(0)
+
+    def add_source(self, source_name, *args):
+
+        if source_name == 'withStrategies' and len(args) != 0:
+            args = self.build_strategy_args(args)
+            if len(args) != 0:
+                self.gremlin.append('.')
+                self.gremlin.append(f'withStrategies({args})')
+            return
+        self._add_to_gremlin(source_name, args)
+
+    def build_strategy_args(self, args):
+        res = []
+        c = 0
+        for arg in args:
+            if c > 0:
+                res.append(',')
+            # special handling for OptionsStrategy
+            from gremlin_python.process.strategies import OptionsStrategy
+            if isinstance(arg, OptionsStrategy):
+                self.options_strategies.append(arg)
+                break
+            if not arg.configuration:
+                res.append(arg.strategy_name)
+            else:
+                res.append(f'new {str(arg)}(')
+                ct = 0
+                for key in arg.configuration:
+                    if ct > 0:
+                        res.append(',')
+                    res.append(f'{key}:')
+                    val = arg.configuration[key]
+                    if isinstance(val, Traversal):
+                        res.append(self._arg_as_string(val.gremlin_lang))
+                    else:
+                        res.append(self._arg_as_string(val))
+                    ct += 1
+                res.append(')')
+            c += 1
+        return ''.join(res)
+
+    def add_step(self, step_name, *args):
+        self._add_to_gremlin(step_name, args)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return ''.join(self.gremlin) == ''.join(self.gremlin) and self.parameters == other.parameters
+        else:
+            return False
+
+    def __copy__(self):
+        gl = GremlinLang()
+        gl.parameters = self.parameters
+        gl.gremlin = self.gremlin
+        return gl
+
+    def __deepcopy__(self, memo=None):
+        if memo is None:
+            memo = {}
+        gl = GremlinLang()
+        gl.parameters = copy.deepcopy(self.parameters, memo)
+        gl.gremlin = copy.deepcopy(self.gremlin, memo)
+        return gl
+
+    def _convert_argument(self, arg):
+        # if arg is None or len(arg) == 0:
+        #     return arg
+        if isinstance(arg, Traversal):
+            if arg.graph is not None:
+                raise TypeError("The child traversal of " + str(
+                    arg) + "was not spawned anonymously - use the __ class rather than a TraversalSource to construct "
+                           "the child traversal.")
+            return arg.gremlin_lang
+        elif isinstance(arg, dict):
+            newDict = {}
+            for key in arg:
+                newDict[self._convert_argument(key)] = self._convert_argument(arg[key])
+            return newDict
+        elif isinstance(arg, list):
+            newList = []
+            for item in arg:
+                newList.append(self._convert_argument(item))
+            return newList
+        elif isinstance(arg, set):
+            newSet = set()
+            for item in arg:
+                newSet.add(self._convert_argument(item))
+            return newSet
+        else:
+            return arg
+
+    def __repr__(self):
+        return (''.join(self.gremlin) if len(self.gremlin) > 0 else "") + \
+            (str(self.parameters) if len(self.parameters) > 0 else "")
+
+    # TODO to be removed or updated once HTTP transaction is implemented
+    # @staticmethod
+    # def _create_graph_op(name, *values):
+    #     bc = Bytecode()
+    #     bc.add_source(name, *values)
+    #     return bc
+    #
+    # @staticmethod
+    # class GraphOp:
+    #     @staticmethod
+    #     def commit():
+    #         return Bytecode._create_graph_op("tx", "commit")
+    #
+    #     @staticmethod
+    #     def rollback():
+    #         return Bytecode._create_graph_op("tx", "rollback")
+
+
+class Parameter:
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+
+    @staticmethod
+    def var(key, value):
+        if key is not None and key.startswith('_'):
+            raise Exception(f'invalid parameter name {key}. Should not start with _.')
+        return Parameter(key, value)
+
+    @staticmethod
+    def value(value):
+        return Parameter(None, value)
+
+
+class AtomicInteger:
+    def __init__(self):
+        self._value = 0
+        self._lock = threading.Lock()
+
+    def get_and_increment(self):
+        with self._lock:
+            value = self._value
+            self._value += 1
+            return value
+
+    def set(self, value):
+        with self._lock:
+            self._value = value
+            return self._value
+
+    @property
+    def value(self):
+        with self._lock:
+            return self._value

--- a/gremlin-python/src/main/python/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/graph.py
@@ -19,10 +19,6 @@
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
-from gremlin_python.process.graph_traversal import GraphTraversalSource
-from gremlin_python.process.traversal import TraversalStrategies
-import warnings
-
 
 class Graph(object):
 

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -264,6 +264,8 @@ def test_client_gremlin_lang_request_options_with_binding(client):
     request_opts['bindings'] = {'y': 4}
     result_set = client.submit('g.V(y).values("name")', request_options=request_opts)
     assert result_set.all().result()[0] == 'josh'
+    result_set = client.submit('g.V(z).values("name")', bindings={'z': 5}, request_options=request_opts)
+    assert result_set.all().result()[0] == 'ripple'
 
 
 def test_iterate_result_set(client):
@@ -366,8 +368,9 @@ def test_multi_thread_pool(client):
 def test_client_gremlin_lang_with_short(client):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.with_('language', 'gremlin-lang').V().has('age', short(16)).count()
+    request_opts = DriverRemoteConnection.extract_request_options(t.gremlin_lang)
     message = create_basic_request_message(t)
-    result_set = client.submit(message)
+    result_set = client.submit(message, request_options=request_opts)
     results = []
     for result in result_set:
         results += result
@@ -377,8 +380,9 @@ def test_client_gremlin_lang_with_short(client):
 def test_client_gremlin_lang_with_long(client):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V().has('age', long(851401972585122)).count()
+    request_opts = DriverRemoteConnection.extract_request_options(t.gremlin_lang)
     message = create_basic_request_message(t)
-    result_set = client.submit(message)
+    result_set = client.submit(message, request_options=request_opts)
     results = []
     for result in result_set:
         results += result
@@ -388,8 +392,9 @@ def test_client_gremlin_lang_with_long(client):
 def test_client_gremlin_lang_with_bigint(client):
     g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.with_('language', 'gremlin-lang').V().has('age', bigint(0x1000_0000_0000_0000_0000)).count()
+    request_opts = DriverRemoteConnection.extract_request_options(t.gremlin_lang)
     message = create_basic_request_message(t)
-    result_set = client.submit(message)
+    result_set = client.submit(message, request_options=request_opts)
     results = []
     for result in result_set:
         results += result

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -22,8 +22,7 @@ from datetime import datetime
 import pytest
 from gremlin_python import statics
 from gremlin_python.statics import long
-from gremlin_python.process.traversal import TraversalStrategy
-from gremlin_python.process.traversal import P, Order, T
+from gremlin_python.process.traversal import TraversalStrategy, P, Order, T, Parameter
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.structure.graph import Vertex
@@ -43,6 +42,17 @@ class TestDriverRemoteConnection(object):
         assert remote_connection.extract_request_options(t.gremlin_lang) == {'batchSize': 100,
                                                                              'evaluationTimeout': 1000}
         assert 6 == t.to_list()[0]
+
+    def test_extract_request_options_with_params(self, remote_connection):
+        g = traversal().with_(remote_connection)
+        t = g.with_("evaluationTimeout",
+                    1000).with_("batchSize", 100).with_("userAgent",
+                                                        "test").V(Parameter.var('ids', [1, 2, 3])).count()
+        assert remote_connection.extract_request_options(t.gremlin_lang) == {'batchSize': 100,
+                                                                             'evaluationTimeout': 1000,
+                                                                             'userAgent': 'test',
+                                                                             'params': {'ids': [1, 2, 3]}}
+        assert 3 == t.to_list()[0]
 
     def test_traversals(self, remote_connection):
         statics.load_statics(globals())

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -17,13 +17,12 @@
 # under the License.
 #
 import os
+from datetime import datetime
 
 import pytest
 from gremlin_python import statics
 from gremlin_python.statics import long
-from gremlin_python.process.traversal import Traverser
 from gremlin_python.process.traversal import TraversalStrategy
-from gremlin_python.process.traversal import Bindings
 from gremlin_python.process.traversal import P, Order, T
 from gremlin_python.process.graph_traversal import __
 from gremlin_python.process.anonymous_traversal import traversal
@@ -38,6 +37,13 @@ test_no_auth_url = gremlin_server_url.format(45940)
 
 class TestDriverRemoteConnection(object):
 
+    def test_extract_request_options(self, remote_connection):
+        g = traversal().with_(remote_connection)
+        t = g.with_("evaluationTimeout", 1000).with_("batchSize", 100).V().count()
+        assert remote_connection.extract_request_options(t.gremlin_lang) == {'batchSize': 100,
+                                                                             'evaluationTimeout': 1000}
+        assert 6 == t.to_list()[0]
+
     def test_traversals(self, remote_connection):
         statics.load_statics(globals())
         g = traversal().with_(remote_connection)
@@ -47,7 +53,7 @@ class TestDriverRemoteConnection(object):
         assert Vertex(1) == g.V(1).next()
         assert Vertex(1) == g.V(Vertex(1)).next()
         assert 1 == g.V(1).id_().next()
-        assert Traverser(Vertex(1)) == g.V(1).nextTraverser()
+        # assert Traverser(Vertex(1)) == g.V(1).nextTraverser()  # TODO check back after bulking added back
         assert 1 == len(g.V(1).toList())
         assert isinstance(g.V(1).toList(), list)
         results = g.V().repeat(__.out()).times(2).name
@@ -88,20 +94,11 @@ class TestDriverRemoteConnection(object):
         assert 'marko' in results
         assert 'vadas' in results
         # #
-        results = g.V().has('person', 'name', 'marko').map(
-            lambda: ("it.get().value('name')", "gremlin-groovy")).toList()
-        assert 1 == len(results)
-        assert 'marko' in results
-        # #
         # this test just validates that the underscored versions of steps conflicting with Gremlin work
         # properly and can be removed when the old steps are removed - TINKERPOP-2272
         results = g.V().filter_(__.values('age').sum_().and_(
             __.max_().is_(P.gt(0)), __.min_().is_(P.gt(0)))).range_(0, 1).id_().next()
         assert 1 == results
-        # #
-        # test binding in P
-        results = g.V().has('person', 'age', Bindings.of('x', P.lt(30))).count().next()
-        assert 2 == results
         # #
         # test dict keys
         # types for dict
@@ -147,6 +144,7 @@ class TestDriverRemoteConnection(object):
         except StopIteration:
             assert True
 
+    @pytest.mark.skip(reason="to be removed, lambda disabled in gremlin lang")
     def test_lambda_traversals(self, remote_connection):
         statics.load_statics(globals())
         assert "remoteconnection[{},gmodern]".format(test_no_auth_url) == str(remote_connection)
@@ -170,7 +168,6 @@ class TestDriverRemoteConnection(object):
         assert 4 == g.V().count().next()
         assert 0 == g.E().count().next()
         assert 1 == g.V().label().dedup().count().next()
-        assert 4 == g.V().filter_(lambda: ("x -> true", "gremlin-groovy")).count().next()
         assert "person" == g.V().label().dedup().next()
         #
         g = traversal().with_(remote_connection). \
@@ -219,8 +216,8 @@ class TestDriverRemoteConnection(object):
             assert False
         except GremlinServerError as err:
             assert err.status_code == 400
-            assert 'The traversal source [does_not_exist] for alias [g] is not configured on the server.' \
-                   in err.status_message
+            assert ('Could not alias [g] to [does_not_exist] as [does_not_exist] not in the Graph or TraversalSource '
+                    'global bindings') in err.status_message
 
     @pytest.mark.skip(reason="enable after making sure authenticated testing server is set up in docker")
     def test_authenticated(self, remote_connection_authenticated):

--- a/gremlin-python/src/main/python/tests/process/test_gremlin_lang.py
+++ b/gremlin-python/src/main/python/tests/process/test_gremlin_lang.py
@@ -1,0 +1,517 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""
+Unit tests for the GremlinLang Class. Modified from deprecated Groovy Translator Tests.
+"""
+from gremlin_python.process.strategies import ReadOnlyStrategy, SubgraphStrategy, OptionsStrategy, PartitionStrategy
+from gremlin_python.process.traversal import within, eq, T, Order, Scope, Column, Operator, P, Pop, Cardinality, \
+    between, inside, WithOptions, ShortestPath, starting_with, ending_with, containing, gt, lte, Parameter
+from gremlin_python.statics import SingleByte, short, long, bigint, BigDecimal
+from gremlin_python.structure.graph import Graph, Vertex, Edge, VertexProperty
+from gremlin_python.process.anonymous_traversal import traversal
+from gremlin_python.process.graph_traversal import __
+from datetime import datetime
+
+
+class TestGremlinLang(object):
+
+    def test_gremlin_lang(self):
+        g = traversal().with_(None)
+
+        tests = list()
+        # 0
+        tests.append([g.V(),
+                      "g.V()"])
+        # 1
+        tests.append([g.V('1', '2', '3', '4'),
+                      "g.V('1','2','3','4')"])
+        # 2
+        tests.append([g.V('3').valueMap(True),
+                      "g.V('3').valueMap(true)"])
+        # 3
+        tests.append([g.V().constant(5),
+                      "g.V().constant(5)"])
+        # 4
+        tests.append([g.V().constant(1.5),
+                      "g.V().constant(1.5D)"])
+        # 5
+        tests.append([g.V().constant('Hello'),
+                      "g.V().constant('Hello')"])
+        # 6
+        tests.append([g.V().hasLabel('airport').limit(5),
+                      "g.V().hasLabel('airport').limit(5)"])
+        # 7
+        tests.append([g.V().hasLabel(within('a', 'b', 'c')),
+                      "g.V().hasLabel(within(['a','b','c']))"])
+        # 8
+        tests.append([g.V().hasLabel('airport', 'continent').out().limit(5),
+                      "g.V().hasLabel('airport','continent').out().limit(5)"])
+        # 9
+        tests.append([g.V().hasLabel('airport').out().values('code').limit(5),
+                      "g.V().hasLabel('airport').out().values('code').limit(5)"])
+        # 10
+        tests.append([g.V('3').as_('a').out('route').limit(10).where(eq('a')).by('region'),
+                      "g.V('3').as('a').out('route').limit(10).where(eq('a')).by('region')"])
+        # 11
+        tests.append([g.V('3').repeat(__.out('route').simplePath()).times(2).path().by('code'),
+                      "g.V('3').repeat(__.out('route').simplePath()).times(2).path().by('code')"])
+        # 12
+        tests.append([g.V().hasLabel('airport').out().has('region', 'US-TX').values('code').limit(5),
+                      "g.V().hasLabel('airport').out().has('region','US-TX').values('code').limit(5)"])
+        # 13
+        tests.append([g.V().hasLabel('airport').union(__.values('city'), __.values('region')).limit(5),
+                      "g.V().hasLabel('airport').union(__.values('city'),__.values('region')).limit(5)"])
+        # 14
+        tests.append([g.V('3').as_('a').out('route', 'routes'),
+                      "g.V('3').as('a').out('route','routes')"])
+        # 15
+        tests.append([g.V().where(__.values('runways').is_(5)),
+                      "g.V().where(__.values('runways').is(5))"])
+        # 16
+        tests.append([g.V('3').repeat(__.out().simplePath()).until(__.has('code', 'AGR')).path().by('code').limit(5),
+                      "g.V('3').repeat(__.out().simplePath()).until(__.has('code','AGR')).path().by('code').limit(5)"])
+        # 17
+        tests.append([g.V().hasLabel('airport').order().by(__.id_()),
+                      "g.V().hasLabel('airport').order().by(__.id())"])
+        # 18
+        tests.append([g.V().hasLabel('airport').order().by(T.id),
+                      "g.V().hasLabel('airport').order().by(T.id)"])
+        # 19
+        tests.append([g.V().hasLabel('airport').order().by(__.id_(), Order.desc),
+                      "g.V().hasLabel('airport').order().by(__.id(),Order.desc)"])
+        # 20
+        tests.append([g.V().hasLabel('airport').order().by('code', Order.desc),
+                      "g.V().hasLabel('airport').order().by('code',Order.desc)"])
+        # 21
+        tests.append([g.V('1', '2', '3').local(__.out().out().dedup().fold()),
+                      "g.V('1','2','3').local(__.out().out().dedup().fold())"])
+        # 22
+        tests.append([g.V('3').out().path().count(Scope.local),
+                      "g.V('3').out().path().count(Scope.local)"])
+        # 23
+        tests.append([g.E().count(),
+                      "g.E().count()"])
+        # 24
+        tests.append([g.V('5').outE('route').inV().path().limit(10),
+                      "g.V('5').outE('route').inV().path().limit(10)"])
+        # 25
+        tests.append([g.V('5').propertyMap().select(Column.keys),
+                      "g.V('5').propertyMap().select(Column.keys)"])
+        # 26
+        tests.append([g.V('5').propertyMap().select(Column.values),
+                      "g.V('5').propertyMap().select(Column.values)"])
+        # 27
+        tests.append([g.V('3').values('runways').math('_ + 1'),
+                      "g.V('3').values('runways').math('_ + 1')"])
+        # 28
+        tests.append([g.V('3').emit().repeat(__.out().simplePath()).times(3).limit(5).path(),
+                      "g.V('3').emit().repeat(__.out().simplePath()).times(3).limit(5).path()"])
+        # 29
+        tests.append([g.V().match(__.as_('a').has('code', 'LHR').as_('b')).select('b').by('code'),
+                      "g.V().match(__.as('a').has('code','LHR').as('b')).select('b').by('code')"])
+        # 30
+        tests.append([g.V().has('test-using-keyword-as-property', 'repeat'),
+                      "g.V().has('test-using-keyword-as-property','repeat')"])
+        # 31
+        tests.append([g.V('1').addE('test').to(__.V('4')),
+                      "g.V('1').addE('test').to(__.V('4'))"])
+        # 32
+        tests.append([g.V().values('runways').max_(),
+                      "g.V().values('runways').max()"])
+        # 33
+        tests.append([g.V().values('runways').min_(),
+                      "g.V().values('runways').min()"])
+        # 34
+        tests.append([g.V().values('runways').sum_(),
+                      "g.V().values('runways').sum()"])
+        # 35
+        tests.append([g.V().values('runways').mean(),
+                      "g.V().values('runways').mean()"])
+        # 36
+        tests.append([g.withSack(0).V('3', '5').sack(Operator.sum_).by('runways').sack(),
+                      "g.withSack(0).V('3','5').sack(Operator.sum).by('runways').sack()"])
+        # 37
+        tests.append([g.V('3').values('runways').store('x').V('4').values('runways').store('x').by(__.constant(1)).V(
+            '6').store('x').by(__.constant(1)).select('x').unfold().sum_(),
+                      "g.V('3').values('runways').store('x').V('4').values('runways').store('x').by(__.constant(1)).V('6').store('x').by(__.constant(1)).select('x').unfold().sum()"])
+        # 38
+        tests.append([g.inject(3, 4, 5),
+                      "g.inject(3,4,5)"])
+        # 39
+        tests.append([g.inject([3, 4, 5]),
+                      "g.inject([3,4,5])"])
+        # 40
+        tests.append([g.inject(3, 4, 5).count(),
+                      "g.inject(3,4,5).count()"])
+        # 41
+        tests.append([g.V().has('runways', gt(5)).count(),
+                      "g.V().has('runways',gt(5)).count()"])
+        # 42
+        tests.append([g.V().has('runways', lte(5.3)).count(),
+                      "g.V().has('runways',lte(5.3D)).count()"])
+        # 43
+        tests.append([g.V().has('code', within(123, 124)),
+                      "g.V().has('code',within([123,124]))"])
+        # 44
+        tests.append([g.V().has('code', within(123, 'abc')),
+                      "g.V().has('code',within([123,'abc']))"])
+        # 45
+        tests.append([g.V().has('code', within('abc', 123)),
+                      "g.V().has('code',within(['abc',123]))"])
+        # 46
+        tests.append([g.V().has('code', within('abc', 'xyz')),
+                      "g.V().has('code',within(['abc','xyz']))"])
+        # 47
+        tests.append([g.V('1', '2').has('region', P.within('US-TX', 'US-GA')),
+                      "g.V('1','2').has('region',within(['US-TX','US-GA']))"])
+        # 48
+        tests.append([g.V().and_(__.has('runways', P.gt(5)), __.has('region', 'US-TX')),
+                      "g.V().and(__.has('runways',gt(5)),__.has('region','US-TX'))"])
+        # 49
+        tests.append([g.V().union(__.has('runways', gt(5)), __.has('region', 'US-TX')),
+                      "g.V().union(__.has('runways',gt(5)),__.has('region','US-TX'))"])
+        # 50
+        tests.append([g.V('3').choose(__.values('runways').is_(3), __.constant('three'), __.constant('not three')),
+                      "g.V('3').choose(__.values('runways').is(3),__.constant('three'),__.constant('not three'))"])
+        # 51
+        tests.append(
+            [g.V('3').choose(__.values('runways')).option(1, __.constant('three')).option(2, __.constant('not three')),
+             "g.V('3').choose(__.values('runways')).option(1,__.constant('three')).option(2,__.constant('not three'))"])
+        # 52
+        tests.append([g.V('3').choose(__.values('runways')).option(1.5, __.constant('one and a half')).option(2, __.constant('not three')),
+                      "g.V('3').choose(__.values('runways')).option(1.5D,__.constant('one and a half')).option(2,__.constant('not three'))"])
+        # 53
+        tests.append([g.V('3').repeat(__.out().simplePath()).until(__.loops().is_(1)).count(),
+                      "g.V('3').repeat(__.out().simplePath()).until(__.loops().is(1)).count()"])
+        # 54
+        tests.append(
+            [g.V().hasLabel('airport').limit(20).group().by('region').by('code').order(Scope.local).by(Column.keys),
+             "g.V().hasLabel('airport').limit(20).group().by('region').by('code').order(Scope.local).by(Column.keys)"])
+        # 55
+        tests.append([g.V('1').as_('a').V('2').as_('a').select(Pop.all_, 'a'),
+                      "g.V('1').as('a').V('2').as('a').select(Pop.all,'a')"])
+        # 56
+        tests.append([g.addV('test').property(Cardinality.set_, 'p1', 10),
+                      "g.addV('test').property(Cardinality.set,'p1',10)"])
+        # 57
+        tests.append([g.addV('test').property(Cardinality.list_, 'p1', 10),
+                      "g.addV('test').property(Cardinality.list,'p1',10)"])
+
+        # 58
+        tests.append([g.addV('test').property(Cardinality.single, 'p1', 10),
+                      "g.addV('test').property(Cardinality.single,'p1',10)"])
+        # 59
+        tests.append([g.V().limit(5).order().by(T.label),
+                      "g.V().limit(5).order().by(T.label)"])
+
+        # 60
+        tests.append([g.V().range_(1, 5),
+                      "g.V().range(1,5)"])
+
+        # 61
+        tests.append([g.addV('test').property('p1', 123),
+                      "g.addV('test').property('p1',123)"])
+
+        # 62
+        tests.append([g.addV('test').property('date', datetime(2021, 2, 1, 9, 30)),
+                      "g.addV('test').property('date',datetime(\"2021-02-01T09:30:00\"))"])
+        # 63
+        tests.append([g.addV('test').property('date', datetime(2021, 2, 1)),
+                      "g.addV('test').property('date',datetime(\"2021-02-01T00:00:00\"))"])
+        # 64
+        tests.append([g.addE('route').from_(__.V('1')).to(__.V('2')),
+                      "g.addE('route').from(__.V('1')).to(__.V('2'))"])
+        # 65
+        tests.append([g.withSideEffect('a', [1, 2]).V('3').select('a'),
+                      "g.withSideEffect('a',[1,2]).V('3').select('a')"])
+        # 66
+        tests.append([g.withSideEffect('a', 1).V('3').select('a'),
+                      "g.withSideEffect('a',1).V('3').select('a')"])
+        # 67
+        tests.append([g.withSideEffect('a', 'abc').V('3').select('a'),
+                      "g.withSideEffect('a','abc').V('3').select('a')"])
+        # 68
+        tests.append([g.V().has('airport', 'region', 'US-NM').limit(3).values('elev').fold().index(),
+                      "g.V().has('airport','region','US-NM').limit(3).values('elev').fold().index()"])
+        # 69
+        tests.append([g.V('3').repeat(__.timeLimit(1000).out().simplePath()).until(__.has('code', 'AGR')).path(),
+                      "g.V('3').repeat(__.timeLimit(1000).out().simplePath()).until(__.has('code','AGR')).path()"])
+
+        # 70
+        tests.append([g.V().hasLabel('airport').where(__.values('elev').is_(gt(14000))),
+                      "g.V().hasLabel('airport').where(__.values('elev').is(gt(14000)))"])
+
+        # 71
+        tests.append([g.V().hasLabel('airport').where(__.out().count().is_(gt(250))).values('code'),
+                      "g.V().hasLabel('airport').where(__.out().count().is(gt(250))).values('code')"])
+
+        # 72
+        tests.append([g.V().hasLabel('airport').filter_(__.out().count().is_(gt(250))).values('code'),
+                      "g.V().hasLabel('airport').filter(__.out().count().is(gt(250))).values('code')"])
+        # 73
+        tests.append([g.withSack(0).
+                     V('3').
+                     repeat(__.outE('route').sack(Operator.sum_).by('dist').inV()).
+                     until(__.has('code', 'AGR').or_().loops().is_(4)).
+                     has('code', 'AGR').
+                     local(__.union(__.path().by('code').by('dist'), __.sack()).fold()).
+                     limit(10),
+                      "g.withSack(0).V('3').repeat(__.outE('route').sack(Operator.sum).by('dist').inV()).until(__.has('code','AGR').or().loops().is(4)).has('code','AGR').local(__.union(__.path().by('code').by('dist'),__.sack()).fold()).limit(10)"])
+
+        # 74
+        tests.append([g.addV().as_('a').addV().as_('b').addE('knows').from_('a').to('b'),
+                      "g.addV().as('a').addV().as('b').addE('knows').from('a').to('b')"])
+
+        # 75
+        tests.append([g.addV('Person').as_('a').addV('Person').as_('b').addE('knows').from_('a').to('b'),
+                      "g.addV('Person').as('a').addV('Person').as('b').addE('knows').from('a').to('b')"])
+
+        # 76
+        tests.append([g.V('3').project('Out', 'In').by(__.out().count()).by(__.in_().count()),
+                      "g.V('3').project('Out','In').by(__.out().count()).by(__.in().count())"])
+
+        # 77
+        tests.append([g.V('44').out().aggregate('a').out().where(within('a')).path(),
+                      "g.V('44').out().aggregate('a').out().where(within(['a'])).path()"])
+
+        # 78
+        tests.append([g.V().has('date', datetime(2021, 2, 22)),
+                      "g.V().has('date',datetime(\"2021-02-22T00:00:00\"))"])
+
+        # 79
+        tests.append([g.V().has('date', within(datetime(2021, 2, 22), datetime(2021, 1, 1))),
+                      "g.V().has('date',within([datetime(\"2021-02-22T00:00:00\"),datetime(\"2021-01-01T00:00:00\")]))"])
+
+        # 80
+        tests.append([g.V().has('date', between(datetime(2021, 1, 1), datetime(2021, 2, 22))),
+                      "g.V().has('date',between(datetime(\"2021-01-01T00:00:00\"),datetime(\"2021-02-22T00:00:00\")))"])
+
+        # 81
+        tests.append([g.V().has('date', inside(datetime(2021, 1, 1), datetime(2021, 2, 22))),
+                      "g.V().has('date',inside(datetime(\"2021-01-01T00:00:00\"),datetime(\"2021-02-22T00:00:00\")))"])
+
+        # 82
+        tests.append([g.V().has('date', P.gt(datetime(2021, 1, 1, 9, 30))),
+                      "g.V().has('date',gt(datetime(\"2021-01-01T09:30:00\")))"])
+
+        # 83
+        tests.append([g.V().has('runways', between(3, 5)),
+                      "g.V().has('runways',between(3,5))"])
+
+        # 84
+        tests.append([g.V().has('runways', inside(3, 5)),
+                      "g.V().has('runways',inside(3,5))"])
+
+        # 85
+        tests.append([g.V('44').outE().elementMap(),
+                      "g.V('44').outE().elementMap()"])
+
+        # 86
+        tests.append([g.V('44').valueMap().by(__.unfold()),
+                      "g.V('44').valueMap().by(__.unfold())"])
+
+        # 87
+        tests.append([g.V('44').valueMap().with_(WithOptions.tokens, WithOptions.labels),
+                      "g.V('44').valueMap().with('~tinkerpop.valueMap.tokens',2)"])
+
+        # 88
+        tests.append([g.V('44').valueMap().with_(WithOptions.tokens),
+                      "g.V('44').valueMap().with('~tinkerpop.valueMap.tokens')"])
+
+        # 89
+        tests.append([g.withStrategies(ReadOnlyStrategy()).addV('test'),
+                      "g.withStrategies(ReadOnlyStrategy).addV('test')"])
+        # 90
+        strategy = SubgraphStrategy(vertices=__.has('region', 'US-TX'), edges=__.hasLabel('route'))
+        tests.append([g.withStrategies(strategy).V().count(),
+                      "g.withStrategies(new SubgraphStrategy(vertices:__.has('region','US-TX'),edges:__.hasLabel('route'))).V().count()"])
+
+        # 91
+        strategy = SubgraphStrategy(vertex_properties=__.hasNot('runways'))
+        tests.append([g.withStrategies(strategy).V().count(),
+                      "g.withStrategies(new SubgraphStrategy(vertexProperties:__.hasNot('runways'))).V().count()"])
+
+        # 92
+        strategy = SubgraphStrategy(vertices=__.has('region', 'US-TX'), vertex_properties=__.hasNot('runways'))
+        tests.append([g.withStrategies(strategy).V().count(),
+                      "g.withStrategies(new SubgraphStrategy(vertices:__.has('region','US-TX'),vertexProperties:__.hasNot('runways'))).V().count()"])
+
+        # 93
+        strategy = SubgraphStrategy(vertices=__.has('region', 'US-TX'), edges=__.hasLabel('route'))
+        tests.append([g.withStrategies(ReadOnlyStrategy(), strategy).V().count(),
+                      "g.withStrategies(ReadOnlyStrategy,new SubgraphStrategy(vertices:__.has('region','US-TX'),edges:__.hasLabel('route'))).V().count()"])
+
+        # 94
+        strategy = SubgraphStrategy(vertices=__.has('region', 'US-TX'))
+        tests.append([g.withStrategies(ReadOnlyStrategy(), strategy).V().count(),
+                      "g.withStrategies(ReadOnlyStrategy,new SubgraphStrategy(vertices:__.has('region','US-TX'))).V().count()"])
+
+        # 95 Note with_() options are now extracted into request message and is no longer sent with the script
+        tests.append([g.with_('evaluationTimeout', 500).V().count(),
+                      "g.V().count()"])
+
+        # 96 Note OptionsStrategy are now extracted into request message and is no longer sent with the script
+        tests.append([g.withStrategies(OptionsStrategy({'evaluationTimeout': 500})).V().count(),
+                      "g.V().count()"])
+
+        # 97
+        tests.append([g.withStrategies(
+            PartitionStrategy(partition_key="partition", write_partition="a", read_partitions=["a"])).addV('test'),
+                      "g.withStrategies(new PartitionStrategy(partitionKey:'partition',writePartition:'a',readPartitions:['a'])).addV('test')"])
+
+        # 98
+        tests.append([g.withComputer().V().shortestPath().with_(ShortestPath.target, __.has('name', 'peter')),
+                      "g.withStrategies(VertexProgramStrategy).V().shortestPath().with('~tinkerpop.shortestPath.target',__.has('name','peter'))"])
+
+        # 99
+        tests.append([g.V().coalesce(__.E(), __.addE('person')),
+                      "g.V().coalesce(__.E(),__.addE('person'))"])
+
+        # 100
+        tests.append([g.inject(1).E(),
+                      "g.inject(1).E()"])
+
+        # 101
+        tests.append([g.V().has("p1", starting_with("foo")),
+                      "g.V().has('p1',startingWith('foo'))"])
+
+        # 102
+        tests.append([g.V().has("p1", ending_with("foo")),
+                      "g.V().has('p1',endingWith('foo'))"])
+
+        # 103
+        class SuperStr(str):
+            pass
+
+        tests.append([g.V(SuperStr("foo_id")),
+                      "g.V('foo_id')"])
+
+        # 104
+        tests.append([g.V().has("p1", containing(SuperStr("foo"))),
+                      "g.V().has('p1',containing('foo'))"])
+
+        # 105
+        tests.append([g.V().has("p1", None),
+                      "g.V().has('p1',null)"])
+
+        # 106
+        vertex = Vertex(0, "person")
+        tests.append([g.V(vertex),
+                      "g.V(new ReferenceVertex(0,'person'))"])
+
+        # 107
+        outVertex = Vertex(0, "person")
+        inVertex = Vertex(1, "person")
+        edge = Edge(2, outVertex, "knows", inVertex)
+        tests.append([g.E(edge),
+                      "g.E(_0)"])
+
+        # 108
+        vp = VertexProperty(3, "time", "18:00", None)
+        tests.append([g.inject(vp),
+                      "g.inject(_1)"])
+
+        # 109
+        tests.append([g.inject({'name': 'java'}, {T.id: 0}, {},
+                               {'age': float(10), 'pos_inf': float("inf"), 'neg_inf': float("-inf"),
+                                'nan': float("nan")}),
+                      "g.inject(['name':'java'],[(T.id):0],[:],['age':10.0D,'pos_inf':+Infinity,'neg_inf':-Infinity,'nan':NaN])"])
+
+        # 110
+        tests.append([g.inject(float(1)).is_(P.eq(1).or_(P.gt(2)).or_(P.lte(3)).or_(P.gte(4))),
+                      "g.inject(1.0D).is(eq(1).or(gt(2)).or(lte(3)).or(gte(4)))"])
+
+        # 111
+        tests.append([g.V().hasLabel('person').has('age', P.gt(10).or_(P.gte(11).and_(P.lt(20))).and_(
+            P.lt(29).or_(P.eq(35)))).name,
+                      "g.V().hasLabel('person').has('age',gt(10).or(gte(11).and(lt(20))).and(lt(29).or(eq(35)))).values('name')"])
+
+        # 112
+        tests.append([g.inject(set('a')),
+                      "g.inject({'a'})"])
+
+        # 113
+        tests.append([g.merge_v(None),
+                      "g.mergeV(null)"])
+
+        # 114
+        tests.append([g.merge_e(None),
+                      "g.mergeE(null)"])
+
+        # 115
+        tests.append([g.addV('\"test\"'),
+                      "g.addV('\"test\"')"])
+
+        # 116
+        tests.append([g.addV('t\'"est'),
+                      "g.addV('t\\'\"est')"])
+
+        # 117
+        tests.append([g.inject(True, SingleByte(1), short(2), 3, long(4), float(5),
+                               float(6), bigint(7), BigDecimal(0, 8)),
+                      "g.inject(true,1B,2S,3,4L,5.0D,6.0D,7N,8M)"])
+
+        #118
+
+        for t in range(len(tests)):
+            gremlin_lang = tests[t][0].gremlin_lang.get_gremlin()
+            assert gremlin_lang == tests[t][1]
+
+    def test_parameters_name_dont_need_escaping(self):
+        g = traversal().with_(None)
+        try:
+            g.V(Parameter.var('\"', [1, 2, 3]))
+        except Exception as ex:
+            assert str(ex) == 'invalid parameter name ".'
+
+    def test_parameters_is_not_number(self):
+        g = traversal().with_(None)
+        try:
+            g.V(Parameter.var('1', [1, 2, 3]))
+        except Exception as ex:
+            assert str(ex) == 'invalid parameter name 1.'
+
+    def test_parameters_is_valid_identifier(self):
+        g = traversal().with_(None)
+        try:
+            g.V(Parameter.var('1a', [1, 2, 3]))
+        except Exception as ex:
+            assert str(ex) == 'invalid parameter name 1a.'
+
+    def test_parameters_is_not_reserved(self):
+        g = traversal().with_(None)
+        try:
+            g.V(Parameter.var('_1', [1, 2, 3]))
+        except Exception as ex:
+            assert str(ex) == 'invalid parameter name _1. Should not start with _.'
+
+    def test_parameters_is_not_duplicate(self):
+        g = traversal().with_(None)
+        try:
+            g.inject(Parameter.var('ids', [1, 2])).V(Parameter.var('ids', [2, 3]))
+        except Exception as ex:
+            assert str(ex) == 'parameter with name ids already exists.'
+
+    def test_parameters_allow_parameter_reuse(self):
+        g = traversal().with_(None)
+        val = [1, 2, 3]
+        p = Parameter.var('ids', val)
+        gremlin = g.inject(p).V(p).gremlin_lang
+        assert 'g.inject(ids).V(ids)' == gremlin.get_gremlin()
+        assert val == gremlin.get_parameters().get('ids')

--- a/gremlin-python/src/main/python/tests/process/test_translator.py
+++ b/gremlin-python/src/main/python/tests/process/test_translator.py
@@ -28,6 +28,7 @@ from gremlin_python.process.translator import *
 from datetime import datetime
 
 
+# TODO to be removed as bytecode and groovy are replaced by gremlin lang scripts
 class TestTranslator(object):
 
     def test_translations(self):

--- a/gremlin-python/src/main/python/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/python/tests/process/test_traversal.py
@@ -36,59 +36,6 @@ anonymous_url = gremlin_server_url.format(45940)
 
 
 class TestTraversal(object):
-    def test_bytecode(self):
-        g = traversal().with_(None)
-        bytecode = g.V().out("created").bytecode
-        assert 0 == len(bytecode.bindings.keys())
-        assert 0 == len(bytecode.source_instructions)
-        assert 2 == len(bytecode.step_instructions)
-        assert "V" == bytecode.step_instructions[0][0]
-        assert "out" == bytecode.step_instructions[1][0]
-        assert "created" == bytecode.step_instructions[1][1]
-        assert 1 == len(bytecode.step_instructions[0])
-        assert 2 == len(bytecode.step_instructions[1])
-        ##
-        bytecode = g.withSack(1).E().groupCount().by("weight").bytecode
-        assert 0 == len(bytecode.bindings.keys())
-        assert 1 == len(bytecode.source_instructions)
-        assert "withSack" == bytecode.source_instructions[0][0]
-        assert 1 == bytecode.source_instructions[0][1]
-        assert 3 == len(bytecode.step_instructions)
-        assert "E" == bytecode.step_instructions[0][0]
-        assert "groupCount" == bytecode.step_instructions[1][0]
-        assert "by" == bytecode.step_instructions[2][0]
-        assert "weight" == bytecode.step_instructions[2][1]
-        assert 1 == len(bytecode.step_instructions[0])
-        assert 1 == len(bytecode.step_instructions[1])
-        assert 2 == len(bytecode.step_instructions[2])
-        ##
-        bytecode = g.V(Bindings.of('a', [1, 2, 3])) \
-            .out(Bindings.of('b', 'created')) \
-            .where(__.in_(Bindings.of('c', 'created'), Bindings.of('d', 'knows')) \
-                   .count().is_(Bindings.of('e', P.gt(2)))).bytecode
-        assert 5 == len(bytecode.bindings.keys())
-        assert [1, 2, 3] == bytecode.bindings['a']
-        assert 'created' == bytecode.bindings['b']
-        assert 'created' == bytecode.bindings['c']
-        assert 'knows' == bytecode.bindings['d']
-        assert P.gt(2) == bytecode.bindings['e']
-        assert Binding('b', 'created') == bytecode.step_instructions[1][1]
-        assert 'binding[b=created]' == str(bytecode.step_instructions[1][1])
-        assert isinstance(hash(bytecode.step_instructions[1][1]), int)
-        ###
-        bytecode = g.V().to(Direction.from_, 'knows').to(Direction.to, 'created').bytecode
-        assert 0 == len(bytecode.bindings.keys())
-        assert 0 == len(bytecode.source_instructions)
-        assert 3 == len(bytecode.step_instructions)
-        assert "V" == bytecode.step_instructions[0][0]
-        assert "to" == bytecode.step_instructions[1][0]
-        assert Direction.OUT == bytecode.step_instructions[1][1]
-        assert "knows" == bytecode.step_instructions[1][2]
-        assert Direction.IN == bytecode.step_instructions[2][1]
-        assert "created" == bytecode.step_instructions[2][2]
-        assert 1 == len(bytecode.step_instructions[0])
-        assert 3 == len(bytecode.step_instructions[1])
-        assert 3 == len(bytecode.step_instructions[2])
 
     def test_P(self):
         # verify that the order of operations is respected
@@ -98,17 +45,12 @@ class TestTraversal(object):
             P.lt("b").or_(P.gt("c")).and_(P.neq("d").or_(P.gte("e"))))
 
     def test_anonymous_traversal(self):
-        bytecode = __.__(1).bytecode
-        assert 0 == len(bytecode.bindings.keys())
-        assert 0 == len(bytecode.source_instructions)
-        assert 1 == len(bytecode.step_instructions)
-        assert "inject" == bytecode.step_instructions[0][0]
-        assert 1 == bytecode.step_instructions[0][1]
+        gremlin = __.__(1).gremlin_lang
+        assert "__.inject(1)" == gremlin.get_gremlin('__')
+
         ##
-        bytecode = __.start().bytecode
-        assert 0 == len(bytecode.bindings.keys())
-        assert 0 == len(bytecode.source_instructions)
-        assert 0 == len(bytecode.step_instructions)
+        gremlin = __.start().gremlin_lang
+        assert "" == gremlin.get_gremlin('')
 
     def test_clone_traversal(self):
         g = traversal().with_(None)
@@ -116,22 +58,23 @@ class TestTraversal(object):
         clone = original.clone().out("knows")
         cloneClone = clone.clone().out("created")
 
-        assert 2 == len(original.bytecode.step_instructions)
-        assert 3 == len(clone.bytecode.step_instructions)
-        assert 4 == len(cloneClone.bytecode.step_instructions)
+        assert "g.V().out('created')" == original.gremlin_lang.get_gremlin()
+        assert "g.V().out('created').out('knows')" == clone.gremlin_lang.get_gremlin()
+        assert "g.V().out('created').out('knows').out('created')" == cloneClone.gremlin_lang.get_gremlin()
 
         original.has("person", "name", "marko")
         clone.V().out()
 
-        assert 3 == len(original.bytecode.step_instructions)
-        assert 5 == len(clone.bytecode.step_instructions)
-        assert 4 == len(cloneClone.bytecode.step_instructions)
+        assert "g.V().out('created').has('person','name','marko')" == original.gremlin_lang.get_gremlin()
+        assert "g.V().out('created').out('knows').V().out()" == clone.gremlin_lang.get_gremlin()
+        assert "g.V().out('created').out('knows').out('created')" == cloneClone.gremlin_lang.get_gremlin()
+
 
     def test_no_sugar_for_magic_methods(self):
         g = traversal().with_(None)
 
         t = g.V().age
-        assert 2 == len(t.bytecode.step_instructions)
+        assert "g.V().values('age')" == t.gremlin_lang.get_gremlin()
 
         try:
             t = g.V().__len__
@@ -150,6 +93,7 @@ class TestTraversal(object):
         except TypeError:
             pass
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_transaction_commit(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().with_(remote_transaction_connection)
@@ -173,6 +117,7 @@ class TestTraversal(object):
         drop_graph_check_count(g)
         verify_gtx_closed(gtx)
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_transaction_rollback(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().with_(remote_transaction_connection)
@@ -196,6 +141,7 @@ class TestTraversal(object):
         drop_graph_check_count(g)
         verify_gtx_closed(gtx)
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_transaction_no_begin(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().with_(remote_transaction_connection)
@@ -247,6 +193,7 @@ class TestTraversal(object):
         tx.rollback()
         assert not tx.isOpen()
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_multi_commit_transaction(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().with_(remote_transaction_connection)
@@ -277,6 +224,7 @@ class TestTraversal(object):
         verify_tx_state([tx1, tx2], False)
         assert g.V().count().next() == start_count + 3
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_multi_rollback_transaction(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().with_(remote_transaction_connection)
@@ -307,6 +255,7 @@ class TestTraversal(object):
         verify_tx_state([tx1, tx2], False)
         assert g.V().count().next() == start_count
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_multi_commit_and_rollback(self, remote_transaction_connection):
         # Start a transaction traversal.
         g = traversal().with_(remote_transaction_connection)
@@ -337,6 +286,7 @@ class TestTraversal(object):
         verify_tx_state([tx1, tx2], False)
         assert g.V().count().next() == start_count + 2
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_transaction_close_tx(self):
         remote_conn = create_connection_to_gtx()
         g = traversal().with_(remote_conn)
@@ -372,6 +322,7 @@ class TestTraversal(object):
 
         drop_graph_check_count(g)
 
+    @pytest.mark.skip(reason="enable after transaction is implemented in HTTP")
     def test_transaction_close_tx_from_parent(self):
         remote_conn = create_connection_to_gtx()
         g = traversal().with_(remote_conn)
@@ -410,7 +361,7 @@ class TestTraversal(object):
 
 def create_connection_to_gtx():
     return DriverRemoteConnection(anonymous_url, 'gtx',
-                                  message_serializer=serializer.GraphBinarySerializersV1())
+                                  message_serializer=serializer.GraphBinarySerializersV4())
 
 
 def add_node_validate_transaction_state(g, g_add_to, g_start_count, g_add_to_start_count, tx_verify_list):


### PR DESCRIPTION
Replaced bytecode with gremlin lang scripts in gremlin-python, similar to what's been implemented in gremlin-java. 

Groovy translators are no longer needed, as well as some other code left over from WebSocket; will be cleaning them up along with bytecode codes in a separate PR after this is merged. 

Some TODOs are pending core changes, e.g. bulking, transactions. 

Local unit and integration tests pass, next step is to implement authentication interface, and modifying docker-compose set up to enable tests during build/GitHub actions.

~~Also added set in gremlin-java gremlin lang as set is now supported in grammar (can separate that into different PR/CTR if preferred).~~ Will open set changes for gremlin-java in separate PR due to additional changes needed. 