### PR TITLE
Regression: Graceful shutdowns for GremlinServer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ This release also includes changes from <<release-3-6-8, 3.6.8>>.
 * Fix cases where Map keys of incomparable types could panic in `gremlin-go`.
 * Fixed an issue where missing necessary parameters for logging, resulting in '%!x(MISSING)' output in `gremlin-go`.
 * Added getter method to `ConcatStep`, `ConjoinStep`, `SplitGlobalStep` and `SplitLocalStep` for their private fields.
+* Gremlin Server docker containers shutdown gracefully when receiving a SIGTERM.
 
 [[release-3-7-2]]
 === TinkerPop 3.7.2 (April 8, 2024)

--- a/gremlin-server/src/main/bin/gremlin-server.sh
+++ b/gremlin-server/src/main/bin/gremlin-server.sh
@@ -209,7 +209,7 @@ startForeground() {
   fi
 
   if [[ -z "$RUNAS" ]]; then
-    $JAVA -Dlogback.configurationFile=$LOGBACK_CONF $JAVA_OPTIONS -cp $CLASSPATH $GREMLIN_SERVER_CMD "$GREMLIN_YAML"
+    exec $JAVA -Dlogback.configurationFile=$LOGBACK_CONF $JAVA_OPTIONS -cp $CLASSPATH $GREMLIN_SERVER_CMD "$GREMLIN_YAML"
     exit 0
   else
     echo Starting in foreground not supported with RUNAS

--- a/gremlin-server/src/main/docker/docker-entrypoint.sh
+++ b/gremlin-server/src/main/docker/docker-entrypoint.sh
@@ -29,12 +29,4 @@ GREMLIN_SERVER=/opt/gremlin-server/bin/gremlin-server.sh
 IP=$(ip -o -4 addr list eth0 | perl -n -e 'if (m{inet\s([\d\.]+)\/\d+\s}xms) { print $1 }')
 sed -i "s|^host:.*|host: $IP|" $CONF_FILE
 
-handler()
-{
-  kill -s SIGINT "$PID"
-}
-
-exec $GREMLIN_SERVER "$@" &
-PID=$(ps | grep -w $GREMLIN_SERVER | grep -v grep | awk 'NR==1 {print $1}')
-trap 'handler $PID' SIGTERM
-wait "$PID"
+exec $GREMLIN_SERVER "$@"


### PR DESCRIPTION
Fixes what seems to be a regression of [TINKERPOP-2950.](https://issues.apache.org/jira/browse/TINKERPOP-2950). Originally fixed in #2397.

With this change, the gremlin-server process will end up as PID 1 and receive all the signals, specifically SIGTERM, and allow the server to shutdown gracefully (and e.g. write a graph to a volume).


<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->