### PR TITLE
TINKERPOP-3100 Fix problem in recursive calls to Traversal lock()

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversalTest.java
@@ -163,7 +163,47 @@ public class DefaultTraversalTest {
                                         ).outV().filter(__.has("weight", P.lt(1))),
                                         __.as("a").outE("followedBy").choose(
                                                 __.has("weight"), __.has("weight", P.gt(1)), __.identity()
-                                        ).inV().where(__.identity())
+                                        ).inV().where(
+                                                __.coalesce(
+                                                        __.where(
+                                                                __.union(
+                                                                        __.as("a").outE("followedBy").choose(
+                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                        ).inV().has("songType", P.neq("cover")).where(
+                                                                                __.coalesce(
+                                                                                        __.where(
+                                                                                                __.union(
+                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                        ).inV().where(
+                                                                                                                __.coalesce(
+                                                                                                                        __.where(
+                                                                                                                                __.union(
+                                                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                                                        ).inV().where(
+                                                                                                                                                __.coalesce(
+                                                                                                                                                        __.where(
+                                                                                                                                                                __.union(
+                                                                                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                                                                                        ).inV().has("songType", P.within("original"))
+                                                                                                                                                                )
+                                                                                                                                                        )
+                                                                                                                                                )
+                                                                                                                                        )
+                                                                                                                                )
+                                                                                                                        )
+                                                                                                                )
+                                                                                                        )
+                                                                                                )
+                                                                                        )
+                                                                                )
+                                                                        )
+                                                                )
+                                                        )
+                                                )
+                                        )
                                 ).dedup().select("a")
                         )
                 ));

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/process/ApplyStrategiesBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/process/ApplyStrategiesBenchmark.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process;
+
+import org.apache.tinkerpop.benchmark.util.AbstractBenchmarkBase;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+
+/**
+ * Benchmark for measuring the performance of applying strategies to a complex traversal.
+ */
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class ApplyStrategiesBenchmark extends AbstractBenchmarkBase {
+
+    private Graph graph = EmptyGraph.instance();
+    private GraphTraversalSource g = traversal().withEmbedded(graph);
+    private Traversal<?, ?> traversal;
+
+    /**
+     * Setup method that constructs the complex traversal before benchmarking on each invocation of the test.
+     */
+    @Setup(Level.Invocation)
+    public void setup() {
+        traversal = g.V().or(
+                __.has("name", P.within(new HashSet<>(Arrays.asList("DARK STAR", "ST. STEPHEN", "CHINA CAT SUNFLOWER")))),
+                __.has("songType", P.eq("cover"))).where(
+                __.coalesce(
+                        __.where(
+                                __.union(
+                                        __.as("a").inE("sungBy").choose(
+                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                        ).outV().filter(__.has("weight", P.lt(1))),
+                                        __.as("a").outE("followedBy").choose(
+                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                        ).inV().where(
+                                                __.coalesce(
+                                                        __.where(
+                                                                __.union(
+                                                                        __.as("a").outE("followedBy").choose(
+                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                        ).inV().has("songType", P.neq("cover")).where(
+                                                                                __.coalesce(
+                                                                                        __.where(
+                                                                                                __.union(
+                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                        ).inV().where(
+                                                                                                                __.coalesce(
+                                                                                                                        __.where(
+                                                                                                                                __.union(
+                                                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                                                        ).inV().where(
+                                                                                                                                                __.coalesce(
+                                                                                                                                                        __.where(
+                                                                                                                                                                __.union(
+                                                                                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                                                                                        ).inV().has("songType", P.within("original"))
+                                                                                                                                                        )
+                                                                                                                                                )
+                                                                                                                                        )
+                                                                                                                                )
+                                                                                                                        )
+                                                                                                                )
+                                                                                                        )
+                                                                                                )
+                                                                                        )
+                                                                                )
+                                                                        )
+                                                                )
+                                                        )
+                                                )
+                                        )
+                                )
+                        ).dedup().select("a")
+                )
+        ));
+    }
+
+    @Override
+    protected int getWarmupIterations() {
+        return 1;
+    }
+
+    @Override
+    protected int getForks() {
+        return 1;
+    }
+
+    /**
+     * Benchmark that measures only the time it takes to apply strategies to a complex traversal.
+     */
+    @Benchmark
+    public Traversal testLockTraversal() {
+        if (traversal.asAdmin().isLocked())
+            throw new RuntimeException("Traversal is locked - that shouldn't be possible if the traversal is new");
+        traversal.asAdmin().applyStrategies();
+        return traversal;
+    }
+}

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/process/TraversalLockBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/gremlin/process/TraversalLockBenchmark.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process;
+
+import org.apache.tinkerpop.benchmark.util.AbstractBenchmarkBase;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+
+/**
+ * Benchmark for measuring the performance of locking a complex traversal.
+ * This benchmark is based on the shouldLock test in the DefaultTraversalTest class.
+ */
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class TraversalLockBenchmark extends AbstractBenchmarkBase {
+
+    private Graph graph = EmptyGraph.instance();
+    private GraphTraversalSource g = traversal().withEmbedded(graph);
+    private Traversal<?, ?> traversal;
+
+    /**
+     * Setup method that constructs the complex traversal before benchmarking on each invocation of the test.
+     */
+    @Setup(Level.Invocation)
+    public void setup() {
+        traversal = g.V().or(
+                __.has("name", P.within(new HashSet<>(Arrays.asList("DARK STAR", "ST. STEPHEN", "CHINA CAT SUNFLOWER")))),
+                __.has("songType", P.eq("cover"))).where(
+                __.coalesce(
+                        __.where(
+                                __.union(
+                                        __.as("a").inE("sungBy").choose(
+                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                        ).outV().filter(__.has("weight", P.lt(1))),
+                                        __.as("a").outE("followedBy").choose(
+                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                        ).inV().where(
+                                                __.coalesce(
+                                                        __.where(
+                                                                __.union(
+                                                                        __.as("a").outE("followedBy").choose(
+                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                        ).inV().has("songType", P.neq("cover")).where(
+                                                                                __.coalesce(
+                                                                                        __.where(
+                                                                                                __.union(
+                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                        ).inV().where(
+                                                                                                                __.coalesce(
+                                                                                                                        __.where(
+                                                                                                                                __.union(
+                                                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                                                        ).inV().where(
+                                                                                                                                                __.coalesce(
+                                                                                                                                                        __.where(
+                                                                                                                                                                __.union(
+                                                                                                                                                                        __.as("a").outE("followedBy").choose(
+                                                                                                                                                                                __.has("weight"), __.has("weight", P.gt(1)), __.identity()
+                                                                                                                                                                        ).inV().has("songType", P.within("original"))
+                                                                                                                                                        )
+                                                                                                                                                )
+                                                                                                                                        )
+                                                                                                                                )
+                                                                                                                        )
+                                                                                                                )
+                                                                                                        )
+                                                                                                )
+                                                                                        )
+                                                                                )
+                                                                        )
+                                                                )
+                                                        )
+                                                )
+                                        )
+                                )
+                        ).dedup().select("a")
+                )
+        ));
+    }
+
+    @Override
+    protected int getWarmupIterations() {
+        return 1;
+    }
+
+    @Override
+    protected int getForks() {
+        return 1;
+    }
+
+    /**
+     * Benchmark that measures only the time it takes to lock a complex traversal.
+     */
+    @Benchmark
+    public Traversal testLockTraversal() {
+        if (traversal.asAdmin().isLocked())
+            throw new RuntimeException("Traversal is locked - that shouldn't be possible if the traversal is new");
+        traversal.asAdmin().lock();
+        return traversal;
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3100

Drastically improves the performance of lock() as you lose the excessive recursion and avoid having to reidentify steps repeatedly.

```
Benchmark                                  Mode  Cnt   Score    Error   Units
TraversalLockBenchmark.testLockTraversal  thrpt   10  ≈ 10⁻⁴           ops/ms
```

after

```
Benchmark                                  Mode  Cnt   Score   Error   Units
TraversalLockBenchmark.testLockTraversal  thrpt   10  18.784 ± 0.334  ops/ms
```

Messily merged this to 3.7-dev with https://github.com/apache/tinkerpop/commit/98ffa44fc27f6326f259265372bb17240162d6c5 and removed the "deep" traversal tests/benchmarks because jdk8 wouldn't compile that code for some reason. works fine for jdk11/17. code is good for jdk8 when the traversal can compile so that performance fix still landed there. retargeted this PR to 3.8-dev where JDK8 is expected to be dropped and put the "deep" test/benchmarks back. This can merge after the JDK8 change goes in.

VOTE +1