### PR TITLE
Use `ws` WebSocket when options are provided

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/socket-connection-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/socket-connection-tests.js
@@ -49,7 +49,49 @@ describe('Connection', function () {
   });
 
   describe('#open()', function () {
+    it('should use the ws WebSocket when ws specific options are provided', function () {
+        let globalWebsocketCalls = 0;
+        globalThis.WebSocket = function (){
+            globalWebsocketCalls++;
+        }
+        const domUnsupportedOptions = [
+            'headers',
+            'ca',
+            'cert',
+            'pfx',
+            'rejectUnauthorized',
+            'agent',
+            'perMessageDeflate',
+        ];
+        const allOptionTests = domUnsupportedOptions.map(wsOption => {
+            const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/401`, {
+                [wsOption]: 'this option is set'
+            });
+            return connection.open()
+        });
+        Promise.allSettled(allOptionTests).then(function() {
+          if(globalWebsocketCalls != domUnsupportedOptions.length){
+            assert.fail('global WebSocket should be used when no ws specific options are provided');
+          }
+        })
+    });
+    it('should use the global WebSocket when options are not provided', function () {
+        let globalWebsocketCalls = 0;
+        globalThis.WebSocket = function (){
+            globalWebsocketCalls++;
+        }
+        const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/401`);
+        return connection
+        .open()
+        .catch(() => {})
+        .finally(function () {
+          if(globalWebsocketCalls <= 0){
+            assert.fail('global WebSocket should be used when no ws specific options are provided');
+          }
+        });
+    });
     it('should handle unexpected response errors with body', function () {
+      globalThis.WebSocket = http.WebSocket;
       const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/401`);
       return connection
         .open()
@@ -63,6 +105,7 @@ describe('Connection', function () {
         });
     });
     it('should handle unexpected response errors with no body', function () {
+      globalThis.WebSocket = undefined;
       const connection = helper.getDriverRemoteConnection(`ws://localhost:${testServerPort}/404`);
       return connection
         .open()


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.4 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->

The current 3.7-dev implementation does not pass `headers` to the WebSocket when utilizing the `globalThis.WebSocket`. This causes issues when initially upgrading to this version of gremlin (or upgrading to Node 22 when the global WebSocket class was enabled by default). This PR ensures that we use the `ws` WebSocket implementation if `ws` specific options are passed along.