### PR TITLE
fix(gremlin-js): bump uuid ^9.0.1 → ^11.1.1 to fix GHSA-w5hq-g745-h8pq

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/package-lock.json
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/package-lock.json
@@ -12,7 +12,7 @@
         "buffer": "^6.0.3",
         "eventemitter3": "^5.0.1",
         "readable-stream": "^4.5.2",
-        "uuid": "^9.0.1",
+        "uuid": "^11.1.1",
         "ws": "^8.16.0"
       },
       "devDependencies": {
@@ -3366,15 +3366,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/package.json
@@ -17,7 +17,7 @@
     "buffer": "^6.0.3",
     "eventemitter3": "^5.0.1",
     "readable-stream": "^4.5.2",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.1",
     "ws": "^8.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Bumps the `uuid` dependency in `gremlin-javascript` from `^9.0.1` to `^11.1.1`.

## Why

`uuid < 11.1.1` is affected by [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) — a missing buffer bounds check in `v3`/`v5`/`v6` UUID generation when a user-supplied `buf` argument is provided. The advisory is rated **moderate** severity.

## Change

```diff
- "uuid": "^9.0.1"
+ "uuid": "^11.1.1"
```

`package-lock.json` updated accordingly. No other changes.