### PR TITLE
Aligned AGENTS.md better with ASF AI contribution guidelines

### DIFF
--- a/.skills/tinkerpop-dev/references/build-java.md
+++ b/.skills/tinkerpop-dev/references/build-java.md
@@ -19,9 +19,18 @@ under the License.
 
 # Java / Core Module Builds
 
-## Building Specific Modules
+## Full Build (skip tests)
 
-Build a single module:
+When modules have unresolved dependency ordering issues (e.g., shaded jars not yet installed, branches changed, etc.), 
+build the entire project first:
+
+```bash
+mvn clean install -DskipTests
+```
+
+## Building and Test Specific Modules
+
+Build and test a single module:
 ```bash
 mvn clean install -pl <module-name>
 ```
@@ -33,7 +42,7 @@ mvn clean install -pl :gremlin-core
 mvn clean install -pl :gremlin-server
 ```
 
-Build a module and its dependencies:
+Build and test a module and its dependencies:
 ```bash
 mvn clean install -pl :gremlin-server -am
 ```
@@ -50,85 +59,9 @@ Run gremlin-server integration tests:
 mvn clean install -pl :gremlin-server -DskipIntegrationTests=false
 ```
 
-Start Gremlin Server with Docker using the standard test configuration:
-```bash
-docker/gremlin-server.sh
-```
-
 ## Integration Tests
 
-Enable integration tests across the project:
+Build and test with all integration tests across the project:
 ```bash
 mvn clean install -DskipIntegrationTests=false
-```
-
-Use the `-DuseEpoll` option to try Netty native transport (Linux only; falls back to
-Java NIO on other OS).
-
-## Test Options
-
-Disable iterator leak assertions:
-```bash
-mvn clean install -DtestIteratorLeaks=false
-```
-
-Specify a test seed for reproducible `Random` behavior:
-```bash
-mvn clean install -DtestSeed=<seed-value>
-```
-When a test fails, the seed is printed in build output (look for "TestHelper" logger).
-Re-run with the same seed to reproduce.
-
-Mute heavy logging in process tests:
-```bash
-mvn clean install -DargLine="-DmuteTestLogs=true"
-```
-
-Run specific tests in a TinkerPop Suite:
-```bash
-export GREMLIN_TESTS='org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest$CountMatchTraversals'
-mvn -Dmaven.javadoc.skip=true --projects tinkergraph-gremlin test
-```
-
-## Docker Images
-
-Build Docker images of Gremlin Server and Console:
-```bash
-mvn clean install -pl :gremlin-server,:gremlin-console -DdockerImages
-```
-
-Skip automatic Docker image build:
-```bash
-mvn clean install -DskipImageBuild
-```
-
-## Other Useful Commands
-
-Check license headers:
-```bash
-mvn apache-rat:check
-```
-
-Check for newer dependencies:
-```bash
-mvn versions:display-dependency-updates
-mvn versions:display-plugin-updates
-```
-
-Test coverage report (must use `install`, not `test`):
-```bash
-mvn clean install -Dcoverage
-```
-Reports go to `gremlin-tools/gremlin-coverage/target/site`.
-
-Benchmarks:
-```bash
-mvn verify -DskipBenchmarks=false
-```
-Reports go to `gremlin-tools/gremlin-benchmark/target/reports/benchmark`.
-
-Regenerate toy graph data (only after IO class changes):
-```bash
-# From tinkergraph-gremlin directory
-mvn clean install -Dio
 ```

--- a/.skills/tinkerpop-dev/references/dev-environment-setup.md
+++ b/.skills/tinkerpop-dev/references/dev-environment-setup.md
@@ -60,7 +60,7 @@ This checks for Java, Maven, Docker, and optionally Python, Node.js, .NET, and G
 After cloning, verify the basic build works:
 
 ```bash
-mvn clean install
+mvn clean install -DskipTests
 ```
 
 This builds all JVM modules. GLV modules will be skipped unless activated (see below).
@@ -137,4 +137,4 @@ For AI coding agent configuration, see the "Using AI Coding Agents" section in
 
 - See `references/build-java.md` for Java module build details
 - See the GLV-specific reference files for language-specific workflows
-- See `references/documentation.md` for documentation generation
+- See `references/documentation.md` for documentation instructions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,21 @@ These local documents are authoritative. If this file appears to contradict them
 - `CONTRIBUTING.md`
 - Developer documentation at `docs/src/dev/**`
 
+## Licensing and Provenance
+
+Apache TinkerPop is licensed under Apache License 2.0. Contributions must meet the 
+[ASF's Generative Tooling guidance](https://www.apache.org/legal/generative-tooling.html). In particular:
+
+* *Do not copy verbatim from incompatibly licensed sources.* This includes GPL / AGPL / LGPL code, proprietary code, 
+unlicensed snippets, and Stack Overflow / blog / forum excerpts whose licensing is unclear. Reimplement from 
+specifications, standards, or Apache-compatible sources (see the ASF 3rd Party Licensing Policy).
+* *Every new source file needs the ASF license header.* See `bin/asf-license-header.txt` for the canonical form.
+* *Attribute generated work in commits.* When AI tooling authored a non-trivial portion of a change, add a trailer to 
+the commit message, for example: `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]`. This aligns with the ASF's 
+recommendation on AI provenance tracking.
+* *The contributor remains responsible for what they submit.* Review generated output for licensing, correctness, and 
+style before committing.
+
 ## Essential Rules
 
 These rules apply to any AI/IDE assistant operating on this repository.
@@ -45,9 +60,9 @@ These rules apply to any AI/IDE assistant operating on this repository.
 - Don't push to any branch.
 - Don't merge any PR or branch.
 - Don't create tags or releases.
+- Don't add `@author` javadoc (or similar) tags for new files, but do not remove existing ones either.
 
 ### When In Doubt
 
-1. Check `CONTRIBUTING.md` and developer docs under `docs/src/dev/developer/`.
-2. Prefer no change over an unsafe or speculative change.
-3. Ask for clarification.
+1. Prefer no change over an unsafe or speculative change.
+2. Ask for clarification.


### PR DESCRIPTION
Focus of this PR is more on AGENTS.md itself, but cleaned up some skill related items I noticed weren't working well. Dropped less used content that an agent likely wouldn't use. 

Inspiration for ASF alignment came from Groovy who are still discussing these changes on their dev list - but i think the component I added is the key one: 

https://github.com/apache/groovy/blob/master/AGENTS.md#licensing-and-provenance-read-first

Used attribution style from linux that I imagine went through much discussion and appears quite flexible: 

https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst#attribution

VOTE +1