### PR TITLE
Speed up Python GraphBinary deserialization (3.7)

### DIFF
--- a/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/io/graphbinaryV1.py
@@ -118,6 +118,9 @@ class DataType(Enum):
 
 NULL_BYTES = [DataType.null.value, 0x01]
 
+# null type code as a plain int, so the per-read null check skips the aenum lookup
+_NULL = DataType.null.value
+
 
 def _make_packer(format_string):
     packer = struct.Struct(format_string)
@@ -187,6 +190,9 @@ class GraphBinaryReader(object):
         self.deserializers = _deserializers.copy()
         if deserializer_map:
             self.deserializers.update(deserializer_map)
+        # Mirror of self.deserializers keyed by int type code instead of DataType.
+        # Avoids the per-read DataType(bt) call, whose aenum construction negatively affects performance on large results.
+        self._deserializer_by_type_code = {dt.value: des.objectify for dt, des in self.deserializers.items()}
 
     def read_object(self, b):
         if isinstance(b, bytearray):
@@ -197,11 +203,15 @@ class GraphBinaryReader(object):
     def to_object(self, buff, data_type=None, nullable=True):
         if data_type is None:
             bt = uint8_unpack(buff.read(1))
-            if bt == DataType.null.value:
+            if bt == _NULL:
                 if nullable:
                     buff.read(1)
                 return None
-            return self.deserializers[DataType(bt)].objectify(buff, self, nullable)
+            try:
+                objectify = self._deserializer_by_type_code[bt]
+            except KeyError:
+                raise ValueError("%r is not a valid DataType" % bt) from None
+            return objectify(buff, self, nullable)
         else:
             return self.deserializers[data_type].objectify(buff, self, nullable)
 


### PR DESCRIPTION
The GraphBinary reader built a `DataType` enum member from the type byte for every object it decoded. That per-object enum construction heavily degrades deserialization performance on large result sets.

The reader now builds a `{type code: deserializer}` lookup table once up front and dispatches on the raw integer instead, avoiding per-object enum construction. Behavior is unchanged: an unknown type code still raises `ValueError("... is not a valid DataType")`.

### Performance

Benchmarked on two cross-region EC2 instances (server in US-EAST-2, client in US-WEST-2) to capture realistic network latency, against the Modern graph over WebSocket on Python 3.11. Each query was run with and without this change, alternating back to back across 3 sweeps, reporting the median.

| Query | Before | After | Change |
|---|---|---|---|
| `g.V().repeat(both()).times(12)` (~200k results) | 6.81 s | 5.36 s | 21% faster |
| `g.V()` (6 results) | 0.181 s | 0.181 s | no change |

The improvement is significant on large result sets, where per-object deserialization cost dominates, and scales with the number of objects returned.