### PR TITLE
Transaction reads should not interfere with add/update/delete

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Increase default `max_content_length`/`max_msg_size` in `gremlin-python` from 4MB to 10MB.
 * Added the `PopContaining` interface designed to get label and `Pop` combinations held in a `PopInstruction` object.
 * Fixed bug preventing a vertex from being dropped and then re-added in the same `TinkerTransaction`
+* Fixed bug which could cause a 'Conflict: element modified in another transaction' when a transaction is attempting to add/drop/update a vertex or edge while another transaction is reading the same vertex or edge.
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/docs/src/reference/implementations-tinkergraph.asciidoc
+++ b/docs/src/reference/implementations-tinkergraph.asciidoc
@@ -221,8 +221,8 @@ supported. You can think of the transaction as belonging to a thread, any traver
 will share the same transaction even if you attempt to start a new transaction.
 
 `TinkerTransactionGraph` provides the `read committed` transaction isolation level. This means that it will always try to
-guard against dirty reads. While you may notice stricter isolation semantics in some cases, you should not depend on
-this behavior as it may change in the future.
+guard against dirty reads but will not prevent non-repeatable reads or phantom reads. While you may notice stricter 
+isolation semantics in some cases, you should not depend on this behavior as it may change in the future.
 
 `TinkerTransactionGraph` employs optimistic locking as its locking strategy. This reduces complexity in the design as
 there are fewer timeouts that the user needs to manage. However, a consequence of this approach is that a transaction

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerElementContainer.java
@@ -59,7 +59,7 @@ final class TinkerElementContainer<T extends TinkerElement> {
     private final ThreadLocal<Boolean> isReadInTx = ThreadLocal.withInitial(() -> false);
 
     /**
-     * Count of usages of container in different transactions.
+     * Count of modification/deletion/addition usages of container in different transactions (reads do not contribute to this count).
      * Needed to understand whether this element is used in other transactions or it can be deleted during rollback.
      */
     private final AtomicInteger usesInTransactions = new AtomicInteger(0);
@@ -97,7 +97,6 @@ final class TinkerElementContainer<T extends TinkerElement> {
 
         if (!isReadInTx.get()) {
             isReadInTx.set(true);
-            usesInTransactions.incrementAndGet();
             tx.markRead(this);
         }
 
@@ -205,7 +204,7 @@ final class TinkerElementContainer<T extends TinkerElement> {
     }
 
     /**
-     * Used to understand if element is in use by any transaction.
+     * Used to understand if element is in use (added, modified, or deleted) by any transaction.
      */
     public boolean inUse() {
         return usesInTransactions.get() > 0;
@@ -245,8 +244,6 @@ final class TinkerElementContainer<T extends TinkerElement> {
         if (isDeletedInTx.get())
             usesInTransactions.decrementAndGet();
         if (isModifiedInTx.get())
-            usesInTransactions.decrementAndGet();
-        if (isReadInTx.get())
             usesInTransactions.decrementAndGet();
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3142

Changed `TinkerElementContainer` to no longer consider element reads as being 'used in a transaction' which should be reserved for element add/update/delete only. This is appropriate for `TinkerTransactionGraph` because the isolation level is 'read committed'. With this isolation level, we do not need to protect against 'unrepeatable reads' or 'phantom reads'.

Prior to this change, a read-only thread could cause a 'Conflict: element modified in another transaction' error in a separate thread which was attempting add/drop/update.