### PR TITLE
Fix Flaky Tests in /gremlin-core

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -161,7 +161,7 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
     }
 
     public Map<String, Traversal.Admin<Object, E>> getByTraversals() {
-        final Map<String, Traversal.Admin<Object, E>> map = new HashMap<>();
+        final Map<String, Traversal.Admin<Object, E>> map = new LinkedHashMap<>();
         this.traversalRing.reset();
         for (final String as : this.selectKeys) {
             map.put(as, this.traversalRing.next());

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -53,7 +53,7 @@ public class ConjoinStepTest extends StepTest {
         assertEquals("5.5,8.0,10.1", __.__(new double[] {5.5, 8.0, 10.1}).conjoin(",").next());
         assertNull(__.__(Arrays.asList(null, null)).conjoin(",").next());
 
-        final Set<Integer> set = new HashSet<>();
+        final Set<Integer> set = new LinkedHashSet<>();
         set.add(10); set.add(11); set.add(12);
         assertEquals("10.11.12", __.__(set).conjoin(".").next());
     }


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.4 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->

## Fix 1
`org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest.testReturnTypes` was found to be flaky using nondex:
```
[ERROR]   ConjoinStepTest.testReturnTypes:58 expected:<1[0.11.12]> but was:<1[1.12.10]>
```
This flakiness can be reproduced with command:
```
mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest#testReturnTypes -Drat.skip=true
```
The test was flaky due to the use of an unordered collection (`HashSet`), that caused assertion failures under different iteration orders. This PR fixed this flakiness by replacing the `HashSet` with `LinkedHashSet`

## Fix 2
`org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategyTest` was wound to be flaky for four sets of parameters:
```
[ERROR]   PathProcessorStrategyTest.doTest:84 __.select(Pop.first,"a","b").by("name").by("age") expected:<[SelectOneStep(first,b,null), TraversalMapStep(value(age))@[b], SelectOneStep(first,a,null), TraversalMapStep(value(name))@[a], SelectStep(last,[a, b])]> but was:<[SelectOneStep(first,a,null), TraversalMapStep(value(name))@[a], SelectOneStep(first,b,null), TraversalMapStep(value(age))@[b], SelectStep(last,[b, a])]>
[ERROR]   PathProcessorStrategyTest.doTest:84 __.select("a","b","c").by("name").by(__.outE().count()) expected:<[SelectOneStep(last,c,null), TraversalMapStep(value(name))@[c], SelectOneStep(last,b,null), TraversalMapStep([VertexStep(OUT,edge), CountGlobalStep])@[b], SelectOneStep(last,a,null), TraversalMapStep(value(name))@[a], SelectStep(last,[a, b, c])]> but was:<[SelectOneStep(last,a,null), TraversalMapStep(value(name))@[a], SelectOneStep(last,c,null), TraversalMapStep(value(name))@[c], SelectOneStep(last,b,null), TraversalMapStep([VertexStep(OUT,edge), CountGlobalStep])@[b], SelectStep(last,[b, c, a])]>
[ERROR]   PathProcessorStrategyTest.doTest:84 __.select("a","b").by().by("age") expected:<[SelectOneStep(last,b,null), TraversalMapStep(value(age))@[b], SelectOneStep(last,a,null), TraversalMapStep(identity)@[a], SelectStep(last,[a, b])]> but was:<[SelectOneStep(last,a,null), TraversalMapStep(identity)@[a], SelectOneStep(last,b,null), TraversalMapStep(value(age))@[b], SelectStep(last,[b, a])]>
[ERROR] org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategyTest.doTest[[SelectStep(last,[a, b],[value(name), value(age)])]](org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategyTest)
[ERROR]   Run 1: PathProcessorStrategyTest.doTest:84 __.select("a","b").by("name").by("age") expected:<[SelectOneStep(last,b,null), TraversalMapStep(value(age))@[b], SelectOneStep(last,a,null), TraversalMapStep(value(name))@[a], SelectStep(last,[a, b])]> but was:<[SelectOneStep(last,a,null), TraversalMapStep(value(name))@[a], SelectOneStep(last,b,null), TraversalMapStep(value(age))@[b], SelectStep(last,[b, a])]>
[ERROR]   Run 2: PathProcessorStrategyTest.doTest:84 __.select(Pop.last,"a","b").by("name").by("age") expected:<[SelectOneStep(last,b,null), TraversalMapStep(value(age))@[b], SelectOneStep(last,a,null), TraversalMapStep(value(name))@[a], SelectStep(last,[a, b])]> but was:<[SelectOneStep(last,a,null), TraversalMapStep(value(name))@[a], SelectOneStep(last,b,null), TraversalMapStep(value(age))@[b], SelectStep(last,[b, a])]>
```
The flakiness can be reproduced with command:
```
mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.PathProcessorStrategyTest  -DnondexMode=ONE -Drat.skip=true
```
The cause of this flakiness is that when processing `select("a","b").by(...).by(...)`, the order of keys is not guaranteed due to use of `HashMap` in `selectStep.getByTraversals()`, resulting in assertion failures non-deterministically. This PR fixed this flakiness by replacing the `HashMap` with `LinkedHashMap`.
