### PR TITLE
Refinements to GValue

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -62,7 +62,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MergeEdgeStepPlac
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MergeStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MergeStepContract;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MergeVertexStepPlaceholder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
+import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStepPlaceholder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStepPlaceholder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStepContract;
@@ -3874,7 +3874,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         if ((endStep instanceof AddEdgeStepContract) ||
                 ((endStep instanceof AddVertexStepContract) && keyValues.length == 0 &&
                   (key instanceof T || (key instanceof String && null == cardinality) || key instanceof Traversal))) {
-            ((PropertyAdding) endStep).addProperty(key, value);
+            ((PropertiesHolder) endStep).addProperty(key, value);
         } else {
             final AddPropertyStepContract<Element> addPropertyStep = new AddPropertyStepPlaceholder<>(this.asAdmin(), cardinality, key, value);
             this.asAdmin().addStep(addPropertyStep);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/HasContainerHolder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/HasContainerHolder.java
@@ -43,7 +43,7 @@ public interface HasContainerHolder<S, E> extends GValueHolder<S, E> {
     }
 
     public default Collection<P<?>> getPredicates() {
-        Collection<P<?>> predicates = getHasContainers().stream().map(p -> p.getPredicate()).collect(Collectors.toList());
+        Collection<P<?>> predicates = getPredicatesGValueSafe();
         for (P<?> predicate : predicates) {
             if (predicate.isParameterized()) {
                 getTraversal().getGValueManager().pinGValues(predicate.getGValues());
@@ -61,11 +61,11 @@ public interface HasContainerHolder<S, E> extends GValueHolder<S, E> {
     }
 
     public default boolean isParameterized() {
-        return getPredicates().stream().anyMatch(P::isParameterized);
+        return getPredicatesGValueSafe().stream().anyMatch(P::isParameterized);
     }
 
     public default void updateVariable(final String name, final Object value) {
-        getPredicates().forEach((p) -> {
+        getPredicatesGValueSafe().forEach((p) -> {
             p.updateVariable(name, value);
         });
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/HasContainerHolder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/HasContainerHolder.java
@@ -45,7 +45,9 @@ public interface HasContainerHolder<S, E> extends GValueHolder<S, E> {
     public default Collection<P<?>> getPredicates() {
         Collection<P<?>> predicates = getHasContainers().stream().map(p -> p.getPredicate()).collect(Collectors.toList());
         for (P<?> predicate : predicates) {
-            getTraversal().getGValueManager().pinGValues(predicate.getGValues());
+            if (predicate.isParameterized()) {
+                getTraversal().getGValueManager().pinGValues(predicate.getGValues());
+            }
         }
         return predicates;
     }
@@ -70,7 +72,7 @@ public interface HasContainerHolder<S, E> extends GValueHolder<S, E> {
 
     public default Collection<GValue<?>> getGValues() {
         Set<GValue<?>> allGValues = new HashSet<>();
-        for (final P<?> p : getPredicates()) {
+        for (final P<?> p : getPredicatesGValueSafe()) {
             allGValues.addAll(p.getGValues());
         }
         return allGValues;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/PropertiesHolder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/PropertiesHolder.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.tinkerpop.gremlin.process.traversal.step; //TODO:: relocate class
+package org.apache.tinkerpop.gremlin.process.traversal.step;
 
 import java.util.List;
 import java.util.Map;
 
-public interface PropertyAdding {
+public interface PropertiesHolder {
     void addProperty(Object key, Object value);
     Map<Object, List<Object>> getProperties();
     boolean removeProperty(Object k);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/PropertyAdding.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/PropertyAdding.java
@@ -25,4 +25,8 @@ public interface PropertyAdding {
     void addProperty(Object key, Object value);
     Map<Object, List<Object>> getProperties();
     boolean removeProperty(Object k);
+
+    default public Map<Object, List<Object>> getPropertiesWithGValues() {
+        return getProperties();
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/IsStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/IsStepContract.java
@@ -34,7 +34,11 @@ public interface IsStepContract<S> extends Step<S, S> {
      *
      * @return the predicate associated with the step
      */
-    public P<?> getPredicate();
+    public P<S> getPredicate();
+
+    default P<S> getPredicateGValueSafe() {
+        return getPredicate();
+    }
 
     public Set<TraverserRequirement> getRequirements();
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/IsStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/IsStepPlaceholder.java
@@ -55,6 +55,7 @@ public final class IsStepPlaceholder<S> extends AbstractStep<S,S> implements GVa
         return this.predicate;
     }
 
+    @Override
     public P<S> getPredicateGValueSafe() {
         return this.predicate;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStepContract.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 
 /**
  * Defines the contract for {@code range} related steps.
@@ -38,4 +39,24 @@ public interface RangeGlobalStepContract<S> extends Step<S, S> {
      * @return the higher bound of the range as an object of type V
      */
     Long getHighRange();
+
+    /**
+     * getLowRange, retaining the GValue container and without pinning the variable. It is the caller's
+     * responsibility to ensure that this value is not used to alter the traversal in any way which is not generalizable
+     * to any parameter value.
+     * @return the lower bound for range().
+     */
+    default GValue<Long> getLowRangeAsGValue() {
+        return GValue.of(getLowRange());
+    }
+
+    /**
+     * getHighRange, retaining the GValue container and without pinning the variable. It is the caller's
+     * responsibility to ensure that this value is not used to alter the traversal in any way which is not generalizable
+     * to any parameter value.
+     * @return the upper bound for range().
+     */
+    default GValue<Long> getHighRangeAsGValue() {
+        return GValue.of(getHighRange());
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeLocalStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeLocalStepContract.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 
 /**
  * Defines the contract for {@code range} related steps.
@@ -38,4 +39,24 @@ public interface RangeLocalStepContract<S> extends Step<S, S> {
      * @return the higher bound of the range as an object of type V
      */
     Long getHighRange();
+
+    /**
+     * getLowRange, retaining the GValue container and without pinning the variable. It is the caller's
+     * responsibility to ensure that this value is not used to alter the traversal in any way which is not generalizable
+     * to any parameter value.
+     * @return the lower bound for range().
+     */
+    default GValue<Long> getLowRangeAsGValue() {
+        return GValue.of(getLowRange());
+    }
+
+    /**
+     * getHighRange, retaining the GValue container and without pinning the variable. It is the caller's
+     * responsibility to ensure that this value is not used to alter the traversal in any way which is not generalizable
+     * to any parameter value.
+     * @return the upper bound for range().
+     */
+    default GValue<Long> getHighRangeAsGValue() {
+        return GValue.of(getHighRange());
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeStepPlaceholder.java
@@ -102,31 +102,23 @@ public abstract class RangeStepPlaceholder<S> extends AbstractStep<S,S> implemen
     }
 
     /**
-     * getLowRange without marking the GValue as dirty and thus automatically pinning the GValue. It is the caller's
+     * getLowRange, retaining the GValue container and without pinning the variable. It is the caller's
      * responsibility to ensure that this value is not used to alter the traversal in any way which is not generalizable
      * to any parameter value.
      * @return the lower bound for range().
      */
-    public long getLowRangeGValueSafe() {
-        return low.get();
+    public GValue<Long> getLowRangeAsGValue() {
+        return low;
     }
 
     /**
-     * getHighRange without marking the GValue as dirty and thus automatically pinning the GValue. It is the caller's
+     * getHighRange, retaining the GValue container and without pinning the variable. It is the caller's
      * responsibility to ensure that this value is not used to alter the traversal in any way which is not generalizable
      * to any parameter value.
      * @return the upper bound for range().
      */
-    public long getHighRangeGValueSafe() {
-        return high.get();
-    }
-
-    public String getLowName() {
-        return low.getName();
-    }
-
-    public String getHighName() {
-        return high.getName();
+    public GValue<Long> getHighRangeAsGValue() {
+        return high;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStepContract.java
@@ -19,7 +19,12 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 
 public interface TailGlobalStepContract<S> extends Step<S, S> {
     Long getLimit();
+
+    default GValue<Long> getLimitAsGValue() {
+        return GValue.of(getLimit());
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStepPlaceholder.java
@@ -69,8 +69,9 @@ public final class TailGlobalStepPlaceholder<S> extends AbstractStep<S, S> imple
         return limit.get();
     }
 
-    public Long getLimitGValueSafe() {
-        return limit.get();
+    @Override
+    public GValue<Long> getLimitAsGValue() {
+        return limit;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailLocalStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailLocalStepContract.java
@@ -19,7 +19,12 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 
 public interface TailLocalStepContract<S> extends Step<S, S> {
     Long getLimit();
+
+    default GValue<Long> getLimitAsGValue() {
+        return GValue.of(getLimit());
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailLocalStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailLocalStepPlaceholder.java
@@ -66,8 +66,9 @@ public final class TailLocalStepPlaceholder<S> extends AbstractStep<S, S> implem
         return limit.get();
     }
 
-    public Long getLimitGValueSafe() {
-        return limit.get();
+    @Override
+    public GValue<Long> getLimitAsGValue() {
+        return limit;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddEdgeStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddEdgeStepPlaceholder.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.GValueConstantTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
+
+import java.util.Collection;
+
+public abstract class AbstractAddEdgeStepPlaceholder<S> extends AbstractAddElementStepPlaceholder<S, Edge, Event.EdgeAddedEvent> implements AddEdgeStepContract<S> {
+    protected Traversal.Admin<?, ?> from;
+    protected Traversal.Admin<?, ?> to;
+
+    public AbstractAddEdgeStepPlaceholder(Traversal.Admin traversal, String label) {
+        super(traversal, label);
+    }
+
+    public AbstractAddEdgeStepPlaceholder(Traversal.Admin traversal, GValue<String> label) {
+        super(traversal, label);
+    }
+
+    public AbstractAddEdgeStepPlaceholder(Traversal.Admin traversal, Traversal.Admin<S, String> labelTraversal) {
+        super(traversal, labelTraversal);
+    }
+
+    @Override
+    public void addTo(final Traversal.Admin<?, ?> toObject) {
+        addTraversal(toObject);
+        if (toObject instanceof GValueConstantTraversal) {
+            traversal.getGValueManager().register(((GValueConstantTraversal<?, ?>) toObject).getGValue());
+        }
+        this.to = toObject;
+    }
+
+    @Override
+    public void addFrom(final Traversal.Admin<?, ?> fromObject) {
+        addTraversal(fromObject);
+        if (fromObject instanceof GValueConstantTraversal) {
+            traversal.getGValueManager().register(((GValueConstantTraversal<?, ?>) fromObject).getGValue());
+        }
+        this.from = fromObject;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        if (from != null) {
+            hash ^= from.hashCode();
+        }
+        if (to != null) {
+            hash ^= to.hashCode();
+        }
+        return hash;
+    }
+
+    @Override
+    public boolean isParameterized() {
+        if (super.isParameterized() ||
+                (from instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) from).isParameterized()) ||
+                (to instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) to).isParameterized())) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean supportsMultiProperties() {
+        return false;
+    }
+
+    @Override
+    public Object getFrom() {
+        return resolveVertexTraversalAndPinVariables(from);
+    }
+
+    @Override
+    public Object getFromWithGValue() {
+        return resolveVertexTraversalAndPreserveGValue(from);
+    }
+
+    @Override
+    public Object getTo() {
+        return resolveVertexTraversalAndPinVariables(to);
+    }
+
+    @Override
+    public Object getToWithGValue() {
+        return resolveVertexTraversalAndPreserveGValue(to);
+    }
+
+    @Override
+    public void updateVariable(String name, Object value) {
+        super.updateVariable(name, value);
+        if (from instanceof GValueConstantTraversal) {
+            ((GValueConstantTraversal<S, String>) from).updateVariable(name, value);
+        }
+        if (to instanceof GValueConstantTraversal) {
+            ((GValueConstantTraversal<S, String>) to).updateVariable(name, value);
+        }
+    }
+
+    @Override
+    public Collection<GValue<?>> getGValues() {
+        Collection<GValue<?>> gValues = super.getGValues();
+        if (from instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) from).getGValue().isVariable()) {
+            gValues.add(((GValueConstantTraversal<S, String>) from).getGValue());
+        }
+        if (to instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) to).getGValue().isVariable()) {
+            gValues.add(((GValueConstantTraversal<S, String>) to).getGValue());
+        }
+        return gValues;
+    }
+
+    @Override
+    public AbstractAddEdgeStepPlaceholder<S> clone() {
+        final AbstractAddEdgeStepPlaceholder<S> clone = (AbstractAddEdgeStepPlaceholder) super.clone();
+        if (from != null) {
+            clone.from = from.clone();
+        }
+        if (to != null) {
+            clone.to = to.clone();
+        }
+        return clone;
+    }
+
+    /**
+     * Attempts to extract a Vertex from a given Traversal. If the traversal is wrapping a GValue, that variable is pinned.
+     * @param vertexTraversal
+     * @return If vertexTraversal is a ConstantTraversal, returns a ReferenceVertex, otherwise returns vertexTraversal as-is
+     */
+    private Object resolveVertexTraversalAndPinVariables(Traversal.Admin<?,?> vertexTraversal) {
+        if (vertexTraversal instanceof GValueConstantTraversal) {
+            GValue<?> gValue = ((GValueConstantTraversal<?, ?>) vertexTraversal).getGValue();
+            if (gValue.isVariable()) {
+                traversal.getGValueManager().pinVariable(gValue.getName());
+            }
+            return new ReferenceVertex(vertexTraversal.next());
+        }
+        if (vertexTraversal instanceof ConstantTraversal) {
+            return new ReferenceVertex(vertexTraversal.next());
+        }
+        // anything other than a ConstantTraversal is returned as-is
+        return vertexTraversal;
+    }
+
+    /**
+     * TODO
+     * @param vertexTraversal
+     * @return If vertexTraversal is a ConstantTraversal, returns the constant vertex or id as a GValue, otherwise returns vertexTraversal as-is
+     */
+    private Object resolveVertexTraversalAndPreserveGValue(Traversal.Admin<?,?> vertexTraversal) {
+        if (vertexTraversal instanceof GValueConstantTraversal) {
+            return ((GValueConstantTraversal<?, ?>) vertexTraversal).getGValue();
+        }
+        if (vertexTraversal instanceof ConstantTraversal) {
+            return new ReferenceVertex(vertexTraversal.next());
+        }
+        // anything other than a ConstantTraversal is returned as-is
+        return vertexTraversal;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddElementStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddElementStepPlaceholder.java
@@ -156,12 +156,13 @@ public abstract class AbstractAddElementStepPlaceholder<S, E extends Element, X 
         return label.next();
     }
 
-    public String getLabelGValueSafe() {
-        return label.next();
+    @Override
+    public GValue<String> getLabelAsGValue() {
+        return label instanceof GValueConstantTraversal ? ((GValueConstantTraversal) label).getGValue() : GValue.of(label.next());
     }
 
     private void setLabel(Object label) {// TODO should this be public and added to step interface?
-        if (getLabelGValueSafe().equals(Vertex.DEFAULT_LABEL)) {
+        if (getLabelAsGValue().get().equals(Vertex.DEFAULT_LABEL)) {
             this.label = label instanceof GValue ? new GValueConstantTraversal<>((GValue) label) : new ConstantTraversal<>((String) label);
             if (label instanceof GValue) {
                 traversal.getGValueManager().register((GValue<?>) label);
@@ -207,10 +208,7 @@ public abstract class AbstractAddElementStepPlaceholder<S, E extends Element, X 
                 gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
     }
 
-    public Map<Object, List<Object>> getPropertiesGValueSafe() {
-        return GValueHelper.resolveProperties(properties);
-    }
-
+    @Override
     public Map<Object, List<Object>> getPropertiesWithGValues() {
         return Collections.unmodifiableMap(properties);
     }
@@ -235,11 +233,9 @@ public abstract class AbstractAddElementStepPlaceholder<S, E extends Element, X 
         return elementId.get();
     }
 
-    public Object getElementIdGValueSafe() {
-        if (elementId == null) {
-            return null;
-        }
-        return elementId.get();
+    @Override
+    public GValue<?> getElementIdAsGValue() {
+        return elementId;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddElementStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddElementStepPlaceholder.java
@@ -211,6 +211,10 @@ public abstract class AbstractAddElementStepPlaceholder<S, E extends Element, X 
         return GValueHelper.resolveProperties(properties);
     }
 
+    public Map<Object, List<Object>> getPropertiesWithGValues() {
+        return Collections.unmodifiableMap(properties);
+    }
+
     @Override
     public boolean removeProperty(Object k) {
         if (properties.containsKey(k)) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddVertexStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractAddVertexStepPlaceholder.java
@@ -26,26 +26,42 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.GValueHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-public class AddVertexStartStepPlaceholder extends AbstractAddVertexStepPlaceholder<Vertex>
-        implements AddVertexStepContract<Vertex>, GValueHolder<Vertex, Vertex> {
+public abstract class AbstractAddVertexStepPlaceholder<S> extends AbstractAddElementStepPlaceholder<S, Vertex, Event.VertexAddedEvent>
+        implements AddVertexStepContract<S>, GValueHolder<S, Vertex> {
 
-    public AddVertexStartStepPlaceholder(final Traversal.Admin traversal, final String label) {
+    private boolean userProvidedLabel;
+
+    public AbstractAddVertexStepPlaceholder(final Traversal.Admin traversal, final String label) {
         super(traversal, label == null ? Vertex.DEFAULT_LABEL : label);
+        userProvidedLabel = label != null;
     }
 
-    public AddVertexStartStepPlaceholder(final Traversal.Admin traversal, final GValue<String> label) {
+    public AbstractAddVertexStepPlaceholder(final Traversal.Admin traversal, final GValue<String> label) {
         super(traversal, label == null ? GValue.of(Vertex.DEFAULT_LABEL) : label);
+        userProvidedLabel = label != null;
     }
 
-    public AddVertexStartStepPlaceholder(final Traversal.Admin traversal, final Traversal.Admin<?,String> vertexLabelTraversal) {
+    public AbstractAddVertexStepPlaceholder(final Traversal.Admin traversal, final Traversal.Admin<S,String> vertexLabelTraversal) {
         super(traversal, vertexLabelTraversal == null ?
-                new ConstantTraversal<>(Vertex.DEFAULT_LABEL) : (Traversal.Admin<Vertex,String>) vertexLabelTraversal);
+                new ConstantTraversal<>(Vertex.DEFAULT_LABEL) : vertexLabelTraversal);
+        userProvidedLabel = vertexLabelTraversal != null;
     }
 
     @Override
-    public AddVertexStartStep asConcreteStep() {
-        AddVertexStartStep step = new AddVertexStartStep(traversal, label instanceof GValueConstantTraversal ? ((GValueConstantTraversal<?, String>) label).getConstantTraversal() : label);
-        super.configureConcreteStep(step);
-        return step;
+    public boolean hasUserProvidedLabel() {
+        return userProvidedLabel;
     }
+
+    @Override
+    public AbstractAddVertexStepPlaceholder<S> clone() {
+        final AbstractAddVertexStepPlaceholder<S> clone = (AbstractAddVertexStepPlaceholder<S>) super.clone();
+        clone.userProvidedLabel = this.userProvidedLabel;
+        return clone;
+    }
+
+    @Override
+    protected boolean supportsMultiProperties() {
+        return true;
+    }
+
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractMergeElementStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AbstractMergeElementStepPlaceholder.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Merge;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.GValueConstantTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValueHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.GValueHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+public abstract class AbstractMergeElementStepPlaceholder<S, E> extends AbstractStep<S, E> implements MergeStepContract<S, E, Map>, GValueHolder<S, E> {
+    protected static final Set allowedTokens = new LinkedHashSet(Arrays.asList(T.id, T.label));
+    protected final boolean isStart;
+    protected Map<Object, List<Object>> properties = new HashMap<>();
+    protected Traversal.Admin<?, Map<Object, Object>> mergeTraversal;
+    protected Traversal.Admin<?, Map<Object, Object>> onCreateTraversal;
+    protected Traversal.Admin<?, Map<Object, Object>> onMatchTraversal;
+
+    public AbstractMergeElementStepPlaceholder(Traversal.Admin traversal, final Traversal.Admin<?, Map<Object, Object>> mergeTraversal, final boolean isStart) {
+        super(traversal);
+        this.mergeTraversal = mergeTraversal;
+        this.isStart = isStart;
+    }
+
+    @Override
+    protected Traverser.Admin<E> processNextStart() throws NoSuchElementException {
+        throw new IllegalStateException("GValuePlaceholder step is not executable");
+    }
+
+    @Override
+    public AbstractMergeElementStepPlaceholder<S, E> clone() {
+        return (AbstractMergeElementStepPlaceholder<S, E>) super.clone();
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return super.getRequirements();
+    }
+
+    @Override
+    public Traversal.Admin getMergeTraversal() {
+        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
+            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getGValue().getName());
+            return ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getConstantTraversal();
+        }
+        return mergeTraversal;
+    }
+
+    @Override
+    public Object getMergeMapWithGValue() {
+        if (mergeTraversal == null) {
+            return null;
+        }
+        if (mergeTraversal instanceof GValueConstantTraversal) {
+            return ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getGValue();
+        }
+        if (mergeTraversal instanceof ConstantTraversal) {
+            return mergeTraversal.next();
+        }
+        return mergeTraversal;
+    }
+
+    @Override
+    public Traversal.Admin getOnCreateTraversal() {
+        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
+            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getGValue().getName());
+            return ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getConstantTraversal();
+        }
+        return onCreateTraversal;
+    }
+
+    @Override
+    public Object getOnCreateMapWithGValue() {
+        if (onCreateTraversal == null) {
+            return null;
+        }
+        if (onCreateTraversal instanceof GValueConstantTraversal) {
+            return ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getGValue();
+        }
+        if (onCreateTraversal instanceof ConstantTraversal) {
+            return onCreateTraversal.next();
+        }
+        return onCreateTraversal;
+    }
+
+    @Override
+    public Traversal.Admin getOnMatchTraversal() {
+        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
+            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getGValue().getName());
+            return ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getConstantTraversal();
+        }
+        return onMatchTraversal;
+    }
+
+    @Override
+    public Object getOnMatchMapWithGValue() {
+        if (onMatchTraversal == null) {
+            return null;
+        }
+        if (onMatchTraversal instanceof GValueConstantTraversal) {
+            return ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getGValue();
+        }
+        if (onMatchTraversal instanceof ConstantTraversal) {
+            return onMatchTraversal.next();
+        }
+        return onMatchTraversal;
+    }
+
+    @Override
+    public boolean isStart() {
+        return isStart;
+    }
+
+    @Override
+    public boolean isFirst() {
+        return true; // Step cannot be iterated so isFirst() is always true
+    }
+
+    @Override
+    public void addChildOption(Merge token, Traversal.Admin traversalOption) {
+        if (token == Merge.onCreate) {
+            setOnCreate(traversalOption);
+        } else if (token == Merge.onMatch) {
+            setOnMatch(traversalOption);
+        } else {
+            throw new UnsupportedOperationException(String.format("Option %s for Merge is not supported", token.name()));
+        }
+    }
+
+    @Override
+    public boolean isUsingPartitionStrategy() {
+        return false;
+    }
+
+    @Override
+    public void setOnMatch(final Traversal.Admin<?, Map<Object, Object>> onMatchMap) {
+        this.onMatchTraversal = onMatchMap;
+        if (onMatchMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchMap).isParameterized()) {
+            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) onMatchMap).getGValue());
+        }
+    }
+
+    @Override
+    public void setOnCreate(final Traversal.Admin<?, Map<Object, Object>> onCreateMap) {
+        this.onCreateTraversal = onCreateMap;
+        if (onCreateMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateMap).isParameterized()) {
+            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) onCreateMap).getGValue());
+        }
+    }
+
+    @Override
+    public void setMerge(Traversal.Admin<?, Map<Object, Object>> mergeMap) {
+        this.mergeTraversal = mergeMap;
+        if (mergeMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) mergeMap).isParameterized()) {
+            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) mergeMap).getGValue());
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        AbstractMergeElementStepPlaceholder<?, ?> that = (AbstractMergeElementStepPlaceholder<?, ?>) o;
+        return isStart == that.isStart && Objects.equals(properties, that.properties) && Objects.equals(mergeTraversal, that.mergeTraversal) && Objects.equals(onCreateTraversal, that.onCreateTraversal) && Objects.equals(onMatchTraversal, that.onMatchTraversal);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), properties, mergeTraversal, onCreateTraversal, onMatchTraversal, isStart);
+    }
+
+    @Override
+    public boolean isParameterized() {
+        return onMatchTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) onMatchTraversal).isParameterized() ||
+                onCreateTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) onCreateTraversal).isParameterized() ||
+                mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) mergeTraversal).isParameterized();
+    }
+
+    @Override
+    public void updateVariable(String name, Object value) {
+        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
+            ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).updateVariable(name, value);
+        }
+        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
+            ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).updateVariable(name, value);
+        }
+        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
+            ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).updateVariable(name, value);
+        }
+    }
+
+    @Override
+    public Collection<GValue<?>> getGValues() {
+        Set<GValue<?>> gValues = new HashSet<>();
+        if (mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) mergeTraversal).getGValue().isVariable()) {
+            gValues.add(((GValueConstantTraversal<?, ?>) mergeTraversal).getGValue());
+        }
+        if (onMatchTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) onMatchTraversal).getGValue().isVariable()) {
+            gValues.add(((GValueConstantTraversal<?, ?>) onMatchTraversal).getGValue());
+        }
+        if (onCreateTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) onCreateTraversal).getGValue().isVariable()) {
+            gValues.add(((GValueConstantTraversal<?, ?>) onCreateTraversal).getGValue());
+        }
+        return gValues;
+    }
+
+    @Override
+    public CallbackRegistry<Event> getMutatingCallbackRegistry() {
+        throw new IllegalStateException("Cannot get mutating CallbackRegistry on GValue placeholder step");
+    }
+
+    /**
+     * This implementation should only be used as a mechanism for supporting {@link PartitionStrategy}.
+     */
+    @Override
+    public void addProperty(Object key, Object value) {
+        if (key instanceof GValue) {
+            throw new IllegalArgumentException("GValue cannot be used as a property key");
+        }
+        if (value instanceof GValue) {
+            traversal.getGValueManager().register((GValue<?>) value);
+        }
+        if (properties.containsKey(key)) {
+            throw new IllegalArgumentException("MergeElement.addProperty only support properties with single cardinality");
+        }
+        properties.put(key, Collections.singletonList(value));
+    }
+
+    @Override
+    public Map<Object, List<Object>> getProperties() {
+        return GValueHelper.resolveProperties(properties,
+                gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
+    }
+
+    @Override
+    public Map<Object, List<Object>> getPropertiesWithGValues() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public boolean removeProperty(Object k) {
+        if (properties.containsKey(k)) {
+            properties.remove(k);
+            return true;
+        }
+        return false;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepPlaceholder.java
@@ -23,14 +23,14 @@ import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.GValueConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValueHolder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
+import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 
 import java.util.Collection;
 
 public class AddEdgeStartStepPlaceholder extends AbstractAddElementStepPlaceholder<Edge, Edge, Event.EdgeAddedEvent>
-        implements AddEdgeStepContract<Edge>, GValueHolder<Edge, Edge>, PropertyAdding {
+        implements AddEdgeStepContract<Edge>, GValueHolder<Edge, Edge>, PropertiesHolder {
 
     private Traversal.Admin<?,?> from;
     private Traversal.Admin<?,?> to;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepPlaceholder.java
@@ -22,18 +22,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.GValueConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
-import org.apache.tinkerpop.gremlin.process.traversal.step.GValueHolder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 
-import java.util.Collection;
-
-public class AddEdgeStartStepPlaceholder extends AbstractAddElementStepPlaceholder<Edge, Edge, Event.EdgeAddedEvent>
-        implements AddEdgeStepContract<Edge>, GValueHolder<Edge, Edge>, PropertiesHolder {
-
-    private Traversal.Admin<?,?> from;
-    private Traversal.Admin<?,?> to;
+public class AddEdgeStartStepPlaceholder extends AbstractAddEdgeStepPlaceholder<Edge> {
 
     public AddEdgeStartStepPlaceholder(final Traversal.Admin traversal, final String edgeLabel) {
         super(traversal, edgeLabel == null ? Edge.DEFAULT_LABEL : edgeLabel);
@@ -50,36 +41,6 @@ public class AddEdgeStartStepPlaceholder extends AbstractAddElementStepPlacehold
     }
 
     @Override
-    public void addTo(final Traversal.Admin<?, ?> toObject) {
-        addTraversal(toObject);
-        if (toObject instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, ?>) toObject).getGValue());
-        }
-        this.to = toObject;
-    }
-
-    @Override
-    public void addFrom(final Traversal.Admin<?, ?> fromObject) {
-        addTraversal(fromObject);
-        if (fromObject instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, ?>) fromObject).getGValue());
-        }
-        this.from = fromObject;
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = super.hashCode();
-        if (from != null) {
-            hash ^= from.hashCode();
-        }
-        if (to != null) {
-            hash ^= to.hashCode();
-        }
-        return hash;
-    }
-
-    @Override
     public AddEdgeStartStep asConcreteStep() {
         AddEdgeStartStep step = new AddEdgeStartStep(traversal, label instanceof GValueConstantTraversal ? ((GValueConstantTraversal<?, String>) label).getConstantTraversal() : label);
         super.configureConcreteStep(step);
@@ -90,73 +51,5 @@ public class AddEdgeStartStepPlaceholder extends AbstractAddElementStepPlacehold
             step.addTo(to instanceof GValueConstantTraversal ? ((GValueConstantTraversal<?, String>) to).getConstantTraversal() : to);
         }
         return step;
-    }
-
-    @Override
-    public boolean isParameterized() {
-        if (super.isParameterized() ||
-                (from instanceof GValueConstantTraversal && ((GValueConstantTraversal<Edge, String>) from).isParameterized()) ||
-                (to instanceof GValueConstantTraversal && ((GValueConstantTraversal<Edge, String>) to).isParameterized())) {
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    protected boolean supportsMultiProperties() {
-        return false;
-    }
-
-    @Override
-    public Object getFrom() {
-        return resolveVertexTraversal(from, gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
-    }
-
-    public Object getFromGValueSafe() {
-        return resolveVertexTraversal(from);
-    }
-
-    @Override
-    public Object getTo() {
-        return resolveVertexTraversal(to, gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
-    }
-
-    public Object getToGValueSafe() {
-        return resolveVertexTraversal(to);
-    }
-
-    @Override
-    public void updateVariable(String name, Object value) {
-        super.updateVariable(name, value);
-        if (from instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<Edge, String>) from).updateVariable(name, value);
-        }
-        if (to instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<Edge, String>) to).updateVariable(name, value);
-        }
-    }
-
-    @Override
-    public Collection<GValue<?>> getGValues() {
-        Collection<GValue<?>> gValues = super.getGValues();
-        if (from instanceof GValueConstantTraversal && ((GValueConstantTraversal<Edge, String>) from).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<Edge, String>) from).getGValue());
-        }
-        if (to instanceof GValueConstantTraversal && ((GValueConstantTraversal<Edge, String>) to).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<Edge, String>) to).getGValue());
-        }
-        return gValues;
-    }
-
-    @Override
-    public AddEdgeStartStepPlaceholder clone() {
-        final AddEdgeStartStepPlaceholder clone = (AddEdgeStartStepPlaceholder) super.clone();
-        if (from != null){
-            clone.from = from.clone();
-        }
-        if (to != null){
-            clone.to = to.clone();
-        }
-        return clone;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStepPlaceholder.java
@@ -18,19 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
-import java.util.Collection;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.GValueConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 
-public class AddEdgeStepPlaceholder<S> extends AbstractAddElementStepPlaceholder<S, Edge, Event.EdgeAddedEvent>
-        implements AddEdgeStepContract<S> {
-
-    private Traversal.Admin<?,?> from;
-    private Traversal.Admin<?,?> to;
+public class AddEdgeStepPlaceholder<S> extends AbstractAddEdgeStepPlaceholder<S> {
 
     public AddEdgeStepPlaceholder(final Traversal.Admin traversal, final String edgeLabel) {
         super(traversal, edgeLabel == null ? Edge.DEFAULT_LABEL : edgeLabel);
@@ -46,36 +40,6 @@ public class AddEdgeStepPlaceholder<S> extends AbstractAddElementStepPlaceholder
     }
 
     @Override
-    public void addTo(final Traversal.Admin<?, ?> toObject) {
-        addTraversal(toObject);
-        if (toObject instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, ?>) toObject).getGValue());
-        }
-        this.to = toObject;
-    }
-
-    @Override
-    public void addFrom(final Traversal.Admin<?, ?> fromObject) {
-        addTraversal(fromObject);
-        if (fromObject instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, ?>) fromObject).getGValue());
-        }
-        this.from = fromObject;
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = super.hashCode();
-        if (from != null) {
-            hash ^= from.hashCode();
-        }
-        if (to != null) {
-            hash ^= to.hashCode();
-        }
-        return hash;
-    }
-
-    @Override
     public AddEdgeStep<S> asConcreteStep() {
         AddEdgeStep<S> step = new AddEdgeStep<>(traversal, label instanceof GValueConstantTraversal ? ((GValueConstantTraversal<S, String>) label).getConstantTraversal() : label);
         super.configureConcreteStep(step);
@@ -88,71 +52,4 @@ public class AddEdgeStepPlaceholder<S> extends AbstractAddElementStepPlaceholder
         return step;
     }
 
-    @Override
-    public boolean isParameterized() {
-        if (super.isParameterized() ||
-                (from instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) from).isParameterized()) ||
-                (to instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) to).isParameterized())) {
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    protected boolean supportsMultiProperties() {
-        return false;
-    }
-
-    @Override
-    public Object getFrom() {
-        return resolveVertexTraversal(from, gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
-    }
-
-    public Object getFromGValueSafe() {
-        return resolveVertexTraversal(from);
-    }
-
-    @Override
-    public Object getTo() {
-        return resolveVertexTraversal(to, gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
-    }
-
-    public Object getToGValueSafe() {
-        return resolveVertexTraversal(to);
-    }
-
-    @Override
-    public void updateVariable(String name, Object value) {
-        super.updateVariable(name, value);
-        if (from instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<S, String>) from).updateVariable(name, value);
-        }
-        if (to instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<S, String>) to).updateVariable(name, value);
-        }
-    }
-
-    @Override
-    public Collection<GValue<?>> getGValues() {
-        Collection<GValue<?>> gValues = super.getGValues();
-        if (from instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) from).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<S, String>) from).getGValue());
-        }
-        if (to instanceof GValueConstantTraversal && ((GValueConstantTraversal<S, String>) to).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<S, String>) to).getGValue());
-        }
-        return gValues;
-    }
-
-    @Override
-    public AddEdgeStepPlaceholder<S> clone() {
-        final AddEdgeStepPlaceholder<S> clone = (AddEdgeStepPlaceholder) super.clone();
-        if (from != null){
-            clone.from = from.clone();
-        }
-        if (to != null){
-            clone.to = to.clone();
-        }
-        return clone;
-    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddElementStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddElementStepContract.java
@@ -20,13 +20,13 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
+import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 
 import java.util.HashSet;
 
-public interface AddElementStepContract<S, E> extends Step<S, E>, PropertyAdding, TraversalParent, Scoping {
+public interface AddElementStepContract<S, E> extends Step<S, E>, PropertiesHolder, TraversalParent, Scoping {
     Object getLabel();
 
     default GValue<?> getLabelAsGValue(){

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddElementStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddElementStepContract.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -28,7 +29,15 @@ import java.util.HashSet;
 public interface AddElementStepContract<S, E> extends Step<S, E>, PropertyAdding, TraversalParent, Scoping {
     Object getLabel();
 
+    default GValue<?> getLabelAsGValue(){
+        return GValue.of(getLabel());
+    }
+
     Object getElementId();
+
+    default GValue<?> getElementIdAsGValue() {
+        return GValue.of(getElementId());
+    }
 
     void setElementId(Object elementId);
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStepPlaceholder.java
@@ -23,7 +23,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.GValueConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValueHolder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 public class AddVertexStartStepPlaceholder extends AbstractAddVertexStepPlaceholder<Vertex>

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStepPlaceholder.java
@@ -19,49 +19,21 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.GValueConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
-import org.apache.tinkerpop.gremlin.process.traversal.step.GValueHolder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-public class AddVertexStepPlaceholder<S> extends AbstractAddElementStepPlaceholder<S, Vertex, Event.VertexAddedEvent>
-        implements AddVertexStepContract<S>, GValueHolder<S, Vertex> {
+public class AddVertexStepPlaceholder<S> extends AbstractAddVertexStepPlaceholder<S> {
 
-    private boolean userProvidedLabel;
-
-    public AddVertexStepPlaceholder(final Traversal.Admin traversal, final String label) {
-        super(traversal, label == null ? Vertex.DEFAULT_LABEL : label);
-        userProvidedLabel = label != null;
+    public AddVertexStepPlaceholder(Traversal.Admin traversal, String label) {
+        super(traversal, label);
     }
 
-    public AddVertexStepPlaceholder(final Traversal.Admin traversal, final GValue<String> label) {
-        super(traversal, label == null ? GValue.of(Vertex.DEFAULT_LABEL) : label);
-        userProvidedLabel = label != null;
+    public AddVertexStepPlaceholder(Traversal.Admin traversal, GValue<String> label) {
+        super(traversal, label);
     }
 
-    public AddVertexStepPlaceholder(final Traversal.Admin traversal, final Traversal.Admin<S,String> vertexLabelTraversal) {
-        super(traversal, vertexLabelTraversal == null ?
-                new ConstantTraversal<>(Vertex.DEFAULT_LABEL) : vertexLabelTraversal);
-        userProvidedLabel = vertexLabelTraversal != null;
-    }
-
-    @Override
-    public boolean hasUserProvidedLabel() {
-        return userProvidedLabel;
-    }
-
-    @Override
-    public AddVertexStepPlaceholder<S> clone() {
-        final AddVertexStepPlaceholder<S> clone = (AddVertexStepPlaceholder<S>) super.clone();
-        clone.userProvidedLabel = this.userProvidedLabel;
-        return clone;
-    }
-
-    @Override
-    protected boolean supportsMultiProperties() {
-        return true;
+    public AddVertexStepPlaceholder(Traversal.Admin traversal, Traversal.Admin<S, String> vertexLabelTraversal) {
+        super(traversal, vertexLabelTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStep.java
@@ -200,6 +200,10 @@ public final class CallStep<S, E> extends AbstractStep<S, E> implements AutoClos
     }
 
     @Override
+    public Map getStaticParams() {
+        return Collections.unmodifiableMap(this.staticParams);
+    }
+
     public Map getMergedParams() {
         if (mapTraversal == null && parameters.isEmpty()) {
             // static params only

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStepContract.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Configuring;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.structure.service.Service;
 import org.apache.tinkerpop.gremlin.structure.service.ServiceRegistry;
@@ -29,11 +30,18 @@ import java.util.Map;
 public interface CallStepContract<S, E> extends Step<S, E>, Configuring, TraversalParent {
     Service<S, E> service();
 
+    default Service<S, E> serviceGValueSafe() {
+        return service();
+    }
+
     String getServiceName();
 
-    /**
-     * TODO: re-evaluate if we should change this to return the static params only
-     */
+    Map getStaticParams();
+
+    default GValue<Map> getStaticParamsAsGValue() {
+        return GValue.of(getStaticParams());
+    }
+
     Map getMergedParams();
 
     ServiceRegistry getServiceRegistry();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStepContract.java
@@ -19,8 +19,11 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
 import org.apache.tinkerpop.gremlin.structure.Element;
+
+import java.util.Arrays;
 
 public interface GraphStepContract<S, E extends Element> extends Step<S, E>, GraphComputing {
 
@@ -33,6 +36,10 @@ public interface GraphStepContract<S, E extends Element> extends Step<S, E>, Gra
     boolean returnsEdge();
 
     Object[] getIds();
+
+    default GValue<?>[] getIdsAsGValues() {
+        return Arrays.stream(getIds()).map(o -> GValue.of(o)).toArray(GValue[]::new);
+    }
 
     void clearIds();
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStepPlaceholder.java
@@ -54,6 +54,7 @@ public class GraphStepPlaceholder<S, E extends Element> extends AbstractStep<S, 
         }
     }
 
+    @Override
     public String toString() {
         return StringFactory.stepString(this, this.returnClass.getSimpleName().toLowerCase(), Arrays.toString(this.ids));
     }
@@ -88,8 +89,9 @@ public class GraphStepPlaceholder<S, E extends Element> extends AbstractStep<S, 
         return GValue.resolveToValues(this.ids);
     }
 
-    public Object[] getIdsGValueSafe() {
-        return GValue.resolveToValues(this.ids);
+    @Override
+    public GValue<?>[] getIdsAsGValues() {
+        return this.ids.clone();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStepPlaceholder.java
@@ -52,18 +52,12 @@ import java.util.Set;
 /**
  * Implementation for the {@code mergeV()} step covering both the start step version and the one used mid-traversal.
  */
-public class MergeEdgeStepPlaceholder<S> extends AbstractStep<S, Edge> implements MergeStepContract<S, Edge, Map<Object, Object>>, GValueHolder<S, Edge> {
-
-    private static final Set allowedTokens = new LinkedHashSet(Arrays.asList(T.id, T.label, Direction.IN, Direction.OUT));
-    private Map<Object, List<Object>> properties = new HashMap<>();
+public class MergeEdgeStepPlaceholder<S> extends AbstractMergeElementStepPlaceholder<S, Edge> {
 
     public static void validateMapInput(final Map map, final boolean ignoreTokens) {
         MergeElementStep.validate(map, ignoreTokens, allowedTokens, "mergeE");
     }
 
-    private Traversal.Admin<?,Map<Object,Object>> mergeTraversal;
-    private Traversal.Admin<?,Map<Object,Object>> onCreateTraversal;
-    private Traversal.Admin<?,Map<Object,Object>> onMatchTraversal;
     private Traversal.Admin<S,Map<Object,Object>> outVTraversal = null;
     private Traversal.Admin<S,Map<Object,Object>> inVTraversal = null;
     private final boolean isStart;
@@ -83,128 +77,11 @@ public class MergeEdgeStepPlaceholder<S> extends AbstractStep<S, Edge> implement
     }
 
     public MergeEdgeStepPlaceholder(final Traversal.Admin traversal, final boolean isStart, final Traversal.Admin<?,Map<Object, Object>> mergeTraversal) {
-        super(traversal);
+        super(traversal, mergeTraversal, isStart);
         this.isStart = isStart;
         this.mergeTraversal = mergeTraversal;
         if (mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).isParameterized()) {
             traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getGValue());
-        }
-    }
-
-    @Override
-    protected Traverser.Admin<Edge> processNextStart() throws NoSuchElementException {
-        return null;
-    }
-
-    @Override
-    public MergeEdgeStepPlaceholder<S> clone() {
-        return (MergeEdgeStepPlaceholder<S>) super.clone();
-    }
-
-    @Override
-    public Set<TraverserRequirement> getRequirements() {
-        return super.getRequirements();
-    }
-
-    @Override
-    public Traversal.Admin getMergeTraversal() {
-        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getGValue().getName());
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getConstantTraversal();
-        }
-        return mergeTraversal;
-    }
-
-    public Traversal.Admin getMergeTraversalGValueSafe() {
-        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getConstantTraversal();
-        }
-        return mergeTraversal;
-    }
-
-    @Override
-    public Traversal.Admin getOnCreateTraversal() {
-        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getGValue().getName());
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getConstantTraversal();
-        }
-        return onCreateTraversal;
-    }
-
-    public Traversal.Admin getOnCreateTraversalGValueSafe() {
-        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getConstantTraversal();
-        }
-        return onCreateTraversal;
-    }
-
-    @Override
-    public Traversal.Admin getOnMatchTraversal() {
-        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getGValue().getName());
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getConstantTraversal();
-        }
-        return onMatchTraversal;
-    }
-
-    public Traversal.Admin getOnMatchTraversalGValueSafe() {
-        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getConstantTraversal();
-        }
-        return onMatchTraversal;
-    }
-
-    @Override
-    public boolean isStart() {
-        return isStart;
-    }
-
-    @Override
-    public boolean isFirst() {
-        return true; // Step cannot be iterated so isFirst() is always true
-    }
-
-    @Override
-    public void addChildOption(Merge token, Traversal.Admin traversalOption) {
-        if (token == Merge.onCreate) {
-            setOnCreate(traversalOption);
-        } else if (token == Merge.onMatch) {
-            setOnMatch(traversalOption);
-        } else if (token == Merge.outV) {
-            this.outVTraversal = traversalOption;
-        } else if (token == Merge.inV) {
-            this.inVTraversal = traversalOption;
-        }else {
-            throw new UnsupportedOperationException(String.format("Option %s for Merge is not supported", token.name()));
-        }
-    }
-
-    @Override
-    public boolean isUsingPartitionStrategy() {
-        return false;
-    }
-
-    @Override
-    public void setOnMatch(final Traversal.Admin<?,Map<Object, Object>> onMatchMap) {
-        this.onMatchTraversal = onMatchMap;
-        if (onMatchMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchMap).isParameterized()) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) onMatchMap).getGValue());
-        }
-    }
-
-    @Override
-    public void setOnCreate(final Traversal.Admin<?,Map<Object, Object>> onCreateMap) {
-        this.onCreateTraversal = onCreateMap;
-        if (onCreateMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateMap).isParameterized()) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) onCreateMap).getGValue());
-        }
-    }
-
-    @Override
-    public void setMerge(Traversal.Admin<?,Map<Object, Object>> mergeMap) {
-        this.mergeTraversal = mergeMap;
-        if (mergeMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) mergeMap).isParameterized()) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) mergeMap).getGValue());
         }
     }
 
@@ -214,12 +91,12 @@ public class MergeEdgeStepPlaceholder<S> extends AbstractStep<S, Edge> implement
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         MergeEdgeStepPlaceholder<?> that = (MergeEdgeStepPlaceholder<?>) o;
-        return isStart == that.isStart && Objects.equals(properties, that.properties) && Objects.equals(mergeTraversal, that.mergeTraversal) && Objects.equals(onCreateTraversal, that.onCreateTraversal) && Objects.equals(onMatchTraversal, that.onMatchTraversal) && Objects.equals(outVTraversal, that.outVTraversal) && Objects.equals(inVTraversal, that.inVTraversal);
+        return Objects.equals(outVTraversal, that.outVTraversal) && Objects.equals(inVTraversal, that.inVTraversal);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), properties, mergeTraversal, onCreateTraversal, onMatchTraversal, outVTraversal, inVTraversal, isStart);
+        return Objects.hash(super.hashCode(), outVTraversal, inVTraversal);
     }
 
     @Override
@@ -247,81 +124,5 @@ public class MergeEdgeStepPlaceholder<S> extends AbstractStep<S, Edge> implement
 
         TraversalHelper.copyLabels(this, step, false);
         return step;
-    }
-
-    @Override
-    public boolean isParameterized() {
-        return onMatchTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) onMatchTraversal).isParameterized() ||
-                onCreateTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) onCreateTraversal).isParameterized() ||
-                mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) mergeTraversal).isParameterized();
-    }
-
-    @Override
-    public void updateVariable(String name, Object value) {
-        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).updateVariable(name, value);
-        }
-        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).updateVariable(name, value);
-        }
-        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).updateVariable(name, value);
-        }
-    }
-
-    @Override
-    public Collection<GValue<?>> getGValues() {
-        Set<GValue<?>> gValues = new HashSet<>();
-        if (mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) mergeTraversal).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<?, ?>) mergeTraversal).getGValue());
-        }
-        if (onMatchTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) onMatchTraversal).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<?, ?>) onMatchTraversal).getGValue());
-        }
-        if (onCreateTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) onCreateTraversal).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<?, ?>) onCreateTraversal).getGValue());
-        }
-        return gValues;
-    }
-
-    @Override
-    public CallbackRegistry<Event> getMutatingCallbackRegistry() {
-        throw new IllegalStateException("Cannot get mutating CallbackRegistry on GValue placeholder step");
-    }
-
-    /**
-     * This implementation should only be used as a mechanism for supporting {@link PartitionStrategy}.
-     */
-    @Override
-    public void addProperty(Object key, Object value) {
-        if (key instanceof GValue) {
-            throw new IllegalArgumentException("GValue cannot be used as a property key");
-        }
-        if (value instanceof GValue) {
-            traversal.getGValueManager().register((GValue<?>) value);
-        }
-        if (properties.containsKey(key)) {
-            throw new IllegalArgumentException("MergeElement.addProperty only support properties with single cardinality");
-        }
-        properties.put(key, Collections.singletonList(value));
-    }
-
-    @Override
-    public Map<Object, List<Object>> getProperties() {
-        return GValueHelper.resolveProperties(properties,
-                gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
-    }
-
-    public Map<Object, List<Object>> getPropertiesGValueSafe() {
-        return GValueHelper.resolveProperties(properties);
-    }
-
-    @Override
-    public boolean removeProperty(Object k) {
-        if (properties.containsKey(k)) {
-            properties.remove(k);
-            return true;
-        }
-        return false;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeStepContract.java
@@ -20,7 +20,9 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Merge;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Deleting;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Writing;
@@ -34,9 +36,48 @@ public interface MergeStepContract<S, E, C> extends Writing<Event>, Deleting<Eve
 
     Traversal.Admin<S, Map> getMergeTraversal();
 
+    /**
+     * Gets the merge map from this step. If the map was originally passed as a {@link GValue<Map>}, that is returned
+     * directly. If it was originally passed as a {@link Map} or {@link ConstantTraversal<Map>}, then a {@link Map} is
+     * returned. Otherwise, the MergeMap is returned in Traversal form.
+     */
+    default Object getMergeMapWithGValue() {
+        Traversal mergeTraversal = getMergeTraversal();
+        if (mergeTraversal instanceof ConstantTraversal) {
+            return mergeTraversal.next();
+        }
+        return mergeTraversal;
+    }
+
     Traversal.Admin<S, Map> getOnCreateTraversal();
 
+    /**
+     * Gets the onCreate map from this step. If the map was originally passed as a {@link GValue<Map>}, that is returned
+     * directly. If it was originally passed as a {@link Map} or {@link ConstantTraversal<Map>}, then a {@link Map} is
+     * returned. Otherwise, the onCreate is returned in Traversal form.
+     */
+    default Object getOnCreateMapWithGValue() {
+        Traversal onCreateTraversal = getOnCreateTraversal();
+        if (onCreateTraversal instanceof ConstantTraversal) {
+            return onCreateTraversal.next();
+        }
+        return onCreateTraversal;
+    }
+
     Traversal.Admin<S, Map<String, ?>> getOnMatchTraversal();
+
+    /**
+     * Gets the onMatch map from this step. If the map was originally passed as a {@link GValue<Map>}, that is returned
+     * directly. If it was originally passed as a {@link Map} or {@link ConstantTraversal<Map>}, then a {@link Map} is
+     * returned. Otherwise, the onMatch is returned in Traversal form.
+     */
+    default Object getOnMatchMapWithGValue() {
+        Traversal onMatchTraversal = getOnMatchTraversal();
+        if (onMatchTraversal instanceof ConstantTraversal) {
+            return onMatchTraversal.next();
+        }
+        return onMatchTraversal;
+    }
 
     boolean isStart();
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeStepContract.java
@@ -21,7 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Merge;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Deleting;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
+import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Writing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
@@ -30,7 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequire
 import java.util.Map;
 import java.util.Set;
 
-public interface MergeStepContract<S, E, C> extends Writing<Event>, Deleting<Event>, TraversalOptionParent<Merge, S, C>, PropertyAdding {
+public interface MergeStepContract<S, E, C> extends Writing<Event>, Deleting<Event>, TraversalOptionParent<Merge, S, C>, PropertiesHolder {
 
     Traversal.Admin<S, Map> getMergeTraversal();
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStepPlaceholder.java
@@ -51,19 +51,11 @@ import java.util.Set;
 /**
  * Implementation for the {@code mergeV()} step covering both the start step version and the one used mid-traversal.
  */
-public class MergeVertexStepPlaceholder<S> extends AbstractStep<S, Vertex> implements MergeStepContract<S, Vertex, Map>, GValueHolder<S, Vertex> {
-
-    private static final Set allowedTokens = new LinkedHashSet(Arrays.asList(T.id, T.label));
-    private Map<Object, List<Object>> properties = new HashMap<>();
+public class MergeVertexStepPlaceholder<S> extends AbstractMergeElementStepPlaceholder<S, Vertex> {
 
     public static void validateMapInput(final Map map, final boolean ignoreTokens) {
         MergeElementStep.validate(map, ignoreTokens, allowedTokens, "mergeV");
     }
-
-    private Traversal.Admin<?,Map<Object,Object>> mergeTraversal;
-    private Traversal.Admin<?,Map<Object,Object>> onCreateTraversal;
-    private Traversal.Admin<?,Map<Object,Object>> onMatchTraversal;
-    private final boolean isStart;
 
     public MergeVertexStepPlaceholder(final Traversal.Admin traversal, final boolean isStart) {
         this(traversal, isStart, new IdentityTraversal<>());
@@ -80,139 +72,10 @@ public class MergeVertexStepPlaceholder<S> extends AbstractStep<S, Vertex> imple
     }
 
     public MergeVertexStepPlaceholder(final Traversal.Admin traversal, final boolean isStart, final Traversal.Admin<?,Map<Object, Object>> mergeTraversal) {
-        super(traversal);
-        this.isStart = isStart;
-        this.mergeTraversal = mergeTraversal;
+        super(traversal, mergeTraversal, isStart);
         if (mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).isParameterized()) {
             traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getGValue());
         }
-    }
-
-    @Override
-    protected Traverser.Admin<Vertex> processNextStart() throws NoSuchElementException {
-        return null;
-    }
-
-    @Override
-    public MergeVertexStepPlaceholder<S> clone() {
-        return (MergeVertexStepPlaceholder<S>) super.clone();
-    }
-
-    @Override
-    public Set<TraverserRequirement> getRequirements() {
-        return super.getRequirements();
-    }
-
-    @Override
-    public Traversal.Admin getMergeTraversal() {
-        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getGValue().getName());
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getConstantTraversal();
-        }
-        return mergeTraversal;
-    }
-
-    public Traversal.Admin getMergeTraversalGValueSafe() {
-        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).getConstantTraversal();
-        }
-        return mergeTraversal;
-    }
-
-    @Override
-    public Traversal.Admin getOnCreateTraversal() {
-        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getGValue().getName());
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getConstantTraversal();
-        }
-        return onCreateTraversal;
-    }
-
-    public Traversal.Admin getOnCreateTraversalGValueSafe() {
-        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).getConstantTraversal();
-        }
-        return onCreateTraversal;
-    }
-
-    @Override
-    public Traversal.Admin getOnMatchTraversal() {
-        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
-            traversal.getGValueManager().pinVariable(((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getGValue().getName());
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getConstantTraversal();
-        }
-        return onMatchTraversal;
-    }
-
-    public Traversal.Admin getOnMatchTraversalGValueSafe() {
-        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
-            return ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).getConstantTraversal();
-        }
-        return onMatchTraversal;
-    }
-
-    @Override
-    public boolean isStart() {
-        return isStart;
-    }
-
-    @Override
-    public boolean isFirst() {
-        return true; // Step cannot be iterated so isFirst() is always true
-    }
-
-    @Override
-    public void addChildOption(Merge token, Traversal.Admin traversalOption) {
-        if (token == Merge.onCreate) {
-            setOnCreate(traversalOption);
-        } else if (token == Merge.onMatch) {
-            setOnMatch(traversalOption);
-        } else {
-            throw new UnsupportedOperationException(String.format("Option %s for Merge is not supported", token.name()));
-        }
-    }
-
-    @Override
-    public boolean isUsingPartitionStrategy() {
-        return false;
-    }
-
-    @Override
-    public void setOnMatch(final Traversal.Admin<?,Map<Object, Object>> onMatchMap) {
-        this.onMatchTraversal = onMatchMap;
-        if (onMatchMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchMap).isParameterized()) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) onMatchMap).getGValue());
-        }
-    }
-
-    @Override
-    public void setOnCreate(final Traversal.Admin<?,Map<Object, Object>> onCreateMap) {
-        this.onCreateTraversal = onCreateMap;
-        if (onCreateMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateMap).isParameterized()) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) onCreateMap).getGValue());
-        }
-    }
-
-    @Override
-    public void setMerge(Traversal.Admin<?,Map<Object, Object>> mergeMap) {
-        this.mergeTraversal = mergeMap;
-        if (mergeMap instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, Map<Object, Object>>) mergeMap).isParameterized()) {
-            traversal.getGValueManager().register(((GValueConstantTraversal<?, Map<Object, Object>>) mergeMap).getGValue());
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        MergeVertexStepPlaceholder<?> that = (MergeVertexStepPlaceholder<?>) o;
-        return isStart == that.isStart && Objects.equals(properties, that.properties) && Objects.equals(mergeTraversal, that.mergeTraversal) && Objects.equals(onCreateTraversal, that.onCreateTraversal) && Objects.equals(onMatchTraversal, that.onMatchTraversal);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), properties, mergeTraversal, onCreateTraversal, onMatchTraversal, isStart);
     }
 
     @Override
@@ -235,79 +98,4 @@ public class MergeVertexStepPlaceholder<S> extends AbstractStep<S, Vertex> imple
         return step;
     }
 
-    @Override
-    public boolean isParameterized() {
-        return onMatchTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) onMatchTraversal).isParameterized() ||
-                onCreateTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) onCreateTraversal).isParameterized() ||
-                mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal) mergeTraversal).isParameterized();
-    }
-
-    @Override
-    public void updateVariable(String name, Object value) {
-        if (mergeTraversal != null && mergeTraversal instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<?, Map<Object, Object>>) mergeTraversal).updateVariable(name, value);
-        }
-        if (onMatchTraversal != null && onMatchTraversal instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<?, Map<Object, Object>>) onMatchTraversal).updateVariable(name, value);
-        }
-        if (onCreateTraversal != null && onCreateTraversal instanceof GValueConstantTraversal) {
-            ((GValueConstantTraversal<?, Map<Object, Object>>) onCreateTraversal).updateVariable(name, value);
-        }
-    }
-
-    @Override
-    public Collection<GValue<?>> getGValues() {
-        Set<GValue<?>> gValues = new HashSet<>();
-        if (mergeTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) mergeTraversal).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<?, ?>) mergeTraversal).getGValue());
-        }
-        if (onMatchTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) onMatchTraversal).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<?, ?>) onMatchTraversal).getGValue());
-        }
-        if (onCreateTraversal instanceof GValueConstantTraversal && ((GValueConstantTraversal<?, ?>) onCreateTraversal).getGValue().isVariable()) {
-            gValues.add(((GValueConstantTraversal<?, ?>) onCreateTraversal).getGValue());
-        }
-        return gValues;
-    }
-
-    @Override
-    public CallbackRegistry<Event> getMutatingCallbackRegistry() {
-        throw new IllegalStateException("Cannot get mutating CallbackRegistry on GValue placeholder step");
-    }
-
-    /**
-     * This implementation should only be used as a mechanism for supporting {@link PartitionStrategy}.
-     */
-    @Override
-    public void addProperty(Object key, Object value) {
-        if (key instanceof GValue) {
-            throw new IllegalArgumentException("GValue cannot be used as a property key");
-        }
-        if (value instanceof GValue) {
-            traversal.getGValueManager().register((GValue<?>) value);
-        }
-        if (properties.containsKey(key)) {
-            throw new IllegalArgumentException("MergeElement.addProperty only support properties with single cardinality");
-        }
-        properties.put(key, Collections.singletonList(value));
-    }
-
-    @Override
-    public Map<Object, List<Object>> getProperties() {
-        return GValueHelper.resolveProperties(properties,
-                gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
-    }
-
-    public Map<Object, List<Object>> getPropertiesGValueSafe() {
-        return GValueHelper.resolveProperties(properties);
-    }
-
-    @Override
-    public boolean removeProperty(Object k) {
-        if (properties.containsKey(k)) {
-            properties.remove(k);
-            return true;
-        }
-        return false;
-    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStepContract.java
@@ -19,17 +19,23 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import java.util.Arrays;
 import java.util.Set;
 
 public interface VertexStepContract<E extends Element> extends Step<Vertex, E> {
     Direction getDirection();
 
     String[] getEdgeLabels();
+
+    default GValue<String>[] getEdgeLabelsAsGValues() {
+        return Arrays.stream(getEdgeLabels()).map(GValue::of).toArray(GValue[]::new);
+    }
 
     Class<E> getReturnClass();
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStepPlaceholder.java
@@ -74,8 +74,9 @@ public class VertexStepPlaceholder<E extends Element> extends AbstractStep<Verte
         return Arrays.stream(GValue.resolveToValues(edgeLabels)).toArray(String[]::new);
     }
 
-    public String[] getEdgeLabelsGValueSafe() {
-        return Arrays.stream(GValue.resolveToValues(edgeLabels)).toArray(String[]::new);
+    @Override
+    public GValue<String>[] getEdgeLabelsAsGValues() {
+        return edgeLabels;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepContract.java
@@ -23,13 +23,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Deleting;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Writing;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
+import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
 import java.util.HashSet;
 
-public interface AddPropertyStepContract<S> extends Step<S, S>, TraversalParent, Scoping, PropertyAdding, Writing<Event.ElementPropertyChangedEvent>, Deleting<Event.ElementPropertyChangedEvent> {
+public interface AddPropertyStepContract<S> extends Step<S, S>, TraversalParent, Scoping, PropertiesHolder, Writing<Event.ElementPropertyChangedEvent>, Deleting<Event.ElementPropertyChangedEvent> {
     VertexProperty.Cardinality getCardinality();
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepContract.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepContract.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Deleting;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Writing;
@@ -49,4 +50,11 @@ public interface AddPropertyStepContract<S> extends Step<S, S>, TraversalParent,
      * Get the property value
      */
     Object getValue();
+
+    /**
+     * Get the value as a GValue, without pinning the variable
+     */
+    default GValue<?> getValueAsGValue() {
+        return GValue.of(getValue());
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepPlaceholder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepPlaceholder.java
@@ -118,10 +118,11 @@ public class AddPropertyStepPlaceholder<S extends Element> extends AbstractStep<
     }
 
     /**
-     * Get the value without pinning the variable.
+     * Get the value as a GValue, without pinning the variable
      */
-    public Object getValueGValueSafe() {
-        return value == null ? null : value.get();
+    @Override
+    public GValue<?> getValueAsGValue() {
+        return value;
     }
 
     @Override
@@ -204,8 +205,9 @@ public class AddPropertyStepPlaceholder<S extends Element> extends AbstractStep<
                 gValue -> traversal.getGValueManager().pinVariable(gValue.getName()));
     }
 
-    public Map<Object, List<Object>> getPropertiesGValueSafe() {
-        return GValueHelper.resolveProperties(properties);
+    @Override
+    public Map<Object, List<Object>> getPropertiesWithGValues() {
+        return Collections.unmodifiableMap(properties);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/PartitionStrategy.java
@@ -28,17 +28,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStepPlaceholder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStepPlaceholder;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStepPlaceholder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LambdaMapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MergeStepContract;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
+import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertyMapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStepContract;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStepPlaceholder;
@@ -238,7 +233,7 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
             // ends up being a Vertex or not.  AddPropertyStep currently chooses to simply not bother
             // to use the additional "property mutations" if the Element being mutated is a Edge or
             // VertexProperty
-            ((PropertyAdding) step).addProperty(partitionKey, writePartition);
+            ((PropertiesHolder) step).addProperty(partitionKey, writePartition);
 
             if (vertexFeatures.isPresent()) {
                 // GraphTraversal folds g.addV().property('k','v') to just AddVertexStep/AddVertexStartStep so this
@@ -260,7 +255,7 @@ public final class PartitionStrategy extends AbstractTraversalStrategy<Traversal
 
                                 // need to remove the property from the AddVertex/StartStep because it's now being
                                 // added via the AddPropertyStep
-                                ((PropertyAdding) step).removeProperty(k);
+                                ((PropertiesHolder) step).removeProperty(k);
 
                                 TraversalHelper.insertAfterStep(addPropertyStep, step, traversal);
                             });

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.VertexPr
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.PathFilterStep;
@@ -31,10 +32,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.TreeStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStepContract;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStepPlaceholder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeSideEffectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.javatuples.Pair;
@@ -110,8 +113,11 @@ public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<
      * @param step2     the vertex-emitting step to replace
      */
     private static void optimizeSteps(final Traversal.Admin traversal, final VertexStepContract step1, final Step step2) {
-        final Step newStep = new VertexStep(traversal, Vertex.class, step1.getDirection(), step1.getEdgeLabels());
-        //TODO:: preserve GValue and leave unpinned if step1 is a GValueHolder
+        final Step newStep = step1 instanceof VertexStepPlaceholder ?
+                // It is safe to use getGValues() here as edgeLabels are the only GValues in VertexStepPlaceholder,
+                // although the interface is not ideal.
+                new VertexStepPlaceholder<>(traversal, Vertex.class, step1.getDirection(), ((VertexStepPlaceholder<?>) step1).getGValues().toArray(new GValue[0])) :
+                new VertexStep(traversal, Vertex.class, step1.getDirection(), step1.getEdgeLabels());
         for (final String label : (Iterable<String>) step2.getLabels()) {
             newStep.addLabel(label);
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ReservedKeysVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ReservedKeysVerificationStrategy.java
@@ -21,7 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.strategy.verification;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.step.PropertyAdding;
+import org.apache.tinkerpop.gremlin.process.traversal.step.PropertiesHolder;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -53,8 +53,8 @@ public class ReservedKeysVerificationStrategy extends AbstractWarningVerificatio
     @Override
     void verify(final Traversal.Admin<?, ?> traversal) throws VerificationException {
         for (final Step<?, ?> step : traversal.getSteps()) {
-            if (step instanceof PropertyAdding) {
-                final PropertyAdding propertySettingStep = (PropertyAdding) step;
+            if (step instanceof PropertiesHolder) {
+                final PropertiesHolder propertySettingStep = (PropertiesHolder) step;
                 final Map<Object, List<Object>> properties = propertySettingStep.getProperties();
                 for (String key : reservedKeys) {
                     if (properties.containsKey(key)) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/RangeGlobalStepTest.java
@@ -71,10 +71,10 @@ public class RangeGlobalStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLowHighRangeGValueSafeShouldNotPinVariables() {
+    public void getLowHighRangeAsGValueShouldNotPinVariables() {
         GraphTraversal.Admin<Object, Object> traversal = __.range(GValue.of(LOW_NAME, LOW_VALUE), GValue.of(HIGH_NAME, HIGH_VALUE)).asAdmin();
-        assertEquals(LOW_VALUE, ((RangeStepPlaceholder.RangeGlobalStepPlaceholder) traversal.getSteps().get(0)).getLowRangeGValueSafe());
-        assertEquals(HIGH_VALUE, ((RangeStepPlaceholder.RangeGlobalStepPlaceholder) traversal.getSteps().get(0)).getHighRangeGValueSafe());
+        assertEquals(GValue.of(LOW_NAME, LOW_VALUE), ((RangeStepPlaceholder.RangeGlobalStepPlaceholder) traversal.getSteps().get(0)).getLowRangeAsGValue());
+        assertEquals(GValue.of(HIGH_NAME, HIGH_VALUE), ((RangeStepPlaceholder.RangeGlobalStepPlaceholder) traversal.getSteps().get(0)).getHighRangeAsGValue());
         verifyVariables(traversal, Set.of(), Set.of(LOW_NAME, HIGH_NAME));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStepTest.java
@@ -65,9 +65,9 @@ public class TailGlobalStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLimitGValueSafeShouldNotPinVariable() {
+    public void getLimitAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Object> traversal = __.tail(GValue.of(GVALUE_NAME, LIMIT_10)).asAdmin();
-        assertNotNull(((TailGlobalStepPlaceholder) traversal.getSteps().get(0)).getLimitGValueSafe());
+        assertEquals(GValue.of(GVALUE_NAME, LIMIT_10), ((TailGlobalStepPlaceholder) traversal.getSteps().get(0)).getLimitAsGValue());
         verifySingleUnpinnedVariable(traversal, GVALUE_NAME);
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepTest.java
@@ -105,9 +105,9 @@ public class AddEdgeStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLabelGValueSafeShouldNotPinVariable() {
+    public void getLabelAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Edge, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals("likes", ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getLabelGValueSafe());
+        assertEquals(GValue.of("label", "likes"), ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getLabelAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 
@@ -125,9 +125,9 @@ public class AddEdgeStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getElementIdGValueSafeShouldNotPinVariable() {
+    public void getElementIdAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Edge, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals("1234", ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getElementIdGValueSafe());
+        assertEquals(GValue.of("id", "1234"), ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getElementIdAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 
@@ -186,10 +186,10 @@ public class AddEdgeStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getPropertiesGValueSafeShouldNotPinVariable() {
+    public void getPropertiesWithGValuesShouldNotPinVariable() {
         GraphTraversal.Admin<Edge, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals(List.of("great"), ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0))
-                .getPropertiesGValueSafe().get("rating"));
+        assertEquals(List.of(GValue.of("r", "great")), ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0))
+                .getPropertiesWithGValues().get("rating"));
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStartStepTest.java
@@ -145,9 +145,9 @@ public class AddEdgeStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getFromGValueSafeShouldNotPinVariable() {
+    public void getFromWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Edge, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals(1, ((Vertex) (((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getFromGValueSafe())).id());
+        assertEquals(GValue.of("from", 1), ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getFromWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 
@@ -165,9 +165,9 @@ public class AddEdgeStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getToShouldNotPinVariable() {
+    public void getToWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Edge, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals(2, ((Vertex) (((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getToGValueSafe())).id());
+        assertEquals(GValue.of("to", 2), ((AddEdgeStartStepPlaceholder) traversal.getSteps().get(0)).getToWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStepTest.java
@@ -218,9 +218,9 @@ public class AddEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getFromGValueSafeShouldNotPinVariable() {
+    public void getFromWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals(1, ((Vertex) (((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getFromGValueSafe())).id());
+        assertEquals(GValue.of("from", 1), ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getFromWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 
@@ -248,9 +248,9 @@ public class AddEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getToShouldNotPinVariable() {
+    public void getToWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals(2, ((Vertex) (((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getToGValueSafe())).id());
+        assertEquals(GValue.of("to", 2), ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getToWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddEdgeStepTest.java
@@ -144,8 +144,8 @@ public class AddEdgeStepTest extends GValueStepTest {
         step.addProperty("type", GValue.of("friendship"));
 
         assertTrue(step.removeProperty("type"));
-        assertFalse(step.getPropertiesGValueSafe().containsKey("type"));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("weight"));
+        assertFalse(step.getPropertiesWithGValues().containsKey("type"));
+        assertTrue(step.getPropertiesWithGValues().containsKey("weight"));
         assertFalse(step.removeProperty("type"));
     }
 
@@ -178,9 +178,9 @@ public class AddEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLabelGValueSafeShouldNotPinVariable() {
+    public void getLabelAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals("likes", ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getLabelGValueSafe());
+        assertEquals(GValue.of("label", "likes"), ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getLabelAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 
@@ -198,9 +198,9 @@ public class AddEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getElementIdGValueSafeShouldNotPinVariable() {
+    public void getElementIdAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals("1234", ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getElementIdGValueSafe());
+        assertEquals(GValue.of("id", "1234"), ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getElementIdAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 
@@ -279,10 +279,10 @@ public class AddEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getPropertiesGValueSafeShouldNotPinVariable() {
+    public void getPropertiesWithGValuesShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Edge> traversal = getAddEdgeGValueTraversal();
-        assertEquals(List.of("great"), ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0))
-                .getPropertiesGValueSafe().get("rating"));
+        assertEquals(List.of(GValue.of("r", "great")), ((AddEdgeStepPlaceholder<?>) traversal.getSteps().get(0))
+                .getPropertiesWithGValues().get("rating"));
         verifyVariables(traversal, Set.of(), Set.of("label", "from", "to", "id", "r"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStartStepTest.java
@@ -99,9 +99,9 @@ public class AddVertexStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLabelGValueSafeShouldNotPinVariable() {
+    public void getLabelAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Vertex, Vertex> traversal = getAddPersonGValueTraversal();
-        assertEquals("person", ((AddVertexStartStepPlaceholder) traversal.getSteps().get(0)).getLabelGValueSafe());
+        assertEquals(GValue.of("label", "person"), ((AddVertexStartStepPlaceholder) traversal.getSteps().get(0)).getLabelAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "id", "a"));
     }
     
@@ -120,9 +120,9 @@ public class AddVertexStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getElementIdGValueSafeShouldNotPinVariable() {
+    public void getElementIdAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Vertex, Vertex> traversal = getAddPersonGValueTraversal();
-        assertEquals("1234", ((AddVertexStartStepPlaceholder) traversal.getSteps().get(0)).getElementIdGValueSafe());
+        assertEquals(GValue.of("id", "1234"), ((AddVertexStartStepPlaceholder) traversal.getSteps().get(0)).getElementIdAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "id", "a"));
     }
 
@@ -140,10 +140,10 @@ public class AddVertexStartStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getPropertiesGValueSafeShouldNotPinVariable() {
+    public void getPropertiesWithGValuesShouldNotPinVariable() {
         GraphTraversal.Admin<Vertex, Vertex> traversal = getAddPersonGValueTraversal();
-        assertEquals(List.of(29), ((AddVertexStartStepPlaceholder) traversal.getSteps().get(0))
-                .getPropertiesGValueSafe().get("age"));
+        assertEquals(List.of(GValue.of("a", 29)), ((AddVertexStartStepPlaceholder) traversal.getSteps().get(0))
+                .getPropertiesWithGValues().get("age"));
         verifyVariables(traversal, Set.of(), Set.of("label", "id", "a"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AddVertexStepTest.java
@@ -200,8 +200,8 @@ public class AddVertexStepTest extends GValueStepTest {
         step.addProperty("age", GValue.of(27));
 
         assertTrue(step.removeProperty("name"));
-        assertFalse(step.getPropertiesGValueSafe().containsKey("name"));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("age"));
+        assertFalse(step.getPropertiesWithGValues().containsKey("name"));
+        assertTrue(step.getPropertiesWithGValues().containsKey("age"));
         assertFalse(step.removeProperty("name"));
     }
 
@@ -279,9 +279,9 @@ public class AddVertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLabelGValueSafeShouldNotPinVariable() {
+    public void getLabelAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Vertex> traversal = getAddPersonGValueTraversal();
-        assertEquals("person", ((AddVertexStepPlaceholder) traversal.getSteps().get(0)).getLabelGValueSafe());
+        assertEquals(GValue.of("label", "person"), ((AddVertexStepPlaceholder) traversal.getSteps().get(0)).getLabelAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "id", "a"));
     }
     
@@ -300,9 +300,9 @@ public class AddVertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getElementIdGValueSafeShouldNotPinVariable() {
+    public void getElementIdAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Vertex> traversal = getAddPersonGValueTraversal();
-        assertEquals("1234", ((AddVertexStepPlaceholder) traversal.getSteps().get(0)).getElementIdGValueSafe());
+        assertEquals(GValue.of("id", "1234"), ((AddVertexStepPlaceholder) traversal.getSteps().get(0)).getElementIdAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("label", "id", "a"));
     }
 
@@ -320,10 +320,10 @@ public class AddVertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getPropertiesGValueSafeShouldNotPinVariable() {
+    public void getPropertiesWithGValuesShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Vertex> traversal = getAddPersonGValueTraversal();
-        assertEquals(List.of(29), ((AddVertexStepPlaceholder) traversal.getSteps().get(0))
-                .getPropertiesGValueSafe().get("age"));
+        assertEquals(List.of(GValue.of("a", 29)), ((AddVertexStepPlaceholder) traversal.getSteps().get(0))
+                .getPropertiesWithGValues().get("age"));
         verifyVariables(traversal, Set.of(), Set.of("label", "id", "a"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CallStepTest.java
@@ -115,9 +115,9 @@ public class CallStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getMergedParamsGValueSafeShouldNotPinVariables() {
+    public void getStaticParamsAsGValueShouldNotPinVariables() {
         GraphTraversal.Admin<Object, Object> traversal = getGValueTraversal();
-        assertEquals(STATIC_PARAMS, ((CallStepPlaceholder<?, ?>) traversal.getSteps().get(0)).getMergedParamsGValueSafe());
+        assertEquals(GValue.of("params", STATIC_PARAMS), ((CallStepPlaceholder<?, ?>) traversal.getSteps().get(0)).getStaticParamsAsGValue());
         verifyVariables(traversal, Set.of(), Set.of("params"));
     }
 
@@ -136,20 +136,6 @@ public class CallStepTest extends GValueStepTest {
         assertEquals(Map.of("foo", "bar", "fizz", "fuzz", "abc", 123), 
                 ((CallStepPlaceholder<?, ?>) traversal.getSteps().get(1)).getMergedParams());
         verifyVariables(traversal, Set.of("params"), Set.of());
-    }
-
-    /**
-     * This test needs to be revisited as the variables are pinned when the child traversal is executed
-     */
-    @Test
-    @Ignore
-    public void getMergedParamsGValueSafeWithChildTraversalShouldNotPinVariables() {
-        when(mockedRegistry.get(TEST_SERVICE, false, STATIC_PARAMS)).thenReturn(mockedService);
-        when(mockedService.getRequirements()).thenReturn(Set.of());
-        GraphTraversal.Admin<?, ?> traversal = getGValueWithChildTraversal();
-        assertEquals(Map.of("foo", "bar", "fizz", "fuzz", "abc", 123),
-                ((CallStepPlaceholder<?, ?>) traversal.getSteps().get(1)).getMergedParamsGValueSafe());
-        verifyVariables(traversal, Set.of(), Set.of("params"));
     }
 
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStepTest.java
@@ -97,10 +97,10 @@ public class GraphStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getIdsGValueSafeShouldNotPinVariable() {
+    public void getIdsAsGValuesShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getGraphStepGValueTraversal();
-        assertEquals(new Object[]{1,2,3,4}, ((GraphStepPlaceholder<?,?>) traversal.getSteps().get(0))
-                .getIdsGValueSafe());
+        assertEquals(new GValue[]{GValue.of("x", 1), GValue.of("y", 2), GValue.of(3), GValue.of("z", 4)},
+                ((GraphStepPlaceholder<?,?>) traversal.getSteps().get(0)).getIdsAsGValues());
         verifyVariables(traversal, Set.of(), Set.of("x","y","z"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeEdgeStepTest.java
@@ -95,12 +95,12 @@ public class MergeEdgeStepTest extends GValueStepTest {
                 true);
         step.addProperty("name", GValue.of("vadas"));
         step.addProperty("age", GValue.of(27));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("name"));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("age"));
+        assertTrue(step.getProperties().containsKey("name"));
+        assertTrue(step.getProperties().containsKey("age"));
 
         assertTrue(step.removeProperty("name"));
-        assertFalse(step.getPropertiesGValueSafe().containsKey("name"));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("age"));
+        assertFalse(step.getProperties().containsKey("name"));
+        assertTrue(step.getProperties().containsKey("age"));
         assertFalse(step.removeProperty("name"));
     }
 
@@ -208,9 +208,9 @@ public class MergeEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getMergeTraversalGValueSafeShouldNotPinVariable() {
+    public void getMergeMapWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeEGValueTraversal();
-        assertEquals(NAME_MAP, ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getMergeTraversalGValueSafe().next());
+        assertEquals(GValue.of("mergeMap", NAME_MAP), ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getMergeMapWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap"));
     }
 
@@ -228,9 +228,9 @@ public class MergeEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getOnCreateTraversalGValueSafeShouldNotPinVariable() {
+    public void getOnCreateMapWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeEGValueTraversal();
-        assertEquals(AGE_30_MAP, ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getOnCreateTraversalGValueSafe().next());
+        assertEquals(GValue.of("createMap", AGE_30_MAP), ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getOnCreateMapWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap"));
     }
 
@@ -248,9 +248,9 @@ public class MergeEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getOnMatchTraversalGValueSafeShouldNotPinVariable() {
+    public void getOnMatchMapWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeEGValueTraversal();
-        assertEquals(AGE_29_MAP, ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getOnMatchTraversalGValueSafe().next());
+        assertEquals(GValue.of("matchMap", AGE_29_MAP), ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0)).getOnMatchMapWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap"));
     }
 
@@ -272,13 +272,13 @@ public class MergeEdgeStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getPropertiesGValueSafeShouldNotPinVariable() {
+    public void getPropertiesWithGValuesShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeEGValueTraversal();
         MergeEdgeStepPlaceholder step = (MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0);
         //There is no direct way to add properties to mergeV via Gremlin, this interface is only exposed for the purposes of PartitionStrategy
         step.addProperty("key", GValue.of("x", "value"));
-        assertEquals(List.of("value"), ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0))
-                .getPropertiesGValueSafe().get("key"));
+        assertEquals(List.of(GValue.of("x", "value")), ((MergeEdgeStepPlaceholder<?>) traversal.getSteps().get(0))
+                .getPropertiesWithGValues().get("key"));
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap", "x"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MergeVertexStepTest.java
@@ -110,12 +110,12 @@ public class MergeVertexStepTest extends GValueStepTest {
                 true);
         step.addProperty("name", GValue.of("vadas"));
         step.addProperty("age", GValue.of(27));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("name"));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("age"));
+        assertTrue(step.getProperties().containsKey("name"));
+        assertTrue(step.getProperties().containsKey("age"));
 
         assertTrue(step.removeProperty("name"));
-        assertFalse(step.getPropertiesGValueSafe().containsKey("name"));
-        assertTrue(step.getPropertiesGValueSafe().containsKey("age"));
+        assertFalse(step.getProperties().containsKey("name"));
+        assertTrue(step.getProperties().containsKey("age"));
         assertFalse(step.removeProperty("name"));
     }
 
@@ -261,9 +261,9 @@ public class MergeVertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getMergeTraversalGValueSafeShouldNotPinVariable() {
+    public void getMergeMapWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeVGValueTraversal();
-        assertEquals(NAME_MAP, ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0)).getMergeTraversalGValueSafe().next());
+        assertEquals(GValue.of("mergeMap", NAME_MAP), ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0)).getMergeMapWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap"));
     }
 
@@ -281,9 +281,9 @@ public class MergeVertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getOnCreateTraversalGValueSafeShouldNotPinVariable() {
+    public void getOnCreateMapWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeVGValueTraversal();
-        assertEquals(AGE_30_MAP, ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0)).getOnCreateTraversalGValueSafe().next());
+        assertEquals(GValue.of("createMap", AGE_30_MAP), ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0)).getOnCreateMapWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap"));
     }
 
@@ -301,9 +301,9 @@ public class MergeVertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getOnMatchTraversalGValueSafeShouldNotPinVariable() {
+    public void getOnMatchMapWithGValueShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeVGValueTraversal();
-        assertEquals(AGE_29_MAP, ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0)).getOnMatchTraversalGValueSafe().next());
+        assertEquals(GValue.of("matchMap", AGE_29_MAP), ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0)).getOnMatchMapWithGValue());
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap"));
     }
 
@@ -325,13 +325,13 @@ public class MergeVertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getPropertiesGValueSafeShouldNotPinVariable() {
+    public void getPropertiesWithGValuesShouldNotPinVariable() {
         GraphTraversal.Admin<?, ?> traversal = getMergeVGValueTraversal();
         MergeVertexStepPlaceholder step = (MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0);
         //There is no direct way to add properties to mergeV via Gremlin, this interface is only exposed for the purposes of PartitionStrategy
         step.addProperty("key", GValue.of("x", "value"));
-        assertEquals(List.of("value"), ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0))
-                .getPropertiesGValueSafe().get("key"));
+        assertEquals(List.of(GValue.of("x", "value")), ((MergeVertexStepPlaceholder<?>) traversal.getSteps().get(0))
+                .getPropertiesWithGValues().get("key"));
         verifyVariables(traversal, Set.of(), Set.of("mergeMap", "matchMap", "createMap", "x"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStepTest.java
@@ -79,10 +79,10 @@ public class RangeLocalStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLowHighRangeGValueSafeShouldNotPinVariables() {
+    public void getLowHighRangeAsGValueShouldNotPinVariables() {
         GraphTraversal.Admin<Object, Object> traversal = __.range(Scope.local, GValue.of(LOW_NAME, LOW_VALUE), GValue.of(HIGH_NAME, HIGH_VALUE)).asAdmin();
-        assertEquals(LOW_VALUE, ((RangeStepPlaceholder.RangeLocalStepPlaceholder) traversal.getSteps().get(0)).getLowRangeGValueSafe());
-        assertEquals(HIGH_VALUE, ((RangeStepPlaceholder.RangeLocalStepPlaceholder) traversal.getSteps().get(0)).getHighRangeGValueSafe());
+        assertEquals(GValue.of(LOW_NAME, LOW_VALUE), ((RangeStepPlaceholder.RangeLocalStepPlaceholder) traversal.getSteps().get(0)).getLowRangeAsGValue());
+        assertEquals(GValue.of(HIGH_NAME, HIGH_VALUE), ((RangeStepPlaceholder.RangeLocalStepPlaceholder) traversal.getSteps().get(0)).getHighRangeAsGValue());
         verifyVariables(traversal, Set.of(), Set.of(LOW_NAME, HIGH_NAME));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStepTest.java
@@ -67,9 +67,9 @@ public class TailLocalStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getLimitGValueSafeShouldNotPinVariable() {
+    public void getLimitAsGValueShouldNotPinVariable() {
         GraphTraversal.Admin<Object, Object> traversal = __.tail(Scope.local, GValue.of(GVALUE_NAME, LIMIT_10)).asAdmin();
-        assertNotNull(((TailLocalStepPlaceholder) traversal.getSteps().get(0)).getLimitGValueSafe());
+        assertEquals(GValue.of(GVALUE_NAME, LIMIT_10), ((TailLocalStepPlaceholder) traversal.getSteps().get(0)).getLimitAsGValue());
         verifySingleUnpinnedVariable(traversal, GVALUE_NAME);
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/VertexStepTest.java
@@ -121,11 +121,11 @@ public class VertexStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getEdgeLabelsGValueSafeShouldNotPinVariables() {
+    public void getEdgeLabelsAsGValuesShouldNotPinVariables() {
         GraphTraversal.Admin<Vertex, Vertex> traversal = getVertexGValueTraversal();
-        String[] edgeLabels = ((VertexStepPlaceholder<?>) traversal.getSteps().get(0)).getEdgeLabelsGValueSafe();
+        GValue<String>[] edgeLabels = ((VertexStepPlaceholder<?>) traversal.getSteps().get(0)).getEdgeLabelsAsGValues();
         assertEquals(2, edgeLabels.length);
-        assertTrue(List.of(edgeLabels).containsAll(List.of("knows", "created")));
+        assertTrue(List.of(edgeLabels).containsAll(List.of(GValue.of("k", "knows"), GValue.of("c", "created"))));
         verifyVariables(traversal, Set.of(), Set.of("k", "c"));
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AddPropertyStepTest.java
@@ -97,16 +97,16 @@ public class AddPropertyStepTest extends GValueStepTest {
     }
 
     @Test
-    public void getValueGValueSafeShouldNotPinVariable() {
+    public void getValueAsGValueShouldNotPinVariable() {
         final GraphTraversal.Admin<Object, Object> traversal = __.property(PNAME, GValue.of(GNAME, PVALUE)).asAdmin();
-        assertEquals(PVALUE, ((AddPropertyStepPlaceholder) traversal.getSteps().get(0)).getValueGValueSafe());
+        assertEquals(GValue.of(GNAME, PVALUE), ((AddPropertyStepPlaceholder) traversal.getSteps().get(0)).getValueAsGValue());
         verifySingleUnpinnedVariable(traversal, GNAME);
     }
 
     @Test
-    public void getPropertiesGValueSafeShouldNotPinVariable() {
+    public void getPropertiesWithGValuesShouldNotPinVariable() {
         final GraphTraversal.Admin<Object, Object> traversal = __.property(PNAME, PVALUE, META_NAME, GValue.of(GMETA_NAME, META_VALUE)).asAdmin();
-        assertEquals(List.of(META_VALUE), ((AddPropertyStepPlaceholder) traversal.getSteps().get(0)).getPropertiesGValueSafe().get(META_NAME));
+        assertEquals(List.of(GValue.of(GMETA_NAME, META_VALUE)), ((AddPropertyStepPlaceholder) traversal.getSteps().get(0)).getPropertiesWithGValues().get(META_NAME));
         verifySingleUnpinnedVariable(traversal, GMETA_NAME);
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifier.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifier.java
@@ -186,64 +186,11 @@ public class GValueManagerVerifier {
         }
 
         /**
-         * Verifies that all variables are preserved
+         * Verifies that all variables are preserved and unpinned
          */
         public AfterVerifier<S, E> variablesArePreserved() {
-            final Set<String> currentVariables = manager.getVariableNames();
-            assertEquals("All variables should be preserved", preVariables, currentVariables);
-            return this;
-        }
-
-        /**
-         * Verifies that the contents of the GValueManager before and after applying strategies are unchanged.
-         * This ensures that they have the same Step references, StepContract objects, and the contents of the
-         * StepContracts are also the same.
-         */
-        public AfterVerifier<S, E> notModified() {
-            // Verify that the same steps are in the manager
-            // Use identity-based sets for Step objects
-            final Set<Step> preSteps = Collections.newSetFromMap(new IdentityHashMap<>());
-            preSteps.addAll(preStepGValues.keySet());
-
-            final Set<Step> currentSteps = Collections.newSetFromMap(new IdentityHashMap<>());
-            currentSteps.addAll(TraversalHelper.gatherGValuePlaceholders(traversal));
-
-            assertEquals("Steps in GValueManager should be unchanged", preSteps.size(), currentSteps.size());
-
-            for (Step preStep : preSteps) {
-                boolean found = false;
-                for (Step currentStep : currentSteps) {
-                    if (preStep.toString().equals(currentStep.toString())) {
-                        found = true;
-
-                        // Verify that the step has the same GValues
-                        final Collection<GValue<?>> preGValuesForStep = preStepGValues.get(preStep);
-                        final Collection<GValue<?>> currentGValuesForStep = currentStep instanceof GValueHolder ?
-                                ((GValueHolder<?, ?>) currentStep).getGValues() :
-                                Collections.emptySet();
-                        assertEquals("GValues for step should be unchanged", preGValuesForStep, currentGValuesForStep);
-
-                        // Verify that the step has the same variables
-                        final Set<String> preVariablesForStep = preStepVariables.get(preStep);
-                        if (preVariablesForStep != null) {
-                            final Set<String> currentVariablesForStep = currentGValuesForStep.stream()
-                                    .filter(GValue::isVariable)
-                                    .map(GValue::getName)
-                                    .collect(Collectors.toSet());
-                            assertEquals("Variables for step should be unchanged", preVariablesForStep, currentVariablesForStep);
-                        }
-
-                        // TODO:: Verify that the GValues are the same if they exist
-                        break;
-                    }
-                }
-                assertTrue("Step not found in current steps: " + preStep, found);
-            }
-
-            // Verify that the same GValues are in the manager
-            final Set<GValue<?>> currentGValues = manager.getGValues();
-            assertEquals("GValues in GValueManager should be unchanged", preGValues, currentGValues);
-
+            final Set<String> currentVariables = manager.getUnpinnedVariableNames();
+            assertEquals("All variables should be preserved and unpinned", preVariables, currentVariables);
             return this;
         }
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifier.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifier.java
@@ -271,10 +271,8 @@ public class GValueManagerVerifier {
 
             RangeGlobalStepPlaceholder<?> rangeGlobalStepPlaceholder = (RangeGlobalStepPlaceholder<?>) step;
 
-            assertEquals("Low range should match", expectedLow, rangeGlobalStepPlaceholder.getLowRangeGValueSafe());
-            assertEquals("High range should match", expectedHigh, rangeGlobalStepPlaceholder.getHighRangeGValueSafe());
-            assertEquals("Low range name should match", lowName, rangeGlobalStepPlaceholder.getLowName());
-            assertEquals("High range name should match", highName, rangeGlobalStepPlaceholder.getHighName());
+            assertEquals("Low range should match", GValue.of(lowName, expectedLow), rangeGlobalStepPlaceholder.getLowRangeAsGValue());
+            assertEquals("High range should match", GValue.of(highName, expectedHigh), rangeGlobalStepPlaceholder.getHighRangeAsGValue());
 
             return self();
         }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifier.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifier.java
@@ -288,9 +288,9 @@ public class GValueManagerVerifier {
 
             VertexStepPlaceholder<?> vertexStepPlaceholder = (VertexStepPlaceholder<?>) step;
 
-            assertEquals("Label count should match", expectedLabelCount, vertexStepPlaceholder.getEdgeLabelsGValueSafe().length);
+            assertEquals("Label count should match", expectedLabelCount, vertexStepPlaceholder.getEdgeLabelsAsGValues().length);
             assertTrue("Expected names should match", CollectionUtils.isEqualCollection(expectedNames, vertexStepPlaceholder.getGValues().stream().map(GValue::getName).collect(Collectors.toSet())));
-            assertTrue("Expected values should match", CollectionUtils.isEqualCollection(expectedValues, Set.of(vertexStepPlaceholder.getEdgeLabelsGValueSafe())));
+            assertTrue("Expected values should match", CollectionUtils.isEqualCollection(expectedValues, Set.of(GValue.resolveToValues(vertexStepPlaceholder.getEdgeLabelsAsGValues()))));
 
             return self();
         }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifierTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/GValueManagerVerifierTest.java
@@ -146,23 +146,6 @@ public class GValueManagerVerifierTest {
     }
 
     /**
-     * Tests the notModified method of AfterVerifier.
-     */
-    @Test
-    public void testNotModified() {
-        // Create a traversal with GValues
-        final Traversal.Admin<?, ?> traversal = __.filter(__.has("age", GValue.of("x", 25))).asAdmin();
-
-        // Verify that the state is unchanged after applying the NoOpStrategy
-        GValueManagerVerifier.verify(traversal, NoOpStrategy.instance())
-                .beforeApplying()
-                .stepsOfClassAreParameterized(true, HasStep.class)
-                .afterApplying()
-                .variablesArePreserved()
-                .notModified();
-    }
-
-    /**
      * Tests the managerIsEmpty method of AbstractVerifier.
      */
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/CountStrategyTest.java
@@ -282,6 +282,13 @@ public class CountStrategyTest {
                     {__.count().as("c").is(GValue.of("x", 0))},
                     {__.union(__.count().is(GValue.of("x", 0)), __.out().count())},
                     {__.coalesce(__.count().is(GValue.of("x", 0)), __.out().count())},
+
+                    // This case may be controversial, as the GValues are accessed by the strategy, but ultimately the traversal
+                    // is not modified. The variables are pinned regardless as those variables could later be updated to values
+                    // in which the strategy is active. Leaving the variables unpinned in such a case would not lead to an
+                    // incorrect traversal, however it may result in certain cached traversals missing out on the CountStrategy
+                    // optimizations.
+                    {__.count().is(P.within(GValue.of("x", "string"), GValue.of("y", "another")))},
             });
         }
 
@@ -312,7 +319,6 @@ public class CountStrategyTest {
                     {__.flatMap(__.count().is(GValue.of("x", 0))).as("a")},
                     {__.limit(5).count().is(GValue.of("x", 0))},
                     {__.range(1, 5).count().is(GValue.of("x", 0))},
-                    {__.count().is(P.within(GValue.of("x", "string"), GValue.of("y", "another")))},
             });
         }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/FilterRankingStrategyTest.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.GValueManagerVerifier;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.GValueReductionStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.translator.GroovyTranslator;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.util.CollectionUtil;
@@ -288,10 +289,10 @@ public class FilterRankingStrategyTest {
                     // Examples with TraversalStrategies.GlobalCache
                     {has("value", GValue.ofInteger("x", 0)).or(out(), in()).as(Graph.Hidden.hide("x")).has("value", GValue.ofInteger("y", 1)).dedup(),
                              CollectionUtil.asSet("x", "y"),
-                             TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
+                             TraversalStrategies.GlobalCache.getStrategies(Graph.class).removeStrategies(GValueReductionStrategy.class).toList()},
                     {has("value", GValue.ofInteger("x", 0)).filter(or(not(has("age")), has("age", GValue.ofInteger("y", 1)))).has("value", GValue.ofInteger("z", 1)).dedup(),
                              CollectionUtil.asSet("x", "y", "z"),
-                             TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList()},
+                             TraversalStrategies.GlobalCache.getStrategies(Graph.class).removeStrategies(GValueReductionStrategy.class).toList()},
             });
         }
 


### PR DESCRIPTION
This is a followup to https://github.com/apache/tinkerpop/pull/3157 with some fixes and refinements now that these changes have had more time to marinate.

Changes are as follows:

- Refactors
  - Rename PropertyAdding interface to PropertiesHolder
  - Introduce AbstractAddEdgeStepPlaceholder, AbstractAddVertexStepPlaceholder, and AbstractMergeElementStepPlaceholder to deduplicate some of the repetitive code in some of the placeholders
- Strategy Fixes
  - Fix strategy tests not correctly verifying that GValues are unpinned which previously led to false positives
  - Fix excessive variable pinning in PartitionStrategy, SubgraphStrategy, IncidentToAdjacentStrategy, and AdjacentToIncidentStrategy
- StepContract/Placeholder Refinement
  - Get rid of placeholder exclusive methods as these add unnecessary branching and casts to strategies. All placeholder methods now must override from the contract
  - Replace most "GValueSafe" getters with "AsGValue" or "WithGValue" getter that directly produces GValues without pinning variables. This is as the main use case for accessing step arguments without pinning variables is to blindly copy all arguments to a new step, in which case its preferred to retain the GValue structure. It's arguably invalid to copy a value on its own to a new step without pinning the variable or retaining the GValue boxing as it would break future calls to `updateVariable()`
  
Here is a complete listing of the changes to the Placeholder/Contract interfaces:

- CallStep
  - Replace getMergedParamsGValueSafe() with getStaticParamsAsGValue, note switch from mergedParams to static only.
  - Stuck with public Service<S, E> serviceGValueSafe()
- GraphStep
  - Replace getIdsGValueSafe with getIdsAsGValues
- VertexStep
  - Replace getEdgeLabelsGValueSafe with getEdgeLabelsAsGValues
- MergeV/EStep
  - Replace getMergeTraversalGValueSafe with getMergeMapWithGValue
  - Replace getOnCreateTraversalGValueSafe with getOnCreateMapWithGValue
  - Replace getOnMatchTraversalGValueSafe with getOnMatchMapWithGValue
  - Return types are complicated, see javadocs in MergeStepContract
- IsStep
  - Retained getPredicateGValueSafe()
- AddElement
  - Replace getLabelGValueSafe with getLabelAsGValue
  - Replace getElementIdGValueSafe with getElementIdAsGValue
  - Replace getPropertiesGValueSafe with getPropertiesWithGValues
- AddVertex
  - Covered by AddElement changes.
- AddEdge
  - Replace getFrom/ToGValueSafe with getFrom/ToWithGValue
  - Return types are complicated, see javadocs in AddEdgeStepContract
- AddProperty
  - Replace getValueGValueSafe with getValueAsGValue
- RangeGlobal/Local
  - Replace getLowRangeGValueSafe with getLowRangeAsGValue
  - Replace getHighRangeGValueSafe with getHighRangeAsGValue
  - Remove getLowName and getHighName
- TailGlobal/Local
  - Replace getLimitGValueSafe with getLimitAsGValue
- HasContainerHolder
  - Retains getPredicatesGValueSafe()

Lingering thoughts: Don’t like interface on methods which might return GValues or Traversals (getFrom()/getTo() in AddE, getMergeMap… in mergeV/E), these cases need more consideration.