### PR TITLE
TINKERPOP-3182 Fixed inconsistency in Path GraphSON serialization

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Improved Java driver host availability on connection pool initialization.
 * Added getter for `parameterItems` and `valueTraversal` on `DifferenceStep`.
+* Added properties to `Element` objects found in a `Path` for GraphSON v2 and v3 and GraphBinary.
+* Fixed edge properties for GraphBinary which were not deserializing properly.
 
 [[release-3-7-4]]
 === TinkerPop 3.7.4 (Release Date: August 1, 2025)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/types/PathSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/binary/types/PathSerializer.java
@@ -52,7 +52,9 @@ public class PathSerializer extends SimpleTypeSerializer<Path> {
             path.extend(objects.get(ix), labels.get(ix));
         }
 
-        return ReferenceFactory.detach(path);
+        // before 3.7.5, we forced detachment to reference here. better to just allow materializeProperties to control
+        // detachment or not.
+        return path;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2.java
@@ -258,10 +258,15 @@ class GraphSONSerializersV2 {
                 throws IOException, JsonGenerationException {
             jsonGenerator.writeStartObject();
 
+            // prior to 3.7.5, the code was such that:
             // paths shouldn't serialize with properties if the path contains graph elements
-            final Path p = DetachedFactory.detach(path, false);
-            jsonGenerator.writeObjectField(GraphSONTokens.LABELS, p.labels());
-            jsonGenerator.writeObjectField(GraphSONTokens.OBJECTS, p.objects());
+            //
+            // however, there was the idea that v2 untyped, with just a couple documented exceptions, should essentially
+            // match v1 which does include the properties (Path objects are not documented as exceptions). as of 3.7.5,
+            // we remove detachment to references and allow users to control the inclusion or exclusion of properties
+            // with the materializeProperties option.
+            jsonGenerator.writeObjectField(GraphSONTokens.LABELS, path.labels());
+            jsonGenerator.writeObjectField(GraphSONTokens.OBJECTS, path.objects());
 
             jsonGenerator.writeEndObject();
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV3.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV3.java
@@ -281,10 +281,14 @@ class GraphSONSerializersV3 {
                 throws IOException, JsonGenerationException {
             jsonGenerator.writeStartObject();
 
+            // prior to 3.7.5, the code was such that:
             // paths shouldn't serialize with properties if the path contains graph elements
-            final Path p = DetachedFactory.detach(path, false);
-            jsonGenerator.writeObjectField(GraphSONTokens.LABELS, p.labels());
-            jsonGenerator.writeObjectField(GraphSONTokens.OBJECTS, p.objects());
+            //
+            // however, there was the idea that v3 untyped should essentially match v1 which does include the
+            // properties. as of 3.7.5, we remove detachment to references and allow users to control the inclusion
+            // or exclusion of properties with the materializeProperties option.
+            jsonGenerator.writeObjectField(GraphSONTokens.LABELS, path.labels());
+            jsonGenerator.writeObjectField(GraphSONTokens.OBJECTS, path.objects());
 
             jsonGenerator.writeEndObject();
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -333,5 +333,52 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
                 Assert.True(vp.Properties == null || vp.Properties.Length == 0);
             }
         }
+        
+        [Fact]
+        public void shouldUseMaterializedPropertiesTokenInPath()
+        {
+            var connection = _connectionFactory.CreateRemoteConnection();
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var p = g.With("materializeProperties", "tokens").V().Has("name", "marko").OutE().InV().HasLabel("software").Path().Next();
+            
+            Assert.NotNull(p);
+            Assert.Equal(3, p.Count);
+            
+            var a = p[0] as Vertex;
+            var b = p[1] as Edge;
+            var c = p[2] as Vertex;
+            
+            Assert.NotNull(a);
+            Assert.NotNull(b);
+            Assert.NotNull(c);
+            
+            // GraphSON will deserialize into null and GraphBinary to []
+            Assert.True(a.Properties == null || a.Properties.Length == 0);
+            Assert.True(b.Properties == null || b.Properties.Length == 0);
+            Assert.True(c.Properties == null || c.Properties.Length == 0);
+        }
+        
+        [Fact]
+        public void shouldMaterializePropertiesAllInPath()
+        {
+            var connection = _connectionFactory.CreateRemoteConnection();
+            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var p = g.With("materializeProperties", "all").V().Has("name", "marko").OutE().InV().HasLabel("software").Path().Next();
+
+            Assert.NotNull(p);
+            Assert.Equal(3, p.Count);
+
+            var a = p[0] as Vertex;
+            var b = p[1] as Edge;
+            var c = p[2] as Vertex;
+
+            Assert.NotNull(a);
+            Assert.NotNull(b);
+            Assert.NotNull(c);
+
+            Assert.True(a.Properties != null && a.Properties.Length > 0);
+            Assert.True(b.Properties != null && b.Properties.Length > 0);
+            Assert.True(c.Properties != null && c.Properties.Length > 0);
+        }
     }
 }

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -1266,5 +1266,59 @@ func TestConnection(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, 0, len(properties))
 		}
+
+		// Path elements should also have no materialized properties when tokens is set
+		r, err := g.With("materializeProperties", MaterializeProperties.Tokens).V().Has("person", "name", "marko").OutE().InV().HasLabel("software").Path().Next()
+		assert.Nil(t, err)
+		p, err := r.GetPath()
+		assert.Nil(t, err)
+		assert.NotNil(t, p)
+		assert.Equal(t, 3, len(p.Objects))
+
+		// first element should be a Vertex
+		if a, ok := p.Objects[0].(*Vertex); assert.True(t, ok) {
+			props, ok := a.Properties.([]interface{})
+			assert.True(t, ok)
+			assert.Equal(t, 0, len(props))
+		}
+		// second element should be an Edge
+		if b, ok := p.Objects[1].(*Edge); assert.True(t, ok) {
+			props, ok := b.Properties.([]interface{})
+			assert.True(t, ok)
+			assert.Equal(t, 0, len(props))
+		}
+		// third element should be a Vertex
+		if c, ok := p.Objects[2].(*Vertex); assert.True(t, ok) {
+			props, ok := c.Properties.([]interface{})
+			assert.True(t, ok)
+			assert.Equal(t, 0, len(props))
+		}
+
+		// Path elements should have materialized properties when all is set
+		r, err = g.With("materializeProperties", MaterializeProperties.All).V().Has("person", "name", "marko").OutE().InV().HasLabel("software").Path().Next()
+		assert.Nil(t, err)
+		p, err = r.GetPath()
+		assert.Nil(t, err)
+		assert.NotNil(t, p)
+		assert.Equal(t, 3, len(p.Objects))
+
+		// first element should be a Vertex with properties present
+		if a, ok := p.Objects[0].(*Vertex); assert.True(t, ok) {
+			props, ok := a.Properties.([]interface{})
+			assert.True(t, ok)
+			assert.Greater(t, len(props), 0)
+		}
+		// second element should be an Edge with properties present
+		if b, ok := p.Objects[1].(*Edge); assert.True(t, ok) {
+			props, ok := b.Properties.([]interface{})
+			assert.True(t, ok)
+			assert.Greater(t, len(props), 0)
+		}
+		// third element should be a Vertex with properties present
+		if c, ok := p.Objects[2].(*Vertex); assert.True(t, ok) {
+			props, ok := c.Properties.([]interface{})
+			assert.True(t, ok)
+			assert.Greater(t, len(props), 0)
+		}
 	})
 }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/structure/graph.js
@@ -79,10 +79,12 @@ class Edge extends Element {
     this.inV = inV;
     this.properties = {};
     if (properties) {
-      const keys = Object.keys(properties);
-      for (let i = 0; i < keys.length; i++) {
-        const k = keys[i];
-        this.properties[k] = properties[k].value;
+      if (Array.isArray(properties)) {
+        // Handle array of Property objects
+        properties.forEach((prop) => (this.properties[prop.key] = prop.value));
+      } else {
+        // Handle object format as before
+        Object.keys(properties).forEach((k) => (this.properties[k] = properties[k].value));
       }
     }
   }

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/graphson-test.js
@@ -128,12 +128,28 @@ describe('GraphSONReader', function () {
     assert.ok(result.objects);
     assert.ok(result.labels);
     assert.strictEqual(result.objects[2], 'lop');
-    assert.ok(result.objects[0] instanceof graph.Vertex);
-    assert.ok(result.objects[1] instanceof graph.Vertex);
-    assert.strictEqual(result.objects[0].label, 'person');
-    assert.strictEqual(result.objects[1].label, 'software');
+    const a = result.objects[0];
+    const bc = result.objects[1];
+    assert.ok(a instanceof graph.Vertex);
+    assert.ok(bc instanceof graph.Vertex);
+    assert.strictEqual(a.label, 'person');
+    assert.strictEqual(bc.label, 'software');
+    assert.ok(a.properties);
+    assert.ok(a.properties['name']);
+    assert.strictEqual(a.properties['name'].length, 1);
+    assert.strictEqual(a.properties['name'][0].value, 'marko');
+    assert.ok(a.properties['age']);
+    assert.strictEqual(a.properties['age'].length, 1);
+    assert.strictEqual(a.properties['age'][0].value, 29);
+    assert.ok(bc.properties);
+    assert.ok(bc.properties['name']);
+    assert.strictEqual(bc.properties['name'].length, 1);
+    assert.strictEqual(bc.properties['name'][0].value, 'lop');
+    assert.ok(bc.properties['lang']);
+    assert.strictEqual(bc.properties['lang'].length, 1);
+    assert.strictEqual(bc.properties['lang'][0].value, 'java');
   });
-  it('should parse paths from GraphSON3', function () {
+  it('should parse paths from GraphSON3 without properties', function () {
     const obj = {
       "@type" : "g:Path",
       "@value" : {
@@ -180,10 +196,14 @@ describe('GraphSONReader', function () {
     assert.ok(result.objects);
     assert.ok(result.labels);
     assert.strictEqual(result.objects[2], 'lop');
-    assert.ok(result.objects[0] instanceof graph.Vertex);
-    assert.ok(result.objects[1] instanceof graph.Vertex);
-    assert.strictEqual(result.objects[0].label, 'person');
-    assert.strictEqual(result.objects[1].label, 'software');
+    const a = result.objects[0];
+    const bc = result.objects[1];
+    assert.ok(a instanceof graph.Vertex);
+    assert.ok(bc instanceof graph.Vertex);
+    assert.strictEqual(a.label, 'person');
+    assert.strictEqual(bc.label, 'software');
+    assert.ok(a.properties === undefined);
+    assert.ok(bc.properties === undefined);
   });
 });
 describe('GraphSONWriter', function () {

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -127,6 +127,21 @@ class TestDriverRemoteConnection(object):
         results = g.with_("materializeProperties", "tokens").V().properties().to_list()
         for vp in results:
             assert vp.properties is None or len(vp.properties) == 0
+        # #
+        # test materializeProperties in Path - GraphSON will deserialize into None and GraphBinary to []
+        p = g.with_("materializeProperties", "tokens").V().has('name', 'marko').outE().inV().has_label('software').path().next()
+        assert 3 == len(p.objects)
+        assert p.objects[0].properties is None or len(p.objects[0].properties) == 0
+        assert p.objects[1].properties is None or len(p.objects[1].properties) == 0
+        assert p.objects[2].properties is None or len(p.objects[2].properties) == 0
+        # #
+        # test materializeProperties in Path - 'all' should materialize properties on each element
+        p = g.with_("materializeProperties", "all").V().has('name', 'marko').outE().inV().has_label('software').path().next()
+        assert 3 == len(p.objects)
+        assert p.objects[0].properties is not None and len(p.objects[0].properties) > 0
+        # edges have dict-like properties; ensure not empty
+        assert p.objects[1].properties is not None and len(p.objects[1].properties) > 0
+        assert p.objects[2].properties is not None and len(p.objects[2].properties) > 0
 
     def test_lambda_traversals(self, remote_connection):
         statics.load_statics(globals())

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.AbstractTraverser;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
@@ -327,8 +328,13 @@ public class Context {
             final Object firstElement = aggregate.get(0);
 
             if (firstElement instanceof Element) {
-                for (int i = 0; i < aggregate.size(); i++)
+                for (int i = 0; i < aggregate.size(); i++) {
                     aggregate.set(i, ReferenceFactory.detach((Element) aggregate.get(i)));
+                }
+            } else if (firstElement instanceof Path) {
+                for (int i = 0; i < aggregate.size(); i++) {
+                    aggregate.set(i, ReferenceFactory.detach((Path) aggregate.get(i)));
+                }
             } else if (firstElement instanceof AbstractTraverser) {
                 for (final Object item : aggregate)
                     ((AbstractTraverser) item).detach();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -172,7 +172,7 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
     public void shouldHandlePathResult() throws Exception {
         final ResultSet results = client.submit("gmodern.V().out().path()");
         final Path p = results.all().get().get(0).getPath();
-        assertThat(p, instanceOf(ReferencePath.class));
+        assertThat(p, instanceOf(Path.class));
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -721,25 +722,21 @@ public class SerializationTest {
             final Vertex detachedVOut = detached.get("a");
             assertEquals(vOut.label(), detachedVOut.label());
             assertEquals(vOut.id(), detachedVOut.id());
-
-            // this is a SimpleTraverser so no properties are present in detachment
-            assertFalse(detachedVOut.properties().hasNext());
+            assertEquals("marko", detachedVOut.value("name").toString());
+            assertEquals(Integer.valueOf(29), detachedVOut.value("age"));
 
             final Edge e = p.get("b");
             final Edge detachedE = detached.get("b");
             assertEquals(e.label(), detachedE.label());
             assertEquals(e.id(), detachedE.id());
-
-            // this is a SimpleTraverser so no properties are present in detachment
-            assertFalse(detachedE.properties().hasNext());
+            assertEquals((double) e.value("weight"), detachedE.value("weight"), 0.0001d);
 
             final Vertex vIn = p.get("c");
             final Vertex detachedVIn = detached.get("c");
             assertEquals(vIn.label(), detachedVIn.label());
             assertEquals(vIn.id(), detachedVIn.id());
-
-            // this is a SimpleTraverser so no properties are present in detachment
-            assertFalse(detachedVIn.properties().hasNext());
+            assertEquals("lop", detachedVIn.value("name").toString());
+            assertEquals("java", detachedVIn.value("lang").toString());
         }
 
         @Test
@@ -923,25 +920,21 @@ public class SerializationTest {
             final Vertex detachedVOut = detached.get("a");
             assertEquals(vOut.label(), detachedVOut.label());
             assertEquals(vOut.id(), detachedVOut.id());
-
-            // this is a SimpleTraverser so no properties are present in detachment
-            assertFalse(detachedVOut.properties().hasNext());
+            assertEquals("marko", detachedVOut.value("name").toString());
+            assertEquals(Integer.valueOf(29), detachedVOut.value("age"));
 
             final Edge e = p.get("b");
             final Edge detachedE = detached.get("b");
             assertEquals(e.label(), detachedE.label());
             assertEquals(e.id(), detachedE.id());
-
-            // this is a SimpleTraverser so no properties are present in detachment
-            assertFalse(detachedE.properties().hasNext());
+            assertEquals((double) e.value("weight"), detachedE.value("weight"), 0.0001d);
 
             final Vertex vIn = p.get("c");
             final Vertex detachedVIn = detached.get("c");
             assertEquals(vIn.label(), detachedVIn.label());
             assertEquals(vIn.id(), detachedVIn.id());
-
-            // this is a SimpleTraverser so no properties are present in detachment
-            assertFalse(detachedVIn.properties().hasNext());
+            assertEquals("lop", detachedVIn.value("name").toString());
+            assertEquals("java", detachedVIn.value("lang").toString());
         }
 
         @Test

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
@@ -79,6 +79,7 @@ public final class Tokens {
     public static final String ARGS_HOST = "host";
     public static final String ARGS_SESSION = "session";
     public static final String ARGS_MANAGE_TRANSACTION = "manageTransaction";
+
     /**
      * The name of the argument that allows to control the serialization of properties on the server.
      */
@@ -88,8 +89,8 @@ public final class Tokens {
      * The name of the value denoting that all properties of Element should be returned.
      * Should be used with {@code ARGS_MATERIALIZE_PROPERTIES}
      */
-
     public static final String MATERIALIZE_PROPERTIES_ALL = "all";
+
     /**
      * The name of the value denoting that only `ID` and `Label` of Element should be returned.
      * Should be used with {@code ARGS_MATERIALIZE_PROPERTIES}
@@ -130,7 +131,7 @@ public final class Tokens {
     public static final String STATUS_ATTRIBUTE_STACK_TRACE = "stackTrace";
 
     /**
-     * A {@link ResultSet#statusAttributes()} key for user-facing warnings.
+     * A {@code ResultSet#statusAttributes()} key for user-facing warnings.
      * <p>
      * Implementations that set this key should consider using one of
      * these two recommended value types:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3182

`Path` objects were being forcibly detached by reference in GraphSON v1/v2 which put it at odds with v1 untyped. Inclusion or removal of properties should be controlled via `materializeProperties` only.

There's still a bit of weirdness here for Javascript particularly if you note the assertions in our tests. That should be resolved separately with a breaking change: [TINKERPOP-3186](https://issues.apache.org/jira/browse/TINKERPOP-3186).

VOTE +1