### PR TITLE
Fixed broken image links in documentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -62,6 +62,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed bug which could cause a 'Conflict: element modified in another transaction' when a transaction is attempting to add/drop/update a vertex or edge while another transaction is reading the same vertex or edge.
 * Upgraded Node version from 18 to 20
 * Upgraded Go to version 1.24
+* Fixed broken image links in published documentation
 
 [[release-3-7-3]]
 === TinkerPop 3.7.3 (October 23, 2024)

--- a/docs/javadoc/overview.html
+++ b/docs/javadoc/overview.html
@@ -17,7 +17,7 @@ limitations under the License.
 <html>
 <body>
 <!-- The contents below get injected to the javadoc "overview.html".  -->
-<a href="http://tinkerpop.apache.org" target="_blank"><img src="https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/apache-tinkerpop-logo.png" width="300px"/></a><br/>
+<a href="http://tinkerpop.apache.org" target="_blank"><img src="https://tinkerpop.apache.org/img/apache-tinkerpop-logo.png" width="300px"/></a><br/>
 TinkerPop3 provides graph computing capabilities for both graph databases (OLTP) and graph analytic systems (OLAP) under the Apache2 license.
 </body>
 </html>

--- a/docs/src/upgrade/release-3.0.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.0.x-incubating.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.0.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-hindu.png[width=225]
+image::gremlin-hindu.png[width=225]
 
 *A Gremlin Rāga in 7/16 Time*
 

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.1.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-gangster.png[width=225]
+image::gremlin-gangster.png[width=225]
 
 *A 187 On The Undercover Gremlinz*
 

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.2.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/nine-inch-gremlins.png[width=225]
+image::nine-inch-gremlins.png[width=225]
 
 *Nine Inch Gremlins*
 

--- a/docs/src/upgrade/release-3.3.x.asciidoc
+++ b/docs/src/upgrade/release-3.3.x.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.3.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-mozart.png[width=225]
+image::gremlin-mozart.png[width=225]
 
 *Gremlin Symphony #40 in G Minor*
 

--- a/docs/src/upgrade/release-3.4.x.asciidoc
+++ b/docs/src/upgrade/release-3.4.x.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.4.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/avant-gremlin.png[width=225]
+image::avant-gremlin.png[width=225]
 
 *Avant-Gremlin Construction #3 for Theremin and Flowers*
 

--- a/docs/src/upgrade/release-3.5.x.asciidoc
+++ b/docs/src/upgrade/release-3.5.x.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.5.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-sleeping-beauty.png[width=225]
+image::gremlin-sleeping-beauty.png[width=225]
 
 *The Sleeping Gremlin: No. 18 Entr'acte Symphonique*
 

--- a/docs/src/upgrade/release-3.6.x.asciidoc
+++ b/docs/src/upgrade/release-3.6.x.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.6.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-victorian.png[width=185]
+image::gremlin-victorian.png[width=185]
 
 *Tinkerheart*
 

--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -17,7 +17,7 @@ limitations under the License.
 
 = TinkerPop 3.7.0
 
-image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/images/gremlin-zamfir.png[width=185]
+image::gremlin-zamfir.png[width=185]
 
 *Gremfir Master of the Pan Flute*
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3174

Fixed broken image links in documentation which were referencing the github domain and blocked by apache when viewing the tinkerpop website.