### PR TITLE
TINKERPOP-3139 Fixed serialization and deserialization of IndexStep

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Change signature of `hasId(P<Object>)` and `hasValue(P<Object>)` to `hasId(P<?>)` and `hasValue(P<?>)`.
 * Improved error message for when `emit()` is used without `repeat()`.
 * Changed `PythonTranslator` to generate snake case step naming instead of camel case.
+* Fixed bug in `IndexStep` which prevented Java serialization due to non-serializable lambda usage by creating serializable function classes.
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IndexStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/IndexStepTest.java
@@ -18,16 +18,18 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.WithOptions;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -45,5 +47,31 @@ public class IndexStepTest extends StepTest {
     @Test
     public void testDefault() {
         assertEquals(__.index(), __.index().with(WithOptions.indexer, WithOptions.list));
+    }
+
+    @Test
+    public void testListIndexerSerializationDeserializationRoundTrip() {
+        // serialization and deserialization should not throw exception
+        byte[] serialized = SerializationUtils.serialize(__.index().with(WithOptions.indexer, WithOptions.list));
+        Object deserialized = SerializationUtils.deserialize(serialized);
+
+        DefaultTraversal<Object, Object> gtr = (DefaultTraversal<Object, Object>) deserialized;
+        assertEquals(1, gtr.getSteps().size());
+        IndexStep<Object, Object> step = (IndexStep<Object, Object>) gtr.getSteps().get(0);
+        assertEquals(IndexStep.IndexerType.LIST, step.getIndexerType());
+        assertTrue(step.getIndexer() instanceof IndexStep.ListIndexFunction);
+    }
+
+    @Test
+    public void testMapIndexerSerializationDeserializationRoundTrip() {
+        // serialization and deserialization should not throw exception
+        byte[] serialized = SerializationUtils.serialize(__.index().with(WithOptions.indexer, WithOptions.map));
+        Object deserialized = SerializationUtils.deserialize(serialized);
+
+        DefaultTraversal<Object, Object> gtr = (DefaultTraversal<Object, Object>) deserialized;
+        assertEquals(1, gtr.getSteps().size());
+        IndexStep<Object, Object> step = (IndexStep<Object, Object>) gtr.getSteps().get(0);
+        assertEquals(IndexStep.IndexerType.MAP, step.getIndexerType());
+        assertTrue(step.getIndexer() instanceof IndexStep.MapIndexFunction);
     }
 }


### PR DESCRIPTION
Fixed serialization and deserialization of `IndexStep` by moving non-serializable lambdas to serializable implementations of the functional interface. This code pattern is similar to that of other steps like `GroupCountStep`, `MeanGlobalStep`, etc. Added unit tests to test round trip serialization->deserialization.

https://issues.apache.org/jira/browse/TINKERPOP-3139