### PR TITLE
TINKERPOP-2974: Corrected documentation to only use one by modulator for valueMap example

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -5034,7 +5034,7 @@ To turn list of values into single items, the `by()` modulator can be used as sh
 [gremlin-groovy,theCrew]
 ----
 g.V().valueMap().by(unfold())
-g.V().valueMap('name','location').by().by(unfold())
+g.V().valueMap('name','location').by(unfold())
 ----
 
 If the `id`, `label`, `key`, and `value` of the `Element` is desired, then the `with()` modulator can be used to


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2974

Corrected documentation to only use one by modulator for `valueMap` example as it is no longer supported after TINKERPOP-2974 was fixed by https://github.com/apache/tinkerpop/pull/3098.

I also searched the documentation for other steps which also had multiple by modulators disabled (https://issues.apache.org/jira/browse/TINKERPOP-3121) but didn't find any examples that needed updating.

