### PR TITLE
Bumped slf4j and other logging related infrastructure.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-4-0-0]]
 === TinkerPop 4.0.0 (NOT OFFICIALLY RELEASED YET)
 
-
+* Bumped SLF4j to 2.0.16.
 
 [[release-4-0-0-beta-1]]
 === TinkerPop 4.0.0-beta.1 (January 17, 2025)

--- a/docs/src/upgrade/release-4.x.x.asciidoc
+++ b/docs/src/upgrade/release-4.x.x.asciidoc
@@ -30,6 +30,13 @@ complete list of all the modifications that are part of this release.
 
 === Upgrading for Users
 
+==== SLF4j 2.x
+
+TinkerPop has generally upgraded to SLF4j 2.x which brings with it some important changes to log initialization which
+may affect user applications that are upgrading from TinkerPop 3.x. Please see the
+[SLF4j documentation](https://www.slf4j.org/faq.html#changesInVersion200) that explains the differences and how they
+might apply.
+
 === Upgrading for Providers
 
 ==== Graph System Providers

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -39,10 +39,6 @@ limitations under the License.
             <artifactId>tinkergraph-gremlin</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
         <!-- commons-codec is a dependency of httpclient - excluded in root pom to bring all commons-codec versions inline -->
         <dependency>
             <groupId>commons-codec</groupId>
@@ -235,6 +231,13 @@ limitations under the License.
                                     <shadedPattern>io.shaded.netty</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <!-- exclude jdk21 classes for now -->
+                            <filters>
+                                <filter>
+                                    <artifact>ch.qos.logback:logback-core</artifact>
+                                    <excludes>versions/21/**</excludes>
+                                </filter>
+                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"></transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">

--- a/gremlin-console/src/main/static/LICENSE
+++ b/gremlin-console/src/main/static/LICENSE
@@ -223,8 +223,7 @@ MIT Licenses
 
 The Apache TinkerPop project bundles the following components under the MIT License:
 
-     JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
-     SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
+     SLF4J API Module (org.slf4j:slf4j-api:2.0.16 - http://www.slf4j.org) - for details, see licenses/slf4j
      Foundation stylesheet for CodeRay (http://foundation.zurb.com) - for details, see licenses/foundation
      normalize.css 2.1.2 (http://necolas.github.io/normalize.css/) - for details, see licenses/normalize
 
@@ -238,5 +237,5 @@ The Apache TinkerPop project bundles the following components under the ISC Lice
 
 The Apache TinkerPop project bundles the following components under the Eclipse Public License 1.0:
 
-     logback-core (ch.qos.logback:logback-core:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback
-     logback-classic (ch.qos.logback:logback-classic:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback
+     logback-core (ch.qos.logback:logback-core:1.3.15 - https://logback.qos.ch) - for details, see licenses/logback
+     logback-classic (ch.qos.logback:logback-classic:1.3.15 - https://logback.qos.ch) - for details, see licenses/logback

--- a/gremlin-core/pom.xml
+++ b/gremlin-core/pom.xml
@@ -40,18 +40,20 @@ limitations under the License.
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- commons-configuration2 requires beanutils because we rely on file loaders -->
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -178,9 +178,8 @@ limitations under the License.
                             <artifactSet>
                                 <!-- exclude logging stuff from uberjar - shading prevents proper logger initialization -->
                                 <excludes>
-                                    <exclude>ch.qos.logback:logback-classic</exclude>
+                                    <exclude>ch.qos.logback:*</exclude>
                                     <exclude>org.slf4j:slf4j-api</exclude>
-                                    <exclude>org.slf4j:jcl-over-slf4j</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>

--- a/gremlin-driver/src/main/static/LICENSE
+++ b/gremlin-driver/src/main/static/LICENSE
@@ -221,7 +221,7 @@ MIT Licenses
 
 The Apache TinkerPop project bundles the following components under the MIT License:
 
-     SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org)
+     SLF4J API Module (org.slf4j:slf4j-api:2.0.16 - http://www.slf4j.org)
        - shaded to org.shaded.slf4j
        - for details, see licenses/slf4j
 
@@ -231,5 +231,5 @@ Other Licenses
 
 The Apache TinkerPop project bundles the following components under the Eclipse Public License 1.0:
 
-     logback-core (ch.qos.logback:logback-core:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback
-     logback-classic (ch.qos.logback:logback-classic:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback
+     logback-core (ch.qos.logback:logback-core:1.3.15 - https://logback.qos.ch) - for details, see licenses/logback
+     logback-classic (ch.qos.logback:logback-classic:1.3.15 - https://logback.qos.ch) - for details, see licenses/logback

--- a/gremlin-server/src/main/static/LICENSE
+++ b/gremlin-server/src/main/static/LICENSE
@@ -223,8 +223,7 @@ MIT Licenses
 
 The Apache TinkerPop project bundles the following components under the MIT License:
 
-     JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
-     SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org) - for details, see licenses/slf4j
+     SLF4J API Module (org.slf4j:slf4j-api:2.0.16 - http://www.slf4j.org) - for details, see licenses/slf4j
      Foundation stylesheet for CodeRay (http://foundation.zurb.com) - for details, see licenses/foundation
      normalize.css 2.1.2 (http://necolas.github.io/normalize.css/) - for details, see licenses/normalize
 
@@ -238,5 +237,5 @@ The Apache TinkerPop project bundles the following components under the ISC Lice
 
 The Apache TinkerPop project bundles the following components under the Eclipse Public License 1.0:
 
-     logback-core (ch.qos.logback:logback-core:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback
-     logback-classic (ch.qos.logback:logback-classic:1.2.3 - https://logback.qos.ch) - for details, see licenses/logback
+     logback-core (ch.qos.logback:logback-core:1.3.15 - https://logback.qos.ch) - for details, see licenses/logback
+     logback-classic (ch.qos.logback:logback-classic:1.3.15 - https://logback.qos.ch) - for details, see licenses/logback

--- a/gremlin-tools/gremlin-socket-server/pom.xml
+++ b/gremlin-tools/gremlin-socket-server/pom.xml
@@ -33,10 +33,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>

--- a/gremlin-util/pom.xml
+++ b/gremlin-util/pom.xml
@@ -28,10 +28,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
         <!-- TEST -->
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>

--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -64,6 +64,14 @@ limitations under the License.
                     <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.nimbusds</groupId>
                     <artifactId>nimbus-jose-jwt</artifactId>
                 </exclusion>
@@ -139,6 +147,11 @@ limitations under the License.
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>27.0-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.3.4</version>
         </dependency>
         <!-- use jackson 2.13.5 to fit better with spark where Scala module 2.13.4 requires Jackson Databind version >= 2.13.0 and < 2.14.0 -->
         <dependency>

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopConfiguration.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopConfiguration.java
@@ -46,6 +46,11 @@ public final class HadoopConfiguration extends AbstractConfiguration implements 
     }
 
     @Override
+    protected boolean containsValueInternal(final Object o) {
+        return properties.containsValue(o);
+    }
+
+    @Override
     protected Iterator<String> getKeysInternal() {
         return properties.keySet().iterator();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -153,10 +153,10 @@ limitations under the License.
         <antlr4.version>4.9.1</antlr4.version>
         <caffeine.version>2.3.1</caffeine.version>
         <commons.collections.version>4.4</commons.collections.version>
-        <commons.configuration.version>2.9.0</commons.configuration.version>
+        <commons.configuration.version>2.11.0</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.io.version>2.8.0</commons.io.version>
-        <commons.lang3.version>3.12.0</commons.lang3.version>
+        <commons.lang3.version>3.17.0</commons.lang3.version>
         <commons.text.version>1.10.0</commons.text.version>
         <cucumber.version>6.11.0</cucumber.version>
         <exp4j.version>0.4.8</exp4j.version>
@@ -170,11 +170,11 @@ limitations under the License.
         <jbcrypt.version>0.4</jbcrypt.version>
         <junit.version>4.13.1</junit.version>
         <kerby.version>2.0.3</kerby.version>
-        <logback.version>1.2.13</logback.version>
+        <logback.version>1.3.15</logback.version>
         <metrics.version>3.0.2</metrics.version>
         <mockito.version>3.10.0</mockito.version>
         <netty.version>4.1.101.Final</netty.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spark.version>3.5.4</spark.version>
         <awssdk.version>2.29.3</awssdk.version>
@@ -622,6 +622,7 @@ limitations under the License.
                         <argLine>
                             -Dlogback.configuration=${logback-test.properties}
                             -Dlog4j.configuration=${log4j-test.properties}
+                            -Dslf4j.provider=ch.qos.logback.classic.spi.LogbackServiceProvider
                             -Dbuild.dir=${project.build.directory}
                             -Dis.testing=true -Djava.net.preferIPv4Stack=true ${suresafeArgs}
                             ${jdk17JvmArgs}
@@ -650,6 +651,7 @@ limitations under the License.
                                 <argLine>
                                     -Dlogback.configuration=${logback-test.properties}
                                     -Dlog4j.configuration=${log4j-test.properties}
+                                    -Dslf4j.provider=ch.qos.logback.classic.spi.LogbackServiceProvider
                                     -Dhost=localhost -Dport=8182
                                     -Dbuild.dir=${project.build.directory} -Dis.testing=true
                                     -Djava.net.preferIPv4Stack=true ${suresafeArgs}
@@ -707,7 +709,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
                     </configuration>
@@ -887,11 +889,6 @@ limitations under the License.
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
@@ -1973,6 +1970,7 @@ limitations under the License.
                             <argLine>
                                 -Dlogback.configuration=${logback-silent.properties}
                                 -Dlog4j.configuration=${log4j-silent.properties}
+                                -Dslf4j.provider=ch.qos.logback.classic.spi.LogbackServiceProvider
                                 -Dbuild.dir=${project.build.directory} -Dis.testing=true
                                 -Djava.net.preferIPv4Stack=true ${suresafeArgs}
                                 ${jdk17JvmArgs}
@@ -2081,6 +2079,7 @@ limitations under the License.
                         <configuration>
                             <argLine>@{surefireArgLine} -Dlogback.configuration=${logback-test.properties}
                                 -Dlog4j.configuration=${log4j-test.properties}
+                                -Dslf4j.provider=ch.qos.logback.classic.spi.LogbackServiceProvider
                                 -Dbuild.dir=${project.build.directory} -Dis.testing=true ${suresafeArgs}
                                 -Djava.net.preferIPv4Stack=true
                             </argLine>
@@ -2092,6 +2091,7 @@ limitations under the License.
                         <configuration>
                             <argLine>@{failsafeArgLine} -Dlogback.configuration=${logback-test.properties}
                                 -Dlog4j.configuration=${log4j-test.properties} -Dhost=localhost -Dport=8182
+                                -Dslf4j.provider=ch.qos.logback.classic.spi.LogbackServiceProvider
                                 -Dbuild.dir=${project.build.directory} -Dis.testing=true ${suresafeArgs}
                                 -Djava.net.preferIPv4Stack=true
                             </argLine>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -152,10 +152,6 @@ limitations under the License.
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
                 </exclusion>
@@ -190,11 +186,6 @@ limitations under the License.
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>
                     <artifactId>snappy-java</artifactId>
-                </exclusion>
-                <!-- Excluding this log4j binding as it leads to NoSuchMethodErrors -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
                 <!-- prefer TinkerPop's netty -->
                 <exclusion>

--- a/sparql-gremlin/pom.xml
+++ b/sparql-gremlin/pom.xml
@@ -32,6 +32,12 @@ limitations under the License.
             <artifactId>apache-jena-libs</artifactId>
             <type>pom</type>
             <version>3.12.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>


### PR DESCRIPTION
Updated all logging dependencies. Required minor changes to configuration with slf4j 2.0 as static logger approach has been removed in favor of service loader. 

VOTE +1