### PR TITLE
Console plugins file can't accept empty lines

### DIFF
--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -143,10 +143,16 @@ class Console {
         // if there are active plugins then initialize them in the order that they are listed
         activePlugins.each { pluginName ->
             def pluggedIn = mediator.availablePlugins[pluginName]
-            pluggedIn.activate()
 
-            if (!io.quiet)
-                io.out.println(Colorizer.render(Preferences.infoColor, "plugin activated: " + pluggedIn.getPlugin().getName()))
+            if (pluggedIn != null) {
+                pluggedIn.activate()
+
+                if (!io.quiet)
+                    io.out.println(Colorizer.render(Preferences.infoColor, "plugin activated: " + pluggedIn.getPlugin().getName()))
+            } else {
+                if (!io.quiet)
+                    io.out.println(Colorizer.render(Preferences.infoColor, "invalid plugin: " + pluginName))
+            }
         }
 
         // remove any "uninstalled" plugins from plugin state as it means they were installed, activated, but not

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
@@ -72,7 +72,7 @@ class Mediator {
 
     static def readPluginState() {
         def file = new File(ConsoleFs.PLUGIN_CONFIG_FILE)
-        return file.exists() ? file.readLines() : []
+        return file.exists() ? file.readLines().findAll {it } : []
     }
 
     def void close() {


### PR DESCRIPTION
As reported in [3.7.0 gremlin-groovy console with multi-line statements](https://groups.google.com/g/gremlin-users/c/U2gIxmRcrI8/m/WzX3eyhTAAAJ)

An empty line in the plugins.txt file will cause a NPE to occur.

Fixed by adding if else statement to check for null pluggedIn variable.
If null pluggedIn variable detected, will output invalid plugin on console.