### PR TITLE
TINKERPOP-3181 Improved host availability on initialization.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-7-5]]
 === TinkerPop 3.7.5 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Improved Java driver host availability on connection pool initialization.
+
 [[release-3-7-4]]
 === TinkerPop 3.7.4 (Release Date: August 1, 2025)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3181

If the `ConnectionPool` creates at least one good connection on initialization, allow the `Client` to have an available `Host` even if it's less than the `minPoolSize`. Allow normal recovery options to attempt reconnects and fall into unavailability the standard ways.

VOTE +1