### PR TITLE
Add unexpected-response handler to gremlin-javascript connection websocket

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -84,6 +84,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Use `TraversalStrategyProxy` in Java, or `TraversalStrategy` in Python to pass custom strategies in traversals
 * Removed `minSize` setting for Gremlin Driver connection pool since connections are now short-lived HTTP connections
 * Added `idleConnectionTimeout` setting for Gremlin Driver and automatic closing of idle connections
+* Added `unexpected-response` handler to `ws` for `gremlin-javascript`
 
 == TinkerPop 3.7.0 (Gremfir Master of the Pan Flute)
 


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.4 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->
This PR helps provide more information to the end user when a websocket `unexpected-response` is encountered. This is particularly helpful for using AWS Neptune, which sometimes encounters an "unexpected-response" status code, with a body describing the issue.