### PR TITLE
Fix WebSocket API inconsistency in Gremlin connection

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/connection.js
@@ -163,10 +163,11 @@ class Connection extends EventEmitter {
 
     this._ws.addEventListener('open', this.#handleOpen);
     this._ws.addEventListener('error', this.#handleError);
-    this._ws.on('unexpected-response', this.#handleUnexpectedResponse);
+    if (!useGlobalWebSocket) {
+      this._ws.on('unexpected-response', this.#handleUnexpectedResponse);
+    }
     this._ws.addEventListener('message', this.#handleMessage);
     this._ws.addEventListener('close', this.#handleClose);
-
     return await this._openPromise;
   }
 
@@ -415,7 +416,11 @@ class Connection extends EventEmitter {
     });
     this._ws.removeEventListener('open', this.#handleOpen);
     this._ws.removeEventListener('error', this.#handleError);
-    this._ws.off('unexpected-response', this.#handleUnexpectedResponse);
+    // Only remove unexpected-response listener for Node.js WebSocket (ws package)
+    // Browser WebSocket does not have this event and .off() method
+    if (this._ws && 'off' in this._ws) {
+      this._ws.off('unexpected-response', this.#handleUnexpectedResponse);
+    }
     this._ws.removeEventListener('message', this.#handleMessage);
     this._ws.removeEventListener('close', this.#handleClose);
     this._openPromise = null;


### PR DESCRIPTION
Fix WebSocket API inconsistency causing "this._ws.on is not a function" error

  The Gremlin JavaScript driver was mixing browser WebSocket API (.addEventListener)
  with Node.js WebSocket API (.on) in the same connection logic. This caused runtime
  errors when globalThis.WebSocket was detected but the browser WebSocket implementation
  doesn't support the .on() method used for 'unexpected-response' events.

  Changes:
  - Conditionally attach 'unexpected-response' listener only for Node.js WebSocket (ws package)
  - Preserve existing useGlobalWebSocket logic for legitimate browser/polyfill scenarios
  - Update cleanup method to safely remove listeners based on WebSocket type

  This maintains backward compatibility while fixing the cross-platform API incompatibility
  that prevented connections in environments with WebSocket polyfills or global WebSocket objects.


This is related to https://issues.apache.org/jira/browse/TINKERPOP-3160

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.5 (non-breaking only)
    3.8-dev -> 3.8.0
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->