### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -61,7 +61,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-netty</artifactId>
+            <artifactId>ayza-for-netty</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@ limitations under the License.
         <snakeyaml.version>2.0</snakeyaml.version>
         <spark.version>3.5.4</spark.version>
         <awssdk.version>2.29.3</awssdk.version>
-        <sslcontext.kickstart.version>9.1.0</sslcontext.kickstart.version>
+        <ayza.version>10.0.0</ayza.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -779,8 +779,8 @@ limitations under the License.
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-netty</artifactId>
-                <version>${sslcontext.kickstart.version}</version>
+                <artifactId>ayza-for-netty</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.codahale.metrics</groupId>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to ayza. The latest version is 10.0.0

Sorry for the inconvenience

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.5 (non-breaking only)
    3.8-dev -> 3.8.0
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->