### PR TITLE
.NET error logging improvemnet 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 *.DS_Store
 *.ipr
 *.swp
+TestResults/
 buildAll.sh
 build_output.txt
 .classpath

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from <<release-3-7-XXX, 3.7.XXX>>.
 
+* Improved .NET test output on build
 * Modified mathematical operators to prevent overflows in steps such as `sum()` and 'sack()' to prefer promotion to the next highest number type.
 * Added `DateTime` ontop of the existing 'datetime' grammar.
 * Added UUID() + UUID(value) to grammar

--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - DOCKER_ENVIRONMENT=true
     working_dir: /gremlin-dotnet
     command: >
-      bash -c "dotnet test ./Gremlin.Net.sln -c Release;
+      bash -c "dotnet tool update -g dotnet-trx; dotnet test ./Gremlin.Net.sln -c Release --logger trx; $HOME/.dotnet/tools/trx;
       EXIT_CODE=$$?; chown -R `stat -c "%u:%g" .` .; exit $$EXIT_CODE"
     depends_on:
       gremlin-server-test-dotnet:

--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - DOCKER_ENVIRONMENT=true
     working_dir: /gremlin-dotnet
     command: >
-      bash -c "dotnet tool update -g dotnet-trx; dotnet test ./Gremlin.Net.sln -c Release --logger trx; $HOME/.dotnet/tools/trx;
+      bash -c "dotnet tool update -g dotnet-trx; dotnet test ./Gremlin.Net.sln -c Release --logger trx; /root/.dotnet/tools/trx;
       EXIT_CODE=$$?; chown -R `stat -c "%u:%g" .` .; exit $$EXIT_CODE"
     depends_on:
       gremlin-server-test-dotnet:

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,7 @@ limitations under the License.
                         <exclude>**/*.graffle</exclude>
                         <exclude>**/*.svg</exclude>
                         <exclude>**/goal.txt</exclude>
+                        <exclude>**/*.trx</exclude>
                         <exclude>**/src/main/resources/META-INF/services/**</exclude>
                         <exclude>**/src/test/resources/mockito-extensions/**</exclude>
                         <exclude>**/src/test/resources/META-INF/services/**</exclude>


### PR DESCRIPTION
.NET has typically had bad error reporting on build where any failures would be hidden away in a large list. 

I have now implemented a trx add-on which nicely displays any errors in a grouped tidy fashion.

See [https://github.com/devlooped/dotnet-trx](https://github.com/devlooped/dotnet-trx) for more details


Some example outputs....

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/0a78fca2-395e-498a-848b-8fedf6bd61c0" />

![image](https://github.com/user-attachments/assets/eca1dbec-ceaa-4459-a03d-53afcc1900df)
