### PR TITLE
HTTP connection pooling

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -79,6 +79,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Updated `ElementIdStrategy.getConfiguration()` to help with serialization.
 * Updated `TraversalStrategyProxy` to utilize strategy names instead of strategy classes
 * Use `TraversalStrategyProxy` in Java, or `TraversalStrategy` in Python to pass custom strategies in traversals
+* Removed `minSize` setting for Gremlin Driver connection pool since connections are now short-lived HTTP connections
+* Added `idleConnectionTimeout` setting for Gremlin Driver and automatic closing of idle connections
 
 == TinkerPop 3.7.0 (Gremfir Master of the Pan Flute)
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -800,12 +800,11 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.maxResponseContentLength |The maximum length in bytes that a message can be received from the server. |2147483647
 |connectionPool.maxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |4
 |connectionPool.maxSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |16
-|connectionPool.maxSize |The maximum size of a connection pool for a host. |8
+|connectionPool.maxSize |The maximum size of a connection pool for a host. |128
 |connectionPool.maxWaitForConnection |The amount of time in milliseconds to wait for a new connection before timing out. |3000
 |connectionPool.maxWaitForClose |The amount of time in milliseconds to wait for pending messages to be returned from the server before closing the connection. |3000
 |connectionPool.minInProcessPerConnection |The minimum number of in-flight requests that can occur on a connection. |1
 |connectionPool.minSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |8
-|connectionPool.minSize |The minimum size of a connection pool for a host. |2
 |connectionPool.reconnectInterval |The amount of time in milliseconds to wait before trying to reconnect to a dead host. |1000
 |connectionPool.resultIterationBatchSize |The override value for the size of the result batches to be returned from the server. |64
 |connectionPool.sslCipherSuites |The list of JSSE ciphers to support for SSL connections. If specified, only the ciphers that are listed and supported will be enabled. If not specified, the JVM default is used.  |_none_
@@ -815,6 +814,7 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.trustStorePassword |The password of the `trustStore` if it is password-protected |_none_
 |connectionPool.validationRequest |A script that is used to test server connectivity. A good script to use is one that evaluates quickly and returns no data. The default simply returns an empty string, but if a graph is required by a particular provider, a good traversal might be `g.inject()`. |_''_
 |connectionPool.connectionSetupTimeoutMillis | Duration of time in milliseconds provided for connection setup to complete which includes WebSocket protocol handshake and SSL handshake. |15000
+|connectionPool.idleConnectionTimeout | Duration of time in milliseconds that the driver will allow a channel to not receive read or writes before it automatically closes. |180000
 |hosts |The list of hosts that the driver will connect to. |localhost
 |jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
 public abstract class Client {
 
     private static final Logger logger = LoggerFactory.getLogger(Client.class);
-    public static final String TOO_MANY_IN_FLIGHT_REQUESTS = "Number of active requests exceeds pool size. " +
+    public static final String TOO_MANY_IN_FLIGHT_REQUESTS = "Number of active requests (%s) exceeds pool size (%s). " +
             "Consider increasing the value for maxConnectionPoolSize.";
 
     protected final Cluster cluster;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -190,9 +190,6 @@ public final class Settings {
             if (connectionPoolConf.containsKey("sslSkipCertValidation"))
                 cpSettings.sslSkipCertValidation = connectionPoolConf.getBoolean("sslSkipCertValidation");
 
-            if (connectionPoolConf.containsKey("minSize"))
-                cpSettings.minSize = connectionPoolConf.getInt("minSize");
-
             if (connectionPoolConf.containsKey("maxSize"))
                 cpSettings.maxSize = connectionPoolConf.getInt("maxSize");
 
@@ -216,6 +213,9 @@ public final class Settings {
 
             if (connectionPoolConf.containsKey("connectionSetupTimeoutMillis"))
                 cpSettings.connectionSetupTimeoutMillis = connectionPoolConf.getLong("connectionSetupTimeoutMillis");
+
+            if (connectionPoolConf.containsKey("idleConnectionTimeout"))
+                cpSettings.idleConnectionTimeout = connectionPoolConf.getLong("idleConnectionTimeout");
 
             settings.connectionPool = cpSettings;
         }
@@ -301,12 +301,7 @@ public final class Settings {
         public boolean sslSkipCertValidation = false;
 
         /**
-         * The minimum size of a connection pool for a {@link Host}. By default this is set to 2.
-         */
-        public int minSize = ConnectionPool.MIN_POOL_SIZE;
-
-        /**
-         * The maximum size of a connection pool for a {@link Host}. By default this is set to 8.
+         * The maximum size of a connection pool for a {@link Host}. By default this is set to 500.
          */
         public int maxSize = ConnectionPool.MAX_POOL_SIZE;
 
@@ -352,6 +347,14 @@ public final class Settings {
          * complete by then.
          */
         public long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
+
+        /**
+         * Time in milliseconds that the driver will allow a channel to not receive read or writes before it automatically closes.
+         * Note that while this value is to be provided as milliseconds it will resolve to
+         * second precision. Set this value to 0 to disable this feature.
+         */
+        public long idleConnectionTimeout = Connection.CONNECTION_IDLE_TIMEOUT_MILLIS;
+
     }
 
     public static class SerializerSettings {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoder.java
@@ -46,7 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.tinkerpop.gremlin.driver.handler.SslCheckHandler.REQUEST_SENT;
+import static org.apache.tinkerpop.gremlin.driver.handler.InactiveChannelHandler.REQUEST_SENT;
 
 /**
  * Converts {@link RequestMessage} to a {@code HttpRequest}.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/IdleConnectionHandler.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/IdleConnectionHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.handler;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.AttributeKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Detects {@link IdleStateEvent}s and closes the channel with the goal of releasing resources that haven't been used in a while.
+ */
+@ChannelHandler.Sharable
+public class IdleConnectionHandler extends ChannelDuplexHandler {
+    private static final Logger logger = LoggerFactory.getLogger(IdleConnectionHandler.class);
+    public static final AttributeKey<IdleStateEvent> IDLE_STATE_EVENT = AttributeKey.valueOf("idleStateEvent");
+
+    /**
+     * Detects if an {@link IdleStateEvent} has occurred and closes the channel.
+     */
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+        if (evt instanceof IdleStateEvent) {
+            final IdleStateEvent e = (IdleStateEvent) evt;
+            logger.info("Detected IdleStateEvent {} - closing channel {}", e, ctx.channel().id().asShortText());
+            ctx.channel().attr(IDLE_STATE_EVENT).set(e);
+            ctx.close();
+        }
+    }
+}

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ConfigurationEvaluator.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ConfigurationEvaluator.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
  */
 public class ConfigurationEvaluator {
 
-    private final List<Integer> minConnectionPoolSizeRange = Arrays.asList(4,8,12,16,32,64,96,128,192,256,384,512);
     private final List<Integer> maxConnectionPoolSizeRange = Arrays.asList(16,32,64,96,128,192,256,384,512);
     private final List<Integer> workerPoolSizeRange = Arrays.asList(1,2,3,4,8,16,32);
     private final List<Integer> nioPoolSizeRange = Arrays.asList(1,2,4);
@@ -45,28 +44,23 @@ public class ConfigurationEvaluator {
         for (int ir = 0; ir < nioPoolSizeRange.size(); ir++) {
             for (int is = 0; is < parallelismSizeRange.size(); is++) {
                 for (int it = 0; it < workerPoolSizeRange.size(); it++) {
-                    for (int iw = 0; iw < minConnectionPoolSizeRange.size(); iw++) {
-                        for (int ix = 0; ix < maxConnectionPoolSizeRange.size(); ix++) {
-                            if (minConnectionPoolSizeRange.get(iw) <= maxConnectionPoolSizeRange.get(ix)) {
-                                final String s = String.join(",", String.valueOf(ir), String.valueOf(is), String.valueOf(it), String.valueOf(iw), String.valueOf(ix));
-                                if (!configsTried.contains(s)) {
-                                    final Object[] argsToProfiler =
-                                            Stream.of("nioPoolSize", nioPoolSizeRange.get(ir).toString(),
-                                                    "parallelism", parallelismSizeRange.get(is).toString(),
-                                                    "workerPoolSize", workerPoolSizeRange.get(it).toString(),
-                                                    "minConnectionPoolSize", minConnectionPoolSizeRange.get(iw).toString(),
-                                                    "maxConnectionPoolSize", maxConnectionPoolSizeRange.get(ix).toString(),
-                                                    "noExit", Boolean.TRUE.toString()).toArray();
+                    for (int ix = 0; ix < maxConnectionPoolSizeRange.size(); ix++) {
+                        final String s = String.join(",", String.valueOf(ir), String.valueOf(is), String.valueOf(it), String.valueOf(ix));
+                        if (!configsTried.contains(s)) {
+                            final Object[] argsToProfiler =
+                                    Stream.of("nioPoolSize", nioPoolSizeRange.get(ir).toString(),
+                                            "parallelism", parallelismSizeRange.get(is).toString(),
+                                            "workerPoolSize", workerPoolSizeRange.get(it).toString(),
+                                            "maxConnectionPoolSize", maxConnectionPoolSizeRange.get(ix).toString(),
+                                            "noExit", Boolean.TRUE.toString()).toArray();
 
-                                    final Object[] withExtraArgs = args.length > 0 ? Stream.concat(Stream.of(args), Stream.of(argsToProfiler)).toArray() : argsToProfiler;
+                            final Object[] withExtraArgs = args.length > 0 ? Stream.concat(Stream.of(args), Stream.of(argsToProfiler)).toArray() : argsToProfiler;
 
-                                    final String[] stringProfilerArgs = Arrays.copyOf(withExtraArgs, withExtraArgs.length, String[].class);
-                                    System.out.println("Testing with: " + Arrays.toString(stringProfilerArgs));
-                                    ProfilingApplication.main(stringProfilerArgs);
-                                    TimeUnit.SECONDS.sleep(5);
-                                    configsTried.add(s);
-                                }
-                            }
+                            final String[] stringProfilerArgs = Arrays.copyOf(withExtraArgs, withExtraArgs.length, String[].class);
+                            System.out.println("Testing with: " + Arrays.toString(stringProfilerArgs));
+                            ProfilingApplication.main(stringProfilerArgs);
+                            TimeUnit.SECONDS.sleep(5);
+                            configsTried.add(s);
                         }
                     }
                 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ProfilingApplication.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ProfilingApplication.java
@@ -184,7 +184,6 @@ public class ProfilingApplication {
         final int executions = Integer.parseInt(options.getOrDefault("executions", "10").toString());
         final int nioPoolSize = Integer.parseInt(options.getOrDefault("nioPoolSize", "1").toString());
         final int requests = Integer.parseInt(options.getOrDefault("requests", "10000").toString());
-        final int minConnectionPoolSize = Integer.parseInt(options.getOrDefault("minConnectionPoolSize", "256").toString());
         final int maxConnectionPoolSize = Integer.parseInt(options.getOrDefault("maxConnectionPoolSize", "256").toString());
         final int maxWaitForConnection = Integer.parseInt(options.getOrDefault("maxWaitForConnection", "3000").toString());
         final int workerPoolSize = Integer.parseInt(options.getOrDefault("workerPoolSize", Runtime.getRuntime().availableProcessors() * 2).toString());
@@ -195,7 +194,6 @@ public class ProfilingApplication {
         final String script = options.getOrDefault("script", "1+1").toString();
 
         final Cluster cluster = Cluster.build(host)
-                .minConnectionPoolSize(minConnectionPoolSize)
                 .maxConnectionPoolSize(maxConnectionPoolSize)
                 .nioPoolSize(nioPoolSize)
                 .maxWaitForConnection(maxWaitForConnection)
@@ -226,7 +224,7 @@ public class ProfilingApplication {
                 final File f = null == fileName ? null : new File(fileName.toString());
                 if (f != null && f.length() == 0) {
                     try (final PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(f, true)))) {
-                        writer.println("parallelism\tnioPoolSize\tminConnectionPoolSize\tmaxConnectionPoolSize\tworkerPoolSize\trequestPerSecond");
+                        writer.println("parallelism\tnioPoolSize\tmaxConnectionPoolSize\tworkerPoolSize\trequestPerSecond");
                     }
                 }
 
@@ -257,7 +255,7 @@ public class ProfilingApplication {
                 System.out.println(String.format("avg req/sec: %s", averageRequestPerSecond));
                 if (f != null) {
                     try (final PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(f, true)))) {
-                        writer.println(String.join("\t", String.valueOf(parallelism), String.valueOf(nioPoolSize), String.valueOf(minConnectionPoolSize), String.valueOf(maxConnectionPoolSize), String.valueOf(workerPoolSize), String.valueOf(averageRequestPerSecond)));
+                        writer.println(String.join("\t", String.valueOf(parallelism), String.valueOf(nioPoolSize), String.valueOf(maxConnectionPoolSize), String.valueOf(workerPoolSize), String.valueOf(averageRequestPerSecond)));
                     }
                 }
             } else if (TestType.LATENCY == testType) {

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
@@ -40,9 +40,6 @@ public class ClusterBuilderTest {
         return Arrays.asList(new Object[][]{
                 {"maxConnectionPoolSize0", Cluster.build().maxConnectionPoolSize(0), "maxConnectionPoolSize must be greater than zero"},
                 {"maxConnectionPoolSizeNeg1", Cluster.build().maxConnectionPoolSize(-1), "maxConnectionPoolSize must be greater than zero"},
-                {"minConnectionPoolSizeNeg1", Cluster.build().minConnectionPoolSize(-1), "minConnectionPoolSize must be greater than or equal to zero"},
-                {"minConnectionPoolSizeLteMax", Cluster.build().minConnectionPoolSize(100).maxConnectionPoolSize(99), "maxConnectionPoolSize cannot be less than minConnectionPoolSize"},
-                {"minConnectionPoolSizeLteMax", Cluster.build().minConnectionPoolSize(100).maxConnectionPoolSize(99), "maxConnectionPoolSize cannot be less than minConnectionPoolSize"},
                 {"maxConnectionPoolSize0", Cluster.build().maxWaitForConnection(0), "maxWaitForConnection must be greater than zero"},
                 {"maxWaitForClose0", Cluster.build().maxWaitForClose(0), "maxWaitForClose must be greater than zero"},
                 {"maxWaitForCloseNeg1", Cluster.build().maxWaitForClose(-1), "maxWaitForClose must be greater than zero"},
@@ -54,6 +51,9 @@ public class ClusterBuilderTest {
                 {"nioPoolSize0", Cluster.build().nioPoolSize(0), "nioPoolSize must be greater than zero"},
                 {"nioPoolSizeNeg1", Cluster.build().nioPoolSize(-1), "nioPoolSize must be greater than zero"},
                 {"connectionSetupTimeoutMillis0", Cluster.build().connectionSetupTimeoutMillis(0), "connectionSetupTimeoutMillis must be greater than zero"},
+                {"idleConnectionTimeoutMillisNeg1", Cluster.build().idleConnectionTimeoutMillis(-1), "idleConnectionTimeoutMillis must be zero or greater than or equal to 1000"},
+                {"idleConnectionTimeoutMillisOne", Cluster.build().idleConnectionTimeoutMillis(1), "idleConnectionTimeoutMillis must be zero or greater than or equal to 1000"},
+                {"idleConnectionTimeoutMillis999", Cluster.build().idleConnectionTimeoutMillis(999), "idleConnectionTimeoutMillis must be zero or greater than or equal to 1000"},
                 {"workerPoolSize0", Cluster.build().workerPoolSize(0), "workerPoolSize must be greater than zero"},
                 {"workerPoolSizeNeg1", Cluster.build().workerPoolSize(-1), "workerPoolSize must be greater than zero"}});
     }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ConnectionPoolTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ConnectionPoolTest.java
@@ -63,10 +63,9 @@ public class ConnectionPoolTest {
 
         final Client client = new Client.ClusteredClient(cluster);
 
-        // create pool with 1 connection
-        final ConnectionPool connectionPool = new ConnectionPool(host, client,
-                Optional.of(1), Optional.of(2), connectionFactory);
-        // try to borrow this connection.
+        // create pool - starts with 1 connection
+        final ConnectionPool connectionPool = new ConnectionPool(host, client, Optional.of(2), connectionFactory);
+        // try to borrow a connection.
         final Connection conn0 = connectionPool.borrowConnection(100, TimeUnit.MILLISECONDS);
 
         assertNotNull(connectionPool);
@@ -90,6 +89,7 @@ public class ConnectionPoolTest {
         }
 
         // return conn0 to pool, can be borrowed again
+        connectionPool.returnConnection(conn0);
         when(mockConn0.isBorrowed()).thenReturn(new AtomicBoolean(false));
         final Connection conn00 = connectionPool.borrowConnection(100, TimeUnit.MILLISECONDS);
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -58,7 +58,6 @@ public class SettingsTest {
         conf.setProperty("connectionPool.sslEnabledProtocols", Arrays.asList("TLSv1.1","TLSv1.2"));
         conf.setProperty("connectionPool.sslCipherSuites", Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"));
         conf.setProperty("connectionPool.sslSkipCertValidation", true);
-        conf.setProperty("connectionPool.minSize", 100);
         conf.setProperty("connectionPool.maxSize", 200);
         conf.setProperty("connectionPool.minSimultaneousUsagePerConnection", 300);
         conf.setProperty("connectionPool.maxSimultaneousUsagePerConnection", 400);
@@ -71,6 +70,7 @@ public class SettingsTest {
         conf.setProperty("connectionPool.channelizer", "channelizer0");
         conf.setProperty("connectionPool.validationRequest", "g.inject()");
         conf.setProperty("connectionPool.connectionSetupTimeoutMillis", 15000);
+        conf.setProperty("connectionPool.idleConnectionTimeout", 160000);
 
         final Settings settings = Settings.from(conf);
 
@@ -95,12 +95,12 @@ public class SettingsTest {
         assertEquals(Arrays.asList("TLSv1.1","TLSv1.2"), settings.connectionPool.sslEnabledProtocols);
         assertEquals(Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"), settings.connectionPool.sslCipherSuites);
         assertThat(settings.connectionPool.sslSkipCertValidation, is(true));
-        assertEquals(100, settings.connectionPool.minSize);
         assertEquals(200, settings.connectionPool.maxSize);
         assertEquals(700, settings.connectionPool.maxWaitForConnection);
         assertEquals(800, settings.connectionPool.maxResponseContentLength);
         assertEquals(900, settings.connectionPool.reconnectInterval);
         assertEquals(15000, settings.connectionPool.connectionSetupTimeoutMillis);
+        assertEquals(160000, settings.connectionPool.idleConnectionTimeout);
         assertEquals(1100, settings.connectionPool.resultIterationBatchSize);
         assertEquals("g.inject()", settings.connectionPool.validationRequest);
     }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/IdleConnectionHandlerTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/IdleConnectionHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.driver.handler;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.timeout.IdleStateEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IdleConnectionHandlerTest {
+    private EmbeddedChannel testChannel;
+
+    @Before
+    public void setup() {
+        testChannel = new EmbeddedChannel(new IdleConnectionHandler());
+    }
+
+    @After
+    public void teardown() {
+        // if any exceptions happened, throw them otherwise the test will only silently fail
+        testChannel.checkException();
+    }
+
+
+    @Test
+    public void userEventTriggered_setsIdleStateEventAttribute() {
+        testChannel.pipeline().fireUserEventTriggered(IdleStateEvent.WRITER_IDLE_STATE_EVENT);
+        assertTrue(testChannel.hasAttr(IdleConnectionHandler.IDLE_STATE_EVENT));
+    }
+
+    @Test
+    public void userEventTriggered_notIdleStateEvent_doesNotSetAttribute() {
+        testChannel.pipeline().fireUserEventTriggered("some other event");
+        assertFalse(testChannel.hasAttr(IdleConnectionHandler.IDLE_STATE_EVENT));
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -260,7 +260,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final AtomicInteger handshakeRequests = new AtomicInteger(0);
 
         final Cluster cluster = TestClientFactory.build().
-                minConnectionPoolSize(1).maxConnectionPoolSize(1).
+                maxConnectionPoolSize(1).
                 addInterceptor("counter", r -> {
                     handshakeRequests.incrementAndGet();
                     return r;
@@ -964,8 +964,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     @Test
     public void shouldBeThreadSafeToUseOneClient() throws Exception {
         final Cluster cluster = TestClientFactory.build().workerPoolSize(2)
-                .maxConnectionPoolSize(16)
-                .minConnectionPoolSize(8).create();
+                .maxConnectionPoolSize(16).create();
         final Client client = cluster.connect();
 
         final Map<Integer, Integer> results = new ConcurrentHashMap<>();
@@ -1168,8 +1167,8 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
      */
     @Test
     public void shouldReturnClearExceptionCauseWhenClientIsTooBusyAndConnectionPoolIsFull() throws InterruptedException {
+        int maxSize = 1;
         final Cluster cluster = TestClientFactory.build()
-                .minConnectionPoolSize(1)
                 .maxConnectionPoolSize(1)
                 .connectionSetupTimeoutMillis(100)
                 .maxWaitForConnection(150)
@@ -1183,7 +1182,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             } catch (Exception e) {
                 final Throwable root = ExceptionHelper.getRootCause(e);
                 assertTrue(root instanceof TimeoutException);
-                assertTrue(root.getMessage().contains(Client.TOO_MANY_IN_FLIGHT_REQUESTS));
+                assertTrue(root.getMessage().contains(String.format(Client.TOO_MANY_IN_FLIGHT_REQUESTS, maxSize, maxSize)));
             }
         }
 


### PR DESCRIPTION
Changed connection pooling to reflect having switched from long lived web socket connections to short lived http connections:
- sped up obtaining a new connection by removing method-level synchronization of getAvailableConnection and introducing a separate set for available connections
- introduced cleanup of idle connections to release resources
- removed minSize since idle connections are now cleaned up and the pool can become empty if there is no traffic
- increased maxSize default to 128
- increased core pool size of ScheduledThreadPoolExecutor that is used for creating new connections to number of available processors
- added logging to help troubleshoot connection related integration tests failures

ProfilingApplication throughput results of master-http prior to these changes (with small min pool size of 50):
```
[ec2-user@ip-xxxxx bin]$ ./profile-driver.sh parallelism 16 executions 5 requests 1000000 minConnectionPoolSize 50 maxConnectionPoolSize 5000 host xxxxx
---------------------THROUGHPUT TEST SELECTED---------------------
---------------------------WARMUP CYCLE---------------------------
[warmup-1] requests: 1000 | time(s): 0.874164166    | req/sec: 1144    | too slow: 0
[warmup-2] requests: 1000 | time(s): 0.80377202     | req/sec: 1244    | too slow: 0
[warmup-3] requests: 1000 | time(s): 0.797980361    | req/sec: 1253    | too slow: 0
[warmup-4] requests: 1000 | time(s): 0.798658453    | req/sec: 1252    | too slow: 0
[warmup-5] requests: 1000 | time(s): 0.798385122    | req/sec: 1253    | too slow: 0
----------------------------TEST CYCLE----------------------------
[test-1]   requests: 1000000 | time(s): 48.756697463   | req/sec: 20510   | too slow: 1
[test-2]   requests: 1000000 | time(s): 48.614801918   | req/sec: 20570   | too slow: 0
[test-3]   requests: 1000000 | time(s): 48.647116064   | req/sec: 20556   | too slow: 0
[test-4]   requests: 1000000 | time(s): 48.577865007   | req/sec: 20586   | too slow: 0
[test-5]   requests: 1000000 | time(s): 48.646597705   | req/sec: 20556   | too slow: 0
avg req/sec: 20555
```

ProfilingApplication throughput results after these changes are applied (no more min pool size but connection pool is created initially with 1 connection at startup):
```
[ec2-user@ip-xxxxx bin]$ ./profile-driver.sh parallelism 16 executions 5 requests 1000000 maxConnectionPoolSize 5000 host xxxxx
---------------------THROUGHPUT TEST SELECTED---------------------
---------------------------WARMUP CYCLE---------------------------
[warmup-1] requests: 1000 | time(s): 0.829135665    | req/sec: 1206    | too slow: 0
[warmup-2] requests: 1000 | time(s): 0.75848205     | req/sec: 1318    | too slow: 0
[warmup-3] requests: 1000 | time(s): 0.853421271    | req/sec: 1172    | too slow: 0
[warmup-4] requests: 1000 | time(s): 0.755844005    | req/sec: 1323    | too slow: 0
[warmup-5] requests: 1000 | time(s): 0.800583459    | req/sec: 1249    | too slow: 0
----------------------------TEST CYCLE----------------------------
[test-1]   requests: 1000000 | time(s): 31.881409634   | req/sec: 31366   | too slow: 0
[test-2]   requests: 1000000 | time(s): 31.6027552     | req/sec: 31643   | too slow: 0
[test-3]   requests: 1000000 | time(s): 32.396470504   | req/sec: 30868   | too slow: 0
[test-4]   requests: 1000000 | time(s): 32.165162331   | req/sec: 31090   | too slow: 0
[test-5]   requests: 1000000 | time(s): 31.820634099   | req/sec: 31426   | too slow: 0
avg req/sec: 31278
```

JProfiler screenshot of hotspots prior to these changes:
![Screenshot 2024-10-22 at 2 08 39 PM](https://github.com/user-attachments/assets/c16e93d1-fec6-4454-90d0-3fa014691101)

JProfiler screenshot of hotspots after these changes:
![Screenshot 2024-10-30 at 10 20 12 AM](https://github.com/user-attachments/assets/e5a99b11-2de1-4bd5-85ae-41c1775acea5)

