### PR TITLE
Update Java GLV examples for consistency with other GLVs

### DIFF
--- a/gremlin-driver/src/main/java/examples/Connections.java
+++ b/gremlin-driver/src/main/java/examples/Connections.java
@@ -35,6 +35,10 @@ import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
 import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 
 public class Connections {
+    static final String SERVER_HOST = System.getenv().getOrDefault("GREMLIN_SERVER_HOST", "localhost");
+    static final int SERVER_PORT = Integer.parseInt(System.getenv().getOrDefault("GREMLIN_SERVER_PORT", "8182"));
+    static final String VERTEX_LABEL = System.getenv().getOrDefault("VERTEX_LABEL", "connection");
+
     public static void main(String[] args) throws Exception {
         withEmbedded();
         withRemote();
@@ -56,15 +60,12 @@ public class Connections {
 
     // Connecting to the server
     private static void withRemote() throws Exception {
-        Cluster cluster = Cluster.build("localhost").port(8182).create();
+        Cluster cluster = Cluster.build(SERVER_HOST).port(SERVER_PORT).create();
         GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
 
-        // Drop existing vertices
-        g.V().drop().iterate();
-
         // Simple query to verify connection
-        g.addV().iterate();
-        long count = g.V().count().next();
+        g.addV(VERTEX_LABEL).iterate();
+        long count = g.V().hasLabel(VERTEX_LABEL).count().next();
         System.out.println("Vertex count: " + count);
 
         // Cleanup
@@ -75,12 +76,12 @@ public class Connections {
     // Connecting and customizing configurations with a cluster
     // See reference/#gremlin-java-configuration for full list of configurations
     private static void withCluster() throws Exception {
-        Cluster cluster = Cluster.build("localhost").
+        Cluster cluster = Cluster.build(SERVER_HOST).
             channelizer(Channelizer.WebSocketChannelizer.class).
             keepAliveInterval(180000).
             maxConnectionPoolSize(8).
             path("/gremlin").
-            port(8182).
+            port(SERVER_PORT).
             serializer(new GraphBinaryMessageSerializerV1()).
             create();
         GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
@@ -98,7 +99,8 @@ public class Connections {
         IoRegistry registry = new FakeIoRegistry(); // an IoRegistry instance exposed by a specific graph provider
         TypeSerializerRegistry typeSerializerRegistry = TypeSerializerRegistry.build().addRegistry(registry).create();
         MessageSerializer serializer = new GraphBinaryMessageSerializerV1(typeSerializerRegistry);
-        Cluster cluster = Cluster.build("localhost").
+        Cluster cluster = Cluster.build(SERVER_HOST).
+            port(SERVER_PORT).
             serializer(serializer).
             create();
         Client client = cluster.connect();

--- a/gremlin-driver/src/main/java/examples/ModernTraversals.java
+++ b/gremlin-driver/src/main/java/examples/ModernTraversals.java
@@ -19,11 +19,11 @@ under the License.
 
 package examples;
 
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 
 import java.util.List;
 
@@ -33,10 +33,13 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 import static org.apache.tinkerpop.gremlin.structure.T.id;
 
 public class ModernTraversals {
-    public static void main(String[] args) {
-        // Performs basic traversals on the Modern toy graph which can be created using TinkerFactory
-        Graph modern = TinkerFactory.createModern();
-        GraphTraversalSource g = traversal().withEmbedded(modern);
+    static final String SERVER_HOST = System.getenv().getOrDefault("GREMLIN_SERVER_HOST", "localhost");
+    static final int SERVER_PORT = Integer.parseInt(System.getenv().getOrDefault("GREMLIN_SERVER_PORT", "8182"));
+
+    public static void main(String[] args) throws Exception {
+        // Performs basic traversals on the Modern toy graph loaded on the server
+        Cluster cluster = Cluster.build(SERVER_HOST).port(SERVER_PORT).create();
+        GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
 
         List<Edge> e1 = g.V(1).bothE().toList(); // (1)
         List<Edge> e2 = g.V(1).bothE().where(otherV().hasId(2)).toList(); // (2)
@@ -54,6 +57,10 @@ public class ModernTraversals {
         System.out.println("5: " + e5.toString());
         System.out.println("6: " + e6.toString());
 
+        // Cleanup
+        cluster.close();
+        g.close();
+
         /*
         1. There are three edges from the vertex with the identifier of "1".
         2. Filter those three edges using the where()-step using the identifier of the vertex returned by otherV() to
@@ -69,3 +76,5 @@ public class ModernTraversals {
         */
     }
 }
+
+

--- a/gremlin-examples/gremlin-java/BasicGremlin.java
+++ b/gremlin-examples/gremlin-java/BasicGremlin.java
@@ -19,24 +19,28 @@ under the License.
 
 package examples;
 
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 
 import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 
 public class BasicGremlin {
-    public static void main(String[] args) {
-        Graph graph = TinkerGraph.open();
-        GraphTraversalSource g = traversal().withEmbedded(graph);
+    static final String SERVER_HOST = "localhost";
+    static final int SERVER_PORT = 8182;
+    static final String VERTEX_LABEL = "person";
+
+    public static void main(String[] args) throws Exception {
+        Cluster cluster = Cluster.build(SERVER_HOST).port(SERVER_PORT).create();
+        GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
 
         // Basic Gremlin: adding and retrieving data
-        Vertex v1 = g.addV("person").property("name","marko").next();
-        Vertex v2 = g.addV("person").property("name","stephen").next();
-        Vertex v3 = g.addV("person").property("name","vadas").next();
+        Vertex v1 = g.addV(VERTEX_LABEL).property("name","marko").next();
+        Vertex v2 = g.addV(VERTEX_LABEL).property("name","stephen").next();
+        Vertex v3 = g.addV(VERTEX_LABEL).property("name","vadas").next();
 
         // Be sure to use a terminating step like next() or iterate() so that the traversal "executes"
         // Iterate() does not return any data and is used to just generate side-effects (i.e. write data to the database)
@@ -44,13 +48,17 @@ public class BasicGremlin {
         g.V(v1).addE("knows").to(v3).property("weight",0.75).iterate();
 
         // Retrieve the data from the "marko" vertex
-        Object marko = g.V().has("person","name","marko").values("name").next();
+        Object marko = g.V().has(VERTEX_LABEL,"name","marko").values("name").next();
         System.out.println("name: " + marko);
 
         // Find the "marko" vertex and then traverse to the people he "knows" and return their data
-        List<Object> peopleMarkoKnows = g.V().has("person","name","marko").out("knows").values("name").toList();
+        List<Object> peopleMarkoKnows = g.V().has(VERTEX_LABEL,"name","marko").out("knows").values("name").toList();
         for (Object person : peopleMarkoKnows) {
             System.out.println("marko knows " + person);
         }
+
+        // Cleanup
+        cluster.close();
+        g.close();
     }
 }

--- a/gremlin-examples/gremlin-java/ModernTraversals.java
+++ b/gremlin-examples/gremlin-java/ModernTraversals.java
@@ -19,11 +19,11 @@ under the License.
 
 package examples;
 
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 
 import java.util.List;
 
@@ -33,10 +33,13 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 import static org.apache.tinkerpop.gremlin.structure.T.id;
 
 public class ModernTraversals {
-    public static void main(String[] args) {
-        // Performs basic traversals on the Modern toy graph which can be created using TinkerFactory
-        Graph modern = TinkerFactory.createModern();
-        GraphTraversalSource g = traversal().withEmbedded(modern);
+    static final String SERVER_HOST = "localhost";
+    static final int SERVER_PORT = 8182;
+
+    public static void main(String[] args) throws Exception {
+        // Performs basic traversals on the Modern toy graph loaded on the server
+        Cluster cluster = Cluster.build(SERVER_HOST).port(SERVER_PORT).create();
+        GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
 
         List<Edge> e1 = g.V(1).bothE().toList(); // (1)
         List<Edge> e2 = g.V(1).bothE().where(otherV().hasId(2)).toList(); // (2)
@@ -53,6 +56,10 @@ public class ModernTraversals {
         System.out.println("4: " + e4.toString());
         System.out.println("5: " + e5.toString());
         System.out.println("6: " + e6.toString());
+
+        // Cleanup
+        cluster.close();
+        g.close();
 
         /*
         1. There are three edges from the vertex with the identifier of "1".


### PR DESCRIPTION
Updates Java examples in `gremlin-driver` and `gremlin-examples/java` for consistency with other GLVs and to prepare examples for CI integration. There will be a follow-up PR to execute Java examples during integration tests similar to other GLVs.

Changes Made:
- Changed examples from embedded graphs to remote connections for consistency with other GLVs
- Made server URLs and ports configurable via environment variables
- Added configurable vertex labels to isolate data
