### PR TITLE
Partial Java 21/25 support for TinkerPop 3.8.x

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,6 +37,39 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -pl $EXCLUDE_MODULES -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk21:
+    name: mvn clean install - jdk21
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      # spark-gremlin is excluded because Spark 3.3.x does not run on Java 21: its off-heap Platform initializer
+      # reflects on the private DirectByteBuffer(long, int) constructor that JDK 21 removed. Java 21 support arrived
+      # in Spark 4.0 (SPARK-43831), which requires Java 17+ and Scala 2.13, so the 3.8 line cannot adopt it.
+      - name: Build with Maven
+        run: mvn clean install -pl $EXCLUDE_MODULES,-:spark-gremlin -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  java-jdk25:
+    name: mvn clean install - jdk25
+    timeout-minutes: 45
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+      # spark-gremlin is excluded because no Spark release TinkerPop can adopt yet supports Java 25 (Spark 4.x, which
+      # adds Java 25 support, requires Java 17+ and Scala 2.13). hadoop-gremlin runs on Java 25 as of Hadoop 3.4.3.
+      - name: Build with Maven
+        run: mvn clean install -pl $EXCLUDE_MODULES,-:spark-gremlin -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   java-jdk11:
     name: mvn clean install - jdk11
     timeout-minutes: 45

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,9 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 
 This release also includes changes from prior 3.7.x releases.
 
+* Enabled building and running with Java 21 and Java 25 (experimental; `spark-gremlin` excluded, as Spark 3.3.x only runs on Java 8 through 17).
+* Bumped to Groovy 4.0.32 which adds support for parsing Java 25 bytecode.
+* Bumped Hadoop to 3.4.3 (and Kerby to 2.0.3) to enable `hadoop-gremlin` to build and run on Java 25.
 * Add missing `Configuring` interface to `GraphStepPlaceholder` and `VertexStepPlaceholder`
 
 [[release-3-8-1]]

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -29,7 +29,10 @@ image:conspiracy.png[]
 == System Configuration
 
 At a minimum, development of TinkerPop requires link:https://openjdk.java.net/projects/jdk/11/[Java 11]. Since 3.7.0, you can also build with
-link:https://openjdk.org/projects/jdk/17/[Java 17]. Note, however, that there are some issues with deep reflection
+link:https://openjdk.org/projects/jdk/17/[Java 17]. Since 3.8.2, there is also experimental support for building and
+testing with link:https://openjdk.org/projects/jdk/21/[Java 21] and link:https://openjdk.org/projects/jdk/25/[Java 25],
+covering every module except `spark-gremlin` (the Spark version it uses only runs on Java 8 through 17).
+Note, however, that there are some issues with deep reflection
 so there are `--add-opens` JVM options included in the pom files to enable this to work. Maven (requiring a minimum of
 link:https://maven.apache.org/download.cgi[Maven 3.5.3+]) is used as the common build system, which even
 controls the builds of non-JVM link:https://tinkerpop.apache.org/docs/x.y.z/reference/#gremlin-drivers-variants[GLVs]

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -693,6 +693,7 @@ The following table outlines recommended runtime versions by the release in whic
 |3.6.0 | Java 8, 11
 |3.7.0 | Java 8, 11, 17
 |3.8.0 | Java 11, 17
+|3.8.2 | Java 11, 17 (experimental support for Java 21 and 25)
 |===
 
 [[gremlin-java-connecting]]

--- a/docs/src/upgrade/release-3.8.2.asciidoc
+++ b/docs/src/upgrade/release-3.8.2.asciidoc
@@ -22,3 +22,29 @@ under the License.
 
 Please see the link:https://github.com/apache/tinkerpop/blob/3.8.2/CHANGELOG.asciidoc#release-3-8-2[changelog] for a
 complete list of all the modifications that are part of this release.
+
+=== Upgrading for Users
+
+==== Experimental Support for JDK 21 and JDK 25
+
+TinkerPop can now be built and run with Java 21 and Java 25, in addition to the existing support for Java 11 and
+Java 17. This support is experimental: every module except `spark-gremlin` (see below) is built and tested with
+Java 21 and Java 25. Supporting Java 25 required an upgrade of Groovy to 4.0.32, which bundles a version of ASM that
+is able to parse Java 25 bytecode (class file version 69). The build's Java version enforcement was relaxed
+accordingly to permit Java 11 through Java 25.
+
+As is the case with Java 17, some libraries still rely on deep reflection (most notably the Kryo serialization library
+that is used with OLAP), so it may be necessary to `--add-opens` or `--add-exports` certain modules to run on Java 21
+or Java 25. The same set of options documented for JDK 17 applies to the newer JDKs and is used by TinkerPop's own
+automated tests.
+
+To support Java 25, Hadoop was upgraded from 3.3.3 to 3.4.3, which migrated off the removed Security Manager APIs (most
+notably `Subject.getSubject()`, which no longer functions on Java 25). As a result the `hadoop-gremlin` module now
+builds and runs on Java 21 and Java 25 as well.
+
+The `spark-gremlin` module is not supported on Java 21 or Java 25. Spark 3.3.x only runs on Java 8 through 17 — on
+Java 21 its off-heap memory support fails to initialize because JDK 21 removed the private `DirectByteBuffer(long, int)`
+constructor that it accesses reflectively. Java 21 support arrived in Spark 4.0 and Java 25 support in Spark 4.1, but
+those releases require Java 17 as a minimum and Scala 2.13, which would drop Java 11 support for that module.
+`spark-gremlin` therefore continues to target Spark 3.3.x and is built and tested with Java 11 and Java 17 only; it is
+excluded from the Java 21 and Java 25 builds.

--- a/gremlin-archetype/gremlin-archetype-dsl/src/main/resources/archetype-resources/pom.xml
+++ b/gremlin-archetype/gremlin-archetype-dsl/src/main/resources/archetype-resources/pom.xml
@@ -65,6 +65,19 @@ limitations under the License.
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
+                    <!--
+                    Explicitly declare the annotation processor path so that the GremlinDslProcessor runs. As of JDK 23,
+                    javac no longer runs annotation processors that are only discovered on the classpath unless they are
+                    requested explicitly, and the processor is required to generate the DSL classes (e.g.
+                    SocialTraversalSource).
+                    -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.apache.tinkerpop</groupId>
+                            <artifactId>gremlin-annotations</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/gremlin-console/src/main/bin/gremlin.sh
+++ b/gremlin-console/src/main/bin/gremlin.sh
@@ -108,9 +108,10 @@ if [ -n "$SCRIPT_DEBUG" ]; then
     set -x
 fi
 
-# Try to detect JDK version and add specific flag for JDK 17 to allow use of neo4j-gremlin
+# Try to detect the JDK major version and add specific flags for JDK 17 and newer to allow use of neo4j-gremlin
 JAVA_VERSION=$($JAVA -version 2>&1 | awk -F '"' '/version/ {print $2}')
-if [[ "$JAVA_VERSION" == 17* ]]; then
+JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION" | awk -F. '{if ($1 == 1) print $2; else print $1}')
+if [[ "$JAVA_MAJOR_VERSION" -ge 17 ]]; then
     JVM_OPTS+=( "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED" )
     JVM_OPTS+=( "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED" )
 fi

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategy.java
@@ -51,7 +51,7 @@ public final class LambdaRestrictionStrategy extends AbstractTraversalStrategy<T
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
         for (final Step<?, ?> step : traversal.getSteps()) {
-            if ((step instanceof LambdaHolder || step instanceof ComparatorHolder) && step.toString().contains("lambda"))
+            if ((step instanceof LambdaHolder || step instanceof ComparatorHolder) && step.toString().toLowerCase().contains("lambda"))
                 throw new VerificationException("The provided traversal contains a lambda step: " + step, traversal);
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/StringFactory.java
@@ -242,7 +242,8 @@ public final class StringFactory {
     }
 
     private static boolean hasLambda(final String objectString) {
-        return objectString.contains("$Lambda$") || // JAVA (org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraphPlayTest$$Lambda$1/1711574013@61a52fb)
+        return objectString.contains("$Lambda$") || // JAVA <21 (org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraphPlayTest$$Lambda$1/1711574013@61a52fb)
+                objectString.contains("$$Lambda/") || // JAVA 21+ (org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraphPlayTest$$Lambda/0x00007fc001151000@61a52fb)
                 objectString.contains("$_run_closure") || // GROOVY (groovysh_evaluate$_run_closure1@db44aa2)
                 objectString.contains("<lambda>");  // PYTHON (<function <lambda> at 0x10dfaec80>)
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/ImportGremlinPluginTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/ImportGremlinPluginTest.java
@@ -147,8 +147,15 @@ public class ImportGremlinPluginTest {
                 .fieldsImports(Collections.singletonList(Math.class.getCanonicalName() + "#*")).create();
 
         final DefaultImportCustomizer customizer = (DefaultImportCustomizer) module.getCustomizers().get()[0];
-        assertThat(customizer.getFieldImports(), is(new HashSet<>(
-                Arrays.asList(Math.class.getField("PI"), Math.class.getField("E")))));
+        // Math.TAU was added in Java 19
+        final HashSet<Field> expectedFields = new HashSet<>(Arrays.asList(
+                Math.class.getField("PI"), Math.class.getField("E")));
+        try {
+            expectedFields.add(Math.class.getField("TAU"));
+        } catch (NoSuchFieldException ignored) {
+            // TAU not available in Java < 19
+        }
+        assertThat(customizer.getFieldImports(), is(expectedFields));
     }
 
     @Test

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -153,6 +153,38 @@ limitations under the License.
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.apache.tinkerpop</groupId>
+                            <artifactId>gremlin-annotations</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.apache.tinkerpop</groupId>
+                            <artifactId>gremlin-core</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.apache.tinkerpop</groupId>
+                            <artifactId>gremlin-shaded</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.apache.tinkerpop</groupId>
+                            <artifactId>gremlin-language</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>com.squareup</groupId>
+                            <artifactId>javapoet</artifactId>
+                            <version>${javapoet.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.antlr</groupId>
+                            <artifactId>antlr4-runtime</artifactId>
+                            <version>${antlr4.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>
@@ -160,9 +192,9 @@ limitations under the License.
 
     <profiles>
         <profile>
-            <id>jdk11</id>
+            <id>jdk11-and-newer</id>
             <activation>
-                <jdk>[11,18)</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <build>
                 <plugins>
@@ -172,8 +204,8 @@ limitations under the License.
                         <configuration>
                             <!--
                             need to override source path as we don't seem to get the groovy-stubs automatically. this worked
-                            under java 8 but errors under java 11 due to missing files on the path. i guess java 8 was more
-                            forgiving.
+                            under java 8 but errors under java 11 and newer due to missing files on the path. i guess java 8
+                            was more forgiving.
                             -->
                             <sourcepath>${pom.basedir}/src/main/java:${project.build.directory}/generated-sources/annotations:${project.build.directory}/generated-sources/groovy-stubs/main</sourcepath>
                         </configuration>

--- a/gremlin-test/pom.xml
+++ b/gremlin-test/pom.xml
@@ -88,6 +88,14 @@ limitations under the License.
             <groupId>org.apache.kerby</groupId>
             <artifactId>kerb-simplekdc</artifactId>
             <version>${kerby.version}</version>
+            <exclusions>
+                <!-- only used by the kadmin CLI tool which is not exercised by the test KDC; excluding it avoids a
+                     version clash with the jline brought in by Hadoop's yarn client -->
+                <exclusion>
+                    <groupId>org.jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -128,7 +128,7 @@ limitations under the License.
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.8.1</version>
+            <version>9.30.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -162,16 +162,16 @@ limitations under the License.
         <commons.text.version>1.15.0</commons.text.version>
         <cucumber.version>7.21.1</cucumber.version>
         <exp4j.version>0.4.8</exp4j.version>
-        <groovy.version>4.0.25</groovy.version>
+        <groovy.version>4.0.32</groovy.version>
         <guice.version>4.2.3</guice.version>
-        <hadoop.version>3.3.3</hadoop.version>
+        <hadoop.version>3.4.3</hadoop.version>
         <hamcrest.version>3.0</hamcrest.version>
         <java.tuples.version>1.2</java.tuples.version>
         <javadoc-plugin.version>3.3.1</javadoc-plugin.version>
         <javapoet.version>1.13.0</javapoet.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <junit.version>4.13.1</junit.version>
-        <kerby.version>2.0.1</kerby.version>
+        <kerby.version>2.0.3</kerby.version>
         <logback.version>1.2.13</logback.version>
         <metrics.version>3.0.2</metrics.version>
         <mockito.version>5.19.0</mockito.version>
@@ -253,7 +253,7 @@ limitations under the License.
                             <rules>
                                 <DependencyConvergence/>
                                 <requireJavaVersion>
-                                    <version>[11,18)</version>
+                                    <version>[11,26)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.5.3,)</version>
@@ -770,6 +770,13 @@ limitations under the License.
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
+            </dependency>
+            <!-- xnio-api (pulled in transitively by the Kerby test KDC's kerb-admin) references conflicting
+                 wildfly-common versions; pin to the newer one so dependency convergence is satisfied -->
+            <dependency>
+                <groupId>org.wildfly.common</groupId>
+                <artifactId>wildfly-common</artifactId>
+                <version>1.5.4.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -25,6 +25,25 @@ limitations under the License.
     </parent>
     <artifactId>spark-gremlin</artifactId>
     <name>Apache TinkerPop :: Spark Gremlin</name>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spark 3.3.x and Hadoop 3.4.x pull in different 4.1.x Netty patch releases. Align every Netty
+                 artifact to the version TinkerPop standardizes on so that dependency convergence is satisfied. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Spark requires dropwizard metrics 4.x; Hadoop 3.4.x pulls in the older 3.2.4 -->
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>4.2.7</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -177,7 +196,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
-            <version>4.2.0</version>
+            <version>5.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
Add **partial** (experimental) support for building and running with Java 21 and Java 25.
All modules except `spark-gremlin` become compatible with Java 21 and Java 25, and both versions get their own GitHub Actions build job. The reference docs (supported-runtime table), developer docs (system configuration), 3.8.2 upgrade docs, and CHANGELOG note the new experimental support.

This may potentially help graph providers that don't use `spark-gremlin` to upgrade to Java 21 or 25.
Providers that do require `spark-gremlin` will not be able to upgrade past Java 17 on TinkerPop 3.x versions. Full Java 21/25 upgrade requires dropping Java 11 support. You can find the full upgrade in PR #3489 which targets TinkerPop 4.0.0.

The reason Spark can't be upgraded to a newer version on the `3.8-dev` branch is that no Spark version is compatible with both Java 11 and Java 21/25 — Java 21 support arrived in Spark 4.0 ([SPARK-43831](https://issues.apache.org/jira/browse/SPARK-43831)) and Java 25 support in Spark 4.1, and Spark 4.x requires Java 17 as a minimum (and Scala 2.13). Spark 3.3.x itself does not run on Java 21 or newer: its off-heap `Platform` class reflects on the private `DirectByteBuffer(long, int)` constructor that JDK 21 removed, so `Platform.<clinit>` fails with `NoSuchMethodException` (verified by running the `spark-gremlin` tests on JDK 21: 28 of 36 tests fail with `NoClassDefFoundError: Could not initialize class org.apache.spark.unsafe.array.ByteArrayMethods`).

Validated locally with a full `mvn clean install` (the same module set as the new CI job) on Java 21; all modules pass.

There was the first attempt to add Java 25 support in the PR #3283
This PR can be considered as continuation
