### PR TITLE
TINKERPOP-2647 improved plugin error message in Gremlin Console

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug in server `Settings` where it was referencing a property that was back in 3.3.0 and generating a warning log.
 * Improved performance of `Traversal.lock()` which was being called excessively.
 * Added log entry in `WsAndHttpChannelizerHandler` to catch general errors that escape the handlers.
+* Improved invalid plugin error message in Gremlin Console.
 * Added a `MessageSizeEstimator` implementation to cover `Frame` allowing Gremlin Server to better estimate message sizes for the direct buffer.
 * Fixed bug in Gremlin Console for field accessor issue with JDK17.
 * Improved logging around triggers of the `writeBufferHighWaterMark` so that they occur more than once but do not excessively fill the logs.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -158,7 +158,8 @@ class Console {
                 if (!io.quiet)
                     io.out.println(Colorizer.render(Preferences.infoColor, "plugin activated: " + pluggedIn.getPlugin().getName()))
             } else if (!io.quiet) {
-                    io.out.println(Colorizer.render(Preferences.infoColor, "invalid plugin: " + pluginName))
+                io.out.println(Colorizer.render(Preferences.infoColor, "invalid plugin: " + pluginName + " -- removing reference to this plugin."))
+
             }
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2647

I was trying to fix this issue, and I found that it wasn't failing the same way as described and the console state seems to get cleaned up on its own:

```
gremlin> :install org.apache.tinkerpop neo4j-gremlin 3.7.4-SNAPSHOT
==>Loaded: [org.apache.tinkerpop, neo4j-gremlin, 3.7.4-SNAPSHOT] - restart the console to use [tinkerpop.neo4j]
gremlin> :plugin use tinkerpop.neo4j
==>tinkerpop.neo4j activated
gremlin> :uninstall neo4j-gremlin
==>Uninstalled neo4j-gremlin - restart the console for removal to take effect
gremlin> :x

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
invalid plugin: org.apache.tinkerpop.gremlin.neo4j.jsr223.Neo4jGremlinPlugin
gremlin> 
```

The error didn't occur for spark or neo4j, but I found that the invalid plugin message wasn't as clear as it could be. I was confused by what was happening. I would like to suggest this small change to the messaging. It clarifies the action taken by the console. 

```
gremlin> :install org.apache.tinkerpop neo4j-gremlin 3.7.4-SNAPSHOT
==>Loaded: [org.apache.tinkerpop, neo4j-gremlin, 3.7.4-SNAPSHOT] - restart the console to use [tinkerpop.neo4j]
gremlin> :plugin use tinkerpop.neo4j
==>tinkerpop.neo4j activated
gremlin> :uninstall neo4j-gremlin
==>Uninstalled neo4j-gremlin - restart the console for removal to take effect
gremlin> :x

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
invalid plugin: org.apache.tinkerpop.gremlin.neo4j.jsr223.Neo4jGremlinPlugin -- removing reference to this plugin.
gremlin> 
```
