### PR TITLE
Add log entry in WsAndHttpChannelizerHandler

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-7-4]]
 === TinkerPop 3.7.4 (NOT OFFICIALLY RELEASED YET)
 
+* Add log entry in WsAndHttpChannelizerHandler.
+
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)
 


### PR DESCRIPTION
The log entry here is necessary because when an exception thrown by
Netty reaches exceptionCaught(), if the error is not printed, the
server side will not be able to know what has happened.

For example, if the maxContentLength in JanusGraph's Gremlin-Server
configuration is set to 65536, and the client sends data over this
size via WebSocket, the JanusGraph server logs will appear normal,
but the client will experience a disconnection, making it difficult
to immediately identify the cause of the issue.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->