### PR TITLE
Re-enable GraphSON message serializer for debugging.

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -822,7 +822,7 @@ The following table describes the various configuration options for the Gremlin 
 |path |The URL path to the Gremlin Server. |_/gremlin_
 |port |The port of the Gremlin Server to connect to. The same port will be applied for all hosts. |8192
 |protocol |Sets the `AuthProperties.Property.PROTOCOL` properties for authentication to Gremlin Server. |_none_
-|serializer.className |The fully qualified class name of the `MessageSerializer` that will be used to communicate with the server. Note that the serializer configured on the client should be supported by the server configuration. |_none_
+|serializer.className |The fully qualified class name of the `MessageSerializer` that will be used to deserialize responses from the server. Note that the serializer configured on the client should be supported by the server configuration. |_none_
 |serializer.config |A `Map` of configuration settings for the serializer. |_none_
 |username |The username to submit on requests that require authentication. |_none_
 |workerPoolSize |Size of the pool for handling background work. |available processors * 2

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -31,9 +31,10 @@ import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.driver.auth.Auth;
-import org.apache.tinkerpop.gremlin.driver.interceptor.GraphBinarySerializationInterceptor;
+import org.apache.tinkerpop.gremlin.driver.interceptor.PayloadSerializingInterceptor;
 import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4;
 import org.apache.tinkerpop.gremlin.util.ser.Serializers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -149,6 +150,10 @@ public final class Cluster {
 
     public static Builder build(final String address) {
         return new Builder(address);
+    }
+
+    public static Builder build(final RequestInterceptor serializingInterceptor) {
+        return new Builder(serializingInterceptor);
     }
 
     public static Builder build(final File configurationFile) throws FileNotFoundException {
@@ -511,12 +516,18 @@ public final class Cluster {
         private boolean enableBulkedResult = false;
 
         private Builder() {
-            addInterceptor(SERIALIZER_INTERCEPTOR_NAME, new GraphBinarySerializationInterceptor());
+            addInterceptor(SERIALIZER_INTERCEPTOR_NAME,
+                    new PayloadSerializingInterceptor(new GraphBinaryMessageSerializerV4()));
         }
 
         private Builder(final String address) {
             addContactPoint(address);
-            addInterceptor(SERIALIZER_INTERCEPTOR_NAME, new GraphBinarySerializationInterceptor());
+            addInterceptor(SERIALIZER_INTERCEPTOR_NAME,
+                    new PayloadSerializingInterceptor(new GraphBinaryMessageSerializerV4()));
+        }
+
+        private Builder(final RequestInterceptor bodySerializer) {
+            addInterceptor(SERIALIZER_INTERCEPTOR_NAME, bodySerializer);
         }
 
         /**

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoder.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.handler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.DefaultHttpObject;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.AttributeMap;
+import io.netty.util.CharsetUtil;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.util.ser.SerTokens;
+import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
+import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.apache.tinkerpop.gremlin.driver.Channelizer.HttpChannelizer.LAST_CONTENT_READ_RESPONSE;
+import static org.apache.tinkerpop.gremlin.driver.handler.HttpGremlinResponseStreamDecoder.IS_BULKED;
+
+public class HttpGremlinResponseDecoder extends MessageToMessageDecoder<FullHttpResponse> {
+    private static final String MESSAGE_NAME = "message";
+    private final MessageSerializer<?> serializer;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public HttpGremlinResponseDecoder(final MessageSerializer<?> serializer) {
+        this.serializer = serializer;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, FullHttpResponse msg, List<Object> out) throws Exception {
+        final ByteBuf content = msg.content();
+        ResponseMessage response;
+        
+        try {
+            // no more chunks expected
+            if (isError(msg.status()) && !serializer.mimeTypesSupported()[0].equals(msg.headers().get(HttpHeaderNames.CONTENT_TYPE))) {
+                final String json = content.toString(CharsetUtil.UTF_8);
+                final JsonNode node = mapper.readTree(json);
+                final String message = node.has(MESSAGE_NAME) ? node.get(MESSAGE_NAME).asText() : "";
+                response = ResponseMessage.build()
+                        .code(msg.status())
+                        .statusMessage(message.isEmpty() ? msg.status().reasonPhrase() : message)
+                        .create();
+            } else {
+                response = serializer.deserializeBinaryResponse(content);
+            }
+
+            ctx.channel().attr(IS_BULKED).set(response.getResult().isBulked());
+            out.add(response);
+            out.add(LAST_CONTENT_READ_RESPONSE);
+        } catch (SerializationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean isError(final HttpResponseStatus status) {
+        return status != HttpResponseStatus.OK;
+    }
+}

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/interceptor/PayloadSerializingInterceptor.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/interceptor/PayloadSerializingInterceptor.java
@@ -29,14 +29,21 @@ import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4;
 import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
+import org.apache.tinkerpop.gremlin.util.ser.Serializers;
+
+import java.util.Map;
 
 /**
- * A {@link RequestInterceptor} that serializes the request body to the {@code GraphBinary} format. This interceptor
- * should be run before other interceptors that need to calculate values based on the request body.
+ * A {@link RequestInterceptor} that serializes the request body usng the provided {@link MessageSerializer}. This
+ * interceptor should be run before other interceptors that need to calculate values based on the request body.
  */
-public class GraphBinarySerializationInterceptor implements RequestInterceptor {
-    // Should be thread-safe as the GraphBinaryWriter doesn't maintain state.
-    private static final MessageSerializer serializer = new GraphBinaryMessageSerializerV4();
+public class PayloadSerializingInterceptor implements RequestInterceptor {
+    // Should be thread-safe as the GraphBinaryWriter/GraphSONMessageSerializer doesn't maintain state.
+    private final MessageSerializer serializer;
+
+    public PayloadSerializingInterceptor(final MessageSerializer serializer) {
+        this.serializer = serializer;
+    }
 
     @Override
     public HttpRequest apply(HttpRequest httpRequest) {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/SimpleHttpClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/SimpleHttpClient.java
@@ -28,7 +28,7 @@ import org.apache.tinkerpop.gremlin.driver.Channelizer;
 import org.apache.tinkerpop.gremlin.driver.handler.HttpContentDecompressionHandler;
 import org.apache.tinkerpop.gremlin.driver.handler.HttpGremlinResponseStreamDecoder;
 import org.apache.tinkerpop.gremlin.driver.handler.HttpGremlinRequestEncoder;
-import org.apache.tinkerpop.gremlin.driver.interceptor.GraphBinarySerializationInterceptor;
+import org.apache.tinkerpop.gremlin.driver.interceptor.PayloadSerializingInterceptor;
 import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import io.netty.bootstrap.Bootstrap;
@@ -110,7 +110,8 @@ public class SimpleHttpClient extends AbstractClient {
                                     new HttpGremlinResponseStreamDecoder(serializer, Integer.MAX_VALUE),
                                     new HttpGremlinRequestEncoder(serializer,
                                             Collections.singletonList(
-                                                    Pair.of("serializer", new GraphBinarySerializationInterceptor())),
+                                                    Pair.of("serializer", new PayloadSerializingInterceptor(
+                                                            new GraphBinaryMessageSerializerV4()))),
                                             false, false, uri),
                                     callbackResponseHandler);
                         }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterTest.java
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.driver;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.tinkerpop.gremlin.driver.interceptor.GraphBinarySerializationInterceptor;
+import org.apache.tinkerpop.gremlin.driver.interceptor.PayloadSerializingInterceptor;
 import org.junit.Test;
 
 import java.util.List;
@@ -132,7 +132,7 @@ public class ClusterTest {
     public void shouldContainBodySerializerByDefault() {
         final List<Pair<String, ? extends RequestInterceptor>> interceptors = Cluster.build().create().getRequestInterceptors();
         assertEquals(1, interceptors.size());
-        assertTrue(interceptors.get(0).getRight() instanceof GraphBinarySerializationInterceptor);
+        assertTrue(interceptors.get(0).getRight() instanceof PayloadSerializingInterceptor);
     }
 
     @Test

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -743,9 +743,9 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         } catch (Exception re) {
             final Throwable root = ExceptionHelper.getRootCause(re);
 
-            // went with two possible error messages here as i think that there is some either non-deterministic
-            // behavior around the error message or it's environmentally dependent (e.g. different jdk, versions, etc)
-            assertThat(root.getMessage(), Matchers.anyOf(is("Connection to server is no longer active"), is("Connection reset by peer")));
+            // the server sends back a 413 Request Entity Too Large now in HTTP so detect that rather than the
+            // underlying connection closing due to error.
+            assertThat(root.getMessage(), Matchers.anyOf(is("Request Entity Too Large")));
 
             // validate that we can still send messages to the server
             assertEquals(2, client.submit("1+1").all().join().get(0).getInt());

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/TestClientFactory.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.server;
 
 import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.RequestInterceptor;
 import org.apache.tinkerpop.gremlin.driver.simple.SimpleHttpClient;
 
 import java.net.URI;
@@ -40,6 +41,10 @@ public final class TestClientFactory {
 
     public static Cluster.Builder build(final String address) {
         return Cluster.build(address).port(PORT);
+    }
+
+    public static Cluster.Builder build(final RequestInterceptor serializingInterceptor) {
+        return Cluster.build(serializingInterceptor).port(PORT);
     }
 
     public static Cluster open() {


### PR DESCRIPTION
The GraphSONv4 MessageSerializer doesn't support chunking so the HttpObjectAggregator is added back and the
HttpGremlinResponseStreamDecoder is replaced with the original, non-streaming version. This is mainly for debugging and testing purposes so lowered performance is expected.

VOTE +1
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->