### PR TITLE
Update SigV4 interceptor to use latest aws sdk version

### DIFF
--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -25,6 +25,9 @@ limitations under the License.
     </parent>
     <artifactId>gremlin-driver</artifactId>
     <name>Apache TinkerPop :: Gremlin Driver</name>
+    <properties>
+        <awssdk.version>2.29.3</awssdk.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
@@ -53,22 +56,22 @@ limitations under the License.
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>http-auth-aws</artifactId>
-            <version>2.29.3</version>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
-            <version>2.29.3</version>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.29.3</version>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>protocol-core</artifactId>
-            <version>2.29.3</version>
+            <version>${awssdk.version}</version>
         </dependency>
         <!-- TinkerGraph is an optional dependency that is only required if doing deserialization of Graph instances -->
         <dependency>

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -65,6 +65,21 @@ limitations under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>2.29.3</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>2.29.3</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.29.3</version>
+        </dependency>
         <!-- TinkerGraph is an optional dependency that is only required if doing deserialization of Graph instances -->
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -51,21 +51,6 @@ limitations under the License.
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.12.720</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>http-auth-aws</artifactId>
             <version>2.29.3</version>
@@ -78,6 +63,11 @@ limitations under the License.
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
+            <version>2.29.3</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>protocol-core</artifactId>
             <version>2.29.3</version>
         </dependency>
         <!-- TinkerGraph is an optional dependency that is only required if doing deserialization of Graph instances -->

--- a/gremlin-driver/src/main/java/examples/Connections.java
+++ b/gremlin-driver/src/main/java/examples/Connections.java
@@ -19,35 +19,26 @@ under the License.
 
 package examples;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
-import org.apache.tinkerpop.gremlin.driver.auth.Auth;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.AbstractIoRegistry;
 import org.apache.tinkerpop.gremlin.structure.io.IoRegistry;
 import org.apache.tinkerpop.gremlin.structure.io.binary.TypeSerializerRegistry;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.apache.tinkerpop.gremlin.util.MessageSerializer;
-import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4;
-import org.apache.tinkerpop.gremlin.util.ser.Serializers;
-import org.apache.tinkerpop.shaded.jackson.core.JsonProcessingException;
-import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 
 public class Connections {
     public static void main(String[] args) throws Exception {
-//        withEmbedded();
-//        withRemote();
+        withEmbedded();
+        withRemote();
         withCluster();
-//        withSerializer();
+        withSerializer();
     }
 
     // Creating an embedded graph
@@ -83,59 +74,17 @@ public class Connections {
     // Connecting and customizing configurations with a cluster
     // See reference/#gremlin-java-configuration for full list of configurations
     private static void withCluster() throws Exception {
-//        Cluster cluster = Cluster.build("localhost").
-//            maxConnectionPoolSize(8).
-//            path("/gremlin").
-//            port(8182).
-//            serializer(new GraphBinaryMessageSerializerV4()).
-//            create();
-
-        Cluster cluster = Cluster.build()
-                .addContactPoint("URL")
-                .path("/queries")
-                .port(443)
-                .serializer(Serializers.GRAPHSON_V4)
-                .enableSsl(true)
-                .maxConnectionPoolSize(1)
-                .removeInterceptor(Cluster.SERIALIZER_INTERCEPTOR_NAME) // We don't want the body to be serialized
-                .addInterceptor("queries-format", request -> {
-                    final RequestMessage rm = (RequestMessage) request.getBody();
-                    final Map<String, Object> queriesBody = new HashMap<>();
-
-                    queriesBody.put("query", rm.getGremlin());
-                    queriesBody.put("language", "GREMLIN");
-                    final Map fields = rm.getFields();
-                    if (fields.containsKey("bindings")) queriesBody.put("parameters", fields.get("bindings"));
-
-                    ObjectMapper om = new ObjectMapper();
-                    byte[] payload;
-                    try {
-                        payload = om.writeValueAsBytes(queriesBody);
-                    } catch (JsonProcessingException jpe) {
-                        throw new RuntimeException(jpe);
-                    }
-                    request.setBody(payload);
-
-                    Map<String, String> headers = request.headers();
-                    headers.remove("accept");
-                    headers.remove("accept-encoding");
-                    headers.put("content-type", "application/json");
-                    headers.put("content-length", String.valueOf(payload.length));
-
-                    return request;
-                })
-                .auth(Auth.sigv4("us-east-1", "neptune-graph"))
-                .enableUserAgentOnConnect(false)
-                .create();
-
-
+        Cluster cluster = Cluster.build("localhost").
+                maxConnectionPoolSize(8).
+                path("/gremlin").
+                port(8182).
+                serializer(new GraphBinaryMessageSerializerV4()).
+                create();
         GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
 
-        //g.addV().iterate();
-        GraphTraversal<Vertex, Vertex> v = g.V();
-        GraphTraversal<Vertex, Long> count = v.count();
-        Long next = count.next();
-        System.out.println("Vertex count: " + next);
+        g.addV().iterate();
+        long count = g.V().count().next();
+        System.out.println("Vertex count: " + count);
 
         cluster.close();
         g.close();
@@ -147,8 +96,8 @@ public class Connections {
         TypeSerializerRegistry typeSerializerRegistry = TypeSerializerRegistry.build().addRegistry(registry).create();
         MessageSerializer serializer = new GraphBinaryMessageSerializerV4(typeSerializerRegistry);
         Cluster cluster = Cluster.build("localhost").
-            serializer(serializer).
-            create();
+                serializer(serializer).
+                create();
         Client client = cluster.connect();
         GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(client, "g"));
 

--- a/gremlin-driver/src/main/java/examples/Connections.java
+++ b/gremlin-driver/src/main/java/examples/Connections.java
@@ -75,11 +75,11 @@ public class Connections {
     // See reference/#gremlin-java-configuration for full list of configurations
     private static void withCluster() throws Exception {
         Cluster cluster = Cluster.build("localhost").
-                maxConnectionPoolSize(8).
-                path("/gremlin").
-                port(8182).
-                serializer(new GraphBinaryMessageSerializerV4()).
-                create();
+            maxConnectionPoolSize(8).
+            path("/gremlin").
+            port(8182).
+            serializer(new GraphBinaryMessageSerializerV4()).
+            create();
         GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
 
         g.addV().iterate();
@@ -96,8 +96,8 @@ public class Connections {
         TypeSerializerRegistry typeSerializerRegistry = TypeSerializerRegistry.build().addRegistry(registry).create();
         MessageSerializer serializer = new GraphBinaryMessageSerializerV4(typeSerializerRegistry);
         Cluster cluster = Cluster.build("localhost").
-                serializer(serializer).
-                create();
+            serializer(serializer).
+            create();
         Client client = cluster.connect();
         GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(client, "g"));
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Auth.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Auth.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.driver.auth;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import org.apache.tinkerpop.gremlin.driver.RequestInterceptor;
 import org.apache.tinkerpop.gremlin.driver.Settings;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 public interface Auth extends RequestInterceptor {
     String AUTH_BASIC = "basic";
@@ -34,7 +35,7 @@ public interface Auth extends RequestInterceptor {
         return new Sigv4(regionName, serviceName);
     }
 
-    static Auth sigv4(final String regionName, final AWSCredentialsProvider awsCredentialsProvider, final String serviceName) {
+    static Auth sigv4(final String regionName, final AwsCredentialsProvider awsCredentialsProvider, final String serviceName) {
         return new Sigv4(regionName, awsCredentialsProvider, serviceName);
     }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Auth.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Auth.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.driver.auth;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import org.apache.tinkerpop.gremlin.driver.RequestInterceptor;
 import org.apache.tinkerpop.gremlin.driver.Settings;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4.java
@@ -18,20 +18,20 @@
  */
 package org.apache.tinkerpop.gremlin.driver.auth;
 
-import com.amazonaws.auth.BasicSessionCredentials;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import org.apache.http.entity.StringEntity;
+import java.util.Set;
 import org.apache.tinkerpop.gremlin.driver.HttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpMethod;
@@ -40,17 +40,18 @@ import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
-import static com.amazonaws.auth.internal.SignerConstants.AUTHORIZATION;
-import static com.amazonaws.auth.internal.SignerConstants.HOST;
-import static com.amazonaws.auth.internal.SignerConstants.X_AMZ_CONTENT_SHA256;
-import static com.amazonaws.auth.internal.SignerConstants.X_AMZ_DATE;
-import static com.amazonaws.auth.internal.SignerConstants.X_AMZ_SECURITY_TOKEN;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.AUTHORIZATION;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.HOST;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_CONTENT_SHA256;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_DATE;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_SECURITY_TOKEN;
 
 /**
  * A {@link org.apache.tinkerpop.gremlin.driver.RequestInterceptor} that provides headers required for SigV4. Because
  * the signing process requires final header and body data, this interceptor should almost always be last.
  */
 public class Sigv4 implements Auth {
+    private static final Logger logger = LoggerFactory.getLogger(Sigv4.class);
     private final AwsCredentialsProvider awsCredentialsProvider;
     private final AwsV4HttpSigner aws4Signer;
     private final String serviceName;
@@ -73,47 +74,65 @@ public class Sigv4 implements Auth {
         try {
             // Convert Http request into an AWS SDK signable request
             final SdkHttpRequest awsSignableRequest = toSignableRequest(httpRequest);
+            final AwsCredentials credentials = awsCredentialsProvider.resolveCredentials();
+            final ContentStreamProvider content = toContentStream(httpRequest);
 
             // Sign the AWS SDK signable request (which internally adds some HTTP headers)
-            final AwsCredentials credentials = awsCredentialsProvider.resolveCredentials();
-
-            if (!(httpRequest.getBody() instanceof byte[])) {
-                throw new IllegalArgumentException("Expected byte[] in HttpRequest body but got " + httpRequest.getBody().getClass());
-            }
-
-            final byte[] body = (byte[]) httpRequest.getBody();
-            final ContentStreamProvider content = (body.length != 0) ? ContentStreamProvider.fromByteArray(body) : ContentStreamProvider.fromUtf8String("");
-
             SignedRequest signed = aws4Signer.sign(r -> r.identity(credentials)
                     .request(awsSignableRequest)
                     .payload(content)
                     .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, this.serviceName)
                     .putProperty(AwsV4HttpSigner.REGION_NAME, this.regionName));
 
-            // extract session token if temporary credentials are provided
-            String sessionToken = "";
-            if ((credentials instanceof BasicSessionCredentials)) {
-                sessionToken = ((BasicSessionCredentials) credentials).getSessionToken();
-            }
-
-            final Map<String, String> headers = httpRequest.headers();
-            headers.remove(HttpRequest.Headers.HOST);
-            headers.put(HOST, signed.request().host());
-            headers.put(X_AMZ_DATE, signed.request().headers().get(X_AMZ_DATE).get(0));
-            headers.put(AUTHORIZATION, signed.request().headers().get(AUTHORIZATION).get(0));
-            headers.put(X_AMZ_CONTENT_SHA256, signed.request().headers().get(X_AMZ_CONTENT_SHA256).get(0));
-            headers.put(X_AMZ_SECURITY_TOKEN, signed.request().headers().get(X_AMZ_SECURITY_TOKEN).get(0));
-
-            if (!sessionToken.isEmpty()) {
-                headers.put(X_AMZ_SECURITY_TOKEN, sessionToken);
-            }
+            Map<String, String> headers = httpRequest.headers();
+            setSignedHeaders(headers, signed);
+            setSessionToken(headers, credentials);
         } catch (final Exception ex) {
+            logger.error("Error signing HTTP request: {}", ex.getMessage(), ex);
             throw new AuthenticationException(ex);
         }
         return httpRequest;
     }
 
-    private SdkHttpRequest toSignableRequest(final HttpRequest request) throws IOException {
+    private void setSessionToken(Map<String, String> headers, AwsCredentials credentials) {
+        // extract session token if temporary credentials are provided
+        String sessionToken = "";
+        if ((credentials instanceof AwsSessionCredentials)) {
+            sessionToken = ((AwsSessionCredentials) credentials).sessionToken();
+        }
+        if (!sessionToken.isEmpty()) {
+            headers.put(X_AMZ_SECURITY_TOKEN, sessionToken);
+        }
+    }
+
+    private void setSignedHeaders(Map<String, String> headers, SignedRequest signed) {
+        headers.remove(HttpRequest.Headers.HOST);
+        headers.put(HOST, signed.request().host());
+        Map<String, List<String>> signedHeaders = signed.request().headers();
+        headers.put(X_AMZ_DATE, getSingleHeaderValue(signedHeaders, X_AMZ_DATE));
+        headers.put(AUTHORIZATION, getSingleHeaderValue(signedHeaders, AUTHORIZATION));
+        headers.put(X_AMZ_CONTENT_SHA256, getSingleHeaderValue(signedHeaders, X_AMZ_CONTENT_SHA256));
+        headers.put(X_AMZ_SECURITY_TOKEN, getSingleHeaderValue(signedHeaders, X_AMZ_SECURITY_TOKEN));
+    }
+
+    private String getSingleHeaderValue(Map<String, List<String>> headers, String headerName) {
+        Set<String> headerValues = new HashSet<>(headers.containsKey(headerName) ? headers.get(headerName) : Collections.emptySet());
+        if (headerValues.size() != 1) {
+            throw new IllegalArgumentException(String.format("Expected 1 header %s but found %d", headerName, headerValues.size()));
+        }
+        return headerValues.iterator().next();
+    }
+
+    private ContentStreamProvider toContentStream(HttpRequest httpRequest) {
+        // carry over the entity (or an empty entity, if no entity is provided)
+        if (!(httpRequest.getBody() instanceof byte[])) {
+            throw new IllegalArgumentException("Expected byte[] in HttpRequest body but got " + httpRequest.getBody().getClass());
+        }
+        final byte[] body = (byte[]) httpRequest.getBody();
+        return (body.length != 0) ? ContentStreamProvider.fromByteArray(body) : ContentStreamProvider.fromUtf8String("");
+    }
+
+    private SdkHttpRequest toSignableRequest(final HttpRequest request) {
 
         // make sure the request contains the minimal required set of information
         checkNotNull(request.getUri(), "The request URI must not be null");
@@ -135,22 +154,16 @@ public class Sigv4 implements Auth {
         final URI uri = request.getUri();
         final Map<String, List<String>> parametersInternal = extractParametersFromQueryString(uri.getQuery());
 
-        // carry over the entity (or an empty entity, if no entity is provided)
-        if (!(request.getBody() instanceof byte[])) {
-            throw new IllegalArgumentException("Expected byte[] in HttpRequest body but got " + request.getBody().getClass());
-        }
-
-        final byte[] body = (byte[]) request.getBody();
-        final InputStream content = (body.length != 0) ? new ByteArrayInputStream(body) : new StringEntity("").getContent();
         final URI endpointUri = URI.create(uri.getScheme() + "://" + uri.getHost());
 
-        return convertToSignableRequest(
-                request.getMethod(),
-                endpointUri,
-                uri.getPath(),
-                headersInternal,
-                parametersInternal,
-                content);
+        // create the HTTP AWS SdkHttpRequest and carry over information
+        return SdkHttpRequest.builder()
+                .uri(endpointUri)
+                .encodedPath(uri.getPath())
+                .method(SdkHttpMethod.fromValue(request.getMethod()))
+                .headers(headersInternal)
+                .rawQueryParameters(parametersInternal)
+                .build();
     }
 
     private HashMap<String, List<String>> extractParametersFromQueryString(final String queryStr) {
@@ -188,34 +201,6 @@ public class Sigv4 implements Auth {
         }
 
         return parameters;
-    }
-
-    private SdkHttpRequest convertToSignableRequest(
-            final String httpMethodName,
-            final URI httpEndpointUri,
-            final String resourcePath,
-            final Map<String, List<String>> httpHeaders,
-            final Map<String, List<String>> httpParameters,
-            final InputStream httpContent) {
-
-        // create the HTTP AWS SDK Signable Request and carry over information
-//        final DefaultRequest<?> awsRequest = new DefaultRequest<>(aws4Signer.getServiceName());
-//        awsRequest.setHttpMethod(HttpMethodName.fromValue(httpMethodName));
-//        awsRequest.setEndpoint(httpEndpointUri);
-//        awsRequest.setResourcePath(resourcePath);
-//        awsRequest.setHeaders(httpHeaders);
-//        awsRequest.setParameters(httpParameters);
-//        awsRequest.setContent(httpContent);
-
-        SdkHttpRequest httpRequest = SdkHttpRequest.builder()
-                .uri(httpEndpointUri)
-                .encodedPath(resourcePath)
-                .method(SdkHttpMethod.fromValue(httpMethodName))
-                .headers(httpHeaders)
-                .rawQueryParameters(httpParameters)
-                .build();
-
-        return httpRequest;
     }
 
     private void checkNotNull(final Object obj, final String errMsg) {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4.java
@@ -72,10 +72,10 @@ public class Sigv4 implements Auth {
     @Override
     public HttpRequest apply(final HttpRequest httpRequest) {
         try {
+            final ContentStreamProvider content = toContentStream(httpRequest);
             // Convert Http request into an AWS SDK signable request
             final SdkHttpRequest awsSignableRequest = toSignableRequest(httpRequest);
             final AwsCredentials credentials = awsCredentialsProvider.resolveCredentials();
-            final ContentStreamProvider content = toContentStream(httpRequest);
 
             // Sign the AWS SDK signable request (which internally adds some HTTP headers)
             final SignedRequest signed = aws4Signer.sign(r -> r.identity(credentials)

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
@@ -1,0 +1,72 @@
+package org.apache.tinkerpop.gremlin.driver.auth;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import org.apache.tinkerpop.gremlin.driver.HttpRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.AUTHORIZATION;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.HOST;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_CONTENT_SHA256;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_DATE;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_SECURITY_TOKEN;
+
+public class Sigv4Test {
+    public static final String US_WEST_2 = "us-west-2";
+    public static final String SERVICE_NAME = "service-name";
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock
+    private AwsCredentialsProvider credentialsProvider;
+    private Sigv4 sigv4;
+
+    @Before
+    public void setup() {
+        sigv4 = new Sigv4(US_WEST_2, credentialsProvider, SERVICE_NAME);
+    }
+
+    @Test
+    public void shouldAddSignedHeaders() throws Exception {
+        when(credentialsProvider.resolveCredentials()).thenReturn(AwsBasicCredentials.create("foo", "bar"));
+        HttpRequest httpRequest = createRequest();
+        sigv4.apply(httpRequest);
+        validateExpectedHeaders(httpRequest);
+    }
+
+    @Test
+    public void shouldAddSignedHeadersAndSessionToken() throws Exception {
+        String sessionToken = "foobarz";
+        when(credentialsProvider.resolveCredentials()).thenReturn(AwsSessionCredentials.create("foo", "bar", sessionToken));
+        HttpRequest httpRequest = createRequest();
+        sigv4.apply(httpRequest);
+        validateExpectedHeaders(httpRequest);
+        assertEquals(sessionToken, httpRequest.headers().get(X_AMZ_SECURITY_TOKEN));
+    }
+
+    private HttpRequest createRequest() throws URISyntaxException {
+        HttpRequest httpRequest = new HttpRequest(new HashMap<>(), "{\"gremlin\":\"2-1\"}".getBytes(StandardCharsets.UTF_8), new URI("http://localhost:8182?a=1&b=2"));
+        httpRequest.headers().put("Content-Type", "application/json");
+        return httpRequest;
+    }
+
+    private void validateExpectedHeaders(HttpRequest httpRequest) {
+        assertEquals("localhost", httpRequest.headers().get(HOST));
+        assertNotNull(httpRequest.headers().get(X_AMZ_DATE));
+        assertNotNull(httpRequest.headers().get(AUTHORIZATION));
+        assertNotNull(httpRequest.headers().get(X_AMZ_CONTENT_SHA256));
+    }
+
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
@@ -15,6 +15,10 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -25,7 +29,7 @@ import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerCo
 import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_SECURITY_TOKEN;
 
 public class Sigv4Test {
-    public static final String US_WEST_2 = "us-west-2";
+    public static final String REGION = "us-west-2";
     public static final String SERVICE_NAME = "service-name";
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -35,7 +39,7 @@ public class Sigv4Test {
 
     @Before
     public void setup() {
-        sigv4 = new Sigv4(US_WEST_2, credentialsProvider, SERVICE_NAME);
+        sigv4 = new Sigv4(REGION, credentialsProvider, SERVICE_NAME);
     }
 
     @Test
@@ -65,8 +69,11 @@ public class Sigv4Test {
     private void validateExpectedHeaders(HttpRequest httpRequest) {
         assertEquals("localhost", httpRequest.headers().get(HOST));
         assertNotNull(httpRequest.headers().get(X_AMZ_DATE));
-        assertNotNull(httpRequest.headers().get(AUTHORIZATION));
         assertNotNull(httpRequest.headers().get(X_AMZ_CONTENT_SHA256));
+        assertThat(httpRequest.headers().get(AUTHORIZATION),
+                allOf(startsWith("AWS4-HMAC-SHA256 Credential=foo"),
+                        containsString("/" + REGION + "/service-name/aws4_request"),
+                        containsString("Signature=")));
     }
 
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tinkerpop.gremlin.driver.auth;
 
 import java.net.URI;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -31,8 +31,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
 import static org.apache.tinkerpop.gremlin.driver.auth.Auth.basic;
 import static org.apache.tinkerpop.gremlin.driver.auth.Auth.sigv4;
@@ -89,10 +89,8 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
     @Test
     public void shouldPassSigv4ToServer() throws Exception {
         final AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
-        final AwsCredentials credentials = mock(AwsCredentials.class);
+        final AwsSessionCredentials credentials = AwsSessionCredentials.create("I am AWSAccessKeyId", "I am AWSSecretKey", "I am AWSSessionToken");
         when(credentialsProvider.resolveCredentials()).thenReturn(credentials);
-//        when(credentials.getAWSAccessKeyId()).thenReturn("I am AWSAccessKeyId");
-//        when(credentials.getAWSSecretKey()).thenReturn("I am AWSSecretKey");
 
         final AtomicReference<HttpRequest> httpRequest = new AtomicReference<>();
         final Cluster cluster = TestClientFactory.build()

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import io.netty.handler.codec.http.FullHttpRequest;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.HttpRequest;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -34,6 +34,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import static org.apache.tinkerpop.gremlin.driver.auth.Auth.basic;
 import static org.apache.tinkerpop.gremlin.driver.auth.Auth.sigv4;
@@ -89,11 +91,11 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldPassSigv4ToServer() throws Exception {
-        final AWSCredentialsProvider credentialsProvider = mock(AWSCredentialsProvider.class);
-        final AWSCredentials credentials = mock(AWSCredentials.class);
-        when(credentialsProvider.getCredentials()).thenReturn(credentials);
-        when(credentials.getAWSAccessKeyId()).thenReturn("I am AWSAccessKeyId");
-        when(credentials.getAWSSecretKey()).thenReturn("I am AWSSecretKey");
+        final AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
+        final AwsCredentials credentials = mock(AwsCredentials.class);
+        when(credentialsProvider.resolveCredentials()).thenReturn(credentials);
+//        when(credentials.getAWSAccessKeyId()).thenReturn("I am AWSAccessKeyId");
+//        when(credentials.getAWSSecretKey()).thenReturn("I am AWSSecretKey");
 
         final AtomicReference<HttpRequest> httpRequest = new AtomicReference<>();
         final Cluster cluster = TestClientFactory.build()


### PR DESCRIPTION
Updated SigV4 interceptor to use the latest version of `software.amazon.awssdk` and removed old dependency on `aws-java-sdk-core`. Since latest version of `SignedRequest` has headers that support multiple values for the same header via Map<String,List> I added validation checks that the expected signed headers only have 1 value.