### PR TITLE
Re-enable GraphSON testing for gremlin-python

### DIFF
--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -64,7 +64,8 @@ services:
       && python3 ./setup.py test
       && python3 ./setup.py install
       && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.graphbinary-v4.0' --user-data='bulked=true'
-      && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.graphbinary-v4.0';
+      && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.graphbinary-v4.0'
+      && radish -f dots -e -t -b ./radish ./gremlin-test --user-data='serializer=application/vnd.gremlin-v4.0+json';
       EXIT_CODE=$$?; chown -R `stat -c "%u:%g" .` .; exit $$EXIT_CODE"
     depends_on:
       gremlin-server-test-python:

--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -100,7 +100,27 @@ class AiohttpHTTPTransport(AbstractBaseTransport):
 
     def read(self, stream_chunk=None):
         if not stream_chunk:
-            raise Exception('missing handling of streamed responses to protocol')
+            '''
+            GraphSON does not support streaming deserialization, we are aggregating data and bypassing streamed
+             deserialization while GraphSON is enabled for testing. Remove after GraphSON is removed.
+            '''
+            async def async_read():
+                async with async_timeout.timeout(self._read_timeout):
+                    data_buffer = b""
+                    async for data, end_of_http_chunk in self._http_req_resp.content.iter_chunks():
+                        try:
+                            data_buffer += data
+                        except ClientPayloadError:
+                            # server disconnect during streaming will cause ClientPayLoadError from aiohttp
+                            raise GremlinServerError({'code': 500,
+                                                      'message': 'Server disconnected - please try to reconnect',
+                                                      'exception': ClientPayloadError})
+                    if self._max_content_len and len(
+                            data_buffer) > self._max_content_len:
+                        raise Exception(f'Response size {len(data_buffer)} exceeds limit {self._max_content_len} bytes')
+                    return data_buffer
+            return self._loop.run_until_complete(async_read())
+            # raise Exception('missing handling of streamed responses to protocol')
 
         # Inner function to perform async read.
         async def async_read():

--- a/gremlin-python/src/main/python/gremlin_python/driver/connection.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/connection.py
@@ -86,7 +86,13 @@ class Connection:
 
     def _receive(self):
         try:
-            self._transport.read(self.stream_chunk)
+            '''
+            GraphSON does not support streaming deserialization, we are aggregating data and bypassing streamed
+             deserialization while GraphSON is enabled for testing. Remove after GraphSON is removed.
+            '''
+            self._protocol.data_received_aggregate(self._transport.read(), self._result_set)
+            # re-enable streaming after graphSON removal
+            # self._transport.read(self.stream_chunk)
         finally:
             self._pool.put_nowait(self)
 

--- a/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/serializer.py
@@ -40,7 +40,7 @@ __author__ = 'David M. Brown (davebshow@gmail.com), Lyndon Bauto (lyndonb@bitqui
 GraphSONV4
 """
 
-class GraphSONSerializerV4(object):
+class GraphSONSerializersV4(object):
     """
     Message serializer for GraphSON. Allow users to pass custom reader,
     writer, and version kwargs for custom serialization. Otherwise,
@@ -89,7 +89,7 @@ class GraphSONSerializerV4(object):
             msg = json.loads(message if isinstance(message, str) else message.decode('utf-8'))
             return self._graphson_reader.to_object(msg)
         else:
-            # graphSON does not stream, the first chunk contains all info
+            # graphSON does not stream, all results are aggregated inside the first chunk
             return ""
 
 """

--- a/gremlin-python/src/main/python/radish/terrain.py
+++ b/gremlin-python/src/main/python/radish/terrain.py
@@ -96,6 +96,8 @@ def __create_remote(server_graph_name):
 
     if world.config.user_data["serializer"] == "application/vnd.graphbinary-v4.0":
         s = serializer.GraphBinarySerializersV4()
+    elif world.config.user_data["serializer"] == "application/vnd.gremlin-v4.0+json":
+        s = serializer.GraphSONSerializersV4()
     else:
         raise ValueError('serializer not found - ' + world.config.user_data["serializer"])
 

--- a/gremlin-python/src/main/python/tests/conftest.py
+++ b/gremlin-python/src/main/python/tests/conftest.py
@@ -25,6 +25,7 @@ import pytest
 import logging
 import queue
 
+from gremlin_python.driver import serializer
 from gremlin_python.driver.client import Client
 from gremlin_python.driver.connection import Connection
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
@@ -110,11 +111,17 @@ def graphbinary_serializer_v4(request):
     return GraphBinarySerializersV4()
 
 
-@pytest.fixture(params=['graphbinaryv4'])
+@pytest.fixture(params=['graphbinaryv4','graphsonv4'])
 def remote_connection(request):
     try:
         if request.param == 'graphbinaryv4':
-            remote_conn = DriverRemoteConnection(anonymous_url, 'gmodern')
+            remote_conn = DriverRemoteConnection(anonymous_url, 'gmodern',
+                                                 request_serializer=serializer.GraphBinarySerializersV4(),
+                                                 response_serializer=serializer.GraphBinarySerializersV4())
+        elif request.param == 'graphsonv4':
+            remote_conn = DriverRemoteConnection(anonymous_url, 'gmodern',
+                                                 request_serializer=serializer.GraphSONSerializersV4(),
+                                                 response_serializer=serializer.GraphSONSerializersV4())
         else:
             raise ValueError("Invalid serializer option - " + request.param)
     except OSError:

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -40,8 +40,8 @@ class TestDriverRemoteConnection(object):
     # in conftest.py and remove this
     def test_graphSONV4_temp(self):
         remote_conn = DriverRemoteConnection(test_no_auth_url, 'gmodern',
-                                             request_serializer=serializer.GraphSONSerializerV4(),
-                                             response_serializer=serializer.GraphSONSerializerV4())
+                                             request_serializer=serializer.GraphSONSerializersV4(),
+                                             response_serializer=serializer.GraphSONSerializersV4())
         g = traversal().with_(remote_conn)
         assert long(6) == g.V().count().to_list()[0]
         # #


### PR DESCRIPTION
Updated to handling aggregating results as GraphSON doesn't deserialize streams, re-enabled GraphSON testing in tests, and updated GraphSON class naming to be more consistent. 