### PR TITLE
TINKERPOP-3177: Fix configuration of sessions in Go Client

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug in 'gremlin-server.sh' to account for spaces in directory names.
 * Deprecated `gremlin_python.process.__.has_key_` in favor of `gremlin_python.process.__.has_key`.
 * Added `gremlin.spark.outputRepartition` configuration to customize the partitioning of HDFS files from `OutputRDD`.
+* Added `ClientSettings.Session` configuration in `gremlin-go` to configure a sessioned client.
 * Allowed `mergeV()` and `mergeE()` to supply `null` in `Map` values.
 * Change signature of `hasId(P<Object>)` and `hasValue(P<Object>)` to `hasId(P<?>)` and `hasValue(P<?>)`.
 * Improved error message for when `emit()` is used without `repeat()`.

--- a/gremlin-go/driver/client.go
+++ b/gremlin-go/driver/client.go
@@ -42,6 +42,7 @@ type ClientSettings struct {
 	EnableCompression bool
 	ReadBufferSize    int
 	WriteBufferSize   int
+	Session           string
 
 	// Minimum amount of concurrent active traversals on a connection to trigger creation of a new connection
 	NewConnectionThreshold int
@@ -124,7 +125,7 @@ func NewClient(url string, configurations ...func(settings *ClientSettings)) (*C
 		logHandler:      logHandler,
 		transporterType: settings.TransporterType,
 		connections:     pool,
-		session:         "",
+		session:         settings.Session,
 	}
 
 	return client, nil

--- a/gremlin-go/driver/client_test.go
+++ b/gremlin-go/driver/client_test.go
@@ -146,6 +146,38 @@ func TestClient(t *testing.T) {
 
 		AssertVertexPropertiesWithProperties(t, result)
 	})
+
+	t.Run("Test sessioned client", func(t *testing.T) {
+		skipTestsIfNotEnabled(t, integrationTestSuiteName, testNoAuthEnable)
+		client, err := NewClient(testNoAuthUrl,
+			func(settings *ClientSettings) {
+				settings.TlsConfig = testNoAuthTlsConfig
+				settings.AuthInfo = testNoAuthAuthInfo
+				settings.TraversalSource = testServerModernGraphAlias
+				settings.Session = "sessionID"
+			})
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		defer client.Close()
+
+		resultSet, err := client.Submit("x = 1+1")
+		assert.NoError(t, err)
+		assert.NotNil(t, resultSet)
+
+		result, ok, err := resultSet.One()
+		assert.NoError(t, err)
+		assert.True(t, ok)
+		assert.EqualValues(t, 2, result.Data)
+
+		resultSet, err = client.Submit("x+1")
+		assert.NoError(t, err)
+		assert.NotNil(t, resultSet)
+
+		result, ok, err = resultSet.One()
+		assert.NoError(t, err)
+		assert.True(t, ok)
+		assert.EqualValues(t, 3, result.Data)
+	})
 }
 
 func AssertVertexPropertiesWithProperties(t *testing.T, result *Result) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3177

Adds missing configuration to allow use of sessioned Client in `gremlin-go`.

VOTE +1