### PR TITLE
TINKERPOP-3167 Fixed NPE when borrowing a connection

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added server metrics to help better detect and diagnose write pauses due to the `writeBufferHighWaterMark`: `channels.paused`, `channels.total`, and `channels.write-pauses`.
 * Changed `IdentityRemovalStrategy` to omit `IdentityStep` if only with `RepeatEndStep` under `RepeatStep`.
 * Changed Gremlin grammar to make use of `g` to spawn child traversals a syntax error.
+* Fixed bug where the `Host` to `ConnectionPool` mapping on the `Client` in `gremlin-driver` can have no entries and therefore lead to a `NullPointerException` when borrowing a connection.
 * Added `unexpected-response` handler to `ws` for `gremlin-javascript`
 * Fixed bug in `TinkerTransactionGraph` where a read-only transaction may leave elements trapped in a "zombie transaction".
 * Fixed bug in `gremlin.sh` where it couldn't accept a directory name containing spaces.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -433,7 +433,7 @@ public abstract class Client {
      */
     public final static class ClusteredClient extends Client {
 
-        ConcurrentMap<Host, ConnectionPool> hostConnectionPools = new ConcurrentHashMap<>();
+        final ConcurrentMap<Host, ConnectionPool> hostConnectionPools = new ConcurrentHashMap<>();
         private final AtomicReference<CompletableFuture<Void>> closing = new AtomicReference<>(null);
         private Throwable initializationFailure = null;
 
@@ -543,9 +543,20 @@ public abstract class Client {
                 this.initializationFailure = ex;
             }
 
-            // throw an error if there is no host available after initializing connection pool.
-            if (cluster.availableHosts().isEmpty())
+            // throw an error if there is no host available after initializing connection pool. we used
+            // to test cluster.availableHosts().isEmpty() but checking if we actually have hosts in
+            // the connection pool seems a bit more fireproof. if we look at initializeConnectionSetupForHost
+            // we can see that a successful initialization of the host/connection pool pair is followed by
+            // marking the host available and notifying the load balancing strategy. by relying directly on
+            // the state of hostConnectionPools we ensure that there is actually a concrete
+            // host/connection pool pair. even if the connection pool has immediate problems, it can fallback
+            // to its normal reconnection operation and won't put chooseConnection in a state where it can
+            // get a NPE if hostConnectionPools ends up being empty. it seems as if the safest minimum
+            // requirement for leaving this method is to ensure that at least one ConnectionPool constructor
+            // completed for at least one Host.
+            if (hostConnectionPools.isEmpty()) {
                 throwNoHostAvailableException();
+            }
 
             // try to re-initiate any unavailable hosts in the background.
             final List<Host> unavailableHosts = cluster.allHosts()
@@ -588,7 +599,7 @@ public abstract class Client {
                 // hosts that don't initialize connection pools will come up as a dead host.
                 hostConnectionPools.put(host, new ConnectionPool(host, ClusteredClient.this));
 
-                // hosts are not marked as available at cluster initialization, and are made available here instead.
+                // hosts are not marked as available at cluster initialization and are made available here instead.
                 host.makeAvailable();
 
                 // added a new host to the cluster so let the load-balancer know.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -840,6 +840,9 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
             stopServer();
 
+            // the client used to be quiet about an unavailable host and i'm not sure why we liked the description
+            // that follows:
+            //
             // We create a new client here which will fail to initialize but the original client still has
             // host marked as connected. Since the second client failed during initialization, it has no way to
             // test if a host is indeed unreachable because it doesn't have any established connections. It will not add
@@ -849,7 +852,18 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
             // keepAlive message or the next request, whichever is earlier. In this case, we will simulate the second
             // scenario by sending a new request on first client. The request would fail (since server is down) and
             // client should mark the host unavailable.
-            cluster.connect().init();
+            // ...
+            // at 3.7.4 we don't let cluster level host availability determine for the client if
+            // NoHostAvailableException should be thrown. we rely on the ground truth of the actually initialization of
+            // the ConnectionPool and if at least one Host managed to create one. as such, it's more likely now that
+            // a NoHostAvailableException be thrown in this scenario, rather than it silently succeeding because
+            // client1 thinks it's still good.
+            try {
+                cluster.connect().init();
+                fail("Should have thrown NHA");
+            } catch (NoHostAvailableException ex) {
+
+            }
 
             try {
                 client1.submit("1+1").all().join();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3167

There is a chance that the Client.hostConnectionPools can land in a state where it has zero hosts present which leads to the returned ConnectionPool itself to be null. Borrowing a Connection then leads to a NullPointerException. Specifically, the `pool` ends up null [here](https://github.com/apache/tinkerpop/blob/3a48401d83656a31c459f541550b62be67084970/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java#L520) and then the NPE happens next line on `borrowConnection`.  

By preferring a check during init of actual connection pool creation the Client avoids a state where it could grab a null pool. This change doesn't address some of the synchronization issues that likely contributed to allowing the NPE in the first place, but there doesn't seem to be evidence that having an inconsistent state here can lead to issues outside of init().

VOTE +1