### PR TITLE
Avoid the issue of connections not being released.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -84,6 +84,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Use `TraversalStrategyProxy` in Java, or `TraversalStrategy` in Python to pass custom strategies in traversals
 * Removed `minSize` setting for Gremlin Driver connection pool since connections are now short-lived HTTP connections
 * Added `idleConnectionTimeout` setting for Gremlin Driver and automatic closing of idle connections
+* Enable TCP Keep-Alive in GremlinServer.
 
 == TinkerPop 3.7.0 (Gremfir Master of the Pan Flute)
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -146,6 +146,11 @@ public class GremlinServer {
             b.childOption(ChannelOption.WRITE_BUFFER_WATER_MARK,
                     new WriteBufferWaterMark(settings.writeBufferLowWaterMark, settings.writeBufferHighWaterMark));
             b.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+            // Enable TCP Keep-Alive to detect if the remote peer is still reachable.
+            // Keep-Alive sends periodic probes to check if the remote peer is still active.
+            // If the remote peer is unreachable, the connection will be closed, preventing
+            // resource leaks and avoiding the maintenance of stale connections.
+            b.childOption(ChannelOption.SO_KEEPALIVE, true);
 
             // fire off any lifecycle scripts that were provided by the user. hooks get initialized during
             // ServerGremlinExecutor initialization


### PR DESCRIPTION
Enable TCP Keep-Alive to detect if the remote peer is still reachable. Keep-Alive sends periodic probes to check if the remote peer is still active. If the remote peer is unreachable, the connection will be closed, preventing resource leaks and avoiding the maintenance of stale connections.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.4 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->