### PR TITLE
Refactor JS CI jobs to use matrix strategy and add Node 26

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -238,11 +238,15 @@ jobs:
         run: |
           mvn clean install -pl -:gremlin-javascript,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl gremlin-driver -DskipIntegrationTests=false
-  javascript-node20:
-    name: javascript-all-node20
+  javascript:
+    name: javascript-glv-node${{ matrix.node-version }}
     timeout-minutes: 15
     needs: cache-gremlin-server-docker-image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22', '24', '26']
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 11
@@ -264,61 +268,7 @@ jobs:
       - name: Build with Maven
         run: |
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :gremlin-javascript,:gremlint -Dnode.test.version=20
-  javascript-node22:
-    name: javascript-glv-node22
-    timeout-minutes: 15
-    needs: cache-gremlin-server-docker-image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up JDK 11
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Get Cached Server Base Image
-        uses: actions/cache@v5
-        id: gremlin-server-test-docker-image
-        with:
-          path: |
-            ./gremlin-server/*
-            ~/.m2/repository/org/apache/tinkerpop/*
-          key: ${{ github.sha }}
-      - name: Load Docker Image
-        working-directory: ./gremlin-server
-        run: docker load --input gremlin-server.tar
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :gremlin-javascript -Dnode.test.version=22
-  javascript-node24:
-    name: javascript-glv-node24
-    timeout-minutes: 15
-    needs: cache-gremlin-server-docker-image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up JDK 11
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Get Cached Server Base Image
-        uses: actions/cache@v5
-        id: gremlin-server-test-docker-image
-        with:
-          path: |
-            ./gremlin-server/*
-            ~/.m2/repository/org/apache/tinkerpop/*
-          key: ${{ github.sha }}
-      - name: Load Docker Image
-        working-directory: ./gremlin-server
-        run: docker load --input gremlin-server.tar
-      - name: Build with Maven
-        run: |
-          mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :gremlin-javascript -Dnode.test.version=24
+          mvn verify -pl :gremlin-javascript,:gremlint -Dnode.test.version=${{ matrix.node-version }}
   python:
     name: python-${{ matrix.python-version }}
     timeout-minutes: 20

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 * Fixed conjoin has incorrect null handling.
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
+* Add Node 26 support for `gremlin-javascript` and `gremlint`.
 
 [[release-3-7-6]]
 === TinkerPop 3.7.6 (Release Date: April 1, 2026)

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1483,8 +1483,8 @@ java -cp target/run-examples-shaded.jar examples.ModernTraversals
 == Gremlin-JavaScript
 
 image:gremlin-js.png[width=130,float=right] Apache TinkerPop's Gremlin-JavaScript implements Gremlin within the
-JavaScript language. It targets Node.js runtime and can be used on different operating systems on any Node.js 20 or
-above. Since the JavaScript naming conventions are very similar to that of Java, it should be very easy to switch
+JavaScript language. It targets Node.js runtime and can be used on different operating systems. Since the JavaScript
+naming conventions are very similar to that of Java, it should be very easy to switch
 between Gremlin-Java and Gremlin-JavaScript.
 
 [source,bash]
@@ -1494,15 +1494,16 @@ The following table outlines recommended runtime versions by the release in whic
 
 [cols="1,1,1",options="header"]
 |===
-|Version |Min Node.js |npm Version
-|3.4.0 |≥6 |N/A
-|3.5.0 |≥10 |6.14.16
-|3.5.7 |≥16 |8.19.4
-|3.6.0 |≥10 |8.1.2
-|3.6.5 |≥16 |8.19.4
-|3.6.7 |≥18 |9.6.7
-|3.7.0 |≥18 |9.6.7
-|3.7.4 |≥20 |10.8.2
+|Version |Recommended Node.js Version |npm Version
+|3.4.0 |6 |N/A
+|3.5.0 |10 |6.14.16
+|3.5.7 |16 |8.19.4
+|3.6.0 |10 |8.1.2
+|3.6.5 |16 |8.19.4
+|3.6.7 |18 |9.6.7
+|3.7.0 |18 |9.6.7
+|3.7.4 |20, 22, 24 |10.8.2
+|3.7.7 |20, 22, 24, 26 |10.8.2
 |===
 
 [[gremlin-javascript-connecting]]


### PR DESCRIPTION
Copies the new runtime matrix test pattern from python over to node, and enables testing on node 26 (new release, future LTS). I have locally verified the build also passes in 3.8-dev and master with Node 26.

VOTE +1