### PR TITLE
[TINKERPOP-3112] Javascript: fix memory leak on server error

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bump Netty to 4.1.100
 * Bump Logback to 1.2.13
 * Bump Ivy to 2.5.2
+* Fixed a memory leak in the Javascript driver when there is a server error response.
 
 [[release-3-6-7]]
 === TinkerPop 3.6.7 (April 8, 2024)

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -344,6 +344,7 @@ class Connection extends EventEmitter {
 
       return;
     } else if (response.status.code >= 400) {
+      this._clearHandler(response.requestId);
       // callback in error
       return handler.callback(
         // TINKERPOP-2285: keep the old server error message in case folks are parsing that - fix in a future breaking version


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->

Jira link: https://issues.apache.org/jira/browse/TINKERPOP-3112

This PR fixes a memory leak in the case the server responds with an error.
I observed the leak in our environment, took heap snapshots and traced it down to not removing response handlers in case of a server error.
