### PR TITLE
Add unexpected-response handler to gremlin-javascript connection websocket

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Add log entry in `WsAndHttpChannelizerHandler`.
 * Changed `IdentityRemovalStrategy` to omit `IdentityStep` if only with `RepeatEndStep` under `RepeatStep`.
 * Changed Gremlin grammar to make use of `g` to spawn child traversals a syntax error.
+* Added `unexpected-response` handler to `ws` for `gremlin-javascript`
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -260,7 +260,8 @@ class Connection extends EventEmitter {
       });
       res.on('error', reject);
     });
-    const errorMessage = `Unexpected server response code ${res.statusCode} with body:\n${body.toString()}`;
+    const statusCodeErrorMessage = `Unexpected server response code ${res.statusCode}`;
+    const errorMessage = body ? `${statusCodeErrorMessage} with body:\n${body.toString()}` : statusCodeErrorMessage;
     const error = new Error(errorMessage);
     this.#handleError({
       error,

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -256,7 +256,7 @@ class Connection extends EventEmitter {
         chunks.push(data instanceof Buffer ? data : Buffer.from(data));
       });
       res.on('end', () => {
-        resolve(Buffer.concat(chunks));
+        resolve(chunks.length ? Buffer.concat(chunks) : null);
       });
       res.on('error', reject);
     });

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -147,7 +147,7 @@ class Connection extends EventEmitter {
 
     this._ws.addEventListener('open', this.#handleOpen);
     this._ws.addEventListener('error', this.#handleError);
-    this._ws.addEventListener('unexpected-response', this.#handleUnexpectedResponse);
+    this._ws.on('unexpected-response', this.#handleUnexpectedResponse);
     this._ws.addEventListener('message', this.#handleMessage);
     this._ws.addEventListener('close', this.#handleClose);
 
@@ -398,7 +398,7 @@ class Connection extends EventEmitter {
     });
     this._ws.removeEventListener('open', this.#handleOpen);
     this._ws.removeEventListener('error', this.#handleError);
-    this._ws.removeEventListener('unexpected-response', this.#handleUnexpectedResponse);
+    this._ws.off('unexpected-response', this.#handleUnexpectedResponse);
     this._ws.removeEventListener('message', this.#handleMessage);
     this._ws.removeEventListener('close', this.#handleClose);
     this._openPromise = null;

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -252,7 +252,7 @@ class Connection extends EventEmitter {
   #handleUnexpectedResponse = async (_req, res) => {
     const body = await new Promise((resolve, reject) => {
       const chunks = [];
-      res.on('data', data => {
+      res.on('data', (data) => {
         chunks.push(data instanceof Buffer ? data : Buffer.from(data));
       });
       res.on('end', () => {
@@ -266,7 +266,7 @@ class Connection extends EventEmitter {
       error,
       message: errorMessage,
       type: 'unexpected-response',
-      target: this._ws
+      target: this._ws,
     });
   };
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
@@ -21,7 +21,6 @@
 
 const assert = require('assert');
 const AssertionError = require('assert');
-const http = require('http');
 const { traversal } = require('../../lib/process/anonymous-traversal');
 const Bytecode = require('../../lib/process/bytecode');
 const helper = require('../helper');
@@ -78,30 +77,6 @@ describe('DriverRemoteConnection', function () {
           .catch(function (err) {
             assert.ok(err);
             assert.ok(err.message.indexOf('401') > 0);
-          });
-      });
-
-      it('should handle unexpected response errors', async function () {
-        const testServerPort = 45944;
-        const testServerStatusCode = 500;
-        const testServerResponseBody = 'Throttled';
-        const server = http.createServer(function(_req, res) {
-          res.statusCode = testServerStatusCode;
-          res.end(testServerResponseBody);
-        });
-        await new Promise((resolve) => server.listen(testServerPort, resolve));
-        connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/gremlin`);
-        return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
-          .then(function() {
-            assert.fail("invalid status codes should throw");
-          })
-          .catch(function (err) {
-            assert.ok(err);
-            assert.ok(err.message.indexOf(testServerStatusCode) > 0);
-            assert.ok(err.message.indexOf(testServerResponseBody) > 0);
-          })
-          .finally(function() {
-            server.close();
           });
       });
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
@@ -21,6 +21,7 @@
 
 const assert = require('assert');
 const AssertionError = require('assert');
+const http = require('http');
 const { traversal } = require('../../lib/process/anonymous-traversal');
 const Bytecode = require('../../lib/process/bytecode');
 const helper = require('../helper');
@@ -77,6 +78,30 @@ describe('DriverRemoteConnection', function () {
           .catch(function (err) {
             assert.ok(err);
             assert.ok(err.message.indexOf('401') > 0);
+          });
+      });
+
+      it('should handle unexpected response errors', async function () {
+        const testServerPort = 45944;
+        const testServerStatusCode = 500;
+        const testServerResponseBody = 'Throttled';
+        const server = http.createServer(function(_req, res) {
+          res.statusCode = testServerStatusCode;
+          res.end(testServerResponseBody);
+        });
+        await new Promise((resolve) => server.listen(testServerPort, resolve));
+        connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/gremlin`);
+        return connection.submit(new Bytecode().addStep('V', []).addStep('tail', []))
+          .then(function() {
+            assert.fail("invalid status codes should throw");
+          })
+          .catch(function (err) {
+            assert.ok(err);
+            assert.ok(err.message.indexOf(testServerStatusCode) > 0);
+            assert.ok(err.message.indexOf(testServerResponseBody) > 0);
+          })
+          .finally(function() {
+            server.close();
           });
       });
 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/socket-connection-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/socket-connection-tests.js
@@ -1,0 +1,77 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+/**
+ * @author Kyle Boyer
+ */
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const url = require('url');
+const helper = require('../helper');
+
+const testServerPort = 45944;
+const testServer401ResponseBody = 'Invalid credentials provided';
+
+describe('Connection', function () {
+    const server = http.createServer(function(req, res) {
+        const parsedUrl = url.parse(req.url, true);
+        const pathname = parsedUrl.pathname;
+        if(pathname === '/401'){
+            res.statusCode = 401;
+            return res.end(testServer401ResponseBody);
+        }
+        res.statusCode = 404;
+        res.end();
+    });
+  before(function () {
+    return new Promise((resolve) => server.listen(testServerPort, resolve));
+  });
+  after(function () {
+    return server.close();
+  });
+
+  describe('#open()', function () {
+    it('should handle unexpected response errors with body', function () {
+      const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/401`);
+      return connection.open()
+        .then(function() {
+            assert.fail("invalid status codes should throw");
+        })
+        .catch(function (err) {
+            assert.ok(err);
+            assert.ok(err.message.indexOf(401) > 0);
+            assert.ok(err.message.indexOf(testServer401ResponseBody) > 0);
+        })
+    });
+    it('should handle unexpected response errors with no body', function () {
+      const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/404`);
+      return connection.open()
+        .then(function() {
+            assert.fail("invalid status codes should throw");
+        })
+        .catch(function (err) {
+            assert.ok(err);
+            assert.ok(err.message.indexOf(404) > 0);
+            assert.ok(err.message.indexOf('body') < 0);
+        })
+    });
+  });
+});

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/socket-connection-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/socket-connection-tests.js
@@ -31,16 +31,16 @@ const testServerPort = 45944;
 const testServer401ResponseBody = 'Invalid credentials provided';
 
 describe('Connection', function () {
-    const server = http.createServer(function(req, res) {
-        const parsedUrl = url.parse(req.url, true);
-        const pathname = parsedUrl.pathname;
-        if(pathname === '/401'){
-            res.statusCode = 401;
-            return res.end(testServer401ResponseBody);
-        }
-        res.statusCode = 404;
-        res.end();
-    });
+  const server = http.createServer(function (req, res) {
+    const parsedUrl = url.parse(req.url, true);
+    const pathname = parsedUrl.pathname;
+    if (pathname === '/401') {
+      res.statusCode = 401;
+      return res.end(testServer401ResponseBody);
+    }
+    res.statusCode = 404;
+    res.end();
+  });
   before(function () {
     return new Promise((resolve) => server.listen(testServerPort, resolve));
   });
@@ -51,27 +51,29 @@ describe('Connection', function () {
   describe('#open()', function () {
     it('should handle unexpected response errors with body', function () {
       const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/401`);
-      return connection.open()
-        .then(function() {
-            assert.fail("invalid status codes should throw");
+      return connection
+        .open()
+        .then(function () {
+          assert.fail('invalid status codes should throw');
         })
         .catch(function (err) {
-            assert.ok(err);
-            assert.ok(err.message.indexOf(401) > 0);
-            assert.ok(err.message.indexOf(testServer401ResponseBody) > 0);
-        })
+          assert.ok(err);
+          assert.ok(err.message.indexOf(401) > 0);
+          assert.ok(err.message.indexOf(testServer401ResponseBody) > 0);
+        });
     });
     it('should handle unexpected response errors with no body', function () {
       const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/404`);
-      return connection.open()
-        .then(function() {
-            assert.fail("invalid status codes should throw");
+      return connection
+        .open()
+        .then(function () {
+          assert.fail('invalid status codes should throw');
         })
         .catch(function (err) {
-            assert.ok(err);
-            assert.ok(err.message.indexOf(404) > 0);
-            assert.ok(err.message.indexOf('body') < 0);
-        })
+          assert.ok(err);
+          assert.ok(err.message.indexOf(404) > 0);
+          assert.ok(err.message.indexOf('body') < 0);
+        });
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.4 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->
This PR helps provide more information to the end user when a websocket unexpected-response is encountered. This is particularly helpful for using AWS Neptune, which sometimes encounters an "unexpected-response" status code, with a body describing the issue.

This is the same PR as https://github.com/apache/tinkerpop/pull/2935 just targeting the correct base branch.