### PR TITLE
fix flaky tests in ParametersTest

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Comparator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,7 +58,10 @@ public class ParametersTest {
 
         final Object[] params = parameters.getKeyValues(mock(Traverser.Admin.class));
         assertEquals(6, params.length);
-        assertThat(Arrays.equals(new Object[] {"a", null, "b", "bat", "c", "cat"}, params), is(true));
+        Object[] expected = new Object[] {"a", null, "b", "bat", "c", "cat"};
+        Arrays.sort(params, Comparator.nullsFirst(Comparator.comparing(Object::toString)));
+        Arrays.sort(expected, Comparator.nullsFirst(Comparator.comparing(Object::toString)));
+        assertThat(Arrays.equals(expected, params), is(true));
     }
 
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Comparator;
+import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -58,10 +58,15 @@ public class ParametersTest {
 
         final Object[] params = parameters.getKeyValues(mock(Traverser.Admin.class));
         assertEquals(6, params.length);
-        Object[] expected = new Object[] {"a", null, "b", "bat", "c", "cat"};
-        Arrays.sort(params, Comparator.nullsFirst(Comparator.comparing(Object::toString)));
-        Arrays.sort(expected, Comparator.nullsFirst(Comparator.comparing(Object::toString)));
-        assertThat(Arrays.equals(expected, params), is(true));
+        Map<Object, Object> paramsMap = new HashMap<>();
+        for (int i = 0; i < params.length; i += 2) {
+            paramsMap.put(params[i], params[i + 1]);
+        }
+        Map<Object, Object> expectedMap = new HashMap<>();
+        expectedMap.put("a", null);
+        expectedMap.put("b", "bat");
+        expectedMap.put("c", "cat");
+        assertThat(paramsMap.equals(expectedMap), is(true));
     }
 
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
@@ -76,7 +76,15 @@ public class ParametersTest {
 
         final Object[] params = parameters.getKeyValues(mock(Traverser.Admin.class));
         assertEquals(6, params.length);
-        assertThat(Arrays.equals(new Object[] {"a", "axe", "b", "bat", "c", "cat"}, params), is(true));
+        Map<Object, Object> paramsMap = new HashMap<>();
+        for (int i = 0; i < params.length; i += 2) {
+            paramsMap.put(params[i], params[i + 1]);
+        }
+        Map<Object, Object> expectedMap = new HashMap<>();
+        expectedMap.put("a", "axe");
+        expectedMap.put("b", "bat");
+        expectedMap.put("c", "cat");
+        assertThat(paramsMap.equals(expectedMap), is(true));
     }
 
     @Test
@@ -86,7 +94,14 @@ public class ParametersTest {
 
         final Object[] params = parameters.getKeyValues(mock(Traverser.Admin.class), "b");
         assertEquals(4, params.length);
-        assertThat(Arrays.equals(new Object[] {"a", "axe", "c", "cat"}, params), is(true));
+        Map<Object, Object> paramsMap = new HashMap<>();
+        for (int i = 0; i < params.length; i += 2) {
+            paramsMap.put(params[i], params[i + 1]);
+        }
+        Map<Object, Object> expectedMap = new HashMap<>();
+        expectedMap.put("a", "axe");
+        expectedMap.put("c", "cat");
+        assertThat(paramsMap.equals(expectedMap), is(true));
     }
 
     @Test


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->
### Description
One flaky test shouldAllowNullValues is found using Nondex. This PR now fixes it without introducing new plugins / dependencies. The test was found to be flaky when running the following command:
```
mvn -pl gremlin-core \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
-Dtest=org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldAllowNullValues \
-Drat.numUnapprovedLicenses=200
```
The `params` array contains retrieved keys and value from a HashMap, that may lead to inconsistent test results due to the non-deterministic ordering of elements in a HashMap. 

### Proposed Fix
The expected keys and values are now stored in a new array 'expected'. Sort both 'params' and 'expected'. The comparison between 'params' and 'expected' has consistent results.