### PR TITLE
TINKERPOP-3179 Add WithComputer() to GraphTraversalSource in gremlin-go

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 3.7.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Added `NextN(n)` to `Traversal` in `gremlin-go` for batched result iteration, providing API parity with `next(n)` in the Java, Python, and .NET GLVs.
+* Added `WithComputer()` to `GraphTraversalSource` in `gremlin-go`, providing OLAP configuration parity with other language variants.
 * Fixed conjoin has incorrect null handling.
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 * Add Node 26 support for `gremlin-javascript` and `gremlint`.

--- a/gremlin-go/driver/cucumber/cucumberSteps_test.go
+++ b/gremlin-go/driver/cucumber/cucumberSteps_test.go
@@ -407,12 +407,9 @@ func (tg *tinkerPopGraph) chooseGraph(graphName string) error {
 		}
 	}
 
-	// TODO: Uncoment code here to use WithComputer once this is implemented.
-	// In this version strategies are not implemented (and therefore WithComputer also isn't implmented).
 	for _, tag := range tg.scenario.Tags {
 		if tag.Name == "@GraphComputerOnly" {
-			return godog.ErrPending
-			// tg.g.WithComputer()
+			tg.g = tg.g.WithComputer()
 		} else if tag.Name == "@AllowNullPropertyValues" {
 			// The GLV suite does not test against a graph that has null property values enabled, skipping via Pending Error
 			return godog.ErrPending

--- a/gremlin-go/driver/graphTraversalSource.go
+++ b/gremlin-go/driver/graphTraversalSource.go
@@ -142,6 +142,17 @@ func (gts *GraphTraversalSource) With(key interface{}, value interface{}) *Graph
 	return source
 }
 
+// WithComputer adds a GraphComputer to be used to process the Traversal as an OLAP job. It applies a
+// VertexProgramStrategy to the traversal source configured with the supplied options. Calling it with no
+// configuration submits the Traversal for OLAP execution using the server's default GraphComputer.
+func (gts *GraphTraversalSource) WithComputer(config ...VertexProgramStrategyConfig) *GraphTraversalSource {
+	var c VertexProgramStrategyConfig
+	if len(config) > 0 {
+		c = config[0]
+	}
+	return gts.WithStrategies(VertexProgramStrategy(c))
+}
+
 // WithRemote adds a remote to be used throughout the life of a spawned Traversal.
 func (gts *GraphTraversalSource) WithRemote(remoteConnection *DriverRemoteConnection) *GraphTraversalSource {
 	gts.remoteConnection = remoteConnection

--- a/gremlin-go/driver/graphTraversalSource_test.go
+++ b/gremlin-go/driver/graphTraversalSource_test.go
@@ -66,4 +66,39 @@ func TestGraphTraversalSource(t *testing.T) {
 			assert.Equal(t, map[string]interface{}{"foo": "not bar"}, config)
 		})
 	})
+
+	t.Run("GraphTraversalSource.WithComputer tests", func(t *testing.T) {
+		const vertexProgramStrategyName = "org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy"
+
+		t.Run("Test for no configuration", func(t *testing.T) {
+			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
+			source := g.WithComputer()
+			assert.NotNil(t, source)
+			assert.Equal(t, 1, len(source.bytecode.sourceInstructions))
+			instruction := source.bytecode.sourceInstructions[0]
+			assert.Equal(t, "withStrategies", instruction.operator)
+			strategy := instruction.arguments[0].(*traversalStrategy)
+			assert.Equal(t, vertexProgramStrategyName, strategy.name)
+			// An empty configuration causes the server to fall back to its default GraphComputer via instance().
+			assert.Equal(t, map[string]interface{}{}, strategy.configuration)
+		})
+
+		t.Run("Test for configured computer", func(t *testing.T) {
+			g := &GraphTraversalSource{graph: &Graph{}, bytecode: NewBytecode(nil), remoteConnection: nil}
+			source := g.WithComputer(VertexProgramStrategyConfig{
+				GraphComputer: "org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComputer",
+				Workers:       4,
+			})
+			assert.NotNil(t, source)
+			assert.Equal(t, 1, len(source.bytecode.sourceInstructions))
+			instruction := source.bytecode.sourceInstructions[0]
+			assert.Equal(t, "withStrategies", instruction.operator)
+			strategy := instruction.arguments[0].(*traversalStrategy)
+			assert.Equal(t, vertexProgramStrategyName, strategy.name)
+			assert.Equal(t, map[string]interface{}{
+				"graphComputer": "org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComputer",
+				"workers":       4,
+			}, strategy.configuration)
+		})
+	})
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-3179

Adds the `WithComputer()` source step to gremlin-go for OLAP configuration parity with the Java, Python, JavaScript, and .NET GLVs. It applies a VertexProgramStrategy to the traversal source, delegating to WithStrategies.

Enables the `@GraphComputerOnly` Gherkin scenarios in the Go cucumber suite, which previously returned godog.ErrPending, and adds unit coverage for the emitted bytecode.

VOTE +1