### PR TITLE
Fix Four Flaky Tests in gremlin-core

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV1.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV1.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -339,14 +340,14 @@ final class GraphSONSerializersV1 {
         }
 
         public void ser(final TraversalExplanation te, final JsonGenerator jsonGenerator) throws IOException {
-            final Map<String, Object> m = new HashMap<>();
+            final Map<String, Object> m = new LinkedHashMap<>();
             m.put(GraphSONTokens.ORIGINAL, getStepsAsList(te.getOriginalTraversal()));
 
             final List<Pair<TraversalStrategy, Traversal.Admin<?,?>>> strategyTraversals = te.getStrategyTraversals();
 
             final List<Map<String,Object>> intermediates = new ArrayList<>();
             for (final Pair<TraversalStrategy, Traversal.Admin<?, ?>> pair : strategyTraversals) {
-                final Map<String,Object> intermediate = new HashMap<>();
+                final Map<String,Object> intermediate = new LinkedHashMap<>();
                 intermediate.put(GraphSONTokens.STRATEGY, pair.getValue0().toString());
                 intermediate.put(GraphSONTokens.CATEGORY, pair.getValue0().getTraversalCategory().getSimpleName());
                 intermediate.put(GraphSONTokens.TRAVERSAL, getStepsAsList(pair.getValue1()));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV2.java
@@ -65,6 +65,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -300,14 +301,14 @@ class GraphSONSerializersV2 {
         @Override
         public void serialize(final TraversalExplanation traversalExplanation, final JsonGenerator jsonGenerator,
                               final SerializerProvider serializerProvider) throws IOException {
-            final Map<String, Object> m = new HashMap<>();
+            final Map<String, Object> m = new LinkedHashMap<>();
             m.put(GraphSONTokens.ORIGINAL, getStepsAsList(traversalExplanation.getOriginalTraversal()));
 
             final List<Pair<TraversalStrategy, Traversal.Admin<?, ?>>> strategyTraversals = traversalExplanation.getStrategyTraversals();
 
             final List<Map<String, Object>> intermediates = new ArrayList<>();
             for (final Pair<TraversalStrategy, Traversal.Admin<?, ?>> pair : strategyTraversals) {
-                final Map<String, Object> intermediate = new HashMap<>();
+                final Map<String, Object> intermediate = new LinkedHashMap<>();
                 intermediate.put(GraphSONTokens.STRATEGY, pair.getValue0().toString());
                 intermediate.put(GraphSONTokens.CATEGORY, pair.getValue0().getTraversalCategory().getSimpleName());
                 intermediate.put(GraphSONTokens.TRAVERSAL, getStepsAsList(pair.getValue1()));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV3.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializersV3.java
@@ -322,14 +322,14 @@ class GraphSONSerializersV3 {
         @Override
         public void serialize(final TraversalExplanation traversalExplanation, final JsonGenerator jsonGenerator,
                               final SerializerProvider serializerProvider) throws IOException {
-            final Map<String, Object> m = new HashMap<>();
+            final Map<String, Object> m = new LinkedHashMap<>();
             m.put(GraphSONTokens.ORIGINAL, getStepsAsList(traversalExplanation.getOriginalTraversal()));
 
             final List<Pair<TraversalStrategy, Traversal.Admin<?, ?>>> strategyTraversals = traversalExplanation.getStrategyTraversals();
 
             final List<Map<String, Object>> intermediates = new ArrayList<>();
             for (final Pair<TraversalStrategy, Traversal.Admin<?, ?>> pair : strategyTraversals) {
-                final Map<String, Object> intermediate = new HashMap<>();
+                final Map<String, Object> intermediate = new LinkedHashMap<>();
                 intermediate.put(GraphSONTokens.STRATEGY, pair.getValue0().toString());
                 intermediate.put(GraphSONTokens.CATEGORY, pair.getValue0().getTraversalCategory().getSimpleName());
                 intermediate.put(GraphSONTokens.TRAVERSAL, getStepsAsList(pair.getValue1()));


### PR DESCRIPTION
Hi! We detected flakiness in the following tests using the Nondex tool, The reason for the flakiness is similar to [#2943](https://github.com/apache/tinkerpop/pull/2943), which is due to the use of unordered collections.
```
org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest.shouldHandleTraversalExplanation[v1]
org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest.shouldHandleTraversalExplanation[v2-default]
org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest.shouldHandleTraversalExplanation[v2]
org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest.shouldHandleTraversalExplanation[v3]
```

And correspondingly, the flakiness could be reproduced by running the following commands:
```
  mvn clean -pl gremlin-core \
    edu.illinois:nondex-maven-plugin:2.2.1:nondex \
    -Dtest="org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest#shouldHandleTraversalExplanation[v1]" \
    -Drat.skip=true
```
```
  mvn clean -pl gremlin-core \
    edu.illinois:nondex-maven-plugin:2.2.1:nondex \
    -Dtest="org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest#shouldHandleTraversalExplanation[v2]" \
    -Drat.skip=true
```
```
  mvn clean -pl gremlin-core \
    edu.illinois:nondex-maven-plugin:2.2.1:nondex \
    -Dtest="org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest#shouldHandleTraversalExplanation[v2-default]" \
    -Drat.skip=true
```
```
  mvn clean -pl gremlin-core \
    edu.illinois:nondex-maven-plugin:2.2.1:nondex \
    -Dtest="org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONMapperTest#shouldHandleTraversalExplanation[v3]" \
    -Drat.skip=true
```
And the error might be as follows:
```
[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   GraphSONMapperTest.shouldHandleTraversalExplanation:182 expected:<...exStep(OUT,edge)"],"[intermediate":[],"final":["InjectStep([])","VertexStep(OUT,vertex)","EdgeVertexStep(OUT)","VertexStep(OUT,edge)"]]}> but was:<...exStep(OUT,edge)"],"[final":["InjectStep([])","VertexStep(OUT,vertex)","EdgeVertexStep(OUT)","VertexStep(OUT,edge)"],"intermediate":[]]}>
[INFO]
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
Once fixed, the output should be `build success` without test errors.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.5 (non-breaking only)
    3.8-dev -> 3.8.0
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->