### PR TITLE
Add testing and docs for supported Python versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -320,10 +320,16 @@ jobs:
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-javascript -Dnode.test.version=24
   python:
-    name: python
+    name: python-${{ matrix.python-version }}
     timeout-minutes: 20
     needs: cache-gremlin-server-docker-image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 11
@@ -331,10 +337,10 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
       - name: Build with Maven
         run: |
           touch gremlin-python/.glv

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.7.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Fixed conjoin has incorrect null handling.
+* Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 
 [[release-3-7-6]]
 === TinkerPop 3.7.6 (Release Date: April 1, 2026)

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -2467,13 +2467,13 @@ The following table outlines recommended runtime versions by the release in whic
 
 [cols="1,1,1",options="header"]
 |===
-|Version |Min Python |Key Dependencies
+|Version |Recommended Python |Key Dependencies
 |3.4.0 |2.7 |tornado
-|3.5.0 |≥3.0 |aiohttp
-|3.6.0 |≥3.8 |aiohttp
-|3.6.8 |≥3.9 |aiohttp
-|3.7.0 |≥3.8 |aiohttp
-|3.7.3 |≥3.9 |aiohttp
+|3.5.0 |3.0 |aiohttp
+|3.6.0 |3.8 |aiohttp
+|3.6.8 |3.9 |aiohttp
+|3.7.0 |3.8-3.13 |aiohttp
+|3.7.3 |3.9-3.13 |aiohttp
 |===
 
 [[gremlin-python-connecting]]

--- a/gremlin-python/AGENTS.md
+++ b/gremlin-python/AGENTS.md
@@ -9,7 +9,8 @@ supplements the root `AGENTS.md` file.
 
 To build and run tests for `gremlin-python`, ensure the following:
 
-*   **Python Version**: Python 3.9 or higher must be installed.
+*   **Python Version**: A supported Python version must be installed. `gremlin-python` supports Python 3.9 through
+    3.13.
 *   **Virtual Environment**: While a virtual environment is recommended for local development, the preferred way to 
     run tests is via Maven and Docker, which handles environment isolation automatically.
 *   **Docker**: Docker and Docker Compose must be installed and running.

--- a/gremlin-python/docker-compose.yml
+++ b/gremlin-python/docker-compose.yml
@@ -46,7 +46,7 @@ services:
 
   gremlin-python-integration-tests:
     container_name: gremlin-python-integration-tests
-    image: python:3.9
+    image: python:${PYTHON_VERSION:-3.9}
     volumes:
       - ${BUILD_DIR:-./src/main/python}:/python_app
       - ../gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features:/python_app/gremlin-test/features
@@ -95,7 +95,7 @@ services:
 
   gremlin-python-package:
     container_name: gremlin-python-package
-    image: python:3.9
+    image: python:${PYTHON_VERSION:-3.9}
     volumes:
       - ${PACKAGE_DIR:-./src/main/python}:/python_package
     working_dir: /python_package

--- a/gremlin-python/src/main/python/pyproject.toml
+++ b/gremlin-python/src/main/python/pyproject.toml
@@ -26,7 +26,7 @@ description = "Gremlin-Python for Apache TinkerPop"
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = {text = "Apache 2"}
 maintainers = [{name = "Apache TinkerPop", email = "dev@tinkerpop.apache.org"}]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "nest_asyncio",
     "aiohttp>=3.8.0,<4.0.0",
@@ -38,7 +38,12 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3"
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
Run gremlin-python tests across all [supported Python versions](https://tinkerpop.apache.org/docs/current/reference/#Gremlin-Python) in parallel

Converts the single-version python job in build-test.yml into a fail-fast: false matrix covering Python 3.9-3.13, and
parameterizes gremlin-python/docker-compose.yml (image: python:${PYTHON_VERSION:-3.9}) so the matrix value actually reaches theinterpreter inside Docker.

Updated docs to reflect these changes as well.

## Design
The python build-test for multiple versions are running in parallel and should take around the same time to complete (~25 min.) as before this change.
<img width="232" height="392" alt="Screenshot 2026-05-08 at 11 47 00 AM" src="https://github.com/user-attachments/assets/ee5cf3d6-6bd6-4c45-897d-f0720024e633" />


## Follow up tasks
Merge to 3.8-dev and master changing the lower bound to 3.10 but maintain the upper bound to 3.13

## Note

Assisted-by: Devin: Claude Opus 4.7
