### PR TITLE
TINKERPOP-3243 Add next(n) batch iteration to gremlin-javascript

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.7.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Added `NextN(n)` to `Traversal` in `gremlin-go` for batched result iteration, providing API parity with `next(n)` in the Java, Python, and .NET GLVs.
+* Added `next(n)` to `Traversal` in `gremlin-javascript` for batched result iteration, providing API parity with `next(n)` in the Java, Python, and .NET GLVs.
 * Fixed conjoin has incorrect null handling.
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 * Add Node 26 support for `gremlin-javascript` and `gremlint`.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -1536,6 +1536,9 @@ Given that I/O operations in Node.js are asynchronous by default, <<terminal-ste
 * `Traversal.toList()`: Returns a `Promise` with an `Array` as result value.
 * `Traversal.next()`: Returns a `Promise` with a `{ value, done }` tuple as result value, according to the
 link:https://github.com/tc39/proposal-async-iteration[async iterator proposal].
+* `Traversal.next(amount)`: Returns a `Promise` with an `Array` of up to `amount` result values, the batched form
+of `next(n)` available in the other GLVs. The `Array` is always returned when an `amount` is supplied, so `next(1)`
+resolves to an `Array` of one value, and an `amount` of zero or less resolves to an empty `Array`.
 * `Traversal.iterate()`: Returns a `Promise` without a value.
 
 For example:

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/traversal.js
@@ -94,12 +94,35 @@ class Traversal {
   }
 
   /**
-   * Async iterator method implementation.
-   * Returns a promise containing an iterator item.
-   * @returns {Promise.<{value, done}>}
+   * Returns the next result from the traversal.
+   *
+   * When called without an argument, returns a Promise that resolves to an iterator
+   * item ({value, done}), following the async iterator protocol.
+   *
+   * When called with an amount, returns a Promise that resolves to an Array containing
+   * up to {@code amount} result values. The Array form is always used when an amount is
+   * supplied, including {@code next(1)}, which resolves to an Array of one value rather
+   * than a bare value, matching the behavior of next(n) in the other Gremlin language
+   * variants. If fewer results remain, the Array contains only those that remain, and an
+   * amount of zero or less yields an empty Array.
+   * @param {Number} [amount] The number of results to retrieve.
+   * @returns {Promise.<{value, done}>|Promise.<Array>}
    */
-  next() {
-    return this._applyStrategies().then(() => this._getNext());
+  next(amount) {
+    if (amount === undefined || amount === null) {
+      return this._applyStrategies().then(() => this._getNext());
+    }
+    return this._applyStrategies().then(() => {
+      const result = [];
+      for (let i = 0; i < amount; i++) {
+        const it = this._getNext();
+        if (it.done) {
+          break;
+        }
+        result.push(it.value);
+      }
+      return result;
+    });
   }
 
   /**

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
@@ -129,6 +129,26 @@ describe('Traversal', function () {
         });
     });
   });
+  describe('#next(amount)', function () {
+    it('should submit the traversal and return a batch of up to amount results', function () {
+      var g = traversal().withRemote(connection);
+      var t = g.V();
+      return t.next(2)
+        .then(function (batch) {
+          assert.ok(Array.isArray(batch));
+          assert.strictEqual(batch.length, 2);
+          batch.forEach(v => assert.ok(v instanceof Vertex));
+          return t.next(10);
+        }).then(function (batch) {
+          // gmodern has 6 vertices, 2 already consumed, so only 4 remain
+          assert.strictEqual(batch.length, 4);
+          batch.forEach(v => assert.ok(v instanceof Vertex));
+          return t.next(2);
+        }).then(function (batch) {
+          assert.deepStrictEqual(batch, []);
+        });
+    });
+  });
   describe('#materializeProperties()', function () {
     it('should skip vertex properties when tokens is set', function () {
       var g = traversal().withRemote(connection);

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
@@ -157,6 +157,75 @@ describe('Traversal', function () {
     });
   });
 
+  describe('#next(amount)', function () {
+    function createTraversal(traversers) {
+      const strategyMock = {
+        apply: function (traversal) {
+          traversal.traversers = traversers;
+          return Promise.resolve();
+        }
+      };
+      const strategies = new TraversalStrategies();
+      strategies.addStrategy(strategyMock);
+      return new t.Traversal(null, strategies, null);
+    }
+
+    it('should return a Promise with an array of up to amount values', function () {
+      const traversal = createTraversal([ new t.Traverser(1, 1), new t.Traverser(2, 1), new t.Traverser(3, 1) ]);
+      return traversal.next(2)
+        .then(function (batch) {
+          assert.deepStrictEqual(batch, [ 1, 2 ]);
+          return traversal.next(2);
+        })
+        .then(function (batch) {
+          assert.deepStrictEqual(batch, [ 3 ]);
+        });
+    });
+
+    it('should return an array of one when amount is one', function () {
+      const traversal = createTraversal([ new t.Traverser(1, 1), new t.Traverser(2, 1) ]);
+      return traversal.next(1).then(function (batch) {
+        assert.deepStrictEqual(batch, [ 1 ]);
+      });
+    });
+
+    it('should expand bulk into separate values', function () {
+      const traversal = createTraversal([ new t.Traverser(1, 2), new t.Traverser(2, 1) ]);
+      return traversal.next(2).then(function (batch) {
+        assert.deepStrictEqual(batch, [ 1, 1 ]);
+      });
+    });
+
+    it('should return only the remaining values when fewer than amount exist', function () {
+      const traversal = createTraversal([ new t.Traverser(1, 1), new t.Traverser(2, 1) ]);
+      return traversal.next(5).then(function (batch) {
+        assert.deepStrictEqual(batch, [ 1, 2 ]);
+      });
+    });
+
+    it('should return an empty array when amount is zero', function () {
+      const traversal = createTraversal([ new t.Traverser(1, 1) ]);
+      return traversal.next(0).then(function (batch) {
+        assert.deepStrictEqual(batch, []);
+      });
+    });
+
+    it('should return an empty array when amount is negative', function () {
+      const traversal = createTraversal([ new t.Traverser(1, 1) ]);
+      return traversal.next(-1).then(function (batch) {
+        assert.deepStrictEqual(batch, []);
+      });
+    });
+
+    it('should still return an iterator item when called without an amount', function () {
+      const traversal = createTraversal([ new t.Traverser(1, 1) ]);
+      return traversal.next().then(function (item) {
+        assert.strictEqual(item.value, 1);
+        assert.strictEqual(item.done, false);
+      });
+    });
+  });
+
   if (Symbol.asyncIterator) {
     describe('@@asyncIterator', function () {
       it('should expose the async iterator', function () {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3243

Adds an overloaded next(amount) to Traversal that resolves to a Promise<Array> of up to `amount` result values, bringing gremlin-javascript to parity with next(n) in the Java, Python, .NET, and Go GLVs. 

VOTE +1