### PR TITLE
Clarify Assisted-by trailer format in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,14 @@ Apache TinkerPop is licensed under Apache License 2.0. Contributions must meet t
 unlicensed snippets, and Stack Overflow / blog / forum excerpts whose licensing is unclear. Reimplement from 
 specifications, standards, or Apache-compatible sources (see the ASF 3rd Party Licensing Policy).
 * *Every new source file needs the ASF license header.* See `bin/asf-license-header.txt` for the canonical form.
-* *Attribute generated work in commits.* When AI tooling authored a non-trivial portion of a change, add a trailer to 
-the commit message, for example: `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]`. This aligns with the ASF's 
-recommendation on AI provenance tracking.
+* *Attribute generated work in commits.* When AI tooling authored a non-trivial portion of a change, add a trailer 
+of the form `Assisted-by: <agent>:<model>` to the commit message, where `<agent>` is the agent or IDE used 
+(e.g. `Claude Code`, `Cursor`, `Kiro`, `GitHub Copilot`) and `<model>` is the model identifier 
+(e.g. `claude-opus-4-7`, `gpt-5`). Append a bracketed entry per additional auxiliary tool (e.g. `[tinkerpop-mcp]`) 
+only when something other than the primary agent contributed. For example, 
+`Assisted-by: Claude Code:claude-opus-4-7`, `Assisted-by: Cursor:gpt-5`, or 
+`Assisted-by: Claude Code:claude-opus-4-7 [tinkerpop-mcp]`. This aligns with the ASF's recommendation on AI 
+provenance tracking.
 * *The contributor remains responsible for what they submit.* Review generated output for licensing, correctness, and 
 style before committing.
 


### PR DESCRIPTION
## Summary

- The current template `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]` is being interpreted inconsistently — at least two contributors have placed the model family in the agent slot and the IDE/CLI in brackets, when the intended structure (per @spmallette) is `<agent>:<model>` with brackets reserved for auxiliary tools.
- Names each placeholder explicitly and adds three concrete examples in the prose covering the common single-agent case and the rarer auxiliary-tool case.
- Style matches the rest of AGENTS.md — inline backticks throughout, no fenced or indented code blocks introduced.

## Context

Raised by @spmallette on [#3416](https://github.com/apache/tinkerpop/pull/3416#issuecomment-4363617916):

> I'd envisioned: `Assisted-by: Claude Code:claude-opus-4-7` ... I might need to better define that to get what I want there. It's interpreting the "tool" to be Claude Code - maybe because the tool is not seen as optional??

This PR addresses that by naming each placeholder and providing examples that demonstrate the intended form. The bracket interpretation in the new wording — "auxiliary tools beyond the primary agent" — reflects my reading; happy to revise if a different meaning is preferred.

## Branches

`AGENTS.md` exists only on `master`, so this is master-only.

## Test plan

- [x] Renders correctly on GitHub
- [x] No fenced or indented code blocks introduced — existing AGENTS.md prose-with-inline-backticks style preserved
- [x] All in-prose examples conform to the new format

## Notes

This change was AI-assisted; the commit's `Assisted-by:` trailer demonstrates the new format.