### PR TITLE
Update Map serializer according to GraphBinaryV4 IO specs

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/GraphBinaryWriter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/GraphBinaryWriter.java
@@ -45,6 +45,7 @@ public class GraphBinaryWriter {
     private final TypeSerializerRegistry registry;
     private final static byte VALUE_FLAG_NULL = 1;
     private final static byte VALUE_FLAG_NONE = 0;
+    private final static byte VALUE_FLAG_ORDERED = 2;
     public final static byte VERSION_BYTE = (byte)0x81;
     private final static byte[] unspecifiedNullBytes = new byte[] { DataType.UNSPECIFIED_NULL.getCodeByte(), 0x01};
     private final static byte[] customTypeCodeBytes = new byte[] { DataType.CUSTOM.getCodeByte() };
@@ -135,4 +136,13 @@ public class GraphBinaryWriter {
     public void writeValueFlagNone(Buffer buffer) {
         buffer.writeByte(VALUE_FLAG_NONE);
     }
+
+    /**
+     * Writes a single byte with value 2, representing an ordered value_flag.
+     */
+    public void writeValueFlagOrdered(Buffer buffer) {
+        buffer.writeByte(VALUE_FLAG_ORDERED);
+    }
+
+
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/types/SimpleTypeSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/types/SimpleTypeSerializer.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.structure.io.binary.TypeSerializer;
 import org.apache.tinkerpop.gremlin.structure.io.Buffer;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 
 /**
  * Base class for serialization of types that don't contain type specific information only {type_code}, {value_flag}
@@ -61,10 +62,11 @@ public abstract class SimpleTypeSerializer<T> implements TypeSerializer<T> {
 
     /**
      * Reads a non-nullable value according to the type format.
-     * @param buffer A buffer which reader index has been set to the beginning of the {value}.
+     *
+     * @param buffer  A buffer which reader index has been set to the beginning of the {value}.
      * @param context The binary reader.
-     * @return
      * @throws IOException
+     * @since 4.0.0
      */
     protected abstract T readValue(final Buffer buffer, final GraphBinaryReader context) throws IOException;
 
@@ -85,7 +87,11 @@ public abstract class SimpleTypeSerializer<T> implements TypeSerializer<T> {
         }
 
         if (nullable) {
-            context.writeValueFlagNone(buffer);
+            if (value instanceof LinkedHashMap) {
+                context.writeValueFlagOrdered(buffer);
+            } else {
+                context.writeValueFlagNone(buffer);
+            }
         }
 
         writeValue(value, buffer, context);

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV4.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphbinaryV4.py
@@ -19,6 +19,7 @@ under the License.
 
 import uuid
 import math
+from collections import OrderedDict
 
 from datetime import datetime, timedelta, timezone
 from gremlin_python.statics import long, bigint, BigDecimal, SingleByte, SingleChar, ByteBufferType
@@ -146,6 +147,13 @@ class TestGraphBinaryV4(object):
 
         x = {"ripple": [], "peter": ["created"], "noone": ["blah"], "vadas": [],
              "josh": ["created", "created"], "lop": [], "marko": [666, "created", "knows", "knows"]}
+        output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
+        assert x == output
+
+    def test_ordered_dict(self):
+        x = OrderedDict()
+        x['a'] = 1
+        x['b'] = 2
         output = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(x))
         assert x == output
 

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/AbstractRoundTripTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/AbstractRoundTripTest.java
@@ -81,6 +81,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -106,6 +107,10 @@ public abstract class AbstractRoundTripTest {
 
         final Map<String, Map<String, Integer>> nestedMap = new HashMap<>();
         nestedMap.put("first", map);
+
+        final Map<String, Integer> orderedMap = new LinkedHashMap<>();
+        map.put("one", 1);
+        map.put("two", 2);
 
         final List<Object> list = new ArrayList<>();
         list.add("string 1");
@@ -214,7 +219,8 @@ public abstract class AbstractRoundTripTest {
                 new Object[] {"ListSingle", list, null},
                 new Object[] {"ListNested", nestedList, null},
                 new Object[] {"Map", map, null},
-                new Object[] {"Map", nestedMap, null},
+                new Object[] {"MapNested", nestedMap, null},
+                new Object[] {"OrderedMap", orderedMap, null},
                 new Object[] {"Set", set, null},
                 new Object[] {"SetNested", nestedSet, null});
     }


### PR DESCRIPTION
Changes:
* Add ordered `value_flag` `0x02` to Map serializers in Java and Python drivers.

Note this branch was based off of [graphbinary-add-datetime](https://github.com/apache/tinkerpop/tree/graphbinary-add-datetime) feature branch, as such the PR is to that branch to minimize file diff and facilitate review. Target branch will be changed to `master-http` once the feature branch is merged in https://github.com/apache/tinkerpop/pull/2776. 