### PR TITLE
Bump commons configuration2 -> 2.15.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 This release also includes changes from prior 3.7.x releases.
 
 * Add missing `Configuring` interface to `GraphStepPlaceholder` and `VertexStepPlaceholder`
+* Bumped `commons-configuration2` to 2.15.0.
 
 [[release-3-8-1]]
 === TinkerPop 3.8.1 (Release Date: April 1, 2026)

--- a/gremlin-core/pom.xml
+++ b/gremlin-core/pom.xml
@@ -46,6 +46,12 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -33,6 +33,12 @@ limitations under the License.
                 <artifactId>netty</artifactId>
                 <version>3.10.6.Final</version>
             </dependency>
+            <dependency>
+                <!-- Override Hadoop 3.3.3's commons-configuration2 2.1.1 to align with TinkerPop BOM -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commons.configuration.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopConfiguration.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopConfiguration.java
@@ -66,6 +66,11 @@ public final class HadoopConfiguration extends AbstractConfiguration implements 
     }
 
     @Override
+    protected boolean containsValueInternal(final Object value) {
+        return properties.containsValue(value);
+    }
+
+    @Override
     protected void addPropertyDirect(final String key, final Object value) {
         this.properties.put(key, value);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ limitations under the License.
         <antlr4.version>4.9.1</antlr4.version>
         <caffeine.version>2.3.1</caffeine.version>
         <commons.collections.version>3.2.2</commons.collections.version>
-        <commons.configuration.version>2.9.0</commons.configuration.version>
+        <commons.configuration.version>2.15.0</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -775,6 +775,12 @@ limitations under the License.
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
                 <version>${commons.configuration.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@ limitations under the License.
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.configuration.version>2.15.0</commons.configuration.version>
         <commons.lang.version>2.6</commons.lang.version>
-        <commons.io.version>2.8.0</commons.io.version>
+        <commons.io.version>2.22.0</commons.io.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.text.version>1.10.0</commons.text.version>
         <cucumber.version>7.21.1</cucumber.version>


### PR DESCRIPTION
**WIP** This chain was longer than I expected, so when I have time to get back to this I'll evaluate whether it makes sense to just get the relevant dependencies upgraded upstream instead. 
(Consumers need to overwrite `commons-configuration2` to avoid the ghsa until it is upgraded here.) 

Bumps `commons-configuration2` from `2.9.0` to `2.15.0` to fix `GHSA-337m-mw94-2v6g`. 
Also adds an explicit override in `hadoop-gremlin` to satisfy DependencyConvergence, as Hadoop `3.3.3` pins this at `2.1.1`. 
Excludes `commons-logging` from `commons-configuration2` in `gremlin-core`, as `2.15.0` bumps it to `1.3.6` which conflicts with the `1.2` pulled in transitively via Hadoop.