### PR TITLE
TINKERPOP-3038: Console plugins file can't accept empty lines

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed Gremlin grammar to make use of `g` to spawn child traversals a syntax error.
 * Added `unexpected-response` handler to `ws` for `gremlin-javascript`
 * Fixed bug in `TinkerTransactionGraph` where a read-only transaction may leave elements trapped in a "zombie transaction".
+* Changed console to consider typos and empty lines in plugins.txt by skipping over or clarifying as invalid.
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,7 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed Gremlin grammar to make use of `g` to spawn child traversals a syntax error.
 * Added `unexpected-response` handler to `ws` for `gremlin-javascript`
 * Fixed bug in `TinkerTransactionGraph` where a read-only transaction may leave elements trapped in a "zombie transaction".
-* Changed console to consider typos and empty lines in plugins.txt by skipping over or clarifying as invalid.
+* Fixed issue in `gremlin-console` where it couldn't accept plugin files that included empty lines or invalid plugin names.
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -151,10 +151,15 @@ class Console {
         // if there are active plugins then initialize them in the order that they are listed
         activePlugins.each { pluginName ->
             def pluggedIn = mediator.availablePlugins[pluginName]
-            pluggedIn.activate()
 
-            if (!io.quiet)
-                io.out.println(Colorizer.render(Preferences.infoColor, "plugin activated: " + pluggedIn.getPlugin().getName()))
+            if (pluggedIn != null) {
+                pluggedIn.activate()
+
+                if (!io.quiet)
+                    io.out.println(Colorizer.render(Preferences.infoColor, "plugin activated: " + pluggedIn.getPlugin().getName()))
+            } else if (!io.quiet) {
+                    io.out.println(Colorizer.render(Preferences.infoColor, "invalid plugin: " + pluginName))
+            }
         }
 
         // remove any "uninstalled" plugins from plugin state as it means they were installed, activated, but not

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
@@ -22,6 +22,8 @@ import org.apache.tinkerpop.gremlin.jsr223.console.RemoteAcceptor
 
 import java.util.concurrent.atomic.AtomicBoolean
 
+import org.apache.commons.lang3.StringUtils
+
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
@@ -104,7 +106,7 @@ class Mediator {
 
     static def readPluginState() {
         def file = new File(ConsoleFs.PLUGIN_CONFIG_FILE)
-        return file.exists() ? file.readLines() : []
+        return file.exists() ? file.readLines().findAll { StringUtils.isNotEmpty(it) } : []
     }
 
     def void close() {


### PR DESCRIPTION
TINKERPOP: https://issues.apache.org/jira/browse/TINKERPOP-3038

Added if statement in console.groovy to check for invalid plugins in plugins.txt (outputs invalid plugin and incorrect plugin name on console)
Added check to skip empty lines in plugins.txt on Mediator.groovy.