### PR TITLE
Fix issue with DotNet 8 when a traverser is empty

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * The default logging level for Gremlin Console in Windows is set to the same WARN level as for Linux.
 * Updated to Docker Compose V2 with `docker-compose` changed to `docker compose` in pom and script files.
 * Add command line option `-l` to change logging level for Gremlin Console in Windows.
+* Fixed a bug with DotNet 8 when there are no results on a query.
 
 [[release-3-6-7]]
 === TinkerPop 3.6.7 (April 8, 2024)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
@@ -198,9 +198,10 @@ namespace Gremlin.Net.Process.Traversal
         /// </summary>
         /// <returns>The result.</returns>
         public E Next()
-        {
-            MoveNext();
-            return Current;
+        { 
+            return MoveNext() 
+                ? Current 
+                : default;
         }
 
         /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/DefaultTraversal.cs
@@ -199,9 +199,7 @@ namespace Gremlin.Net.Process.Traversal
         /// <returns>The result.</returns>
         public E Next()
         { 
-            return MoveNext() 
-                ? Current 
-                : default;
+            return MoveNext() ? Current : default;
         }
 
         /// <summary>

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/TraversalTests.cs
@@ -98,6 +98,17 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
 
             Assert.Null(drainedTraversal.Next());
         }
+        
+        [Fact]
+        public void ShouldReturnNullWhenTraverserIsEmpty()
+        {
+            var someObjs = new List<object?>();
+            var traversal = new TestTraversal(someObjs);
+
+            var emptyTraversal = traversal.Iterate();
+
+            Assert.Null(emptyTraversal.Next());
+        }
 
         [Fact]
         public void ShouldReturnNullWhenNextIsCalledAndNoTraverserIsAvailable()


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->
I found an issue with the driver when upgrading to .NET 8.0, caused from changes on how the Enumerator works.
Current is always in a state of throwing an exception if the Traversers are empty. Before MoveNext() is called it throws "Enumeration has not started. Call MoveNext." and after the call it throws "System.InvalidOperationException: Enumeration already finished."