### PR TITLE
Fix console integration tests

### DIFF
--- a/gremlin-console/src/test/python/tests/test_console.py
+++ b/gremlin-console/src/test/python/tests/test_console.py
@@ -175,11 +175,9 @@ class TestConsole(object):
     def _expect_gremlin_header(child):
         # skip/read the Gremlin graphics
         child.expect("\r\n")
-        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities","plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
-        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
-        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
-        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
-        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities","plugin activated: tinkerpop.tinkergraph"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
         TestConsole._expect_prompt(child)
 
     @staticmethod

--- a/gremlin-console/src/test/python/tests/test_console.py
+++ b/gremlin-console/src/test/python/tests/test_console.py
@@ -175,9 +175,11 @@ class TestConsole(object):
     def _expect_gremlin_header(child):
         # skip/read the Gremlin graphics
         child.expect("\r\n")
-        child.expect(["plugin activated: tinkerpop.server", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
-        child.expect(["plugin activated: tinkerpop.server", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
-        child.expect(["plugin activated: tinkerpop.server", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities","plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph", "plugin activated: tinkerpop.sugar", "plugin activated: tinkerpop.credentials"])
         TestConsole._expect_prompt(child)
 
     @staticmethod

--- a/gremlin-console/src/test/python/tests/test_console.py
+++ b/gremlin-console/src/test/python/tests/test_console.py
@@ -175,7 +175,7 @@ class TestConsole(object):
     def _expect_gremlin_header(child):
         # skip/read the Gremlin graphics
         child.expect("\r\n")
-        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities","plugin activated: tinkerpop.tinkergraph"])
+        child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
         child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
         child.expect(["plugin activated: tinkerpop.remote", "plugin activated: tinkerpop.utilities", "plugin activated: tinkerpop.tinkergraph"])
         TestConsole._expect_prompt(child)


### PR DESCRIPTION
I noticed that the gremlin console integration tests were all failing due changes in the plugin activation text in the console header. This PR simply fixes the tests by updating it to reflect the plugins which are currently loaded by default. Consideration into which plugins should be activated by default may be warranted.

The current console header looks like this:
```

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.remote
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.sugar
plugin activated: tinkerpop.credentials
plugin activated: tinkerpop.tinkergraph
gremlin> 
```