### PR TITLE
Update GraphSONv4 format for edge's vertex reference.

### DIFF
--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -425,8 +425,9 @@ JSON String form of UUID.
 ==== Edge
 
 JSON Object (required keys are: id, label, inVLabel, outVLabel, inV, outV) +
-"id", "inV", "outV" is any GraphSON 4.0 type +
-"label", "inVLabel", "outVLabel" value is a `g:List` of `String` +
+"id" is any GraphSON 4.0 type +
+"inV", "outV" is an Object that contains "id" which is any GraphSON 4.0 type and "label" which is a `g:List` of `String`
+"label" is a `g:List` of `String` +
 "properties" is an optional Object containing Arrays of `g:Property`
 
 The untyped version has one additional required key "type" which is always "vertex".
@@ -443,19 +444,23 @@ The untyped version has one additional required key "type" which is always "vert
     "label": [
       "develops"
     ],
-    "inVLabel": [
-      "software"
-    ],
-    "outVLabel": [
-      "person"
-    ],
     "inV": {
-      "@type": "g:Int32",
-      "@value": 10
+      "id": {
+        "@type": "g:Int32",
+        "@value": 10
+      },
+      "label": [
+        "software"
+      ]
     },
     "outV": {
-      "@type": "g:Int32",
-      "@value": 1
+      "id": {
+        "@type": "g:Int32",
+        "@value": 1
+      },
+      "label": [
+        "person"
+      ]
     },
     "properties": {
       "since": [
@@ -483,14 +488,18 @@ The untyped version has one additional required key "type" which is always "vert
     "develops"
   ],
   "type": "edge",
-  "inVLabel": [
-    "software"
-  ],
-  "outVLabel": [
-    "person"
-  ],
-  "inV": 10,
-  "outV": 1,
+  "inV": {
+    "id": 10,
+    "label": [
+      "software"
+    ]
+  },
+  "outV": {
+    "id": 1,
+    "label": [
+      "person"
+    ]
+  },
   "properties": {
     "since": [
       2009
@@ -1012,19 +1021,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "develops"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 1
+            "id": {
+              "@type": "g:Int32",
+              "@value": 1
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "since": [
@@ -1052,19 +1065,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "develops"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 11
+            "id": {
+              "@type": "g:Int32",
+              "@value": 11
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 1
+            "id": {
+              "@type": "g:Int32",
+              "@value": 1
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "since": [
@@ -1092,19 +1109,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 1
+            "id": {
+              "@type": "g:Int32",
+              "@value": 1
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1132,19 +1153,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 11
+            "id": {
+              "@type": "g:Int32",
+              "@value": 11
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 1
+            "id": {
+              "@type": "g:Int32",
+              "@value": 1
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1172,19 +1197,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "develops"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 7
+            "id": {
+              "@type": "g:Int32",
+              "@value": 7
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "since": [
@@ -1212,19 +1241,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "develops"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 11
+            "id": {
+              "@type": "g:Int32",
+              "@value": 11
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 7
+            "id": {
+              "@type": "g:Int32",
+              "@value": 7
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "since": [
@@ -1252,19 +1285,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 7
+            "id": {
+              "@type": "g:Int32",
+              "@value": 7
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1292,19 +1329,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 11
+            "id": {
+              "@type": "g:Int32",
+              "@value": 11
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 7
+            "id": {
+              "@type": "g:Int32",
+              "@value": 7
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1332,19 +1373,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "develops"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 8
+            "id": {
+              "@type": "g:Int32",
+              "@value": 8
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "since": [
@@ -1372,19 +1417,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 8
+            "id": {
+              "@type": "g:Int32",
+              "@value": 8
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1412,19 +1461,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 11
+            "id": {
+              "@type": "g:Int32",
+              "@value": 11
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 8
+            "id": {
+              "@type": "g:Int32",
+              "@value": 8
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1452,19 +1505,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 9
+            "id": {
+              "@type": "g:Int32",
+              "@value": 9
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1492,19 +1549,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "uses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "person"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 11
+            "id": {
+              "@type": "g:Int32",
+              "@value": 11
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 9
+            "id": {
+              "@type": "g:Int32",
+              "@value": 9
+            },
+            "label": [
+              "person"
+            ]
           },
           "properties": {
             "skill": [
@@ -1532,19 +1593,23 @@ two required keys: "vertices" and "edges" +
           "label": [
             "traverses"
           ],
-          "inVLabel": [
-            "software"
-          ],
-          "outVLabel": [
-            "software"
-          ],
           "inV": {
-            "@type": "g:Int32",
-            "@value": 11
+            "id": {
+              "@type": "g:Int32",
+              "@value": 11
+            },
+            "label": [
+              "software"
+            ]
           },
           "outV": {
-            "@type": "g:Int32",
-            "@value": 10
+            "id": {
+              "@type": "g:Int32",
+              "@value": 10
+            },
+            "label": [
+              "software"
+            ]
           }
         }
       }
@@ -1771,14 +1836,18 @@ two required keys: "vertices" and "edges" +
         "develops"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 10,
-      "outV": 1,
+      "inV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 1,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "since": [
           2009
@@ -1791,14 +1860,18 @@ two required keys: "vertices" and "edges" +
         "develops"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 11,
-      "outV": 1,
+      "inV": {
+        "id": 11,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 1,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "since": [
           2010
@@ -1811,14 +1884,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 10,
-      "outV": 1,
+      "inV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 1,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           4
@@ -1831,14 +1908,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 11,
-      "outV": 1,
+      "inV": {
+        "id": 11,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 1,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           5
@@ -1851,14 +1932,18 @@ two required keys: "vertices" and "edges" +
         "develops"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 10,
-      "outV": 7,
+      "inV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 7,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "since": [
           2010
@@ -1871,14 +1956,18 @@ two required keys: "vertices" and "edges" +
         "develops"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 11,
-      "outV": 7,
+      "inV": {
+        "id": 11,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 7,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "since": [
           2011
@@ -1891,14 +1980,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 10,
-      "outV": 7,
+      "inV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 7,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           5
@@ -1911,14 +2004,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 11,
-      "outV": 7,
+      "inV": {
+        "id": 11,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 7,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           4
@@ -1931,14 +2028,18 @@ two required keys: "vertices" and "edges" +
         "develops"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 10,
-      "outV": 8,
+      "inV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 8,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "since": [
           2012
@@ -1951,14 +2052,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 10,
-      "outV": 8,
+      "inV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 8,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           3
@@ -1971,14 +2076,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 11,
-      "outV": 8,
+      "inV": {
+        "id": 11,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 8,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           3
@@ -1991,14 +2100,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 10,
-      "outV": 9,
+      "inV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 9,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           5
@@ -2011,14 +2124,18 @@ two required keys: "vertices" and "edges" +
         "uses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "person"
-      ],
-      "inV": 11,
-      "outV": 9,
+      "inV": {
+        "id": 11,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 9,
+        "label": [
+          "person"
+        ]
+      },
       "properties": {
         "skill": [
           3
@@ -2031,14 +2148,18 @@ two required keys: "vertices" and "edges" +
         "traverses"
       ],
       "type": "edge",
-      "inVLabel": [
-        "software"
-      ],
-      "outVLabel": [
-        "software"
-      ],
-      "inV": 11,
-      "outV": 10
+      "inV": {
+        "id": 11,
+        "label": [
+          "software"
+        ]
+      },
+      "outV": {
+        "id": 10,
+        "label": [
+          "software"
+        ]
+      }
     }
   ]
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperTest.java
@@ -113,7 +113,7 @@ public class GraphSONMapperTest {
         else if (version.startsWith("v2"))
             assertEquals("{\"id\":123,\"label\":\"knows\",\"inVLabel\":\"person\",\"outVLabel\":\"person\",\"inV\":2,\"outV\":1,\"properties\":{\"weight\":{\"key\":\"weight\",\"value\":0.5}}}", json);
         else if (version.startsWith("v4"))
-            assertEquals("{\"id\":123,\"label\":[\"knows\"],\"type\":\"edge\",\"inVLabel\":[\"person\"],\"outVLabel\":[\"person\"],\"inV\":2,\"outV\":1,\"properties\":{\"weight\":[0.5]}}", json);
+            assertEquals("{\"id\":123,\"label\":[\"knows\"],\"type\":\"edge\",\"inV\":{\"id\":2,\"label\":[\"person\"]},\"outV\":{\"id\":1,\"label\":[\"person\"]},\"properties\":{\"weight\":[0.5]}}", json);
         else
             throw new IllegalStateException("Version not accounted for in asserts");
     }

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/no-prop-edge-v4.json
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/no-prop-edge-v4.json
@@ -6,15 +6,19 @@
       "@value" : 13
     },
     "label" : [ "develops" ],
-    "inVLabel" : [ "software" ],
-    "outVLabel" : [ "person" ],
     "inV" : {
-      "@type" : "g:Int32",
-      "@value" : 10
+      "id" : {
+        "@type" : "g:Int32",
+        "@value" : 10
+      },
+      "label" : [ "software" ]
     },
     "outV" : {
-      "@type" : "g:Int32",
-      "@value" : 1
+      "id" : {
+        "@type" : "g:Int32",
+        "@value" : 1
+      },
+      "label" : [ "person" ]
     }
   }
 }

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/tinker-graph-v4.json
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/tinker-graph-v4.json
@@ -410,15 +410,19 @@
           "@value" : 13
         },
         "label" : [ "develops" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 1
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 1
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "since" : [ {
@@ -441,15 +445,19 @@
           "@value" : 14
         },
         "label" : [ "develops" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 11
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 11
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 1
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 1
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "since" : [ {
@@ -472,15 +480,19 @@
           "@value" : 15
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 1
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 1
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -503,15 +515,19 @@
           "@value" : 16
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 11
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 11
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 1
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 1
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -534,15 +550,19 @@
           "@value" : 17
         },
         "label" : [ "develops" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 7
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 7
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "since" : [ {
@@ -565,15 +585,19 @@
           "@value" : 18
         },
         "label" : [ "develops" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 11
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 11
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 7
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 7
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "since" : [ {
@@ -596,15 +620,19 @@
           "@value" : 19
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 7
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 7
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -627,15 +655,19 @@
           "@value" : 20
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 11
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 11
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 7
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 7
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -658,15 +690,19 @@
           "@value" : 21
         },
         "label" : [ "develops" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 8
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 8
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "since" : [ {
@@ -689,15 +725,19 @@
           "@value" : 22
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 8
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 8
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -720,15 +760,19 @@
           "@value" : 23
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 11
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 11
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 8
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 8
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -751,15 +795,19 @@
           "@value" : 24
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 9
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 9
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -782,15 +830,19 @@
           "@value" : 25
         },
         "label" : [ "uses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "person" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 11
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 11
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 9
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 9
+          },
+          "label" : [ "person" ]
         },
         "properties" : {
           "skill" : [ {
@@ -813,15 +865,19 @@
           "@value" : 26
         },
         "label" : [ "traverses" ],
-        "inVLabel" : [ "software" ],
-        "outVLabel" : [ "software" ],
         "inV" : {
-          "@type" : "g:Int32",
-          "@value" : 11
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 11
+          },
+          "label" : [ "software" ]
         },
         "outV" : {
-          "@type" : "g:Int32",
-          "@value" : 10
+          "id" : {
+            "@type" : "g:Int32",
+            "@value" : 10
+          },
+          "label" : [ "software" ]
         }
       }
     } ]

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/traversal-edge-v4-no-types.json
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/traversal-edge-v4-no-types.json
@@ -2,10 +2,14 @@
   "id" : 13,
   "label" : [ "develops" ],
   "type" : "edge",
-  "inVLabel" : [ "software" ],
-  "outVLabel" : [ "person" ],
-  "inV" : 10,
-  "outV" : 1,
+  "inV" : {
+    "id" : 10,
+    "label" : [ "software" ]
+  },
+  "outV" : {
+    "id" : 1,
+    "label" : [ "person" ]
+  },
   "properties" : {
     "since" : [ 2009 ]
   }

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/traversal-edge-v4.json
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/traversal-edge-v4.json
@@ -6,15 +6,19 @@
       "@value" : 13
     },
     "label" : [ "develops" ],
-    "inVLabel" : [ "software" ],
-    "outVLabel" : [ "person" ],
     "inV" : {
-      "@type" : "g:Int32",
-      "@value" : 10
+      "id" : {
+        "@type" : "g:Int32",
+        "@value" : 10
+      },
+      "label" : [ "software" ]
     },
     "outV" : {
-      "@type" : "g:Int32",
-      "@value" : 1
+      "id" : {
+        "@type" : "g:Int32",
+        "@value" : 1
+      },
+      "label" : [ "person" ]
     },
     "properties" : {
       "since" : [ {

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/structure/io/AbstractUntypedCompatibilityTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/structure/io/AbstractUntypedCompatibilityTest.java
@@ -59,17 +59,17 @@ public abstract class AbstractUntypedCompatibilityTest extends AbstractCompatibi
         assertEquals(resource.id(), fromStatic.get("id"));
         assertEquals(Collections.singletonList(resource.label()), fromStatic.get("label"));
         assertEquals(resource.id(), fromStatic.get("id"));
-        assertEquals(Collections.singletonList(resource.inVertex().label()), fromStatic.get("inVLabel"));
-        assertEquals(Collections.singletonList(resource.outVertex().label()), fromStatic.get("outVLabel"));
-        assertEquals(resource.inVertex().id(), fromStatic.get("inV"));
-        assertEquals(resource.outVertex().id(), fromStatic.get("outV"));
+        assertEquals(Collections.singletonList(resource.inVertex().label()), ((Map) fromStatic.get("inV")).get("label"));
+        assertEquals(Collections.singletonList(resource.outVertex().label()), ((Map) fromStatic.get("outV")).get("label"));
+        assertEquals(resource.inVertex().id(), ((Map) fromStatic.get("inV")).get("id"));
+        assertEquals(resource.outVertex().id(), ((Map) fromStatic.get("outV")).get("id"));
         assertEquals(resource.id(), recycled.get("id"));
         assertEquals(Collections.singletonList(resource.label()), recycled.get("label"));
         assertEquals(resource.id(), recycled.get("id"));
-        assertEquals(Collections.singletonList(resource.inVertex().label()), recycled.get("inVLabel"));
-        assertEquals(Collections.singletonList(resource.outVertex().label()), recycled.get("outVLabel"));
-        assertEquals(resource.inVertex().id(), recycled.get("inV"));
-        assertEquals(resource.outVertex().id(), recycled.get("outV"));
+        assertEquals(Collections.singletonList(resource.inVertex().label()), ((Map) recycled.get("inV")).get("label"));
+        assertEquals(Collections.singletonList(resource.outVertex().label()), ((Map) recycled.get("outV")).get("label"));
+        assertEquals(resource.inVertex().id(), ((Map) recycled.get("inV")).get("id"));
+        assertEquals(resource.outVertex().id(), ((Map) recycled.get("outV")).get("id"));
 
         // deal with incompatibilities
         if (getCompatibility().equals("v1-no-types") || getCompatibility().equals("v3-no-types")) {


### PR DESCRIPTION
Moved id, label into the inV and outV as this logically makes more sense as its the correct representation of a reference/detached vertex.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->