### PR TITLE
Supported python version matrix for CI/CD

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -301,13 +301,6 @@ jobs:
           EXCLUDE="${EXCLUDE_MODULES/,-:gremlin-python},$EXCLUDE_FOR_GLV"
           mvn clean install -pl $EXCLUDE -q -DskipTests -Dci
           mvn verify -pl gremlin-python
-      - name: Upload test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-reports-${{ matrix.python-version }}
-          path: gremlin-python/target/python3/python-reports/
-          if-no-files-found: ignore
   dotnet:
     name: .NET
     timeout-minutes: 20

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -274,10 +274,16 @@ jobs:
           mvn clean install -pl $EXCLUDE -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript -Dnode.test.version=24 -Dhost.uid=$(id -u) -Dhost.gid=$(id -g)
   python:
-    name: python
+    name: python-${{ matrix.python-version }}
     timeout-minutes: 20
     needs: cache-gremlin-server-docker-image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 11
@@ -285,16 +291,23 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Set up Python 3.x
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - name: Build with Maven
         run: |
           touch gremlin-python/.glv
           EXCLUDE="${EXCLUDE_MODULES/,-:gremlin-python},$EXCLUDE_FOR_GLV"
           mvn clean install -pl $EXCLUDE -q -DskipTests -Dci
           mvn verify -pl gremlin-python
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-reports-${{ matrix.python-version }}
+          path: gremlin-python/target/python3/python-reports/
+          if-no-files-found: ignore
   dotnet:
     name: .NET
     timeout-minutes: 20

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -43,7 +43,7 @@ services:
 
   gremlin-python-integration-tests:
     container_name: gremlin-python-integration-tests
-    image: python:3.10
+    image: python:${PYTHON_VERSION:-3.10}
     volumes:
       - ${BUILD_DIR:-./src/main/python}:/python_app
       - ../gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features:/python_app/gremlin-test/features
@@ -86,7 +86,7 @@ services:
 
   gremlin-python-package:
     container_name: gremlin-python-package
-    image: python:3.10
+    image: python:${PYTHON_VERSION:-3.10}
     volumes:
       - ${PACKAGE_DIR:-./src/main/python}:/python_package
     working_dir: /python_package


### PR DESCRIPTION
## Summary
Run gremlin-python tests across all [supported Python versions](https://tinkerpop.apache.org/docs/current/reference/#Gremlin-Python) in parallel

Converts the single-version python job in build-test.yml into a fail-fast: false matrix covering Python 3.10-3.14, and
parameterizes gremlin-python/docker-compose.yml (image: python:${PYTHON_VERSION:-3.10}) so the matrix value actually reaches theinterpreter inside Docker. Default behavior for local mvn verify -pl gremlin-python is unchanged. Per-version JUnit reports areuploaded as artifacts.

## Design
The python build-test for multiple versions are running in parallel and should take around the same time to complete (~25 min.) as before this change.
<img width="516" height="497" alt="Screenshot 2026-05-05 at 9 30 23 AM" src="https://github.com/user-attachments/assets/feb16930-7deb-4e2a-96c1-42c7e8e14463" />


## Follow up tasks

- This is a CI/CD change only and should be backported to 3.8-dev and 3.7-dev. Python 3.9 should be added to the matrix for 3.7-dev. 
- Other GLVs should adopt this change as well for documented supported versions

 
## TODO
There is an error from testing regarding `asyncio.get_event_loop` for Python 3.14 that is in progress.


## Note

Assisted-by: Devin: Claude Opus 4.7
