### PR TITLE
Change server response to 400 for malformed queries

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.TimedInterruptTimeoutException;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
+import org.apache.tinkerpop.gremlin.language.grammar.GremlinParserException;
 import org.apache.tinkerpop.gremlin.process.traversal.Failure;
 import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
@@ -294,6 +295,9 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
             final GremlinError error = GremlinError.longRequest(requestMessage);
             logger.warn(error.getMessage());
             return error;
+        }
+        if (t instanceof GremlinParserException) {
+            return GremlinError.parsing(requestMessage.getGremlin());
         }
 
         logger.warn(String.format("Exception processing request [%s].", requestMessage));

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -297,7 +297,7 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
             return error;
         }
         if (t instanceof GremlinParserException) {
-            return GremlinError.parsing(requestMessage.getGremlin());
+            return GremlinError.parsing((GremlinParserException) t);
         }
 
         logger.warn(String.format("Exception processing request [%s].", requestMessage));

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
@@ -87,7 +87,7 @@ public class GremlinError {
     }
 
     public static GremlinError parsing(final String script) {
-        final String message = String.format("Failed to parse malformed script [%s]",  script);
+        final String message = String.format("Failed to interpret Gremlin query [%s]",  script);
         return new GremlinError(HttpResponseStatus.BAD_REQUEST, message, "MalformedQueryException");
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
@@ -86,6 +86,11 @@ public class GremlinError {
         return new GremlinError(HttpResponseStatus.BAD_REQUEST, message, "InvalidRequestException");
     }
 
+    public static GremlinError parsing(final String script) {
+        final String message = String.format("Failed to parse malformed script [%s]",  script);
+        return new GremlinError(HttpResponseStatus.BAD_REQUEST, message, "MalformedQueryException");
+    }
+
     // execution errors
     public static GremlinError timeout(final RequestMessage requestMessage ) {
         final String message = String.format("A timeout occurred during traversal evaluation of [%s] - consider increasing the limit given to evaluationTimeout",

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.server.util;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.tinkerpop.gremlin.language.grammar.GremlinParserException;
 import org.apache.tinkerpop.gremlin.process.traversal.Failure;
 import org.apache.tinkerpop.gremlin.util.ExceptionHelper;
 import org.apache.tinkerpop.gremlin.util.Tokens;
@@ -86,8 +87,8 @@ public class GremlinError {
         return new GremlinError(HttpResponseStatus.BAD_REQUEST, message, "InvalidRequestException");
     }
 
-    public static GremlinError parsing(final String script) {
-        final String message = String.format("Failed to interpret Gremlin query [%s]",  script);
+    public static GremlinError parsing(final GremlinParserException error) {
+        final String message = String.format(error.getMessage());
         return new GremlinError(HttpResponseStatus.BAD_REQUEST, message, "MalformedQueryException");
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
@@ -88,8 +88,7 @@ public class GremlinError {
     }
 
     public static GremlinError parsing(final GremlinParserException error) {
-        final String message = String.format(error.getMessage());
-        return new GremlinError(HttpResponseStatus.BAD_REQUEST, message, "MalformedQueryException");
+        return new GremlinError(HttpResponseStatus.BAD_REQUEST, error.getMessage(), "MalformedQueryException");
     }
 
     // execution errors

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -874,7 +874,6 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         try (SimpleClient client = TestClientFactory.createSimpleHttpClient()) {
             final RequestMessage request = RequestMessage
                     .build("g.inject(1, 2, g.V())")
-                    .addLanguage("gremlin-groovy")
                     .create();
             final List<ResponseMessage> responses = client.submit(request);
             assertEquals(HttpResponseStatus.BAD_REQUEST, responses.get(0).getStatus().getCode());

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -870,6 +870,22 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
+    public void shouldFailWithMalformedQuery() throws Exception {
+        try (SimpleClient client = TestClientFactory.createSimpleHttpClient()) {
+            final RequestMessage request = RequestMessage
+                    .build("g.inject(1, 2, g.V())")
+                    .addLanguage("gremlin-groovy")
+                    .create();
+            final List<ResponseMessage> responses = client.submit(request);
+            assertEquals(HttpResponseStatus.BAD_REQUEST, responses.get(0).getStatus().getCode());
+            assertEquals("MalformedQueryException", responses.get(0).getStatus().getException());
+            for (ResponseMessage resp : responses.subList(1, responses.size())) {
+                assertEquals(0, resp.getResult().getData().size());
+            }
+        }
+    }
+
+    @Test
     @Ignore("Lambda is not supported")
     public void shouldSupportLambdasUsingWithRemote() throws Exception {
         final GraphTraversalSource g = traversal().withRemote(conf);


### PR DESCRIPTION
Alters the servers response to bad queries from `500 Internal Server Error` to `400 Bad Request`. Note that malformed groovy scripts may still produce `500 Internal Server Error` as groovy is unable to statically verify correct gremlin syntax.

VOTE +1