### PR TITLE
Remove P.getOriginalValue()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -82,6 +82,7 @@ This release also includes changes from <<release-3-7-XXX, 3.7.XXX>>.
 * Deprecated `ProcessLimitedStandardSuite` and `ProcessLimitedComputerSuite` in favor of `ProcessEmbeddedStandardSuite` and `ProcessEmbeddedComputerSuite` respectively.
 * Deprecated `ProcessStandardSuite` and the `ProcessComputerSuite` in favor of Gherkin testing and the `ProcessEmbeddedStandardSuite` and `ProcessEmbeddedComputerSuite` for testing JVM-specific Gremlin behaviors.
 * Removed lambda oriented Gremlin testing from Gherkin test suite.
+* Removed `P.getOriginalValue()` in favor of `P.getValue()`
 * Increase minimum Java version from 1.8 to 11 for building and running.
 * Moved all lambda oriented Gremlin tests to `LambdaStepTest` in the Java test suite.
 * Removed the `@RemoteOnly` testing tag in Gherkin as lambda tests have all been moved to the Java test suite.

--- a/docs/src/upgrade/release-3.8.x.asciidoc
+++ b/docs/src/upgrade/release-3.8.x.asciidoc
@@ -196,6 +196,12 @@ See: link:https://issues.apache.org/jira/browse/TINKERPOP-3083[TINKERPOP-3083]
 Starting from this version, `gremlin-javascript` will deserialize `Set` data into a ECMAScript 2015 Set. Previously,
 these were deserialized into arrays.
 
+==== Removal of P.getOriginalValue()
+
+`P.getOriginalValue()` has been removed as it was not offering much value and was often confused with `P.getValue()`.
+Usage of `P.getOriginalValue()` often leads to unexpected results if called on a predicate which has had its value reset
+after construction. All usages of `P.getOriginalValue()` should be replaced with `P.getValue()`.
+
 ==== Gremlin Grammar Changes
 
 A number of changes have been introduced to the Gremlin grammar to help make it be more consistent and easier to use.
@@ -546,7 +552,7 @@ The `DiscardStep` is now renamed to `DiscardStep`. Providers who developed strat
 `DiscardStep` should switch to `DiscardStep`. Note that `DiscardStep` has been repurposed as `none(P)` for filtering
 collections as a complement to `any(P)` and `all(P)`.
 
-==== Set minimum Java version to 11
+===== Set minimum Java version to 11
 
 TinkerPop 3.8 requires a minimum of Java 11 for building and running. Support for Java 1.8 has been dropped.
 
@@ -654,6 +660,12 @@ All the following types in the grammar have been renamed to follow consistent ru
 
 Additionally, `genericLiteralListArgument` and `stringLiteralList` have been removed in favor of `genericArgumentVarags`
 and `stringNullableLiteralVarargs` respectively.
+
+===== Removal of P.getOriginalValue()
+
+`P.getOriginalValue()` has been removed as it was not offering much value and was often confused with `P.getValue()`.
+Usage of `P.getOriginalValue()` often leads to unexpected results if called on a predicate which has had its value reset
+after construction. All usages of `P.getOriginalValue()` should be replaced with `P.getValue()`.
 
 ==== Graph Driver Providers
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/P.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/P.java
@@ -36,24 +36,14 @@ public class P<V> implements Predicate<V>, Serializable, Cloneable {
 
     protected PBiPredicate<V, V> biPredicate;
     protected V value;
-    protected V originalValue;
 
     public P(final PBiPredicate<V, V> biPredicate, final V value) {
         this.value = value;
-        this.originalValue = value;
         this.biPredicate = biPredicate;
     }
 
     public PBiPredicate<V, V> getBiPredicate() {
         return this.biPredicate;
-    }
-
-    /**
-     * Gets the original value used at time of construction of the {@code P}. This value can change its type
-     * in some cases.
-     */
-    public V getOriginalValue() {
-        return originalValue;
     }
 
     /*
@@ -80,8 +70,8 @@ public class P<V> implements Predicate<V>, Serializable, Cloneable {
     @Override
     public int hashCode() {
         int result = this.biPredicate.hashCode();
-        if (null != this.originalValue)
-            result ^= this.originalValue.hashCode();
+        if (null != this.value)
+            result ^= this.value.hashCode();
         return result;
     }
 
@@ -90,17 +80,17 @@ public class P<V> implements Predicate<V>, Serializable, Cloneable {
         return other instanceof P &&
                 ((P) other).getClass().equals(this.getClass()) &&
                 ((P) other).getBiPredicate().equals(this.biPredicate) &&
-                ((((P) other).getOriginalValue() == null && this.originalValue == null) || ((P) other).getOriginalValue().equals(this.originalValue));
+                ((((P) other).getValue() == null && this.value == null) || ((P) other).getValue().equals(this.value));
     }
 
     @Override
     public String toString() {
-        return null == this.originalValue ? this.biPredicate.toString() : this.biPredicate.toString() + "(" + this.originalValue + ")";
+        return null == this.value ? this.biPredicate.toString() : this.biPredicate.toString() + "(" + this.value + ")";
     }
 
     @Override
     public P<V> negate() {
-        return new P<>(this.biPredicate.negate(), this.originalValue);
+        return new P<>(this.biPredicate.negate(), this.value);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TextP.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TextP.java
@@ -36,12 +36,12 @@ public class TextP extends P<String> {
 
     @Override
     public String toString() {
-        return null == this.originalValue ? this.biPredicate.toString() : this.biPredicate.toString() + "(" + this.originalValue + ")";
+        return null == this.value ? this.biPredicate.toString() : this.biPredicate.toString() + "(" + this.value + ")";
     }
 
     @Override
     public TextP negate() {
-        return new TextP(this.biPredicate.negate(), this.originalValue);
+        return new TextP(this.biPredicate.negate(), this.value);
     }
 
     public TextP clone() {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/PTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/PTest.java
@@ -36,6 +36,7 @@ import java.util.Random;
 import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -293,6 +294,91 @@ public class PTest {
             assertEquals(P.eq(1).or(P.eq(2).and(P.eq(3).or(P.eq(4)))), new OrP<>(Arrays.asList(P.eq(1), new AndP<>(Arrays.asList(P.eq(2), new OrP<>(Arrays.asList(P.eq(3), P.eq(4))))))));
             assertEquals(P.eq(1).and(P.eq(2).or(P.eq(3).and(P.eq(4)))), new AndP<>(Arrays.asList(P.eq(1), new OrP<>(Arrays.asList(P.eq(2), new AndP<>(Arrays.asList(P.eq(3), P.eq(4))))))));
             assertEquals(P.eq(1).and(P.eq(2).and(P.eq(3).or(P.eq(4)))), new AndP<>(Arrays.asList(P.eq(1), P.eq(2), new OrP<>(Arrays.asList(P.eq(3), P.eq(4))))));
+        }
+    }
+    
+    public static class SetValueTest {
+
+        private static final int INITIAL_VALUE = 5;
+        private static final int UPDATED_VALUE = 10;
+        private static final String EQ_FORMAT = "eq(%d)";
+        private static final String NEQ_FORMAT = "neq(%d)";
+        public static final String GT_FORMAT = "gt(%d)";
+        public static final String LT_FORMAT = "lt(%d)";
+
+        @Test
+        public void shouldUseUpdatedValueAfterSetValue() {
+            P<Integer> predicate = P.eq(INITIAL_VALUE);
+            assertTrue(predicate.test(INITIAL_VALUE));
+            assertEquals(String.format(EQ_FORMAT, INITIAL_VALUE), predicate.toString());
+            assertEquals(predicate, P.eq(INITIAL_VALUE));
+            assertEquals(Integer.valueOf(INITIAL_VALUE), predicate.getValue());
+            
+            predicate.setValue(UPDATED_VALUE);
+            assertTrue(predicate.test(UPDATED_VALUE));
+            assertFalse(predicate.test(INITIAL_VALUE));
+            assertEquals(String.format(EQ_FORMAT, UPDATED_VALUE), predicate.toString());
+            assertEquals(predicate, P.eq(UPDATED_VALUE));
+            assertNotEquals(predicate, P.eq(INITIAL_VALUE));
+            assertEquals(Integer.valueOf(UPDATED_VALUE), predicate.getValue());
+        }
+
+        @Test
+        public void shouldUseUpdatedValueAfterSetValueForNegation() {
+            P<Integer> predicate = P.eq(INITIAL_VALUE);
+            P<Integer> negated = predicate.negate();
+            assertFalse(negated.test(INITIAL_VALUE));
+            assertEquals(String.format(NEQ_FORMAT, INITIAL_VALUE), negated.toString());
+            
+            predicate.setValue(UPDATED_VALUE);
+            P<Integer> updatedNegated = predicate.negate();
+            assertTrue(updatedNegated.test(INITIAL_VALUE));
+            assertFalse(updatedNegated.test(UPDATED_VALUE));
+            assertEquals(String.format(NEQ_FORMAT, UPDATED_VALUE), updatedNegated.toString());
+        }
+
+        @Test
+        public void shouldHandleNullValuesForSetValue() {
+            P<Integer> predicate = P.eq(INITIAL_VALUE);
+            predicate.setValue(null);
+            
+            assertTrue(predicate.test(null));
+            assertFalse(predicate.test(INITIAL_VALUE));
+            assertEquals("eq", predicate.toString());
+            assertEquals(predicate, P.eq(null));
+            assertNotEquals(predicate, P.eq(INITIAL_VALUE));
+        }
+
+        @Test
+        public void shouldUseUpdatedValueAfterSetValueForGreaterThan() {
+            P<Integer> gtPredicate = P.gt(INITIAL_VALUE);
+            gtPredicate.setValue(UPDATED_VALUE);
+            assertTrue(gtPredicate.test(UPDATED_VALUE + 1));
+            assertFalse(gtPredicate.test(UPDATED_VALUE));
+            assertEquals(String.format(GT_FORMAT, UPDATED_VALUE), gtPredicate.toString());
+        }
+
+        @Test
+        public void shouldUseUpdatedValueAfterSetValueForLessThan() {
+            P<Integer> ltPredicate = P.lt(INITIAL_VALUE);
+            ltPredicate.setValue(UPDATED_VALUE);
+            assertTrue(ltPredicate.test(UPDATED_VALUE - 1));
+            assertFalse(ltPredicate.test(UPDATED_VALUE));
+            assertEquals(String.format(LT_FORMAT, UPDATED_VALUE), ltPredicate.toString());
+        }
+
+        @Test
+        public void shouldUseUpdatedValueAfterSetValueContaining() {
+            String initial = "old";
+            String updated = "new";
+            TextP textPredicate = TextP.containing(initial);
+            textPredicate.setValue(updated);
+            
+            assertTrue(textPredicate.test(updated + "text"));
+            assertFalse(textPredicate.test(initial + "text"));
+            assertEquals(String.format("containing(%s)", updated), textPredicate.toString());
+            assertEquals(textPredicate, TextP.containing(updated));
+            assertNotEquals(textPredicate, TextP.containing(initial));
         }
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
@@ -193,7 +193,7 @@ public class MatchStepTest extends StepTest {
             assertEquals(WherePredicateStep.class, pattern.getStartStep().getNextStep().getClass());
             assertEquals(MatchStep.MatchEndStep.class, pattern.getStartStep().getNextStep().getNextStep().getClass());
             assertFalse(((WherePredicateStep<?>) pattern.getStartStep().getNextStep()).getStartKey().isPresent());
-            assertEquals("d", ((WherePredicateStep<?>) pattern.getStartStep().getNextStep()).getPredicate().get().getOriginalValue());
+            assertEquals("d", ((WherePredicateStep<?>) pattern.getStartStep().getNextStep()).getPredicate().get().getValue());
         });
     }
 


### PR DESCRIPTION
`P.getOriginalValue()` is not providing much value and it often confused with `P.getValue()`. I would argue that all existing usages of originalValue in P and TextP are incorrect as they lead to very strange behaviour after `P.setValue()` is called:
```
gremlin> predicate = P.eq(5)
==>eq(5)
gremlin> predicate.equals(P.eq(5))
==>true
gremlin> predicate.setValue(10)
==>null
gremlin> predicate.equals(P.eq(5))
==>true
gremlin> predicate.equals(P.eq(10))
==>false
gremlin> predicate.test(5)
==>false
gremlin> predicate.test(10)
==>true
gremlin> predicate.toString()
==>eq(5)
```

The only other usage in our code is in MatchStepTest which is unaffected by switching to `P.getValue()`. My vote is to get rid of `originalValue` altogether as it is not offering any value and just leads to unnecessary confusion.

VOTE +1