### PR TITLE
Add getOldChar() and getNewChar() getters to ReplaceGlobalStep and ReplaceLocalStep

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ReplaceGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ReplaceGlobalStep.java
@@ -65,6 +65,14 @@ public final class ReplaceGlobalStep<S, E> extends ScalarMapStep<S, E> {
         return Collections.singleton(TraverserRequirement.OBJECT);
     }
 
+    public String getOldChar() {
+        return this.oldChar;
+    }
+
+    public String getNewChar() {
+        return this.newChar;
+    }
+
     @Override
     public int hashCode() {
         int result = super.hashCode();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ReplaceLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ReplaceLocalStep.java
@@ -56,6 +56,14 @@ public final class ReplaceLocalStep<S, E> extends StringLocalStep<S, E> {
     @Override
     public String getStepName() { return "replace(local)"; }
 
+    public String getOldChar() {
+        return this.oldChar;
+    }
+
+    public String getNewChar() {
+        return this.newChar;
+    }
+
     @Override
     public int hashCode() {
         int result = super.hashCode();


### PR DESCRIPTION
ReplaceGlobalStep and ReplaceLocalStep currently expose oldChar and newChar only as constructor parameters with no public accessors. Graph database implementations that perform ahead-of-time query translation need to inspect these parameters during the translation phase to generate optimized execution plans — for example, to determine whether the replace operation can be pushed down to a native query engine or whether null arguments should be treated as a no-op at translation time. Without getters, translators have no way to access these values from the step object.

This PR adds getOldChar() and getNewChar() public getters to both steps. The change is non-breaking and follows the same pattern used by other parameterized steps such as SubstringGlobalStep and SplitGlobalStep.

TARGET: 3.8-dev — should be merged forward to master (4.0.0).