### PR TITLE
Fix connection pool bug which can cause delays in obtaining a connection

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -157,6 +157,9 @@ final class ConnectionPool {
         // Get valid connection
         Connection availableConnection;
         try {
+            // acquire lock before attempting to obtain an available connection and potentially waiting for one
+            // to prevent race conditions with other threads that are releasing or creating new connections
+            // otherwise signal may be called before await which would result in timeouts
             waitLock.lock();
             availableConnection = getAvailableConnection();
             if (availableConnection == null) {
@@ -534,7 +537,7 @@ final class ConnectionPool {
 
         return available;
     }
-
+    
     private void awaitAvailableConnection(long timeout, TimeUnit unit) throws InterruptedException {
         logger.debug("Wait {} {} for an available connection on {} with {}", timeout, unit, host, Thread.currentThread());
         logConnectionPoolStatus();

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ProfilingApplication.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/util/ProfilingApplication.java
@@ -203,7 +203,7 @@ public class ProfilingApplication {
         final boolean suppressStackTraces = Boolean.parseBoolean(options.getOrDefault("suppressStackTraces", "false").toString());
 
         final boolean exercise = Boolean.parseBoolean(options.getOrDefault("exercise", "false").toString());
-        final String script = options.getOrDefault("script", "1+1").toString();
+        final String script = options.getOrDefault("script", "g.inject(1)").toString();
 
         final Cluster cluster = Cluster.build(host)
                 .maxConnectionPoolSize(maxConnectionPoolSize)


### PR DESCRIPTION
It has been observed in some environments that integration tests such as `GraphBinaryGroovyRemoteFeatureTest` can encounter 16 second delays between test executions. Investigation shows this can occur if one thread is attempting to obtain a connection and another thread is creating or releasing a connection at the same time. It is possible for the thread releasing or creating a connection to signal the `hasAvailableConnection` condition after the other thread has determined there are no available connections but before calling `await` on the condition. Thus the thread obtaining the connection will wait for default timeout of 16 seconds before attempting to retrieve a connection again, causing the observed delays.

This fix involves locking the `waitLock` before obtaining and potentially calling await for an available connection which prevents other threads from signalling the `hasAvailableConnection` before other threads call `await`. The fix was tested by observing integration test execution on environments which previously produced the 16 second delays and also by executing `ProfilingApplication`. The results of `ProfilingApplication` did not demonstrate any degradation of average requests per second.