### PR TITLE
[TINKERPOP-3024] Deprecate has_key_() for has_key() in python

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed issue in `gremlin-console` where it couldn't accept plugin files that included empty lines or invalid plugin names.
 * Modified grammar to make `none()` usage more consistent as a filter step where it can now be used to chain additional traversal steps and be used anonymously.
 * Added missing anonymous support for `disjunct()` in Python and Javascript.
+* Deprecated gremlin_python.process.__.has_key_ in favor of gremlin_python.process.__.has_key.
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -2585,7 +2585,7 @@ In situations where Python reserved words and global functions overlap with stan
 bits of conflicting Gremlin get an underscore appended as a suffix:
 
 *Steps* - <<all-step,all_()>>, <<and-step,and_()>>, <<any-step,any_()>>, <<as-step,as_()>>, <<filter-step,filter_()>>, <<from-step,from_()>>,
-<<has-step,has_key_>>, <<id-step,id_()>>, <<is-step,is_()>>, <<in-step,in_()>>, <<max-step,max_()>>,
+<<id-step,id_()>>, <<is-step,is_()>>, <<in-step,in_()>>, <<max-step,max_()>>,
 <<min-step,min_()>>, <<not-step,not_()>>, <<or-step,or_()>>, <<range-step,range_()>>, <<sum-step,sum_()>>,
 <<with-step,with_()>>
 

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -542,9 +542,16 @@ class GraphTraversal(Traversal):
             "gremlin_python.process.GraphTraversalSource.hasKey will be replaced by "
             "gremlin_python.process.GraphTraversalSource.has_key.",
             DeprecationWarning)
-        return self.has_key_(*args)
+        return self.has_key(*args)
 
     def has_key_(self, *args):
+        warnings.warn(
+            "gremlin_python.process.GraphTraversalSource.has_key_ will be replaced by "
+            "gremlin_python.process.GraphTraversalSource.has_key.",
+            DeprecationWarning)
+        return self.has_key(*args)
+    
+    def has_key(self, *args):
         self.bytecode.add_step("hasKey", *args)
         return self
 
@@ -1301,11 +1308,19 @@ class __(object, metaclass=MagicType):
             "gremlin_python.process.__.hasKey will be replaced by "
             "gremlin_python.process.__.has_key.",
             DeprecationWarning)
-        return cls.has_key_(*args)
+        return cls.has_key(*args)
 
     @classmethod
     def has_key_(cls, *args):
-        return cls.graph_traversal(None, None, Bytecode()).has_key_(*args)
+        warnings.warn(
+            "gremlin_python.process.__.has_key_ will be replaced by "
+            "gremlin_python.process.__.has_key.",
+            DeprecationWarning)
+        return cls.has_key(*args)
+    
+    @classmethod
+    def has_key (cls, *args):
+        return cls.graph_traversal(None, None, Bytecode()).has_key(*args)
 
     @classmethod
     def hasLabel(cls, *args):
@@ -2020,12 +2035,14 @@ def has_id(*args):
 
 
 def hasKey(*args):
-    return __.has_key_(*args)
+    return __.has_key(*args)
 
 
 def has_key_(*args):
-    return __.has_key_(*args)
+    return __.has_key(*args)
 
+def has_key(*args):
+    return __.has_key(*args)
 
 def hasLabel(*args):
     return __.has_label(*args)
@@ -2485,7 +2502,7 @@ statics.add_static('has_id', has_id)
 
 statics.add_static('hasKey', hasKey)
 
-statics.add_static('has_key', has_key_)
+statics.add_static('has_key', has_key)
 
 statics.add_static('hasLabel', hasLabel)
 


### PR DESCRIPTION
Tinkerpop: https://issues.apache.org/jira/browse/TINKERPOP-3024

has_key_() was added to python because it was reserved on Dictionary but that was removed in python 3. since TinkerPop doesn't support python 2 anymore there is little need for this difference anymore. deprecate the underscore suffixed version and add the property has_key() version.