### PR TITLE
Add pluggable auth in gremlin-python with HTTP

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * `EmbeddedRemoteConnection` will use `Gremlinlang`, not `JavaTranslator`.
 * Java `Client` will no longer support submitting traversals. `DriverRemoteConnection` should be used instead.
 * Removed usage of `Bytecode` from `gremlin-python`.
+* Added `auth` module in `gremlin-python` for pluggable authentication.
 * Fixed `GremlinLangScriptEngine` handling for some strategies.
 
 == TinkerPop 3.7.0 (Gremfir Master of the Pan Flute)

--- a/gremlin-python/src/main/python/gremlin_python/driver/auth.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/auth.py
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+def basic(username, password):
+    from aiohttp import BasicAuth as aiohttpBasicAuth
+
+    def apply(request):
+        return request['headers'].update({'authorization': aiohttpBasicAuth(username, password).encode()})
+
+    return apply
+
+
+def sigv4(region, service):
+    import os
+    from boto3 import Session
+    from botocore.auth import SigV4Auth
+    from botocore.awsrequest import AWSRequest
+
+    def apply(request):
+        access_key = os.environ.get('AWS_ACCESS_KEY_ID', '')
+        secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
+        session_token = os.environ.get('AWS_SESSION_TOKEN', '')
+
+        session = Session(
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            aws_session_token=session_token,
+            region_name=region
+        )
+
+        sigv4_request = AWSRequest(method="POST", url=request['url'], data=request['payload'])
+        SigV4Auth(session.get_credentials(), service, region).add_auth(sigv4_request)
+        request['headers'].update(sigv4_request.headers)
+        request['payload'] = sigv4_request.data
+        return request
+
+    return apply
+

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -21,9 +21,8 @@ from concurrent.futures import Future
 import warnings
 
 from gremlin_python.driver import client, serializer
-from gremlin_python.driver.remote_connection import (
-    RemoteConnection, RemoteTraversal)
-from gremlin_python.driver.request import TokensV4
+from gremlin_python.driver.remote_connection import RemoteConnection, RemoteTraversal
+from gremlin_python.driver.request import Tokens
 
 log = logging.getLogger("gremlinpython")
 
@@ -34,7 +33,7 @@ class DriverRemoteConnection(RemoteConnection):
 
     def __init__(self, url, traversal_source="g", protocol_factory=None,
                  transport_factory=None, pool_size=None, max_workers=None,
-                 username="", password="",
+                 auth=None,
                  message_serializer=None, headers=None,
                  enable_user_agent_on_connect=True, **transport_kwargs):
         log.info("Creating DriverRemoteConnection with url '%s'", str(url))
@@ -44,8 +43,7 @@ class DriverRemoteConnection(RemoteConnection):
         self.__transport_factory = transport_factory
         self.__pool_size = pool_size
         self.__max_workers = max_workers
-        self.__username = username
-        self.__password = password
+        self.__auth = auth
         self.__message_serializer = message_serializer
         self.__headers = headers
         self.__enable_user_agent_on_connect = enable_user_agent_on_connect
@@ -59,8 +57,7 @@ class DriverRemoteConnection(RemoteConnection):
                                      pool_size=pool_size,
                                      max_workers=max_workers,
                                      message_serializer=message_serializer,
-                                     username=username,
-                                     password=password,
+                                     auth=auth,
                                      headers=headers,
                                      enable_user_agent_on_connect=enable_user_agent_on_connect,
                                      **transport_kwargs)
@@ -121,7 +118,7 @@ class DriverRemoteConnection(RemoteConnection):
     def extract_request_options(gremlin_lang):
         request_options = {}
         for os in gremlin_lang.options_strategies:
-            request_options.update({token: os.configuration[token] for token in TokensV4
+            request_options.update({token: os.configuration[token] for token in Tokens
                                     if token in os.configuration})
         if gremlin_lang.parameters is not None and len(gremlin_lang.parameters) > 0:
             request_options["params"] = gremlin_lang.parameters

--- a/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/protocol.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import json
 import logging
 import abc
 
@@ -54,12 +53,9 @@ class AbstractBaseProtocol(metaclass=abc.ABCMeta):
 
 class GremlinServerHTTPProtocol(AbstractBaseProtocol):
 
-    def __init__(self,
-                 message_serializer,
-                 username='', password=''):
+    def __init__(self, message_serializer, auth=None):
+        self._auth = auth
         self._message_serializer = message_serializer
-        self._username = username
-        self._password = password
         self._response_msg = {'status': {'code': 0,
                                          'message': '',
                                          'exception': ''},
@@ -71,18 +67,13 @@ class GremlinServerHTTPProtocol(AbstractBaseProtocol):
         super(GremlinServerHTTPProtocol, self).connection_made(transport)
 
     def write(self, request_message):
-
-        basic_auth = {}
-        if self._username and self._password:
-            basic_auth['username'] = self._username
-            basic_auth['password'] = self._password
-
         content_type = str(self._message_serializer.version, encoding='utf-8')
+
         message = {
-            'headers': {'CONTENT-TYPE': content_type,
-                        'ACCEPT': content_type},
+            'headers': {'content-type': content_type,
+                        'accept': content_type},
             'payload': self._message_serializer.serialize_message(request_message),
-            'auth': basic_auth
+            'auth': self._auth
         }
 
         self._transport.write(message)

--- a/gremlin-python/src/main/python/gremlin_python/driver/request.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/request.py
@@ -20,8 +20,8 @@ import collections
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
-RequestMessageV4 = collections.namedtuple(
-    'RequestMessageV4', ['fields', 'gremlin'])
+RequestMessage = collections.namedtuple(
+    'RequestMessage', ['fields', 'gremlin'])
 
-TokensV4 = ['batchSize', 'bindings', 'g', 'gremlin', 'language',
-            'evaluationTimeout', 'materializeProperties', 'timeoutMs', 'userAgent']
+Tokens = ['batchSize', 'bindings', 'g', 'gremlin', 'language',
+          'evaluationTimeout', 'materializeProperties', 'timeoutMs', 'userAgent']

--- a/gremlin-python/src/main/python/tests/driver/test_auth.py
+++ b/gremlin-python/src/main/python/tests/driver/test_auth.py
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import os
+from aiohttp import BasicAuth as aiohttpBasicAuth
+from gremlin_python.driver.auth import basic, sigv4
+
+
+def create_mock_request():
+    return {'headers':
+            {'content-type': 'application/vnd.graphbinary-v4.0',
+             'accept': 'application/vnd.graphbinary-v4.0'},
+            'payload': b'',
+            'url': 'https://test_url:8182/gremlin'}
+
+
+class TestAuth(object):
+
+    def test_basic_auth_request(self):
+        mock_request = create_mock_request()
+        assert 'authorization' not in mock_request['headers']
+        basic('username', 'password')(mock_request)
+        assert 'authorization' in mock_request['headers']
+        assert aiohttpBasicAuth('username', 'password').encode() == mock_request['headers']['authorization']
+
+    def test_sigv4_auth_request(self):
+        mock_request = create_mock_request()
+        assert 'Authorization' not in mock_request['headers']
+        assert 'X-Amz-Date' not in mock_request['headers']
+        os.environ['AWS_ACCESS_KEY_ID'] = 'MOCK_ID'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'MOCK_KEY'
+        sigv4('gremlin-east-1', 'tinkerpop-sigv4')(mock_request)
+        assert mock_request['headers']['X-Amz-Date'] is not None
+        assert mock_request['headers']['Authorization'].startswith('AWS4-HMAC-SHA256 Credential=MOCK_ID')
+        assert 'gremlin-east-1/tinkerpop-sigv4/aws4_request' in mock_request['headers']['Authorization']
+        assert 'Signature=' in mock_request['headers']['Authorization']
+
+    def test_sigv4_auth_request_session_token(self):
+        mock_request = create_mock_request()
+        assert 'Authorization' not in mock_request['headers']
+        assert 'X-Amz-Date' not in mock_request['headers']
+        assert 'X-Amz-Security-Token' not in mock_request['headers']
+        os.environ['AWS_SESSION_TOKEN'] = 'MOCK_TOKEN'
+        sigv4('gremlin-east-1', 'tinkerpop-sigv4')(mock_request)
+        assert mock_request['headers']['X-Amz-Date'] is not None
+        assert mock_request['headers']['Authorization'].startswith('AWS4-HMAC-SHA256 Credential=')
+        assert mock_request['headers']['X-Amz-Security-Token'] == 'MOCK_TOKEN'
+        assert 'gremlin-east-1/tinkerpop-sigv4/aws4_request' in mock_request['headers']['Authorization']
+        assert 'Signature=' in mock_request['headers']['Authorization']
+
+

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -25,7 +25,7 @@ import pytest
 from gremlin_python.driver.client import Client
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.driver.protocol import GremlinServerError
-from gremlin_python.driver.request import RequestMessageV4
+from gremlin_python.driver.request import RequestMessage
 from gremlin_python.process.graph_traversal import __, GraphTraversalSource
 from gremlin_python.process.traversal import TraversalStrategies, Parameter
 from gremlin_python.process.strategies import OptionsStrategy
@@ -41,8 +41,7 @@ test_no_auth_url = gremlin_server_url.format(45940)
 
 
 def create_basic_request_message(traversal, source='gmodern'):
-    msg = RequestMessageV4(fields={'g': source}, gremlin=traversal.gremlin_lang.get_gremlin())
-    return msg
+    return RequestMessage(fields={'g': source}, gremlin=traversal.gremlin_lang.get_gremlin())
 
 
 def test_connection(connection):


### PR DESCRIPTION
Referencing the Java driver, added an interface for authentication with HTTP, with basic and SigV4 auth as reference implementations. e.g. `username='stephen', password='password'` is replaced by `auth=basic('stephen', 'password')`.

Local tests pass, will be updating the docker compose set-up as next step for integration tests. 