### PR TITLE
TINKERPOP-3015 Use wildcard instead of Object for hasId/hasValue predicates

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated `gremlin_python.process.__.has_key_` in favor of `gremlin_python.process.__.has_key`.
 * Added `gremlin.spark.outputRepartition` configuration to customize the partitioning of HDFS files from `OutputRDD`.
 * Allowed `mergeV()` and `mergeE()` to supply `null` in `Map` values.
+* Change signature of `hasId(P<Object>)` and `hasValue(P<Object>)` to `hasId(P<?>)` and `hasValue(P<?>)`.
 * Improved error message for when `emit()` is used without `repeat()`.
 
 [[release-3-7-3]]

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -2381,7 +2381,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      */
     public default GraphTraversal<S, E> hasId(final Object id, final Object... otherIds) {
         if (id instanceof P) {
-            return this.hasId((P) id);
+            return this.hasId((P<?>) id);
         }
         else {
             this.asAdmin().getBytecode().addStep(Symbols.hasId, id, otherIds);
@@ -2424,7 +2424,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#has-step" target="_blank">Reference Documentation - Has Step</a>
      * @since 3.2.4
      */
-    public default GraphTraversal<S, E> hasId(final P<Object> predicate) {
+    public default GraphTraversal<S, E> hasId(final P<?> predicate) {
         if (null == predicate)
             return hasId((Object) null);
 
@@ -2485,7 +2485,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      */
     public default GraphTraversal<S, E> hasValue(final Object value, final Object... otherValues) {
         if (value instanceof P)
-            return this.hasValue((P) value);
+            return this.hasValue((P<?>) value);
         else {
             this.asAdmin().getBytecode().addStep(Symbols.hasValue, value, otherValues);
             final List<Object> values = new ArrayList<>();
@@ -2519,7 +2519,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * @see <a href="http://tinkerpop.apache.org/docs/${project.version}/reference/#has-step" target="_blank">Reference Documentation - Has Step</a>
      * @since 3.2.4
      */
-    public default GraphTraversal<S, E> hasValue(final P<Object> predicate) {
+    public default GraphTraversal<S, E> hasValue(final P<?> predicate) {
         // if calling hasValue(null), the likely use the caller is going for is not a "no predicate" but a eq(null)
         if (null == predicate) {
             return hasValue((String) null);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -993,7 +993,7 @@ public class __ {
     /**
      * @see GraphTraversal#hasId(P)
      */
-    public static <A> GraphTraversal<A, A> hasId(final P<Object> predicate) {
+    public static <A> GraphTraversal<A, A> hasId(final P<?> predicate) {
         return __.<A>start().hasId(predicate);
     }
 
@@ -1021,7 +1021,7 @@ public class __ {
     /**
      * @see GraphTraversal#hasValue(P)
      */
-    public static <A> GraphTraversal<A, A> hasValue(final P<Object> predicate) {
+    public static <A> GraphTraversal<A, A> hasValue(final P<?> predicate) {
         return __.<A>start().hasValue(predicate);
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3015

Update hasId(P) signature to accept P<?> instead of P<Object>. This allows for types such as P<String> which are not subtypes of P<Object> to be passed directly to this method, instead of going through the hasId(Object) overload and then casting to a P raw type. Note that the P special case handling still exists in hasId(Object) to cover any cases in which the correct overload is not identifiable at compile-time.

All of the above applies equivalently for hasValue().

This is non-breaking and targeting 3.7-dev as all it is doing is allowing more predicates to go into hasId(P) directly, and skipping the cast to the P raw-type.

My vote is VOTE +1