### PR TITLE
chore(gremlinpython): remove async_timeout for python 3.11 and newer

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -16,10 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from aiohttp import ClientResponseError
 import aiohttp
 import asyncio
-import async_timeout
-from aiohttp import ClientResponseError
+import sys
+
+if sys.version_info >= (3, 11):
+    import asyncio as async_timeout
+else:
+    import async_timeout
 
 from gremlin_python.driver.transport import AbstractBaseTransport
 

--- a/gremlin-python/src/main/python/setup.py
+++ b/gremlin-python/src/main/python/setup.py
@@ -48,7 +48,7 @@ install_requires = [
     'aiohttp>=3.8.0,<4.0.0',
     'aenum>=1.4.5,<4.0.0',
     'isodate>=0.6.0,<1.0.0',
-    'async-timeout>=4.0.3,<5.0.0'
+    'async-timeout>=4.0.3,<5.0; python_version < "3.11"',
 ]
 
 setup(
@@ -78,7 +78,7 @@ setup(
     ],
     install_requires=install_requires,
     extras_require={
-        'kerberos': 'kerberos>=1.3.0,<2.0.0',    # Does not install in Microsoft Windows
+        'kerberos': 'kerberos>=1.3.0,<2.0.0; sys_platform != "win32"',  # Does not install in Microsoft Windows
         'ujson': 'ujson>=2.0.0'
     },
     classifiers=[


### PR DESCRIPTION
This removes the async_timeout dependency for python 3.11 and newer

This came from the conversation in https://github.com/apache/tinkerpop/pull/2844

To test this locally I attempted the following by looking at the GitHub Actions workflows, but it didn't succeed. Any recommendations to build and test the python package would be great - or pointers to docs that I missed. Thanks

```bash
brew install temurin@11
export JAVA_HOME=$(/usr/libexec/java_home -v 11)
export PATH=$JAVA_HOME/bin:$PATH

mvn clean install -DskipTests -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
# Failed, but after python

mvn clean install -pl gremlin-server -DskipTests -DskipIntegrationTests=true -Dci -am
docker save --output gremlin-server.tar tinkerpop/gremlin-server

touch gremlin-python/.glv
mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
mvn verify -pl gremlin-python
```