### PR TITLE
Add THREAT_MODEL.md + SECURITY.md and wire AGENTS.md (security-model discoverability)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,9 @@ These rules apply to any AI/IDE assistant operating on this repository.
 
 1. Prefer no change over an unsafe or speculative change.
 2. Ask for clarification.
+
+## Security
+
+For Apache TinkerPop's threat model — trust boundaries, in-scope / out-of-scope, the security properties
+the project does and does not provide, and known non-findings — see [SECURITY.md](SECURITY.md), which
+points to [THREAT_MODEL.md](THREAT_MODEL.md). Consult it before triaging or reporting security issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Security Policy
+
+Apache TinkerPop's threat model — the assumptions, trust boundaries, what is in and out of scope, the
+security properties the project does and does not provide, and known non-findings — is documented in
+[THREAT_MODEL.md](THREAT_MODEL.md). Please read it before reporting a security issue.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately following the
+[ASF security process](https://www.apache.org/security/) — email
+[security@apache.org](mailto:security@apache.org). Do not open public GitHub issues for security reports.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,20 @@
 <!--
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
 -->
 
 # Security Policy

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,18 +1,20 @@
 <!--
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
 -->
 
 # Apache TinkerPop — Threat Model (v0 draft)
@@ -20,326 +22,632 @@ limitations under the License.
 ## §1 Header
 
 - **Project:** Apache TinkerPop (`apache/tinkerpop`) — a graph computing framework: the Gremlin query
-  language, the traversal machine, Gremlin Server (remote query execution), the GraphSON / Gryo /
-  GraphBinary serialization formats, and the Gremlin Language Variants (Java, Python, .NET, Go, JS).
+  language, the traversal machine, Gremlin Server (remote query execution), the GraphSON and GraphBinary
+  wire serializers and the Gryo IO format, and the Gremlin Language Variants (Java, Python, .NET, Go, JS).
   *(documented — `README.md`, repo layout)*
-- **Scope of this model:** the **`apache/tinkerpop` monorepo**, active branches `master`, `3.7-dev`,
-  `3.8-dev` *(maintainer — colegreer, scope confirmation)*. The model focuses on the network-facing and
-  deserialization surfaces (see §2); provider graph databases that embed TinkerPop are out of scope (§3).
-- **Date:** 2026-06-05. **Status:** DRAFT v0 — first pass by the ASF Security team via the
+- **Scope of this model:** the **`apache/tinkerpop` monorepo**, active branch `master`. The model focuses on
+  the network-facing and deserialization surfaces (see §2). Provider graph databases that make use of
+  reference code are out of scope (§3).
+- **Date:** 2026-06-05. **Status:** DRAFT v0, a first pass by the ASF Security team via the
   threat-model-producer rubric, for the TinkerPop PMC to react to. **Author:** ASF Security team, for PMC
   ratification.
-- **Version binding:** versioned with the project; a report against release *N* is triaged against the
+- **Version binding:** versioned with the project. A report against release *N* is triaged against the
   model as it stood at *N*, not against `HEAD`.
 - **Reporting cross-reference:** §8-property violations → report privately per the ASF process
-  (`security@apache.org`); §3 / §9 findings are closed citing this document.
-- **Provenance legend:** *(documented)* = stated in TinkerPop's own docs / reference / source;
-  *(maintainer)* = confirmed by a TinkerPop PMC member through this process; *(inferred)* = reasoned from
-  the reference docs, architecture, and graph-server domain knowledge, **not yet confirmed** — every
+  (`security@apache.org`). §3 / §9 findings are closed citing this document.
+- **Provenance legend:** *(documented)* = stated in TinkerPop's own docs / reference / source.
+  *(maintainer)* = confirmed by a TinkerPop PMC member through this process. *(inferred)* = reasoned from
+  the reference docs, architecture, and graph-server domain knowledge, **not yet confirmed**. Every
   *(inferred)* claim has a matching §14 open question.
-- **Draft confidence:** a v0 with **no PMC confirmation folded in yet** — the deployment posture, the
-  default auth/TLS stance, the script-execution sandboxing story, and the serialization (Gryo)
-  disposition are the highest-value items for the PMC to confirm in §14.
-- **What TinkerPop is:** TinkerPop is an embeddable graph-computing framework. Applications and graph
-  databases (providers) embed `gremlin-core` to run Gremlin traversals; **Gremlin Server** exposes that
-  capability over the network (WebSocket sub-protocol + HTTP), accepting both **string-based Gremlin
-  scripts** (evaluated by the `gremlin-groovy` Groovy script engine) and **bytecode-based traversals**
-  (the GLVs). *(documented — reference docs)*
+- **Draft confidence:** a v0 with **no PMC confirmation folded in yet**. The deployment posture, the
+  default auth/TLS stance, the script-execution sandboxing story, and the serialization disposition are the
+  highest-value items for the PMC to confirm in §14.
+- **What TinkerPop is:** a graph computing framework for graph databases (OLTP) and graph analytic systems
+  (OLAP). It **defines** a common interface/language (Gremlin) plus protocols/APIs, and ships
+  production-ready reference implementations. This includes a reference in-memory graph (TinkerGraph), Gremlin
+  Server, and the language variants (GLVs). Gremlin traversals run in one of two environments. In
+  **embedded**, the caller runs traversals directly in their application via `gremlin-core`. In **remote**,
+  Gremlin is sent over the wire (as a **script**) to a server that executes it. *(documented)*
 
 ## §2 Scope and intended use
 
-- **Primary use:** an operator-deployed graph-traversal engine. In production it is typically embedded by
-  a graph database (a "provider") or run as **Gremlin Server** behind the application tier, on a
-  **trusted network** *(inferred — confirm deployment posture, §14 Q1)*. Gremlin Server is the main
-  network-facing trust boundary.
+- **Primary use:** TinkerPop runs in two environments (§1). In **embedded**, the caller runs traversals in
+  its own JVM via `gremlin-core`, so there is no network trust boundary and the caller owns the whole
+  surface. In **remote**, Gremlin is sent over the wire to a server. This model focuses on the **remote**
+  case, where **Gremlin Server** is the main network-facing trust boundary. Gremlin Server **is intended to
+  be deployable on the public internet**, but the shipped `gremlin-server.yaml` is a getting-started/testing
+  config that **must not be deployed as-is**. A public or otherwise untrusted-facing deployment is expected
+  to layer on TLS and an authenticator. *(maintainer)*
+- **Embedded surface.** Embedded has **no network, transport, auth, or HTTP-protocol surface** (those exist
+  only with a server). It exposes the same input-consuming primitives as remote, and only where the caller
+  feeds them untrusted data: the **`io()` readers** (GraphSON, Gryo, GraphML), the **`gremlin-language`
+  parser** if untrusted strings are parsed, and **expensive steps** (e.g. `regex`). The responsibility rules
+  are **identical to remote** because they attach to the primitive, not the environment. *(maintainer)*
 - **Caller roles** (Gremlin Server is a network service):
-  - **remote client** — connects over the WebSocket sub-protocol or HTTP, submits Gremlin (script or
-    bytecode). Trust level depends entirely on whether the operator enabled authentication, authorization,
-    and script restrictions. *(inferred — §14 Q2)*
-  - **embedding application / provider** — links `gremlin-core` in-process and drives traversals directly.
-    Trusted within the compile-time + configuration boundary. *(inferred)*
+  - **remote client** — connects over HTTP/1.1, submits Gremlin as a gremlin-lang string (or, if
+    `gremlin-groovy` is explicitly enabled, a Groovy script). Trust level depends entirely on whether
+    the operator enabled authentication, authorization, and script restrictions. Authentication is **off
+    in the shipped default** (`gremlin-server.yaml` has no `authentication` block, and the default is
+    `AllowAllAuthenticator`). *(documented)*
+  - **application / provider** — runs `gremlin-core` directly, whether embedded in its own process or as
+    Gremlin Server. A provider may also supply the `Authenticator`/`Authorizer` implementations the server
+    runs. Trusted within the compile-time + configuration boundary. *(maintainer)*
   - **operator** — runs Gremlin Server, controls `gremlin-server.yaml`, serializers, auth, TLS, the script
-    engine configuration, and the host. Trusted for the instance. *(inferred)*
+    engine configuration, and the host. Trusted for the instance. *(maintainer)*
 
-**Component-family table** *(in/out = in/out of this model; all rows inferred unless noted)*:
+**Component-family table** *(in/out = in/out of this model)*:
 
 | Family | Entry point | Touches outside the process | In model? |
 | --- | --- | --- | --- |
-| **Gremlin Server** (`gremlin-server`) | WebSocket sub-protocol + HTTP request handlers | network (listens), invokes the script engine + traversal machine | **In** *(documented: remote execution endpoint)* |
-| **Script engine** (`gremlin-groovy`) | `GremlinGroovyScriptEngine` evaluating string scripts | runs supplied Groovy in-process | **In — central code-execution surface; see §9** *(documented: scripts are evaluated)* |
-| **Gremlin language parser** (`gremlin-language`) | ANTLR grammar for string Gremlin (script-engine-free) | — | **In** — parser robustness on untrusted Gremlin strings *(inferred)* |
+| **Gremlin Server** (`gremlin-server`) | HTTP/1.1 endpoint (gremlin-lang string requests, GraphSON/GraphBinary serialization) | network (listens), invokes the script engine + traversal machine | **In** *(documented: remote execution endpoint, `HttpChannelizer`)* |
+| **Script engine** (default `gremlin-lang`, optional `gremlin-groovy`) | evaluates the request's script string | default parses only Gremlin (no code execution). Optional Groovy runs supplied code in-process | **In**. The default is a parser surface. Enabling `gremlin-groovy` is a non-default operator choice whose RCE is by-design (§9) *(documented: scripts are evaluated)* |
+| **Gremlin language parser** (`gremlin-language`) | ANTLR grammar for string Gremlin (script-engine-free) | — | **In**, parser must not crash/hang/OOM on malformed input, nor let a crafted string break out of a literal to inject steps *(maintainer)* |
+| **GQL parser** (`gql-gremlin`) | ANTLR grammar for the GQL string of a `match(String)` request | — | **In**, reference code active on the default distribution (TinkerGraph registers it), with the same parser robustness/integrity as `gremlin-language`. Non-executable if a provider registers no declarative-match strategy (§3) *(documented — `match(String)`, `GqlDeclarativeMatchStrategy`)* |
 | **Core traversal machine + structure API** (`gremlin-core`) | `GraphTraversal`, strategies, `Vertex`/`Edge` | filesystem (IO formats) | **In** *(documented)* |
-| **Serialization** (`gremlin-core`/`gremlin-util`/`gremlin-shaded`) | GraphSON (JSON), GraphBinary, **Gryo (Kryo-based)** readers | deserializes wire/file bytes | **In — deserialization of untrusted bytes; see §9** *(documented: 3 formats; Gryo wraps shaded Kryo)* |
-| **Java driver** (`gremlin-driver`) | client connecting to Gremlin Server; deserializes server responses | network (connects) | **In** (client side) *(inferred)* |
-| **Gremlin Language Variants** (`gremlin-python`, `-dotnet`, `-go`, `-js`) | build bytecode, serialize/deserialize | network (connect) | **In, lower priority** — client-side; deserialize server responses *(inferred — §14 Q9)* |
-| **Reference graph** (`tinkergraph-gremlin`) | in-memory graph implementation | filesystem (persistence option) | **In** — the reference provider *(inferred)* |
-| **OLAP** (`hadoop-gremlin`, `spark-gremlin`) | `GraphComputer` over Hadoop/Spark | network, filesystem, cluster | **In if deployed; operator cluster infra** *(inferred — §14 Q10)* |
-| **Operator tooling** (`gremlin-console`) | interactive REPL run by the operator | — | **Out** — operator-trusted local tool *(inferred)* |
-| `gremlin-test`, `gremlin-examples`, `gremlin-tools`, `gremlin-annotations` | test/build/example code | — | **Out** *(see §3)* |
+| **Serialization** (`gremlin-core`/`gremlin-util`/`gremlin-shaded`) | GraphSON + GraphBinary wire readers. Gryo (Kryo) is IO-format-only, not on the wire | deserializes untrusted wire bytes. Gryo only reads IO/file bytes | **In** (see §9) *(documented — `Serializers` enum: GraphSON + GraphBinary)* |
+| **Gremlin Language Variants** (Java `gremlin-driver`, `gremlin-python`, `-dotnet`, `-go`, `-js`) | deserialize server responses | network (connect) | **In**, response-deserialization robustness + TLS cert validation. Java shares the JVM serializers. The others have own per-language deserializers not covered by hardening the JVM server *(documented — each GLV ships its own GraphBinary code)* |
+| **Reference graph** (`tinkergraph-gremlin`) | in-memory graph, the **shipped default graph**, with optional file persistence via the `io()` readers | filesystem (persistence) | **In**, TinkerPop reference code on the default reachable path, so a defect in unmodified TinkerGraph is `VALID` (§3). Loading a persisted graph uses the same GraphSON/Gryo/GraphML readers (§6 IO surface). A custom `graphFormat` reader is provider code (§3) *(documented — `gremlin-server.yaml` → `tinkergraph-empty.properties`, `AbstractTinkerGraph.loadGraph()`)* |
+| **OLAP** (`gremlin-core`/`tinkergraph` computer, `hadoop-gremlin`, `spark-gremlin`) | `GraphComputer`, remote-reachable when the operator configures an OLAP-capable graph | network, filesystem, cluster | **In**, reference code (incl. Hadoop/Spark modules). The third-party Hadoop/Spark runtime + cluster config are out (§3) *(documented — in-tree modules)* |
+| **`gremlin-console`** | local Groovy REPL. `:remote console` submits **arbitrary Groovy scripts** to a server and deserializes responses. `:install` loads plugins (credentials/hadoop/spark) via Grape | network (connects) | Local REPL **Out** (operator-trusted). As a remote client, submitting arbitrary Groovy = server-side RCE **by-design** (§9), subject to server auth. Response-deserialization robustness + TLS cert validation **In** (like a GLV). Plugins are operator-installed code in the operator's own JVM, so the install decision, the third-party download channel (Grape), and plugin behavior are **Out** (trusted-input, §3) *(documented — `DriverRemoteAcceptor`, `InstallCommand`/Grape; `gremlin-applications.asciidoc`)* |
+| Test-only / example / build modules (e.g. `gremlin-test`, `gremlin-examples`, `gremlin-tools`, `gremlin-annotations`) | test/build/example code | — | **Out** *(see §3)* |
 
 ## §3 Out of scope (explicit non-goals)
 
-- **Provider graph databases that embed TinkerPop** (e.g. third-party graph DBs implementing the
-  structure/`GraphComputer` SPI). A vulnerability in a provider's own code is routed to that provider, not
-  here; this model covers TinkerPop's own code and its *use* of the SPI. *(inferred — §14 Q3)*
-- **The embedding application's own authentication / authorization of its end users.** TinkerPop has no
-  concept of the embedding application's end users. *(inferred)*
+- **Provider code and provider modifications to the reference code.** TinkerPop ships production-ready
+  **reference code** (`gremlin-core`, `gremlin-server`, `tinkergraph-gremlin`, etc.) that providers
+  are free to use in whole, in part, or not at all. The boundary is drawn by **what code the defect
+  reproduces in**, not by where that code runs (provider code typically runs in the same process as TinkerPop
+  code):
+  - **In-model:** a defect reproducible in **unmodified TinkerPop reference code**, even when it is running
+    as part of a provider's product.
+  - **Out-of-model → route to the provider:** a defect that depends on the **provider's own code or their
+    modifications** to the reference code, such as a modified `Channelizer`/`GraphManager`, an
+    added request handler, their `Graph`/`GraphComputer` implementation, a **`call()` service they register**
+    (`ServiceRegistry` is empty by default), or their `Authenticator`/`Authorizer` decision logic.
+  - **Hard case (→ `MODEL-GAP`, §12/§13):** a defect that reproduces only under a **mix** of reference and
+    provider code and cannot be cleanly attributed to either. This is not silently dropped to the provider.
+    It triggers a joint determination and a §12 model revision.
+
+  Triage test: *is the defective code TinkerPop's?* A defect in unmodified TinkerPop reference code is
+  in-model, whatever product or graph it runs inside. A defect that depends on the provider's own code or
+  modifications is the provider's. If it genuinely can't be told, `MODEL-GAP`. *(maintainer)*
+- **The calling application's own authentication / authorization of its end users.** TinkerPop has no
+  concept of the calling application's end users. *(maintainer)*
 - **Attackers who already control the host, the Gremlin Server process, `gremlin-server.yaml`, or the
-  graph data directory.** They have the operator's authority by definition. *(inferred)*
-- **`gremlin-test/`, `gremlin-examples/`, build/distribution tooling, `gremlin-console`** as a production
-  trust surface. *(inferred)*
-- **Confidentiality of data in transit when the operator has not enabled TLS** — see §10; the TLS posture
-  is the operator's deployment responsibility unless the project claims TLS-by-default (§14 Q5). *(inferred)*
+  graph data directory.** They have the operator's authority by definition. *(maintainer)*
+- **Operator-configured code-execution/side-effect surfaces:** the Script I/O Format (`ScriptInputFormat`/
+  `ScriptOutputFormat` run operator-supplied Groovy from HDFS) and `EventStrategy` `MutationListener`
+  callbacks. The code comes from operator/provider config, not a remote request (though a remote mutating
+  traversal can *trigger* an already-registered listener). Trusted-input. *(documented — Script I/O Format;
+  `EventStrategy`)*
+- **Any test-only module, any example-only module, and build/distribution tooling** as a production trust
+  surface (e.g. `gremlin-test`, `gremlin-examples`, `gremlin-tools`). *(maintainer)*
+- **Confidentiality of data in transit when the operator has not enabled TLS** (see §10). TLS is **off by
+  default** (`ssl.enabled: false`), so the TLS posture is the operator's deployment responsibility.
+  *(documented — `gremlin-server.yaml`, `gremlin-applications.asciidoc` config table)*
+- **`gremlint` (incl. hosted gremlint)** — a client-side Gremlin formatter (parse-and-reprint, no query
+  execution). When hosted, input stays in the user's own browser (no URL-shared state, no XSS sink, no
+  backend), so a user is responsible for what they input, and a pathological input only affects their own
+  browser tab. *(documented — `gremlint/src`, `docs/gremlint`)*
+- **`gremlin-javascript` client-side Gremlin parser / `GremlinTranslator`** — a parse-and-reprint translator
+  (no query execution), off the request/response path, so not a network surface. Its shipped consumers are
+  Gremlator (a browser SPA where the input is the user's own, affecting only their own tab, like `gremlint`)
+  and `gremlin-mcp` (its untrusted-input robustness is the `gremlin-mcp` surface's concern). As a library export, parsing caller-chosen input is the
+  consuming application's responsibility. *(documented — `gremlin-javascript` grammar/translator; Gremlator)*
+- **`gremlin-mcp`** — a shipped MCP server that bridges an AI agent to a Gremlin Server (a GLV-like client
+  plus an agent tool boundary). Findings route by the model's usual axis. A **decision** (running it, what
+  graph it targets, what an agent may do through it) is the user's, so it is out-of-model and documented as
+  trusted-environments-only. A **code defect** in `gremlin-mcp`, such as a tool handler crashing/hanging/
+  OOMing on malformed input (an LLM can emit anything) or mishandling a server response, is in-model like
+  any TinkerPop bug (§8). *(documented — `gremlin-js/gremlin-mcp`)*
+- **Client-side `RequestInterceptor` (GLV)** — a calling application can register an interceptor to mutate
+  the outgoing HTTP request (the standard hook for auth/signing). What a registered interceptor does, and a
+  bug within it, is the **calling application's** responsibility (out-of-model), like any code it supplies.
+  The GLV correctly *running* registered interceptors (invoking them, in order, without corrupting the
+  request) is TinkerPop code and **in-model**. *(documented — `RequestInterceptor`)*
 
 ## §4 Trust boundaries and data flow
 
-- **Primary trust boundary: the Gremlin Server remote request surface.** Bytes arriving over the WebSocket
-  sub-protocol or HTTP — whether a **string script** or **bytecode traversal**, plus the serialized request
-  payload — are untrusted. The script engine, traversal machine, and structure/storage layer sit behind
-  this boundary. *(documented: remote endpoint; trust posture inferred — §14 Q2)*
+Data flow for a remote request. The `‖` marks the trust boundary, and everything right of it runs on the server.
+
+```
+                                          TRUST BOUNDARY
+ calling app → GLV (build gremlin-lang          ‖
+   string) → HTTP request ────────────────────▶ ‖ HTTP/1.1 decode
+                                                 ‖   → authenticate → deserialize request body
+                                                 ‖       (GraphSON / GraphBinary / JSON)
+                                                 ‖   → authorize → execute (gremlin-lang parser /
+                                                 ‖       traversal machine) → graph + storage / io() files
+ GLV ◀──────── deserialize response ──────────── ‖   → iterate results → encode response
+```
+
+- Untrusted input crosses left-to-right at the boundary (request bytes). The response path crosses
+  right-to-left back to the GLV (server-response bytes are untrusted from the client's standpoint, §8).
+- The **embedded** environment has no boundary, since the caller runs `gremlin-core` in-process (§2).
+- The **`io()` / file surface** feeds the graph/storage box from disk, untrusted only if the caller loads
+  untrusted files (§6).
+
+- **Primary trust boundary: the Gremlin Server remote request surface.** Bytes arriving over HTTP/1.1 are
+  untrusted, including the request line, headers, and the serialized request body carrying the Gremlin
+  string. The script engine, traversal machine, and structure/storage layer sit behind this boundary. HTTP/1.1
+  is the **only** transport (`HttpChannelizer`), so the **HTTP protocol layer is itself a pre-auth surface
+  distinct from request-body deserialization**: the request line, headers, chunked/streamed bodies, and
+  keep-alive connection handling must all be parsed per the HTTP/1.1 specification and must be safe against
+  malformed or maliciously crafted requests (§8 memory-safety covers it). No crafted HTTP message, header, or
+  request sequence may crash, hang, exhaust, or gain unauthorized access to the server. *(documented —
+  `HttpChannelizer`, remote endpoint)*
 - **The script-execution boundary (the highest-stakes one).** A string-based request is evaluated by the
-  Groovy script engine. Absent a configured sandbox / allow-list, **evaluating an attacker-supplied script
-  is arbitrary code execution on the server** — this is inherent to the script-based interface, not a bug
-  (§9). The question for triage is whether a given deployment restricts scripting (bytecode-only,
-  allow-list, sandbox) and who is authorized to submit scripts. *(documented: scripts are evaluated;
-  sandbox specifics inferred — §14 Q4)*
-- **The deserialization boundary.** GraphSON, GraphBinary, and Gryo readers parse untrusted request bytes
-  (and, on the driver/GLV side, untrusted server-response bytes). Gryo is Kryo-based; Kryo deserialization
-  of untrusted input is a well-known RCE class unless type registration is locked down. *(documented:
-  formats exist; default-enabled set + Gryo hardening inferred — §14 Q6)*
+  configured script engine. The shipped default is `GremlinLangScriptEngine`, which parses **only Gremlin**
+  and is **not** a code-execution surface. An operator can instead configure `gremlin-groovy`, which
+  evaluates arbitrary code: absent a configured sandbox / allow-list, **evaluating an attacker-supplied
+  Groovy script is arbitrary code execution on the server**. That is inherent to the general-purpose script
+  engine, not a bug, and enabling it is a non-default operator choice (`BY-DESIGN` / out-of-model, §9). The
+  question for triage is whether a deployment enabled `gremlin-groovy`, whether it restricted scripting
+  (allow-list, sandbox), and who is authorized to submit scripts. *(documented — `gremlin-server.yaml`
+  default engine, `gremlin-applications.asciidoc` "Protecting Script Execution")*
+- **The deserialization boundary.** GraphSON and GraphBinary readers parse untrusted request bytes (and, on
+  the driver/GLV side, untrusted server-response bytes). Gryo is IO-only (not on the wire). *(documented —
+  wire set is GraphSON + GraphBinary)*
 - **Reachability preconditions** (the test a triager applies first):
   - A finding reachable only by submitting a **script** is in-model only subject to the §9 ruling: if the
-    deployment allows scripting to the principal, server-side code execution is by-design. *(inferred)*
-  - A finding in the **Gremlin parser / bytecode / traversal machine / deserializers** reachable from a
+    deployment allows scripting to the principal, server-side code execution is by-design. *(documented)*
+  - A finding in the **Gremlin parser / traversal machine / deserializers** reachable from a
     client operating within its privileges (or pre-auth) is **in-model** for memory-safety / bounded-
-    resource robustness. *(inferred)*
+    resource robustness. *(maintainer)*
   - A finding requiring control of `gremlin-server.yaml` or host access is **out-of-model: trusted-input**.
-    *(inferred)*
+    *(maintainer)*
 
 ## §5 Assumptions about the environment
 
-- **Runtime:** JVM (server, core, groovy, driver); the GLVs run on their respective runtimes
+- **Runtime:** JVM (server, core, groovy, driver). The GLVs run on their respective runtimes
   (CPython, .NET, Go, Node). *(documented — README / build)*
-- **Deployment:** Gremlin Server is assumed to run inside a **trusted network**, fronted by the
-  application tier, not exposed directly to the public internet. *(inferred — §14 Q1)*
+- **Deployment:** Gremlin Server is safe enough to run on the public internet **once hardened** beyond the
+  shipped `gremlin-server.yaml`, at minimum with TLS plus an authenticator (either built-in mechanism
+  suffices over TLS). The insecure getting-started default is a testing convenience, not a supported
+  production posture. Realistically, a production deployment also layers a provider's
+  `Authenticator`/`Authorizer` on top (no authorizer ships, see §5a), so auth/authz is a **shared
+  responsibility**. The provider supplies the policy (the plugin implementations), while Gremlin Server owns
+  the enforcement machinery that runs them on every request (§8). *(maintainer)*
 - **Filesystem:** the graph data / config directories are private to the server process and not writable by
-  untrusted local users. *(inferred)*
-- **Concurrency:** the server is multi-threaded and serves concurrent sessions; thread-safety of the
-  traversal/IO path is a correctness assumption. *(inferred)*
-- **What the server does to its host** (negative inventory — predominantly inferred, a confirmation
-  target): listens on network ports; reads/writes its configured graph + data directories; reads config;
-  **executes supplied Groovy when script requests are enabled**; loads provider graph implementations the
-  operator configured. *(inferred — §14 Q4)*
+  untrusted local users. Securing the host is the operator's responsibility, and an attacker who can write
+  them already has the operator's authority (§3). *(maintainer)*
+- **Concurrency:** the standard request path is isolated per request (thread-pool dispatch, per-request
+  script bindings), so one request should not affect another. Transactions are the deliberate stateful
+  exception (§11b). *(maintainer)*
+- **What the server does to its host** (negative inventory): listens on network ports; reads/writes its
+  configured graph + data directories; reads config; **executes supplied Groovy when script requests are
+  enabled** *(documented — script evaluation, `gremlin-applications.asciidoc`)*; loads provider graph
+  implementations the operator configured. *(maintainer)*
 
 ## §5a Build-time and configuration variants
 
 Knobs that change which security properties hold (Gremlin Server, `gremlin-server.yaml`):
 
-- **Authentication** — `Authenticator` (PlainText/SASL with a credentials graph; `Krb5Authenticator` for
-  Kerberos). Whether authentication is **off by default** (the shipped sample/getting-started configs) is
-  the key question. *(documented: mechanisms exist; default-off inferred — §14 Q2)*
-- **Authorization** — an `Authorizer` interface (e.g. allow-listing which Gremlin a principal may run).
-  In-model only when configured; default likely none. *(documented: section exists; default inferred — §14 Q2)*
-- **TLS/SSL** — configurable on the server connector; whether it is **off by default** drives the
-  transport-confidentiality property (§9). *(inferred — §14 Q5)*
-- **Script execution restriction** — "Protecting Script Execution": sandbox / compilation customizers /
-  allow-list / preferring bytecode-only. Whether any restriction is on by default, or scripting is
-  unrestricted out of the box, is the single highest-stakes config question. *(documented: guidance exists;
-  default inferred — §14 Q4)*
-- **Enabled serializers** — which of GraphSON / GraphBinary / **Gryo** are registered by default, and
-  whether Gryo (Kryo) is locked to registered types. *(documented: formats exist; defaults inferred — §14 Q6)*
+- **Authentication** — `Authenticator` (username/password against a credentials graph via
+  `SimpleAuthenticator`). Authentication is **off by default** (the shipped `gremlin-server.yaml` has no
+  `authentication` block, and the default is `AllowAllAuthenticator`). The built-in `SimpleAuthenticator`
+  mechanism is **secure enough for a public-internet deployment when combined with TLS**. In practice,
+  though, deployments layer a provider's own `Authenticator` on top (e.g. SSO / bearer-token), so the
+  built-in is more often a baseline than the production mechanism. *(documented — `SimpleAuthenticator`
+  ships; auth off by default)*
+- **Authorization** — an `Authorizer` SPI exists, but **no implementation ships** with Gremlin Server (the
+  only one in-tree, `AllowListAuthorizer`, is a test example), so there is **no meaningful authorization
+  control out of the box**, and providing it is expected to fall to the provider. In-model only when
+  configured, and the default is none. *(documented — `gremlin-applications.asciidoc` "Authorization":
+  no impl ships)*
+- **Restricting traversals via `TraversalStrategy`** — an operator/`Authorizer` can constrain a
+  `GraphTraversalSource` with `ReadOnlyStrategy` (block mutations), `SubgraphStrategy`/`PartitionStrategy`
+  (scope visible data / tenancy), and `VertexProgramRestrictionStrategy` (restrict OLAP). These are **traversal-layer,
+  not storage-layer**: `PartitionStrategy` is bypassable via direct `Vertex.property()`, and
+  `ReservedKeysVerificationStrategy` does not cover `mergeV`/`mergeE`. A client can also remove an applied
+  strategy outright via `withoutStrategies()` unless an `Authorizer` denies it (§9). In-model only when
+  pinned by a configured `Authorizer`. *(documented — `the-traversal.asciidoc` "TraversalStrategy";
+  `gremlin-applications.asciidoc` "Authorization")*
+- **TLS/SSL** — configurable on the server connector, **off by default** (`ssl.enabled: false` in the
+  shipped `gremlin-server.yaml`, enabled only in `gremlin-server-secure.yaml`). Drives the
+  transport-confidentiality property (§9). *(documented)*
+- **Audit logging** — `enableAuditLog` records the authenticated user, remote address, and gremlin query.
+  It is **off by default** (`false`, "for privacy reasons") and absent from the shipped config, so a default
+  deployment keeps no attribution record (§9). *(documented — `gremlin-applications.asciidoc` config table;
+  `Settings.enableAuditLog`)*
+- **Script execution restriction** — a script engine is only an arbitrary-code-execution surface if it
+  evaluates a general-purpose language. The default `GremlinLangScriptEngine` parses **only Gremlin** and can
+  neither evaluate arbitrary code nor run lambdas, so it has no such surface to restrict. The restriction
+  controls (sandbox / compilation customizers / allow-list) apply to `gremlin-groovy`, which is **not
+  enabled in the shipped configs**. (`LambdaRestrictionStrategy` exists but, being a removable strategy,
+  is no real restriction against a client that can script, §9.) **Where `gremlin-groovy`
+  is added it is unrestricted out of the box:** no shipped config configures a sandbox or a lambda
+  restriction. The docs are explicit that TinkerPop offers no complete out-of-the-box protection against
+  nefarious scripts. *(documented — `gremlin-applications.asciidoc` "Protecting Script Execution", the sample
+  configs)*
+- **Enabled serializers** — wire set is GraphSON + GraphBinary. Gryo is IO-format-only, not on the wire,
+  and defaults to a locked registration allow-list (`registrationRequired=true`). Disabling that lock removes
+  the untrusted-input protection (§9). *(documented — sample configs, `gremlin-applications.asciidoc`
+  "Serialization")*
 
 ## §6 Assumptions about inputs
 
-Per-surface trust table *(inferred unless noted)*:
+Per-surface trust table:
 
 | Surface | Input | Attacker-controllable? | Caller/operator must enforce |
 | --- | --- | --- | --- |
-| Gremlin Server — string script request | Groovy/Gremlin script text | **yes** (pre-auth if auth off) | auth; script restriction / sandbox / bytecode-only; who may script |
-| Gremlin Server — bytecode/traversal request | serialized traversal bytecode | **yes**, within privileges | auth; traversal-step allow-list; resource limits |
-| Request deserialization (GraphSON / GraphBinary / Gryo) | serialized bytes | **yes** (pre-auth) | enabled-serializer choice; Gryo type-registration lockdown |
-| Gremlin string parser (`gremlin-language` ANTLR) | Gremlin string | **yes** | parser robustness (no crash/OOM/hang) |
-| Driver / GLV — server response | serialized bytes from the server | yes if the server (or a MITM without TLS) is hostile | TLS; trust in the server |
+| Gremlin Server — script request | Gremlin (or, if `gremlin-groovy` is enabled, Groovy) script text | **yes** (pre-auth if auth off) | auth; script restriction / sandbox; who may script; traversal-step allow-list; resource limits |
+| Gremlin Server — transaction id | server-generated UUID, echoed back by the client on follow-up requests | **yes** (a client can present any id) | looked up with no owning-user check, so any client presenting a valid id shares that transaction (see §11b) |
+| Request deserialization (GraphSON / GraphBinary) | serialized bytes | **yes** (pre-auth only when auth is off, see the ordering note below) | robustness of the wire serializers |
+| Graph IO — Gryo/GraphSON/GraphML files (`io()` step, persistence, OLAP) | on-disk / cluster bytes | only if the caller loads untrusted files | GraphSON, locked Gryo (`registrationRequired=true`), and GraphML with the default XML factory owe deserializer integrity. Unlocked Gryo and a caller-supplied unhardened `XMLInputFactory` (XXE) are the caller's responsibility |
+| Gremlin string parser (`gremlin-language` ANTLR) | Gremlin string | **yes** | parser robustness, no crash/hang/OOM on malformed input and no grammar breakout / step injection (distinct from execution cost, §8/Q7) |
+| Any string the grammar accepts as an argument (e.g. a `regex` pattern) | Gremlin string | **yes** | a grammatically valid string must not enable DoS (e.g. ReDoS via a pathological pattern), the Q7 super-linear-amplification carve-out (§8) |
+| GLV (client) — server response | serialized bytes from the server | yes if the server is malicious/compromised, or a MITM (TLS off / cert not validated) | response-deserialization robustness; TLS with cert validation |
 | `gremlin-server.yaml`, host, data dir | local | no — operator-trusted | filesystem permissions |
 
-- **Shape / rate:** whether Gremlin Server bounds per-request CPU/memory, result-set size, traversal depth,
-  or concurrent requests — and the line between a bug and operator-managed capacity — is an open item
-  (§8 resource line, §14 Q7). *(inferred)*
+- **Pre-auth vs post-auth (ordering note):** "pre-auth" marks what an attacker can reach **without valid
+  credentials**, which is what makes a defect there security-critical (§8). Gremlin Server authenticates
+  **before** it deserializes the request body (§4 diagram): a request that fails authentication is rejected
+  with its body still unparsed. On a deployment with an authenticator configured, the body deserializers
+  are therefore a **post-auth** surface, reachable only by a client that already holds valid credentials.
+  They are pre-auth only where auth is off (the shipped default). What remains pre-auth on **every**
+  deployment is the HTTP protocol layer itself, since the request line, headers, and body bytes must be
+  read and buffered (bounded by `maxRequestContentLength`) before the server can even check credentials.
+  A deserializer bug is in-model either way. The ordering only sets its severity. *(documented — §4 flow;
+  `HttpChannelizer` pipeline order)*
+- **Shape / rate:** Gremlin Server has per-request limits (`evaluationTimeout`, `maxRequestContentLength`,
+  `maxParameters`, `maxWorkQueueSize`) and transaction bounds (`idleTransactionTimeout`,
+  `maxTransactionLifetime`, `maxConcurrentTransactions`) but **no traversal-depth or result-count cap**.
+  The bug-vs-capacity line is the §8 resource split. *(documented — `gremlin-applications.asciidoc` config
+  table)*
+- **Script-cache growth (`gremlin-groovy` only):** with the opt-in Groovy engine enabled, a client
+  submitting many distinct, unparameterized scripts grows the compiled-script / global-function cache toward
+  `OutOfMemoryError`. The operator mitigates by bounding `classMapCacheSpecification` and preferring
+  parameterized scripts (the Q7 resource split, a documented remote DoS unless bounded). The default
+  `GremlinLangScriptEngine` instead caches parsed traversals, off by default and bounded when enabled, so it
+  carries no such growth. *(documented — `gremlin-applications.asciidoc` "Cache Management")*
 
 ## §7 Adversary model
 
-- **Primary adversary:** a network client that can reach the Gremlin Server port from within the deployment
-  — either **unauthenticated** (if auth is off / pre-auth) or **authenticated with limited privileges** —
-  trying to execute code on the server (via scripts), read/write graph data outside its intent, crash or
-  exhaust the server with malformed requests or expensive traversals, or exploit a deserializer. *(inferred
-  — §14 Q2/Q7)*
-- **Capabilities assumed:** can open connections, send arbitrary protocol bytes / scripts / bytecode /
-  serialized payloads, and supply large/malformed input. *(inferred)*
-- **Out of scope:** anyone with operator/host/config control (already authoritative); a client that only
-  reaches the server because it was directly publicly exposed against guidance (non-supported posture, §3);
-  side-channel/timing adversaries unless the PMC wants them in. *(inferred — §14 Q1)*
+- **Client → server (primary):** the highest-stakes surface (most code, most exposure). A network client
+  that can reach the Gremlin Server port from within the deployment, either **unauthenticated** (if auth is
+  off / pre-auth) or **authenticated with limited privileges**, trying to execute code on the server (via
+  scripts), read/write graph data outside its intent, crash or exhaust the server with malformed requests or
+  expensive traversals, or exploit a deserializer. *Capabilities:* can open connections, send arbitrary
+  HTTP requests / scripts / serialized payloads, and supply large/malformed input. *(maintainer)*
+- **Server → client:** a malicious or compromised server, or a network attacker on the wire when TLS is off,
+  targeting a GLV through the response it returns: crafted response bytes to crash/OOM/RCE the client, or
+  harvesting the credentials the client sends in its request (§8/§9). *(maintainer)*
+- **Untrusted input → embedded:** in the embedded environment there is no network client, but untrusted data
+  can still reach an in-process `gremlin-core` primitive through the calling application — an `io()` reader
+  fed an untrusted file, the `gremlin-language` parser fed an untrusted string, or an expensive step fed a
+  crafted argument. The relevant robustness properties (§8) apply identically, since they attach to the
+  primitive, not the environment (§2/§6). *(maintainer)*
+- **Out of scope:** anyone with operator/host/config control (already authoritative). Also an attacker who
+  reaches a server left on the **insecure getting-started default** (no TLS, no auth), which is an operator
+  hardening failure (§9/§10), not a code bug, though the pre-auth robustness properties (§8) still apply to
+  the exposed surface. Side-channel/timing adversaries are **out of scope**. *(maintainer —
+  public exposure of a hardened server is in scope, whereas exposure of the insecure default is an operator
+  failure)*
 
 ## §8 Security properties the project provides
 
-*(Inferred pending PMC confirmation — a property only counts once the project commits to it.)*
+**Assets these properties defend (what is being protected):**
 
-- **Authentication + authorization enforcement (when configured).** With an `Authenticator`/`Authorizer`
-  set, an unauthenticated or unauthorized client cannot execute requests beyond its grants. *Violation
-  symptom:* auth/authz bypass. *Severity:* security-critical. *(inferred — §14 Q2)*
+- **Server availability** — the Gremlin Server process staying up under malformed or pre-auth input.
+- **Server-side code-execution / host integrity** — not running attacker code beyond what scripting/lambdas
+  grant by design (§9).
+- **Graph data confidentiality and integrity** — read/write/delete of the graph, bounded by auth/authz and
+  traversal strategies (§5a/§9).
+- **Credentials** — the server-side credential store and the credentials a client presents (§5a/§9).
+- **Client (GLV) integrity** — a client not harmed by hostile server responses.
+
+**Properties:**
+
+- **Enforcement of configured restrictions.** With an `Authenticator`/`Authorizer` set, an
+  unauthenticated or unauthorized client cannot execute requests beyond its grants (§11b transaction
+  sharing excepted). The same holds for restrictions living in server configuration that no request can
+  touch: a *configured* script sandbox / compilation customizer / allow-list must not be evadable from a
+  request. A restrictive `TraversalStrategy` (`ReadOnlyStrategy`, `SubgraphStrategy`, ...) counts as a
+  configured restriction **only when an `Authorizer` denies its removal or modification**, because the
+  Gremlin language itself lets a request remove strategies via `withoutStrategies()` (§9). This is the §8
+  anchor for the "bypasses a *configured* restriction" rulings in §9/§11a. *Violation symptom:* auth/authz bypass, or a request evading a
+  configured restriction. *Severity:* security-critical. *(maintainer)*
+- **Credential-store handling (when the built-in mechanism is used).** Where a deployment uses
+  `SimpleAuthenticator` with the credentials graph, passwords are stored and verified as BCrypt hashes,
+  never as plaintext. A provider's own `Authenticator` and credential store are the provider's (§3).
+  *Violation symptom:* plaintext credential storage, or disclosure of stored credential material to a
+  client. *Severity:* high. *(documented — `SimpleAuthenticator`, credentials DSL)*
 - **Memory / availability safety on the request + deserialization surface.** Malformed or pre-auth input
-  (protocol frames, Gremlin strings, serialized payloads) yields a clean error, not a crash, OOM, hang, or
-  unbounded allocation of the server. *Violation symptom:* server crash / unbounded allocation / deadlock
-  from malformed or pre-auth input. *Severity:* security-critical (remote DoS) if pre-auth. *(inferred —
-  §14 Q7)*
-- **Deserializer integrity.** GraphSON / GraphBinary / Gryo reading attacker bytes does not lead to
-  arbitrary object instantiation / code execution beyond the documented type set. *Violation symptom:*
-  deserialization gadget / RCE. *Severity:* critical. **The strength of this property for Gryo (Kryo)
-  depends on type-registration lockdown** — see §9 / §14 Q6. *(inferred)*
-- **Resource bounds — split, not unspecified.** Malformed/pre-auth input that crashes/OOMs/hangs the server
-  is **in-model** (above). Ordinary expensive traversals are **operator capacity/resource management**, NOT
-  in-model — unless a specific bug applies (super-linear amplification, a missing limit where one is
-  expected, an unbounded traversal). *(inferred — §14 Q7)*
+  (HTTP messages, Gremlin strings, serialized payloads) yields a clean error, not a crash, OOM, hang, or
+  unbounded allocation of the server. This covers not just the request body but the **HTTP transport layer
+  itself**: Gremlin Server must handle the HTTP/1.1 specification correctly, so any request must be handled
+  safely however its request line, headers, chunked/streamed body, or keep-alive connection sequence is
+  crafted, with no path to access or DoS the server. *Violation symptom:* server crash / unbounded
+  allocation / deadlock from a malformed or pre-auth request, or a crafted HTTP message or request sequence.
+  *Severity:* security-critical (remote DoS) if pre-auth. *(maintainer)*
+- **Request isolation.** One request's bindings and state must not leak into or alter another's
+  (per-request bindings, thread-pool dispatch, §5). Transactions are the deliberate stateful exception
+  (§11b). *Violation symptom:* cross-request state leakage or interference. *Severity:*
+  security-critical. *(maintainer)*
+- **Parser integrity (`gremlin-language`).** A crafted Gremlin string cannot break out of a string literal
+  to inject additional traversal steps. This is the safe string-to-traversal path, distinct from building a
+  Groovy string by concatenation, which is the calling application's concern (§9). The same holds for the
+  GQL string of a `match(String)` request, parsed server-side by the `gql-gremlin` grammar. That grammar is
+  reference code active on the default distribution (TinkerGraph registers it), so its robustness (no
+  crash/hang/OOM on malformed GQL) and integrity (no breakout into the enclosing traversal) are in-model. A provider that does
+  not register a declarative-match strategy leaves the step non-executable (§3). *Violation symptom:*
+  grammar breakout / step injection from a value that should stay a literal. *Severity:* critical.
+  *(maintainer)*
+- **Deserializer integrity.** The wire deserializer (GraphBinary), GraphSON and **Gryo in its locked default
+  (`registrationRequired=true`)** reading attacker bytes do not lead to arbitrary object instantiation / code
+  execution beyond the registered type set. Because `inject()` and value arguments let a request carry any
+  supported type, a bug in a **registered** type's (de)serializer that crashes/OOMs the reader is also
+  in-model, on **both** the server (request) and the GLV (response) side. The GraphML reader disables
+  external entities and DTDs by default (XXE-safe). *Violation symptom:* deserialization gadget / RCE / XXE,
+  or a registered-type serializer crashing/OOMing either end. *Severity:* critical. Gryo is not on the wire,
+  and unlocked Gryo or a caller-supplied unhardened XML factory is out-of-model (user responsibility, §9).
+  *(documented)*
+- **Provider Defined Type (PDT) hydration.** Wire (de)serialization of the PDT holder is a registered type
+  like any other (TinkerPop, above). Turning it into a typed object via a `PDTRegistry` adapter is **opt-in,
+  off by default** (added by the operator server-side, the user client-side). The registered types and their
+  constructor/`fromFields` side effects are **that party's** responsibility (§3). The hydration **mechanism**
+  is TinkerPop's: it must stay **inert with no registry configured** (no request triggers hydration when
+  nothing is registered) and, when configured, **instantiate only registered types** (an unknown name stays
+  a data holder, not a gadget) without crash/OOM/hang. *Severity:* critical. *(documented — `PDTRegistry`,
+  `@ProviderDefined`)*
+- **Resource bounds — split.** Malformed/pre-auth input that crashes/OOMs/hangs the server is **in-model**
+  (above). Ordinary expensive traversals / large results are **operator capacity**, NOT in-model, unless a
+  specific bug applies (super-linear amplification, a missing-where-expected limit, an unbounded traversal).
+  A grammatically valid string the parser accepts must not itself enable DoS from small input, e.g. ReDoS via
+  a pathological `regex` pattern, which is the in-model amplification case. *(maintainer)*
+- **Client (GLV) robustness against hostile server responses.** A GLV deserializing response bytes from a
+  malicious/compromised server (or a MITM) does not crash/OOM/execute code. *Violation symptom:* client
+  crash/OOM/RCE from crafted responses. *Severity:* critical. *(maintainer)*
+- **No pass-through string can harm the GLV.** Outbound request construction is otherwise not a surface,
+  because its input is the trusted calling application. This property covers only the pass-through case: an
+  application forwarding an untrusted end-user string verbatim (e.g. `client.submit(userString)`) must not
+  cause code execution, a crash, a hang, or resource exhaustion **in the GLV itself**. Its *server-side*
+  effect is Gremlin-injection, the application's responsibility (§9). *Violation symptom:* a submitted
+  string that harms the GLV that submitted it. *Severity:* high. *(maintainer)*
 
 ## §9 Security properties the project does *not* provide
 
-*(The highest-value section for integrators — inferred unless tagged; confirm each.)*
+*(The highest-value section for integrators.)*
 
-- **Script execution is arbitrary code execution by design — not a sandbox.** When string-script requests
-  are enabled, the Groovy script engine evaluates attacker-supplied code in the server process. Submitting
-  a script that runs server-side code is **`BY-DESIGN`** for a principal the deployment permits to script;
-  it is the operator's job to restrict scripting (bytecode-only, allow-list, sandbox) and to authenticate
-  who may script. A scan reporting "Gremlin Server allows arbitrary code execution via scripts" is
-  by-design unless it bypasses a *configured* restriction. *(inferred — §14 Q4)*
-- **No transport confidentiality/integrity unless TLS is enabled.** If TLS is off (see §5a/§14 Q5), the
-  server does not defend against a network attacker reading/modifying client traffic. *(inferred)*
+- **Groovy script execution is arbitrary code execution by design, not a sandbox.** The shipped default
+  `GremlinLangScriptEngine` evaluates only Gremlin and runs no arbitrary code. When an operator instead
+  enables `gremlin-groovy`, that engine evaluates attacker-supplied code in the server process. The docs
+  state scripts then have "access to the full power of their language and the JVM." Submitting a Groovy
+  script that runs server-side code is **`BY-DESIGN`** for a principal the deployment permits to script.
+  Enabling `gremlin-groovy` is a non-default operator choice. Restricting it (allow-list, sandbox) or
+  keeping the default Groovy-free engine, and authenticating who may script, is the operator's job. A scan
+  reporting "Gremlin Server allows arbitrary code execution via scripts" is by-design unless it bypasses a
+  *configured* restriction. *(documented — `gremlin-applications.asciidoc` "Protecting Script Execution")*
+- **No transport confidentiality/integrity unless TLS is enabled.** TLS is off in the shipped default (see
+  §5a). Until the operator enables it, the server does not defend against a network attacker reading or
+  modifying client traffic. On the client side, a GLV sends its credentials with the request, so without TLS
+  (or against a MITM) a driver can disclose those credentials to a hostile endpoint. A driver configured
+  without TLS / certificate validation is a misconfiguration and is out-of-scope. *(documented — TLS off by
+  default)*
 - **No authentication or authorization by default (assumed).** If the shipped/default configuration runs
-  with auth off, an exposed server is reachable by anyone on the network — an operator deployment concern,
-  not a code bug. *(inferred — §14 Q2)*
-- **Gryo / Kryo deserialization is not a safe boundary against untrusted input** unless type registration is
-  locked down. Operators who enable Gryo on an untrusted surface own that risk; prefer GraphBinary. *(inferred
-  — §14 Q6)*
+  with auth off, an exposed server is reachable by anyone on the network. This is an operator deployment
+  concern, not a code bug. *(documented)*
+- **No attribution/audit by default.** Audit logging is off by default (§5a), so a default deployment keeps
+  no record of who ran which query. Enabling it (`enableAuditLog`) is the operator's responsibility (§10).
+  *(documented)*
+- **No built-in data-access control.** There is no element-level (CRUD) authorization on graph data.
+  Access is bounded only by which traversal sources the operator exposes and by a provider-supplied
+  `Authorizer` (which does not ship, §5a). A client within its grants can read/write/delete any data the
+  exposed traversal source reaches. *(documented — no authorizer ships, authz is traversal-source/step-level)*
+- **Gryo / Kryo deserializer integrity holds only under the locked default.** Gryo defaults to a registration
+  allow-list (`registrationRequired=true`), so it is not an arbitrary-instantiation sink, and a break within
+  that locked config is a `VALID` bug like any deserializer. **Running Gryo unlocked
+  (`registrationRequired=false`) is not a safe boundary against untrusted bytes and is the user's
+  responsibility.** (A few registered types use Java native serialization, a gadget caveat even when locked.)
+  Gryo is not on the wire, so this is an IO/file-surface concern (`io()` step, persistence, OLAP).
+  *(documented)*
+- **A `TraversalStrategy` is not an access-control boundary on its own.** The Gremlin language lets any
+  request remove or replace strategies on its traversal source (`withoutStrategies()`,
+  `withStrategies()`), so a strategy applied by the operator only restricts a client when an `Authorizer`
+  denies strategy removal/modification, as the reference documentation states. Strategies also act at the
+  traversal layer, not the storage layer (§5a). *(documented — Gremlin grammar `withoutStrategies`;
+  `gremlin-applications.asciidoc` "Authorization")*
 - **Ordinary resource exhaustion is not a defended property.** Expensive traversals / large results that
-  consume CPU/memory are an operator capacity concern unless a specific bug applies (§8). *(inferred — §14 Q7)*
-- **No defense against a malicious operator / host.** *(inferred)*
+  consume CPU/memory are an operator capacity concern unless a specific bug applies (§8). *(maintainer)*
+- **No defense against a malicious operator / host.** *(maintainer)*
 - **False friends:**
-  - "Authentication is available" does **not** mean it is **on** — it must be configured (§5a). *(inferred)*
-  - **Bytecode is safer than scripts but is not a sandbox** — a bytecode traversal still executes traversal
-    steps server-side; injection/abuse via an embedding app that builds traversals from its own untrusted
-    input is the embedding app's responsibility. *(inferred)*
-  - "Gremlin is just a query language" — the **string** form runs through a Groovy engine, so it is code,
-    not a constrained query. *(inferred)*
+  - "Authentication is available" does **not** mean it is **on**. It must be configured (§5a). *(maintainer)*
+  - **A safe-language script is not a sandbox for the calling application's own injection.** Injection/abuse
+    via a calling application that builds a Gremlin string by concatenating its own untrusted input is the
+    calling application's responsibility. Note this is distinct from a `gremlin-language` parser breakout,
+    which is an in-model TinkerPop bug (§8). *(maintainer)*
+  - "Gremlin is just a query language" is misleading. The **string** form can run through a Groovy engine, so
+    it is code, not a constrained query. *(maintainer)*
 
 ## §10 Downstream responsibilities (operator/deployer)
 
-*(Inferred unless tagged — confirm.)*
-
-- Deploy Gremlin Server inside a trusted network; do **not** expose it directly to an untrusted/public
-  network, especially with scripting enabled and auth off. *(inferred — §14 Q1)*
+- Do **not** deploy the shipped getting-started `gremlin-server.yaml` as-is. Before exposing Gremlin Server
+  on a public/untrusted network, harden it: enable TLS and an authenticator, and (given no authorizer ships)
+  supply an `Authorizer`, especially if scripting is enabled. *(maintainer)*
 - Enable authentication (`Authenticator`) and authorization (`Authorizer`) for any non-trivial deployment.
-  *(inferred — §14 Q2)*
-- **Restrict script execution:** prefer bytecode-based traversals; if scripts are needed, apply the
-  "Protecting Script Execution" controls (sandbox / compilation customizers / allow-list) and restrict who
-  may submit scripts. *(documented: guidance exists — §14 Q4)*
-- Enable TLS where traffic crosses an untrusted segment. *(inferred — §14 Q5)*
-- Prefer **GraphBinary**; only enable **Gryo** on a trusted surface, with type registration locked down.
-  *(inferred — §14 Q6)*
-- Apply per-request / per-traversal resource limits and result-size caps appropriate to capacity. *(inferred
-  — §14 Q7)*
-- Set filesystem permissions so only the server user can read the config / data directories. *(inferred)*
+  *(documented)*
+- **Restrict script execution:** prefer the default Groovy-free `GremlinLangScriptEngine`, which evaluates
+  only Gremlin. If `gremlin-groovy` is needed, apply the "Protecting Script Execution" controls (sandbox /
+  compilation customizers / allow-list) and restrict who may submit scripts. *(documented)*
+- Enable TLS (off by default) where traffic crosses an untrusted segment. *(documented)*
+- Scope `cors.allowedOrigins` to specific origins for browser-facing deployments (defaults to `["*"]`). *(documented)*
+- Enable audit logging (`enableAuditLog`, off by default) where attribution of requests is needed. *(documented)*
+- Use the wire serializers (GraphBinary recommended for drivers). Keep Gryo locked
+  (`registrationRequired=true`), and do not read untrusted files through **unlocked** Gryo. *(documented)*
+- Apply per-request resource limits (`evaluationTimeout`, `maxRequestContentLength`, etc.) appropriate to capacity.
+  *(documented)*
+- Set filesystem permissions so only the server user can read the config / data directories. *(maintainer)*
 
 ## §11 Known misuse patterns
 
-*(Draft one-liners — expand before publishing.)*
+*(Draft one-liners, expand before publishing.)*
 
-- Exposing Gremlin Server to an untrusted network with scripting enabled and authentication off. *(inferred)*
+- Exposing the shipped getting-started default (no TLS, no auth) on an untrusted network instead of
+  hardening it first, especially with scripting enabled. *(maintainer)*
 - Treating the script-engine sandbox as a complete RCE boundary rather than restricting who may script.
-  *(inferred)*
-- Building Gremlin (string or bytecode) by concatenating the embedding application's untrusted input
-  (Gremlin-injection). *(inferred)*
-- Enabling Gryo on an untrusted request surface without type-registration lockdown. *(inferred)*
+  *(maintainer)*
+- Building Gremlin by concatenating the calling application's untrusted input into a Groovy string
+  (Gremlin-injection). This is distinct from a `gremlin-language` parser breakout, which is in-model (§8).
+  *(maintainer)*
+- Reading untrusted files through **unlocked** Gryo (`registrationRequired=false`). *(documented)*
 
 ## §11a Known non-findings (recurring false positives)
 
-*(Inferred unless tagged; the PMC's confirmations here are the highest-leverage suppression input.)*
+*(Inferred unless tagged. The PMC's confirmations here are the highest-leverage suppression input.)*
 
 - "Gremlin Server executes arbitrary code via scripts" — by-design when scripting is enabled for the
-  principal (§9); not a finding unless it bypasses a *configured* restriction. *(inferred — §14 Q4)*
-- "No authentication / no TLS by default" — operator deployment responsibility (§9/§10); not a code bug in
-  itself. *(inferred — §14 Q2/Q5)*
-- "Gryo/Kryo deserialization can be exploited" — when the operator enabled Gryo on an untrusted surface;
-  operator responsibility, prefer GraphBinary (§9/§10). *(inferred — §14 Q6)*
+  principal (§9), and not a finding unless it bypasses a *configured* restriction. Disposition:
+  `BY-DESIGN: property-disclaimed`. *(documented)*
+- "String lambdas enable code execution" — a string lambda is server-side code like any script, so this is
+  by-design when a code-capable engine is configured (§9), and not a finding unless it bypasses a
+  *configured* restriction. Disposition: `BY-DESIGN: property-disclaimed`. *(documented)*
+- "No authentication / no TLS by default" — operator deployment responsibility (§9/§10), not a code bug in
+  itself. Disposition: `BY-DESIGN: property-disclaimed`. *(documented)*
+- "Gryo/Kryo deserialization can be exploited" — Gryo is not on the wire, so a request-path report is
+  factually mistaken and needs no disposition (§13). Under the locked default
+  (`registrationRequired=true`) a real break is `VALID`, whereas exploiting **unlocked** Gryo on
+  untrusted files is the user's responsibility (§9/§10). Disposition for the unlocked-file variant:
+  `BY-DESIGN: property-disclaimed`. *(documented)*
 - "Expensive traversal consumes CPU/memory" — operator capacity concern, unless a specific bug applies
-  (§8/§9). *(inferred — §14 Q7)*
-- "Embedding app builds a traversal from untrusted input (Gremlin-injection)" — the embedding app's
-  responsibility (§9). *(inferred)*
-- Findings in `gremlin-test/`, `gremlin-examples/`, tooling — out of scope (§3). *(inferred)*
+  (§8/§9). Disposition: `BY-DESIGN: property-disclaimed`. *(maintainer)*
+- "A configured `ReadOnlyStrategy` / `SubgraphStrategy` / `PartitionStrategy` was bypassed" — whether by
+  removing the strategy via `withoutStrategies()` or by stepping around it (direct `Vertex.property()`,
+  `mergeV`/`mergeE`), a strategy is not an access-control boundary on its own (§9). A finding only exists
+  where a configured `Authorizer` pins the strategy and the pin is evaded (§8). Disposition:
+  `BY-DESIGN: property-disclaimed`. *(documented)*
+- "Calling application concatenates untrusted input into a Groovy string (Gremlin-injection)" — the calling
+  application's responsibility (§9). A `gremlin-language` parser breakout is the opposite: an in-model
+  TinkerPop bug (§8). Disposition: `BY-DESIGN: property-disclaimed`. *(maintainer)*
+- Findings in any test-only module, any module containing examples, or build tooling (e.g. `gremlin-test`,
+  `gremlin-examples`, `gremlin-tools`) — out of scope (§3). Disposition:
+  `OUT-OF-MODEL: unsupported-component`. *(maintainer)*
+
+## §11b Known problems
+
+*(Acknowledged, accepted weaknesses of Gremlin Server as it works today.)*
+
+- **Transactions can be shared.** A transaction is identified by a server-generated UUID and looked up with
+  **no owning-user check**, so any client presenting a valid id accesses that transaction's state. The default
+  server provides no per-user isolation, and this is accepted as how Gremlin Server works. A deployment
+  needing isolation must use a provider that adds it. *(documented)*
 
 ## §12 Conditions that would change this model
 
 - A change to the default auth / TLS / scripting posture (e.g. auth-on-by-default, scripts-off-by-default).
 - A new client-reachable surface or protocol on Gremlin Server.
-- A change to the default-enabled serializer set, or Gryo type-registration policy.
-- Promoting `gremlin-console` / `gremlin-examples` into a production trust surface.
+- A change to the default-enabled wire serializer set, or the reintroduction of Gryo (or any Kryo-based
+  format) as a wire serializer.
+- Promoting a test-only / example module into a production trust surface.
 - A change to the OLAP (Hadoop/Spark) trust posture.
 - A report that cannot be routed to a single §13 disposition (→ revise the model).
 
 ## §13 Triage dispositions
 
-| Disposition | Meaning | Licensed by |
+A disposition is the answer a security report receives after triage: a TinkerPop bug that needs a fix,
+some other party's responsibility, or known and accepted behavior. A report may contain more than one
+finding, and each finding gets **exactly one** disposition from the table below. The rows do not
+overlap. A finding that seems to match two rows, or none, means the table itself has a defect and takes
+`MODEL-GAP` so that the model gets fixed (§12). A report claiming something the code simply does not do
+(for example, Gryo reachable over the network) is answered by correcting the facts and needs no
+disposition at all.
+
+A finding is classified by **what the attack needs in order to work**, not by the setup it happened to
+be demonstrated on. For example, a crash bug shown against a server running the insecure
+getting-started configuration does not need that configuration. The same crash works, without
+credentials, against a hardened server too, so it is `VALID`. The insecure default decides the outcome
+only when the finding is, in substance, "this particular server was left unhardened."
+
+The lists in §11a and §11b exist to save repeated work: each entry is a finding that keeps coming back,
+recorded together with the disposition it takes. They are worked examples of this table, not extra
+rules on top of it.
+
+| Disposition | Meaning | Based on |
 | --- | --- | --- |
-| `VALID` | Violates a §8 property via an in-scope adversary/input (auth/authz bypass, pre-auth/malformed-input crash/OOM/hang, deserializer RCE beyond the documented type set, parser memory-safety). | §8, §6, §7 |
-| `VALID-HARDENING` | No §8 property broken, but a §11 misuse is easy enough to harden. | §11 |
-| `OUT-OF-MODEL: trusted-input` | Requires operator/host/config control. | §6, §7 |
-| `OUT-OF-MODEL: adversary-not-in-scope` | Requires a capability the model excludes (host control, side channel, direct public exposure against guidance). | §3, §7 |
-| `OUT-OF-MODEL: unsupported-component` | Lands in `gremlin-test/`, `gremlin-examples/`, tooling, or a separate provider graph DB. | §3 |
-| `OUT-OF-MODEL: non-default-build` | Only manifests under a discouraged/non-default §5a setting (e.g. Gryo enabled on an untrusted surface, scripting unrestricted where the deployment intends bytecode-only). | §5a |
-| `BY-DESIGN: property-disclaimed` | Concerns a §9-disclaimed property (script execution within its grant, no-TLS/no-auth default, ordinary resource exhaustion, malicious operator). | §9 |
-| `KNOWN-NON-FINDING` | Matches a §11a entry. | §11a |
-| `MODEL-GAP` | Cannot be cleanly routed — triggers a §12 revision. | §12 |
+| `VALID` | A real TinkerPop bug: it breaks one of the §8 security properties through an attacker or input the model covers. Examples: bypassing authentication/authorization or slipping past a configured restriction, crashing or hanging the server with malformed or unauthenticated input, a deserializer executing code it should not, or the parser mishandling crafted input or letting a value escape its string literal. | §8, §6, §7 |
+| `VALID-HARDENING` | Not a vulnerability, but still useful: no §8 property is broken, and the report points at a practical change that would make one of the §11 misuse patterns harder to fall into. Example: "no authentication by default" is by design, but a startup warning when `AllowAllAuthenticator` is active would be a sensible outcome of that report and takes this disposition. Tracked as an ordinary improvement. | §11 |
+| `OUT-OF-MODEL: trusted-input` | The attack only works for someone who already has the operator's own access: the host, the server process, `gremlin-server.yaml`, or the data directory. This includes a malicious operator (§9). Someone with that access can already do anything the operator can, so the attack gains nothing new. | §6, §7 |
+| `OUT-OF-MODEL: adversary-not-in-scope` | The attack needs an attacker the model deliberately leaves out (side channels/timing), or the whole finding is that one specific deployment was left on the insecure getting-started default, which is that operator's mistake to fix. A complaint about the shipped default itself is `BY-DESIGN`. A real code bug that was merely demonstrated on an unhardened server is judged on its own needs, usually `VALID`. | §3, §7 |
+| `OUT-OF-MODEL: unsupported-component` | The buggy code is not TinkerPop's (§3 triage test): it is in a test-only or example module, in build tooling, or in a provider's own code or their modifications to the reference code (including a remote graph provider that shares no TinkerPop code). Sent to the provider. | §3 |
+| `OUT-OF-MODEL: non-default-build` | A genuine bug, but one that only exists when the operator turns on a discouraged, non-default §5a setting, for example a robustness bug inside the optional `gremlin-groovy` engine. Different from `BY-DESIGN`: behavior §9 already disclaims, such as Groovy scripts running code, is not a bug at all and takes that row instead. | §5a |
+| `BY-DESIGN: property-disclaimed` | The behavior is exactly what §9 says TinkerPop does not defend against: scripts executing code within what the deployment allows, the shipped no-TLS/no-auth default, ordinary resource exhaustion from expensive queries, reading untrusted files through unlocked Gryo, or an application building queries out of its own users' raw input. The software works as documented. When the scenario needs the operator's own access, `trusted-input` applies instead. | §9 |
+| `KNOWN-PROBLEM` | Matches the acknowledged weakness in §11b (transaction sharing), which the §8 enforcement property explicitly excepts. Already known and accepted, not a new finding. A deployment that needs the missing protection must use a provider that adds it. | §11b |
+| `MODEL-GAP` | Fits no row, or more than one. That is a defect in the model itself, and §12 requires revising it. | §12 |
 
 ## §14 Open questions for the maintainers
 
-Every *(inferred)* claim in the body maps to one of these. Proposed answers are inline; please confirm,
-correct, or strike.
-
-1. **Deployment posture.** Is "Gremlin Server inside a trusted network, behind the app tier, not directly
-   public" the right §2/§5 framing? *Proposed: yes.*
-2. **Default auth/authz posture.** Do the shipped/default Gremlin Server configs run with authentication
-   and authorization **off**, leaving it to the operator to enable? Is an unauthenticated exposed server an
-   operator-misconfiguration (`OUT-OF-MODEL`) rather than a code bug? *Proposed: yes — auth/authz are
-   opt-in.*
-3. **Provider SPI boundary.** Confirm that vulnerabilities in third-party provider graph databases that
-   embed TinkerPop route to those providers, not here (this model covers TinkerPop's own code + its use of
-   the SPI). *Proposed: yes.*
-4. **Script execution (highest-stakes).** Confirm that string-script evaluation = server-side code
-   execution by design, that restricting it (sandbox / allow-list / bytecode-only / who-may-script) is the
-   operator's responsibility, and what — if any — restriction is **on by default**. Is "Gremlin Server runs
-   arbitrary code via scripts" `BY-DESIGN` unless a *configured* restriction is bypassed? *Proposed: yes,
-   by-design; restriction is operator-configured.*
-5. **TLS default.** Is TLS **off by default** on the server connector? Is no-TLS-by-default an operator
-   responsibility (§9/§10)? *Proposed: off by default; operator enables.*
-6. **Serialization / Gryo.** Which serializers are registered by default? Is **Gryo (Kryo)** locked to
-   registered types, and is a Gryo-deserialization finding on an operator-enabled untrusted surface
-   `OUT-OF-MODEL: non-default-build` (with GraphBinary the recommended default)? Conversely, is a
-   deserializer flaw in the **default** set `VALID`? *Proposed: prefer GraphBinary; Gryo-on-untrusted is
-   operator responsibility; a flaw in the default set is VALID.*
-7. **Resource line.** Confirm the split: malformed/pre-auth input causing crash/OOM/hang is `VALID`;
-   ordinary expensive traversals / large results are operator capacity unless a specific bug applies
-   (super-linear amplification, missing-expected-limit, unbounded traversal/recursion). Are there built-in
-   per-request limits (timeout, result cap, traversal depth)? *Proposed: split as stated.*
-8. **Parser robustness.** Confirm that memory-safety / bounded-resource on the `gremlin-language` ANTLR
-   parser and the bytecode path against malformed input is a property TinkerPop commits to (§8). *Proposed:
-   yes.*
-9. **GLV (driver) scope.** Are the Gremlin Language Variants (`gremlin-python`/`-dotnet`/`-go`/`-js`) in
-   scope for this batch, or deferred? They are client-side and deserialize server responses. *Proposed:
-   in-scope but lower priority; flag if any should be deferred.*
-10. **OLAP scope.** Are `hadoop-gremlin` / `spark-gremlin` (`GraphComputer` over a cluster) in scope, or
-    treated as operator cluster infrastructure out of this model? *Proposed: operator infra; flag if you
-    want them fully in.*
-11. **§11a seeds.** What do scanners/researchers most often report that the PMC considers a non-finding,
-    beyond the seed list above? *(seeds §11a)*
-12. **Canonical location / triage policy.** Confirm this model lives as root `THREAT_MODEL.md` referenced
-    from a new `SECURITY.md`, wired from `AGENTS.md`, and that the PMC owns revisions. *Proposed: yes.*
+1. **Deployment posture.** ~~Is "Gremlin Server inside a trusted network, behind the app tier, not directly
+   public" the right §2/§5 framing?~~ **RESOLVED (maintainer):** Gremlin Server *is* intended to be
+   deployable on the public internet, but only after hardening beyond the shipped getting-started
+   `gremlin-server.yaml`, meaning TLS plus an authenticator (either built-in mechanism is adequate over TLS).
+   Reaching a server left on the insecure default is an operator hardening failure (`OUT-OF-MODEL`), not
+   evidence of a trusted-network assumption. Auth/authz is a shared responsibility. Providers typically
+   supply the `Authenticator`/`Authorizer` policy (no authorizer ships), while Gremlin Server owns the
+   enforcement machinery (§2/§5/§5a/§7/§8/§10).
+2. **Default auth/authz posture.** ~~Do the shipped/default Gremlin Server configs run with authentication
+   and authorization **off**?~~ **RESOLVED (documented):** yes. `gremlin-server.yaml` has no
+   `authentication` block (default `AllowAllAuthenticator`) and ships no authorizer. The docs state "Gremlin
+   Server is configured to allow all requests to be processed (i.e. no authentication)" and "not shipped
+   with `Authorizer` implementations" (`gremlin-applications.asciidoc` "Security"). Reaching a server left
+   on that default is an operator hardening failure (`OUT-OF-MODEL`), not a code bug (per §14 Q1). The
+   framework's duty to *run* a configured authenticator/authorizer remains an in-model §8 property.
+3. **Provider boundary.** ~~Confirm that vulnerabilities in third-party provider graph databases route to
+   those providers.~~ **RESOLVED (maintainer):** the boundary is drawn by **what code the defect reproduces
+   in**, not where it runs. Unmodified TinkerPop **reference code** (`gremlin-core`, `gremlin-server`, the
+   reference graph, serializers) is in-model even when running as part of a provider's product. A defect
+   requiring the **provider's own code or their modifications** routes to the provider. This includes a
+   **remote graph provider** that shares no TinkerPop code and only conforms to the HTTP API +
+   serializer specs. A defect reproducible only under a **mix** of the two is `MODEL-GAP` (joint
+   determination, not silently the provider's). Triage test: *does it reproduce on the unmodified reference
+   distribution?* (§3).
+4. **Script execution (highest-stakes).** ~~Confirm that string-script evaluation = server-side code
+   execution by design, that restricting it (sandbox / allow-list / who-may-script) is the operator's
+   responsibility, and what restriction (if any) is **on by default**. Is "Gremlin Server runs arbitrary
+   code via scripts" `BY-DESIGN` unless a *configured* restriction is bypassed?~~ **RESOLVED
+   (documented):** yes, by-design when a code-capable engine (`gremlin-groovy`) is configured. The shipped
+   default is the Gremlin-only `GremlinLangScriptEngine`, which evaluates no arbitrary code (§4/§5a/§9/§10/§11a).
+5. **TLS default.** ~~Is TLS **off by default** on the server connector? Is no-TLS-by-default an operator
+   responsibility (§9/§10)?~~ **RESOLVED (documented):** yes, `ssl.enabled: false` in the shipped
+   `gremlin-server.yaml`, and the operator enables it (§3/§5a/§9/§10).
+6. **Serialization / Gryo.** ~~Which serializers are registered by default?~~ **RESOLVED (documented):** the
+   server wire set is GraphSON + GraphBinary, while GLV clients default to (and now ship only) GraphBinary. Gryo is
+   IO-format-only (not on the wire) and defaults to a locked
+   registration allow-list (`registrationRequired=true`). A Gryo request-path report is a non-finding. A
+   flaw in a wire serializer or in **locked** Gryo is `VALID`, whereas **unlocked** Gryo on untrusted files
+   is the user's responsibility (§2/§4/§5a/§6/§8/§9/§10/§11a).
+7. **Resource line.** ~~Confirm the split, and whether built-in per-request limits exist.~~ **RESOLVED:**
+   split confirmed *(maintainer)*. Malformed/pre-auth crash/OOM/hang is `VALID`. Ordinary expensive
+   traversals / large results are operator capacity unless a specific bug applies (super-linear
+   amplification, missing-where-expected limit, unbounded traversal/recursion). Built-in per-request limits
+   exist (`evaluationTimeout`, `maxRequestContentLength`, `maxParameters`, `maxWorkQueueSize`, plus
+   transaction bounds `idleTransactionTimeout`/`maxTransactionLifetime`/`maxConcurrentTransactions`),
+   with **no** traversal-depth or result-count cap *(documented)* (§6/§8/§9/§10/§11a).
+8. **Parser robustness.** ~~Confirm parser memory-safety against malformed input is a committed
+   property.~~ **RESOLVED (maintainer):** yes, the `gremlin-language` parser must not
+   crash/hang/OOM on **malformed input**, and a crafted string must not break out of a literal to inject
+   steps (`VALID`, §8). This covers parsing robustness and integrity. The *execution* cost of a well-formed
+   query is the Q7 capacity split, where an accidental/amplified OOM from a small query is in-model but a
+   legitimately huge query is operator capacity. Injection via Groovy string-concatenation in the calling
+   application is out-of-model (§9/§11a).
+9. **GLV scope.** ~~Are the GLVs in scope, or deferred?~~ **RESOLVED (maintainer):** all GLVs (Java
+   `gremlin-driver` included, since it is the Java GLV) are in scope. The in-model client surface is
+   **response-deserialization robustness against a malicious/compromised server or MITM, plus TLS cert
+   validation** (§8). Outbound request/message construction is **not** a surface, because its input is the
+   trusted calling application. Feeding untrusted end-user input into a traversal/script is Gremlin-injection
+   and the calling application's responsibility (§9/§11a). Sending bad bytes *to* the server folds into the
+   server's §8 request-robustness (§2/§6/§8).
+10. **OLAP scope.** ~~Are `hadoop-gremlin` / `spark-gremlin` in scope, or operator infra?~~ **RESOLVED
+    (maintainer):** OLAP is **in-model as TinkerPop reference code**, covering the `gremlin-core`/`tinkergraph`
+    computer *and* the `hadoop-gremlin`/`spark-gremlin` reference modules (per the Q3 reference-code rule),
+    reachable remotely when the operator configures an OLAP-capable graph. Only the **third-party Hadoop/Spark
+    runtime and the cluster deployment/config** are out-of-model (§3). The Gryo untrusted-file risk on this IO
+    surface stays as in Q6 (§2/§3/§6).
+11. **§11a seeds.** Generalized the test/example/tooling non-finding to a **category** (any test-only or
+    example module, not a fixed name list). Remains a **standing invitation** for the PMC to append further
+    recurring false-positives (§11a).
+12. **Canonical location.** ~~Confirm this model lives as root `THREAT_MODEL.md`, referenced from
+    `SECURITY.md`, wired from `AGENTS.md`.~~ **RESOLVED (documented):** verified. Root `THREAT_MODEL.md`,
+    referenced from `SECURITY.md`, which is wired from `AGENTS.md`.
 
 ## §15 Machine-readable companion
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,348 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Apache TinkerPop — Threat Model (v0 draft)
+
+## §1 Header
+
+- **Project:** Apache TinkerPop (`apache/tinkerpop`) — a graph computing framework: the Gremlin query
+  language, the traversal machine, Gremlin Server (remote query execution), the GraphSON / Gryo /
+  GraphBinary serialization formats, and the Gremlin Language Variants (Java, Python, .NET, Go, JS).
+  *(documented — `README.md`, repo layout)*
+- **Scope of this model:** the **`apache/tinkerpop` monorepo**, active branches `master`, `3.7-dev`,
+  `3.8-dev` *(maintainer — colegreer, scope confirmation)*. The model focuses on the network-facing and
+  deserialization surfaces (see §2); provider graph databases that embed TinkerPop are out of scope (§3).
+- **Date:** 2026-06-05. **Status:** DRAFT v0 — first pass by the ASF Security team via the
+  threat-model-producer rubric, for the TinkerPop PMC to react to. **Author:** ASF Security team, for PMC
+  ratification.
+- **Version binding:** versioned with the project; a report against release *N* is triaged against the
+  model as it stood at *N*, not against `HEAD`.
+- **Reporting cross-reference:** §8-property violations → report privately per the ASF process
+  (`security@apache.org`); §3 / §9 findings are closed citing this document.
+- **Provenance legend:** *(documented)* = stated in TinkerPop's own docs / reference / source;
+  *(maintainer)* = confirmed by a TinkerPop PMC member through this process; *(inferred)* = reasoned from
+  the reference docs, architecture, and graph-server domain knowledge, **not yet confirmed** — every
+  *(inferred)* claim has a matching §14 open question.
+- **Draft confidence:** a v0 with **no PMC confirmation folded in yet** — the deployment posture, the
+  default auth/TLS stance, the script-execution sandboxing story, and the serialization (Gryo)
+  disposition are the highest-value items for the PMC to confirm in §14.
+- **What TinkerPop is:** TinkerPop is an embeddable graph-computing framework. Applications and graph
+  databases (providers) embed `gremlin-core` to run Gremlin traversals; **Gremlin Server** exposes that
+  capability over the network (WebSocket sub-protocol + HTTP), accepting both **string-based Gremlin
+  scripts** (evaluated by the `gremlin-groovy` Groovy script engine) and **bytecode-based traversals**
+  (the GLVs). *(documented — reference docs)*
+
+## §2 Scope and intended use
+
+- **Primary use:** an operator-deployed graph-traversal engine. In production it is typically embedded by
+  a graph database (a "provider") or run as **Gremlin Server** behind the application tier, on a
+  **trusted network** *(inferred — confirm deployment posture, §14 Q1)*. Gremlin Server is the main
+  network-facing trust boundary.
+- **Caller roles** (Gremlin Server is a network service):
+  - **remote client** — connects over the WebSocket sub-protocol or HTTP, submits Gremlin (script or
+    bytecode). Trust level depends entirely on whether the operator enabled authentication, authorization,
+    and script restrictions. *(inferred — §14 Q2)*
+  - **embedding application / provider** — links `gremlin-core` in-process and drives traversals directly.
+    Trusted within the compile-time + configuration boundary. *(inferred)*
+  - **operator** — runs Gremlin Server, controls `gremlin-server.yaml`, serializers, auth, TLS, the script
+    engine configuration, and the host. Trusted for the instance. *(inferred)*
+
+**Component-family table** *(in/out = in/out of this model; all rows inferred unless noted)*:
+
+| Family | Entry point | Touches outside the process | In model? |
+| --- | --- | --- | --- |
+| **Gremlin Server** (`gremlin-server`) | WebSocket sub-protocol + HTTP request handlers | network (listens), invokes the script engine + traversal machine | **In** *(documented: remote execution endpoint)* |
+| **Script engine** (`gremlin-groovy`) | `GremlinGroovyScriptEngine` evaluating string scripts | runs supplied Groovy in-process | **In — central code-execution surface; see §9** *(documented: scripts are evaluated)* |
+| **Gremlin language parser** (`gremlin-language`) | ANTLR grammar for string Gremlin (script-engine-free) | — | **In** — parser robustness on untrusted Gremlin strings *(inferred)* |
+| **Core traversal machine + structure API** (`gremlin-core`) | `GraphTraversal`, strategies, `Vertex`/`Edge` | filesystem (IO formats) | **In** *(documented)* |
+| **Serialization** (`gremlin-core`/`gremlin-util`/`gremlin-shaded`) | GraphSON (JSON), GraphBinary, **Gryo (Kryo-based)** readers | deserializes wire/file bytes | **In — deserialization of untrusted bytes; see §9** *(documented: 3 formats; Gryo wraps shaded Kryo)* |
+| **Java driver** (`gremlin-driver`) | client connecting to Gremlin Server; deserializes server responses | network (connects) | **In** (client side) *(inferred)* |
+| **Gremlin Language Variants** (`gremlin-python`, `-dotnet`, `-go`, `-js`) | build bytecode, serialize/deserialize | network (connect) | **In, lower priority** — client-side; deserialize server responses *(inferred — §14 Q9)* |
+| **Reference graph** (`tinkergraph-gremlin`) | in-memory graph implementation | filesystem (persistence option) | **In** — the reference provider *(inferred)* |
+| **OLAP** (`hadoop-gremlin`, `spark-gremlin`) | `GraphComputer` over Hadoop/Spark | network, filesystem, cluster | **In if deployed; operator cluster infra** *(inferred — §14 Q10)* |
+| **Operator tooling** (`gremlin-console`) | interactive REPL run by the operator | — | **Out** — operator-trusted local tool *(inferred)* |
+| `gremlin-test`, `gremlin-examples`, `gremlin-tools`, `gremlin-annotations` | test/build/example code | — | **Out** *(see §3)* |
+
+## §3 Out of scope (explicit non-goals)
+
+- **Provider graph databases that embed TinkerPop** (e.g. third-party graph DBs implementing the
+  structure/`GraphComputer` SPI). A vulnerability in a provider's own code is routed to that provider, not
+  here; this model covers TinkerPop's own code and its *use* of the SPI. *(inferred — §14 Q3)*
+- **The embedding application's own authentication / authorization of its end users.** TinkerPop has no
+  concept of the embedding application's end users. *(inferred)*
+- **Attackers who already control the host, the Gremlin Server process, `gremlin-server.yaml`, or the
+  graph data directory.** They have the operator's authority by definition. *(inferred)*
+- **`gremlin-test/`, `gremlin-examples/`, build/distribution tooling, `gremlin-console`** as a production
+  trust surface. *(inferred)*
+- **Confidentiality of data in transit when the operator has not enabled TLS** — see §10; the TLS posture
+  is the operator's deployment responsibility unless the project claims TLS-by-default (§14 Q5). *(inferred)*
+
+## §4 Trust boundaries and data flow
+
+- **Primary trust boundary: the Gremlin Server remote request surface.** Bytes arriving over the WebSocket
+  sub-protocol or HTTP — whether a **string script** or **bytecode traversal**, plus the serialized request
+  payload — are untrusted. The script engine, traversal machine, and structure/storage layer sit behind
+  this boundary. *(documented: remote endpoint; trust posture inferred — §14 Q2)*
+- **The script-execution boundary (the highest-stakes one).** A string-based request is evaluated by the
+  Groovy script engine. Absent a configured sandbox / allow-list, **evaluating an attacker-supplied script
+  is arbitrary code execution on the server** — this is inherent to the script-based interface, not a bug
+  (§9). The question for triage is whether a given deployment restricts scripting (bytecode-only,
+  allow-list, sandbox) and who is authorized to submit scripts. *(documented: scripts are evaluated;
+  sandbox specifics inferred — §14 Q4)*
+- **The deserialization boundary.** GraphSON, GraphBinary, and Gryo readers parse untrusted request bytes
+  (and, on the driver/GLV side, untrusted server-response bytes). Gryo is Kryo-based; Kryo deserialization
+  of untrusted input is a well-known RCE class unless type registration is locked down. *(documented:
+  formats exist; default-enabled set + Gryo hardening inferred — §14 Q6)*
+- **Reachability preconditions** (the test a triager applies first):
+  - A finding reachable only by submitting a **script** is in-model only subject to the §9 ruling: if the
+    deployment allows scripting to the principal, server-side code execution is by-design. *(inferred)*
+  - A finding in the **Gremlin parser / bytecode / traversal machine / deserializers** reachable from a
+    client operating within its privileges (or pre-auth) is **in-model** for memory-safety / bounded-
+    resource robustness. *(inferred)*
+  - A finding requiring control of `gremlin-server.yaml` or host access is **out-of-model: trusted-input**.
+    *(inferred)*
+
+## §5 Assumptions about the environment
+
+- **Runtime:** JVM (server, core, groovy, driver); the GLVs run on their respective runtimes
+  (CPython, .NET, Go, Node). *(documented — README / build)*
+- **Deployment:** Gremlin Server is assumed to run inside a **trusted network**, fronted by the
+  application tier, not exposed directly to the public internet. *(inferred — §14 Q1)*
+- **Filesystem:** the graph data / config directories are private to the server process and not writable by
+  untrusted local users. *(inferred)*
+- **Concurrency:** the server is multi-threaded and serves concurrent sessions; thread-safety of the
+  traversal/IO path is a correctness assumption. *(inferred)*
+- **What the server does to its host** (negative inventory — predominantly inferred, a confirmation
+  target): listens on network ports; reads/writes its configured graph + data directories; reads config;
+  **executes supplied Groovy when script requests are enabled**; loads provider graph implementations the
+  operator configured. *(inferred — §14 Q4)*
+
+## §5a Build-time and configuration variants
+
+Knobs that change which security properties hold (Gremlin Server, `gremlin-server.yaml`):
+
+- **Authentication** — `Authenticator` (PlainText/SASL with a credentials graph; `Krb5Authenticator` for
+  Kerberos). Whether authentication is **off by default** (the shipped sample/getting-started configs) is
+  the key question. *(documented: mechanisms exist; default-off inferred — §14 Q2)*
+- **Authorization** — an `Authorizer` interface (e.g. allow-listing which Gremlin a principal may run).
+  In-model only when configured; default likely none. *(documented: section exists; default inferred — §14 Q2)*
+- **TLS/SSL** — configurable on the server connector; whether it is **off by default** drives the
+  transport-confidentiality property (§9). *(inferred — §14 Q5)*
+- **Script execution restriction** — "Protecting Script Execution": sandbox / compilation customizers /
+  allow-list / preferring bytecode-only. Whether any restriction is on by default, or scripting is
+  unrestricted out of the box, is the single highest-stakes config question. *(documented: guidance exists;
+  default inferred — §14 Q4)*
+- **Enabled serializers** — which of GraphSON / GraphBinary / **Gryo** are registered by default, and
+  whether Gryo (Kryo) is locked to registered types. *(documented: formats exist; defaults inferred — §14 Q6)*
+
+## §6 Assumptions about inputs
+
+Per-surface trust table *(inferred unless noted)*:
+
+| Surface | Input | Attacker-controllable? | Caller/operator must enforce |
+| --- | --- | --- | --- |
+| Gremlin Server — string script request | Groovy/Gremlin script text | **yes** (pre-auth if auth off) | auth; script restriction / sandbox / bytecode-only; who may script |
+| Gremlin Server — bytecode/traversal request | serialized traversal bytecode | **yes**, within privileges | auth; traversal-step allow-list; resource limits |
+| Request deserialization (GraphSON / GraphBinary / Gryo) | serialized bytes | **yes** (pre-auth) | enabled-serializer choice; Gryo type-registration lockdown |
+| Gremlin string parser (`gremlin-language` ANTLR) | Gremlin string | **yes** | parser robustness (no crash/OOM/hang) |
+| Driver / GLV — server response | serialized bytes from the server | yes if the server (or a MITM without TLS) is hostile | TLS; trust in the server |
+| `gremlin-server.yaml`, host, data dir | local | no — operator-trusted | filesystem permissions |
+
+- **Shape / rate:** whether Gremlin Server bounds per-request CPU/memory, result-set size, traversal depth,
+  or concurrent requests — and the line between a bug and operator-managed capacity — is an open item
+  (§8 resource line, §14 Q7). *(inferred)*
+
+## §7 Adversary model
+
+- **Primary adversary:** a network client that can reach the Gremlin Server port from within the deployment
+  — either **unauthenticated** (if auth is off / pre-auth) or **authenticated with limited privileges** —
+  trying to execute code on the server (via scripts), read/write graph data outside its intent, crash or
+  exhaust the server with malformed requests or expensive traversals, or exploit a deserializer. *(inferred
+  — §14 Q2/Q7)*
+- **Capabilities assumed:** can open connections, send arbitrary protocol bytes / scripts / bytecode /
+  serialized payloads, and supply large/malformed input. *(inferred)*
+- **Out of scope:** anyone with operator/host/config control (already authoritative); a client that only
+  reaches the server because it was directly publicly exposed against guidance (non-supported posture, §3);
+  side-channel/timing adversaries unless the PMC wants them in. *(inferred — §14 Q1)*
+
+## §8 Security properties the project provides
+
+*(Inferred pending PMC confirmation — a property only counts once the project commits to it.)*
+
+- **Authentication + authorization enforcement (when configured).** With an `Authenticator`/`Authorizer`
+  set, an unauthenticated or unauthorized client cannot execute requests beyond its grants. *Violation
+  symptom:* auth/authz bypass. *Severity:* security-critical. *(inferred — §14 Q2)*
+- **Memory / availability safety on the request + deserialization surface.** Malformed or pre-auth input
+  (protocol frames, Gremlin strings, serialized payloads) yields a clean error, not a crash, OOM, hang, or
+  unbounded allocation of the server. *Violation symptom:* server crash / unbounded allocation / deadlock
+  from malformed or pre-auth input. *Severity:* security-critical (remote DoS) if pre-auth. *(inferred —
+  §14 Q7)*
+- **Deserializer integrity.** GraphSON / GraphBinary / Gryo reading attacker bytes does not lead to
+  arbitrary object instantiation / code execution beyond the documented type set. *Violation symptom:*
+  deserialization gadget / RCE. *Severity:* critical. **The strength of this property for Gryo (Kryo)
+  depends on type-registration lockdown** — see §9 / §14 Q6. *(inferred)*
+- **Resource bounds — split, not unspecified.** Malformed/pre-auth input that crashes/OOMs/hangs the server
+  is **in-model** (above). Ordinary expensive traversals are **operator capacity/resource management**, NOT
+  in-model — unless a specific bug applies (super-linear amplification, a missing limit where one is
+  expected, an unbounded traversal). *(inferred — §14 Q7)*
+
+## §9 Security properties the project does *not* provide
+
+*(The highest-value section for integrators — inferred unless tagged; confirm each.)*
+
+- **Script execution is arbitrary code execution by design — not a sandbox.** When string-script requests
+  are enabled, the Groovy script engine evaluates attacker-supplied code in the server process. Submitting
+  a script that runs server-side code is **`BY-DESIGN`** for a principal the deployment permits to script;
+  it is the operator's job to restrict scripting (bytecode-only, allow-list, sandbox) and to authenticate
+  who may script. A scan reporting "Gremlin Server allows arbitrary code execution via scripts" is
+  by-design unless it bypasses a *configured* restriction. *(inferred — §14 Q4)*
+- **No transport confidentiality/integrity unless TLS is enabled.** If TLS is off (see §5a/§14 Q5), the
+  server does not defend against a network attacker reading/modifying client traffic. *(inferred)*
+- **No authentication or authorization by default (assumed).** If the shipped/default configuration runs
+  with auth off, an exposed server is reachable by anyone on the network — an operator deployment concern,
+  not a code bug. *(inferred — §14 Q2)*
+- **Gryo / Kryo deserialization is not a safe boundary against untrusted input** unless type registration is
+  locked down. Operators who enable Gryo on an untrusted surface own that risk; prefer GraphBinary. *(inferred
+  — §14 Q6)*
+- **Ordinary resource exhaustion is not a defended property.** Expensive traversals / large results that
+  consume CPU/memory are an operator capacity concern unless a specific bug applies (§8). *(inferred — §14 Q7)*
+- **No defense against a malicious operator / host.** *(inferred)*
+- **False friends:**
+  - "Authentication is available" does **not** mean it is **on** — it must be configured (§5a). *(inferred)*
+  - **Bytecode is safer than scripts but is not a sandbox** — a bytecode traversal still executes traversal
+    steps server-side; injection/abuse via an embedding app that builds traversals from its own untrusted
+    input is the embedding app's responsibility. *(inferred)*
+  - "Gremlin is just a query language" — the **string** form runs through a Groovy engine, so it is code,
+    not a constrained query. *(inferred)*
+
+## §10 Downstream responsibilities (operator/deployer)
+
+*(Inferred unless tagged — confirm.)*
+
+- Deploy Gremlin Server inside a trusted network; do **not** expose it directly to an untrusted/public
+  network, especially with scripting enabled and auth off. *(inferred — §14 Q1)*
+- Enable authentication (`Authenticator`) and authorization (`Authorizer`) for any non-trivial deployment.
+  *(inferred — §14 Q2)*
+- **Restrict script execution:** prefer bytecode-based traversals; if scripts are needed, apply the
+  "Protecting Script Execution" controls (sandbox / compilation customizers / allow-list) and restrict who
+  may submit scripts. *(documented: guidance exists — §14 Q4)*
+- Enable TLS where traffic crosses an untrusted segment. *(inferred — §14 Q5)*
+- Prefer **GraphBinary**; only enable **Gryo** on a trusted surface, with type registration locked down.
+  *(inferred — §14 Q6)*
+- Apply per-request / per-traversal resource limits and result-size caps appropriate to capacity. *(inferred
+  — §14 Q7)*
+- Set filesystem permissions so only the server user can read the config / data directories. *(inferred)*
+
+## §11 Known misuse patterns
+
+*(Draft one-liners — expand before publishing.)*
+
+- Exposing Gremlin Server to an untrusted network with scripting enabled and authentication off. *(inferred)*
+- Treating the script-engine sandbox as a complete RCE boundary rather than restricting who may script.
+  *(inferred)*
+- Building Gremlin (string or bytecode) by concatenating the embedding application's untrusted input
+  (Gremlin-injection). *(inferred)*
+- Enabling Gryo on an untrusted request surface without type-registration lockdown. *(inferred)*
+
+## §11a Known non-findings (recurring false positives)
+
+*(Inferred unless tagged; the PMC's confirmations here are the highest-leverage suppression input.)*
+
+- "Gremlin Server executes arbitrary code via scripts" — by-design when scripting is enabled for the
+  principal (§9); not a finding unless it bypasses a *configured* restriction. *(inferred — §14 Q4)*
+- "No authentication / no TLS by default" — operator deployment responsibility (§9/§10); not a code bug in
+  itself. *(inferred — §14 Q2/Q5)*
+- "Gryo/Kryo deserialization can be exploited" — when the operator enabled Gryo on an untrusted surface;
+  operator responsibility, prefer GraphBinary (§9/§10). *(inferred — §14 Q6)*
+- "Expensive traversal consumes CPU/memory" — operator capacity concern, unless a specific bug applies
+  (§8/§9). *(inferred — §14 Q7)*
+- "Embedding app builds a traversal from untrusted input (Gremlin-injection)" — the embedding app's
+  responsibility (§9). *(inferred)*
+- Findings in `gremlin-test/`, `gremlin-examples/`, tooling — out of scope (§3). *(inferred)*
+
+## §12 Conditions that would change this model
+
+- A change to the default auth / TLS / scripting posture (e.g. auth-on-by-default, scripts-off-by-default).
+- A new client-reachable surface or protocol on Gremlin Server.
+- A change to the default-enabled serializer set, or Gryo type-registration policy.
+- Promoting `gremlin-console` / `gremlin-examples` into a production trust surface.
+- A change to the OLAP (Hadoop/Spark) trust posture.
+- A report that cannot be routed to a single §13 disposition (→ revise the model).
+
+## §13 Triage dispositions
+
+| Disposition | Meaning | Licensed by |
+| --- | --- | --- |
+| `VALID` | Violates a §8 property via an in-scope adversary/input (auth/authz bypass, pre-auth/malformed-input crash/OOM/hang, deserializer RCE beyond the documented type set, parser memory-safety). | §8, §6, §7 |
+| `VALID-HARDENING` | No §8 property broken, but a §11 misuse is easy enough to harden. | §11 |
+| `OUT-OF-MODEL: trusted-input` | Requires operator/host/config control. | §6, §7 |
+| `OUT-OF-MODEL: adversary-not-in-scope` | Requires a capability the model excludes (host control, side channel, direct public exposure against guidance). | §3, §7 |
+| `OUT-OF-MODEL: unsupported-component` | Lands in `gremlin-test/`, `gremlin-examples/`, tooling, or a separate provider graph DB. | §3 |
+| `OUT-OF-MODEL: non-default-build` | Only manifests under a discouraged/non-default §5a setting (e.g. Gryo enabled on an untrusted surface, scripting unrestricted where the deployment intends bytecode-only). | §5a |
+| `BY-DESIGN: property-disclaimed` | Concerns a §9-disclaimed property (script execution within its grant, no-TLS/no-auth default, ordinary resource exhaustion, malicious operator). | §9 |
+| `KNOWN-NON-FINDING` | Matches a §11a entry. | §11a |
+| `MODEL-GAP` | Cannot be cleanly routed — triggers a §12 revision. | §12 |
+
+## §14 Open questions for the maintainers
+
+Every *(inferred)* claim in the body maps to one of these. Proposed answers are inline; please confirm,
+correct, or strike.
+
+1. **Deployment posture.** Is "Gremlin Server inside a trusted network, behind the app tier, not directly
+   public" the right §2/§5 framing? *Proposed: yes.*
+2. **Default auth/authz posture.** Do the shipped/default Gremlin Server configs run with authentication
+   and authorization **off**, leaving it to the operator to enable? Is an unauthenticated exposed server an
+   operator-misconfiguration (`OUT-OF-MODEL`) rather than a code bug? *Proposed: yes — auth/authz are
+   opt-in.*
+3. **Provider SPI boundary.** Confirm that vulnerabilities in third-party provider graph databases that
+   embed TinkerPop route to those providers, not here (this model covers TinkerPop's own code + its use of
+   the SPI). *Proposed: yes.*
+4. **Script execution (highest-stakes).** Confirm that string-script evaluation = server-side code
+   execution by design, that restricting it (sandbox / allow-list / bytecode-only / who-may-script) is the
+   operator's responsibility, and what — if any — restriction is **on by default**. Is "Gremlin Server runs
+   arbitrary code via scripts" `BY-DESIGN` unless a *configured* restriction is bypassed? *Proposed: yes,
+   by-design; restriction is operator-configured.*
+5. **TLS default.** Is TLS **off by default** on the server connector? Is no-TLS-by-default an operator
+   responsibility (§9/§10)? *Proposed: off by default; operator enables.*
+6. **Serialization / Gryo.** Which serializers are registered by default? Is **Gryo (Kryo)** locked to
+   registered types, and is a Gryo-deserialization finding on an operator-enabled untrusted surface
+   `OUT-OF-MODEL: non-default-build` (with GraphBinary the recommended default)? Conversely, is a
+   deserializer flaw in the **default** set `VALID`? *Proposed: prefer GraphBinary; Gryo-on-untrusted is
+   operator responsibility; a flaw in the default set is VALID.*
+7. **Resource line.** Confirm the split: malformed/pre-auth input causing crash/OOM/hang is `VALID`;
+   ordinary expensive traversals / large results are operator capacity unless a specific bug applies
+   (super-linear amplification, missing-expected-limit, unbounded traversal/recursion). Are there built-in
+   per-request limits (timeout, result cap, traversal depth)? *Proposed: split as stated.*
+8. **Parser robustness.** Confirm that memory-safety / bounded-resource on the `gremlin-language` ANTLR
+   parser and the bytecode path against malformed input is a property TinkerPop commits to (§8). *Proposed:
+   yes.*
+9. **GLV (driver) scope.** Are the Gremlin Language Variants (`gremlin-python`/`-dotnet`/`-go`/`-js`) in
+   scope for this batch, or deferred? They are client-side and deserialize server responses. *Proposed:
+   in-scope but lower priority; flag if any should be deferred.*
+10. **OLAP scope.** Are `hadoop-gremlin` / `spark-gremlin` (`GraphComputer` over a cluster) in scope, or
+    treated as operator cluster infrastructure out of this model? *Proposed: operator infra; flag if you
+    want them fully in.*
+11. **§11a seeds.** What do scanners/researchers most often report that the PMC considers a non-finding,
+    beyond the seed list above? *(seeds §11a)*
+12. **Canonical location / triage policy.** Confirm this model lives as root `THREAT_MODEL.md` referenced
+    from a new `SECURITY.md`, wired from `AGENTS.md`, and that the PMC owns revisions. *Proposed: yes.*
+
+## §15 Machine-readable companion
+
+Deferred for v0. A `threat-model.yaml` can later encode the §6 trust table, §2/§3 component scoping, §8
+property/severity/symptom rows, §9 false friends, §11a non-findings, and §13 dispositions for automated
+triage.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -17,37 +17,26 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Apache TinkerPop — Threat Model (v0 draft)
+# Apache TinkerPop — Threat Model
 
 ## §1 Header
 
 - **Project:** Apache TinkerPop (`apache/tinkerpop`) — a graph computing framework: the Gremlin query
   language, the traversal machine, Gremlin Server (remote query execution), the GraphSON and GraphBinary
   wire serializers and the Gryo IO format, and the Gremlin Language Variants (Java, Python, .NET, Go, JS).
-  *(documented — `README.md`, repo layout)*
 - **Scope of this model:** the **`apache/tinkerpop` monorepo**, active branch `master`. The model focuses on
   the network-facing and deserialization surfaces (see §2). Provider graph databases that make use of
   reference code are out of scope (§3).
-- **Date:** 2026-06-05. **Status:** DRAFT v0, a first pass by the ASF Security team via the
-  threat-model-producer rubric, for the TinkerPop PMC to react to. **Author:** ASF Security team, for PMC
-  ratification.
-- **Version binding:** versioned with the project. A report against release *N* is triaged against the
-  model as it stood at *N*, not against `HEAD`.
+- **Version binding:** versioned with the project. A report against release *x.y.z* is triaged against the
+  model as it stood at *x.y.z*, not against `HEAD`.
 - **Reporting cross-reference:** §8-property violations → report privately per the ASF process
   (`security@apache.org`). §3 / §9 findings are closed citing this document.
-- **Provenance legend:** *(documented)* = stated in TinkerPop's own docs / reference / source.
-  *(maintainer)* = confirmed by a TinkerPop PMC member through this process. *(inferred)* = reasoned from
-  the reference docs, architecture, and graph-server domain knowledge, **not yet confirmed**. Every
-  *(inferred)* claim has a matching §14 open question.
-- **Draft confidence:** a v0 with **no PMC confirmation folded in yet**. The deployment posture, the
-  default auth/TLS stance, the script-execution sandboxing story, and the serialization disposition are the
-  highest-value items for the PMC to confirm in §14.
 - **What TinkerPop is:** a graph computing framework for graph databases (OLTP) and graph analytic systems
   (OLAP). It **defines** a common interface/language (Gremlin) plus protocols/APIs, and ships
   production-ready reference implementations. This includes a reference in-memory graph (TinkerGraph), Gremlin
   Server, and the language variants (GLVs). Gremlin traversals run in one of two environments. In
   **embedded**, the caller runs traversals directly in their application via `gremlin-core`. In **remote**,
-  Gremlin is sent over the wire (as a **script**) to a server that executes it. *(documented)*
+  Gremlin is sent over the wire (as a **script**) to a server that executes it.
 
 ## §2 Scope and intended use
 
@@ -57,38 +46,39 @@ under the License.
   case, where **Gremlin Server** is the main network-facing trust boundary. Gremlin Server **is intended to
   be deployable on the public internet**, but the shipped `gremlin-server.yaml` is a getting-started/testing
   config that **must not be deployed as-is**. A public or otherwise untrusted-facing deployment is expected
-  to layer on TLS and an authenticator. *(maintainer)*
+  to layer on TLS and an authenticator.
 - **Embedded surface.** Embedded has **no network, transport, auth, or HTTP-protocol surface** (those exist
   only with a server). It exposes the same input-consuming primitives as remote, and only where the caller
   feeds them untrusted data: the **`io()` readers** (GraphSON, Gryo, GraphML), the **`gremlin-language`
   parser** if untrusted strings are parsed, and **expensive steps** (e.g. `regex`). The responsibility rules
-  are **identical to remote** because they attach to the primitive, not the environment. *(maintainer)*
+  are **identical to remote** because they attach to the primitive, not the environment.
 - **Caller roles** (Gremlin Server is a network service):
   - **remote client** — connects over HTTP/1.1, submits Gremlin as a gremlin-lang string (or, if
     `gremlin-groovy` is explicitly enabled, a Groovy script). Trust level depends entirely on whether
     the operator enabled authentication, authorization, and script restrictions. Authentication is **off
     in the shipped default** (`gremlin-server.yaml` has no `authentication` block, and the default is
-    `AllowAllAuthenticator`). *(documented)*
+    `AllowAllAuthenticator`).
   - **application / provider** — runs `gremlin-core` directly, whether embedded in its own process or as
     Gremlin Server. A provider may also supply the `Authenticator`/`Authorizer` implementations the server
-    runs. Trusted within the compile-time + configuration boundary. *(maintainer)*
+    runs. Trusted within the compile-time + configuration boundary.
   - **operator** — runs Gremlin Server, controls `gremlin-server.yaml`, serializers, auth, TLS, the script
-    engine configuration, and the host. Trusted for the instance. *(maintainer)*
+    engine configuration, and the host. Trusted for the instance.
 
 **Component-family table** *(in/out = in/out of this model)*:
 
 | Family | Entry point | Touches outside the process | In model? |
 | --- | --- | --- | --- |
-| **Gremlin Server** (`gremlin-server`) | HTTP/1.1 endpoint (gremlin-lang string requests, GraphSON/GraphBinary serialization) | network (listens), invokes the script engine + traversal machine | **In** *(documented: remote execution endpoint, `HttpChannelizer`)* |
-| **Script engine** (default `gremlin-lang`, optional `gremlin-groovy`) | evaluates the request's script string | default parses only Gremlin (no code execution). Optional Groovy runs supplied code in-process | **In**. The default is a parser surface. Enabling `gremlin-groovy` is a non-default operator choice whose RCE is by-design (§9) *(documented: scripts are evaluated)* |
-| **Gremlin language parser** (`gremlin-language`) | ANTLR grammar for string Gremlin (script-engine-free) | — | **In**, parser must not crash/hang/OOM on malformed input, nor let a crafted string break out of a literal to inject steps *(maintainer)* |
-| **GQL parser** (`gql-gremlin`) | ANTLR grammar for the GQL string of a `match(String)` request | — | **In**, reference code active on the default distribution (TinkerGraph registers it), with the same parser robustness/integrity as `gremlin-language`. Non-executable if a provider registers no declarative-match strategy (§3) *(documented — `match(String)`, `GqlDeclarativeMatchStrategy`)* |
-| **Core traversal machine + structure API** (`gremlin-core`) | `GraphTraversal`, strategies, `Vertex`/`Edge` | filesystem (IO formats) | **In** *(documented)* |
-| **Serialization** (`gremlin-core`/`gremlin-util`/`gremlin-shaded`) | GraphSON + GraphBinary wire readers. Gryo (Kryo) is IO-format-only, not on the wire | deserializes untrusted wire bytes. Gryo only reads IO/file bytes | **In** (see §9) *(documented — `Serializers` enum: GraphSON + GraphBinary)* |
-| **Gremlin Language Variants** (Java `gremlin-driver`, `gremlin-python`, `-dotnet`, `-go`, `-js`) | deserialize server responses | network (connect) | **In**, response-deserialization robustness + TLS cert validation. Java shares the JVM serializers. The others have own per-language deserializers not covered by hardening the JVM server *(documented — each GLV ships its own GraphBinary code)* |
-| **Reference graph** (`tinkergraph-gremlin`) | in-memory graph, the **shipped default graph**, with optional file persistence via the `io()` readers | filesystem (persistence) | **In**, TinkerPop reference code on the default reachable path, so a defect in unmodified TinkerGraph is `VALID` (§3). Loading a persisted graph uses the same GraphSON/Gryo/GraphML readers (§6 IO surface). A custom `graphFormat` reader is provider code (§3) *(documented — `gremlin-server.yaml` → `tinkergraph-empty.properties`, `AbstractTinkerGraph.loadGraph()`)* |
-| **OLAP** (`gremlin-core`/`tinkergraph` computer, `hadoop-gremlin`, `spark-gremlin`) | `GraphComputer`, remote-reachable when the operator configures an OLAP-capable graph | network, filesystem, cluster | **In**, reference code (incl. Hadoop/Spark modules). The third-party Hadoop/Spark runtime + cluster config are out (§3) *(documented — in-tree modules)* |
-| **`gremlin-console`** | local Groovy REPL. `:remote console` submits **arbitrary Groovy scripts** to a server and deserializes responses. `:install` loads plugins (credentials/hadoop/spark) via Grape | network (connects) | Local REPL **Out** (operator-trusted). As a remote client, submitting arbitrary Groovy = server-side RCE **by-design** (§9), subject to server auth. Response-deserialization robustness + TLS cert validation **In** (like a GLV). Plugins are operator-installed code in the operator's own JVM, so the install decision, the third-party download channel (Grape), and plugin behavior are **Out** (trusted-input, §3) *(documented — `DriverRemoteAcceptor`, `InstallCommand`/Grape; `gremlin-applications.asciidoc`)* |
+| **Gremlin Server** (`gremlin-server`) | HTTP/1.1 endpoint (gremlin-lang string requests, GraphSON/GraphBinary serialization) | network (listens), invokes the script engine + traversal machine | **In** |
+| **Script engine** (default `gremlin-lang`, optional `gremlin-groovy`) | evaluates the request's script string | default parses only Gremlin (no code execution). Optional Groovy runs supplied code in-process | **In**. The default is a parser surface. Enabling `gremlin-groovy` is a non-default operator choice whose RCE is by-design (§9) |
+| **Gremlin language parser** (`gremlin-language`) | ANTLR grammar for string Gremlin (script-engine-free) | — | **In**, parser must not crash/hang/OOM on malformed input, nor let a crafted string break out of a literal to inject steps |
+| **GQL parser** (`gql-gremlin`) | ANTLR grammar for the GQL string of a `match(String)` request | — | **In**, reference code active on the default distribution (TinkerGraph registers it), with the same parser robustness/integrity as `gremlin-language`. Non-executable if a provider registers no declarative-match strategy (§3) |
+| **Core traversal machine + structure API** (`gremlin-core`) | `GraphTraversal`, strategies, `Vertex`/`Edge` | filesystem (IO formats) | **In** |
+| **Serialization** (`gremlin-core`/`gremlin-util`/`gremlin-shaded`) | GraphSON + GraphBinary wire readers. Gryo (Kryo) is IO-format-only, not on the wire | deserializes untrusted wire bytes. Gryo only reads IO/file bytes | **In** (see §9) |
+| **Gremlin Language Variants** (Java `gremlin-driver`, `gremlin-python`, `-dotnet`, `-go`, `-js`) | deserialize server responses | network (connect) | **In**, response-deserialization robustness + TLS cert validation. Java shares the JVM serializers. The others have own per-language deserializers not covered by hardening the JVM server |
+| **Reference graph** (`tinkergraph-gremlin`) | in-memory graph, the **shipped default graph**, with optional file persistence via the `io()` readers | filesystem (persistence) | **In**, TinkerPop reference code on the default reachable path, so a defect in unmodified TinkerGraph is `VALID` (§3). Loading a persisted graph uses the same GraphSON/Gryo/GraphML readers (§6 IO surface). A custom `graphFormat` reader is provider code (§3) |
+| **OLAP** (`gremlin-core`/`tinkergraph` computer, `hadoop-gremlin`, `spark-gremlin`) | `GraphComputer`, remote-reachable when the operator configures an OLAP-capable graph | network, filesystem, cluster | **In**, reference code (incl. Hadoop/Spark modules). The third-party Hadoop/Spark runtime + cluster config are out (§3) |
+| **`gremlin-console`** | local Groovy REPL. `:remote console` submits **arbitrary Groovy scripts** to a server and deserializes responses. `:install` loads plugins (credentials/hadoop/spark) via Grape | network (connects) | Local REPL **Out** (operator-trusted). As a remote client, submitting arbitrary Groovy = server-side RCE **by-design** (§9), subject to server auth. Response-deserialization robustness + TLS cert validation **In** (like a GLV). Plugins are operator-installed code in the operator's own JVM, so the install decision, the third-party download channel (Grape), and plugin behavior are **Out** (trusted-input, §3) |
+| **`gremlint`** | client-side Gremlin formatter (parse-and-reprint, no query execution); published as a library for integration into client applications. | none (runs in the caller's browser/process) | **In**, valid surface for security reports since it's a published, user-integrated library |
 | Test-only / example / build modules (e.g. `gremlin-test`, `gremlin-examples`, `gremlin-tools`, `gremlin-annotations`) | test/build/example code | — | **Out** *(see §3)* |
 
 ## §3 Out of scope (explicit non-goals)
@@ -110,41 +100,36 @@ under the License.
 
   Triage test: *is the defective code TinkerPop's?* A defect in unmodified TinkerPop reference code is
   in-model, whatever product or graph it runs inside. A defect that depends on the provider's own code or
-  modifications is the provider's. If it genuinely can't be told, `MODEL-GAP`. *(maintainer)*
+  modifications is the provider's. If it genuinely can't be told, `MODEL-GAP`.
 - **The calling application's own authentication / authorization of its end users.** TinkerPop has no
-  concept of the calling application's end users. *(maintainer)*
+  concept of the calling application's end users.
 - **Attackers who already control the host, the Gremlin Server process, `gremlin-server.yaml`, or the
-  graph data directory.** They have the operator's authority by definition. *(maintainer)*
+  graph data directory.** They have the operator's authority by definition.
 - **Operator-configured code-execution/side-effect surfaces:** the Script I/O Format (`ScriptInputFormat`/
   `ScriptOutputFormat` run operator-supplied Groovy from HDFS) and `EventStrategy` `MutationListener`
   callbacks. The code comes from operator/provider config, not a remote request (though a remote mutating
   traversal can *trigger* an already-registered listener). Trusted-input. *(documented — Script I/O Format;
   `EventStrategy`)*
 - **Any test-only module, any example-only module, and build/distribution tooling** as a production trust
-  surface (e.g. `gremlin-test`, `gremlin-examples`, `gremlin-tools`). *(maintainer)*
+  surface (e.g. `gremlin-test`, `gremlin-examples`, `gremlin-tools`).
 - **Confidentiality of data in transit when the operator has not enabled TLS** (see §10). TLS is **off by
   default** (`ssl.enabled: false`), so the TLS posture is the operator's deployment responsibility.
-  *(documented — `gremlin-server.yaml`, `gremlin-applications.asciidoc` config table)*
-- **`gremlint` (incl. hosted gremlint)** — a client-side Gremlin formatter (parse-and-reprint, no query
-  execution). When hosted, input stays in the user's own browser (no URL-shared state, no XSS sink, no
-  backend), so a user is responsible for what they input, and a pathological input only affects their own
-  browser tab. *(documented — `gremlint/src`, `docs/gremlint`)*
 - **`gremlin-javascript` client-side Gremlin parser / `GremlinTranslator`** — a parse-and-reprint translator
   (no query execution), off the request/response path, so not a network surface. Its shipped consumers are
   Gremlator (a browser SPA where the input is the user's own, affecting only their own tab, like `gremlint`)
   and `gremlin-mcp` (its untrusted-input robustness is the `gremlin-mcp` surface's concern). As a library export, parsing caller-chosen input is the
-  consuming application's responsibility. *(documented — `gremlin-javascript` grammar/translator; Gremlator)*
+  consuming application's responsibility.
 - **`gremlin-mcp`** — a shipped MCP server that bridges an AI agent to a Gremlin Server (a GLV-like client
   plus an agent tool boundary). Findings route by the model's usual axis. A **decision** (running it, what
   graph it targets, what an agent may do through it) is the user's, so it is out-of-model and documented as
   trusted-environments-only. A **code defect** in `gremlin-mcp`, such as a tool handler crashing/hanging/
   OOMing on malformed input (an LLM can emit anything) or mishandling a server response, is in-model like
-  any TinkerPop bug (§8). *(documented — `gremlin-js/gremlin-mcp`)*
+  any TinkerPop bug (§8).
 - **Client-side `RequestInterceptor` (GLV)** — a calling application can register an interceptor to mutate
   the outgoing HTTP request (the standard hook for auth/signing). What a registered interceptor does, and a
   bug within it, is the **calling application's** responsibility (out-of-model), like any code it supplies.
   The GLV correctly *running* registered interceptors (invoking them, in order, without corrupting the
-  request) is TinkerPop code and **in-model**. *(documented — `RequestInterceptor`)*
+  request) is TinkerPop code and **in-model**.
 
 ## §4 Trust boundaries and data flow
 
@@ -190,34 +175,33 @@ Data flow for a remote request. The `‖` marks the trust boundary, and everythi
   wire set is GraphSON + GraphBinary)*
 - **Reachability preconditions** (the test a triager applies first):
   - A finding reachable only by submitting a **script** is in-model only subject to the §9 ruling: if the
-    deployment allows scripting to the principal, server-side code execution is by-design. *(documented)*
+    deployment allows scripting to the principal, server-side code execution is by-design.
   - A finding in the **Gremlin parser / traversal machine / deserializers** reachable from a
     client operating within its privileges (or pre-auth) is **in-model** for memory-safety / bounded-
-    resource robustness. *(maintainer)*
+    resource robustness.
   - A finding requiring control of `gremlin-server.yaml` or host access is **out-of-model: trusted-input**.
-    *(maintainer)*
 
 ## §5 Assumptions about the environment
 
 - **Runtime:** JVM (server, core, groovy, driver). The GLVs run on their respective runtimes
-  (CPython, .NET, Go, Node). *(documented — README / build)*
+  (CPython, .NET, Go, Node).
 - **Deployment:** Gremlin Server is safe enough to run on the public internet **once hardened** beyond the
   shipped `gremlin-server.yaml`, at minimum with TLS plus an authenticator (either built-in mechanism
   suffices over TLS). The insecure getting-started default is a testing convenience, not a supported
   production posture. Realistically, a production deployment also layers a provider's
   `Authenticator`/`Authorizer` on top (no authorizer ships, see §5a), so auth/authz is a **shared
   responsibility**. The provider supplies the policy (the plugin implementations), while Gremlin Server owns
-  the enforcement machinery that runs them on every request (§8). *(maintainer)*
+  the enforcement machinery that runs them on every request (§8).
 - **Filesystem:** the graph data / config directories are private to the server process and not writable by
   untrusted local users. Securing the host is the operator's responsibility, and an attacker who can write
-  them already has the operator's authority (§3). *(maintainer)*
+  them already has the operator's authority (§3).
 - **Concurrency:** the standard request path is isolated per request (thread-pool dispatch, per-request
   script bindings), so one request should not affect another. Transactions are the deliberate stateful
-  exception (§11b). *(maintainer)*
+  exception (§11b).
 - **What the server does to its host** (negative inventory): listens on network ports; reads/writes its
   configured graph + data directories; reads config; **executes supplied Groovy when script requests are
-  enabled** *(documented — script evaluation, `gremlin-applications.asciidoc`)*; loads provider graph
-  implementations the operator configured. *(maintainer)*
+  enabled**; loads provider graph
+  implementations the operator configured.
 
 ## §5a Build-time and configuration variants
 
@@ -245,7 +229,7 @@ Knobs that change which security properties hold (Gremlin Server, `gremlin-serve
   `gremlin-applications.asciidoc` "Authorization")*
 - **TLS/SSL** — configurable on the server connector, **off by default** (`ssl.enabled: false` in the
   shipped `gremlin-server.yaml`, enabled only in `gremlin-server-secure.yaml`). Drives the
-  transport-confidentiality property (§9). *(documented)*
+  transport-confidentiality property (§9).
 - **Audit logging** — `enableAuditLog` records the authenticated user, remote address, and gremlin query.
   It is **off by default** (`false`, "for privacy reasons") and absent from the shipped config, so a default
   deployment keeps no attribution record (§9). *(documented — `gremlin-applications.asciidoc` config table;
@@ -300,7 +284,7 @@ Per-surface trust table:
   `OutOfMemoryError`. The operator mitigates by bounding `classMapCacheSpecification` and preferring
   parameterized scripts (the Q7 resource split, a documented remote DoS unless bounded). The default
   `GremlinLangScriptEngine` instead caches parsed traversals, off by default and bounded when enabled, so it
-  carries no such growth. *(documented — `gremlin-applications.asciidoc` "Cache Management")*
+  carries no such growth.
 
 ## §7 Adversary model
 
@@ -309,15 +293,15 @@ Per-surface trust table:
   off / pre-auth) or **authenticated with limited privileges**, trying to execute code on the server (via
   scripts), read/write graph data outside its intent, crash or exhaust the server with malformed requests or
   expensive traversals, or exploit a deserializer. *Capabilities:* can open connections, send arbitrary
-  HTTP requests / scripts / serialized payloads, and supply large/malformed input. *(maintainer)*
+  HTTP requests / scripts / serialized payloads, and supply large/malformed input.
 - **Server → client:** a malicious or compromised server, or a network attacker on the wire when TLS is off,
   targeting a GLV through the response it returns: crafted response bytes to crash/OOM/RCE the client, or
-  harvesting the credentials the client sends in its request (§8/§9). *(maintainer)*
+  harvesting the credentials the client sends in its request (§8/§9).
 - **Untrusted input → embedded:** in the embedded environment there is no network client, but untrusted data
   can still reach an in-process `gremlin-core` primitive through the calling application — an `io()` reader
   fed an untrusted file, the `gremlin-language` parser fed an untrusted string, or an expensive step fed a
   crafted argument. The relevant robustness properties (§8) apply identically, since they attach to the
-  primitive, not the environment (§2/§6). *(maintainer)*
+  primitive, not the environment (§2/§6).
 - **Out of scope:** anyone with operator/host/config control (already authoritative). Also an attacker who
   reaches a server left on the **insecure getting-started default** (no TLS, no auth), which is an operator
   hardening failure (§9/§10), not a code bug, though the pre-auth robustness properties (§8) still apply to
@@ -347,12 +331,12 @@ Per-surface trust table:
   configured restriction **only when an `Authorizer` denies its removal or modification**, because the
   Gremlin language itself lets a request remove strategies via `withoutStrategies()` (§9). This is the §8
   anchor for the "bypasses a *configured* restriction" rulings in §9/§11a. *Violation symptom:* auth/authz bypass, or a request evading a
-  configured restriction. *Severity:* security-critical. *(maintainer)*
+  configured restriction. *Severity:* security-critical.
 - **Credential-store handling (when the built-in mechanism is used).** Where a deployment uses
   `SimpleAuthenticator` with the credentials graph, passwords are stored and verified as BCrypt hashes,
   never as plaintext. A provider's own `Authenticator` and credential store are the provider's (§3).
   *Violation symptom:* plaintext credential storage, or disclosure of stored credential material to a
-  client. *Severity:* high. *(documented — `SimpleAuthenticator`, credentials DSL)*
+  client. *Severity:* high.
 - **Memory / availability safety on the request + deserialization surface.** Malformed or pre-auth input
   (HTTP messages, Gremlin strings, serialized payloads) yields a clean error, not a crash, OOM, hang, or
   unbounded allocation of the server. This covers not just the request body but the **HTTP transport layer
@@ -360,11 +344,11 @@ Per-surface trust table:
   safely however its request line, headers, chunked/streamed body, or keep-alive connection sequence is
   crafted, with no path to access or DoS the server. *Violation symptom:* server crash / unbounded
   allocation / deadlock from a malformed or pre-auth request, or a crafted HTTP message or request sequence.
-  *Severity:* security-critical (remote DoS) if pre-auth. *(maintainer)*
+  *Severity:* security-critical (remote DoS) if pre-auth.
 - **Request isolation.** One request's bindings and state must not leak into or alter another's
   (per-request bindings, thread-pool dispatch, §5). Transactions are the deliberate stateful exception
   (§11b). *Violation symptom:* cross-request state leakage or interference. *Severity:*
-  security-critical. *(maintainer)*
+  security-critical.
 - **Parser integrity (`gremlin-language`).** A crafted Gremlin string cannot break out of a string literal
   to inject additional traversal steps. This is the safe string-to-traversal path, distinct from building a
   Groovy string by concatenation, which is the calling application's concern (§9). The same holds for the
@@ -373,7 +357,7 @@ Per-surface trust table:
   crash/hang/OOM on malformed GQL) and integrity (no breakout into the enclosing traversal) are in-model. A provider that does
   not register a declarative-match strategy leaves the step non-executable (§3). *Violation symptom:*
   grammar breakout / step injection from a value that should stay a literal. *Severity:* critical.
-  *(maintainer)*
+ 
 - **Deserializer integrity.** The wire deserializer (GraphBinary), GraphSON and **Gryo in its locked default
   (`registrationRequired=true`)** reading attacker bytes do not lead to arbitrary object instantiation / code
   execution beyond the registered type set. Because `inject()` and value arguments let a request carry any
@@ -382,7 +366,6 @@ Per-surface trust table:
   external entities and DTDs by default (XXE-safe). *Violation symptom:* deserialization gadget / RCE / XXE,
   or a registered-type serializer crashing/OOMing either end. *Severity:* critical. Gryo is not on the wire,
   and unlocked Gryo or a caller-supplied unhardened XML factory is out-of-model (user responsibility, §9).
-  *(documented)*
 - **Provider Defined Type (PDT) hydration.** Wire (de)serialization of the PDT holder is a registered type
   like any other (TinkerPop, above). Turning it into a typed object via a `PDTRegistry` adapter is **opt-in,
   off by default** (added by the operator server-side, the user client-side). The registered types and their
@@ -395,16 +378,16 @@ Per-surface trust table:
   (above). Ordinary expensive traversals / large results are **operator capacity**, NOT in-model, unless a
   specific bug applies (super-linear amplification, a missing-where-expected limit, an unbounded traversal).
   A grammatically valid string the parser accepts must not itself enable DoS from small input, e.g. ReDoS via
-  a pathological `regex` pattern, which is the in-model amplification case. *(maintainer)*
+  a pathological `regex` pattern, which is the in-model amplification case.
 - **Client (GLV) robustness against hostile server responses.** A GLV deserializing response bytes from a
   malicious/compromised server (or a MITM) does not crash/OOM/execute code. *Violation symptom:* client
-  crash/OOM/RCE from crafted responses. *Severity:* critical. *(maintainer)*
+  crash/OOM/RCE from crafted responses. *Severity:* critical.
 - **No pass-through string can harm the GLV.** Outbound request construction is otherwise not a surface,
   because its input is the trusted calling application. This property covers only the pass-through case: an
   application forwarding an untrusted end-user string verbatim (e.g. `client.submit(userString)`) must not
   cause code execution, a crash, a hang, or resource exhaustion **in the GLV itself**. Its *server-side*
   effect is Gremlin-injection, the application's responsibility (§9). *Violation symptom:* a submitted
-  string that harms the GLV that submitted it. *Severity:* high. *(maintainer)*
+  string that harms the GLV that submitted it. *Severity:* high.
 
 ## §9 Security properties the project does *not* provide
 
@@ -418,7 +401,7 @@ Per-surface trust table:
   Enabling `gremlin-groovy` is a non-default operator choice. Restricting it (allow-list, sandbox) or
   keeping the default Groovy-free engine, and authenticating who may script, is the operator's job. A scan
   reporting "Gremlin Server allows arbitrary code execution via scripts" is by-design unless it bypasses a
-  *configured* restriction. *(documented — `gremlin-applications.asciidoc` "Protecting Script Execution")*
+  *configured* restriction.
 - **No transport confidentiality/integrity unless TLS is enabled.** TLS is off in the shipped default (see
   §5a). Until the operator enables it, the server does not defend against a network attacker reading or
   modifying client traffic. On the client side, a GLV sends its credentials with the request, so without TLS
@@ -427,21 +410,21 @@ Per-surface trust table:
   default)*
 - **No authentication or authorization by default (assumed).** If the shipped/default configuration runs
   with auth off, an exposed server is reachable by anyone on the network. This is an operator deployment
-  concern, not a code bug. *(documented)*
+  concern, not a code bug.
 - **No attribution/audit by default.** Audit logging is off by default (§5a), so a default deployment keeps
   no record of who ran which query. Enabling it (`enableAuditLog`) is the operator's responsibility (§10).
-  *(documented)*
+ 
 - **No built-in data-access control.** There is no element-level (CRUD) authorization on graph data.
   Access is bounded only by which traversal sources the operator exposes and by a provider-supplied
   `Authorizer` (which does not ship, §5a). A client within its grants can read/write/delete any data the
-  exposed traversal source reaches. *(documented — no authorizer ships, authz is traversal-source/step-level)*
+  exposed traversal source reaches.
 - **Gryo / Kryo deserializer integrity holds only under the locked default.** Gryo defaults to a registration
   allow-list (`registrationRequired=true`), so it is not an arbitrary-instantiation sink, and a break within
   that locked config is a `VALID` bug like any deserializer. **Running Gryo unlocked
   (`registrationRequired=false`) is not a safe boundary against untrusted bytes and is the user's
   responsibility.** (A few registered types use Java native serialization, a gadget caveat even when locked.)
   Gryo is not on the wire, so this is an IO/file-surface concern (`io()` step, persistence, OLAP).
-  *(documented)*
+ 
 - **A `TraversalStrategy` is not an access-control boundary on its own.** The Gremlin language lets any
   request remove or replace strategies on its traversal source (`withoutStrategies()`,
   `withStrategies()`), so a strategy applied by the operator only restricts a client when an `Authorizer`
@@ -449,48 +432,44 @@ Per-surface trust table:
   traversal layer, not the storage layer (§5a). *(documented — Gremlin grammar `withoutStrategies`;
   `gremlin-applications.asciidoc` "Authorization")*
 - **Ordinary resource exhaustion is not a defended property.** Expensive traversals / large results that
-  consume CPU/memory are an operator capacity concern unless a specific bug applies (§8). *(maintainer)*
-- **No defense against a malicious operator / host.** *(maintainer)*
+  consume CPU/memory are an operator capacity concern unless a specific bug applies (§8).
+- **No defense against a malicious operator / host.**
 - **False friends:**
-  - "Authentication is available" does **not** mean it is **on**. It must be configured (§5a). *(maintainer)*
+  - "Authentication is available" does **not** mean it is **on**. It must be configured (§5a).
   - **A safe-language script is not a sandbox for the calling application's own injection.** Injection/abuse
     via a calling application that builds a Gremlin string by concatenating its own untrusted input is the
     calling application's responsibility. Note this is distinct from a `gremlin-language` parser breakout,
-    which is an in-model TinkerPop bug (§8). *(maintainer)*
+    which is an in-model TinkerPop bug (§8).
   - "Gremlin is just a query language" is misleading. The **string** form can run through a Groovy engine, so
-    it is code, not a constrained query. *(maintainer)*
+    it is code, not a constrained query.
 
 ## §10 Downstream responsibilities (operator/deployer)
 
 - Do **not** deploy the shipped getting-started `gremlin-server.yaml` as-is. Before exposing Gremlin Server
   on a public/untrusted network, harden it: enable TLS and an authenticator, and (given no authorizer ships)
-  supply an `Authorizer`, especially if scripting is enabled. *(maintainer)*
+  supply an `Authorizer`, especially if scripting is enabled.
 - Enable authentication (`Authenticator`) and authorization (`Authorizer`) for any non-trivial deployment.
-  *(documented)*
 - **Restrict script execution:** prefer the default Groovy-free `GremlinLangScriptEngine`, which evaluates
   only Gremlin. If `gremlin-groovy` is needed, apply the "Protecting Script Execution" controls (sandbox /
-  compilation customizers / allow-list) and restrict who may submit scripts. *(documented)*
-- Enable TLS (off by default) where traffic crosses an untrusted segment. *(documented)*
-- Scope `cors.allowedOrigins` to specific origins for browser-facing deployments (defaults to `["*"]`). *(documented)*
-- Enable audit logging (`enableAuditLog`, off by default) where attribution of requests is needed. *(documented)*
+  compilation customizers / allow-list) and restrict who may submit scripts.
+- Enable TLS (off by default) where traffic crosses an untrusted segment.
+- Scope `cors.allowedOrigins` to specific origins for browser-facing deployments (defaults to `["*"]`).
+- Enable audit logging (`enableAuditLog`, off by default) where attribution of requests is needed.
 - Use the wire serializers (GraphBinary recommended for drivers). Keep Gryo locked
-  (`registrationRequired=true`), and do not read untrusted files through **unlocked** Gryo. *(documented)*
+  (`registrationRequired=true`), and do not read untrusted files through **unlocked** Gryo.
 - Apply per-request resource limits (`evaluationTimeout`, `maxRequestContentLength`, etc.) appropriate to capacity.
-  *(documented)*
-- Set filesystem permissions so only the server user can read the config / data directories. *(maintainer)*
+- Set filesystem permissions so only the server user can read the config / data directories.
 
 ## §11 Known misuse patterns
 
 *(Draft one-liners, expand before publishing.)*
 
 - Exposing the shipped getting-started default (no TLS, no auth) on an untrusted network instead of
-  hardening it first, especially with scripting enabled. *(maintainer)*
+  hardening it first, especially with scripting enabled.
 - Treating the script-engine sandbox as a complete RCE boundary rather than restricting who may script.
-  *(maintainer)*
 - Building Gremlin by concatenating the calling application's untrusted input into a Groovy string
   (Gremlin-injection). This is distinct from a `gremlin-language` parser breakout, which is in-model (§8).
-  *(maintainer)*
-- Reading untrusted files through **unlocked** Gryo (`registrationRequired=false`). *(documented)*
+- Reading untrusted files through **unlocked** Gryo (`registrationRequired=false`).
 
 ## §11a Known non-findings (recurring false positives)
 
@@ -498,30 +477,30 @@ Per-surface trust table:
 
 - "Gremlin Server executes arbitrary code via scripts" — by-design when scripting is enabled for the
   principal (§9), and not a finding unless it bypasses a *configured* restriction. Disposition:
-  `BY-DESIGN: property-disclaimed`. *(documented)*
+  `BY-DESIGN: property-disclaimed`.
 - "String lambdas enable code execution" — a string lambda is server-side code like any script, so this is
   by-design when a code-capable engine is configured (§9), and not a finding unless it bypasses a
-  *configured* restriction. Disposition: `BY-DESIGN: property-disclaimed`. *(documented)*
+  *configured* restriction. Disposition: `BY-DESIGN: property-disclaimed`.
 - "No authentication / no TLS by default" — operator deployment responsibility (§9/§10), not a code bug in
-  itself. Disposition: `BY-DESIGN: property-disclaimed`. *(documented)*
+  itself. Disposition: `BY-DESIGN: property-disclaimed`.
 - "Gryo/Kryo deserialization can be exploited" — Gryo is not on the wire, so a request-path report is
   factually mistaken and needs no disposition (§13). Under the locked default
   (`registrationRequired=true`) a real break is `VALID`, whereas exploiting **unlocked** Gryo on
   untrusted files is the user's responsibility (§9/§10). Disposition for the unlocked-file variant:
-  `BY-DESIGN: property-disclaimed`. *(documented)*
+  `BY-DESIGN: property-disclaimed`.
 - "Expensive traversal consumes CPU/memory" — operator capacity concern, unless a specific bug applies
-  (§8/§9). Disposition: `BY-DESIGN: property-disclaimed`. *(maintainer)*
+  (§8/§9). Disposition: `BY-DESIGN: property-disclaimed`.
 - "A configured `ReadOnlyStrategy` / `SubgraphStrategy` / `PartitionStrategy` was bypassed" — whether by
   removing the strategy via `withoutStrategies()` or by stepping around it (direct `Vertex.property()`,
   `mergeV`/`mergeE`), a strategy is not an access-control boundary on its own (§9). A finding only exists
   where a configured `Authorizer` pins the strategy and the pin is evaded (§8). Disposition:
-  `BY-DESIGN: property-disclaimed`. *(documented)*
+  `BY-DESIGN: property-disclaimed`.
 - "Calling application concatenates untrusted input into a Groovy string (Gremlin-injection)" — the calling
   application's responsibility (§9). A `gremlin-language` parser breakout is the opposite: an in-model
-  TinkerPop bug (§8). Disposition: `BY-DESIGN: property-disclaimed`. *(maintainer)*
+  TinkerPop bug (§8). Disposition: `BY-DESIGN: property-disclaimed`.
 - Findings in any test-only module, any module containing examples, or build tooling (e.g. `gremlin-test`,
   `gremlin-examples`, `gremlin-tools`) — out of scope (§3). Disposition:
-  `OUT-OF-MODEL: unsupported-component`. *(maintainer)*
+  `OUT-OF-MODEL: unsupported-component`.
 
 ## §11b Known problems
 
@@ -530,7 +509,7 @@ Per-surface trust table:
 - **Transactions can be shared.** A transaction is identified by a server-generated UUID and looked up with
   **no owning-user check**, so any client presenting a valid id accesses that transaction's state. The default
   server provides no per-user isolation, and this is accepted as how Gremlin Server works. A deployment
-  needing isolation must use a provider that adds it. *(documented)*
+  needing isolation must use a provider that adds it.
 
 ## §12 Conditions that would change this model
 
@@ -573,84 +552,3 @@ rules on top of it.
 | `BY-DESIGN: property-disclaimed` | The behavior is exactly what §9 says TinkerPop does not defend against: scripts executing code within what the deployment allows, the shipped no-TLS/no-auth default, ordinary resource exhaustion from expensive queries, reading untrusted files through unlocked Gryo, or an application building queries out of its own users' raw input. The software works as documented. When the scenario needs the operator's own access, `trusted-input` applies instead. | §9 |
 | `KNOWN-PROBLEM` | Matches the acknowledged weakness in §11b (transaction sharing), which the §8 enforcement property explicitly excepts. Already known and accepted, not a new finding. A deployment that needs the missing protection must use a provider that adds it. | §11b |
 | `MODEL-GAP` | Fits no row, or more than one. That is a defect in the model itself, and §12 requires revising it. | §12 |
-
-## §14 Open questions for the maintainers
-
-1. **Deployment posture.** ~~Is "Gremlin Server inside a trusted network, behind the app tier, not directly
-   public" the right §2/§5 framing?~~ **RESOLVED (maintainer):** Gremlin Server *is* intended to be
-   deployable on the public internet, but only after hardening beyond the shipped getting-started
-   `gremlin-server.yaml`, meaning TLS plus an authenticator (either built-in mechanism is adequate over TLS).
-   Reaching a server left on the insecure default is an operator hardening failure (`OUT-OF-MODEL`), not
-   evidence of a trusted-network assumption. Auth/authz is a shared responsibility. Providers typically
-   supply the `Authenticator`/`Authorizer` policy (no authorizer ships), while Gremlin Server owns the
-   enforcement machinery (§2/§5/§5a/§7/§8/§10).
-2. **Default auth/authz posture.** ~~Do the shipped/default Gremlin Server configs run with authentication
-   and authorization **off**?~~ **RESOLVED (documented):** yes. `gremlin-server.yaml` has no
-   `authentication` block (default `AllowAllAuthenticator`) and ships no authorizer. The docs state "Gremlin
-   Server is configured to allow all requests to be processed (i.e. no authentication)" and "not shipped
-   with `Authorizer` implementations" (`gremlin-applications.asciidoc` "Security"). Reaching a server left
-   on that default is an operator hardening failure (`OUT-OF-MODEL`), not a code bug (per §14 Q1). The
-   framework's duty to *run* a configured authenticator/authorizer remains an in-model §8 property.
-3. **Provider boundary.** ~~Confirm that vulnerabilities in third-party provider graph databases route to
-   those providers.~~ **RESOLVED (maintainer):** the boundary is drawn by **what code the defect reproduces
-   in**, not where it runs. Unmodified TinkerPop **reference code** (`gremlin-core`, `gremlin-server`, the
-   reference graph, serializers) is in-model even when running as part of a provider's product. A defect
-   requiring the **provider's own code or their modifications** routes to the provider. This includes a
-   **remote graph provider** that shares no TinkerPop code and only conforms to the HTTP API +
-   serializer specs. A defect reproducible only under a **mix** of the two is `MODEL-GAP` (joint
-   determination, not silently the provider's). Triage test: *does it reproduce on the unmodified reference
-   distribution?* (§3).
-4. **Script execution (highest-stakes).** ~~Confirm that string-script evaluation = server-side code
-   execution by design, that restricting it (sandbox / allow-list / who-may-script) is the operator's
-   responsibility, and what restriction (if any) is **on by default**. Is "Gremlin Server runs arbitrary
-   code via scripts" `BY-DESIGN` unless a *configured* restriction is bypassed?~~ **RESOLVED
-   (documented):** yes, by-design when a code-capable engine (`gremlin-groovy`) is configured. The shipped
-   default is the Gremlin-only `GremlinLangScriptEngine`, which evaluates no arbitrary code (§4/§5a/§9/§10/§11a).
-5. **TLS default.** ~~Is TLS **off by default** on the server connector? Is no-TLS-by-default an operator
-   responsibility (§9/§10)?~~ **RESOLVED (documented):** yes, `ssl.enabled: false` in the shipped
-   `gremlin-server.yaml`, and the operator enables it (§3/§5a/§9/§10).
-6. **Serialization / Gryo.** ~~Which serializers are registered by default?~~ **RESOLVED (documented):** the
-   server wire set is GraphSON + GraphBinary, while GLV clients default to (and now ship only) GraphBinary. Gryo is
-   IO-format-only (not on the wire) and defaults to a locked
-   registration allow-list (`registrationRequired=true`). A Gryo request-path report is a non-finding. A
-   flaw in a wire serializer or in **locked** Gryo is `VALID`, whereas **unlocked** Gryo on untrusted files
-   is the user's responsibility (§2/§4/§5a/§6/§8/§9/§10/§11a).
-7. **Resource line.** ~~Confirm the split, and whether built-in per-request limits exist.~~ **RESOLVED:**
-   split confirmed *(maintainer)*. Malformed/pre-auth crash/OOM/hang is `VALID`. Ordinary expensive
-   traversals / large results are operator capacity unless a specific bug applies (super-linear
-   amplification, missing-where-expected limit, unbounded traversal/recursion). Built-in per-request limits
-   exist (`evaluationTimeout`, `maxRequestContentLength`, `maxParameters`, `maxWorkQueueSize`, plus
-   transaction bounds `idleTransactionTimeout`/`maxTransactionLifetime`/`maxConcurrentTransactions`),
-   with **no** traversal-depth or result-count cap *(documented)* (§6/§8/§9/§10/§11a).
-8. **Parser robustness.** ~~Confirm parser memory-safety against malformed input is a committed
-   property.~~ **RESOLVED (maintainer):** yes, the `gremlin-language` parser must not
-   crash/hang/OOM on **malformed input**, and a crafted string must not break out of a literal to inject
-   steps (`VALID`, §8). This covers parsing robustness and integrity. The *execution* cost of a well-formed
-   query is the Q7 capacity split, where an accidental/amplified OOM from a small query is in-model but a
-   legitimately huge query is operator capacity. Injection via Groovy string-concatenation in the calling
-   application is out-of-model (§9/§11a).
-9. **GLV scope.** ~~Are the GLVs in scope, or deferred?~~ **RESOLVED (maintainer):** all GLVs (Java
-   `gremlin-driver` included, since it is the Java GLV) are in scope. The in-model client surface is
-   **response-deserialization robustness against a malicious/compromised server or MITM, plus TLS cert
-   validation** (§8). Outbound request/message construction is **not** a surface, because its input is the
-   trusted calling application. Feeding untrusted end-user input into a traversal/script is Gremlin-injection
-   and the calling application's responsibility (§9/§11a). Sending bad bytes *to* the server folds into the
-   server's §8 request-robustness (§2/§6/§8).
-10. **OLAP scope.** ~~Are `hadoop-gremlin` / `spark-gremlin` in scope, or operator infra?~~ **RESOLVED
-    (maintainer):** OLAP is **in-model as TinkerPop reference code**, covering the `gremlin-core`/`tinkergraph`
-    computer *and* the `hadoop-gremlin`/`spark-gremlin` reference modules (per the Q3 reference-code rule),
-    reachable remotely when the operator configures an OLAP-capable graph. Only the **third-party Hadoop/Spark
-    runtime and the cluster deployment/config** are out-of-model (§3). The Gryo untrusted-file risk on this IO
-    surface stays as in Q6 (§2/§3/§6).
-11. **§11a seeds.** Generalized the test/example/tooling non-finding to a **category** (any test-only or
-    example module, not a fixed name list). Remains a **standing invitation** for the PMC to append further
-    recurring false-positives (§11a).
-12. **Canonical location.** ~~Confirm this model lives as root `THREAT_MODEL.md`, referenced from
-    `SECURITY.md`, wired from `AGENTS.md`.~~ **RESOLVED (documented):** verified. Root `THREAT_MODEL.md`,
-    referenced from `SECURITY.md`, which is wired from `AGENTS.md`.
-
-## §15 Machine-readable companion
-
-Deferred for v0. A `threat-model.yaml` can later encode the §6 trust table, §2/§3 component scoping, §8
-property/severity/symptom rows, §9 false friends, §11a non-findings, and §13 dispositions for automated
-triage.


### PR DESCRIPTION
Adds a draft `THREAT_MODEL.md` for Apache TinkerPop, a `SECURITY.md` pointing to it, and a `## Security` section in `AGENTS.md`, so automated security scanners (and researchers) can mechanically discover the project's threat model via the `AGENTS.md` -> `SECURITY.md` -> `THREAT_MODEL.md` chain.

The threat model is a **v0 draft authored by the ASF Security team** for the PMC to own and refine. It follows a standard rubric (scope, trust boundaries, adversary model, security properties provided / not provided, downstream responsibilities, known non-findings, triage dispositions). Every claim carries a provenance tag — `*(documented)*` / `*(inferred)*` / `*(maintainer)*` — and **every `*(inferred)*` claim routes to a numbered question in §14** for the PMC to confirm, correct, or strike. The highest-value items to confirm: the default authentication/TLS posture, the script-execution disposition (string scripts run through the Groovy engine), and the Gryo/serialization handling.

`THREAT_MODEL.md` and `SECURITY.md` carry the ASF license header; `AGENTS.md` is RAT-excluded. No code or behaviour changes — documentation only.

This is a proposal for the PMC to review — please adjust, correct, or reject as needed.