### PR TITLE
[TINKERPOP-3116] async_timeout not declared in gremlinpython dependencies

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Bump Ivy to 2.5.2
 * Fixed a memory leak in the Javascript driver when there is a server error response.
 * Throw more descriptive error in `gremlin-go` when request size exceeds `WriteBufferSize`
+* Fixed a missing runtime dependency in `gremlin-python`
 
 [[release-3-6-7]]
 === TinkerPop 3.6.7 (April 8, 2024)

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -18,7 +18,6 @@ under the License.
 """
 import codecs
 import os
-import sys
 import time
 from setuptools import setup
 
@@ -48,7 +47,8 @@ install_requires = [
     'nest_asyncio',
     'aiohttp>=3.8.0,<4.0.0',
     'aenum>=1.4.5,<4.0.0',
-    'isodate>=0.6.0,<1.0.0'
+    'isodate>=0.6.0,<1.0.0',
+    'async-timeout>=4.0.3,<5.0.0'
 ]
 
 setup(


### PR DESCRIPTION
This adds `async_timeout` to `gremlin-python`'s `setup.py` as a runtime dependency which is required when using python >= 3.11