### PR TITLE
TINKERPOP-3155 Fixed typo for Operator.addAll to check that all args are collections instead of just the first

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Changed `PythonTranslator` to generate snake case step naming instead of camel case.
 * Changed `gremlin-go` Client `ReadBufferSize` and `WriteBufferSize` defaults to 1048576 (1MB) to align with DriverRemoteConnection.
 * Fixed bug in `IndexStep` which prevented Java serialization due to non-serializable lambda usage by creating serializable function classes.
+* Fixed bug in `Operator` which was caused only a single method parameter to be Collection type checked instead of all parameters.
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
@@ -186,7 +186,7 @@ public enum Operator implements BinaryOperator<Object> {
 
             if (a instanceof Map && b instanceof Map)
                 ((Map<?, ?>) a).putAll((Map) b);
-            else if (a instanceof Collection && a instanceof Collection)
+            else if (a instanceof Collection && b instanceof Collection)
                 ((Collection<?>) a).addAll((Collection) b);
             else
                 throw new IllegalArgumentException(String.format("Objects must be both of Map or Collection: a=%s b=%s",

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/OperatorExceptionTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/OperatorExceptionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
+import java.util.Arrays;
 import org.junit.Test;
 
 /**
@@ -43,5 +44,10 @@ public class OperatorExceptionTest {
     @Test(expected = ClassCastException.class)
     public void shouldThrowIfValueToSumIsNotNumeric() {
         Operator.sum.apply("1", "1");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowForAddAllIfBothArgsNotCollection() {
+        Operator.addAll.apply(Arrays.asList(1,2,3), "not a collection");
     }
 }


### PR DESCRIPTION
[TINKERPOP-3155](https://issues.apache.org/jira/browse/TINKERPOP-3155) 

Fixed typo for Operator.addAll to check that all args are collections instead of just the first and added unit test.
