### PR TITLE
Changed structure feature test parameter name

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
@@ -392,7 +392,7 @@ public class PropertyTest {
             uniformIntegerList.add(300);
         }
 
-        @Parameterized.Parameters(name = "supports{0}({1})")
+        @Parameterized.Parameters(name = "supports{0}")
         public static Iterable<Object[]> data() {
             return Arrays.asList(new Object[][]{
                     {PropertyFeatures.FEATURE_BOOLEAN_VALUES, true},

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VariablesTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VariablesTest.java
@@ -232,7 +232,7 @@ public class VariablesTest {
         }
 
 
-        @Parameterized.Parameters(name = "supports{0}({1})")
+        @Parameterized.Parameters(name = "supports{0}")
         public static Iterable<Object[]> data() {
             return Arrays.asList(new Object[][]{
                     {Graph.Features.VariableFeatures.FEATURE_BOOLEAN_VALUES, true},


### PR DESCRIPTION
Removed the second variable in the parameter name since it made it so that the tests couldn't be opted out of.

For example, they would require one specify `specific = supportsIntegerArrayValues([I@1d2b8249)`.