### PR TITLE
Fix Flaky .Net and server tests

### DIFF
--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/PropertyDeserializationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/PropertyDeserializationTests.cs
@@ -35,6 +35,11 @@ using Xunit;
 
 namespace Gremlin.Net.IntegrationTest.Driver
 {
+    /// <summary>
+    /// Serialized with Gherkin tests to avoid reading vertices through an active GraphComputerView
+    /// when @GraphComputerOnly scenarios run concurrently, which would expose transient compute properties.
+    /// </summary>
+    [Collection("GremlinServerTests")]
     public class PropertyDeserializationTests
     {
         private readonly RemoteConnectionFactory _connectionFactory = new();

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -37,10 +37,10 @@ using Xunit.Abstractions;
 
 namespace Gremlin.Net.IntegrationTest.Gherkin
 {
-    [CollectionDefinition(nameof(GherkinTestDefinition), DisableParallelization = true)]
-    public class GherkinTestDefinition { }
+    [CollectionDefinition(nameof(GremlinServerTests), DisableParallelization = true)]
+    public class GremlinServerTests { }
 
-    [Collection(nameof(GherkinTestDefinition))]
+    [Collection(nameof(GremlinServerTests))]
     public class GherkinTestRunner
     {
         private static readonly IDictionary<string, IgnoreReason> IgnoredScenarios =

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -34,6 +34,7 @@ using Gremlin.Net.Process.Traversal.Strategy.Decoration;
 
 namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 {
+    [Collection("GremlinServerTests")]
     public class GraphTraversalTests
     {
         private readonly RemoteConnectionFactory _connectionFactory = new RemoteConnectionFactory();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpTransactionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpTransactionIntegrateTest.java
@@ -96,7 +96,7 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
                 settings.transactionTimeout = 1000;
                 break;
             case "shouldTimeoutIdleTransactionWithNoOperations":
-                settings.transactionTimeout = 1;
+                settings.transactionTimeout = 500;
                 break;
             case "shouldTimeoutAndRejectLateCommit":
             case "shouldTrackTransactionCountAccurately":
@@ -333,7 +333,7 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
     public void shouldTimeoutIdleTransactionWithNoOperations() throws Exception {
         final String txId = beginTx(client, GTX);
 
-        // wait for the transaction to timeout (configured at 1ms)
+        // wait for the transaction to timeout (configured at 500ms)
         Thread.sleep(1000);
 
         // the transaction should be gone
@@ -382,12 +382,16 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
 
         assertEquals(3, txManager.getActiveTransactionCount());
 
-        // commit one
-        commitTx(client, txId1, GTX);
+        // commit one - must close response to ensure server-side processing completes
+        try (final CloseableHttpResponse r = commitTx(client, txId1, GTX)) {
+            assertEquals(200, r.getStatusLine().getStatusCode());
+        }
         assertEquals(2, txManager.getActiveTransactionCount());
 
         // rollback one
-        rollbackTx(client, txId2, GTX);
+        try (final CloseableHttpResponse r = rollbackTx(client, txId2, GTX)) {
+            assertEquals(200, r.getStatusLine().getStatusCode());
+        }
         assertEquals(1, txManager.getActiveTransactionCount());
 
         // let the third one timeout


### PR DESCRIPTION
`shouldTrackTransactionCountAccurately` was racing because commitTx()
and rollbackTx() returned without consuming the HTTP response. With
chunked transfer encoding, the client can receive response headers
before the server completes transactionManager.destroy(). Wrapping
in try-with-resources ensures the full response is read, guaranteeing
server-side processing is complete before asserting the count.

`shouldTimeoutIdleTransactionWithNoOperations` used a 1ms timeout,
which could expire during the beginTx() HTTP round-trip itself,
causing getFirstHeader(TRANSACTION_ID) to return null and NPE.
Increased to 500ms — still well below the 1000ms sleep that
validates timeout behavior.

`PropertyDeserializationTests` and `GraphTraversalTests` were running
concurrently with `@GraphComputerOnly` Gherkin scenarios. During OLAP
computation, TinkerGraphComputer sets a graphComputerView on the
shared TinkerGraph instance. Any concurrent read through TinkerVertex
sees compute properties (like haltedTraversers) merged with real
properties, causing spurious assertion failures and NPEs.

Place all tests that hit the shared server into a single non-parallel
xUnit collection (GremlinServerTests) so they never overlap with an
active GraphComputer view.

VOTE +1