### PR TITLE
[TINKERPOP-3076] Throw better error if request exceeds WriteBufferSize in Go

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bump Logback to 1.2.13
 * Bump Ivy to 2.5.2
 * Fixed a memory leak in the Javascript driver when there is a server error response.
+* Throw more descriptive error in `gremlin-go` when request size exceeds `WriteBufferSize`
 
 [[release-3-6-7]]
 === TinkerPop 3.6.7 (April 8, 2024)

--- a/gremlin-go/driver/error_codes.go
+++ b/gremlin-go/driver/error_codes.go
@@ -98,6 +98,9 @@ const (
 	err1102TransactionRollbackNotOpenedError errorCode = "E1102_TRANSACTION_ROLLBACK_NOT_OPENED_ERROR"
 	err1103TransactionCommitNotOpenedError   errorCode = "E1103_TRANSACTION_COMMIT_NOT_OPENED_ERROR"
 	err1104TransactionRepeatedCloseError     errorCode = "E1104_TRANSACTION_REPEATED_CLOSE_ERROR"
+
+	// gorillaTransporter.go errors
+	err1201RequestSizeExceedsWriteBufferError errorCode = "E1201_REQUEST_SIZE_EXCEEDS_WRITE_BUFFER_ERROR"
 )
 
 var localizer *i18n.Localizer

--- a/gremlin-go/driver/gorillaTransporter.go
+++ b/gremlin-go/driver/gorillaTransporter.go
@@ -20,7 +20,6 @@ under the License.
 package gremlingo
 
 import (
-	"errors"
 	"net/http"
 	"net/url"
 	"sync"
@@ -102,7 +101,7 @@ func (transporter *gorillaTransporter) Write(data []byte) error {
 		}
 	}
 	if len(data) > transporter.connSettings.writeBufferSize {
-		return errors.New("request too large, consider increasing 'WriteBufferSize' configuration or split into smaller requests")
+		return newError(err1201RequestSizeExceedsWriteBufferError)
 	}
 	transporter.writeChannel <- data
 	return nil

--- a/gremlin-go/driver/gorillaTransporter.go
+++ b/gremlin-go/driver/gorillaTransporter.go
@@ -20,6 +20,7 @@ under the License.
 package gremlingo
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 	"sync"
@@ -99,6 +100,9 @@ func (transporter *gorillaTransporter) Write(data []byte) error {
 		if err != nil {
 			return err
 		}
+	}
+	if len(data) > transporter.connSettings.writeBufferSize {
+		return errors.New("request too large, consider increasing 'WriteBufferSize' configuration or split into smaller requests")
 	}
 	transporter.writeChannel <- data
 	return nil

--- a/gremlin-go/driver/gorillaTransporter_test.go
+++ b/gremlin-go/driver/gorillaTransporter_test.go
@@ -67,13 +67,17 @@ func (conn *mockWebsocketConn) SetPongHandler(h func(appData string) error) {
 }
 
 func getNewGorillaTransporter() (gorillaTransporter, *mockWebsocketConn) {
+	return getNewGorillaTransporterWithSettings(newDefaultConnectionSettings())
+}
+
+func getNewGorillaTransporterWithSettings(connectionSettings *connectionSettings) (gorillaTransporter, *mockWebsocketConn) {
 	mockConn := new(mockWebsocketConn)
 	return gorillaTransporter{
 		url:          "ws://mockHost:8182/gremlin",
 		logHandler:   newLogHandler(&defaultLogger{}, Info, language.English),
 		connection:   mockConn,
 		isClosed:     false,
-		connSettings: newDefaultConnectionSettings(),
+		connSettings: connectionSettings,
 		writeChannel: make(chan []byte, 100),
 		wg:           &sync.WaitGroup{},
 	}, mockConn
@@ -130,6 +134,30 @@ func TestGorillaTransporter(t *testing.T) {
 			assert.Nil(t, err)
 			isClosed = transporter.IsClosed()
 			assert.True(t, isClosed)
+		})
+	})
+
+	t.Run("Should error if request size exceeds WriteBufferSize", func(t *testing.T) {
+		connSettings := newDefaultConnectionSettings()
+		connSettings.writeBufferSize = 30
+		transporter, mockConn := getNewGorillaTransporterWithSettings(connSettings)
+
+		t.Run("Small message should succeed", func(t *testing.T) {
+			mockConn.On("WriteMessage", 2, make([]byte, 10)).Return(nil)
+			err := transporter.Write(make([]byte, 10))
+			assert.Nil(t, err)
+		})
+
+		t.Run("Large message should error", func(t *testing.T) {
+			mockConn.On("WriteMessage", 2, make([]byte, 10)).Return(nil)
+			err := transporter.Write(make([]byte, 31))
+			assert.ErrorContains(t, err, "request too large")
+		})
+
+		t.Run("Exact size should succeed", func(t *testing.T) {
+			mockConn.On("WriteMessage", 2, make([]byte, 10)).Return(nil)
+			err := transporter.Write(make([]byte, 30))
+			assert.Nil(t, err)
 		})
 	})
 }

--- a/gremlin-go/driver/gorillaTransporter_test.go
+++ b/gremlin-go/driver/gorillaTransporter_test.go
@@ -151,7 +151,7 @@ func TestGorillaTransporter(t *testing.T) {
 		t.Run("Large message should error", func(t *testing.T) {
 			mockConn.On("WriteMessage", 2, make([]byte, 10)).Return(nil)
 			err := transporter.Write(make([]byte, 31))
-			assert.ErrorContains(t, err, "request too large")
+			assert.Equal(t, newError(err1201RequestSizeExceedsWriteBufferError), err)
 		})
 
 		t.Run("Exact size should succeed", func(t *testing.T) {

--- a/gremlin-go/driver/resources/error-messages/en.json
+++ b/gremlin-go/driver/resources/error-messages/en.json
@@ -51,5 +51,7 @@
   "E1101_TRANSACTION_REPEATED_OPEN_ERROR": "E1101: transaction already started on this object",
   "E1102_TRANSACTION_ROLLBACK_NOT_OPENED_ERROR": "E1102: cannot rollback a transaction that is not started",
   "E1103_TRANSACTION_COMMIT_NOT_OPENED_ERROR": "E1103: cannot commit a transaction that is not started",
-  "E1104_TRANSACTION_REPEATED_CLOSE_ERROR": "E1104: cannot close a transaction that has previously been closed"
+  "E1104_TRANSACTION_REPEATED_CLOSE_ERROR": "E1104: cannot close a transaction that has previously been closed",
+
+  "E1201_REQUEST_SIZE_EXCEEDS_WRITE_BUFFER_ERROR": "E1201: Request size cannot exceed the configured WriteBufferSize. Consider increasing WriteBufferSize or splitting into smaller requests"
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3076

Gorilla has an implicit frame size limit imposed by WriteBufferSize. Requests which exceed this limit cannot be parsed by gremlin server and currently lead to cryptic errors in the server. This PR simply adds a client side check to throw a more descriptive error to the user. The resulting behaviour is very similar to how `maxContentLength` functions in the java driver.

VOTE +1