### PR TITLE
TINKERPOP-3141 Allow drop add vertex in same transaction

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Support hot reloading of SSL certificates.
 * Increase default `max_content_length`/`max_msg_size` in `gremlin-python` from 4MB to 10MB.
 * Added the `PopContaining` interface designed to get label and `Pop` combinations held in a `PopInstruction` object.
+* Fixed bug preventing a vertex from being dropped and then re-added in the same `TinkerTransaction`
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
@@ -154,6 +154,20 @@ final class TinkerElementContainer<T extends TinkerElement> {
     }
 
     /**
+     * Unmark element as deleted in the current transaction. Does nothing if the element was not previously marked as deleted.
+     *
+     * @see #markDeleted(TinkerTransaction)
+     */
+    public void unmarkDeleted(final TinkerTransaction tx) {
+        // only unmark as deleted if it was previously marked as deleted
+        if (isDeletedInTx.get()) {
+            usesInTransactions.decrementAndGet();
+            isDeletedInTx.set(false);
+            tx.markChanged(this);
+        }
+    }
+
+    /**
      * Mark element as changed in the current transaction.
      * A copy of the element is made and set as a value in the transaction.
      * @param transactionElement updated element

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerTransactionGraph.java
@@ -152,11 +152,19 @@ public final class TinkerTransactionGraph extends AbstractTinkerGraph {
         if (container != null && container.get() != null)
             throw Exceptions.vertexWithIdAlreadyExists(idValue);
 
+        long version = txNumber;
+        if (container != null && container.isDeleted() && container.getModified() != null) {
+            // vertex being added was previously deleted 
+            // we need to reference the version from the deleted state when adding the vertex back
+            version = container.getModified().version();
+            container.unmarkDeleted((TinkerTransaction) tx());
+        }
+        
         // no existing container, let's use new one
         if (container == null)
             container = newContainer;
 
-        final TinkerVertex vertex = new TinkerVertex(idValue, label, this, txNumber);
+        final TinkerVertex vertex = new TinkerVertex(idValue, label, this, version);
         ElementHelper.attachProperties(vertex, VertexProperty.Cardinality.list, keyValues);
         container.setDraft(vertex, (TinkerTransaction) tx());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3141

Account for the scenario of dropping and re-adding a vertex within the same transaction by adding a new `unmarkDeleted` method to the `TinkerElementContainer` and calling `unmarkDeleted` from `addVertex` if it is detected that the vertex had been previously deleted. Added logic to reference the previously deleted vertex version when adding the vertex back to avoid transaction conflict error.