### PR TITLE
Rename grammar types to improve descriptiveness and consistency

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,7 @@ This release also includes changes from <<release-3-7-XXX, 3.7.XXX>>.
 * Moved all lambda oriented Gremlin tests to `LambdaStepTest` in the Java test suite.
 * Removed the `@RemoteOnly` testing tag in Gherkin as lambda tests have all been moved to the Java test suite.
 * Updated gremlin-javascript to use GraphBinary as default instead of GraphSONv3
+* Renamed many types in the grammar for consistent use of terms "Literal", "Argument", and "Varargs"
 
 == TinkerPop 3.7.0 (Gremfir Master of the Pan Flute)
 

--- a/docs/src/upgrade/release-3.8.x.asciidoc
+++ b/docs/src/upgrade/release-3.8.x.asciidoc
@@ -347,6 +347,26 @@ The exception thrown should contain the following: "valueMap()/propertyMap() ste
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-2974[TINKERPOP-2974]
 
+===== Grammar Type Renaming
+
+All of the following types in the grammar have been renamed to follow consistent rules:
+
+`genericLiteralArgument` -> `genericArgument`
+`structureVertex` -> `structureVertexLiteral`
+`stringLiteralVarargsArgument` -> `stringNullableArgumentVarargs`
+`genericLiteralMapArgument` -> `genericMapArgument`
+`genericLiteralMapNullable` -> `genericMapNullableLiteral`
+`genericLiteralMapNullableArgument` -> `genericMapNullableArgument`
+`traversalStrategyList` -> `traversalStrategyVarargs`
+`genericLiteralVarargs` -> `genericArgumentVarags`
+`genericLiteralCollection` -> `genericCollectionLiteral`
+`genericLiteralList` -> `genericLiteralVarargs`
+`genericLiteralRange` -> `genericRangeLiteral`
+`stringLiteralVarargs` -> `stringNullableLiteralVarargs`
+`genericLiteralMap` -> `genericMapLiteral`
+
+Additionally, `genericLiteralListArgument` and `stringLiteralList` have been removed in favor of `genericArgumentVarags` and `stringNullableLiteralVarargs` respectively.
+
 ==== Graph Driver Providers
 
 ==== The Switch from Date to OffsetDateTime

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/ArgumentVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/ArgumentVisitor.java
@@ -23,7 +23,6 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.lang.reflect.Array;
 import java.time.OffsetDateTime;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 
@@ -76,8 +75,8 @@ public class ArgumentVisitor extends DefaultGremlinBaseVisitor<Object> {
     /**
      * Wrapper for visit function for object types.
      */
-    public Object parseObject(final GremlinParser.GenericLiteralArgumentContext ctx) {
-        return visitGenericLiteralArgument(ctx);
+    public Object parseObject(final GremlinParser.GenericArgumentContext ctx) {
+        return visitGenericArgument(ctx);
     }
 
     /**
@@ -90,40 +89,29 @@ public class ArgumentVisitor extends DefaultGremlinBaseVisitor<Object> {
     /**
      * Wrapper for visit function for {@code Map} types.
      */
-    public Map parseMap(final GremlinParser.GenericLiteralMapArgumentContext ctx) {
-        return (Map) visitGenericLiteralMapArgument(ctx);
+    public Map parseMap(final GremlinParser.GenericMapArgumentContext ctx) {
+        return (Map) visitGenericMapArgument(ctx);
     }
 
     /**
      * Wrapper for visit function for {@code Map} types.
      */
-    public Map parseMap(final GremlinParser.GenericLiteralMapNullableArgumentContext ctx) {
-        return (Map) visitGenericLiteralMapNullableArgument(ctx);
+    public Map parseMap(final GremlinParser.GenericMapNullableArgumentContext ctx) {
+        return (Map) visitGenericMapNullableArgument(ctx);
     }
 
     /**
      * Wrapper for visit function for list types.
      */
-    public Object[] parseObjectVarargs(final GremlinParser.GenericLiteralListArgumentContext ctx) {
-        if (ctx.genericLiteralList() != null) {
-            return antlr.genericVisitor.parseObjectList(ctx.genericLiteralList());
-        } else {
-            final Object l = visitVariable(ctx.variable());
-            if (null == l) {
-                return null;
-            } else if (l.getClass().isArray()) {
-                final int length = Array.getLength(l);
-                final Object[] result = new Object[length];
-                for (int i = 0; i < length; i++) {
-                    result[i] = Array.get(l, i);
-                }
-                return result;
-            } else if (l instanceof Iterable) {
-                return IteratorUtils.list(((Iterable<?>) l).iterator()).toArray();
-            } else {
-                return new Object[] { l };
-            }
+    public Object[] parseObjectVarargs(final GremlinParser.GenericArgumentVarargsContext ctx) {
+        if (ctx == null || ctx.genericArgument() == null) {
+            return new Object[0];
         }
+        return ctx.genericArgument()
+                .stream()
+                .filter(Objects::nonNull)
+                .map(antlr.argumentVisitor::visitGenericArgument)
+                .toArray(Object[]::new);
     }
 
     /**
@@ -188,7 +176,7 @@ public class ArgumentVisitor extends DefaultGremlinBaseVisitor<Object> {
     }
 
     @Override
-    public Object visitGenericLiteralArgument(final GremlinParser.GenericLiteralArgumentContext ctx) {
+    public Object visitGenericArgument(final GremlinParser.GenericArgumentContext ctx) {
         if (ctx.genericLiteral() != null) {
             return antlr.genericVisitor.visitGenericLiteral(ctx.genericLiteral());
         } else {
@@ -197,38 +185,27 @@ public class ArgumentVisitor extends DefaultGremlinBaseVisitor<Object> {
     }
 
     @Override
-    public Object visitGenericLiteralListArgument(final GremlinParser.GenericLiteralListArgumentContext ctx) {
-        if (ctx.genericLiteralList() != null) {
-            return antlr.genericVisitor.visitChildren(ctx.genericLiteralList());
-        } else {
-            return visitVariable(ctx.variable());
-        }
-    }
-
-    @Override
     public Object visitStructureVertexArgument(final GremlinParser.StructureVertexArgumentContext ctx) {
-        if (ctx.structureVertex() != null) {
-            return antlr.structureVisitor.visitStructureVertex(ctx.structureVertex());
+        if (ctx.structureVertexLiteral() != null) {
+            return antlr.structureVisitor.visitStructureVertexLiteral(ctx.structureVertexLiteral());
         } else {
             return visitVariable(ctx.variable());
         }
     }
 
     @Override
-    public Object visitGenericLiteralMapArgument(final GremlinParser.GenericLiteralMapArgumentContext ctx) {
-        if (ctx.genericLiteralMap() != null) {
-            return antlr.genericVisitor.visitGenericLiteralMap(ctx.genericLiteralMap());
+    public Object visitGenericMapArgument(final GremlinParser.GenericMapArgumentContext ctx) {
+        if (ctx.genericMapLiteral() != null) {
+            return antlr.genericVisitor.visitGenericMapLiteral(ctx.genericMapLiteral());
         } else {
             return visitVariable(ctx.variable());
         }
     }
 
     @Override
-    public Object visitGenericLiteralMapNullableArgument(final GremlinParser.GenericLiteralMapNullableArgumentContext ctx) {
-        if (ctx.nullLiteral() != null) {
-            return null;
-        } else if (ctx.genericLiteralMap() != null) {
-            return antlr.genericVisitor.visitGenericLiteralMap(ctx.genericLiteralMap());
+    public Object visitGenericMapNullableArgument(final GremlinParser.GenericMapNullableArgumentContext ctx) {
+        if (ctx.genericMapNullableLiteral() != null) {
+            return antlr.genericVisitor.visitGenericMapNullableLiteral(ctx.genericMapNullableLiteral());
         } else {
             return visitVariable(ctx.variable());
         }
@@ -237,7 +214,7 @@ public class ArgumentVisitor extends DefaultGremlinBaseVisitor<Object> {
     /**
      * Parse a string literal varargs, and return a string array
      */
-    public String[] parseStringVarargs(final GremlinParser.StringLiteralVarargsArgumentContext varargsArgumentContext) {
+    public String[] parseStringVarargs(final GremlinParser.StringNullableArgumentVarargsContext varargsArgumentContext) {
         if (varargsArgumentContext == null || varargsArgumentContext.stringNullableArgument() == null) {
             return new String[0];
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/DefaultGremlinBaseVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/DefaultGremlinBaseVisitor.java
@@ -1250,7 +1250,7 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitTraversalStrategyList(final GremlinParser.TraversalStrategyListContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitTraversalStrategyVarargs(final GremlinParser.TraversalStrategyVarargsContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1266,27 +1266,23 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralList(final GremlinParser.GenericLiteralListContext ctx) { notImplemented(ctx); return null; }
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override public T visitGenericLiteralExpr(final GremlinParser.GenericLiteralExprContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralRange(final GremlinParser.GenericLiteralRangeContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericRangeLiteral(final GremlinParser.GenericRangeLiteralContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitStringLiteralList(final GremlinParser.StringLiteralListContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitStringNullableLiteralVarargs(final GremlinParser.StringNullableLiteralVarargsContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitStringLiteralExpr(final GremlinParser.StringLiteralExprContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitStringNullableArgumentVarargs(final GremlinParser.StringNullableArgumentVarargsContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1294,7 +1290,7 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1374,7 +1370,7 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitStructureVertex(final GremlinParser.StructureVertexContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1459,10 +1455,6 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	 * {@inheritDoc}
 	 */
 	@Override public T visitDateArgument(final GremlinParser.DateArgumentContext ctx) { notImplemented(ctx); return null; }
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override public T visitUuidArgument(final GremlinParser.UuidArgumentContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1614,11 +1606,11 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralArgument(final GremlinParser.GenericLiteralArgumentContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericArgument(final GremlinParser.GenericArgumentContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralListArgument(GremlinParser.GenericLiteralListArgumentContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericArgumentVarargs(GremlinParser.GenericArgumentVarargsContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1626,15 +1618,11 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralMapArgument(final GremlinParser.GenericLiteralMapArgumentContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericMapArgument(final GremlinParser.GenericMapArgumentContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralMapNullableArgument(final GremlinParser.GenericLiteralMapNullableArgumentContext ctx) { notImplemented(ctx); return null; }
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override public T visitStringLiteralVarargs(final GremlinParser.StringLiteralVarargsContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericMapNullableArgument(final GremlinParser.GenericMapNullableArgumentContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1670,7 +1658,7 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1690,11 +1678,7 @@ public class DefaultGremlinBaseVisitor<T> extends AbstractParseTreeVisitor<T> im
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override public T visitGenericLiteralMapNullable(final GremlinParser.GenericLiteralMapNullableContext ctx) { notImplemented(ctx); return null; }
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override public T visitStringLiteralVarargsArgument(final GremlinParser.StringLiteralVarargsArgumentContext ctx) { notImplemented(ctx); return null; }
+	@Override public T visitGenericMapNullableLiteral(final GremlinParser.GenericMapNullableLiteralContext ctx) { notImplemented(ctx); return null; }
 	/**
 	 * {@inheritDoc}
 	 */

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GenericLiteralVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/GenericLiteralVisitor.java
@@ -101,8 +101,8 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
     /**
      * Parse a map literal context and return the map literal
      */
-    public Map parseMap(final GremlinParser.GenericLiteralMapContext mapLiteral) {
-        return (Map) visitGenericLiteralMap(mapLiteral);
+    public Map parseMap(final GremlinParser.GenericMapLiteralContext mapLiteral) {
+        return (Map) visitGenericMapLiteral(mapLiteral);
     }
 
     /**
@@ -113,20 +113,13 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
     }
 
     /**
-     * Parse a String literal list context and return a string array
-     */
-    public String[] parseStringList(final GremlinParser.StringLiteralListContext stringLiteralList) {
-        return (String[]) visitStringLiteralList(stringLiteralList);
-    }
-
-    /**
      * Parse a generic literal list, and return an object array
      */
-    public Object[] parseObjectList(final GremlinParser.GenericLiteralListContext objectLiteralList) {
-        if (objectLiteralList == null || objectLiteralList.genericLiteralExpr() == null) {
+    public Object[] parseObjectList(final GremlinParser.GenericCollectionLiteralContext collectionLiteral) {
+        if (collectionLiteral == null || collectionLiteral.genericLiteral() == null) {
             return new Object[0];
         }
-        return objectLiteralList.genericLiteralExpr().genericLiteral()
+        return collectionLiteral.genericLiteral()
                 .stream()
                 .filter(Objects::nonNull)
                 .map(antlr.genericVisitor::visitGenericLiteral)
@@ -137,20 +130,20 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
      * Parse a generic literal varargs, and return an object array
      */
     public Object[] parseObjectVarargs(final GremlinParser.GenericLiteralVarargsContext varargsContext) {
-        if (varargsContext == null || varargsContext.genericLiteralArgument() == null) {
+        if (varargsContext == null || varargsContext.genericLiteralExpr() == null || varargsContext.genericLiteralExpr().genericLiteral() == null) {
             return new Object[0];
         }
-        return varargsContext.genericLiteralArgument()
+        return varargsContext.genericLiteralExpr().genericLiteral()
                 .stream()
                 .filter(Objects::nonNull)
-                .map(antlr.argumentVisitor::visitGenericLiteralArgument)
+                .map(antlr.genericVisitor::visitGenericLiteral)
                 .toArray(Object[]::new);
     }
 
     /**
-     * Parse a string literal varargs, and return an string array
+     * Parse a string literal varargs, and return a string array
      */
-    public String[] parseStringVarargs(final GremlinParser.StringLiteralVarargsContext varargsContext) {
+    public String[] parseStringVarargs(final GremlinParser.StringNullableLiteralVarargsContext varargsContext) {
         if (varargsContext == null) {
             return new String[0];
         }
@@ -164,7 +157,7 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
     /**
      * Parse a TraversalStrategy literal list context and return a string array
      */
-    public static TraversalStrategy[] parseTraversalStrategyList(final GremlinParser.TraversalStrategyListContext traversalStrategyListContext,
+    public static TraversalStrategy[] parseTraversalStrategyList(final GremlinParser.TraversalStrategyVarargsContext traversalStrategyListContext,
                                                                  final DefaultGremlinBaseVisitor<TraversalStrategy> traversalStrategyVisitor) {
         if (traversalStrategyListContext == null || traversalStrategyListContext.traversalStrategyExpr() == null) {
             return new TraversalStrategy[0];
@@ -279,14 +272,6 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
      * {@inheritDoc}
      */
     @Override
-    public Object visitGenericLiteralList(final GremlinParser.GenericLiteralListContext ctx) {
-        return visitChildren(ctx);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public Object visitGenericLiteralExpr(final GremlinParser.GenericLiteralExprContext ctx) {
         final int childCount = ctx.getChildCount();
         switch (childCount) {
@@ -307,7 +292,7 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
     }
 
     @Override
-    public Object visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) {
+    public Object visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) {
         final Set<Object> result = new HashSet<>(ctx.getChildCount() / 2);
         for (GremlinParser.GenericLiteralContext ic : ctx.genericLiteral()) {
             result.add(antlr.genericVisitor.visitGenericLiteral(ic));
@@ -327,7 +312,7 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
      * {@inheritDoc}
      */
     @Override
-    public Object visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) {
+    public Object visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) {
         if (ctx == null) {
             return null;
         }
@@ -354,12 +339,12 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
                 key = visitTraversalDirection((GremlinParser.TraversalDirectionContext) kctx);
             } else if (kctx instanceof GremlinParser.TraversalDirectionLongContext) {
                 key = visitTraversalDirectionLong((GremlinParser.TraversalDirectionLongContext) kctx);
-            }else if (kctx instanceof GremlinParser.GenericLiteralCollectionContext) {
-                key = visitGenericLiteralCollection((GremlinParser.GenericLiteralCollectionContext) kctx);
-            } else if (kctx instanceof GremlinParser.GenericLiteralSetContext) {
-                key = visitGenericLiteralSet((GremlinParser.GenericLiteralSetContext) kctx);
-            } else if (kctx instanceof GremlinParser.GenericLiteralMapContext) {
-                key = visitGenericLiteralMap((GremlinParser.GenericLiteralMapContext) kctx);
+            }else if (kctx instanceof GremlinParser.GenericCollectionLiteralContext) {
+                key = visitGenericCollectionLiteral((GremlinParser.GenericCollectionLiteralContext) kctx);
+            } else if (kctx instanceof GremlinParser.GenericSetLiteralContext) {
+                key = visitGenericSetLiteral((GremlinParser.GenericSetLiteralContext) kctx);
+            } else if (kctx instanceof GremlinParser.GenericMapLiteralContext) {
+                key = visitGenericMapLiteral((GremlinParser.GenericMapLiteralContext) kctx);
             } else if (kctx instanceof GremlinParser.KeywordContext) {
                 key = ((GremlinParser.KeywordContext) kctx).getText();
             } else if (kctx instanceof GremlinParser.NakedKeyContext) {
@@ -377,7 +362,21 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
         return literalMap;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object visitGenericMapNullableLiteral(final GremlinParser.GenericMapNullableLiteralContext ctx) {
+        if (ctx == null) {
+            return null;
+        }
 
+        if (ctx.nullLiteral() != null) {
+            return visitNullLiteral(ctx.nullLiteral());
+        }
+
+        return visitGenericMapLiteral(ctx.genericMapLiteral());
+    }
 
     /**
      * {@inheritDoc}
@@ -388,8 +387,8 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
     }
 
     @Override
-    public Object visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
-        return antlr.structureVisitor.visitStructureVertex(ctx);
+    public Object visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) {
+        return antlr.structureVisitor.visitStructureVertexLiteral(ctx);
     }
 
     /**
@@ -617,7 +616,7 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
      * {@inheritDoc}
      */
     @Override
-    public Object visitGenericLiteralRange(final GremlinParser.GenericLiteralRangeContext ctx) {
+    public Object visitGenericRangeLiteral(final GremlinParser.GenericRangeLiteralContext ctx) {
         final int childIndexOfParameterStart = 0;
         final int childIndexOfParameterEnd = 3;
         final ParseTree startContext = ctx.getChild(childIndexOfParameterStart);
@@ -666,24 +665,12 @@ public class GenericLiteralVisitor extends DefaultGremlinBaseVisitor<Object> {
      * Generic literal collection returns a list of {@code Object}
      */
     @Override
-    public Object visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) {
+    public Object visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) {
         final List<Object> result = new ArrayList<>(ctx.getChildCount() / 2);
         for (GremlinParser.GenericLiteralContext ic : ctx.genericLiteral()) {
             result.add(antlr.genericVisitor.visitGenericLiteral(ic));
         }
         return result;
-    }
-
-    @Override
-    public Object visitStringLiteralList(final GremlinParser.StringLiteralListContext ctx) {
-        if (ctx == null || ctx.stringLiteralExpr() == null) {
-            return new String[0];
-        }
-        return ctx.stringLiteralExpr().stringNullableLiteral()
-                .stream()
-                .filter(Objects::nonNull)
-                .map(this::visitStringNullableLiteral)
-                .toArray(String[]::new);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/ParseTreeContextCastHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/ParseTreeContextCastHelper.java
@@ -31,7 +31,7 @@ public class ParseTreeContextCastHelper {
      * @param childIndex : child index
      * @return casted GenericLiteralContext
      */
-    public static GremlinParser.GenericLiteralArgumentContext castChildToGenericLiteral(final ParseTree ctx, final int childIndex) {
-        return (GremlinParser.GenericLiteralArgumentContext)(ctx.getChild(childIndex));
+    public static GremlinParser.GenericArgumentContext castChildToGenericLiteral(final ParseTree ctx, final int childIndex) {
+        return (GremlinParser.GenericArgumentContext)(ctx.getChild(childIndex));
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/StructureElementVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/StructureElementVisitor.java
@@ -31,8 +31,8 @@ public class StructureElementVisitor extends GremlinBaseVisitor<Element> {
     }
 
     @Override
-    public Vertex visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
-        return new ReferenceVertex(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()),
+    public Vertex visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) {
+        return new ReferenceVertex(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()),
                 (String) antlr.argumentVisitor.visitStringArgument(ctx.stringArgument()));
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalMethodVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalMethodVisitor.java
@@ -36,8 +36,6 @@ import java.util.Map;
 
 import java.util.function.BiFunction;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.SackFunctions.Barrier.normSack;
-
 /**
  * Specific case of TraversalRootVisitor where all TraversalMethods returns
  * a GraphTraversal object.
@@ -66,7 +64,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_V(final GremlinParser.TraversalMethod_VContext ctx) {
-        return this.graphTraversal.V(antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return this.graphTraversal.V(antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -74,7 +72,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_E(final GremlinParser.TraversalMethod_EContext ctx) {
-        return this.graphTraversal.E(antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return this.graphTraversal.E(antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -98,7 +96,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_mergeV_Map(final GremlinParser.TraversalMethod_mergeV_MapContext ctx) {
-        return this.graphTraversal.mergeV(antlr.argumentVisitor.parseMap(ctx.genericLiteralMapNullableArgument()));
+        return this.graphTraversal.mergeV(antlr.argumentVisitor.parseMap(ctx.genericMapNullableArgument()));
     }
 
     /**
@@ -130,7 +128,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_mergeE_Map(final GremlinParser.TraversalMethod_mergeE_MapContext ctx) {
-        return this.graphTraversal.mergeE(antlr.argumentVisitor.parseMap(ctx.genericLiteralMapNullableArgument()));
+        return this.graphTraversal.mergeE(antlr.argumentVisitor.parseMap(ctx.genericMapNullableArgument()));
     }
 
     /**
@@ -217,7 +215,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
             return graphTraversal.as(antlr.genericVisitor.parseString(ctx.stringLiteral()));
         } else {
             return graphTraversal.as(antlr.genericVisitor.parseString(ctx.stringLiteral()),
-                    antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                    antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
         }
     }
 
@@ -250,7 +248,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_both(final GremlinParser.TraversalMethod_bothContext ctx) {
-        return graphTraversal.both(antlr.argumentVisitor.parseStringVarargs(ctx.stringLiteralVarargsArgument()));
+        return graphTraversal.both(antlr.argumentVisitor.parseStringVarargs(ctx.stringNullableArgumentVarargs()));
     }
 
     /**
@@ -258,7 +256,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_bothE(final GremlinParser.TraversalMethod_bothEContext ctx) {
-        return graphTraversal.bothE(antlr.argumentVisitor.parseStringVarargs(ctx.stringLiteralVarargsArgument()));
+        return graphTraversal.bothE(antlr.argumentVisitor.parseStringVarargs(ctx.stringNullableArgumentVarargs()));
     }
 
     /**
@@ -383,7 +381,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
             return graphTraversal.cap(antlr.genericVisitor.parseString(ctx.stringLiteral()));
         } else {
             return graphTraversal.cap(antlr.genericVisitor.parseString(ctx.stringLiteral()),
-                    antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                    antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
         }
     }
 
@@ -462,7 +460,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_combine_Object(final GremlinParser.TraversalMethod_combine_ObjectContext ctx) {
-        return graphTraversal.combine(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+        return graphTraversal.combine(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -487,7 +485,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_constant(final GremlinParser.TraversalMethod_constantContext ctx) {
         return graphTraversal
-                .constant(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+                .constant(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -521,7 +519,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_dedup_Scope_String(final GremlinParser.TraversalMethod_dedup_Scope_StringContext ctx) {
         return graphTraversal.dedup(
                 TraversalEnumParser.parseTraversalEnumFromContext(Scope.class, ctx.traversalScope()),
-                antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -529,7 +527,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_dedup_String(final GremlinParser.TraversalMethod_dedup_StringContext ctx) {
-        return graphTraversal.dedup(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.dedup(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -537,7 +535,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_difference_Object(final GremlinParser.TraversalMethod_difference_ObjectContext ctx) {
-        return graphTraversal.difference(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+        return graphTraversal.difference(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -545,7 +543,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_disjunct_Object(final GremlinParser.TraversalMethod_disjunct_ObjectContext ctx) {
-        return graphTraversal.disjunct(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+        return graphTraversal.disjunct(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -634,7 +632,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_fold_Object_BiFunction(final GremlinParser.TraversalMethod_fold_Object_BiFunctionContext ctx) {
         return graphTraversal.fold(
-                antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()),
+                antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()),
                 (BiFunction) TraversalEnumParser.parseTraversalEnumFromContext(Operator.class, ctx.getChild(4)));
     }
 
@@ -691,8 +689,8 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasId_Object_Object(final GremlinParser.TraversalMethod_hasId_Object_ObjectContext ctx) {
-        return graphTraversal.hasId(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()),
-                antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return graphTraversal.hasId(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()),
+                antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -720,7 +718,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
             return graphTraversal.hasKey(antlr.genericVisitor.parseString(ctx.stringNullableLiteral()));
         } else {
             return graphTraversal.hasKey(antlr.genericVisitor.parseString(ctx.stringNullableLiteral()),
-                    antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                    antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
         }
     }
 
@@ -741,7 +739,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
             return graphTraversal.hasLabel(antlr.argumentVisitor.parseString(ctx.stringNullableArgument()));
         } else {
             return graphTraversal.hasLabel(antlr.argumentVisitor.parseString(ctx.stringNullableArgument()),
-                    antlr.argumentVisitor.parseStringVarargs(ctx.stringLiteralVarargsArgument()));
+                    antlr.argumentVisitor.parseStringVarargs(ctx.stringNullableArgumentVarargs()));
         }
     }
 
@@ -758,8 +756,8 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_hasValue_Object_Object(final GremlinParser.TraversalMethod_hasValue_Object_ObjectContext ctx) {
-        return graphTraversal.hasValue(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()),
-                antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return graphTraversal.hasValue(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()),
+                antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -784,7 +782,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_has_String_Object(final GremlinParser.TraversalMethod_has_String_ObjectContext ctx) {
         return graphTraversal.has(antlr.genericVisitor.parseString(ctx.stringNullableLiteral()),
-                antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+                antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -803,7 +801,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_has_String_String_Object(final GremlinParser.TraversalMethod_has_String_String_ObjectContext ctx) {
         return graphTraversal.has(antlr.argumentVisitor.parseString(ctx.stringNullableArgument()),
                 antlr.genericVisitor.parseString(ctx.stringNullableLiteral()),
-                antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+                antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -831,7 +829,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_has_T_Object(final GremlinParser.TraversalMethod_has_T_ObjectContext ctx) {
         return graphTraversal.has(TraversalEnumParser.parseTraversalEnumFromContext(T.class, ctx.traversalT()),
-                antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+                antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -873,7 +871,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_in(final GremlinParser.TraversalMethod_inContext ctx) {
-        return graphTraversal.in(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.in(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -881,7 +879,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_inE(final GremlinParser.TraversalMethod_inEContext ctx) {
-        return graphTraversal.inE(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.inE(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -889,7 +887,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_intersect_Object(final GremlinParser.TraversalMethod_intersect_ObjectContext ctx) {
-        return graphTraversal.intersect(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+        return graphTraversal.intersect(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -905,7 +903,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_inject(final GremlinParser.TraversalMethod_injectContext ctx) {
-        return graphTraversal.inject(antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return graphTraversal.inject(antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     @Override
@@ -918,7 +916,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_is_Object(final GremlinParser.TraversalMethod_is_ObjectContext ctx) {
-        return graphTraversal.is(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+        return graphTraversal.is(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -1026,7 +1024,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
         } else if (ctx.ioOptionsValues() != null) {
             o = WithOptionsVisitor.instance().visitIoOptionsValues(ctx.ioOptionsValues());
         } else {
-            o = antlr.argumentVisitor.parseObject(ctx.genericLiteralArgument());
+            o = antlr.argumentVisitor.parseObject(ctx.genericArgument());
         }
         return graphTraversal.with(k, o);
     }
@@ -1090,7 +1088,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_merge_Object(final GremlinParser.TraversalMethod_merge_ObjectContext ctx) {
-        return graphTraversal.merge(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+        return graphTraversal.merge(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -1130,7 +1128,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_option_Object_Traversal(final GremlinParser.TraversalMethod_option_Object_TraversalContext ctx) {
-        return graphTraversal.option(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()),
+        return graphTraversal.option(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()),
                 antlr.tvisitor.visitNestedTraversal(ctx.nestedTraversal()));
     }
 
@@ -1149,7 +1147,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_option_Merge_Map(final GremlinParser.TraversalMethod_option_Merge_MapContext ctx) {
         return graphTraversal.option(
                 TraversalEnumParser.parseTraversalEnumFromContext(Merge.class, ctx.traversalMerge()),
-                (Map) antlr.argumentVisitor.visitGenericLiteralMapNullableArgument(ctx.genericLiteralMapNullableArgument()));
+                (Map) antlr.argumentVisitor.visitGenericMapNullableArgument(ctx.genericMapNullableArgument()));
     }
 
     /**
@@ -1167,18 +1165,14 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public Traversal visitTraversalMethod_option_Merge_Map_Cardinality(final GremlinParser.TraversalMethod_option_Merge_Map_CardinalityContext ctx) {
-        if (ctx.genericLiteralMapNullableArgument().nullLiteral() != null) {
-            return this.graphTraversal.option(TraversalEnumParser.parseTraversalEnumFromContext(Merge.class, ctx.traversalMerge()), (Map) null);
-        }
-
-        if (ctx.genericLiteralMapNullableArgument().variable() != null) {
+        if (ctx.genericMapNullableArgument().variable() != null) {
             return graphTraversal.option(TraversalEnumParser.parseTraversalEnumFromContext(Merge.class, ctx.traversalMerge()),
-                    (Map) antlr.argumentVisitor.visitVariable(ctx.genericLiteralMapNullableArgument().variable()),
+                    (Map) antlr.argumentVisitor.visitVariable(ctx.genericMapNullableArgument().variable()),
                     TraversalEnumParser.parseTraversalEnumFromContext(Cardinality.class, ctx.traversalCardinality()));
         }
 
         return graphTraversal.option(TraversalEnumParser.parseTraversalEnumFromContext(Merge.class, ctx.traversalMerge()),
-                (Map) new GenericLiteralVisitor(antlr).visitGenericLiteralMap(ctx.genericLiteralMapNullableArgument().genericLiteralMap()),
+                (Map) new GenericLiteralVisitor(antlr).visitGenericMapNullableLiteral(ctx.genericMapNullableArgument().genericMapNullableLiteral()),
                 TraversalEnumParser.parseTraversalEnumFromContext(Cardinality.class, ctx.traversalCardinality()));
     }
 
@@ -1228,7 +1222,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_out(final GremlinParser.TraversalMethod_outContext ctx) {
-        return graphTraversal.out(antlr.argumentVisitor.parseStringVarargs(ctx.stringLiteralVarargsArgument()));
+        return graphTraversal.out(antlr.argumentVisitor.parseStringVarargs(ctx.stringNullableArgumentVarargs()));
     }
 
     /**
@@ -1236,7 +1230,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_outE(final GremlinParser.TraversalMethod_outEContext ctx) {
-        return graphTraversal.outE(antlr.argumentVisitor.parseStringVarargs(ctx.stringLiteralVarargsArgument()));
+        return graphTraversal.outE(antlr.argumentVisitor.parseStringVarargs(ctx.stringNullableArgumentVarargs()));
     }
 
     /**
@@ -1289,7 +1283,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_product_Object(final GremlinParser.TraversalMethod_product_ObjectContext ctx) {
-        return graphTraversal.product(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+        return graphTraversal.product(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
     }
 
     /**
@@ -1317,7 +1311,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
             return graphTraversal.project(antlr.genericVisitor.parseString(ctx.stringLiteral()));
         } else {
             return graphTraversal.project(antlr.genericVisitor.parseString(ctx.stringLiteral()),
-                    antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                    antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
         }
     }
 
@@ -1326,7 +1320,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_properties(final GremlinParser.TraversalMethod_propertiesContext ctx) {
-        return graphTraversal.properties(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.properties(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -1334,7 +1328,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_elementMap(final GremlinParser.TraversalMethod_elementMapContext ctx) {
-        return graphTraversal.elementMap(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.elementMap(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -1342,7 +1336,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_propertyMap(final GremlinParser.TraversalMethod_propertyMapContext ctx) {
-        return graphTraversal.propertyMap(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.propertyMap(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -1351,9 +1345,9 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_property_Cardinality_Object_Object_Object(final GremlinParser.TraversalMethod_property_Cardinality_Object_Object_ObjectContext ctx) {
         return graphTraversal.property(TraversalEnumParser.parseTraversalEnumFromContext(Cardinality.class, ctx.traversalCardinality()),
-                antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument(0)),
-                antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument(1)),
-                antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+                antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument(0)),
+                antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument(1)),
+                antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -1362,12 +1356,12 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public GraphTraversal visitTraversalMethod_property_Object_Object_Object(final GremlinParser.TraversalMethod_property_Object_Object_ObjectContext ctx) {
         if (ctx.getChildCount() == 6) {
-            return graphTraversal.property(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument(0)),
-                    antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument(1)));
+            return graphTraversal.property(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument(0)),
+                    antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument(1)));
         } else {
-            return graphTraversal.property(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument(0)),
-                    antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument(1)),
-                    antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+            return graphTraversal.property(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument(0)),
+                    antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument(1)),
+                    antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
         }
     }
 
@@ -1377,7 +1371,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public Traversal visitTraversalMethod_property_Cardinality_Object(final GremlinParser.TraversalMethod_property_Cardinality_ObjectContext  ctx) {
         return graphTraversal.property(TraversalEnumParser.parseTraversalEnumFromContext(Cardinality.class, ctx.traversalCardinality()),
-                antlr.argumentVisitor.parseMap(ctx.genericLiteralMapNullableArgument()));
+                antlr.argumentVisitor.parseMap(ctx.genericMapNullableArgument()));
     }
 
     /**
@@ -1385,7 +1379,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public Traversal visitTraversalMethod_property_Object(final GremlinParser.TraversalMethod_property_ObjectContext ctx) {
-        return graphTraversal.property(antlr.argumentVisitor.parseMap(ctx.genericLiteralMapNullableArgument()));
+        return graphTraversal.property(antlr.argumentVisitor.parseMap(ctx.genericMapNullableArgument()));
     }
 
     /**
@@ -1469,7 +1463,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
                 TraversalEnumParser.parseTraversalEnumFromContext(Pop.class, ctx.traversalPop()),
                 antlr.genericVisitor.parseString(ctx.stringLiteral(0)),
                 antlr.genericVisitor.parseString(ctx.stringLiteral(1)),
-                antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     @Override
@@ -1494,7 +1488,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_select_String_String_String(final GremlinParser.TraversalMethod_select_String_String_StringContext ctx) {
         return graphTraversal.select(antlr.genericVisitor.parseString(ctx.stringLiteral(0)),
                 antlr.genericVisitor.parseString(ctx.stringLiteral(1)),
-                antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     @Override
@@ -1625,7 +1619,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_toE(final GremlinParser.TraversalMethod_toEContext ctx) {
         return graphTraversal.toE(
                 TraversalEnumParser.parseTraversalEnumFromContext(Direction.class, ctx.traversalDirection()),
-                antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -1643,7 +1637,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public GraphTraversal visitTraversalMethod_to_Direction_String(final GremlinParser.TraversalMethod_to_Direction_StringContext ctx) {
         return graphTraversal.to(
                 TraversalEnumParser.parseTraversalEnumFromContext(Direction.class, ctx.traversalDirection()),
-                antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -1724,7 +1718,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_valueMap_String(final GremlinParser.TraversalMethod_valueMap_StringContext ctx) {
-        return graphTraversal.valueMap(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.valueMap(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -1736,7 +1730,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
             return graphTraversal.valueMap((boolean) antlr.genericVisitor.visitBooleanLiteral(ctx.booleanLiteral()));
         } else {
             return graphTraversal.valueMap((boolean) antlr.genericVisitor.visitBooleanLiteral(ctx.booleanLiteral()),
-                    antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+                    antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
         }
     }
 
@@ -1745,7 +1739,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_values(final GremlinParser.TraversalMethod_valuesContext ctx) {
-        return graphTraversal.values(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.values(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**
@@ -1828,7 +1822,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public Traversal visitTraversalMethod_call_string_map(final GremlinParser.TraversalMethod_call_string_mapContext ctx) {
         return graphTraversal.call(antlr.genericVisitor.parseString(ctx.stringLiteral()),
-                                   antlr.argumentVisitor.parseMap(ctx.genericLiteralMapArgument()));
+                                   antlr.argumentVisitor.parseMap(ctx.genericMapArgument()));
     }
 
     /**
@@ -1846,7 +1840,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     @Override
     public Traversal visitTraversalMethod_call_string_map_traversal(final GremlinParser.TraversalMethod_call_string_map_traversalContext ctx) {
         return graphTraversal.call(antlr.genericVisitor.parseString(ctx.stringLiteral()),
-                antlr.argumentVisitor.parseMap(ctx.genericLiteralMapArgument()),
+                antlr.argumentVisitor.parseMap(ctx.genericMapArgument()),
                 antlr.tvisitor.visitNestedTraversal(ctx.nestedTraversal()));
     }
 
@@ -1867,7 +1861,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
      */
     @Override
     public GraphTraversal visitTraversalMethod_concat_String(final GremlinParser.TraversalMethod_concat_StringContext ctx) {
-        return graphTraversal.concat(antlr.genericVisitor.parseStringVarargs(ctx.stringLiteralVarargs()));
+        return graphTraversal.concat(antlr.genericVisitor.parseStringVarargs(ctx.stringNullableLiteralVarargs()));
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalPredicateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalPredicateVisitor.java
@@ -144,18 +144,15 @@ public class TraversalPredicateVisitor extends DefaultGremlinBaseVisitor<P> {
     @Override
     public P visitTraversalPredicate_within(final GremlinParser.TraversalPredicate_withinContext ctx) {
         // called with no args which is valid for java/groovy
-        if (null == ctx.genericLiteralListArgument()) return P.within();
+        if (null == ctx.genericArgumentVarargs()) return P.within();
 
-        final Object arguments = antlr.argumentVisitor.visitGenericLiteralListArgument(ctx.genericLiteralListArgument());
+        final Object[] arguments = antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs());
 
-        if (arguments instanceof Object[]) {
-            // when generic literal list is consist of a comma separated generic literals
-            return P.within((Object []) arguments);
-        } else if (arguments instanceof List || arguments instanceof Set) {
+        if (arguments.length == 1 && arguments[0] instanceof Collection) {
             // when generic literal list is consist of a collection of generic literals, E.g. range
-            return P.within((Collection) arguments);
+            return P.within((Collection) arguments[0]);
         } else {
-            // when generic literal list is consist of a single generic literal
+            // when generic literal list is consist of comma separated generic literals or a single generic literal
             return P.within(arguments);
         }
     }
@@ -166,18 +163,15 @@ public class TraversalPredicateVisitor extends DefaultGremlinBaseVisitor<P> {
     @Override
     public P visitTraversalPredicate_without(final GremlinParser.TraversalPredicate_withoutContext ctx) {
         // called with no args which is valid for java/groovy
-        if (null == ctx.genericLiteralListArgument()) return P.without();
+        if (null == ctx.genericArgumentVarargs()) return P.without();
 
-        final Object arguments = antlr.argumentVisitor.visitGenericLiteralListArgument(ctx.genericLiteralListArgument());
+        final Object[] arguments = antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs());
 
-        if (arguments instanceof Object[]) {
-            // when generic literal list is consist of a comma separated generic literals
-            return P.without((Object [])arguments);
-        } else if (arguments instanceof List) {
+        if (arguments.length == 1 && arguments[0] instanceof Collection) {
             // when generic literal list is consist of a collection of generic literals, E.g. range
-            return P.without((List)arguments);
+            return P.without((Collection) arguments[0]);
         } else {
-            // when generic literal list is consist of a single generic literal
+            // when generic literal list is consist of comma separated generic literals or a single generic literal
             return P.without(arguments);
         }
     }
@@ -238,9 +232,9 @@ public class TraversalPredicateVisitor extends DefaultGremlinBaseVisitor<P> {
         final int childIndexOfParameterFirst = ctx.getChildCount() == 8 ? 4 : 2;
         final int childIndexOfParameterSecond = ctx.getChildCount() == 8 ? 6 : 4;
 
-        final Object first = antlr.argumentVisitor.visitGenericLiteralArgument(
+        final Object first = antlr.argumentVisitor.visitGenericArgument(
                 ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterFirst));
-        final Object second = antlr.argumentVisitor.visitGenericLiteralArgument(
+        final Object second = antlr.argumentVisitor.visitGenericArgument(
                 ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterSecond));
 
         return new Object[]{first, second};
@@ -253,7 +247,7 @@ public class TraversalPredicateVisitor extends DefaultGremlinBaseVisitor<P> {
     private Object getSingleGenericLiteralArgument(final ParseTree ctx) {;
         final int childIndexOfParameterValue = ctx.getChildCount() == 6 ? 4 : 2;
 
-        return antlr.argumentVisitor.visitGenericLiteralArgument(
+        return antlr.argumentVisitor.visitGenericArgument(
                 ParseTreeContextCastHelper.castChildToGenericLiteral(ctx, childIndexOfParameterValue));
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceSelfMethodVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceSelfMethodVisitor.java
@@ -75,9 +75,9 @@ public class TraversalSourceSelfMethodVisitor extends DefaultGremlinBaseVisitor<
     @Override
     public GraphTraversalSource visitTraversalSourceSelfMethod_withSack(final GremlinParser.TraversalSourceSelfMethod_withSackContext ctx) {
         if (ctx.getChildCount() == 4) {
-            return source.withSack(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+            return source.withSack(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
         } else {
-            return source.withSack(antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()),
+            return source.withSack(antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()),
                     TraversalEnumParser.parseTraversalEnumFromContext(Operator.class, ctx.traversalBiFunction().traversalOperator()));
         }
     }
@@ -90,10 +90,10 @@ public class TraversalSourceSelfMethodVisitor extends DefaultGremlinBaseVisitor<
         if (ctx.getChildCount() < 8) {
             // with 4 children withSideEffect() was called without a reducer specified.
             return source.withSideEffect(antlr.argumentVisitor.parseString(ctx.stringArgument()),
-                    antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+                    antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
         } else {
             return source.withSideEffect(antlr.argumentVisitor.parseString(ctx.stringArgument()),
-                    antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()),
+                    antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()),
                     TraversalEnumParser.parseTraversalEnumFromContext(Operator.class, ctx.traversalBiFunction().traversalOperator()));
         }
     }
@@ -109,7 +109,7 @@ public class TraversalSourceSelfMethodVisitor extends DefaultGremlinBaseVisitor<
             return source.withStrategies(traversalStrategyVisitor.visitTraversalStrategy((GremlinParser.TraversalStrategyContext) ctx.getChild(2)));
         } else {
             final Object[] vargs = GenericLiteralVisitor.parseTraversalStrategyList(
-                    (GremlinParser.TraversalStrategyListContext) ctx.getChild(4), traversalStrategyVisitor);
+                    (GremlinParser.TraversalStrategyVarargsContext) ctx.getChild(4), traversalStrategyVisitor);
             final List<TraversalStrategy> strats = new ArrayList<>(Arrays.asList(Arrays.copyOf(vargs, vargs.length, TraversalStrategy[].class)));
             strats.add(0, traversalStrategyVisitor.visitTraversalStrategy((GremlinParser.TraversalStrategyContext) ctx.getChild(2)));
             return source.withStrategies(strats.toArray(new TraversalStrategy[strats.size()]));
@@ -141,7 +141,7 @@ public class TraversalSourceSelfMethodVisitor extends DefaultGremlinBaseVisitor<
             return source.with(antlr.argumentVisitor.parseString(ctx.stringArgument()));
         } else {
             return source.with(antlr.argumentVisitor.parseString(ctx.stringArgument()),
-                    antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument()));
+                    antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument()));
         }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceSpawnMethodVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalSourceSpawnMethodVisitor.java
@@ -84,7 +84,7 @@ public class TraversalSourceSpawnMethodVisitor extends DefaultGremlinBaseVisitor
      */
     @Override
     public GraphTraversal visitTraversalSourceSpawnMethod_E(final GremlinParser.TraversalSourceSpawnMethod_EContext ctx) {
-        return this.traversalSource.E(antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return this.traversalSource.E(antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -92,7 +92,7 @@ public class TraversalSourceSpawnMethodVisitor extends DefaultGremlinBaseVisitor
      */
     @Override
     public GraphTraversal visitTraversalSourceSpawnMethod_V(final GremlinParser.TraversalSourceSpawnMethod_VContext ctx) {
-        return this.traversalSource.V(antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return this.traversalSource.V(antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -100,7 +100,7 @@ public class TraversalSourceSpawnMethodVisitor extends DefaultGremlinBaseVisitor
      */
     @Override
     public GraphTraversal visitTraversalSourceSpawnMethod_inject(final GremlinParser.TraversalSourceSpawnMethod_injectContext ctx) {
-        return this.traversalSource.inject(antlr.genericVisitor.parseObjectVarargs(ctx.genericLiteralVarargs()));
+        return this.traversalSource.inject(antlr.argumentVisitor.parseObjectVarargs(ctx.genericArgumentVarargs()));
     }
 
     /**
@@ -119,7 +119,7 @@ public class TraversalSourceSpawnMethodVisitor extends DefaultGremlinBaseVisitor
      */
     @Override
     public GraphTraversal visitTraversalSourceSpawnMethod_mergeV_Map(final GremlinParser.TraversalSourceSpawnMethod_mergeV_MapContext ctx) {
-        return this.traversalSource.mergeV(antlr.argumentVisitor.parseMap(ctx.genericLiteralMapNullableArgument()));
+        return this.traversalSource.mergeV(antlr.argumentVisitor.parseMap(ctx.genericMapNullableArgument()));
     }
 
     /**
@@ -143,7 +143,7 @@ public class TraversalSourceSpawnMethodVisitor extends DefaultGremlinBaseVisitor
      */
     @Override
     public GraphTraversal visitTraversalSourceSpawnMethod_mergeE_Map(final GremlinParser.TraversalSourceSpawnMethod_mergeE_MapContext ctx) {
-        return this.traversalSource.mergeE(antlr.argumentVisitor.parseMap(ctx.genericLiteralMapNullableArgument()));
+        return this.traversalSource.mergeE(antlr.argumentVisitor.parseMap(ctx.genericMapNullableArgument()));
     }
 
     /**
@@ -168,7 +168,7 @@ public class TraversalSourceSpawnMethodVisitor extends DefaultGremlinBaseVisitor
     @Override
     public GraphTraversal visitTraversalSourceSpawnMethod_call_string_map(final GremlinParser.TraversalSourceSpawnMethod_call_string_mapContext ctx) {
         return this.traversalSource.call(antlr.argumentVisitor.parseString(ctx.stringArgument()),
-                antlr.argumentVisitor.parseMap(ctx.genericLiteralMapArgument()));
+                antlr.argumentVisitor.parseMap(ctx.genericMapArgument()));
     }
 
     /**
@@ -186,7 +186,7 @@ public class TraversalSourceSpawnMethodVisitor extends DefaultGremlinBaseVisitor
     @Override
     public GraphTraversal visitTraversalSourceSpawnMethod_call_string_map_traversal(final GremlinParser.TraversalSourceSpawnMethod_call_string_map_traversalContext ctx) {
         return this.traversalSource.call(antlr.argumentVisitor.parseString(ctx.stringArgument()),
-                antlr.argumentVisitor.parseMap(ctx.genericLiteralMapArgument()),
+                antlr.argumentVisitor.parseMap(ctx.genericMapArgument()),
                 anonymousVisitor.visitNestedTraversal(ctx.nestedTraversal()));
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalStrategyVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/grammar/TraversalStrategyVisitor.java
@@ -58,7 +58,7 @@ public class TraversalStrategyVisitor extends DefaultGremlinBaseVisitor<Traversa
         if (null != contexts) {
             for (GremlinParser.ConfigurationContext ctx : contexts) {
                 final String key = ctx.getChild(0).getText();
-                final Object val = antlr.argumentVisitor.visitGenericLiteralArgument(ctx.genericLiteralArgument());
+                final Object val = antlr.argumentVisitor.visitGenericArgument(ctx.genericArgument());
                 conf.setProperty(key, val);
             }
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/AnonymizedTranslatorVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/AnonymizedTranslatorVisitor.java
@@ -77,22 +77,22 @@ public class AnonymizedTranslatorVisitor extends TranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) {
+    public Void visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) {
         return anonymize(ctx, Set.class);
     }
 
     @Override
-    public Void visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) {
+    public Void visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) {
         return anonymize(ctx, List.class);
     }
 
     @Override
-    public Void visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) {
+    public Void visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) {
         return anonymize(ctx, Map.class);
     }
 
     @Override
-    public Void visitGenericLiteralMapNullableArgument(final GremlinParser.GenericLiteralMapNullableArgumentContext ctx) {
+    public Void visitGenericMapNullableArgument(final GremlinParser.GenericMapNullableArgumentContext ctx) {
         return anonymize(ctx, Map.class);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/DotNetTranslateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/DotNetTranslateVisitor.java
@@ -166,12 +166,12 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralRange(final GremlinParser.GenericLiteralRangeContext ctx) {
+    public Void visitGenericRangeLiteral(final GremlinParser.GenericRangeLiteralContext ctx) {
         throw new TranslatorException(".NET does not support range literals");
     }
 
     @Override
-    public Void visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) {
+    public Void visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) {
         sb.append("new Dictionary<object, object> {");
         for (int i = 0; i < ctx.mapEntry().size(); i++) {
             final GremlinParser.MapEntryContext mapEntryContext = ctx.mapEntry(i);
@@ -184,7 +184,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) {
+    public Void visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) {
         sb.append("new HashSet<object> { ");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);
@@ -197,26 +197,12 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) {
+    public Void visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) {
         sb.append("new List<object> { ");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);
             visit(genericLiteralContext);
             if (i < ctx.genericLiteral().size() - 1)
-                sb.append(", ");
-        }
-        sb.append(" }");
-        return null;
-    }
-
-    @Override
-    public Void visitStringLiteralList(final GremlinParser.StringLiteralListContext ctx) {
-        sb.append("new List<string> { ");
-        for (int ix = 0; ix < ctx.getChild(1).getChildCount(); ix++) {
-            if (ctx.getChild(1).getChild(ix) instanceof TerminalNode)
-                continue;
-            visit(ctx.getChild(1).getChild(ix));
-            if (ix < ctx.getChild(1).getChildCount() - 1)
                 sb.append(", ");
         }
         sb.append(" }");
@@ -330,7 +316,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.stringArgument());
         sb.append(", ");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapArgument());
+        visit(ctx.genericMapArgument());
         sb.append(")");
         return null;
     }
@@ -356,7 +342,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.stringArgument());
         sb.append(", ");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapArgument());
+        visit(ctx.genericMapArgument());
         sb.append(", ");
         sb.append("(ITraversal) ");
         visit(ctx.nestedTraversal());
@@ -370,7 +356,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.getChild(0));
         sb.append("(");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapNullableArgument());
+        visit(ctx.genericMapNullableArgument());
         sb.append(")");
         return null;
     }
@@ -392,7 +378,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.getChild(0));
         sb.append("(");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapNullableArgument());
+        visit(ctx.genericMapNullableArgument());
         sb.append(")");
         return null;
     }
@@ -441,7 +427,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.stringLiteral());
         sb.append(", ");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapArgument());
+        visit(ctx.genericMapArgument());
         sb.append(")");
         return null;
     }
@@ -467,7 +453,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.stringLiteral());
         sb.append(", ");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapArgument());
+        visit(ctx.genericMapArgument());
         sb.append(", ");
         sb.append("(ITraversal) ");
         visit(ctx.nestedTraversal());
@@ -562,8 +548,8 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         tryAppendCastToString(ctx.stringNullableLiteral());
         visit(ctx.stringNullableLiteral());
         sb.append(", ");
-        tryAppendCastToObject(ctx.genericLiteralArgument());
-        visit(ctx.genericLiteralArgument());
+        tryAppendCastToObject(ctx.genericArgument());
+        visit(ctx.genericArgument());
         sb.append(")");
         return null;
     }
@@ -592,8 +578,8 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         tryAppendCastToString(ctx.stringNullableLiteral());
         visit(ctx.stringNullableLiteral());
         sb.append(", ");
-        tryAppendCastToObject(ctx.genericLiteralArgument());
-        visit(ctx.genericLiteralArgument());
+        tryAppendCastToObject(ctx.genericArgument());
+        visit(ctx.genericArgument());
         sb.append(")");
         return null;
     }
@@ -634,8 +620,8 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         sb.append("(");
         visit(ctx.traversalT());
         sb.append(", ");
-        tryAppendCastToObject(ctx.genericLiteralArgument());
-        visit(ctx.genericLiteralArgument());
+        tryAppendCastToObject(ctx.genericArgument());
+        visit(ctx.genericArgument());
         sb.append(")");
         return null;
     }
@@ -677,7 +663,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
     @Override
     public Void visitTraversalMethod_hasKey_String_String(final GremlinParser.TraversalMethod_hasKey_String_StringContext ctx) {
         // if there is only one argument then cast to string otherwise it's ambiguous with hasKey(P)
-        if (ctx.stringLiteralVarargs() == null || ctx.stringLiteralVarargs().getChildCount() == 0) {
+        if (ctx.stringNullableLiteralVarargs() == null || ctx.stringNullableLiteralVarargs().getChildCount() == 0) {
             final String step = ctx.getChild(0).getText();
             sb.append(convertToPascalCase(step));
             sb.append("(");
@@ -693,12 +679,12 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
     @Override
     public Void visitTraversalMethod_hasValue_Object_Object(final GremlinParser.TraversalMethod_hasValue_Object_ObjectContext ctx) {
         // if there is only one argument then cast to object otherwise it's ambiguous with hasValue(P)
-        if (ctx.genericLiteralVarargs() == null || ctx.genericLiteralVarargs().getChildCount() == 0) {
+        if (ctx.genericArgumentVarargs() == null || ctx.genericArgumentVarargs().getChildCount() == 0) {
             final String step = ctx.getChild(0).getText();
             sb.append(convertToPascalCase(step));
             sb.append("(");
-            tryAppendCastToObject(ctx.genericLiteralArgument());
-            visit(ctx.genericLiteralArgument());
+            tryAppendCastToObject(ctx.genericArgument());
+            visit(ctx.genericArgument());
             sb.append(")");
             return null;
         } else {
@@ -729,7 +715,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
     @Override
     public Void visitTraversalMethod_hasLabel_String_String(final GremlinParser.TraversalMethod_hasLabel_String_StringContext ctx) {
         // if there is only one argument then cast to string otherwise it's ambiguous with hasLabel(P)
-        if (ctx.stringLiteralVarargsArgument() == null || ctx.stringLiteralVarargsArgument().getChildCount() == 0) {
+        if (ctx.stringNullableArgumentVarargs() == null || ctx.stringNullableArgumentVarargs().getChildCount() == 0) {
             final String step = ctx.getChild(0).getText();
             sb.append(convertToPascalCase(step));
             sb.append("(");
@@ -808,7 +794,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.getChild(0));
         sb.append("(");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapNullableArgument());
+        visit(ctx.genericMapNullableArgument());
         sb.append(")");
         return null;
     }
@@ -830,7 +816,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.getChild(0));
         sb.append("(");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapNullableArgument());
+        visit(ctx.genericMapNullableArgument());
         sb.append(")");
         return null;
     }
@@ -864,7 +850,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         visit(ctx.traversalMerge());
         sb.append(", ");
         sb.append("(IDictionary<object, object>) ");
-        visit(ctx.genericLiteralMapNullableArgument()); // second argument
+        visit(ctx.genericMapNullableArgument()); // second argument
         sb.append(")");
         return null;
     }
@@ -904,17 +890,17 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
 
     @Override
     public Void visitTraversalMethod_property_Cardinality_Object_Object_Object(final GremlinParser.TraversalMethod_property_Cardinality_Object_Object_ObjectContext ctx) {
-        if (ctx.genericLiteralVarargs() == null || ctx.genericLiteralVarargs().getChildCount() == 0) {
+        if (ctx.genericArgumentVarargs() == null || ctx.genericArgumentVarargs().getChildCount() == 0) {
             final String step = ctx.getChild(0).getText();
             sb.append(convertToPascalCase(step));
             sb.append("(");
             visit(ctx.traversalCardinality());
             sb.append(", ");
-            tryAppendCastToObject(ctx.genericLiteralArgument(0));
-            visit(ctx.genericLiteralArgument(0));
+            tryAppendCastToObject(ctx.genericArgument(0));
+            visit(ctx.genericArgument(0));
             sb.append(", ");
-            tryAppendCastToObject(ctx.genericLiteralArgument(1));
-            visit(ctx.genericLiteralArgument(1));
+            tryAppendCastToObject(ctx.genericArgument(1));
+            visit(ctx.genericArgument(1));
             sb.append(")");
             return null;
         } else {
@@ -1166,7 +1152,7 @@ public class DotNetTranslateVisitor extends AbstractTranslateVisitor {
         }
     }
 
-    private void tryAppendCastToObject(final GremlinParser.GenericLiteralArgumentContext ctx) {
+    private void tryAppendCastToObject(final GremlinParser.GenericArgumentContext ctx) {
         if (ctx.variable() != null || ctx.genericLiteral().nullLiteral() != null)
             sb.append("(object) ");
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/GoTranslateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/GoTranslateVisitor.java
@@ -116,12 +116,12 @@ public class GoTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralRange(final GremlinParser.GenericLiteralRangeContext ctx) {
+    public Void visitGenericRangeLiteral(final GremlinParser.GenericRangeLiteralContext ctx) {
         throw new TranslatorException("Go does not support range literals");
     }
 
     @Override
-    public Void visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) {
+    public Void visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) {
         sb.append(GO_PACKAGE_NAME);
         sb.append("NewSimpleSet(");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
@@ -135,7 +135,7 @@ public class GoTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) {
+    public Void visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) {
         sb.append("[]interface{}{");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);
@@ -148,7 +148,7 @@ public class GoTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) {
+    public Void visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) {
         sb.append("map[interface{}]interface{}{");
         for (int i = 0; i < ctx.mapEntry().size(); i++) {
             final GremlinParser.MapEntryContext mapEntryContext = ctx.mapEntry(i);
@@ -200,7 +200,7 @@ public class GoTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
+    public Void visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) {
         sb.append(GO_PACKAGE_NAME).append("Vertex{Element{");
         visit(ctx.getChild(3)); // id
         sb.append(", ");

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/GroovyTranslateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/GroovyTranslateVisitor.java
@@ -46,7 +46,7 @@ public class GroovyTranslateVisitor extends TranslateVisitor {
     }
 
     @Override
-    public Void visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
+    public Void visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) {
         sb.append("new ");
         sb.append(vertexClassName);
         sb.append("(");
@@ -129,7 +129,7 @@ public class GroovyTranslateVisitor extends TranslateVisitor {
 
     @Override
     public Void visitNullLiteral(final GremlinParser.NullLiteralContext ctx) {
-        if (ctx.getParent() instanceof GremlinParser.GenericLiteralMapNullableArgumentContext) {
+        if (ctx.getParent() instanceof GremlinParser.GenericMapNullableArgumentContext) {
             sb.append("null as Map");
             return null;
         }
@@ -139,7 +139,7 @@ public class GroovyTranslateVisitor extends TranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralSet(GremlinParser.GenericLiteralSetContext ctx) {
+    public Void visitGenericSetLiteral(GremlinParser.GenericSetLiteralContext ctx) {
         sb.append("[");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/JavaTranslateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/JavaTranslateVisitor.java
@@ -53,7 +53,7 @@ public class JavaTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
+    public Void visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) {
         sb.append("new ");
         sb.append(vertexClassName);
         sb.append("(");
@@ -119,7 +119,7 @@ public class JavaTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) {
+    public Void visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) {
         sb.append("new LinkedHashMap<Object, Object>() {{ ");
         for (int i = 0; i < ctx.mapEntry().size(); i++) {
             final GremlinParser.MapEntryContext mapEntryContext = ctx.mapEntry(i);
@@ -247,12 +247,12 @@ public class JavaTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralRange(final GremlinParser.GenericLiteralRangeContext ctx) {
+    public Void visitGenericRangeLiteral(final GremlinParser.GenericRangeLiteralContext ctx) {
         throw new TranslatorException("Java does not support range literals");
     }
 
     @Override
-    public Void visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) {
+    public Void visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) {
         sb.append("new HashSet<Object>() {{ ");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);
@@ -267,7 +267,7 @@ public class JavaTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) {
+    public Void visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) {
         sb.append("new ArrayList<Object>() {{ ");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);
@@ -275,22 +275,6 @@ public class JavaTranslateVisitor extends AbstractTranslateVisitor {
             visit(genericLiteralContext);
             sb.append(");");
             if (i < ctx.genericLiteral().size() - 1)
-                sb.append(" ");
-        }
-        sb.append(" }}");
-        return null;
-    }
-
-    @Override
-    public Void visitStringLiteralList(final GremlinParser.StringLiteralListContext ctx) {
-        sb.append("new ArrayList<String>() {{ ");
-        for (int ix = 0; ix < ctx.getChild(1).getChildCount(); ix++) {
-            if (ctx.getChild(1).getChild(ix) instanceof TerminalNode)
-                continue;
-            sb.append("add(");
-            visit(ctx.getChild(1).getChild(ix));
-            sb.append(");");
-            if (ix < ctx.getChild(1).getChildCount() - 1)
                 sb.append(" ");
         }
         sb.append(" }}");

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/JavascriptTranslateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/JavascriptTranslateVisitor.java
@@ -54,7 +54,7 @@ public class JavascriptTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
+    public Void visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) {
         sb.append("new Vertex(");
         visit(ctx.getChild(3)); // id
         sb.append(", ");
@@ -98,7 +98,7 @@ public class JavascriptTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) {
+    public Void visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) {
         sb.append("new Map([");
         for (int i = 0; i < ctx.mapEntry().size(); i++) {
             final GremlinParser.MapEntryContext mapEntryContext = ctx.mapEntry(i);
@@ -193,12 +193,12 @@ public class JavascriptTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralRange(final GremlinParser.GenericLiteralRangeContext ctx) {
+    public Void visitGenericRangeLiteral(final GremlinParser.GenericRangeLiteralContext ctx) {
         throw new TranslatorException("Javascript does not support range literals");
     }
 
     @Override
-    public Void visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) {
+    public Void visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) {
         sb.append("new Set([");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);
@@ -211,7 +211,7 @@ public class JavascriptTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) {
+    public Void visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) {
         sb.append("[");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/PythonTranslateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/PythonTranslateVisitor.java
@@ -62,7 +62,7 @@ public class PythonTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitStructureVertex(final GremlinParser.StructureVertexContext ctx) {
+    public Void visitStructureVertexLiteral(final GremlinParser.StructureVertexLiteralContext ctx) {
         sb.append("Vertex(");
         visit(ctx.getChild(3)); // id
         sb.append(", ");
@@ -126,7 +126,7 @@ public class PythonTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralMap(final GremlinParser.GenericLiteralMapContext ctx) {
+    public Void visitGenericMapLiteral(final GremlinParser.GenericMapLiteralContext ctx) {
         sb.append("{ ");
         for (int i = 0; i < ctx.mapEntry().size(); i++) {
             final GremlinParser.MapEntryContext mapEntryContext = ctx.mapEntry(i);
@@ -270,12 +270,12 @@ public class PythonTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralRange(final GremlinParser.GenericLiteralRangeContext ctx) {
+    public Void visitGenericRangeLiteral(final GremlinParser.GenericRangeLiteralContext ctx) {
         throw new TranslatorException("Python does not support range literals");
     }
 
     @Override
-    public Void visitGenericLiteralSet(final GremlinParser.GenericLiteralSetContext ctx) {
+    public Void visitGenericSetLiteral(final GremlinParser.GenericSetLiteralContext ctx) {
         sb.append("{");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);
@@ -288,7 +288,7 @@ public class PythonTranslateVisitor extends AbstractTranslateVisitor {
     }
 
     @Override
-    public Void visitGenericLiteralCollection(final GremlinParser.GenericLiteralCollectionContext ctx) {
+    public Void visitGenericCollectionLiteral(final GremlinParser.GenericCollectionLiteralContext ctx) {
         sb.append("[");
         for (int i = 0; i < ctx.genericLiteral().size(); i++) {
             final GremlinParser.GenericLiteralContext genericLiteralContext = ctx.genericLiteral(i);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/TranslateVisitor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/language/translator/TranslateVisitor.java
@@ -253,8 +253,8 @@ public class TranslateVisitor extends GremlinBaseVisitor<Void> {
         appendStepOpen();
 
         final List<ParseTree> list =  ctx.children.stream().filter(
-                t -> t instanceof GremlinParser.GenericLiteralArgumentContext ||
-                              t instanceof GremlinParser.GenericLiteralListArgumentContext ||
+                t -> t instanceof GremlinParser.GenericArgumentContext ||
+                              t instanceof GremlinParser.GenericArgumentVarargsContext ||
                               t instanceof GremlinParser.StringArgumentContext ||
                               t instanceof GremlinParser.TraversalPredicateContext).collect(Collectors.toList());
         for (int ix = 0; ix < list.size(); ix++) {
@@ -384,7 +384,7 @@ public class TranslateVisitor extends GremlinBaseVisitor<Void> {
     }
 
     @Override
-    public Void visitGenericLiteralArgument(final GremlinParser.GenericLiteralArgumentContext ctx) {
+    public Void visitGenericArgument(final GremlinParser.GenericArgumentContext ctx) {
         if (ctx.genericLiteral() != null)
             visitGenericLiteral(ctx.genericLiteral());
         else

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/ArgumentVisitorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/ArgumentVisitorTest.java
@@ -149,12 +149,12 @@ public class ArgumentVisitorTest {
             });
         } else if (clazz.equals(Object.class)) {
             assertParsing(() -> {
-                final GremlinParser.GenericLiteralArgumentContext ctx = parser.genericLiteralArgument();
+                final GremlinParser.GenericArgumentContext ctx = parser.genericArgument();
                 return antlrToLanguage.argumentVisitor.parseObject(ctx);
             });
         } else if (clazz.equals(List.class)) {
             assertParsing(() -> {
-                final GremlinParser.GenericLiteralListArgumentContext ctx = parser.genericLiteralListArgument();
+                final GremlinParser.GenericArgumentVarargsContext ctx = parser.genericArgumentVarargs();
                 return antlrToLanguage.argumentVisitor.parseObjectVarargs(ctx);
             });
         } else if (clazz.equals(Vertex.class)) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/GeneralLiteralVisitorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/language/grammar/GeneralLiteralVisitorTest.java
@@ -63,8 +63,8 @@ public class GeneralLiteralVisitorTest {
     static Object parseGenericLiteralRange(final String query) {
         final GremlinLexer lexer = new GremlinLexer(CharStreams.fromString(query));
         final GremlinParser parser = new GremlinParser(new CommonTokenStream(lexer));
-        final GremlinParser.GenericLiteralRangeContext ctx = parser.genericLiteralRange();
-        return new GenericLiteralVisitor(new GremlinAntlrToJava()).visitGenericLiteralRange(ctx);
+        final GremlinParser.GenericRangeLiteralContext ctx = parser.genericRangeLiteral();
+        return new GenericLiteralVisitor(new GremlinAntlrToJava()).visitGenericRangeLiteral(ctx);
     }
 
     @RunWith(Parameterized.class)

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
@@ -1686,7 +1686,8 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
                {"g_VX1X_out_out_out_tree", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.V().Out().Out().Out().Tree<object>()}}, 
                {"g_VX1X_outE_inV_bothE_otherV_tree", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.V(p["vid1"]).OutE().InV().BothE().OtherV().Tree<object>()}}, 
                {"g_VX1X_outE_inV_bothE_otherV_tree_byXnameX_byXlabelX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.V(p["vid1"]).OutE().InV().BothE().OtherV().Tree<object>().By("name").By(T.Label)}}, 
-               {"g_injectXUUIDX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject<object>(Guid.Parse("f47af10b-58cc-4372-a567-0f02b2f3d479"))}}, 
+               {"g_injectXUUIDX47af10b_58cc_4372_a567_0f02b2f3d479XX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject<object>(Guid.Parse("f47af10b-58cc-4372-a567-0f02b2f3d479"))}}, 
+               {"g_injectXUUIDXXX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject<object>(Guid.NewGuid())}}, 
             };
 
         public static ITraversal UseTraversal(string scenarioName, GraphTraversalSource g, IDictionary<string, object> parameters)

--- a/gremlin-go/driver/cucumber/gremlin.go
+++ b/gremlin-go/driver/cucumber/gremlin.go
@@ -1656,7 +1656,8 @@ var translationMap = map[string][]func(g *gremlingo.GraphTraversalSource, p map[
     "g_VX1X_out_out_out_tree": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.V().Out().Out().Out().Tree()}}, 
     "g_VX1X_outE_inV_bothE_otherV_tree": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.V(p["vid1"]).OutE().InV().BothE().OtherV().Tree()}}, 
     "g_VX1X_outE_inV_bothE_otherV_tree_byXnameX_byXlabelX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.V(p["vid1"]).OutE().InV().BothE().OtherV().Tree().By("name").By(gremlingo.T.Label)}}, 
-    "g_injectXUUIDX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(uuid.MustParse("f47af10b-58cc-4372-a567-0f02b2f3d479"))}}, 
+    "g_injectXUUIDX47af10b_58cc_4372_a567_0f02b2f3d479XX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(uuid.MustParse("f47af10b-58cc-4372-a567-0f02b2f3d479"))}}, 
+    "g_injectXUUIDXXX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(uuid.New())}}, 
 }
 
    func GetTraversal(scenarioName string, g *gremlingo.GraphTraversalSource, parameters map[string]interface{}) (*gremlingo.GraphTraversal, error) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/gremlin.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/gremlin.js
@@ -24,6 +24,7 @@
 //********************************************************************************
 
 
+const uuid = require('uuid');
 const graphTraversalModule = require('../../lib/process/graph-traversal');
 const traversalModule = require('../../lib/process/traversal');
 const { TraversalStrategies, VertexProgramStrategy, OptionsStrategy, PartitionStrategy, 
@@ -1685,7 +1686,8 @@ const gremlins = {
     g_VX1X_out_out_out_tree: [function({g}) { return g.V().out().out().out().tree() }], 
     g_VX1X_outE_inV_bothE_otherV_tree: [function({g, vid1}) { return g.V(vid1).outE().inV().bothE().otherV().tree() }], 
     g_VX1X_outE_inV_bothE_otherV_tree_byXnameX_byXlabelX: [function({g, vid1}) { return g.V(vid1).outE().inV().bothE().otherV().tree().by("name").by(T.label) }], 
-    g_injectXUUIDX: [function({g}) { return g.inject("f47af10b-58cc-4372-a567-0f02b2f3d479") }], 
+    g_injectXUUIDX47af10b_58cc_4372_a567_0f02b2f3d479XX: [function({g}) { return g.inject("f47af10b-58cc-4372-a567-0f02b2f3d479") }], 
+    g_injectXUUIDXXX: [function({g}) { return g.inject(uuid.v4()) }], 
 }
 
 exports.gremlin = gremlins

--- a/gremlin-language/src/main/antlr4/Gremlin.g4
+++ b/gremlin-language/src/main/antlr4/Gremlin.g4
@@ -75,17 +75,17 @@ traversalSourceSelfMethod_withPath
     ;
 
 traversalSourceSelfMethod_withSack
-    : K_WITHSACK LPAREN genericLiteralArgument RPAREN
-    | K_WITHSACK LPAREN genericLiteralArgument COMMA traversalBiFunction RPAREN
+    : K_WITHSACK LPAREN genericArgument RPAREN
+    | K_WITHSACK LPAREN genericArgument COMMA traversalBiFunction RPAREN
     ;
 
 traversalSourceSelfMethod_withSideEffect
-    : K_WITHSIDEEFFECT LPAREN stringArgument COMMA genericLiteralArgument RPAREN
-    | K_WITHSIDEEFFECT LPAREN stringArgument COMMA genericLiteralArgument COMMA traversalBiFunction RPAREN
+    : K_WITHSIDEEFFECT LPAREN stringArgument COMMA genericArgument RPAREN
+    | K_WITHSIDEEFFECT LPAREN stringArgument COMMA genericArgument COMMA traversalBiFunction RPAREN
     ;
 
 traversalSourceSelfMethod_withStrategies
-    : K_WITHSTRATEGIES LPAREN traversalStrategy (COMMA traversalStrategyList)? RPAREN
+    : K_WITHSTRATEGIES LPAREN traversalStrategy (COMMA traversalStrategyVarargs)? RPAREN
     ;
 
 traversalSourceSelfMethod_withoutStrategies
@@ -94,7 +94,7 @@ traversalSourceSelfMethod_withoutStrategies
 
 traversalSourceSelfMethod_with
     : K_WITH LPAREN stringArgument RPAREN
-    | K_WITH LPAREN stringArgument COMMA genericLiteralArgument RPAREN
+    | K_WITH LPAREN stringArgument COMMA genericArgument RPAREN
     ;
 
 traversalSourceSpawnMethod
@@ -122,15 +122,15 @@ traversalSourceSpawnMethod_addV
     ;
 
 traversalSourceSpawnMethod_E
-    : K_E LPAREN genericLiteralVarargs RPAREN
+    : K_E LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalSourceSpawnMethod_V
-    : K_V LPAREN genericLiteralVarargs RPAREN
+    : K_V LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalSourceSpawnMethod_inject
-    : K_INJECT LPAREN genericLiteralVarargs RPAREN
+    : K_INJECT LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalSourceSpawnMethod_io
@@ -138,21 +138,21 @@ traversalSourceSpawnMethod_io
     ;
 
 traversalSourceSpawnMethod_mergeV
-    : K_MERGEV LPAREN genericLiteralMapNullableArgument RPAREN #traversalSourceSpawnMethod_mergeV_Map
+    : K_MERGEV LPAREN genericMapNullableArgument RPAREN #traversalSourceSpawnMethod_mergeV_Map
     | K_MERGEV LPAREN nestedTraversal RPAREN #traversalSourceSpawnMethod_mergeV_Traversal
     ;
 
 traversalSourceSpawnMethod_mergeE
-    : K_MERGEE LPAREN genericLiteralMapNullableArgument RPAREN #traversalSourceSpawnMethod_mergeE_Map
+    : K_MERGEE LPAREN genericMapNullableArgument RPAREN #traversalSourceSpawnMethod_mergeE_Map
     | K_MERGEE LPAREN nestedTraversal RPAREN #traversalSourceSpawnMethod_mergeE_Traversal
     ;
 
 traversalSourceSpawnMethod_call
     : K_CALL LPAREN RPAREN #traversalSourceSpawnMethod_call_empty
     | K_CALL LPAREN stringArgument RPAREN #traversalSourceSpawnMethod_call_string
-    | K_CALL LPAREN stringArgument COMMA genericLiteralMapArgument RPAREN #traversalSourceSpawnMethod_call_string_map
+    | K_CALL LPAREN stringArgument COMMA genericMapArgument RPAREN #traversalSourceSpawnMethod_call_string_map
     | K_CALL LPAREN stringArgument COMMA nestedTraversal RPAREN #traversalSourceSpawnMethod_call_string_traversal
-    | K_CALL LPAREN stringArgument COMMA genericLiteralMapArgument COMMA nestedTraversal RPAREN #traversalSourceSpawnMethod_call_string_map_traversal
+    | K_CALL LPAREN stringArgument COMMA genericMapArgument COMMA nestedTraversal RPAREN #traversalSourceSpawnMethod_call_string_map_traversal
     ;
 
 traversalSourceSpawnMethod_union
@@ -310,11 +310,11 @@ traversalMethod
     ;
 
 traversalMethod_V
-    : K_V LPAREN genericLiteralVarargs RPAREN
+    : K_V LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalMethod_E
-    : K_E LPAREN genericLiteralVarargs RPAREN
+    : K_E LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalMethod_addE
@@ -346,7 +346,7 @@ traversalMethod_any
     ;
 
 traversalMethod_as
-    : K_AS LPAREN stringLiteral (COMMA stringLiteralVarargs)? RPAREN
+    : K_AS LPAREN stringLiteral (COMMA stringNullableLiteralVarargs)? RPAREN
     ;
 
 traversalMethod_asDate
@@ -365,11 +365,11 @@ traversalMethod_barrier
     ;
 
 traversalMethod_both
-    : K_BOTH LPAREN stringLiteralVarargsArgument RPAREN
+    : K_BOTH LPAREN stringNullableArgumentVarargs RPAREN
     ;
 
 traversalMethod_bothE
-    : K_BOTHE LPAREN stringLiteralVarargsArgument RPAREN
+    : K_BOTHE LPAREN stringNullableArgumentVarargs RPAREN
     ;
 
 traversalMethod_bothV
@@ -395,13 +395,13 @@ traversalMethod_by
 
 traversalMethod_call
     : K_CALL LPAREN stringLiteral RPAREN #traversalMethod_call_string
-    | K_CALL LPAREN stringLiteral COMMA genericLiteralMapArgument RPAREN #traversalMethod_call_string_map
+    | K_CALL LPAREN stringLiteral COMMA genericMapArgument RPAREN #traversalMethod_call_string_map
     | K_CALL LPAREN stringLiteral COMMA nestedTraversal RPAREN #traversalMethod_call_string_traversal
-    | K_CALL LPAREN stringLiteral COMMA genericLiteralMapArgument COMMA nestedTraversal RPAREN #traversalMethod_call_string_map_traversal
+    | K_CALL LPAREN stringLiteral COMMA genericMapArgument COMMA nestedTraversal RPAREN #traversalMethod_call_string_map_traversal
     ;
 
 traversalMethod_cap
-    : K_CAP LPAREN stringLiteral (COMMA stringLiteralVarargs)? RPAREN
+    : K_CAP LPAREN stringLiteral (COMMA stringNullableLiteralVarargs)? RPAREN
     ;
 
 traversalMethod_choose
@@ -422,12 +422,12 @@ traversalMethod_coin
     ;
 
 traversalMethod_combine
-    : K_COMBINE LPAREN genericLiteralArgument RPAREN #traversalMethod_combine_Object
+    : K_COMBINE LPAREN genericArgument RPAREN #traversalMethod_combine_Object
     ;
 
 traversalMethod_concat
     : K_CONCAT LPAREN nestedTraversal (COMMA nestedTraversalList)? RPAREN #traversalMethod_concat_Traversal_Traversal
-    | K_CONCAT LPAREN stringLiteralVarargs RPAREN #traversalMethod_concat_String
+    | K_CONCAT LPAREN stringNullableLiteralVarargs RPAREN #traversalMethod_concat_String
     ;
 
 traversalMethod_conjoin
@@ -439,7 +439,7 @@ traversalMethod_connectedComponent
     ;
 
 traversalMethod_constant
-    : K_CONSTANT LPAREN genericLiteralArgument RPAREN
+    : K_CONSTANT LPAREN genericArgument RPAREN
     ;
 
 traversalMethod_count
@@ -461,16 +461,16 @@ traversalMethod_dateDiff
     ;
 
 traversalMethod_dedup
-    : K_DEDUP LPAREN traversalScope (COMMA stringLiteralVarargs)? RPAREN #traversalMethod_dedup_Scope_String
-    | K_DEDUP LPAREN stringLiteralVarargs RPAREN #traversalMethod_dedup_String
+    : K_DEDUP LPAREN traversalScope (COMMA stringNullableLiteralVarargs)? RPAREN #traversalMethod_dedup_Scope_String
+    | K_DEDUP LPAREN stringNullableLiteralVarargs RPAREN #traversalMethod_dedup_String
     ;
 
 traversalMethod_difference
-    : K_DIFFERENCE LPAREN genericLiteralArgument RPAREN #traversalMethod_difference_Object
+    : K_DIFFERENCE LPAREN genericArgument RPAREN #traversalMethod_difference_Object
     ;
 
 traversalMethod_disjunct
-    : K_DISJUNCT LPAREN genericLiteralArgument RPAREN #traversalMethod_disjunct_Object
+    : K_DISJUNCT LPAREN genericArgument RPAREN #traversalMethod_disjunct_Object
     ;
 
 traversalMethod_drop
@@ -482,7 +482,7 @@ traversalMethod_element
     ;
 
 traversalMethod_elementMap
-    : K_ELEMENTMAP LPAREN stringLiteralVarargs RPAREN
+    : K_ELEMENTMAP LPAREN stringNullableLiteralVarargs RPAREN
     ;
 
 traversalMethod_emit
@@ -507,7 +507,7 @@ traversalMethod_flatMap
 
 traversalMethod_fold
     : K_FOLD LPAREN RPAREN #traversalMethod_fold_Empty
-    | K_FOLD LPAREN genericLiteralArgument COMMA traversalBiFunction RPAREN #traversalMethod_fold_Object_BiFunction
+    | K_FOLD LPAREN genericArgument COMMA traversalBiFunction RPAREN #traversalMethod_fold_Object_BiFunction
     ;
 
 traversalMethod_format
@@ -532,29 +532,29 @@ traversalMethod_groupCount
 
 traversalMethod_has
     : K_HAS LPAREN stringNullableLiteral RPAREN #traversalMethod_has_String
-    | K_HAS LPAREN stringNullableLiteral COMMA genericLiteralArgument RPAREN #traversalMethod_has_String_Object
+    | K_HAS LPAREN stringNullableLiteral COMMA genericArgument RPAREN #traversalMethod_has_String_Object
     | K_HAS LPAREN stringNullableLiteral COMMA traversalPredicate RPAREN #traversalMethod_has_String_P
-    | K_HAS LPAREN stringNullableArgument COMMA stringNullableLiteral COMMA genericLiteralArgument RPAREN #traversalMethod_has_String_String_Object
+    | K_HAS LPAREN stringNullableArgument COMMA stringNullableLiteral COMMA genericArgument RPAREN #traversalMethod_has_String_String_Object
     | K_HAS LPAREN stringNullableArgument COMMA stringNullableLiteral COMMA traversalPredicate RPAREN #traversalMethod_has_String_String_P
     | K_HAS LPAREN stringNullableLiteral COMMA nestedTraversal RPAREN #traversalMethod_has_String_Traversal
-    | K_HAS LPAREN traversalT COMMA genericLiteralArgument RPAREN #traversalMethod_has_T_Object
+    | K_HAS LPAREN traversalT COMMA genericArgument RPAREN #traversalMethod_has_T_Object
     | K_HAS LPAREN traversalT COMMA traversalPredicate RPAREN #traversalMethod_has_T_P
     | K_HAS LPAREN traversalT COMMA nestedTraversal RPAREN #traversalMethod_has_T_Traversal
     ;
 
 traversalMethod_hasId
-    : K_HASID LPAREN genericLiteralArgument (COMMA genericLiteralVarargs)? RPAREN #traversalMethod_hasId_Object_Object
+    : K_HASID LPAREN genericArgument (COMMA genericArgumentVarargs)? RPAREN #traversalMethod_hasId_Object_Object
     | K_HASID LPAREN traversalPredicate RPAREN #traversalMethod_hasId_P
     ;
 
 traversalMethod_hasKey
     : K_HASKEY LPAREN traversalPredicate RPAREN #traversalMethod_hasKey_P
-    | K_HASKEY LPAREN stringNullableLiteral (COMMA stringLiteralVarargs)? RPAREN #traversalMethod_hasKey_String_String
+    | K_HASKEY LPAREN stringNullableLiteral (COMMA stringNullableLiteralVarargs)? RPAREN #traversalMethod_hasKey_String_String
     ;
 
 traversalMethod_hasLabel
     : K_HASLABEL LPAREN traversalPredicate RPAREN #traversalMethod_hasLabel_P
-    | K_HASLABEL LPAREN stringNullableArgument (COMMA stringLiteralVarargsArgument)? RPAREN #traversalMethod_hasLabel_String_String
+    | K_HASLABEL LPAREN stringNullableArgument (COMMA stringNullableArgumentVarargs)? RPAREN #traversalMethod_hasLabel_String_String
     ;
 
 traversalMethod_hasNot
@@ -562,7 +562,7 @@ traversalMethod_hasNot
     ;
 
 traversalMethod_hasValue
-    : K_HASVALUE LPAREN genericLiteralArgument (COMMA genericLiteralVarargs)? RPAREN #traversalMethod_hasValue_Object_Object
+    : K_HASVALUE LPAREN genericArgument (COMMA genericArgumentVarargs)? RPAREN #traversalMethod_hasValue_Object_Object
     | K_HASVALUE LPAREN traversalPredicate RPAREN #traversalMethod_hasValue_P
     ;
 
@@ -575,15 +575,15 @@ traversalMethod_identity
     ;
 
 traversalMethod_in
-    : K_IN LPAREN stringLiteralVarargs RPAREN
+    : K_IN LPAREN stringNullableLiteralVarargs RPAREN
     ;
 
 traversalMethod_inE
-    : K_INE LPAREN stringLiteralVarargs RPAREN
+    : K_INE LPAREN stringNullableLiteralVarargs RPAREN
     ;
 
 traversalMethod_intersect
-    : K_INTERSECT LPAREN genericLiteralArgument RPAREN #traversalMethod_intersect_Object
+    : K_INTERSECT LPAREN genericArgument RPAREN #traversalMethod_intersect_Object
     ;
 
 traversalMethod_inV
@@ -595,11 +595,11 @@ traversalMethod_index
     ;
 
 traversalMethod_inject
-    : K_INJECT LPAREN genericLiteralVarargs RPAREN
+    : K_INJECT LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalMethod_is
-    : K_IS LPAREN genericLiteralArgument RPAREN #traversalMethod_is_Object
+    : K_IS LPAREN genericArgument RPAREN #traversalMethod_is_Object
     | K_IS LPAREN traversalPredicate RPAREN #traversalMethod_is_P
     ;
 
@@ -658,18 +658,18 @@ traversalMethod_mean
     ;
 
 traversalMethod_merge
-    : K_MERGE LPAREN genericLiteralArgument RPAREN #traversalMethod_merge_Object
+    : K_MERGE LPAREN genericArgument RPAREN #traversalMethod_merge_Object
     ;
 
 traversalMethod_mergeV
     : K_MERGEV LPAREN RPAREN #traversalMethod_mergeV_empty
-    | K_MERGEV LPAREN genericLiteralMapNullableArgument RPAREN #traversalMethod_mergeV_Map
+    | K_MERGEV LPAREN genericMapNullableArgument RPAREN #traversalMethod_mergeV_Map
     | K_MERGEV LPAREN nestedTraversal RPAREN #traversalMethod_mergeV_Traversal
     ;
 
 traversalMethod_mergeE
     : K_MERGEE LPAREN RPAREN #traversalMethod_mergeE_empty
-    | K_MERGEE LPAREN genericLiteralMapNullableArgument RPAREN #traversalMethod_mergeE_Map
+    | K_MERGEE LPAREN genericMapNullableArgument RPAREN #traversalMethod_mergeE_Map
     | K_MERGEE LPAREN nestedTraversal RPAREN #traversalMethod_mergeE_Traversal
     ;
 
@@ -688,10 +688,10 @@ traversalMethod_not
 
 traversalMethod_option
     : K_OPTION LPAREN traversalPredicate COMMA nestedTraversal RPAREN #traversalMethod_option_Predicate_Traversal
-    | K_OPTION LPAREN traversalMerge COMMA genericLiteralMapNullableArgument RPAREN #traversalMethod_option_Merge_Map
-    | K_OPTION LPAREN traversalMerge COMMA genericLiteralMapNullableArgument COMMA traversalCardinality RPAREN #traversalMethod_option_Merge_Map_Cardinality
+    | K_OPTION LPAREN traversalMerge COMMA genericMapNullableArgument RPAREN #traversalMethod_option_Merge_Map
+    | K_OPTION LPAREN traversalMerge COMMA genericMapNullableArgument COMMA traversalCardinality RPAREN #traversalMethod_option_Merge_Map_Cardinality
     | K_OPTION LPAREN traversalMerge COMMA nestedTraversal RPAREN #traversalMethod_option_Merge_Traversal
-    | K_OPTION LPAREN genericLiteralArgument COMMA nestedTraversal RPAREN #traversalMethod_option_Object_Traversal
+    | K_OPTION LPAREN genericArgument COMMA nestedTraversal RPAREN #traversalMethod_option_Object_Traversal
     | K_OPTION LPAREN nestedTraversal RPAREN #traversalMethod_option_Traversal
     ;
 
@@ -713,11 +713,11 @@ traversalMethod_otherV
     ;
 
 traversalMethod_out
-    : K_OUT LPAREN stringLiteralVarargsArgument RPAREN
+    : K_OUT LPAREN stringNullableArgumentVarargs RPAREN
     ;
 
 traversalMethod_outE
-    : K_OUTE LPAREN stringLiteralVarargsArgument RPAREN
+    : K_OUTE LPAREN stringNullableArgumentVarargs RPAREN
     ;
 
 traversalMethod_outV
@@ -738,7 +738,7 @@ traversalMethod_peerPressure
     ;
 
 traversalMethod_product
-    : K_PRODUCT LPAREN genericLiteralArgument RPAREN #traversalMethod_product_Object
+    : K_PRODUCT LPAREN genericArgument RPAREN #traversalMethod_product_Object
     ;
 
 traversalMethod_profile
@@ -747,22 +747,22 @@ traversalMethod_profile
     ;
 
 traversalMethod_project
-    : K_PROJECT LPAREN stringLiteral (COMMA stringLiteralVarargs)? RPAREN
+    : K_PROJECT LPAREN stringLiteral (COMMA stringNullableLiteralVarargs)? RPAREN
     ;
 
 traversalMethod_properties
-    : K_PROPERTIES LPAREN stringLiteralVarargs RPAREN
+    : K_PROPERTIES LPAREN stringNullableLiteralVarargs RPAREN
     ;
 
 traversalMethod_property
-    : K_PROPERTY LPAREN traversalCardinality COMMA genericLiteralArgument COMMA genericLiteralArgument (COMMA genericLiteralVarargs)? RPAREN #traversalMethod_property_Cardinality_Object_Object_Object
-    | K_PROPERTY LPAREN traversalCardinality COMMA genericLiteralMapNullableArgument RPAREN # traversalMethod_property_Cardinality_Object
-    | K_PROPERTY LPAREN genericLiteralArgument COMMA genericLiteralArgument (COMMA genericLiteralVarargs)? RPAREN #traversalMethod_property_Object_Object_Object
-    | K_PROPERTY LPAREN genericLiteralMapNullableArgument RPAREN # traversalMethod_property_Object
+    : K_PROPERTY LPAREN traversalCardinality COMMA genericArgument COMMA genericArgument (COMMA genericArgumentVarargs)? RPAREN #traversalMethod_property_Cardinality_Object_Object_Object
+    | K_PROPERTY LPAREN traversalCardinality COMMA genericMapNullableArgument RPAREN # traversalMethod_property_Cardinality_Object
+    | K_PROPERTY LPAREN genericArgument COMMA genericArgument (COMMA genericArgumentVarargs)? RPAREN #traversalMethod_property_Object_Object_Object
+    | K_PROPERTY LPAREN genericMapNullableArgument RPAREN # traversalMethod_property_Object
     ;
 
 traversalMethod_propertyMap
-    : K_PROPERTYMAP LPAREN stringLiteralVarargs RPAREN
+    : K_PROPERTYMAP LPAREN stringNullableLiteralVarargs RPAREN
     ;
 
 traversalMethod_range
@@ -806,10 +806,10 @@ traversalMethod_sample
 traversalMethod_select
     : K_SELECT LPAREN traversalColumn RPAREN #traversalMethod_select_Column
     | K_SELECT LPAREN traversalPop COMMA stringLiteral RPAREN #traversalMethod_select_Pop_String
-    | K_SELECT LPAREN traversalPop COMMA stringLiteral COMMA stringLiteral (COMMA stringLiteralVarargs)? RPAREN #traversalMethod_select_Pop_String_String_String
+    | K_SELECT LPAREN traversalPop COMMA stringLiteral COMMA stringLiteral (COMMA stringNullableLiteralVarargs)? RPAREN #traversalMethod_select_Pop_String_String_String
     | K_SELECT LPAREN traversalPop COMMA nestedTraversal RPAREN #traversalMethod_select_Pop_Traversal
     | K_SELECT LPAREN stringLiteral RPAREN #traversalMethod_select_String
-    | K_SELECT LPAREN stringLiteral COMMA stringLiteral (COMMA stringLiteralVarargs)? RPAREN #traversalMethod_select_String_String_String
+    | K_SELECT LPAREN stringLiteral COMMA stringLiteral (COMMA stringNullableLiteralVarargs)? RPAREN #traversalMethod_select_String_String_String
     | K_SELECT LPAREN nestedTraversal RPAREN #traversalMethod_select_Traversal
     ;
 
@@ -871,14 +871,14 @@ traversalMethod_times
     ;
 
 traversalMethod_to
-    : K_TO LPAREN traversalDirection (COMMA stringLiteralVarargs)? RPAREN #traversalMethod_to_Direction_String
+    : K_TO LPAREN traversalDirection (COMMA stringNullableLiteralVarargs)? RPAREN #traversalMethod_to_Direction_String
     | K_TO LPAREN stringLiteral RPAREN #traversalMethod_to_String
     | K_TO LPAREN structureVertexArgument RPAREN #traversalMethod_to_Vertex
     | K_TO LPAREN nestedTraversal RPAREN #traversalMethod_to_Traversal
     ;
 
 traversalMethod_toE
-    : K_TOE LPAREN traversalDirection (COMMA stringLiteralVarargs)? RPAREN
+    : K_TOE LPAREN traversalDirection (COMMA stringNullableLiteralVarargs)? RPAREN
     ;
 
 traversalMethod_toLower
@@ -923,12 +923,12 @@ traversalMethod_value
     ;
 
 traversalMethod_valueMap
-    : K_VALUEMAP LPAREN stringLiteralVarargs RPAREN #traversalMethod_valueMap_String
-    | K_VALUEMAP LPAREN booleanLiteral  (COMMA stringLiteralVarargs)? RPAREN #traversalMethod_valueMap_boolean_String
+    : K_VALUEMAP LPAREN stringNullableLiteralVarargs RPAREN #traversalMethod_valueMap_String
+    | K_VALUEMAP LPAREN booleanLiteral  (COMMA stringNullableLiteralVarargs)? RPAREN #traversalMethod_valueMap_boolean_String
     ;
 
 traversalMethod_values
-    : K_VALUES LPAREN stringLiteralVarargs RPAREN
+    : K_VALUES LPAREN stringNullableLiteralVarargs RPAREN
     ;
 
 traversalMethod_where
@@ -939,7 +939,7 @@ traversalMethod_where
 
 traversalMethod_with
     : K_WITH LPAREN (withOptionKeys | stringLiteral) RPAREN #traversalMethod_with_String
-    | K_WITH LPAREN (withOptionKeys | stringLiteral) COMMA (withOptionsValues | ioOptionsValues | genericLiteralArgument) RPAREN #traversalMethod_with_String_Object
+    | K_WITH LPAREN (withOptionKeys | stringLiteral) COMMA (withOptionsValues | ioOptionsValues | genericArgument) RPAREN #traversalMethod_with_String_Object
     ;
 
 traversalMethod_write
@@ -954,8 +954,8 @@ traversalMethod_write
 // That use case is related to OLAP when the StarGraph does not preserve the label of adjacent vertices or other
 // fail fast scenarios in that processing model. It is not relevant to the grammar however when a user is creating
 // the Vertex to be used in a Traversal and therefore both id and label are required.
-structureVertex
-    : K_NEW? (K_VERTEX | K_REFERENCEVERTEX) LPAREN genericLiteralArgument COMMA stringArgument RPAREN
+structureVertexLiteral
+    : K_NEW? (K_VERTEX | K_REFERENCEVERTEX) LPAREN genericArgument COMMA stringArgument RPAREN
     ;
 
 traversalStrategy
@@ -963,7 +963,7 @@ traversalStrategy
     ;
 
 configuration
-    : (keyword | nakedKey) COLON genericLiteralArgument
+    : (keyword | nakedKey) COLON genericArgument
     ;
 
 traversalScope
@@ -1129,49 +1129,49 @@ traversalBiFunction
     ;
 
 traversalPredicate_eq
-    : (K_P DOT K_EQ | K_EQ) LPAREN genericLiteralArgument RPAREN
+    : (K_P DOT K_EQ | K_EQ) LPAREN genericArgument RPAREN
     ;
 
 traversalPredicate_neq
-    : (K_P DOT K_NEQ | K_NEQ) LPAREN genericLiteralArgument RPAREN
+    : (K_P DOT K_NEQ | K_NEQ) LPAREN genericArgument RPAREN
     ;
 
 traversalPredicate_lt
-    : (K_P DOT K_LT | K_LT) LPAREN genericLiteralArgument RPAREN
+    : (K_P DOT K_LT | K_LT) LPAREN genericArgument RPAREN
     ;
 
 traversalPredicate_lte
-    : (K_P DOT K_LTE | K_LTE) LPAREN genericLiteralArgument RPAREN
+    : (K_P DOT K_LTE | K_LTE) LPAREN genericArgument RPAREN
     ;
 
 traversalPredicate_gt
-    : (K_P DOT K_GT | K_GT) LPAREN genericLiteralArgument RPAREN
+    : (K_P DOT K_GT | K_GT) LPAREN genericArgument RPAREN
     ;
 
 traversalPredicate_gte
-    : (K_P DOT K_GTE | K_GTE) LPAREN genericLiteralArgument RPAREN
+    : (K_P DOT K_GTE | K_GTE) LPAREN genericArgument RPAREN
     ;
 
 traversalPredicate_inside
-    : (K_P DOT K_INSIDE | K_INSIDE) LPAREN genericLiteralArgument COMMA genericLiteralArgument RPAREN
+    : (K_P DOT K_INSIDE | K_INSIDE) LPAREN genericArgument COMMA genericArgument RPAREN
     ;
 
 traversalPredicate_outside
-    : (K_P DOT K_OUTSIDE | K_OUTSIDE) LPAREN genericLiteralArgument COMMA genericLiteralArgument RPAREN
+    : (K_P DOT K_OUTSIDE | K_OUTSIDE) LPAREN genericArgument COMMA genericArgument RPAREN
     ;
 
 traversalPredicate_between
-    : (K_P DOT K_BETWEEN | K_BETWEEN) LPAREN genericLiteralArgument COMMA genericLiteralArgument RPAREN
+    : (K_P DOT K_BETWEEN | K_BETWEEN) LPAREN genericArgument COMMA genericArgument RPAREN
     ;
 
 traversalPredicate_within
     : (K_P DOT K_WITHIN | K_WITHIN) LPAREN RPAREN
-    | (K_P DOT K_WITHIN | K_WITHIN) LPAREN genericLiteralListArgument RPAREN
+    | (K_P DOT K_WITHIN | K_WITHIN) LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalPredicate_without
     : (K_P DOT K_WITHOUT | K_WITHOUT) LPAREN RPAREN
-    | (K_P DOT K_WITHOUT | K_WITHOUT) LPAREN genericLiteralListArgument RPAREN
+    | (K_P DOT K_WITHOUT | K_WITHOUT) LPAREN genericArgumentVarargs RPAREN
     ;
 
 traversalPredicate_not
@@ -1469,48 +1469,40 @@ stringNullableArgument
     | variable
     ;
 
+stringNullableArgumentVarargs
+    : (stringNullableArgument (COMMA stringNullableArgument)*)?
+    ;
+
 dateArgument
     : dateLiteral
     | variable
     ;
 
-genericLiteralArgument
+genericArgument
     : genericLiteral
     | variable
     ;
 
-genericLiteralListArgument
-    : genericLiteralList
+genericArgumentVarargs
+    : (genericArgument (COMMA genericArgument)*)?
+    ;
+
+genericMapArgument
+    : genericMapLiteral
     | variable
     ;
 
-genericLiteralMapArgument
-    : genericLiteralMap
-    | variable
-    ;
-
-genericLiteralMapNullable
-    : genericLiteralMap
-    | nullLiteral
-    ;
-
-genericLiteralMapNullableArgument
-    : genericLiteralMap
-    | nullLiteral
+genericMapNullableArgument
+    : genericMapNullableLiteral
     | variable
     ;
 
 structureVertexArgument
-    : structureVertex
+    : structureVertexLiteral
     | variable
     ;
 
-uuidArgument
-    : uuidLiteral
-    | variable
-    ;
-
-traversalStrategyList
+traversalStrategyVarargs
     : traversalStrategyExpr?
     ;
 
@@ -1534,11 +1526,11 @@ nestedTraversalExpr
     : nestedTraversal (COMMA nestedTraversal)*
     ;
 
-genericLiteralVarargs
-    : (genericLiteralArgument (COMMA genericLiteralArgument)*)?
+genericCollectionLiteral
+    : LBRACK (genericLiteral (COMMA genericLiteral)*)? RBRACK
     ;
 
-genericLiteralList
+genericLiteralVarargs
     : genericLiteralExpr?
     ;
 
@@ -1546,34 +1538,22 @@ genericLiteralExpr
     : genericLiteral (COMMA genericLiteral)*
     ;
 
-genericLiteralRange
+genericMapNullableLiteral
+    : genericMapLiteral
+    | nullLiteral
+    ;
+
+genericRangeLiteral
     : integerLiteral DOT DOT integerLiteral
     | stringLiteral DOT DOT stringLiteral
     ;
 
-genericLiteralSet
+genericSetLiteral
     : LBRACE (genericLiteral (COMMA genericLiteral)*)? RBRACE
     ;
 
-genericLiteralCollection
-    : LBRACK (genericLiteral (COMMA genericLiteral)*)? RBRACK
-    ;
-
-stringLiteralVarargs
+stringNullableLiteralVarargs
     : (stringNullableLiteral (COMMA stringNullableLiteral)*)?
-    ;
-
-stringLiteralVarargsArgument
-    : (stringNullableArgument (COMMA stringNullableArgument)*)?
-    ;
-
-stringLiteralList
-    : stringLiteralExpr?
-    | LBRACK stringLiteralExpr? RBRACK
-    ;
-
-stringLiteralExpr
-    : stringNullableLiteral (COMMA stringNullableLiteral)*
     ;
 
 genericLiteral
@@ -1589,17 +1569,17 @@ genericLiteral
     | traversalMerge
     | traversalPick
     | traversalDT
-    | structureVertex
-    | genericLiteralSet
-    | genericLiteralCollection
-    | genericLiteralRange
+    | structureVertexLiteral
+    | genericSetLiteral
+    | genericCollectionLiteral
+    | genericRangeLiteral
     | nestedTraversal
     | terminatedTraversal
-    | genericLiteralMap
     | uuidLiteral
+    | genericMapLiteral
     ;
 
-genericLiteralMap
+genericMapLiteral
     : LBRACK COLON RBRACK
     | LBRACK mapEntry (COMMA mapEntry)* RBRACK
     ;
@@ -1607,9 +1587,9 @@ genericLiteralMap
 mapKey
     : (LPAREN traversalT RPAREN | traversalTLong)
     | (LPAREN traversalDirection RPAREN | traversalDirectionLong)
-    | (LPAREN genericLiteralSet RPAREN | genericLiteralSet)
-    | (LPAREN genericLiteralCollection RPAREN | genericLiteralCollection)
-    | (LPAREN genericLiteralMap RPAREN | genericLiteralMap)
+    | (LPAREN genericSetLiteral RPAREN | genericSetLiteral)
+    | (LPAREN genericCollectionLiteral RPAREN | genericCollectionLiteral)
+    | (LPAREN genericMapLiteral RPAREN | genericMapLiteral)
     | (LPAREN stringLiteral RPAREN | stringLiteral)
     | (LPAREN numericLiteral RPAREN | numericLiteral)
     | (keyword | nakedKey)

--- a/gremlin-python/src/main/python/radish/gremlin.py
+++ b/gremlin-python/src/main/python/radish/gremlin.py
@@ -1659,5 +1659,6 @@ world.gremlins = {
     'g_VX1X_out_out_out_tree': [(lambda g:g.V().out().out().out().tree())], 
     'g_VX1X_outE_inV_bothE_otherV_tree': [(lambda g, vid1=None:g.V(vid1).out_e().in_v().both_e().other_v().tree())], 
     'g_VX1X_outE_inV_bothE_otherV_tree_byXnameX_byXlabelX': [(lambda g, vid1=None:g.V(vid1).out_e().in_v().both_e().other_v().tree().by('name').by(T.label))], 
-    'g_injectXUUIDX': [(lambda g:g.inject(uuid.UUID('f47af10b-58cc-4372-a567-0f02b2f3d479')))], 
+    'g_injectXUUIDX47af10b_58cc_4372_a567_0f02b2f3d479XX': [(lambda g:g.inject(uuid.UUID('f47af10b-58cc-4372-a567-0f02b2f3d479')))], 
+    'g_injectXUUIDXXX': [(lambda g:g.inject(uuid.uuid4()))], 
 }


### PR DESCRIPTION
Renaming a bunch of types in the grammar to improve consistency and descriptiveness. Some types were redundant and have been removed.

The new names all follow the pattern `<baseType>(<CollectionType>)?(Nullable)?(Literal|Argument)(Varargs)?`

Previously, many types in the grammar used the suffix `List`, when in practice these were varargs as they did not nest arguments in brackets. These have all been renamed to varargs for consistency.

The full list of changes is listed below:

Renamings:
`genericLiteralArgument` -> `genericArgument`
`structureVertex` -> `structureVertexLiteral`
`stringLiteralVarargsArgument` -> `stringNullableArgumentVarargs`
`genericLiteralMapArgument` -> `genericMapArgument`
`genericLiteralMapNullable` -> `genericMapNullableLiteral`
`genericLiteralMapNullableArgument` -> `genericMapNullableArgument`
`traversalStrategyList` -> `traversalStrategyVarargs`
`genericLiteralVarargs` -> `genericArgumentVarags`
`genericLiteralCollection` -> `genericCollectionLiteral` // Could rename to genericListLiteral now that `List` is no longer refers to varargs
`genericLiteralList` -> `genericLiteralVarargs`
`genericLiteralRange` -> `genericRangeLiteral` // Note: should maybe be split into separate `integerRangeLiteral` and `stringRangeLiteral`
`stringLiteralVarargs` -> `stringNullableLiteralVarargs`
`genericLiteralMap` -> `genericMapLiteral`

Changes:
Remove `genericLiteralListArgument` in favour of `genericArgumentVarags` // only used by P.within and P.without
Remove `stringLiteralList` in favour of `stringNullableLiteralVarargs` // was previously unused

VOTE +1