### PR TITLE
Increase default `max_content_length`/`max_msg_size` in python to 10MB

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug in `IndexStep` which prevented Java serialization due to non-serializable lambda usage by creating serializable function classes.
 * Fixed bug in `Operator` which was caused only a single method parameter to be Collection type checked instead of all parameters.
 * Support hot reloading of SSL certificates.
+* Increase default `max_content_length`/`max_msg_size` in `gremlin-python` from 4MB to 10MB.
 * Added the `PopContaining` interface designed to get label and `Pop` combinations held in a `PopInstruction` object.
 
 [[release-3-7-3]]

--- a/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/aiohttp/transport.py
@@ -54,6 +54,8 @@ class AiohttpTransport(AbstractBaseTransport):
         self._enable_compression = enable_compression
         if "max_content_length" in self._aiohttp_kwargs:
             self._aiohttp_kwargs["max_msg_size"] = self._aiohttp_kwargs.pop("max_content_length")
+        if "max_msg_size" not in self._aiohttp_kwargs:
+            self._aiohttp_kwargs["max_msg_size"] = 10 * 1024 * 1024
         if "ssl_options" in self._aiohttp_kwargs:
             self._aiohttp_kwargs["ssl"] = self._aiohttp_kwargs.pop("ssl_options")
         if self._enable_compression and "compress" not in self._aiohttp_kwargs:


### PR DESCRIPTION
Back in the [tornado transport days we had set the max content length in python to 10MB](https://github.com/apache/tinkerpop/blob/3.4-dev/gremlin-python/src/main/jython/gremlin_python/driver/tornado/transport.py#L29). 10MB is consistent with the default max frame length in gremlin-server. It seems the 10MB default was lost in the migration to AiohttpTransport, and we've inherited a reduced 4MB limit from AioHTTP.  Bumping it back to 10MB for consistency with gremlin-server.

VOTE +1