### PR TITLE
Use .on and .off for unexpected-response listener

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.ts
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.ts
@@ -199,8 +199,10 @@ export default class Connection extends EventEmitter {
     this._ws!.addEventListener('open', this.#handleOpen);
     // @ts-expect-error
     this._ws!.addEventListener('error', this.#handleError);
+    // The following listener needs to use `.on` and `.off` because the `ws` package's addEventListener only accepts certain event types
+    // Ref: https://github.com/websockets/ws/blob/8.16.0/lib/event-target.js#L202-L241
     // @ts-expect-error
-    this._ws!.addEventListener('unexpected-response', this.#handleUnexpectedResponse);
+    this._ws!.on('unexpected-response', this.#handleUnexpectedResponse);
     // @ts-expect-error
     this._ws!.addEventListener('message', this.#handleMessage);
     // @ts-expect-error
@@ -446,8 +448,10 @@ export default class Connection extends EventEmitter {
     this._ws?.removeEventListener('open', this.#handleOpen);
     // @ts-expect-error
     this._ws?.removeEventListener('error', this.#handleError);
+    // The following listener needs to use `.on` and `.off` because the `ws` package's addEventListener only accepts certain event types
+    // Ref: https://github.com/websockets/ws/blob/8.16.0/lib/event-target.js#L202-L241
     // @ts-expect-error
-    this._ws?.removeEventListener('unexpected-response', this.#handleUnexpectedResponse);
+    this._ws?.off('unexpected-response', this.#handleUnexpectedResponse);
     // @ts-expect-error
     this._ws?.removeEventListener('message', this.#handleMessage);
     // @ts-expect-error

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.ts
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.ts
@@ -317,12 +317,14 @@ export default class Connection extends EventEmitter {
         chunks.push(data instanceof Buffer ? data : Buffer.from(data));
       });
       res.on('end', () => {
-        resolve(Buffer.concat(chunks));
+        resolve(chunks.length ? Buffer.concat(chunks) : null);
       });
       res.on('error', reject);
     });
     // @ts-ignore
-    const errorMessage = `Unexpected server response code ${res.statusCode} with body:\n${body.toString()}`;
+    const statusCodeErrorMessage = `Unexpected server response code ${res.statusCode}`;
+    // @ts-ignore
+    const errorMessage = body ? `${statusCodeErrorMessage} with body:\n${body.toString()}` : statusCodeErrorMessage;
     const error = new Error(errorMessage);
     this.#handleError({
       error,


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.4 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->

The `unexpected-response` listener needs to use `.on` and `.off` because the `ws` package's `addEventListener` only accepts certain event types
Ref: https://github.com/websockets/ws/blob/8.16.0/lib/event-target.js#L202-L241

Additionally PR #2936 had slightly different logic for the body chunk return, so I have updated that here too.