### PR TITLE
[TINKERPOP 2700] Make WS Compression Configurable in Remaining GLVs 3.7

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -343,6 +343,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * The default logging level for Gremlin Console in Windows is set to the same WARN level as for Linux.
 * Updated to Docker Compose V2 with `docker-compose` changed to `docker compose` in pom and script files.
 * Add command line option `-l` to change logging level for Gremlin Console in Windows.
+* Add `enableCompression` connection setting to Java, Python, and JS GLVs.
 * Increased minimum python version from 3.8 to 3.9
 * Upgraded `gremlin-go` to Go 1.22.
 * Bump Netty to 4.1.100

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -815,6 +815,8 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.trustStorePassword |The password of the `trustStore` if it is password-protected |_none_
 |connectionPool.validationRequest |A script that is used to test server connectivity. A good script to use is one that evaluates quickly and returns no data. The default simply returns an empty string, but if a graph is required by a particular provider, a good traversal might be `g.inject()`. |_''_
 |connectionPool.connectionSetupTimeoutMillis | Duration of time in milliseconds provided for connection setup to complete which includes WebSocket protocol handshake and SSL handshake. |15000
+|enableCompression |Enables permessage-deflate compression. Note that use of compression may increase vulnerability to attacks such as CRIME/BREACH.|true
+|enableUserAgentOnConnect |Enables sending a user agent to the server during connection requests. More details can be found in provider docs link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|true
 |hosts |The list of hosts that the driver will connect to. |localhost
 |jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors
@@ -826,7 +828,6 @@ The following table describes the various configuration options for the Gremlin 
 |serializer.config |A `Map` of configuration settings for the serializer. |_none_
 |username |The username to submit on requests that require authentication. |_none_
 |workerPoolSize |Size of the pool for handling background work. |available processors * 2
-|enableUserAgentOnConnect |Enables sending a user agent to the server during connection requests. More details can be found in provider docs link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|true
 |=========================================================
 
 Please see the link:https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/driver/Cluster.Builder.html[Cluster.Builder javadoc] to get more information on these settings.
@@ -1394,6 +1395,7 @@ can be passed in the constructor of a new `Client` or `DriverRemoteConnection` :
 |options.authenticator |Authenticator |The authentication handler to use. |undefined
 |options.processor |String |The name of the opProcessor to use, leave it undefined or set 'session' when session mode. |undefined
 |options.session |String |The sessionId of Client in session mode. undefined means session-less Client. |undefined
+|options.enableCompression |Boolean |Enables permessage-deflate compression. Note that use of compression may increase vulnerability to attacks such as CRIME/BREACH.|false
 |options.enableUserAgentOnConnect |Boolean |Determines if a user agent will be sent during connection handshake. |true
 |options.headers |Object |An associative array containing the additional header key/values for the initial request. |undefined
 |options.pingEnabled |Boolean |Setup ping interval. |true
@@ -2272,19 +2274,19 @@ can be passed to the `Client` or `DriverRemoteConnection` instance as keyword ar
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Key |Description |Default
+|enable_compression |Enables sending a user agent to the server during connection requests. |False
+|enable_user_agent_on_connect |Enables sending a user agent to the server during connection requests. More details can be found in provider docs
+link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|True
 |headers |Additional headers that will be added to each request message. |`None`
+|kerberized_service |the first part of the principal name configured for the gremlin service|"""
 |max_workers |Maximum number of worker threads. |Number of CPUs * 5
 |message_serializer |The message serializer implementation.|`gremlin_python.driver.serializer.GraphBinarySerializersV1`
 |password |The password to submit on requests that require authentication. |""
 |pool_size |The number of connections used by the pool. |4
 |protocol_factory |A callable that returns an instance of `AbstractBaseProtocol`. |`gremlin_python.driver.protocol.GremlinServerWSProtocol`
+|session | A unique string-based identifier (typically a UUID) to enable a <<sessions,session-based connection>>. This is not a valid configuration for `DriverRemoteConnection`. |None
 |transport_factory |A callable that returns an instance of `AbstractBaseTransport`. |`gremlin_python.driver.aiohttp.transport.AiohttpTransport`
 |username |The username to submit on requests that require authentication. |""
-|kerberized_service |the first part of the principal name configured for the gremlin service|"""
-|session | A unique string-based identifier (typically a UUID) to enable a <<sessions,session-based connection>>. This is not a valid configuration for `DriverRemoteConnection`. |None
-|enable_user_agent_on_connect |Enables sending a user agent to the server during connection requests.
-More details can be found in provider docs
-link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|True
 |=========================================================
 
 Note that the `transport_factory` can allow for additional configuration of the `AiohttpTransport`, which allows

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -210,8 +210,10 @@ public interface Channelizer extends ChannelHandler {
 
             pipeline.addLast("http-codec", new HttpClientCodec());
             pipeline.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
-            // Add compression extension for WebSocket defined in https://tools.ietf.org/html/rfc7692
-            pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
+            if (connection.getCluster().useCompression()) {
+                // Add compression extension for WebSocket defined in https://tools.ietf.org/html/rfc7692
+                pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
+            }
             pipeline.addLast("idle-state-Handler", new IdleStateHandler(0, keepAliveInterval, 0));
             pipeline.addLast("ws-handler", handler);
             pipeline.addLast("gremlin-encoder", gremlinRequestEncoder);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -210,7 +210,7 @@ public interface Channelizer extends ChannelHandler {
 
             pipeline.addLast("http-codec", new HttpClientCodec());
             pipeline.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
-            if (connection.getCluster().useCompression()) {
+            if (connection.getCluster().enableCompression()) {
                 // Add compression extension for WebSocket defined in https://tools.ietf.org/html/rfc7692
                 pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
             }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -210,6 +210,7 @@ public final class Cluster {
                 .minConnectionPoolSize(settings.connectionPool.minSize)
                 .connectionSetupTimeoutMillis(settings.connectionPool.connectionSetupTimeoutMillis)
                 .enableUserAgentOnConnect(settings.enableUserAgentOnConnect)
+                .useCompression(settings.useCompression)
                 .validationRequest(settings.connectionPool.validationRequest);
 
         if (settings.username != null && settings.password != null)
@@ -578,6 +579,13 @@ public final class Cluster {
         return manager.isUserAgentOnConnectEnabled();
     }
 
+    /**
+     * Checks if cluster is configured to use per-message deflate compression
+     */
+    public boolean useCompression() {
+        return manager.useCompression();
+    }
+
     public final static class Builder {
         private List<InetAddress> addresses = new ArrayList<>();
         private int port = 8182;
@@ -615,6 +623,7 @@ public final class Cluster {
         private AuthProperties authProps = new AuthProperties();
         private long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
         private boolean enableUserAgentOnConnect = true;
+        private boolean useCompression = true;
 
         private Builder() {
             // empty to prevent direct instantiation
@@ -1031,6 +1040,14 @@ public final class Cluster {
             return this;
         }
 
+        /**
+         * Configures use of per-message deflate compression. Defaults to true.
+         */
+        public Builder useCompression(final boolean useCompression) {
+            this.useCompression = useCompression;
+            return this;
+        }
+
         List<InetSocketAddress> getContactPoints() {
             return addresses.stream().map(addy -> new InetSocketAddress(addy, port)).collect(Collectors.toList());
         }
@@ -1100,6 +1117,7 @@ public final class Cluster {
         private final int port;
         private final String path;
         private final boolean enableUserAgentOnConnect;
+        private final boolean useCompression;
 
         private final AtomicReference<CompletableFuture<Void>> closeFuture = new AtomicReference<>();
 
@@ -1113,6 +1131,7 @@ public final class Cluster {
             this.contactPoints = builder.getContactPoints();
             this.interceptor = builder.interceptor;
             this.enableUserAgentOnConnect = builder.enableUserAgentOnConnect;
+            this.useCompression = builder.useCompression;
 
             connectionPoolSettings = new Settings.ConnectionPoolSettings();
             connectionPoolSettings.maxInProcessPerConnection = builder.maxInProcessPerConnection;
@@ -1306,6 +1325,13 @@ public final class Cluster {
          */
         public boolean isUserAgentOnConnectEnabled() {
             return enableUserAgentOnConnect;
+        }
+
+        /**
+         * Checks if cluster is configured to use per-message deflate compression
+         */
+        public boolean useCompression() {
+            return useCompression;
         }
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -210,7 +210,7 @@ public final class Cluster {
                 .minConnectionPoolSize(settings.connectionPool.minSize)
                 .connectionSetupTimeoutMillis(settings.connectionPool.connectionSetupTimeoutMillis)
                 .enableUserAgentOnConnect(settings.enableUserAgentOnConnect)
-                .useCompression(settings.useCompression)
+                .enableCompression(settings.enableCompression)
                 .validationRequest(settings.connectionPool.validationRequest);
 
         if (settings.username != null && settings.password != null)
@@ -582,8 +582,8 @@ public final class Cluster {
     /**
      * Checks if cluster is configured to use per-message deflate compression
      */
-    public boolean useCompression() {
-        return manager.useCompression();
+    public boolean enableCompression() {
+        return manager.enableCompression();
     }
 
     public final static class Builder {
@@ -623,7 +623,7 @@ public final class Cluster {
         private AuthProperties authProps = new AuthProperties();
         private long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
         private boolean enableUserAgentOnConnect = true;
-        private boolean useCompression = true;
+        private boolean enableCompression = true;
 
         private Builder() {
             // empty to prevent direct instantiation
@@ -1043,8 +1043,8 @@ public final class Cluster {
         /**
          * Configures use of per-message deflate compression. Defaults to true.
          */
-        public Builder useCompression(final boolean useCompression) {
-            this.useCompression = useCompression;
+        public Builder enableCompression(final boolean enableCompression) {
+            this.enableCompression = enableCompression;
             return this;
         }
 
@@ -1117,7 +1117,7 @@ public final class Cluster {
         private final int port;
         private final String path;
         private final boolean enableUserAgentOnConnect;
-        private final boolean useCompression;
+        private final boolean enableCompression;
 
         private final AtomicReference<CompletableFuture<Void>> closeFuture = new AtomicReference<>();
 
@@ -1131,7 +1131,7 @@ public final class Cluster {
             this.contactPoints = builder.getContactPoints();
             this.interceptor = builder.interceptor;
             this.enableUserAgentOnConnect = builder.enableUserAgentOnConnect;
-            this.useCompression = builder.useCompression;
+            this.enableCompression = builder.enableCompression;
 
             connectionPoolSettings = new Settings.ConnectionPoolSettings();
             connectionPoolSettings.maxInProcessPerConnection = builder.maxInProcessPerConnection;
@@ -1330,8 +1330,8 @@ public final class Cluster {
         /**
          * Checks if cluster is configured to use per-message deflate compression
          */
-        public boolean useCompression() {
-            return useCompression;
+        public boolean enableCompression() {
+            return enableCompression;
         }
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -215,7 +215,7 @@ final class Connection {
             throw new IllegalStateException(String.format("There is already a request pending with an id of: %s", requestMessage.getRequestId()));
 
         // once there is a completed write, then create a traverser for the result set and complete
-        // the promise so that the client knows that that it can start checking for results.
+        // the promise so that the client knows that it can start checking for results.
         final Connection thisConnection = this;
 
         final ChannelPromise requestPromise = channel.newPromise()

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -108,7 +108,7 @@ final class Settings {
     /**
      * Configures use of per-message deflate compression. Defaults to true.
      */
-    public boolean useCompression = true;
+    public boolean enableCompression = true;
 
     /**
      * Read configuration from a file into a new {@link Settings} object.
@@ -159,8 +159,8 @@ final class Settings {
         if (conf.containsKey("enableUserAgentOnConnect"))
             settings.enableUserAgentOnConnect = conf.getBoolean("enableUserAgentOnConnect");
 
-        if (conf.containsKey("useCompression"))
-            settings.useCompression = conf.getBoolean("useCompression");
+        if (conf.containsKey("enableCompression"))
+            settings.enableCompression = conf.getBoolean("enableCompression");
 
         if (conf.containsKey("hosts"))
             settings.hosts = conf.getList("hosts").stream().map(Object::toString).collect(Collectors.toList());

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -106,6 +106,11 @@ final class Settings {
     public boolean enableUserAgentOnConnect = true;
 
     /**
+     * Configures use of per-message deflate compression. Defaults to true.
+     */
+    public boolean useCompression = true;
+
+    /**
      * Read configuration from a file into a new {@link Settings} object.
      *
      * @param stream an input stream containing a Gremlin Server YAML configuration
@@ -153,6 +158,9 @@ final class Settings {
 
         if (conf.containsKey("enableUserAgentOnConnect"))
             settings.enableUserAgentOnConnect = conf.getBoolean("enableUserAgentOnConnect");
+
+        if (conf.containsKey("useCompression"))
+            settings.useCompression = conf.getBoolean("useCompression");
 
         if (conf.containsKey("hosts"))
             settings.hosts = conf.getList("hosts").stream().map(Object::toString).collect(Collectors.toList());

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -47,7 +47,7 @@ public class SettingsTest {
         conf.setProperty("serializer.className", "my.serializers.MySerializer");
         conf.setProperty("serializer.config.any", "thing");
         conf.setProperty("enableUserAgentOnConnect", false);
-        conf.setProperty("useCompression", false);
+        conf.setProperty("enableCompression", false);
         conf.setProperty("connectionPool.enableSsl", true);
         conf.setProperty("connectionPool.keyStore", "server.jks");
         conf.setProperty("connectionPool.keyStorePassword", "password2");
@@ -85,7 +85,7 @@ public class SettingsTest {
         assertEquals("my.serializers.MySerializer", settings.serializer.className);
         assertEquals("thing", settings.serializer.config.get("any"));
         assertEquals(false, settings.enableUserAgentOnConnect);
-        assertEquals(false, settings.useCompression);
+        assertEquals(false, settings.enableCompression);
         assertThat(settings.connectionPool.enableSsl, is(true));
         assertEquals("server.jks", settings.connectionPool.keyStore);
         assertEquals("password2", settings.connectionPool.keyStorePassword);

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -47,6 +47,7 @@ public class SettingsTest {
         conf.setProperty("serializer.className", "my.serializers.MySerializer");
         conf.setProperty("serializer.config.any", "thing");
         conf.setProperty("enableUserAgentOnConnect", false);
+        conf.setProperty("useCompression", false);
         conf.setProperty("connectionPool.enableSsl", true);
         conf.setProperty("connectionPool.keyStore", "server.jks");
         conf.setProperty("connectionPool.keyStorePassword", "password2");
@@ -84,6 +85,7 @@ public class SettingsTest {
         assertEquals("my.serializers.MySerializer", settings.serializer.className);
         assertEquals("thing", settings.serializer.config.get("any"));
         assertEquals(false, settings.enableUserAgentOnConnect);
+        assertEquals(false, settings.useCompression);
         assertThat(settings.connectionPool.enableSsl, is(true));
         assertEquals("server.jks", settings.connectionPool.keyStore);
         assertEquals("password2", settings.connectionPool.keyStorePassword);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -44,7 +44,7 @@ class Client {
    * @param {String} [options.processor] The name of the opProcessor to use, leave it undefined or set 'session' when session mode.
    * @param {String} [options.session] The sessionId of Client in session mode. Defaults to null means session-less Client.
    * @param {http.Agent} [options.agent] The http.Agent implementation to use.
-   * @param {Boolean} [options.useCompression] Enable per-message deflate compression. Defaults to: false.
+   * @param {Boolean} [options.enableCompression] Enable per-message deflate compression. Defaults to: false.
    * @constructor
    */
   constructor(url, options = {}) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/client.js
@@ -44,6 +44,7 @@ class Client {
    * @param {String} [options.processor] The name of the opProcessor to use, leave it undefined or set 'session' when session mode.
    * @param {String} [options.session] The sessionId of Client in session mode. Defaults to null means session-less Client.
    * @param {http.Agent} [options.agent] The http.Agent implementation to use.
+   * @param {Boolean} [options.useCompression] Enable per-message deflate compression. Defaults to: false.
    * @constructor
    */
   constructor(url, options = {}) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -65,7 +65,7 @@ class Connection extends EventEmitter {
    * @param {Object} [options.headers] An associative array containing the additional header key/values for the initial request.
    * @param {Boolean} [options.enableUserAgentOnConnect] Determines if a user agent will be sent during connection handshake. Defaults to: true
    * @param {http.Agent} [options.agent] The http.Agent implementation to use.
-   * @param {Boolean} [options.useCompression] Enable per-message deflate compression. Defaults to: false.
+   * @param {Boolean} [options.enableCompression] Enable per-message deflate compression. Defaults to: false.
    * @constructor
    */
   constructor(url, options) {
@@ -136,7 +136,7 @@ class Connection extends EventEmitter {
             pfx: this.options.pfx,
             rejectUnauthorized: this.options.rejectUnauthorized,
             agent: this.options.agent,
-            perMessageDeflate: this.options.useCompression,
+            perMessageDeflate: this.options.enableCompression,
           }
         : undefined,
     );

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -65,6 +65,7 @@ class Connection extends EventEmitter {
    * @param {Object} [options.headers] An associative array containing the additional header key/values for the initial request.
    * @param {Boolean} [options.enableUserAgentOnConnect] Determines if a user agent will be sent during connection handshake. Defaults to: true
    * @param {http.Agent} [options.agent] The http.Agent implementation to use.
+   * @param {Boolean} [options.useCompression] Enable per-message deflate compression. Defaults to: false.
    * @constructor
    */
   constructor(url, options) {
@@ -135,6 +136,7 @@ class Connection extends EventEmitter {
             pfx: this.options.pfx,
             rejectUnauthorized: this.options.rejectUnauthorized,
             agent: this.options.agent,
+            perMessageDeflate: this.options.useCompression,
           }
         : undefined,
     );

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -50,6 +50,7 @@ class DriverRemoteConnection extends RemoteConnection {
    * @param {Object} [options.headers] An associative array containing the additional header key/values for the initial request.
    * @param {Boolean} [options.enableUserAgentOnConnect] Determines if a user agent will be sent during connection handshake. Defaults to: true
    * @param {http.Agent} [options.agent] The http.Agent implementation to use.
+   * @param {Boolean} [options.useCompression] Enable per-message deflate compression. Defaults to: false.
    * @constructor
    */
   constructor(url, options = {}) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -50,7 +50,7 @@ class DriverRemoteConnection extends RemoteConnection {
    * @param {Object} [options.headers] An associative array containing the additional header key/values for the initial request.
    * @param {Boolean} [options.enableUserAgentOnConnect] Determines if a user agent will be sent during connection handshake. Defaults to: true
    * @param {http.Agent} [options.agent] The http.Agent implementation to use.
-   * @param {Boolean} [options.useCompression] Enable per-message deflate compression. Defaults to: false.
+   * @param {Boolean} [options.enableCompression] Enable per-message deflate compression. Defaults to: false.
    * @constructor
    */
   constructor(url, options = {}) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
@@ -105,7 +105,7 @@ exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(tra
 exports.getGremlinSocketServerClientWithOptions = function getGremlinSocketServerClient(traversalSource, options) {
   const settings = exports.getGremlinSocketServerSettings();
   const url = socketServerUrl + settings.PORT + '/gremlin';
-  let mimeType = getMimeTypeFromSocketServerSettings(settings)
+  const mimeType = getMimeTypeFromSocketServerSettings(settings)
   return new Client(url, { traversalSource, mimeType, ...options});
 };
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
@@ -102,6 +102,13 @@ exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(tra
   return new Client(url, { traversalSource, mimeType });
 };
 
+exports.getGremlinSocketServerClientWithOptions = function getGremlinSocketServerClient(traversalSource, options) {
+  const settings = exports.getGremlinSocketServerSettings();
+  const url = socketServerUrl + settings.PORT + '/gremlin';
+  let mimeType = getMimeTypeFromSocketServerSettings(settings)
+  return new Client(url, { traversalSource, mimeType, ...options});
+};
+
 exports.getGremlinSocketServerClientNoUserAgent = function getGremlinSocketServerClient(traversalSource) {
   const settings = exports.getGremlinSocketServerSettings();
   const url = socketServerUrl + settings.PORT + '/gremlin';

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
@@ -64,28 +64,28 @@ describe('Client', function () {
             await noUserAgentClient.close();
         });
         it('should not request permessage deflate compression by default', async function () {
-            let result = await client.submit('1', null, {requestId: settings.SEC_WEBSOCKET_EXTENSIONS});
-            let returnedExtensions = result.first()
+            const result = await client.submit('1', null, {requestId: settings.SEC_WEBSOCKET_EXTENSIONS});
+            const returnedExtensions = result.first()
             assert.ok(returnedExtensions == undefined || !returnedExtensions.includes("permessage-deflate;"))
         });
         it('should not request permessage deflate compression when disabled', async function () {
-            let noCompressionClient = helper.getGremlinSocketServerClientWithOptions('gmodern',
+            const noCompressionClient = helper.getGremlinSocketServerClientWithOptions('gmodern',
                 {enableCompression: false});
-            let result = await noCompressionClient.submit('1', null,
+            const result = await noCompressionClient.submit('1', null,
                 {requestId: settings.SEC_WEBSOCKET_EXTENSIONS});
 
-            let returnedExtensions = result.first()
+            const returnedExtensions = result.first()
             assert.ok(returnedExtensions == undefined || !returnedExtensions.includes("permessage-deflate;"))
 
             await noCompressionClient.close();
         });
         it('should request permessage deflate compression when enabled', async function () {
-            let compressionClient = helper.getGremlinSocketServerClientWithOptions('gmodern',
+            const compressionClient = helper.getGremlinSocketServerClientWithOptions('gmodern',
                 {enableCompression: true});
-            let result = await compressionClient.submit('1', null,
+            const result = await compressionClient.submit('1', null,
                 {requestId: settings.SEC_WEBSOCKET_EXTENSIONS});
 
-            let returnedExtensions = result.first()
+            const returnedExtensions = result.first()
             assert.ok(returnedExtensions.includes("permessage-deflate;"))
 
             await compressionClient.close();

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
@@ -63,6 +63,33 @@ describe('Client', function () {
 
             await noUserAgentClient.close();
         });
+        it('should not request permessage deflate compression by default', async function () {
+            let result = await client.submit('1', null, {requestId: settings.SEC_WEBSOCKET_EXTENSIONS});
+            let returnedExtensions = result.first()
+            assert.ok(returnedExtensions == undefined || !returnedExtensions.includes("permessage-deflate;"))
+        });
+        it('should not request permessage deflate compression when disabled', async function () {
+            let noCompressionClient = helper.getGremlinSocketServerClientWithOptions('gmodern',
+                {enableCompression: false});
+            let result = await noCompressionClient.submit('1', null,
+                {requestId: settings.SEC_WEBSOCKET_EXTENSIONS});
+
+            let returnedExtensions = result.first()
+            assert.ok(returnedExtensions == undefined || !returnedExtensions.includes("permessage-deflate;"))
+
+            await noCompressionClient.close();
+        });
+        it('should request permessage deflate compression when enabled', async function () {
+            let compressionClient = helper.getGremlinSocketServerClientWithOptions('gmodern',
+                {enableCompression: true});
+            let result = await compressionClient.submit('1', null,
+                {requestId: settings.SEC_WEBSOCKET_EXTENSIONS});
+
+            let returnedExtensions = result.first()
+            assert.ok(returnedExtensions.includes("permessage-deflate;"))
+
+            await compressionClient.close();
+        });
         it('should send per request settings to server', async function () {
             const resultSet = await client.submit('1', null, {
                 requestId: settings.PER_REQUEST_SETTINGS_REQUEST_ID,

--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -29,7 +29,8 @@ __author__ = 'Lyndon Bauto (lyndonb@bitquilltech.com)'
 class AiohttpTransport(AbstractBaseTransport):
     nest_asyncio_applied = False
 
-    def __init__(self, call_from_event_loop=None, read_timeout=None, write_timeout=None, **kwargs):
+    def __init__(self, call_from_event_loop=None, read_timeout=None, write_timeout=None, enable_compression=False,
+                 **kwargs):
         if call_from_event_loop is not None and call_from_event_loop and not AiohttpTransport.nest_asyncio_applied:
             """ 
                 The AiohttpTransport implementation uses the asyncio event loop. Because of this, it cannot be called 
@@ -50,10 +51,13 @@ class AiohttpTransport(AbstractBaseTransport):
         self._aiohttp_kwargs = kwargs
         self._write_timeout = write_timeout
         self._read_timeout = read_timeout
+        self._enable_compression = enable_compression
         if "max_content_length" in self._aiohttp_kwargs:
             self._aiohttp_kwargs["max_msg_size"] = self._aiohttp_kwargs.pop("max_content_length")
         if "ssl_options" in self._aiohttp_kwargs:
             self._aiohttp_kwargs["ssl"] = self._aiohttp_kwargs.pop("ssl_options")
+        if self._enable_compression and "compress" not in self._aiohttp_kwargs:
+            self._aiohttp_kwargs["compress"] = 15  # enable per-message deflate compression with 32k sliding window size
 
     def __del__(self):
         # Close will only actually close if things are left open, so this is safe to call.

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -44,7 +44,7 @@ class Client:
                  transport_factory=None, pool_size=None, max_workers=None,
                  message_serializer=None, username="", password="",
                  kerberized_service="", headers=None, session=None,
-                 enable_user_agent_on_connect=True, use_compression=False,
+                 enable_user_agent_on_connect=True, enable_compression=False,
                  **transport_kwargs):
         log.info("Creating Client with url '%s'", url)
 
@@ -56,10 +56,10 @@ class Client:
         self._headers = headers
         self._enable_user_agent_on_connect = enable_user_agent_on_connect
         self._traversal_source = traversal_source
-        self._use_compression = use_compression
+        self._enable_compression = enable_compression
         if not self._use_http and "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
-        if self._use_compression and "compress" not in transport_kwargs:
+        if self._enable_compression and "compress" not in transport_kwargs:
             transport_kwargs["compress"] = 15  # enable per-message deflate compression with max 32k sliding window size
         if message_serializer is None:
             message_serializer = serializer.GraphBinarySerializersV1()

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -59,8 +59,6 @@ class Client:
         self._enable_compression = enable_compression
         if not self._use_http and "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
-        if self._enable_compression and "compress" not in transport_kwargs:
-            transport_kwargs["compress"] = 15  # enable per-message deflate compression with max 32k sliding window size
         if message_serializer is None:
             message_serializer = serializer.GraphBinarySerializersV1()
 
@@ -81,7 +79,7 @@ class Client:
                     if self._use_http:
                         return AiohttpHTTPTransport(**transport_kwargs)
                     else:
-                        return AiohttpTransport(**transport_kwargs)
+                        return AiohttpTransport(enable_compression=enable_compression, **transport_kwargs)
         self._transport_factory = transport_factory
         if protocol_factory is None:
             def protocol_factory():

--- a/gremlin-python/src/main/python/gremlin_python/driver/client.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/client.py
@@ -44,7 +44,8 @@ class Client:
                  transport_factory=None, pool_size=None, max_workers=None,
                  message_serializer=None, username="", password="",
                  kerberized_service="", headers=None, session=None,
-                 enable_user_agent_on_connect=True, **transport_kwargs):
+                 enable_user_agent_on_connect=True, use_compression=False,
+                 **transport_kwargs):
         log.info("Creating Client with url '%s'", url)
 
         # check via url that we are using http protocol
@@ -55,8 +56,11 @@ class Client:
         self._headers = headers
         self._enable_user_agent_on_connect = enable_user_agent_on_connect
         self._traversal_source = traversal_source
+        self._use_compression = use_compression
         if not self._use_http and "max_content_length" not in transport_kwargs:
             transport_kwargs["max_content_length"] = 10 * 1024 * 1024
+        if self._use_compression and "compress" not in transport_kwargs:
+            transport_kwargs["compress"] = 15  # enable per-message deflate compression with max 32k sliding window size
         if message_serializer is None:
             message_serializer = serializer.GraphBinarySerializersV1()
 

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -39,7 +39,7 @@ class DriverRemoteConnection(RemoteConnection):
                  username="", password="", kerberized_service='',
                  message_serializer=None, graphson_reader=None,
                  graphson_writer=None, headers=None, session=None,
-                 enable_user_agent_on_connect=True, **transport_kwargs):
+                 enable_user_agent_on_connect=True, use_compression=False, **transport_kwargs):
         log.info("Creating DriverRemoteConnection with url '%s'", str(url))
         self.__url = url
         self.__traversal_source = traversal_source
@@ -56,6 +56,7 @@ class DriverRemoteConnection(RemoteConnection):
         self.__headers = headers
         self.__session = session
         self.__enable_user_agent_on_connect = enable_user_agent_on_connect
+        self.__use_compression = use_compression
         self.__transport_kwargs = transport_kwargs
 
         # keeps a list of sessions that have been spawned from this DriverRemoteConnection
@@ -78,6 +79,7 @@ class DriverRemoteConnection(RemoteConnection):
                                      headers=headers,
                                      session=session,
                                      enable_user_agent_on_connect=enable_user_agent_on_connect,
+                                     use_compression=use_compression,
                                      **transport_kwargs)
         self._url = self._client._url
         self._traversal_source = self._client._traversal_source

--- a/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/driver_remote_connection.py
@@ -39,7 +39,7 @@ class DriverRemoteConnection(RemoteConnection):
                  username="", password="", kerberized_service='',
                  message_serializer=None, graphson_reader=None,
                  graphson_writer=None, headers=None, session=None,
-                 enable_user_agent_on_connect=True, use_compression=False, **transport_kwargs):
+                 enable_user_agent_on_connect=True, enable_compression=False, **transport_kwargs):
         log.info("Creating DriverRemoteConnection with url '%s'", str(url))
         self.__url = url
         self.__traversal_source = traversal_source
@@ -56,7 +56,7 @@ class DriverRemoteConnection(RemoteConnection):
         self.__headers = headers
         self.__session = session
         self.__enable_user_agent_on_connect = enable_user_agent_on_connect
-        self.__use_compression = use_compression
+        self.__enable_compression = enable_compression
         self.__transport_kwargs = transport_kwargs
 
         # keeps a list of sessions that have been spawned from this DriverRemoteConnection
@@ -79,7 +79,7 @@ class DriverRemoteConnection(RemoteConnection):
                                      headers=headers,
                                      session=session,
                                      enable_user_agent_on_connect=enable_user_agent_on_connect,
-                                     use_compression=use_compression,
+                                     enable_compression=enable_compression,
                                      **transport_kwargs)
         self._url = self._client._url
         self._traversal_source = self._client._traversal_source

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -110,9 +110,11 @@ def gremlin_socket_server_serializer(socket_server_settings):
 
 @pytest.fixture
 def socket_server_client(request, socket_server_settings, gremlin_socket_server_serializer):
+    marker = request.node.get_closest_marker("client_kwargs")
+    client_kwargs = marker.args[0] if marker is not None else dict()
     url = gremlin_socket_server_url.format(socket_server_settings["PORT"])
     try:
-        client = Client(url, 'g', pool_size=1, message_serializer=gremlin_socket_server_serializer)
+        client = Client(url, 'g', pool_size=1, message_serializer=gremlin_socket_server_serializer, **client_kwargs)
     except OSError:
         pytest.skip('Gremlin Socket Server is not running')
     else:

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -19,6 +19,7 @@
 import os
 
 from gremlin_python import statics
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.statics import long
 from gremlin_python.process.traversal import Traverser
@@ -33,6 +34,8 @@ from gremlin_python.structure.io.util import HashableDict
 from gremlin_python.driver.serializer import GraphSONSerializersV2d0
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
+
+from tests.conftest import anonymous_url
 
 gremlin_server_url = os.environ.get('GREMLIN_SERVER_URL', 'ws://localhost:{}/gremlin')
 test_no_auth_url = gremlin_server_url.format(45940)
@@ -286,3 +289,22 @@ class TestDriverRemoteConnection(object):
         g = traversal().withRemote(remote_connection_authenticated)
 
         assert long(6) == g.V().count().toList()[0]
+
+    def test_should_propagate_use_compression(self):
+        # Use Compression
+        drc = DriverRemoteConnection(anonymous_url, use_compression=True)
+
+        aiohttp_kwargs = drc._client._transport_factory()._aiohttp_kwargs
+        assert aiohttp_kwargs.get("compress") != 0
+
+        # Disable Compression
+        drc = DriverRemoteConnection(anonymous_url, use_compression=False)
+
+        aiohttp_kwargs = drc._client._transport_factory()._aiohttp_kwargs
+        assert aiohttp_kwargs.get("compress") is None or aiohttp_kwargs.get("compress") == 0
+
+        # Default (no compression)
+        drc = DriverRemoteConnection(anonymous_url)
+
+        aiohttp_kwargs = drc._client._transport_factory()._aiohttp_kwargs
+        assert aiohttp_kwargs.get("compress") is None or aiohttp_kwargs.get("compress") == 0

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -290,15 +290,15 @@ class TestDriverRemoteConnection(object):
 
         assert long(6) == g.V().count().toList()[0]
 
-    def test_should_propagate_use_compression(self):
+    def test_should_propagate_enable_compression(self):
         # Use Compression
-        drc = DriverRemoteConnection(anonymous_url, use_compression=True)
+        drc = DriverRemoteConnection(anonymous_url, enable_compression=True)
 
         aiohttp_kwargs = drc._client._transport_factory()._aiohttp_kwargs
         assert aiohttp_kwargs.get("compress") != 0
 
         # Disable Compression
-        drc = DriverRemoteConnection(anonymous_url, use_compression=False)
+        drc = DriverRemoteConnection(anonymous_url, enable_compression=False)
 
         aiohttp_kwargs = drc._client._transport_factory()._aiohttp_kwargs
         assert aiohttp_kwargs.get("compress") is None or aiohttp_kwargs.get("compress") == 0

--- a/gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml
+++ b/gremlin-tools/gremlin-socket-server/conf/test-ws-gremlin.yaml
@@ -50,6 +50,10 @@ CLOSE_CONNECTION_REQUEST_ID_2: 3c4cf18a-c7f2-4dad-b9bf-5c701eb33000
 # that was captured during the web socket handshake.
 USER_AGENT_REQUEST_ID: 20ad7bfb-4abf-d7f4-f9d3-9f1d55bee4ad
 
+# If a request with this ID comes to the server, the server responds with the sec-websocket-extensions header
+# included in the handshake request.
+SEC_WEBSOCKET_EXTENSIONS: 7480d3ec-e24a-424a-8148-6527378e9b35
+
 # If a request with this ID comes to the server, the server responds with a string containing all overridden
 # per request settings from the request message. String will be of the form
 # "requestId=19436d9e-f8fc-4b67-8a76-deec60918424 evaluationTimeout=1234, batchSize=12, userAgent=testUserAgent"

--- a/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/SocketServerSettings.java
+++ b/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/SocketServerSettings.java
@@ -74,6 +74,12 @@ public class SocketServerSettings {
     public UUID USER_AGENT_REQUEST_ID = null;
 
     /**
+     * If a request with this ID comes to the server, the server responds with the sec-websocket-extensions header
+     * included in the handshake request.
+     */
+    public UUID SEC_WEBSOCKET_EXTENSIONS = null;
+
+    /**
      * If a request with this ID comes to the server, the server responds with a string containing all overridden
      * per request settings from the request message. String will be of the form
      * "requestId=19436d9e-f8fc-4b67-8a76-deec60918424 evaluationTimeout=1234, batchSize=12, userAgent=testUserAgent"

--- a/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/TestWSGremlinInitializer.java
+++ b/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/TestWSGremlinInitializer.java
@@ -96,6 +96,7 @@ public class TestWSGremlinInitializer extends TestChannelizers.TestWebSocketServ
     static class ClientTestConfigurableHandler extends MessageToMessageDecoder<BinaryWebSocketFrame> {
         private SocketServerSettings settings;
         private String userAgent = "";
+        private String secWebsocketExtensions = "";
 
         public ClientTestConfigurableHandler(SocketServerSettings settings) { this.settings = settings; }
 
@@ -139,6 +140,8 @@ public class TestWSGremlinInitializer extends TestChannelizers.TestWebSocketServ
                 ctx.channel().writeAndFlush(new CloseWebSocketFrame());
             } else if (msg.getRequestId().equals(settings.USER_AGENT_REQUEST_ID)) {
                 ctx.channel().writeAndFlush(new BinaryWebSocketFrame(returnSimpleBinaryResponse(settings.USER_AGENT_REQUEST_ID, userAgent)));
+            } else if (msg.getRequestId().equals(settings.SEC_WEBSOCKET_EXTENSIONS)) {
+                ctx.channel().writeAndFlush(new BinaryWebSocketFrame(returnSimpleBinaryResponse(settings.SEC_WEBSOCKET_EXTENSIONS, secWebsocketExtensions)));
             } else if (msg.getRequestId().equals(settings.PER_REQUEST_SETTINGS_REQUEST_ID)) {
                 String response = String.format("requestId=%s evaluationTimeout=%d, batchSize=%d, userAgent=%s, materializeProperties=%s",
                         msg.getRequestId(), msg.getArgs().get("evaluationTimeout"),
@@ -185,6 +188,9 @@ public class TestWSGremlinInitializer extends TestChannelizers.TestWebSocketServ
                 HttpHeaders requestHeaders = handshake.requestHeaders();
                 if(requestHeaders.contains(USER_AGENT_HEADER)) {
                     userAgent = requestHeaders.get(USER_AGENT_HEADER);
+                }
+                if(requestHeaders.contains("sec-websocket-extensions")) {
+                    secWebsocketExtensions = requestHeaders.get("sec-websocket-extensions");
                 }
                 else {
                     ctx.fireUserEventTriggered(evt);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2700

Use of compression with sensitive data may make users vulnerable to attacks such as CRIME/BREACH. .Net and Go already had options which allowed users to configure the use of compression. This PR is adding such configuration to the remaining drivers.

Note: There is a corresponding PR to 3.6 which is missing the GremlinSocketServer tests (https://github.com/apache/tinkerpop/pull/2832)