### PR TITLE
Stabilize the flaky shouldWaitForAllResultsToArrive test

### DIFF
--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -645,15 +645,15 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         try {
             final Client client = cluster.connect();
 
-            final AtomicInteger checked = new AtomicInteger(0);
             final ResultSet results = client.submit("g.inject(1,2,3,4,5,6,7,8,9)");
+            // depending on timing every result may already be available on the first check (in particular with HTTP
+            // streaming over a fast loopback), so do not assert that the polling loop runs - only that all nine
+            // results ultimately arrive and the available count never exceeds the total while streaming
             while (!results.allItemsAvailable()) {
                 assertTrue(results.getAvailableItemCount() < 10);
-                checked.incrementAndGet();
                 Thread.sleep(100);
             }
 
-            assertTrue(checked.get() > 0);
             assertEquals(9, results.getAvailableItemCount());
         } finally {
             cluster.close();


### PR DESCRIPTION
`shouldWaitForAllResultsToArrive` asserted that its polling loop ran at least once (checked > 0). With HTTP streaming over a fast loopback, all nine results can already be available on the first allItemsAvailable() check, so the loop
body never runs and the assertion fails intermittently. Drop that timing-dependent assertion; the test now only asserts that all results ultimately arrive.