### PR TITLE
Added CallStep tests, fixed bugs, removed unnecessary code

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStepContract.java
@@ -31,6 +31,9 @@ public interface CallStepContract<S, E> extends Step<S, E>, Configuring, Travers
 
     String getServiceName();
 
+    /**
+     * TODO: re-evaluate if we should change this to return the static params only
+     */
     Map getMergedParams();
 
     ServiceRegistry getServiceRegistry();

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/GraphFactoryTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/GraphFactoryTest.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.Storage;
+import org.apache.tinkerpop.gremlin.structure.service.ServiceRegistry;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.apache.tinkerpop.gremlin.util.TestSupport;
 import org.junit.Test;
@@ -357,6 +358,15 @@ public class GraphFactoryTest {
         @Override
         public void close() throws Exception {
 
+        }
+
+        @Override
+        public ServiceRegistry getServiceRegistry() {
+            // allows tests to configure a mocked or stubbed service registry
+            if (conf.containsKey("service-registry")) {
+                return conf.get(ServiceRegistry.class, "service-registry");
+            }
+            return Graph.super.getServiceRegistry();
         }
     }
 


### PR DESCRIPTION
Added CallStep tests, fixed bugs, removed unnecessary code from placeholder. Allowed MockGraph to have a mocked or stubbed service registry.