### PR TITLE
TINKERPOP-3070 Cannot run console if working directory contains spaces

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,7 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed Gremlin grammar to make use of `g` to spawn child traversals a syntax error.
 * Added `unexpected-response` handler to `ws` for `gremlin-javascript`
 * Fixed bug in `TinkerTransactionGraph` where a read-only transaction may leave elements trapped in a "zombie transaction".
-* Added quotations in 'gremlin.sh' to accept directories with spaces in the name
+* Fixed bug in `gremlin.sh` where it couldn't accept a directory name containing spaces.
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed Gremlin grammar to make use of `g` to spawn child traversals a syntax error.
 * Added `unexpected-response` handler to `ws` for `gremlin-javascript`
 * Fixed bug in `TinkerTransactionGraph` where a read-only transaction may leave elements trapped in a "zombie transaction".
+* Added quotations in 'gremlin.sh' to accept directories with spaces in the name
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/gremlin-console/src/main/bin/gremlin.sh
+++ b/gremlin-console/src/main/bin/gremlin.sh
@@ -116,4 +116,4 @@ fi
 
 # Start the JVM, execute the application, and return its exit code
 # shellcheck disable=SC2068
-exec $JAVA ${JVM_OPTS[@]} org.apache.tinkerpop.gremlin.console.Console "$@"
+exec $JAVA "${JVM_OPTS[@]}" org.apache.tinkerpop.gremlin.console.Console "$@"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3070
If the current working directory contains spaces, gremlin.sh does not handle it properly when launching the console, and the JVM will search for an incorrect main class and fail.

For example if I simply rename the standard console distribution directory to `foo bar`:

foo bar/ $ bin/gremlin.sh                                                                                                                                                                                                                                            
Error: Could not find or load main class bar
Caused by: java.lang.ClassNotFoundException: bar

Added quotations around directory path in order to ensure spaces in directory name are not considered two separate strings