### PR TITLE
Update SigV4 interceptor to use latest aws sdk version

### DIFF
--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -40,12 +40,6 @@ limitations under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.12.6.1</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -25,6 +25,9 @@ limitations under the License.
     </parent>
     <artifactId>gremlin-driver</artifactId>
     <name>Apache TinkerPop :: Gremlin Driver</name>
+    <properties>
+        <awssdk.version>2.29.3</awssdk.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
@@ -51,19 +54,24 @@ limitations under the License.
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.12.720</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>protocol-core</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
         <!-- TinkerGraph is an optional dependency that is only required if doing deserialization of Graph instances -->
         <dependency>

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Auth.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/auth/Auth.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.driver.auth;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import org.apache.tinkerpop.gremlin.driver.RequestInterceptor;
 import org.apache.tinkerpop.gremlin.driver.Settings;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 public interface Auth extends RequestInterceptor {
     String AUTH_BASIC = "basic";
@@ -34,7 +34,7 @@ public interface Auth extends RequestInterceptor {
         return new Sigv4(regionName, serviceName);
     }
 
-    static Auth sigv4(final String regionName, final AWSCredentialsProvider awsCredentialsProvider, final String serviceName) {
+    static Auth sigv4(final String regionName, final AwsCredentialsProvider awsCredentialsProvider, final String serviceName) {
         return new Sigv4(regionName, awsCredentialsProvider, serviceName);
     }
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/Sigv4Test.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.driver.auth;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import org.apache.tinkerpop.gremlin.driver.HttpRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.AUTHORIZATION;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_CONTENT_SHA256;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_DATE;
+import static software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant.X_AMZ_SECURITY_TOKEN;
+
+public class Sigv4Test {
+    private static final String REGION = "us-west-2";
+    private static final String SERVICE_NAME = "service-name";
+    private static final byte[] REQUEST_BODY = "{\"gremlin\":\"2-1\"}".getBytes(StandardCharsets.UTF_8);
+    private static final String HOST = "localhost";
+    private static final String URI_WITH_QUERY_PARAMS = "http://" + HOST + ":8182?a=1&b=2";
+    private static final String KEY = "foo";
+    private static final String SECRET = "bar";
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock
+    private AwsCredentialsProvider credentialsProvider;
+    private Sigv4 sigv4;
+
+    @Before
+    public void setup() {
+        sigv4 = new Sigv4(REGION, credentialsProvider, SERVICE_NAME);
+    }
+
+    @Test
+    public void shouldAddSignedHeaders() throws Exception {
+        when(credentialsProvider.resolveCredentials()).thenReturn(AwsBasicCredentials.create(KEY, SECRET));
+        HttpRequest httpRequest = createRequest();
+        sigv4.apply(httpRequest);
+        validateExpectedHeaders(httpRequest);
+    }
+
+    @Test
+    public void shouldAddSignedHeadersAndSessionToken() throws Exception {
+        String sessionToken = "foobarz";
+        when(credentialsProvider.resolveCredentials()).thenReturn(AwsSessionCredentials.create(KEY, SECRET, sessionToken));
+        HttpRequest httpRequest = createRequest();
+        sigv4.apply(httpRequest);
+        validateExpectedHeaders(httpRequest);
+        assertEquals(sessionToken, httpRequest.headers().get(X_AMZ_SECURITY_TOKEN));
+    }
+
+    @Test
+    public void shouldThrowIfRequestNonByteArray() {
+        Auth.AuthenticationException ex = assertThrows(Auth.AuthenticationException.class,
+                () -> sigv4.apply(new HttpRequest(new HashMap<>(), "not byte array", new URI(URI_WITH_QUERY_PARAMS))));
+        assertTrue(ex.getMessage().contains("Expected byte[] in HttpRequest body"));
+    }
+
+    @Test
+    public void shouldThrowIfNoRequestMethod() {
+        Auth.AuthenticationException ex = assertThrows(Auth.AuthenticationException.class,
+                () -> sigv4.apply(new HttpRequest(new HashMap<>(), REQUEST_BODY, new URI(URI_WITH_QUERY_PARAMS), null)));
+        assertTrue(ex.getMessage().contains("The request method must not be null"));
+    }
+
+    @Test
+    public void shouldThrowIfNoRequestURI() {
+        Auth.AuthenticationException ex = assertThrows(Auth.AuthenticationException.class,
+                () -> sigv4.apply(new HttpRequest(new HashMap<>(), REQUEST_BODY, null)));
+        assertTrue(ex.getMessage().contains("The request URI must not be null"));
+    }
+
+    private HttpRequest createRequest() throws URISyntaxException {
+        HttpRequest httpRequest = new HttpRequest(new HashMap<>(), REQUEST_BODY, new URI(URI_WITH_QUERY_PARAMS));
+        httpRequest.headers().put("Content-Type", "application/json");
+        httpRequest.headers().put("Host", "this-should-be-ignored-for-signed-host-header");
+        return httpRequest;
+    }
+
+    private void validateExpectedHeaders(HttpRequest httpRequest) {
+        assertEquals(HOST, httpRequest.headers().get(SignerConstant.HOST));
+        assertNotNull(httpRequest.headers().get(X_AMZ_DATE));
+        assertNotNull(httpRequest.headers().get(X_AMZ_CONTENT_SHA256));
+        assertThat(httpRequest.headers().get(AUTHORIZATION),
+                allOf(startsWith("AWS4-HMAC-SHA256 Credential=" + KEY),
+                        containsString("/" + REGION + "/service-name/aws4_request"),
+                        containsString("Signature=")));
+    }
+
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import io.netty.handler.codec.http.FullHttpRequest;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.HttpRequest;
@@ -34,6 +31,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
 import static org.apache.tinkerpop.gremlin.driver.auth.Auth.basic;
 import static org.apache.tinkerpop.gremlin.driver.auth.Auth.sigv4;
@@ -89,11 +88,9 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldPassSigv4ToServer() throws Exception {
-        final AWSCredentialsProvider credentialsProvider = mock(AWSCredentialsProvider.class);
-        final AWSCredentials credentials = mock(AWSCredentials.class);
-        when(credentialsProvider.getCredentials()).thenReturn(credentials);
-        when(credentials.getAWSAccessKeyId()).thenReturn("I am AWSAccessKeyId");
-        when(credentials.getAWSSecretKey()).thenReturn("I am AWSSecretKey");
+        final AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
+        final AwsSessionCredentials credentials = AwsSessionCredentials.create("I am AWSAccessKeyId", "I am AWSSecretKey", "I am AWSSessionToken");
+        when(credentialsProvider.resolveCredentials()).thenReturn(credentials);
 
         final AtomicReference<HttpRequest> httpRequest = new AtomicReference<>();
         final Cluster cluster = TestClientFactory.build()


### PR DESCRIPTION
Updated SigV4 interceptor to use the latest version of software.amazon.awssdk and removed old dependency on aws-java-sdk-core. Since latest version of SignedRequest has headers that support multiple values for the same header via Map<String,List> I added validation checks that the expected signed headers only have 1 value.