### PR TITLE
Passing of authenticated user in query lifecycle callbacks in GraphManager.

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -92,7 +92,7 @@ public interface Channelizer extends ChannelHandler {
     abstract class AbstractChannelizer extends ChannelInitializer<SocketChannel> implements Channelizer {
         protected Connection connection;
         protected Cluster cluster;
-        private ConcurrentMap<UUID, ResultQueue> pending;
+        protected ConcurrentMap<UUID, ResultQueue> pending;
 
         protected static final String PIPELINE_GREMLIN_SASL_HANDLER = "gremlin-sasl-handler";
         protected static final String PIPELINE_GREMLIN_HANDLER = "gremlin-handler";
@@ -152,7 +152,7 @@ public interface Channelizer extends ChannelHandler {
     /**
      * WebSocket {@link Channelizer} implementation.
      */
-    public final class WebSocketChannelizer extends AbstractChannelizer {
+    class WebSocketChannelizer extends AbstractChannelizer {
         private static final Logger logger = LoggerFactory.getLogger(WebSocketChannelizer.class);
         private WebSocketClientHandler handler;
 
@@ -255,7 +255,7 @@ public interface Channelizer extends ChannelHandler {
      * channelizer. Only sessionless requests are possible. Some driver configuration options may not be relevant when
      * using HTTP, such as {@link Tokens#ARGS_BATCH_SIZE} since HTTP does not stream results back in that fashion.
      */
-    public final class HttpChannelizer extends AbstractChannelizer {
+    class HttpChannelizer extends AbstractChannelizer {
 
         private HttpClientCodec handler;
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-final class Connection {
+public final class Connection {
     private static final Logger logger = LoggerFactory.getLogger(Connection.class);
 
     private final Channel channel;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultQueue.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultQueue.java
@@ -39,8 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-final class ResultQueue {
-
+public final class ResultQueue {
     private final LinkedBlockingQueue<Result> resultLinkedBlockingQueue;
 
     private Object aggregatedResult = null;
@@ -104,7 +103,7 @@ final class ResultQueue {
         resultLinkedBlockingQueue.drainTo(collection);
     }
 
-    void markComplete(final Map<String,Object> statusAttributes) {
+    public void markComplete(final Map<String,Object> statusAttributes) {
         // if there was some aggregation performed in the queue then the full object is hanging out waiting to be
         // added to the ResultSet
         if (aggregatedResult != null)
@@ -117,7 +116,7 @@ final class ResultQueue {
         this.drainAllWaiting();
     }
 
-    void markError(final Throwable throwable) {
+    public void markError(final Throwable throwable) {
         error.set(throwable);
         this.readComplete.completeExceptionally(throwable);
         this.drainAllWaiting();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import org.apache.tinkerpop.gremlin.server.auth.AuthenticatedUser;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -125,7 +126,7 @@ public interface GraphManager {
             return graph.features().graph().supportsTransactions() && graph.tx().isOpen();
         });
     }
- 
+
     /**
      * This method will be called before a script or query is processed by the
      * gremlin-server.
@@ -133,18 +134,40 @@ public interface GraphManager {
      * @param msg the {@link RequestMessage} received by the gremlin-server.
      */
     default void beforeQueryStart(final RequestMessage msg) {
-
     }
 
     /**
      * This method will be called before a script or query is processed by the
      * gremlin-server.
+     * <p>
+     * This method delegates call to the {@link #beforeQueryStart(RequestMessage)} by default, this functionality
+     * should be preserved by overriding methods if call of the former method is still needed.
+     *
+     * @param msg  the {@link RequestMessage} received by the gremlin-server.
+     * @param user User authenticated in channel processing request
+     */
+    default void beforeQueryStart(final RequestMessage msg, AuthenticatedUser user) {
+        beforeQueryStart(msg);
+    }
+
+    /**
+     * This method is called after the commit / rollback of transaction is called at the end
+     * of query processing. While {@link #onQuerySuccess(RequestMessage)} and {@link #onQueryError(RequestMessage, Throwable)}
+     * methods are called <b>before</b> transaction will be completed.
      *
      * @param msg the {@link RequestMessage} received by the gremlin-server.
+     */
+    default void afterQueryEnd(final RequestMessage msg) {
+    }
+
+    /**
+     * This method will be called if a script or query is processed by the
+     * gremlin-server throws an error.
+     *
+     * @param msg   the {@link RequestMessage} received by the gremlin-server.
      * @param error the exception encountered during processing from the gremlin-server.
      */
     default void onQueryError(final RequestMessage msg, final Throwable error) {
-
     }
 
     /**
@@ -153,6 +176,5 @@ public interface GraphManager {
      * @param msg the {@link RequestMessage} received by the gremlin-server.
      */
     default void onQuerySuccess(final RequestMessage msg) {
-
     }
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GraphManager.java
@@ -151,16 +151,6 @@ public interface GraphManager {
     }
 
     /**
-     * This method is called after the commit / rollback of transaction is called at the end
-     * of query processing. While {@link #onQuerySuccess(RequestMessage)} and {@link #onQueryError(RequestMessage, Throwable)}
-     * methods are called <b>before</b> transaction will be completed.
-     *
-     * @param msg the {@link RequestMessage} received by the gremlin-server.
-     */
-    default void afterQueryEnd(final RequestMessage msg) {
-    }
-
-    /**
      * This method will be called if a script or query is processed by the
      * gremlin-server throws an error.
      *

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/OpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/OpProcessor.java
@@ -21,6 +21,8 @@ package org.apache.tinkerpop.gremlin.server;
 import org.apache.tinkerpop.gremlin.server.op.OpProcessorException;
 import org.apache.tinkerpop.gremlin.util.function.ThrowingConsumer;
 
+import java.util.Optional;
+
 /**
  * Interface for providing commands that websocket requests will respond to.
  *
@@ -32,6 +34,10 @@ public interface OpProcessor extends AutoCloseable {
      * The name of the processor which requests must refer to "processor" field on a request.
      */
     public String getName();
+
+    default Optional<String> replacedOpProcessorName() {
+        return Optional.empty();
+    }
 
     /**
      * Initialize the {@code OpProcessor} with settings from the server. This method should only be called once at

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -240,11 +240,9 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
                     graphManager.onQueryError(msg, t);
                     if (managedTransactionsForRequest)
                         attemptRollback(msg, ctx.getGraphManager(), settings.strictTransactionManagement);
-                    graphManager.afterQueryEnd(msg);
                 })
                 .afterTimeout((b, t) -> {
                     graphManager.onQueryError(msg, t);
-                    graphManager.afterQueryEnd(msg);
                 })
                 .beforeEval(b -> {
                     AuthenticatedUser user = ctx.getChannelHandlerContext().channel().attr(StateKey.AUTHENTICATED_USER).get();
@@ -287,8 +285,6 @@ public abstract class AbstractEvalOpProcessor extends AbstractOpProcessor {
                         // wrap up the exception and rethrow. the error will be written to the client by the evalFuture
                         // as it will completeExceptionally in the GremlinExecutor
                         throw new RuntimeException(ex);
-                    } finally {
-                        graphManager.afterQueryEnd(msg);
                     }
                 }).create();
 


### PR DESCRIPTION
Our database (YouTrackDB) works with records only on a session basis and requires information about the authenticated user for real-time authorisation of user operations for each operation on a specific resource: schema, record, sequence ... and so on. 

So I have introduced one additional lifecycle method and added an authenticated user parameter to the one that is called before the request.

An additional method is called at the end of request processing once the transaction is rolled back if it is managed by session or traversal.