### PR TITLE
Fix Bug in TinkerTransactionGraph transaction used counts

### DIFF
--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
@@ -197,7 +197,7 @@ final class TinkerElementContainer<T extends TinkerElement> {
                 element.removed = true;
             element = null;
             isDeleted = true;
-        } else {
+        } else if (isModifiedInTx.get()){
             element = transactionUpdatedValue.get();
             element.currentVersion = txVersion;
         }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransaction.java
@@ -203,7 +203,7 @@ final class TinkerTransaction extends AbstractThreadLocalTransaction {
 
             final Set<TinkerElementContainer> readElements = txReadElements.get();
             if (readElements != null)
-                readElements.stream().forEach(e -> e.reset());
+                readElements.stream().forEach(e -> e.commit(txVersion));
 
             txChangedVertices.remove();
             txChangedEdges.remove();

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraphTest.java
@@ -1457,4 +1457,24 @@ public class TinkerTransactionGraphTest {
 
         countElementsInNewThreadTx(g, 1, 0);
     }
+
+    @Test
+    public void shouldHandleSequenceOfCreateReadDeleteCreateSameVertex() {
+        final TinkerTransactionGraph graph = TinkerTransactionGraph.open();
+        final GraphTraversalSource g = graph.traversal();
+
+        g.addV().property(T.id, 1).next();
+        graph.tx().commit();
+        g.V().next();
+        graph.tx().commit();
+        g.V().drop().iterate();
+        graph.tx().commit();
+
+        assertEquals(false, graph.hasVertex(1));
+
+        g.addV().property(T.id, 1).next();
+        graph.tx().commit();
+
+        assertEquals(true, graph.hasVertex(1));
+    }
 }


### PR DESCRIPTION
This is based on a [reported issue in discord](https://discord.com/channels/838910279550238720/1260355937604997240/1332331746418491475) where users were observing a `TransactionException` due to concurrent modification in an unexpected case. The test added in this case is a simplified reproducer for the reported issue.

The root cause of the issue is that a read only traversal will increment an elements [usedInTransactions](https://github.com/apache/tinkerpop/blob/077e3eb22c463545c3fc974944d4bf1d5d6a32fd/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java#L65) count as the read operation must call [getWithClone()](https://github.com/apache/tinkerpop/blob/077e3eb22c463545c3fc974944d4bf1d5d6a32fd/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java#L90), however in 3.7.3, the `usedInTransactions` counter is never decremented for read-only elements when the transaction is committed.

In the example used in the test in this PR, vertex 1 will have an incorrect `usedInTransactions` of 1 after the read-only transaction has been committed. This causes the subsequent "delete" query not to remove the vertex from the graph as it is still "in use". This then leads to a TransactionException due to concurrent modification when the final query attempts to create a new vertex with the same ID.