### PR TITLE
Fix serializer_test.go for feature branch

### DIFF
--- a/gremlin-go/driver/response.go
+++ b/gremlin-go/driver/response.go
@@ -19,8 +19,6 @@ under the License.
 
 package gremlingo
 
-import "github.com/google/uuid"
-
 // responseStatus contains the status info of the response.
 type responseStatus struct {
 	code      uint32
@@ -35,7 +33,6 @@ type responseResult struct {
 
 // response represents a response from the server.
 type response struct {
-	responseID     uuid.UUID
 	responseStatus responseStatus
 	responseResult responseResult
 }

--- a/gremlin-go/driver/serializer.go
+++ b/gremlin-go/driver/serializer.go
@@ -63,6 +63,7 @@ func newGraphBinarySerializer(handler *logHandler) serializer {
 	return graphBinarySerializer{&serializer}
 }
 
+// TODO change for graph binary 4.0 version is finalized
 const versionByte byte = 0x81
 
 // serializeMessage serializes a request message into GraphBinary.
@@ -117,12 +118,7 @@ func (gs graphBinarySerializer) deserializeMessage(message []byte) (response, er
 		results = append(results, n)
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "Deserialized results : %s\n", results)
-	if len(results) == 1 {
-		// unwrap single results
-		msg.responseResult.data = results[0]
-	} else {
-		msg.responseResult.data = results
-	}
+	msg.responseResult.data = results
 	code := readUint32Safe(&message, &i)
 	msg.responseStatus.code = code
 	// TODO read status message

--- a/gremlin-go/driver/serializer_test.go
+++ b/gremlin-go/driver/serializer_test.go
@@ -20,7 +20,6 @@ under the License.
 package gremlingo
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -28,14 +27,14 @@ import (
 	"golang.org/x/text/language"
 )
 
-const mapDataOrder1 = "[32 97 112 112 108 105 99 97 116 105 111 110 47 118 110 100 46 103 114 97 112 104 98 105 110 97 114 121 45 118 49 46 48 129 65 210 226 138 32 164 74 176 179 121 216 16 222 222 55 134 0 0 0 4 101 118 97 108 0 0 0 0 0 0 0 2 3 0 0 0 0 7 103 114 101 109 108 105 110 3 0 0 0 0 13 103 46 86 40 41 46 99 111 117 110 116 40 41 3 0 0 0 0 7 97 108 105 97 115 101 115 10 0 0 0 0 1 3 0 0 0 0 1 103 3 0 0 0 0 1 103]"
-const mapDataOrder2 = "[32 97 112 112 108 105 99 97 116 105 111 110 47 118 110 100 46 103 114 97 112 104 98 105 110 97 114 121 45 118 49 46 48 129 65 210 226 138 32 164 74 176 179 121 216 16 222 222 55 134 0 0 0 4 101 118 97 108 0 0 0 0 0 0 0 2 3 0 0 0 0 7 97 108 105 97 115 101 115 10 0 0 0 0 1 3 0 0 0 0 1 103 3 0 0 0 0 1 103 3 0 0 0 0 7 103 114 101 109 108 105 110 3 0 0 0 0 13 103 46 86 40 41 46 99 111 117 110 116 40 41]"
+const mapDataOrder1 = "[129 0 0 0 2 3 0 0 0 0 8 108 97 110 103 117 97 103 101 3 0 0 0 0 12 103 114 101 109 108 105 110 45 108 97 110 103 3 0 0 0 0 1 103 3 0 0 0 0 1 103 0 0 0 13 103 46 86 40 41 46 99 111 117 110 116 40 41]"
+const mapDataOrder2 = "[129 0 0 0 2 3 0 0 0 0 1 103 3 0 0 0 0 1 103 3 0 0 0 0 8 108 97 110 103 117 97 103 101 3 0 0 0 0 12 103 114 101 109 108 105 110 45 108 97 110 103 0 0 0 13 103 46 86 40 41 46 99 111 117 110 116 40 41]"
 
 func TestSerializer(t *testing.T) {
 	t.Run("test serialized request message", func(t *testing.T) {
 		testRequest := request{
 			gremlin: "g.V().count()",
-			fields: map[string]interface{}{"aliases": map[string]interface{}{"g": "g"}},
+			fields:  map[string]interface{}{"g": "g", "language": "gremlin-lang"},
 		}
 		serializer := newGraphBinarySerializer(newLogHandler(&defaultLogger{}, Error, language.English))
 		serialized, _ := serializer.serializeMessage(&testRequest)
@@ -46,76 +45,28 @@ func TestSerializer(t *testing.T) {
 	})
 
 	t.Run("test serialized response message", func(t *testing.T) {
-		responseByteArray := []byte{129, 0, 251, 37, 42, 74, 117, 221, 71, 191, 183, 78, 86, 53, 0, 12, 132, 100, 0, 0, 0, 200, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 4, 104, 111, 115, 116, 3, 0, 0, 0, 0, 16, 47, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 54, 50, 48, 51, 53, 0, 0, 0, 0, 9, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+		// response of status code 200 with message OK and data of list of single item of integer zero
+		responseByteArray := []byte{129, 0, 1, 0, 0, 0, 0, 0, 253, 0, 0, 0, 0, 0, 200, 1, 1}
 		serializer := newGraphBinarySerializer(newLogHandler(&defaultLogger{}, Error, language.English))
 		response, err := serializer.deserializeMessage(responseByteArray)
 		assert.Nil(t, err)
-		assert.Equal(t, "fb252a4a-75dd-47bf-b74e-5635000c8464", response.responseID.String())
-		assert.Equal(t, uint16(200), response.responseStatus.code)
-		assert.Equal(t, "", response.responseStatus.message)
-		assert.Equal(t, []interface{}{int64(0)}, response.responseResult.data)
-	})
-
-	t.Run("test serialized response message w/ custom type", func(t *testing.T) {
-		RegisterCustomTypeReader("janusgraph.RelationIdentifier", exampleJanusgraphRelationIdentifierReader)
-		defer func() {
-			UnregisterCustomTypeReader("janusgraph.RelationIdentifier")
-		}()
-		responseByteArray := []byte{129, 0, 69, 222, 40, 55, 95, 62, 75, 249, 134, 133, 155, 133, 43, 151, 221, 68, 0, 0, 0, 200, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 4, 104, 111, 115, 116, 3, 0, 0, 0, 0, 18, 47, 49, 48, 46, 50, 52, 52, 46, 48, 46, 51, 51, 58, 53, 49, 52, 55, 48, 0, 0, 0, 0, 9, 0, 0, 0, 0, 1, 33, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 29, 106, 97, 110, 117, 115, 103, 114, 97, 112, 104, 46, 82, 101, 108, 97, 116, 105, 111, 110, 73, 100, 101, 110, 116, 105, 102, 105, 101, 114, 0, 0, 16, 1, 0, 0, 0, 0, 0, 0, 0, 0, 16, 240, 0, 0, 0, 0, 0, 0, 100, 21, 0, 0, 0, 0, 0, 0, 24, 30, 0, 0, 0, 0, 0, 0, 0, 32, 56}
-		serializer := newGraphBinarySerializer(newLogHandler(&defaultLogger{}, Error, language.English))
-		response, err := serializer.deserializeMessage(responseByteArray)
-		assert.Nil(t, err)
-		assert.Equal(t, "45de2837-5f3e-4bf9-8685-9b852b97dd44", response.responseID.String())
-		assert.Equal(t, uint16(200), response.responseStatus.code)
-		assert.Equal(t, "", response.responseStatus.message)
-		assert.NotNil(t, response.responseResult.data)
+		assert.Equal(t, uint32(200), response.responseStatus.code)
+		assert.Equal(t, "OK", response.responseStatus.message)
+		assert.Equal(t, []interface{}{int32(0)}, response.responseResult.data)
 	})
 }
 
 func TestSerializerFailures(t *testing.T) {
-	t.Run("test convertArgs failure", func(t *testing.T) {
+	t.Run("test serialize request fields failure", func(t *testing.T) {
+		invalid := "invalid"
 		testRequest := request{
-			// Invalid Input in fields, so should fail
-			fields: map[string]interface{}{"invalidInput": "invalidInput", "aliases": map[string]interface{}{"g": "g"}},
+			// Invalid pointer type in fields, so should fail
+			fields: map[string]interface{}{"invalidInput": &invalid, "g": "g"},
 		}
 		serializer := newGraphBinarySerializer(newLogHandler(&defaultLogger{}, Error, language.English))
 		resp, err := serializer.serializeMessage(&testRequest)
 		assert.Nil(t, resp)
 		assert.NotNil(t, err)
-		assert.True(t, isSameErrorCode(newError(err0704ConvertArgsNoSerializerError), err))
+		assert.True(t, isSameErrorCode(newError(err0407GetSerializerToWriteUnknownTypeError), err))
 	})
-
-	t.Run("test unkownCustomType failure", func(t *testing.T) {
-		responseByteArray := []byte{129, 0, 69, 222, 40, 55, 95, 62, 75, 249, 134, 133, 155, 133, 43, 151, 221, 68, 0, 0, 0, 200, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 4, 104, 111, 115, 116, 3, 0, 0, 0, 0, 18, 47, 49, 48, 46, 50, 52, 52, 46, 48, 46, 51, 51, 58, 53, 49, 52, 55, 48, 0, 0, 0, 0, 9, 0, 0, 0, 0, 1, 33, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 29, 106, 97, 110, 117, 115, 103, 114, 97, 112, 104, 46, 82, 101, 108, 97, 116, 105, 111, 110, 73, 100, 101, 110, 116, 105, 102, 105, 101, 114, 0, 0, 16, 1, 0, 0, 0, 0, 0, 0, 0, 0, 16, 240, 0, 0, 0, 0, 0, 0, 100, 21, 0, 0, 0, 0, 0, 0, 24, 30, 0, 0, 0, 0, 0, 0, 0, 32, 56}
-		serializer := newGraphBinarySerializer(newLogHandler(&defaultLogger{}, Error, language.English))
-		resp, err := serializer.deserializeMessage(responseByteArray)
-		// a partial message will still be returned
-		assert.NotNil(t, resp)
-		assert.NotNil(t, err)
-		assert.True(t, isSameErrorCode(newError(err0409GetSerializerToReadUnknownCustomTypeError), err))
-	})
-}
-
-// exampleJanusgraphRelationIdentifierReader this implementation is not complete and is used only for the purposes of testing custom readers
-func exampleJanusgraphRelationIdentifierReader(data *[]byte, i *int) (interface{}, error) {
-	const relationIdentifierType = 0x1001
-	const longMarker = 0
-
-	// expect type code
-	customDataTyp := readUint32Safe(data, i)
-	if customDataTyp != relationIdentifierType {
-		return nil, fmt.Errorf("unknown type code. got 0x%x, expected 0x%x", customDataTyp, relationIdentifierType)
-	}
-
-	// value flag, expect this to be non-nullable
-	if readByteSafe(data, i) != valueFlagNone {
-		return nil, errors.New("expected non-null value")
-	}
-
-	// outVertexId
-	if readByteSafe(data, i) == longMarker {
-		return readLongSafe(data, i), nil
-	} else {
-		return readString(data, i)
-	}
 }


### PR DESCRIPTION
Fixes for the Golang driver feature branch related to failures with the `serializer_test.go` test.
* Removed tests for custom type serialization. 
* Removed response id as it is no longer used. 
* Adjusted expected serialized request bytes according to TP4 format. 
* Adjusted bytes for testing deserialization according to TP4 format. 
* Removed serializer unwrapping of single item results as it was causing serialization test to fail.