### PR TITLE
Add splitByElement() method for parsing nested list or set

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -107,6 +107,7 @@ This release also includes changes from <<release-3-7-XXX, 3.7.XXX>>.
 * Updated `asString()` step to throw `IllegalArgumentException` with `null` inputs for casting step consistency
 * Renamed `MergeElementStep` to `MergeElementStep` as it is a base class to `mergeV()` and `mergeE()`.
 * Renamed `MergeStep` of `merge()` to `MergeElementStep` for consistency.
+* Added `splitByElement()` in `gremlin-test` for parsing nested list and set
 
 == TinkerPop 3.7.0 (Gremfir Master of the Pan Flute)
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/features/StepDefinition.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/features/StepDefinition.java
@@ -184,7 +184,7 @@ public final class StepDefinition {
     private List<Pair<Pattern, Function<String,Object>>> objectMatcherConverters = new ArrayList<Pair<Pattern, Function<String,Object>>>() {{
         // expects json so that should port to the Gremlin script form - replace curly json braces with square ones
         // for Gremlin sake.
-        add(Pair.with(Pattern.compile("m\\[(.*)\\]"), s -> {
+        add(Pair.with(Pattern.compile("^m\\[(.*)\\]$"), s -> {
             try {
                 // read tree from JSON - can't parse right to Map as each m[] level needs to be managed individually
                 return convertToObject(mapper.readTree(s));
@@ -193,16 +193,14 @@ public final class StepDefinition {
             }
         }));
 
-        add(Pair.with(Pattern.compile("l\\[\\]"), s -> Collections.emptyList()));
-        add(Pair.with(Pattern.compile("l\\[(.*)\\]"), s -> {
-            final String[] items = s.split(",");
-            return Stream.of(items).map(String::trim).map(x -> convertToObject(x)).collect(Collectors.toList());
+        add(Pair.with(Pattern.compile("^l\\[\\]$"), s -> new ArrayList<>()));
+        add(Pair.with(Pattern.compile("^l\\[(.*)\\]$"), s -> {
+            return splitByElement(s).stream().map(x -> convertToObject(x)).collect(Collectors.toList());
         }));
 
-        add(Pair.with(Pattern.compile("s\\[\\]"), s -> Collections.emptySet()));
-        add(Pair.with(Pattern.compile("s\\[(.*)\\]"), s -> {
-            final String[] items = s.split(",");
-            return Stream.of(items).map(String::trim).map(x -> convertToObject(x)).collect(Collectors.toSet());
+        add(Pair.with(Pattern.compile("^s\\[\\]$"), s -> new HashSet<>()));
+        add(Pair.with(Pattern.compile("^s\\[(.*)\\]$"), s -> {
+            return splitByElement(s).stream().map(x -> convertToObject(x)).collect(Collectors.toSet());
         }));
 
         // return the string values as is, used to wrap results that may contain other regex patterns
@@ -640,6 +638,27 @@ public final class StepDefinition {
         // test too, but i guess the test would fail so perhaps ok to just assume it's raw string value that
         // didn't need a transform by default
         return String.format("\"%s\"", pvalue);
+    }
+
+    private List<String> splitByElement(String s) {
+        if (s.trim().isEmpty()) return Collections.emptyList();
+
+        List<String> items = new ArrayList<>();
+        int depth = 0, start = 0;
+
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '[' || c == '{') depth++;
+            else if (c == ']' || c == '}') depth--;
+            else if (c == ',' && depth == 0) {
+                String item = s.substring(start, i).trim();
+                if (!item.isEmpty()) items.add(item);
+                start = i + 1;
+            }
+        }
+        String lastItem = s.substring(start).trim();
+        if (!lastItem.isEmpty()) items.add(lastItem);
+        return items;
     }
 
     private Object convertToObject(final Object pvalue) {


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.5 (non-breaking only)
    3.8-dev -> 3.8.0
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->
Added `splitByElement()` method in `gremlin-test` which splits strings without breaking elements containing commas inside brackets or braces. 
It replaces `split(",")` in list and set parsing to handle structures like `s[l[1,2,3], l[2,3,4]]`.