### PR TITLE
TINKERPOP-3150 Prevent sample step from having multiple by modulators

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -2060,6 +2060,7 @@ This release also includes changes from <<release-3-3-8, 3.3.8>>.
 
 ==== Improvements
 
+* TINKERPOP-3150 Prevent sample step from having multiple by modulators.
 * TINKERPOP-1084 Branch option tokens should be allowed to be traversals.
 * TINKERPOP-1553 Deprecate store() in favor of aggregate(Scope)
 * TINKERPOP-1921 Support hasNext terminal step in GLVs

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
@@ -43,7 +43,8 @@ import java.util.Set;
  */
 public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implements TraversalParent, ByModulating, Seedable {
 
-    private Traversal.Admin<S, Number> probabilityTraversal = new ConstantTraversal<>(1.0d);
+    private final Traversal.Admin<S, Number> initialTraversal = new ConstantTraversal<>(1.0d);
+    private Traversal.Admin<S, Number> probabilityTraversal = initialTraversal;
     private final int amountToSample;
     private final Random random = new Random();
 
@@ -68,6 +69,10 @@ public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implemen
 
     @Override
     public void modulateBy(final Traversal.Admin<?, ?> probabilityTraversal) {
+        if (!this.probabilityTraversal.equals(initialTraversal))
+        {
+            throw new IllegalStateException("GroupCount step can only have one by modulator");
+        }
         this.probabilityTraversal = this.integrateChild(probabilityTraversal);
     }
 

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/filter/Sample.feature
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/filter/Sample.feature
@@ -18,6 +18,15 @@
 @StepClassFilter @StepSample
 Feature: Step - sample()
 
+  Scenario: g_V_sampleX1X_byXageX_byXT_idX
+    Given the modern graph
+    And the traversal of
+      """
+      g.V().sample(1).by("age").by(T.id)
+      """
+    When iterated to list
+    Then the traversal will raise an error
+
   Scenario: g_E_sampleX1X
     Given the modern graph
     And the traversal of


### PR DESCRIPTION
TARGET  3.8-dev

https://issues.apache.org/jira/browse/TINKERPOP-3150

Prevent multiple by operators from being used for sample step  by throwing IllegalStateException if modulateBy is called more than once.