### PR TITLE
Rename evaluationTimeout to timeoutMs

### DIFF
--- a/.skills/tinker-review/scripts/functional/setup.js
+++ b/.skills/tinker-review/scripts/functional/setup.js
@@ -68,7 +68,7 @@ globals << [a : traversal().withEmbedded(graph).withComputer()]
 function serverYaml(port) {
   return `host: localhost
 port: ${port}
-evaluationTimeout: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-review.properties}

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,7 +47,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Removed `Transaction.open()` in favor of `begin()`, which is now the single transaction-start primitive across embedded and remote contexts.
 * Changed `begin()` and `close()` to be idempotent and calling it when a transaction is already in that state no longer throws.
 * Added `maxTransactionLifetime` setting to Gremlin Server, an absolute cap on the total age of an HTTP transaction that interrupts a running operation and rolls the transaction back when it fires (default 600000ms, set to `0` to disable).
-* Changed the Gremlin Server HTTP transaction idle timer to suspend while an operation is running (so a long-running operation is bounded by `evaluationTimeout` rather than the idle timeout) and to honor `0` as "disable idle reclamation"; the `idleTransactionTimeout` default is now 60000ms.
+* Changed the Gremlin Server HTTP transaction idle timer to suspend while an operation is running (so a long-running operation is bounded by `timeoutMs` rather than the idle timeout) and to honor `0` as "disable idle reclamation"; the `idleTransactionTimeout` default is now 60000ms.
 * Added configurable CORS `allowedOrigins` setting to Gremlin Server; warns when wildcard origin is used alongside authentication.
 * Fixed `ByteBuf` leak in `GraphBinaryMessageSerializerV4` when serialization throws an `IOException`.
 * Changed `Tree` to no longer extend `HashMap`; it is now a final class with a tree-shaped API (`childAt`, `hasChild`, `contains`, `findSubtree`, `getOrCreateChild`, `getNodesAtDepth`, `getLeafNodes`, `nodeCount`) and is no longer a `Map`.
@@ -91,6 +91,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated Groovy-based `LifeCycleHook` and `TraversalSource` creation via init scripts in favor of YAML configuration.
 * Updated all default Gremlin Server configs to remove Groovy dependency from initialization.
 * Added script engine allowlist to Gremlin Server - the `scriptEngines` YAML configuration now restricts which engines can serve requests; `gremlin-lang` is always available.
+* Modified the request timeout to a single name `timeoutMs` across the server and GLVs.
 * Modified request parameters from `Map<String, Object>` to gremlin-lang compatible `String`.
 * Renamed the request `bindings` field to `parameters` across the HTTP request body, GraphBinary, and GraphSON, standardizing terminology for query parameters.
 * Modified HTTP API to expect gremlin-lang strings for parameters and update all GLVs to send requests in new format.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,8 +46,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed `gremlin-python` read timeout to derive from a single source (aiohttp `sock_read`), removing a redundant `async_timeout` read wrapper that could race it; a read timeout now deterministically raises `ReadTimeoutError` (a builtin `TimeoutError` subclass).
 * Removed `Transaction.open()` in favor of `begin()`, which is now the single transaction-start primitive across embedded and remote contexts.
 * Changed `begin()` and `close()` to be idempotent and calling it when a transaction is already in that state no longer throws.
-* Added `maxTransactionLifetime` setting to Gremlin Server, an absolute cap on the total age of an HTTP transaction that interrupts a running operation and rolls the transaction back when it fires (default 600000ms, set to `0` to disable).
-* Changed the Gremlin Server HTTP transaction idle timer to suspend while an operation is running (so a long-running operation is bounded by `timeoutMs` rather than the idle timeout) and to honor `0` as "disable idle reclamation"; the `idleTransactionTimeout` default is now 60000ms.
+* Added `maxTransactionLifetimeMillis` setting to Gremlin Server, an absolute cap on the total age of an HTTP transaction that interrupts a running operation and rolls the transaction back when it fires (default 600000ms, set to `0` to disable).
+* Changed the Gremlin Server HTTP transaction idle timer to suspend while an operation is running (so a long-running operation is bounded by `timeoutMillis` rather than the idle timeout) and to honor `0` as "disable idle reclamation"; the `idleTransactionTimeoutMillis` default is now 60000ms.
 * Added configurable CORS `allowedOrigins` setting to Gremlin Server; warns when wildcard origin is used alongside authentication.
 * Fixed `ByteBuf` leak in `GraphBinaryMessageSerializerV4` when serialization throws an `IOException`.
 * Changed `Tree` to no longer extend `HashMap`; it is now a final class with a tree-shaped API (`childAt`, `hasChild`, `contains`, `findSubtree`, `getOrCreateChild`, `getNodesAtDepth`, `getLeafNodes`, `nodeCount`) and is no longer a `Map`.
@@ -91,7 +91,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Deprecated Groovy-based `LifeCycleHook` and `TraversalSource` creation via init scripts in favor of YAML configuration.
 * Updated all default Gremlin Server configs to remove Groovy dependency from initialization.
 * Added script engine allowlist to Gremlin Server - the `scriptEngines` YAML configuration now restricts which engines can serve requests; `gremlin-lang` is always available.
-* Modified the request timeout to a single name `timeoutMs` across the server and GLVs.
+* Modified the request timeout to a single name `timeoutMillis` across the server and GLVs.
+* Renamed the millisecond-valued Gremlin Server settings to carry a `Millis` suffix: `idleConnectionTimeout`, `keepAliveInterval`, `ssl.refreshInterval`, and the metrics reporter `interval` became `idleConnectionTimeoutMillis`, `keepAliveIntervalMillis`, `ssl.refreshIntervalMillis`, and `intervalMillis`.
 * Modified request parameters from `Map<String, Object>` to gremlin-lang compatible `String`.
 * Renamed the request `bindings` field to `parameters` across the HTTP request body, GraphBinary, and GraphSON, standardizing terminology for query parameters.
 * Modified HTTP API to expect gremlin-lang strings for parameters and update all GLVs to send requests in new format.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -274,9 +274,9 @@ Per-surface trust table:
   read and buffered (bounded by `maxRequestContentLength`) before the server can even check credentials.
   A deserializer bug is in-model either way. The ordering only sets its severity. *(documented — §4 flow;
   `HttpChannelizer` pipeline order)*
-- **Shape / rate:** Gremlin Server has per-request limits (`evaluationTimeout`, `maxRequestContentLength`,
-  `maxParameters`, `maxWorkQueueSize`) and transaction bounds (`idleTransactionTimeout`,
-  `maxTransactionLifetime`, `maxConcurrentTransactions`) but **no traversal-depth or result-count cap**.
+- **Shape / rate:** Gremlin Server has per-request limits (`timeoutMillis`, `maxRequestContentLength`,
+  `maxParameters`, `maxWorkQueueSize`) and transaction bounds (`idleTransactionTimeoutMillis`,
+  `maxTransactionLifetimeMillis`, `maxConcurrentTransactions`) but **no traversal-depth or result-count cap**.
   The bug-vs-capacity line is the §8 resource split. *(documented — `gremlin-applications.asciidoc` config
   table)*
 - **Script-cache growth (`gremlin-groovy` only):** with the opt-in Groovy engine enabled, a client
@@ -457,7 +457,7 @@ Per-surface trust table:
 - Enable audit logging (`enableAuditLog`, off by default) where attribution of requests is needed.
 - Use the wire serializers (GraphBinary recommended for drivers). Keep Gryo locked
   (`registrationRequired=true`), and do not read untrusted files through **unlocked** Gryo.
-- Apply per-request resource limits (`evaluationTimeout`, `maxRequestContentLength`, etc.) appropriate to capacity.
+- Apply per-request resource limits (`timeoutMillis`, `maxRequestContentLength`, etc.) appropriate to capacity.
 - Set filesystem permissions so only the server user can read the config / data directories.
 
 ## §11 Known misuse patterns

--- a/docker/gremlin-server/gremlin-server-integration-secure.yaml
+++ b/docker/gremlin-server/gremlin-server-integration-secure.yaml
@@ -17,7 +17,7 @@
 
 host: 0.0.0.0
 port: 45941
-evaluationTimeout: 30000
+timeoutMs: 30000
 graphs: {
   graph: {
     configuration: conf/tinkergraph-empty.properties,

--- a/docker/gremlin-server/gremlin-server-integration-secure.yaml
+++ b/docker/gremlin-server/gremlin-server-integration-secure.yaml
@@ -17,7 +17,7 @@
 
 host: 0.0.0.0
 port: 45941
-timeoutMs: 30000
+timeoutMillis: 30000
 graphs: {
   graph: {
     configuration: conf/tinkergraph-empty.properties,
@@ -51,11 +51,11 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4, config: { serializeResultToString: true }}
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 gremlinPool: 8
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/docker/gremlin-server/gremlin-server-integration.yaml
+++ b/docker/gremlin-server/gremlin-server-integration.yaml
@@ -17,7 +17,7 @@
 
 host: 0.0.0.0
 port: 45940
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: {
@@ -62,11 +62,11 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4, config: { serializeResultToString: true }}
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 gremlinPool: 8
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/docker/gremlin-server/gremlin-server-integration.yaml
+++ b/docker/gremlin-server/gremlin-server-integration.yaml
@@ -17,7 +17,7 @@
 
 host: 0.0.0.0
 port: 45940
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: {

--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -2746,7 +2746,7 @@ The following `RequestMessage` is an example of a simple sessionless request for
 {
   "gremlin": "g.V(x)",
   "materializeProperties": "tokens",
-  "timeoutMs": {
+  "timeoutMillis": {
     "@type": "g:Int64",
     "@value": 1000
   },
@@ -2770,7 +2770,7 @@ The following `RequestMessage` is an example of a simple sessionless request for
 {
   "gremlin": "g.V(x)",
   "materializeProperties": "tokens",
-  "timeoutMs": 1000,
+  "timeoutMillis": 1000,
   "g": "g",
   "parameters": {
     "x": 1

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -1197,7 +1197,7 @@ Gremlin-Hints: <hints>
 
 {
   "gremlin": string,
-  "timeoutMs": number,
+  "timeoutMillis": number,
   "parameters": string,
   "g": string,
   "language" : string,
@@ -1257,7 +1257,7 @@ the serializer specified by the `Content-Type` header. The following are the key
 |=========================================================
 |Key |Description |Value |Required
 |gremlin |The Gremlin query to execute. |String containing script |Yes
-|timeoutMs |The maximum time a query is allowed to execute in milliseconds. |Number between 0 and 2^31-1 |No
+|timeoutMillis |The maximum time a query is allowed to execute in milliseconds. |Number between 0 and 2^31-1 |No
 |parameters |A gremlin-lang string that encodes a map of key/value pairs used during query execution. Its usage depends on "language". For "gremlin-groovy", these are applied as script variable bindings. For "gremlin-lang", these are the query parameters. |String containing a gremlin-lang map literal |No
 |g |The name of the graph traversal source to which the query applies. Default: "g" |String containing traversal source name |No
 |language |The name of the ScriptEngine to use to parse the gremlin query. Default: "gremlin-lang" |String containing ScriptEngine name |No
@@ -1430,15 +1430,15 @@ rejects it with HTTP 400. This prevents cross-graph operations within a single t
 
 ==== Transaction Timeout and Idle Reclamation
 
-A transaction can be bounded at three independent scopes, each disabled with `0`. The `timeoutMs` bounds a single
-operation. The `idleTransactionTimeout` (default 60000ms) bounds the idle gaps between operations: how long a
+A transaction can be bounded at three independent scopes, each disabled with `0`. The `timeoutMillis` bounds a single
+operation. The `idleTransactionTimeoutMillis` (default 60000ms) bounds the idle gaps between operations: how long a
 transaction may remain idle, with no operation running or queued, before it is rolled back and removed; once it is
-removed, a subsequent request with that transaction ID receives a 404. The `maxTransactionLifetime` (default 600000ms)
+removed, a subsequent request with that transaction ID receives a 404. The `maxTransactionLifetimeMillis` (default 600000ms)
 bounds the total age of the transaction regardless of activity, and so may end a transaction while an operation is still
 running; the in-flight request then receives a 504 (`TransactionException`) and subsequent requests receive a 404.
 
 The defaults bound a transaction without any operator configuration; disabling them is a deliberate choice, and a
-per-request `timeoutMs` is honored as sent rather than overridden by the server. How promptly a running operation is
+per-request `timeoutMillis` is honored as sent rather than overridden by the server. How promptly a running operation is
 actually interrupted when a bound fires is a property of the provider's execution and traversal machinery, not
 guaranteed by these settings.
 

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -1430,8 +1430,8 @@ rejects it with HTTP 400. This prevents cross-graph operations within a single t
 
 ==== Transaction Timeout and Idle Reclamation
 
-A transaction can be bounded at three independent scopes, each disabled with `0`. The `evaluationTimeout` bounds a
-single operation. The `idleTransactionTimeout` (default 60000ms) bounds the idle gaps between operations: how long a
+A transaction can be bounded at three independent scopes, each disabled with `0`. The `timeoutMs` bounds a single
+operation. The `idleTransactionTimeout` (default 60000ms) bounds the idle gaps between operations: how long a
 transaction may remain idle, with no operation running or queued, before it is rolled back and removed; once it is
 removed, a subsequent request with that transaction ID receives a 404. The `maxTransactionLifetime` (default 600000ms)
 bounds the total age of the transaction regardless of activity, and so may end a transaction while an operation is still

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -922,36 +922,37 @@ The following table describes the various YAML configuration options that Gremli
 |graphs.<name>.traversalSources[X].language |The `ScriptEngine` language to use for evaluating `gremlinExpression`.  Falls back to the sole configured engine if only one is present, or `gremlin-lang` otherwise. |_auto-detected_
 |gremlinPool |The number of "Gremlin" threads available to execute actual scripts in a `ScriptEngine`. This pool represents the workers available to handle blocking operations in Gremlin Server. When set to `0`, Gremlin Server will use the value provided by `Runtime.availableProcessors()`. |0
 |host |The name of the host to bind the server to. |localhost
-|idleConnectionTimeout |Time in milliseconds that the server will allow a channel to not receive requests from a client before it automatically closes. If enabled, the value provided should typically exceed the amount of time given to `keepAliveInterval`. Note that while this value is to be provided as milliseconds it will resolve to second precision. Set this value to `0` to disable this feature. |0
-|idleTransactionTimeout |Time in milliseconds that a transaction can remain idle (no operation running or queued) before the server forcibly rolls it back and removes it. The idle timer is suspended while an operation is running, so a long-running operation does not trip it (its duration is instead bounded by `timeoutMs`); the timer is armed only once the transaction returns to idle. Set to `0` to disable idle reclamation. |60000
-|keepAliveInterval |Time in milliseconds that the server will allow a channel to not send responses to a client before it sends a "ping" to see if it is still present. If it is present, the client should respond with a "pong" which will thus reset the `idleConnectionTimeout` and keep the channel open. If enabled, this number should be smaller than the value provided to the `idleConnectionTimeout`. Note that while this value is to be provided as milliseconds it will resolve to second precision. Set this value to `0` to disable this feature. |0
+|idleConnectionTimeoutMillis |Time in milliseconds that the server will allow a channel to not receive requests from a client before it automatically closes. If enabled, the value provided should typically exceed the amount of time given to `keepAliveIntervalMillis`. Note that while this value is to be provided as milliseconds it will resolve to second precision. Set this value to `0` to disable this feature. |0
+|idleTransactionTimeoutMillis |Time in milliseconds that a transaction can remain idle (no operation running or queued) before the server forcibly rolls it back and removes it. The idle timer is suspended while an operation is running, so a long-running operation does not trip it (its duration is instead bounded by `timeoutMillis`); the timer is armed only once the transaction returns to idle. Set to `0` to disable idle reclamation. |60000
+|keepAliveIntervalMillis |Time in milliseconds that the server will allow a channel to not send responses to a client before it sends a "ping" to see if it is still present. If it is present, the client should respond with a "pong" which will thus reset the `idleConnectionTimeoutMillis` and keep the channel open. If enabled, this number should be smaller than the value provided to the `idleConnectionTimeoutMillis`. Note that while this value is to be provided as milliseconds it will resolve to second precision. Set this value to `0` to disable this feature. |0
 |maxAccumulationBufferComponents |Maximum number of request components that can be aggregated for a message. |1024
 |maxChunkSize |The maximum length of the content or each chunk.  If the content length exceeds this value, the transfer encoding of the decoded request will be converted to 'chunked' and the content will be split into multiple `HttpContent` objects.  If the transfer encoding of the HTTP request is 'chunked' already, each chunk will be split into smaller chunks if the length of the chunk exceeds this value. |8192
 |maxConcurrentTransactions |The maximum number of concurrent open transactions allowed. When this limit is reached, new `g.tx().begin()` requests are rejected with HTTP 503. Slots are freed when transactions close via commit, rollback, or timeout. |1000
 |maxHeaderSize |The maximum length of all headers. |8192
 |maxInitialLineLength |The maximum length of the initial line (e.g.  "GET / HTTP/1.0") processed in a request, which essentially controls the maximum length of the submitted URI. |4096
 |maxParameters |The maximum number of parameters that can be passed on a request. Larger numbers may impact performance for scripts. This configuration only applies to the `HttpChannelizer`. |16
-|maxTransactionLifetime |Absolute cap in milliseconds on the total age of a transaction regardless of activity. Unlike `idleTransactionTimeout`, it fires even while an operation is running, interrupting it and rolling the transaction back. Set to `0` to disable the cap. |600000
+|maxTransactionLifetimeMillis |Absolute cap in milliseconds on the total age of a transaction regardless of activity. Unlike `idleTransactionTimeoutMillis`, it fires even while an operation is running, interrupting it and rolling the transaction back. Set to `0` to disable the cap. |600000
+|perGraphCloseTimeoutMillis |Time in milliseconds to wait for a transaction commit or rollback operation to complete when closing a graph. |10000
 |maxRequestContentLength |The maximum length of the aggregated content for a request message.  Works in concert with `maxChunkSize` where chunked requests are accumulated back into a single message.  A request exceeding this size will return a `413 - Request Entity Too Large` status code. |10485760
 |maxWorkQueueSize |The maximum size the general processing queue can grow before the `gremlinPool` starts to reject requests. |8192
 |metrics.consoleReporter.enabled |Turns on console reporting of metrics. |false
-|metrics.consoleReporter.interval |Time in milliseconds between reports of metrics to console. |180000
+|metrics.consoleReporter.intervalMillis |Time in milliseconds between reports of metrics to console. |180000
 |metrics.csvReporter.enabled |Turns on CSV reporting of metrics. |false
 |metrics.csvReporter.fileName |The file to write metrics to. |_none_
-|metrics.csvReporter.interval |Time in milliseconds between reports of metrics to file. |180000
+|metrics.csvReporter.intervalMillis |Time in milliseconds between reports of metrics to file. |180000
 |metrics.gangliaReporter.addressingMode |Set to `MULTICAST` or `UNICAST`. |_none_
 |metrics.gangliaReporter.enabled |Turns on Ganglia reporting of metrics. Additional link:https://tinkerpop.apache.org/docs/x.y.z/reference/#metrics[setup] is required. |false
 |metrics.gangliaReporter.host |Define the Ganglia host to report Metrics to. |localhost
-|metrics.gangliaReporter.interval |Time in milliseconds between reports of metrics for Ganglia. |180000
+|metrics.gangliaReporter.intervalMillis |Time in milliseconds between reports of metrics for Ganglia. |180000
 |metrics.gangliaReporter.port |Define the Ganglia port to report Metrics to. |8649
 |metrics.graphiteReporter.enabled |Turns on Graphite reporting of metrics. Additional link:https://tinkerpop.apache.org/docs/x.y.z/reference/#metrics[setup] is required. |false
 |metrics.graphiteReporter.host |Define the Graphite host to report Metrics to. |localhost
-|metrics.graphiteReporter.interval |Time in milliseconds between reports of metrics for Graphite. |180000
+|metrics.graphiteReporter.intervalMillis |Time in milliseconds between reports of metrics for Graphite. |180000
 |metrics.graphiteReporter.port |Define the Graphite port to report Metrics to. |2003
 |metrics.graphiteReporter.prefix |Define a "prefix" to append to metrics keys reported to Graphite. |_none_
 |metrics.jmxReporter.enabled |Turns on JMX reporting of metrics. |false
 |metrics.slf4jReporter.enabled |Turns on SLF4j reporting of metrics. |false
-|metrics.slf4jReporter.interval |Time in milliseconds between reports of metrics to SLF4j. |180000
+|metrics.slf4jReporter.intervalMillis |Time in milliseconds between reports of metrics to SLF4j. |180000
 |port |The port to bind the server to. |8182
 |resultIterationBatchSize |Defines the size in which the result of a request is "batched" back to the client.  In other words, if set to `1`, then a result that had ten items in it would get each result sent back individually.  If set to `2` the same ten results would come back in five batches of two each. |64
 |scriptEngines |A `Map` of `ScriptEngine` implementations to expose through Gremlin Server, where the key is the name given by the `ScriptEngine` implementation.  The key must match the name exactly for the `ScriptEngine` to be constructed.  The value paired with this key is itself a `Map` of configuration for that `ScriptEngine`.  If this value is not set, it will default to "gremlin-lang". |_gremlin-lang_
@@ -970,6 +971,7 @@ The following table describes the various YAML configuration options that Gremli
 |ssl.keyStorePassword |The password of the `keyStore` if it is password-protected. |_none_
 |ssl.keyStoreType |`PKCS12` |_none_
 |ssl.needClientAuth | Optional. One of NONE, REQUIRE.  Enables client certificate authentication at the enforcement level specified. Can be used in combination with Authenticator. |_none_
+|ssl.refreshIntervalMillis |The interval, in milliseconds, at which the trustStore and keyStore files are checked for updates. |60000
 |ssl.sslCipherSuites |The list of JSSE ciphers to support for SSL connections. If specified, only the ciphers that are listed and supported will be enabled. If not specified, the JVM default is used.  |_none_
 |ssl.sslEnabledProtocols |The list of SSL protocols to support for SSL connections. If specified, only the protocols that are listed and supported will be enabled. If not specified, the JVM default is used.  |_none_
 |ssl.trustStore |Required when needClientAuth is REQUIRE. Trusted certificates for verifying the remote endpoint's certificate. If this value is not provided and SSL is enabled, the default `TrustManager` will be used, which will have a set of common public certificates installed to it. |_none_
@@ -977,7 +979,7 @@ The following table describes the various YAML configuration options that Gremli
 |strictTransactionManagement |Set to `true` to require `aliases` to be submitted on every requests, where the `aliases` become the scope of transaction management. |false
 |threadPoolBoss |The number of threads available to Gremlin Server for accepting connections. Should always be set to `1`. |1
 |threadPoolWorker |The number of threads available to Gremlin Server for processing non-blocking reads and writes. |1
-|timeoutMs |The maximum amount of time in milliseconds that a request is allowed to execute on the server before it times out. This is the server-wide default and may be overridden on a per-request basis with the `timeoutMs` request argument. This feature can be turned off by setting the value to `0`. |30000
+|timeoutMillis |The maximum amount of time in milliseconds that a request is allowed to execute on the server before it times out. This is the server-wide default and may be overridden on a per-request basis with the `timeoutMillis` request argument. This feature can be turned off by setting the value to `0`. |30000
 |useEpollEventLoop |Try to use epoll event loops (works only on Linux os) instead of netty NIO. |false
 |writeBufferHighWaterMark | If the number of bytes in the network send buffer exceeds this value then the channel is no longer writeable, accepting no additional writes until buffer is drained and the `writeBufferLowWaterMark` is met. |65536
 |writeBufferLowWaterMark | Once the number of bytes queued in the network send buffer exceeds the `writeBufferHighWaterMark`, the channel will not become writeable again until the buffer is drained and it drops below this value. |32768
@@ -1762,7 +1764,7 @@ continuously:
 client = Cluster.build("localhost").port(8182).create().connect()
 ==>org.apache.tinkerpop.gremlin.driver.Client$ClusteredClient@42ff9a77
 client.submit("while(true) { }")
-org.apache.tinkerpop.gremlin.driver.exception.ResponseException: A timeout occurred during traversal evaluation of [RequestMessage{, fields={parameters={}, language=gremlin-groovy, batchSize=64}, gremlin=while(true) { }}] - consider increasing the limit given to timeoutMs (the maximum time in milliseconds a request may execute on the server)
+org.apache.tinkerpop.gremlin.driver.exception.ResponseException: A timeout occurred during traversal evaluation of [RequestMessage{, fields={parameters={}, language=gremlin-groovy, batchSize=64}, gremlin=while(true) { }}] - consider increasing the limit given to timeoutMillis (the maximum time in milliseconds a request may execute on the server)
 
 The `GroovyCompilerGremlinPlugin` has a number of configuration options:
 
@@ -1916,11 +1918,11 @@ generally means being measured in the low hundreds of milliseconds and "slow" me
 * Requests that are "slow" can really hurt Gremlin Server if they are not properly accounted for. Since these requests
 block a thread until the job is complete or successfully interrupted, lots of long-run requests will eventually consume
 the `gremlinPool` preventing other requests from getting processed from the queue.
-** To limit the impact of this problem, consider properly setting the `timeoutMs` to something "sane".
+** To limit the impact of this problem, consider properly setting the `timeoutMillis` to something "sane".
 In other words, test the traversals being sent to Gremlin Server and determine the maximum time they take to evaluate
 and iterate over results, then set the timeout value accordingly. Also, consider setting a shorter global timeout for
 requests and then use longer per-request timeouts for those specific ones that might execute at a longer rate.
-** Note that `timeoutMs` can only attempt to interrupt the evaluation on timeout.  It allows Gremlin
+** Note that `timeoutMillis` can only attempt to interrupt the evaluation on timeout.  It allows Gremlin
 Server to "ignore" the result of that evaluation, which means the thread in the `gremlinPool` that did the evaluation
 may still be consumed after the timeout if interruption does not succeed on the thread.
 * When using transactions, the server dedicates resources to maintain transaction state for each open transaction. For
@@ -2253,25 +2255,25 @@ IMPORTANT: Not all graph implementations support explicit transactions (for exam
 Use `TinkerTransactionGraph` or another graph implementation that supports explicit transactions. Attempting to begin
 an explicit transaction on a graph that does not support them will result in an error.
 
-Several settings in the Gremlin Server YAML control transaction resource usage. The `idleTransactionTimeout`
+Several settings in the Gremlin Server YAML control transaction resource usage. The `idleTransactionTimeoutMillis`
 (default 60000ms) governs how long a transaction can remain idle (no operation running or queued) before the
 server forcibly rolls it back. The idle timer is suspended while an operation is running, so a long-running operation
 does not trip it; it is armed only once the transaction returns to idle. Set it to `0` to disable idle reclamation. The
-`maxTransactionLifetime` (default 600000ms) is an absolute cap on the total age of a transaction regardless of
-activity. Unlike `idleTransactionTimeout`, it fires even while an operation is running, interrupting it and rolling the
-transaction back. It bounds transaction lifetime and concurrency-slot occupancy absolutely; like `timeoutMs`, its
+`maxTransactionLifetimeMillis` (default 600000ms) is an absolute cap on the total age of a transaction regardless of
+activity. Unlike `idleTransactionTimeoutMillis`, it fires even while an operation is running, interrupting it and rolling the
+transaction back. It bounds transaction lifetime and concurrency-slot occupancy absolutely; like `timeoutMillis`, its
 ability to free the underlying worker thread depends on the operation reaching an interruptible point. Set it to
 `0` to disable the cap. Finally, `maxConcurrentTransactions` (default 1000) caps the number of open transactions
 allowed; when the limit is reached, new begin requests are rejected with HTTP 503.
 
-These compose with the per-operation `timeoutMs` (configurable server-wide and overridable per request) to bound a
-transaction at three independent scopes: a single operation (`timeoutMs`), the gaps between operations
-(`idleTransactionTimeout`), and the transaction as a whole (`maxTransactionLifetime`). The defaults keep a transaction
-bounded out of the box; disabling all of them is a deliberate operator choice, and a per-request `timeoutMs` is always
+These compose with the per-operation `timeoutMillis` (configurable server-wide and overridable per request) to bound a
+transaction at three independent scopes: a single operation (`timeoutMillis`), the gaps between operations
+(`idleTransactionTimeoutMillis`), and the transaction as a whole (`maxTransactionLifetimeMillis`). The defaults keep a transaction
+bounded out of the box; disabling all of them is a deliberate operator choice, and a per-request `timeoutMillis` is always
 honored as sent.
 
 Each open transaction consumes a dedicated thread on the server to maintain thread-local transaction state for the
-underlying graph. Ensure that clients close transactions promptly and that the `idleTransactionTimeout` is set to
+underlying graph. Ensure that clients close transactions promptly and that the `idleTransactionTimeoutMillis` is set to
 reclaim abandoned ones. The `transactions` gauge metric can be used to monitor usage.
 
 In load-balanced deployments, all requests within a transaction must reach the same server instance because
@@ -2673,4 +2675,3 @@ create large or frequently changing value sets, improving performance and stabil
 
 Consult the MCP client documentation for how environment variables are supplied and how tool calls are approved and
 presented to the user.
-

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -923,7 +923,7 @@ The following table describes the various YAML configuration options that Gremli
 |gremlinPool |The number of "Gremlin" threads available to execute actual scripts in a `ScriptEngine`. This pool represents the workers available to handle blocking operations in Gremlin Server. When set to `0`, Gremlin Server will use the value provided by `Runtime.availableProcessors()`. |0
 |host |The name of the host to bind the server to. |localhost
 |idleConnectionTimeout |Time in milliseconds that the server will allow a channel to not receive requests from a client before it automatically closes. If enabled, the value provided should typically exceed the amount of time given to `keepAliveInterval`. Note that while this value is to be provided as milliseconds it will resolve to second precision. Set this value to `0` to disable this feature. |0
-|idleTransactionTimeout |Time in milliseconds that a transaction can remain idle (no operation running or queued) before the server forcibly rolls it back and removes it. The idle timer is suspended while an operation is running, so a long-running operation does not trip it (its duration is instead bounded by `evaluationTimeout`); the timer is armed only once the transaction returns to idle. Set to `0` to disable idle reclamation. |60000
+|idleTransactionTimeout |Time in milliseconds that a transaction can remain idle (no operation running or queued) before the server forcibly rolls it back and removes it. The idle timer is suspended while an operation is running, so a long-running operation does not trip it (its duration is instead bounded by `timeoutMs`); the timer is armed only once the transaction returns to idle. Set to `0` to disable idle reclamation. |60000
 |keepAliveInterval |Time in milliseconds that the server will allow a channel to not send responses to a client before it sends a "ping" to see if it is still present. If it is present, the client should respond with a "pong" which will thus reset the `idleConnectionTimeout` and keep the channel open. If enabled, this number should be smaller than the value provided to the `idleConnectionTimeout`. Note that while this value is to be provided as milliseconds it will resolve to second precision. Set this value to `0` to disable this feature. |0
 |maxAccumulationBufferComponents |Maximum number of request components that can be aggregated for a message. |1024
 |maxChunkSize |The maximum length of the content or each chunk.  If the content length exceeds this value, the transfer encoding of the decoded request will be converted to 'chunked' and the content will be split into multiple `HttpContent` objects.  If the transfer encoding of the HTTP request is 'chunked' already, each chunk will be split into smaller chunks if the length of the chunk exceeds this value. |8192
@@ -962,7 +962,6 @@ The following table describes the various YAML configuration options that Gremli
 |lifecycleHooks |A `List` of Java-based `LifeCycleHook` implementations to instantiate and execute during server startup and shutdown.  See <<server-lifecycle-hooks>>. |_none_
 |lifecycleHooks[X].className |The fully qualified class name of the `LifeCycleHook` implementation. |_none_
 |lifecycleHooks[X].config |A `Map` of configuration passed to the hook's `init(Map)` method. |_none_
-|evaluationTimeout |The amount of time in milliseconds before a request evaluation and iteration of result times out. This feature can be turned off by setting the value to `0`. |30000
 |serializers |A `List` of `Map` settings, where each `Map` represents a `MessageSerializer` implementation to use along with its configuration. If this value is not set, then Gremlin Server will configure with GraphSON and GraphBinary but will not register any `ioRegistries` for configured graphs. |_empty_
 |serializers[X].className |The full class name of the `MessageSerializer` implementation. |_none_
 |serializers[X].config |A `Map` containing `MessageSerializer` specific configurations. |_none_
@@ -978,6 +977,7 @@ The following table describes the various YAML configuration options that Gremli
 |strictTransactionManagement |Set to `true` to require `aliases` to be submitted on every requests, where the `aliases` become the scope of transaction management. |false
 |threadPoolBoss |The number of threads available to Gremlin Server for accepting connections. Should always be set to `1`. |1
 |threadPoolWorker |The number of threads available to Gremlin Server for processing non-blocking reads and writes. |1
+|timeoutMs |The maximum amount of time in milliseconds that a request is allowed to execute on the server before it times out. This is the server-wide default and may be overridden on a per-request basis with the `timeoutMs` request argument. This feature can be turned off by setting the value to `0`. |30000
 |useEpollEventLoop |Try to use epoll event loops (works only on Linux os) instead of netty NIO. |false
 |writeBufferHighWaterMark | If the number of bytes in the network send buffer exceeds this value then the channel is no longer writeable, accepting no additional writes until buffer is drained and the `writeBufferLowWaterMark` is met. |65536
 |writeBufferLowWaterMark | Once the number of bytes queued in the network send buffer exceeds the `writeBufferHighWaterMark`, the channel will not become writeable again until the buffer is drained and it drops below this value. |32768
@@ -1762,7 +1762,7 @@ continuously:
 client = Cluster.build("localhost").port(8182).create().connect()
 ==>org.apache.tinkerpop.gremlin.driver.Client$ClusteredClient@42ff9a77
 client.submit("while(true) { }")
-org.apache.tinkerpop.gremlin.driver.exception.ResponseException: A timeout occurred during traversal evaluation of [RequestMessage{, fields={parameters={}, language=gremlin-groovy, batchSize=64}, gremlin=while(true) { }}] - consider increasing the limit given to evaluationTimeout
+org.apache.tinkerpop.gremlin.driver.exception.ResponseException: A timeout occurred during traversal evaluation of [RequestMessage{, fields={parameters={}, language=gremlin-groovy, batchSize=64}, gremlin=while(true) { }}] - consider increasing the limit given to timeoutMs (the maximum time in milliseconds a request may execute on the server)
 
 The `GroovyCompilerGremlinPlugin` has a number of configuration options:
 
@@ -1916,11 +1916,11 @@ generally means being measured in the low hundreds of milliseconds and "slow" me
 * Requests that are "slow" can really hurt Gremlin Server if they are not properly accounted for. Since these requests
 block a thread until the job is complete or successfully interrupted, lots of long-run requests will eventually consume
 the `gremlinPool` preventing other requests from getting processed from the queue.
-** To limit the impact of this problem, consider properly setting the `evaluationTimeout` to something "sane".
+** To limit the impact of this problem, consider properly setting the `timeoutMs` to something "sane".
 In other words, test the traversals being sent to Gremlin Server and determine the maximum time they take to evaluate
 and iterate over results, then set the timeout value accordingly. Also, consider setting a shorter global timeout for
 requests and then use longer per-request timeouts for those specific ones that might execute at a longer rate.
-** Note that `evaluationTimeout` can only attempt to interrupt the evaluation on timeout.  It allows Gremlin
+** Note that `timeoutMs` can only attempt to interrupt the evaluation on timeout.  It allows Gremlin
 Server to "ignore" the result of that evaluation, which means the thread in the `gremlinPool` that did the evaluation
 may still be consumed after the timeout if interruption does not succeed on the thread.
 * When using transactions, the server dedicates resources to maintain transaction state for each open transaction. For
@@ -2259,13 +2259,13 @@ server forcibly rolls it back. The idle timer is suspended while an operation is
 does not trip it; it is armed only once the transaction returns to idle. Set it to `0` to disable idle reclamation. The
 `maxTransactionLifetime` (default 600000ms) is an absolute cap on the total age of a transaction regardless of
 activity. Unlike `idleTransactionTimeout`, it fires even while an operation is running, interrupting it and rolling the
-transaction back. It bounds transaction lifetime and concurrency-slot occupancy absolutely; like `evaluationTimeout`,
-its ability to free the underlying worker thread depends on the operation reaching an interruptible point. Set it to
+transaction back. It bounds transaction lifetime and concurrency-slot occupancy absolutely; like `timeoutMs`, its
+ability to free the underlying worker thread depends on the operation reaching an interruptible point. Set it to
 `0` to disable the cap. Finally, `maxConcurrentTransactions` (default 1000) caps the number of open transactions
 allowed; when the limit is reached, new begin requests are rejected with HTTP 503.
 
-These compose with the per-operation `evaluationTimeout` (and its per-request `timeoutMs` override) to bound a
-transaction at three independent scopes: a single operation (`evaluationTimeout`), the gaps between operations
+These compose with the per-operation `timeoutMs` (configurable server-wide and overridable per request) to bound a
+transaction at three independent scopes: a single operation (`timeoutMs`), the gaps between operations
 (`idleTransactionTimeout`), and the transaction as a whole (`maxTransactionLifetime`). The defaults keep a transaction
 bounded out of the box; disabling all of them is a deliberate operator choice, and a per-request `timeoutMs` is always
 honored as sent.

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -238,11 +238,11 @@ Some connection options can also be set on individual requests made through the 
 
 [source,go]
 ----
-results, err := g.With("evaluationTimeout", 500).V().Out("knows").ToList()
+results, err := g.With("timeoutMs", 500).V().Out("knows").ToList()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent` and
-`evaluationTimeout`.
+`timeoutMs`.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
 to optimize result transfer. For direct `Client.Submit()` calls, set the connection-level `BulkResults` option to
@@ -514,12 +514,12 @@ Both the `Client` and `DriverRemoteConnection` types have a `SubmitWithOptions(t
 of the standard `Submit()` method. These methods allow a `RequestOptions` struct to be passed in which will augment the
 execution on the server. `RequestOptions` can be constructed
 using `RequestOptionsBuilder`. A good use-case for this feature is to set a per-request override to the
-`evaluationTimeout` so that it only applies to the current request.
+`timeoutMs` so that it only applies to the current request.
 
 [source,go]
 ----
 options := new(RequestOptionsBuilder).
-			SetEvaluationTimeout(5000).
+			SetTimeoutMs(5000).
 			SetBatchSize(32).
 			SetMaterializeProperties("tokens").
 			AddParameter("x", 100).
@@ -528,15 +528,15 @@ resultSet, err := client.SubmitWithOptions("g.V(x).count()", options)
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`,
-`evaluationTimeout` and `materializeProperties`.
+`timeoutMs` and `materializeProperties`.
 `RequestOptions` may also contain a map of query `parameters` to be applied to the supplied
 traversal string.
 
 [source,go]
 ----
-resultSet, err := client.SubmitWithOptions("g.with('evaluationTimeout', 500).addV().iterate();"+
+resultSet, err := client.SubmitWithOptions("g.with('timeoutMs', 500).addV().iterate();"+
   "g.addV().iterate();"+
-  "g.with('evaluationTimeout', 500).addV();", new(RequestOptionsBuilder).SetEvaluationTimeout(500).Create())
+  "g.with('timeoutMs', 500).addV();", new(RequestOptionsBuilder).SetTimeoutMs(500).Create())
 results, err := resultSet.All()
 ----
 
@@ -1039,11 +1039,11 @@ on the `TraversalSource`. For instance to set request timeout to 500 millisecond
 [source,java]
 ----
 GraphTraversalSource g = traversal().with(conf);
-List<Vertex> vertices = g.with(Tokens.ARGS_EVAL_TIMEOUT, 500L).V().out("knows").toList()
+List<Vertex> vertices = g.with(Tokens.TIMEOUT_MS, 500L).V().out("knows").toList()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`,
-`materializeProperties` and `evaluationTimeout`. Use of `Tokens` to reference these options is preferred.
+`materializeProperties` and `timeoutMs`. Use of `Tokens` to reference these options is preferred.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
 to optimize result transfer. This does not apply to direct `Client.submit()` calls, where `bulkResults` must be
@@ -1381,8 +1381,7 @@ which will boost performance and reduce resources required on the server.
 
 There are a number of overloads to `Client.submit()` that accept a `RequestOptions` object. The `RequestOptions`
 provide a way to include options that are specific to the request made with the call to `submit()`. A good use-case for
-this feature is to set a per-request override to the `evaluationTimeout` so that it only applies to the current
-request.
+this feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
 
 [source,java]
 ----
@@ -1940,11 +1939,11 @@ Some connection options can also be set on individual requests made through the 
 
 [source,javascript]
 ----
-const vertices = await g.with_('evaluationTimeout', 500).V().out('knows').toList()
+const vertices = await g.with_('timeoutMs', 500).V().out('knows').toList()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent`,
-`bulkResults`, `materializeProperties` and `evaluationTimeout`.
+`bulkResults`, `materializeProperties` and `timeoutMs`.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
 to optimize result transfer. This does not apply to direct `Client.submit()` calls, where `bulkResults` must be
@@ -2281,16 +2280,15 @@ for (const vertex of result2) {
 
 The `client.submit()` functions accept a `requestOptions` which expects a dictionary. The `requestOptions`
 provide a way to include options that are specific to the request made with the call to `submit()`. A good use-case for
-this feature is to set a per-request override to the `evaluationTimeout` so that it only applies to the current
-request.
+this feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
 
 [source,javascript]
 ----
-const result = await client.submit("g.V().repeat(both()).times(100)", null, { evaluationTimeout: 5000 })
+const result = await client.submit("g.V().repeat(both()).times(100)", null, { timeoutMs: 5000 })
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent`,
-`bulkResults`, `materializeProperties` and `evaluationTimeout`.
+`bulkResults`, `materializeProperties` and `timeoutMs`.
 
 IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
 with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple
@@ -2327,7 +2325,7 @@ per-request settings.
 [source,javascript]
 ----
 try {
-  for await (const item of client.stream('g.V().has("age", gt(age))', { age: 30 }, { evaluationTimeout: 5000 })) {
+  for await (const item of client.stream('g.V().has("age", gt(age))', { age: 30 }, { timeoutMs: 5000 })) {
     console.log(item);
   }
 } catch (err) {
@@ -2679,12 +2677,12 @@ For instance to set request timeout to 500 milliseconds:
 
 [source,csharp]
 ----
-var l = g.With(Tokens.ArgsEvalTimeout, 500).V().Out("knows").Count().ToList();
+var l = g.With(Tokens.ArgsTimeoutMs, 500).V().Out("knows").Count().ToList();
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`,
-`materializeProperties`, and `evaluationTimeout`. These options are available as constants on the
-`Gremlin.Net.Driver.Tokens` class.
+`materializeProperties`, and `timeoutMs`. These options are available as constants on the `Gremlin.Net.Driver.Tokens`
+class.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
 to optimize result transfer. This does not apply to direct `GremlinClient.SubmitAsync()` calls, where `bulkResults`
@@ -2946,7 +2944,7 @@ include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference
 ==== Per Request Settings
 
 A `RequestMessage` can be built with additional fields using the builder pattern. A good use-case for this
-feature is to set a per-request override to the `evaluationTimeout` so that it only applies to the current request.
+feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
 
 [source,csharp]
 ----
@@ -2954,7 +2952,7 @@ include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`, `materializeProperties`
-and `evaluationTimeout`. These options are available as constants on the `Gremlin.Net.Driver.Tokens` class.
+and `timeoutMs`. These options are available as constants on the `Gremlin.Net.Driver.Tokens` class.
 
 ==== Request Interceptors
 
@@ -3339,11 +3337,11 @@ Some connection options can also be set on individual requests made through the 
 
 [source,python]
 ----
-vertices = g.with_('evaluationTimeout', 500).V().out('knows').to_list()
+vertices = g.with_('timeoutMs', 500).V().out('knows').to_list()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `language`,
-`materializeProperties`, `userAgent`, and `evaluationTimeout`.
+`materializeProperties`, `userAgent`, and `timeoutMs`.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `True` per-request
 to optimize result transfer. This does not apply to direct `Client.submit()` calls, where `bulkResults` must be
@@ -3692,16 +3690,15 @@ returns a `concurrent.futures.Future` that resolves to a list when it is complet
 
 The `client.submit()` functions accept a `request_options` which expects a dictionary. The `request_options`
 provide a way to include options that are specific to the request made with the call to `submit()`. A good use-case for
-this feature is to set a per-request override to the `evaluationTimeout` so that it only applies to the current
-request.
+this feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
 
 [source,python]
 ----
-result_set = client.submit('g.V().repeat(both()).times(100)', request_options={'evaluationTimeout': 5000})
+result_set = client.submit('g.V().repeat(both()).times(100)', request_options={'timeoutMs': 5000})
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `requestId`, `userAgent`,
-`materializeProperties` and `evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated).
+`materializeProperties` and `timeoutMs`.
 
 IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
 with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -238,11 +238,11 @@ Some connection options can also be set on individual requests made through the 
 
 [source,go]
 ----
-results, err := g.With("timeoutMs", 500).V().Out("knows").ToList()
+results, err := g.With("timeoutMillis", 500).V().Out("knows").ToList()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent` and
-`timeoutMs`.
+`timeoutMillis`.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
 to optimize result transfer. For direct `Client.Submit()` calls, set the connection-level `BulkResults` option to
@@ -514,12 +514,12 @@ Both the `Client` and `DriverRemoteConnection` types have a `SubmitWithOptions(t
 of the standard `Submit()` method. These methods allow a `RequestOptions` struct to be passed in which will augment the
 execution on the server. `RequestOptions` can be constructed
 using `RequestOptionsBuilder`. A good use-case for this feature is to set a per-request override to the
-`timeoutMs` so that it only applies to the current request.
+`timeoutMillis` so that it only applies to the current request.
 
 [source,go]
 ----
 options := new(RequestOptionsBuilder).
-			SetTimeoutMs(5000).
+			SetTimeoutMillis(5000).
 			SetBatchSize(32).
 			SetMaterializeProperties("tokens").
 			AddParameter("x", 100).
@@ -528,15 +528,15 @@ resultSet, err := client.SubmitWithOptions("g.V(x).count()", options)
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`,
-`timeoutMs` and `materializeProperties`.
+`timeoutMillis` and `materializeProperties`.
 `RequestOptions` may also contain a map of query `parameters` to be applied to the supplied
 traversal string.
 
 [source,go]
 ----
-resultSet, err := client.SubmitWithOptions("g.with('timeoutMs', 500).addV().iterate();"+
+resultSet, err := client.SubmitWithOptions("g.with('timeoutMillis', 500).addV().iterate();"+
   "g.addV().iterate();"+
-  "g.with('timeoutMs', 500).addV();", new(RequestOptionsBuilder).SetTimeoutMs(500).Create())
+  "g.with('timeoutMillis', 500).addV();", new(RequestOptionsBuilder).SetTimeoutMillis(500).Create())
 results, err := resultSet.All()
 ----
 
@@ -1039,11 +1039,11 @@ on the `TraversalSource`. For instance to set request timeout to 500 millisecond
 [source,java]
 ----
 GraphTraversalSource g = traversal().with(conf);
-List<Vertex> vertices = g.with(Tokens.TIMEOUT_MS, 500L).V().out("knows").toList()
+List<Vertex> vertices = g.with(Tokens.TIMEOUT_MILLIS, 500L).V().out("knows").toList()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`,
-`materializeProperties` and `timeoutMs`. Use of `Tokens` to reference these options is preferred.
+`materializeProperties` and `timeoutMillis`. Use of `Tokens` to reference these options is preferred.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
 to optimize result transfer. This does not apply to direct `Client.submit()` calls, where `bulkResults` must be
@@ -1381,27 +1381,27 @@ which will boost performance and reduce resources required on the server.
 
 There are a number of overloads to `Client.submit()` that accept a `RequestOptions` object. The `RequestOptions`
 provide a way to include options that are specific to the request made with the call to `submit()`. A good use-case for
-this feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
+this feature is to set a per-request override to the `timeoutMillis` so that it only applies to the current request.
 
 [source,java]
 ----
 Cluster cluster = Cluster.open();
 Client client = cluster.connect();
-RequestOptions options = RequestOptions.build().timeout(500).create();
+RequestOptions options = RequestOptions.build().timeoutMillis(500).create();
 List<Result> result = client.submit("g.V().repeat(both()).times(100)", options).all().get();
 ----
 
-The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar with
-bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Gremlin Server will respect timeouts set this way
-in scripts as well. With scripts of course, it is possible to send multiple traversals at once in the same script.
+The preferred method for setting a per-request timeout for scripts is demonstrated above, but a script may also use
+`g.with("timeoutMillis", 500)`. Gremlin Server will respect timeouts set this way in scripts as well. With scripts of
+course, it is possible to send multiple traversals at once in the same script.
 In such events, the timeout for the request is interpreted as a sum of all timeouts identified in the script.
 
 [source,java]
 ----
-RequestOptions options = RequestOptions.build().timeout(500).create();
-List<Result> result = client.submit("g.with(EVALUATION_TIMEOUT, 500).addV().iterate();" +
+RequestOptions options = RequestOptions.build().timeoutMillis(500).create();
+List<Result> result = client.submit("g.with(\"timeoutMillis\", 500).addV().iterate();" +
                                     "g.addV().iterate();" + 
-                                    "g.with(EVALUATION_TIMEOUT, 500).addV();", options).all().get();
+                                    "g.with(\"timeoutMillis\", 500).addV();", options).all().get();
 ----
 
 In the above example, `RequestOptions` defines a timeout of 500 milliseconds, but the script has three traversals with
@@ -1939,11 +1939,11 @@ Some connection options can also be set on individual requests made through the 
 
 [source,javascript]
 ----
-const vertices = await g.with_('timeoutMs', 500).V().out('knows').toList()
+const vertices = await g.with_('timeoutMillis', 500).V().out('knows').toList()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent`,
-`bulkResults`, `materializeProperties` and `timeoutMs`.
+`bulkResults`, `materializeProperties` and `timeoutMillis`.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
 to optimize result transfer. This does not apply to direct `Client.submit()` calls, where `bulkResults` must be
@@ -2280,18 +2280,18 @@ for (const vertex of result2) {
 
 The `client.submit()` functions accept a `requestOptions` which expects a dictionary. The `requestOptions`
 provide a way to include options that are specific to the request made with the call to `submit()`. A good use-case for
-this feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
+this feature is to set a per-request override to the `timeoutMillis` so that it only applies to the current request.
 
 [source,javascript]
 ----
-const result = await client.submit("g.V().repeat(both()).times(100)", null, { timeoutMs: 5000 })
+const result = await client.submit("g.V().repeat(both()).times(100)", null, { timeoutMillis: 5000 })
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent`,
-`bulkResults`, `materializeProperties` and `timeoutMs`.
+`bulkResults`, `materializeProperties` and `timeoutMillis`.
 
-IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
-with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple
+IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but a script may
+also use `g.with("timeoutMillis", 500)`. Scripts with multiple traversals and multiple
 timeouts will be interpreted as a sum of all timeouts identified in the script for that request.
 
 ==== Streaming Results
@@ -2325,7 +2325,7 @@ per-request settings.
 [source,javascript]
 ----
 try {
-  for await (const item of client.stream('g.V().has("age", gt(age))', { age: 30 }, { timeoutMs: 5000 })) {
+  for await (const item of client.stream('g.V().has("age", gt(age))', { age: 30 }, { timeoutMillis: 5000 })) {
     console.log(item);
   }
 } catch (err) {
@@ -2677,11 +2677,11 @@ For instance to set request timeout to 500 milliseconds:
 
 [source,csharp]
 ----
-var l = g.With(Tokens.ArgsTimeoutMs, 500).V().Out("knows").Count().ToList();
+var l = g.With(Tokens.ArgsTimeoutMillis, 500).V().Out("knows").Count().ToList();
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`,
-`materializeProperties`, and `timeoutMs`. These options are available as constants on the `Gremlin.Net.Driver.Tokens`
+`materializeProperties`, and `timeoutMillis`. These options are available as constants on the `Gremlin.Net.Driver.Tokens`
 class.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `true` per-request
@@ -2944,7 +2944,7 @@ include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference
 ==== Per Request Settings
 
 A `RequestMessage` can be built with additional fields using the builder pattern. A good use-case for this
-feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
+feature is to set a per-request override to the `timeoutMillis` so that it only applies to the current request.
 
 [source,csharp]
 ----
@@ -2952,7 +2952,7 @@ include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `userAgent`, `materializeProperties`
-and `timeoutMs`. These options are available as constants on the `Gremlin.Net.Driver.Tokens` class.
+and `timeoutMillis`. These options are available as constants on the `Gremlin.Net.Driver.Tokens` class.
 
 ==== Request Interceptors
 
@@ -3337,11 +3337,11 @@ Some connection options can also be set on individual requests made through the 
 
 [source,python]
 ----
-vertices = g.with_('timeoutMs', 500).V().out('knows').to_list()
+vertices = g.with_('timeoutMillis', 500).V().out('knows').to_list()
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `language`,
-`materializeProperties`, `userAgent`, and `timeoutMs`.
+`materializeProperties`, `userAgent`, and `timeoutMillis`.
 
 NOTE: When submitting traversals through `DriverRemoteConnection`, `bulkResults` defaults to `True` per-request
 to optimize result transfer. This does not apply to direct `Client.submit()` calls, where `bulkResults` must be
@@ -3690,26 +3690,26 @@ returns a `concurrent.futures.Future` that resolves to a list when it is complet
 
 The `client.submit()` functions accept a `request_options` which expects a dictionary. The `request_options`
 provide a way to include options that are specific to the request made with the call to `submit()`. A good use-case for
-this feature is to set a per-request override to the `timeoutMs` so that it only applies to the current request.
+this feature is to set a per-request override to the `timeoutMillis` so that it only applies to the current request.
 
 [source,python]
 ----
-result_set = client.submit('g.V().repeat(both()).times(100)', request_options={'timeoutMs': 5000})
+result_set = client.submit('g.V().repeat(both()).times(100)', request_options={'timeoutMillis': 5000})
 ----
 
 The following options are allowed on a per-request basis in this fashion: `batchSize`, `bulkResults`, `requestId`, `userAgent`,
-`materializeProperties` and `timeoutMs`.
+`materializeProperties` and `timeoutMillis`.
 
-IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but those familiar
-with bytecode may try `g.with(EVALUATION_TIMEOUT, 500)` within a script. Scripts with multiple traversals and multiple
+IMPORTANT: The preferred method for setting a per-request timeout for scripts is demonstrated above, but a script may
+also use `g.with("timeoutMillis", 500)`. Scripts with multiple traversals and multiple
 timeouts will be interpreted as a sum of all timeouts identified in the script for that request.
 
 [source,java]
 ----
-RequestOptions options = RequestOptions.build().timeout(500).create();
-List<Result> result = client.submit("g.with(EVALUATION_TIMEOUT, 500).addV().iterate();" +
-                                    "g.addV().iterate();
-                                    "g.with(EVALUATION_TIMEOUT, 500).addV();", options).all().get();
+RequestOptions options = RequestOptions.build().timeoutMillis(500).create();
+List<Result> result = client.submit("g.with(\"timeoutMillis\", 500).addV().iterate();" +
+                                    "g.addV().iterate();" +
+                                    "g.with(\"timeoutMillis\", 500).addV();", options).all().get();
 ----
 
 In the above example, `RequestOptions` defines a timeout of 500 milliseconds, but the script has three traversals with

--- a/docs/src/upgrade/release-4.x.x.asciidoc
+++ b/docs/src/upgrade/release-4.x.x.asciidoc
@@ -154,25 +154,25 @@ As with the earlier JDK 17 support, some libraries still rely on deep reflection
 library used with OLAP), so it may be necessary to `--add-opens` or `--add-exports` certain modules at runtime. The set
 of options used by TinkerPop's own tests is unchanged.
 
-==== Renaming `evaluationTimeout` to `timeoutMs`
+==== Renaming `evaluationTimeout` to `timeoutMillis`
 
-The per-request execution timeout is now referred to by a single name, `timeoutMs`, everywhere. `timeoutMs` is the
-maximum time in milliseconds that a request is allowed to execute on the server before it times out. It can be
+The per-request execution timeout is now referred to by a single name, `timeoutMillis`, everywhere. `timeoutMillis` is
+the maximum time in milliseconds that a request is allowed to execute on the server before it times out. It can be
 configured server-wide and overridden on a per-request basis. Previously the same concept was called
-`evaluationTimeout` in the server configuration, the `with()` script token, and several driver APIs, while the wire
-protocol already used `timeoutMs`. Collapsing to one name removes that inconsistency.
+`evaluationTimeout` in the server configuration, the `with()` script token, and several driver APIs. The `Millis`
+suffix aligns it with the driver connection options such as `connectTimeoutMillis` and `readTimeoutMillis`.
 
 This is a breaking change with no backward-compatible alias. The old `evaluationTimeout` name (and the long-deprecated
 `scriptEvaluationTimeout`) are no longer recognized anywhere. Update each surface as follows:
 
-- *Server config*: the `gremlin-server.yaml` key `evaluationTimeout` becomes `timeoutMs` (default still 30000).
-- *Script token*: `g.with('evaluationTimeout', 500)` becomes `g.with('timeoutMs', 500)`.
-- *Java driver*: `RequestOptions.Builder.timeout(long)` becomes `timeoutMs(long)` and `getTimeout()` becomes `getTimeoutMs()`.
-- *Go driver*: `RequestOptionsBuilder.SetEvaluationTimeout(int)` becomes `SetTimeoutMs(int)`.
-- *.NET driver*: `Tokens.ArgsEvalTimeout` becomes `Tokens.ArgsTimeoutMs` and `RequestMessage.Builder.AddEvaluationTimeout(...)`
-  becomes `AddTimeoutMs(...)`.
-- *JavaScript driver*: the request option `{ evaluationTimeout: N }` becomes `{ timeoutMs: N }`.
-- *Python driver*: use the token `timeoutMs` (e.g. `g.with_('timeoutMs', 500)` or `request_options={'timeoutMs': 500}`).
+- *Server config*: the `gremlin-server.yaml` key `evaluationTimeout` becomes `timeoutMillis` (default still 30000).
+- *Script token*: `g.with('evaluationTimeout', 500)` becomes `g.with('timeoutMillis', 500)`.
+- *Java driver*: `RequestOptions.Builder.timeout(long)` becomes `timeoutMillis(long)` and `getTimeout()` becomes `getTimeoutMillis()`.
+- *Go driver*: `RequestOptionsBuilder.SetEvaluationTimeout(int)` becomes `SetTimeoutMillis(int)`.
+- *.NET driver*: `Tokens.ArgsEvalTimeout` becomes `Tokens.ArgsTimeoutMillis` and `RequestMessage.Builder.AddEvaluationTimeout(...)`
+  becomes `AddTimeoutMillis(...)`.
+- *JavaScript driver*: the request option `{ evaluationTimeout: N }` becomes `{ timeoutMillis: N }`.
+- *Python driver*: use the token `timeoutMillis` (e.g. `g.with_('timeoutMillis', 500)` or `request_options={'timeoutMillis': 500}`).
 
 Driver and server should be upgraded together. A driver sending the old `evaluationTimeout` field to a 4.x server has
 that field silently ignored and falls back to the server's default timeout, as with any unrecognized request argument.
@@ -1013,6 +1013,25 @@ if (hasContainer.hasTraversal()) continue;  // skip - dynamic value, cannot fold
 `GraphStep.processHasContainerIds()` already includes this guard. Providers that implement their own `HasContainer`
 folding strategy should add the same check. Without it, the container's value is read before it has been resolved
 against a traverser, so an unresolved value would be folded into the index lookup and produce incorrect results.
+
+===== Millisecond Server Settings Renamed
+
+The millisecond-valued Gremlin Server settings now carry a `Millis` suffix so that their unit is explicit in the name,
+matching `timeoutMillis` and the driver connection options such as `connectTimeoutMillis`. Providers that ship their
+own `gremlin-server.yaml`, generate server configuration, or read these fields from the `Settings` object must update
+the following keys.
+
+[source,text]
+----
+idleConnectionTimeout        ->  idleConnectionTimeoutMillis
+keepAliveInterval            ->  keepAliveIntervalMillis
+ssl.refreshInterval          ->  ssl.refreshIntervalMillis
+metrics.<reporter>.interval  ->  metrics.<reporter>.intervalMillis
+----
+
+There is no backward-compatible alias, so the old keys are no longer recognized. The transaction settings
+`idleTransactionTimeoutMillis`, `maxTransactionLifetimeMillis`, and `perGraphCloseTimeoutMillis` are new in 4.x and
+also use the suffix.
 
 ==== Graph Driver Providers
 

--- a/docs/src/upgrade/release-4.x.x.asciidoc
+++ b/docs/src/upgrade/release-4.x.x.asciidoc
@@ -154,6 +154,29 @@ As with the earlier JDK 17 support, some libraries still rely on deep reflection
 library used with OLAP), so it may be necessary to `--add-opens` or `--add-exports` certain modules at runtime. The set
 of options used by TinkerPop's own tests is unchanged.
 
+==== Renaming `evaluationTimeout` to `timeoutMs`
+
+The per-request execution timeout is now referred to by a single name, `timeoutMs`, everywhere. `timeoutMs` is the
+maximum time in milliseconds that a request is allowed to execute on the server before it times out. It can be
+configured server-wide and overridden on a per-request basis. Previously the same concept was called
+`evaluationTimeout` in the server configuration, the `with()` script token, and several driver APIs, while the wire
+protocol already used `timeoutMs`. Collapsing to one name removes that inconsistency.
+
+This is a breaking change with no backward-compatible alias. The old `evaluationTimeout` name (and the long-deprecated
+`scriptEvaluationTimeout`) are no longer recognized anywhere. Update each surface as follows:
+
+- *Server config*: the `gremlin-server.yaml` key `evaluationTimeout` becomes `timeoutMs` (default still 30000).
+- *Script token*: `g.with('evaluationTimeout', 500)` becomes `g.with('timeoutMs', 500)`.
+- *Java driver*: `RequestOptions.Builder.timeout(long)` becomes `timeoutMs(long)` and `getTimeout()` becomes `getTimeoutMs()`.
+- *Go driver*: `RequestOptionsBuilder.SetEvaluationTimeout(int)` becomes `SetTimeoutMs(int)`.
+- *.NET driver*: `Tokens.ArgsEvalTimeout` becomes `Tokens.ArgsTimeoutMs` and `RequestMessage.Builder.AddEvaluationTimeout(...)`
+  becomes `AddTimeoutMs(...)`.
+- *JavaScript driver*: the request option `{ evaluationTimeout: N }` becomes `{ timeoutMs: N }`.
+- *Python driver*: use the token `timeoutMs` (e.g. `g.with_('timeoutMs', 500)` or `request_options={'timeoutMs': 500}`).
+
+Driver and server should be upgraded together. A driver sending the old `evaluationTimeout` field to a 4.x server has
+that field silently ignored and falls back to the server's default timeout, as with any unrecognized request argument.
+
 ==== Declarative Pattern Matching
 
 Gremlin has always offered both imperative and declarative styles to writing graph queries. While the imperative style

--- a/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/jsr223/gremlin-server-integration.yaml
+++ b/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/jsr223/gremlin-server-integration.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 45940
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
@@ -26,10 +26,10 @@ lifecycleHooks:
 serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4}                                                              # application/vnd.graphbinary-v4.0
 metrics: {
-  consoleReporter: {enabled: true, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  consoleReporter: {enabled: true, intervalMillis: 180000},
+  csvReporter: {enabled: true, intervalMillis: 180000, fileName: /tmp/gremlin-server-metrics.csv},
   jmxReporter: {enabled: true},
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/jsr223/gremlin-server-integration.yaml
+++ b/gremlin-console/src/test/resources/org/apache/tinkerpop/gremlin/console/jsr223/gremlin-server-integration.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 45940
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptChecker.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptChecker.java
@@ -42,7 +42,7 @@ public class GremlinScriptChecker {
      * At least one of these tokens should be present somewhere in the Gremlin string for {@link #parse(String)} to
      * take any action at all.
      */
-    private static final Set<String> tokens = new HashSet<>(Arrays.asList("timeoutMs", "TIMEOUT_MS",
+    private static final Set<String> tokens = new HashSet<>(Arrays.asList("timeoutMillis", "TIMEOUT_MILLIS",
             "requestId", "REQUEST_ID", "materializeProperties", "ARGS_MATERIALIZE_PROPERTIES"));
 
     /**
@@ -77,12 +77,12 @@ public class GremlinScriptChecker {
     /**
      * Regex fragment for the timeout tokens to look for. There are basically two:
      * <ul>
-     *     <li>{@code timeoutMs} which is a string value and thus single or double quoted</li>
-     *     <li>{@code TIMEOUT_MS} which is a enum type of value which can be referenced with or without a {@code Tokens} qualifier</li>
+     *     <li>{@code timeoutMillis} which is a string value and thus single or double quoted</li>
+     *     <li>{@code TIMEOUT_MILLIS} which is a enum type of value which can be referenced with or without a {@code Tokens} qualifier</li>
      * </ul>
      * See {@link #patternWithOptions} for explain as this regex is embedded in there.
      */
-    private static final String timeoutTokens = "[\"']timeoutMs[\"']|(?:Tokens\\.)?TIMEOUT_MS";
+    private static final String timeoutTokens = "[\"']timeoutMillis[\"']|(?:Tokens\\.)?TIMEOUT_MILLIS";
 
     /**
      * Regex fragment for the timeout tokens to look for. There are basically four:

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptChecker.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptChecker.java
@@ -42,9 +42,8 @@ public class GremlinScriptChecker {
      * At least one of these tokens should be present somewhere in the Gremlin string for {@link #parse(String)} to
      * take any action at all.
      */
-    private static final Set<String> tokens = new HashSet<>(Arrays.asList("evaluationTimeout", "scriptEvaluationTimeout",
-            "ARGS_EVAL_TIMEOUT", "ARGS_SCRIPT_EVAL_TIMEOUT", "requestId", "REQUEST_ID", "materializeProperties",
-            "ARGS_MATERIALIZE_PROPERTIES"));
+    private static final Set<String> tokens = new HashSet<>(Arrays.asList("timeoutMs", "TIMEOUT_MS",
+            "requestId", "REQUEST_ID", "materializeProperties", "ARGS_MATERIALIZE_PROPERTIES"));
 
     /**
      * Matches single line comments, multi-line comments and space characters.
@@ -76,16 +75,14 @@ public class GremlinScriptChecker {
     private static final Pattern patternClean = Pattern.compile("//.*$|/\\*(.|[\\r\\n])*?\\*/|\\s", Pattern.MULTILINE);
 
     /**
-     * Regex fragment for the timeout tokens to look for. There are basically four:
+     * Regex fragment for the timeout tokens to look for. There are basically two:
      * <ul>
-     *     <li>{@code evaluationTimeout} which is a string value and thus single or double quoted</li>
-     *     <li>{@code scriptEvaluationTimeout} which is a string value and thus single or double quoted</li>
-     *     <li>{@code ARGS_EVAL_TIMEOUT} which is a enum type of value which can be referenced with or without a {@code Tokens} qualifier</li>
-     *     <li>{@code ARGS_SCRIPT_EVAL_TIMEOUT} which is a enum type of value which can be referenced with or without a {@code Tokens} qualifier</li>
+     *     <li>{@code timeoutMs} which is a string value and thus single or double quoted</li>
+     *     <li>{@code TIMEOUT_MS} which is a enum type of value which can be referenced with or without a {@code Tokens} qualifier</li>
      * </ul>
      * See {@link #patternWithOptions} for explain as this regex is embedded in there.
      */
-    private static final String timeoutTokens = "[\"']evaluationTimeout[\"']|[\"']scriptEvaluationTimeout[\"']|(?:Tokens\\.)?ARGS_EVAL_TIMEOUT|(?:Tokens\\.)?ARGS_SCRIPT_EVAL_TIMEOUT";
+    private static final String timeoutTokens = "[\"']timeoutMs[\"']|(?:Tokens\\.)?TIMEOUT_MS";
 
     /**
      * Regex fragment for the timeout tokens to look for. There are basically four:

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptCheckerTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptCheckerTest.java
@@ -50,17 +50,17 @@ public class GremlinScriptCheckerTest {
     @Test
     public void shouldNotFindTimeoutCozWeCommentedItOut() {
         assertEquals(Optional.empty(), GremlinScriptChecker.parse("g.\n" +
-                "                                                  // with('evaluationTimeout', 1000L).\n" +
+                "                                                  // with('timeoutMs', 1000L).\n" +
                 "                                                  with(true).V().out('knows')").getTimeout());
     }
 
     @Test
     public void shouldIdentifyTimeoutWithOddSpacing() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout' , 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs' , 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('scriptEvaluationTimeout'   ,  1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs'   ,  1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout',1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs',1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -84,25 +84,25 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutWithLowerL() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000l).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000l).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('scriptEvaluationTimeout', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutWithNoL() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('scriptEvaluationTimeout', 1000).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsStringKeySingleQuoted() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('scriptEvaluationTimeout', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -116,9 +116,7 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutAsStringKeyDoubleQuoted() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(\"evaluationTimeout\", 1000L).with(true).V().out('knows')").
-                getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(\"scriptEvaluationTimeout\", 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(\"timeoutMs\", 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -132,9 +130,9 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKey() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -148,9 +146,9 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKeyWithoutClassName() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -164,17 +162,17 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyMultipleTimeouts() {
-        assertEquals(6000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows');" +
-                "g.with('evaluationTimeout', 1000L).with(true).V().out('knows');\n" +
-                "                                                   //g.with('evaluationTimeout', 1000L).with(true).V().out('knows');\n" +
-                "                                                   /* g.with('evaluationTimeout', 1000L).with(true).V().out('knows');*/\n" +
+        assertEquals(6000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows');" +
+                "g.with('timeoutMs', 1000L).with(true).V().out('knows');\n" +
+                "                                                   //g.with('timeoutMs', 1000L).with(true).V().out('knows');\n" +
+                "                                                   /* g.with('timeoutMs', 1000L).with(true).V().out('knows');*/\n" +
                 "                                                   /* \n" +
-                "g.with('evaluationTimeout', 1000L).with(true).V().out('knows'); \n" +
+                "g.with('timeoutMs', 1000L).with(true).V().out('knows'); \n" +
                 "*/ \n" +
-                "                                                   g.with('evaluationTimeout', 1000L).with(true).V().out('knows');\n" +
-                "                                                   g.with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows');\n" +
-                "                                                   g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows');\n" +
-                "                                                   g.with('scriptEvaluationTimeout', 1000L).with(true).V().out('knows');").
+                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows');").
                 getTimeout().get().longValue());
     }
 
@@ -241,7 +239,7 @@ public class GremlinScriptCheckerTest {
     @Test
     public void shouldFindAllResults() {
         final GremlinScriptChecker.Result r = GremlinScriptChecker.parse(
-                "g.with('evaluationTimeout', 1000).with(true).with(REQUEST_ID, \"db024fca-ed15-4375-95de-4c6106aef895\").with(\"materializeProperties\", 'all').V().out('knows')");
+                "g.with('timeoutMs', 1000).with(true).with(REQUEST_ID, \"db024fca-ed15-4375-95de-4c6106aef895\").with(\"materializeProperties\", 'all').V().out('knows')");
         assertEquals(1000, r.getTimeout().get().longValue());
         assertEquals("db024fca-ed15-4375-95de-4c6106aef895", r.getRequestId().get());
         assertEquals("all", r.getMaterializeProperties().get());
@@ -249,7 +247,7 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldParseLong() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).addV().property(id, 'blue').as('b').\n" +
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).addV().property(id, 'blue').as('b').\n" +
                 "  addV().property(id, 'orange').as('o').\n" +
                 "  addV().property(id, 'red').as('r').\n" +
                 "  addV().property(id, 'green').as('g').\n" +

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptCheckerTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/jsr223/GremlinScriptCheckerTest.java
@@ -50,17 +50,17 @@ public class GremlinScriptCheckerTest {
     @Test
     public void shouldNotFindTimeoutCozWeCommentedItOut() {
         assertEquals(Optional.empty(), GremlinScriptChecker.parse("g.\n" +
-                "                                                  // with('timeoutMs', 1000L).\n" +
+                "                                                  // with('timeoutMillis', 1000L).\n" +
                 "                                                  with(true).V().out('knows')").getTimeout());
     }
 
     @Test
     public void shouldIdentifyTimeoutWithOddSpacing() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs' , 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis' , 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs'   ,  1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis'   ,  1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs',1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis',1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -84,25 +84,25 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutWithLowerL() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000l).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000l).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutWithNoL() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsStringKeySingleQuoted() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -116,7 +116,7 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutAsStringKeyDoubleQuoted() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(\"timeoutMs\", 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(\"timeoutMillis\", 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -130,9 +130,9 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKey() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(Tokens.TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -146,9 +146,9 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKeyWithoutClassName() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
-        assertEquals(1000, GremlinScriptChecker.parse("g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinScriptChecker.parse("g.with(TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
@@ -162,17 +162,17 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldIdentifyMultipleTimeouts() {
-        assertEquals(6000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows');" +
-                "g.with('timeoutMs', 1000L).with(true).V().out('knows');\n" +
-                "                                                   //g.with('timeoutMs', 1000L).with(true).V().out('knows');\n" +
-                "                                                   /* g.with('timeoutMs', 1000L).with(true).V().out('knows');*/\n" +
+        assertEquals(6000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000L).with(true).V().out('knows');" +
+                "g.with('timeoutMillis', 1000L).with(true).V().out('knows');\n" +
+                "                                                   //g.with('timeoutMillis', 1000L).with(true).V().out('knows');\n" +
+                "                                                   /* g.with('timeoutMillis', 1000L).with(true).V().out('knows');*/\n" +
                 "                                                   /* \n" +
-                "g.with('timeoutMs', 1000L).with(true).V().out('knows'); \n" +
+                "g.with('timeoutMillis', 1000L).with(true).V().out('knows'); \n" +
                 "*/ \n" +
-                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows');\n" +
-                "                                                   g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows');\n" +
-                "                                                   g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows');\n" +
-                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows');").
+                "                                                   g.with('timeoutMillis', 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with(Tokens.TIMEOUT_MILLIS, 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with(TIMEOUT_MILLIS, 1000L).with(true).V().out('knows');\n" +
+                "                                                   g.with('timeoutMillis', 1000L).with(true).V().out('knows');").
                 getTimeout().get().longValue());
     }
 
@@ -239,7 +239,7 @@ public class GremlinScriptCheckerTest {
     @Test
     public void shouldFindAllResults() {
         final GremlinScriptChecker.Result r = GremlinScriptChecker.parse(
-                "g.with('timeoutMs', 1000).with(true).with(REQUEST_ID, \"db024fca-ed15-4375-95de-4c6106aef895\").with(\"materializeProperties\", 'all').V().out('knows')");
+                "g.with('timeoutMillis', 1000).with(true).with(REQUEST_ID, \"db024fca-ed15-4375-95de-4c6106aef895\").with(\"materializeProperties\", 'all').V().out('knows')");
         assertEquals(1000, r.getTimeout().get().longValue());
         assertEquals("db024fca-ed15-4375-95de-4c6106aef895", r.getRequestId().get());
         assertEquals("all", r.getMaterializeProperties().get());
@@ -247,7 +247,7 @@ public class GremlinScriptCheckerTest {
 
     @Test
     public void shouldParseLong() {
-        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).addV().property(id, 'blue').as('b').\n" +
+        assertEquals(1000, GremlinScriptChecker.parse("g.with('timeoutMillis', 1000L).addV().property(id, 'blue').as('b').\n" +
                 "  addV().property(id, 'orange').as('o').\n" +
                 "  addV().property(id, 'red').as('r').\n" +
                 "  addV().property(id, 'green').as('g').\n" +

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/GremlinLangTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/GremlinLangTest.java
@@ -125,7 +125,7 @@ public class GremlinLangTest {
                                 "by(__.out(\"knows\").values(\"name\").fold())"},
                 {g.inject(new int[]{5, 6}).union(__.V(Arrays.asList(1, 2)), __.V(Arrays.asList(3L, new int[]{4}))),
                         "g.inject([5,6]).union(__.V([1,2]),__.V([3L,[4]]))"},
-                {g.with("timeoutMs", 1000).V(), "g.V()"},
+                {g.with("timeoutMillis", 1000).V(), "g.V()"},
                 {g.withSideEffect("a", 1).V(), "g.withSideEffect(\"a\",1).V()"},
                 {g.withStrategies(ReadOnlyStrategy.instance()).V(), "g.withStrategies(ReadOnlyStrategy).V()"},
                 {g.withoutStrategies(ReadOnlyStrategy.class).V(), "g.withoutStrategies(ReadOnlyStrategy).V()"},

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/GremlinLangTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/GremlinLangTest.java
@@ -125,7 +125,7 @@ public class GremlinLangTest {
                                 "by(__.out(\"knows\").values(\"name\").fold())"},
                 {g.inject(new int[]{5, 6}).union(__.V(Arrays.asList(1, 2)), __.V(Arrays.asList(3L, new int[]{4}))),
                         "g.inject([5,6]).union(__.V([1,2]),__.V([3L,[4]]))"},
-                {g.with("evaluationTimeout", 1000).V(), "g.V()"},
+                {g.with("timeoutMs", 1000).V(), "g.V()"},
                 {g.withSideEffect("a", 1).V(), "g.withSideEffect(\"a\",1).V()"},
                 {g.withStrategies(ReadOnlyStrategy.instance()).V(), "g.withStrategies(ReadOnlyStrategy).V()"},
                 {g.withoutStrategies(ReadOnlyStrategy.class).V(), "g.withoutStrategies(ReadOnlyStrategy).V()"},

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/RequestMessage.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/RequestMessage.cs
@@ -169,13 +169,14 @@ namespace Gremlin.Net.Driver.Messages
             public bool HasField(string key) => _fields.ContainsKey(key);
 
             /// <summary>
-            ///     Sets the evaluation timeout for this request.
+            ///     Sets the timeout in milliseconds for this request. This is the maximum time the request is
+            ///     allowed to execute on the server before it times out.
             /// </summary>
-            /// <param name="timeout">The timeout value.</param>
+            /// <param name="timeout">The timeout value in milliseconds.</param>
             /// <returns>The <see cref="Builder" />.</returns>
-            public Builder AddEvaluationTimeout(object timeout)
+            public Builder AddTimeoutMs(object timeout)
             {
-                _fields[Tokens.ArgsEvalTimeout] = timeout;
+                _fields[Tokens.ArgsTimeoutMs] = timeout;
                 return this;
             }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/RequestMessage.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Messages/RequestMessage.cs
@@ -174,9 +174,9 @@ namespace Gremlin.Net.Driver.Messages
             /// </summary>
             /// <param name="timeout">The timeout value in milliseconds.</param>
             /// <returns>The <see cref="Builder" />.</returns>
-            public Builder AddTimeoutMs(object timeout)
+            public Builder AddTimeoutMillis(object timeout)
             {
-                _fields[Tokens.ArgsTimeoutMs] = timeout;
+                _fields[Tokens.ArgsTimeoutMillis] = timeout;
                 return this;
             }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
@@ -69,10 +69,10 @@ namespace Gremlin.Net.Driver
         public const string ArgsLanguage = "language";
 
         /// <summary>
-        ///     Argument name that allows the override of the server setting that determines the maximum time to wait for a
-        ///     request to execute on the server.
+        ///     Argument name that allows the override of the server setting that determines the maximum time in
+        ///     milliseconds a request is allowed to execute on the server before it times out.
         /// </summary>
-        public const string ArgsEvalTimeout = "evaluationTimeout";
+        public const string ArgsTimeoutMs = "timeoutMs";
 
         /// <summary>
         ///     Argument name that allows the override of handling properties.

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Tokens.cs
@@ -72,7 +72,7 @@ namespace Gremlin.Net.Driver
         ///     Argument name that allows the override of the server setting that determines the maximum time in
         ///     milliseconds a request is allowed to execute on the server before it times out.
         /// </summary>
-        public const string ArgsTimeoutMs = "timeoutMs";
+        public const string ArgsTimeoutMillis = "timeoutMillis";
 
         /// <summary>
         ///     Argument name that allows the override of handling properties.

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
@@ -130,7 +130,7 @@ using var gremlinClient = new GremlinClient(gremlinServer);
 var response =
     await gremlinClient.SubmitWithSingleResultAsync<string>(
         RequestMessage.Build("g.V().count()").
-            AddField(Tokens.ArgsEvalTimeout, 500).
+            AddField(Tokens.ArgsTimeoutMs, 500).
             Create());
 // end::submittingScriptsWithTimeout[]
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
@@ -130,7 +130,7 @@ using var gremlinClient = new GremlinClient(gremlinServer);
 var response =
     await gremlinClient.SubmitWithSingleResultAsync<string>(
         RequestMessage.Build("g.V().count()").
-            AddField(Tokens.ArgsTimeoutMs, 500).
+            AddField(Tokens.ArgsTimeoutMillis, 500).
             Create());
 // end::submittingScriptsWithTimeout[]
         }

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/DriverRemoteConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/DriverRemoteConnectionTests.cs
@@ -147,14 +147,14 @@ namespace Gremlin.Net.UnitTest.Driver
             gl.AddStep("V", Array.Empty<object>());
             gl.OptionsStrategies.Add(new OptionsStrategy(new Dictionary<string, object>
             {
-                { Tokens.ArgsTimeoutMs, 5000L },
+                { Tokens.ArgsTimeoutMillis, 5000L },
                 { Tokens.ArgsBatchSize, 100 }
             }));
 
             await connection.SubmitAsync<object, object>(gl);
 
             Assert.NotNull(capturedRequest);
-            Assert.Equal(5000L, capturedRequest!.Fields[Tokens.ArgsTimeoutMs]);
+            Assert.Equal(5000L, capturedRequest!.Fields[Tokens.ArgsTimeoutMillis]);
             Assert.Equal(100, capturedRequest.Fields[Tokens.ArgsBatchSize]);
         }
 

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/DriverRemoteConnectionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/DriverRemoteConnectionTests.cs
@@ -147,14 +147,14 @@ namespace Gremlin.Net.UnitTest.Driver
             gl.AddStep("V", Array.Empty<object>());
             gl.OptionsStrategies.Add(new OptionsStrategy(new Dictionary<string, object>
             {
-                { Tokens.ArgsEvalTimeout, 5000L },
+                { Tokens.ArgsTimeoutMs, 5000L },
                 { Tokens.ArgsBatchSize, 100 }
             }));
 
             await connection.SubmitAsync<object, object>(gl);
 
             Assert.NotNull(capturedRequest);
-            Assert.Equal(5000L, capturedRequest!.Fields[Tokens.ArgsEvalTimeout]);
+            Assert.Equal(5000L, capturedRequest!.Fields[Tokens.ArgsTimeoutMs]);
             Assert.Equal(100, capturedRequest.Fields[Tokens.ArgsBatchSize]);
         }
 

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/HttpRequestContextTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/HttpRequestContextTests.cs
@@ -206,7 +206,7 @@ namespace Gremlin.Net.UnitTest.Driver
                 .AddG("g")
                 .AddLanguage("gremlin-lang")
                 .AddBatchSize(100)
-                .AddEvaluationTimeout(30000)
+                .AddTimeoutMs(30000)
                 .Create();
             var context = new HttpRequestContext("POST", new Uri("http://localhost:8182/gremlin"),
                 new Dictionary<string, string>(), message);
@@ -218,7 +218,7 @@ namespace Gremlin.Net.UnitTest.Driver
             Assert.Equal("g", json.RootElement.GetProperty("g").GetString());
             Assert.Equal("gremlin-lang", json.RootElement.GetProperty("language").GetString());
             Assert.Equal(100, json.RootElement.GetProperty("batchSize").GetInt32());
-            Assert.Equal(30000, json.RootElement.GetProperty("evaluationTimeout").GetInt32());
+            Assert.Equal(30000, json.RootElement.GetProperty("timeoutMs").GetInt32());
         }
 
         [Fact]

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/HttpRequestContextTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/HttpRequestContextTests.cs
@@ -206,7 +206,7 @@ namespace Gremlin.Net.UnitTest.Driver
                 .AddG("g")
                 .AddLanguage("gremlin-lang")
                 .AddBatchSize(100)
-                .AddTimeoutMs(30000)
+                .AddTimeoutMillis(30000)
                 .Create();
             var context = new HttpRequestContext("POST", new Uri("http://localhost:8182/gremlin"),
                 new Dictionary<string, string>(), message);
@@ -218,7 +218,7 @@ namespace Gremlin.Net.UnitTest.Driver
             Assert.Equal("g", json.RootElement.GetProperty("g").GetString());
             Assert.Equal("gremlin-lang", json.RootElement.GetProperty("language").GetString());
             Assert.Equal(100, json.RootElement.GetProperty("batchSize").GetInt32());
-            Assert.Equal(30000, json.RootElement.GetProperty("timeoutMs").GetInt32());
+            Assert.Equal(30000, json.RootElement.GetProperty("timeoutMillis").GetInt32());
         }
 
         [Fact]

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/Messages/RequestMessageTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/Messages/RequestMessageTests.cs
@@ -82,10 +82,10 @@ namespace Gremlin.Net.UnitTest.Driver.Messages
         public void ShouldSetAdditionalField()
         {
             var msg = RequestMessage.Build("g.V()")
-                .AddField(Tokens.ArgsEvalTimeout, 5000L)
+                .AddField(Tokens.ArgsTimeoutMs, 5000L)
                 .Create();
 
-            Assert.Equal(5000L, msg.Fields[Tokens.ArgsEvalTimeout]);
+            Assert.Equal(5000L, msg.Fields[Tokens.ArgsTimeoutMs]);
         }
 
         [Fact]

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/Messages/RequestMessageTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Driver/Messages/RequestMessageTests.cs
@@ -82,10 +82,10 @@ namespace Gremlin.Net.UnitTest.Driver.Messages
         public void ShouldSetAdditionalField()
         {
             var msg = RequestMessage.Build("g.V()")
-                .AddField(Tokens.ArgsTimeoutMs, 5000L)
+                .AddField(Tokens.ArgsTimeoutMillis, 5000L)
                 .Create();
 
-            Assert.Equal(5000L, msg.Fields[Tokens.ArgsTimeoutMs]);
+            Assert.Equal(5000L, msg.Fields[Tokens.ArgsTimeoutMillis]);
         }
 
         [Fact]

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GremlinLangTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GremlinLangTests.cs
@@ -731,7 +731,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         {
             // OptionsStrategy is extracted, not rendered in the script
             Assert.Equal("g.V().count()",
-                _g.WithStrategies(new OptionsStrategy(new Dictionary<string, object> { { "timeoutMs", 500 } })).V().Count().GremlinLang.GetGremlin());
+                _g.WithStrategies(new OptionsStrategy(new Dictionary<string, object> { { "timeoutMillis", 500 } })).V().Count().GremlinLang.GetGremlin());
         }
 
         [Fact]

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GremlinLangTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GremlinLangTests.cs
@@ -731,7 +731,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         {
             // OptionsStrategy is extracted, not rendered in the script
             Assert.Equal("g.V().count()",
-                _g.WithStrategies(new OptionsStrategy(new Dictionary<string, object> { { "evaluationTimeout", 500 } })).V().Count().GremlinLang.GetGremlin());
+                _g.WithStrategies(new OptionsStrategy(new Dictionary<string, object> { { "timeoutMs", 500 } })).V().Count().GremlinLang.GetGremlin());
         }
 
         [Fact]

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -234,7 +234,7 @@ public abstract class Client implements RequestSubmitter, RequestSubmitterAsync 
                 .addChunkSize(batchSize);
 
         // apply settings if they were made available
-        options.getTimeoutMs().ifPresent(timeout -> request.addTimeoutMillis(timeout));
+        options.getTimeoutMillis().ifPresent(timeout -> request.addTimeoutMillis(timeout));
         options.getParameters().ifPresent(params -> request.addParameters(params));
         options.getG().ifPresent(g -> request.addG(g));
         options.getLanguage().ifPresent(lang -> request.addLanguage(lang));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -234,7 +234,7 @@ public abstract class Client implements RequestSubmitter, RequestSubmitterAsync 
                 .addChunkSize(batchSize);
 
         // apply settings if they were made available
-        options.getTimeout().ifPresent(timeout -> request.addTimeoutMillis(timeout));
+        options.getTimeoutMs().ifPresent(timeout -> request.addTimeoutMillis(timeout));
         options.getParameters().ifPresent(params -> request.addParameters(params));
         options.getG().ifPresent(g -> request.addG(g));
         options.getLanguage().ifPresent(lang -> request.addLanguage(lang));

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_BATCH_SIZE;
 import static org.apache.tinkerpop.gremlin.util.Tokens.BULK_RESULTS;
-import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MS;
+import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MILLIS;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_G;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_LANGUAGE;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_MATERIALIZE_PROPERTIES;
@@ -46,7 +46,7 @@ public final class RequestOptions {
     private final String graphOrTraversalSource;
     private final String parameters;
     private final Integer batchSize;
-    private final Long timeoutMs;
+    private final Long timeoutMillis;
     private final String language;
     private final String materializeProperties;
     private final String bulkResults;
@@ -56,7 +56,7 @@ public final class RequestOptions {
         this.graphOrTraversalSource = builder.graphOrTraversalSource;
         this.parameters = builder.parametersString;
         this.batchSize = builder.batchSize;
-        this.timeoutMs = builder.timeoutMs;
+        this.timeoutMillis = builder.timeoutMillis;
         this.language = builder.language;
         this.materializeProperties = builder.materializeProperties;
         this.bulkResults = builder.bulkResults;
@@ -75,8 +75,8 @@ public final class RequestOptions {
         return Optional.ofNullable(batchSize);
     }
 
-    public Optional<Long> getTimeoutMs() {
-        return Optional.ofNullable(timeoutMs);
+    public Optional<Long> getTimeoutMillis() {
+        return Optional.ofNullable(timeoutMillis);
     }
 
     public Optional<String> getLanguage() {
@@ -99,8 +99,8 @@ public final class RequestOptions {
         while (itty.hasNext()) {
             final OptionsStrategy optionsStrategy = itty.next();
             final Map<String, Object> options = optionsStrategy.getOptions();
-            if (options.containsKey(TIMEOUT_MS))
-                builder.timeoutMs(((Number) options.get(TIMEOUT_MS)).longValue());
+            if (options.containsKey(TIMEOUT_MILLIS))
+                builder.timeoutMillis(((Number) options.get(TIMEOUT_MILLIS)).longValue());
             if (options.containsKey(ARGS_BATCH_SIZE))
                 builder.batchSize(((Number) options.get(ARGS_BATCH_SIZE)).intValue());
             if (options.containsKey(ARGS_MATERIALIZE_PROPERTIES))
@@ -126,7 +126,7 @@ public final class RequestOptions {
         private Map<String, Object> internalParameters = null;
         private String parametersString = null;
         private Integer batchSize = null;
-        private Long timeoutMs = null;
+        private Long timeoutMillis = null;
         private String materializeProperties = null;
         private String language = null;
         private String bulkResults = null;
@@ -142,7 +142,7 @@ public final class RequestOptions {
             builder.graphOrTraversalSource = options.graphOrTraversalSource;
             builder.parametersString = options.parameters;
             builder.batchSize = options.batchSize;
-            builder.timeoutMs = options.timeoutMs;
+            builder.timeoutMillis = options.timeoutMillis;
             builder.materializeProperties = options.materializeProperties;
             builder.language = options.language;
             builder.bulkResults = options.bulkResults;
@@ -208,12 +208,12 @@ public final class RequestOptions {
         }
 
         /**
-         * The per client request override in milliseconds for the server configured {@code timeoutMs} (the maximum
+         * The per client request override in milliseconds for the server configured {@code timeoutMillis} (the maximum
          * time a request is allowed to execute on the server before it times out). If this value is not set, then the
          * configuration for the server is used.
          */
-        public Builder timeoutMs(final long timeoutMs) {
-            this.timeoutMs = timeoutMs;
+        public Builder timeoutMillis(final long timeoutMillis) {
+            this.timeoutMillis = timeoutMillis;
             return this;
         }
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/RequestOptions.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_BATCH_SIZE;
 import static org.apache.tinkerpop.gremlin.util.Tokens.BULK_RESULTS;
-import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_EVAL_TIMEOUT;
+import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MS;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_G;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_LANGUAGE;
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_MATERIALIZE_PROPERTIES;
@@ -46,7 +46,7 @@ public final class RequestOptions {
     private final String graphOrTraversalSource;
     private final String parameters;
     private final Integer batchSize;
-    private final Long timeout;
+    private final Long timeoutMs;
     private final String language;
     private final String materializeProperties;
     private final String bulkResults;
@@ -56,7 +56,7 @@ public final class RequestOptions {
         this.graphOrTraversalSource = builder.graphOrTraversalSource;
         this.parameters = builder.parametersString;
         this.batchSize = builder.batchSize;
-        this.timeout = builder.timeout;
+        this.timeoutMs = builder.timeoutMs;
         this.language = builder.language;
         this.materializeProperties = builder.materializeProperties;
         this.bulkResults = builder.bulkResults;
@@ -75,8 +75,8 @@ public final class RequestOptions {
         return Optional.ofNullable(batchSize);
     }
 
-    public Optional<Long> getTimeout() {
-        return Optional.ofNullable(timeout);
+    public Optional<Long> getTimeoutMs() {
+        return Optional.ofNullable(timeoutMs);
     }
 
     public Optional<String> getLanguage() {
@@ -99,8 +99,8 @@ public final class RequestOptions {
         while (itty.hasNext()) {
             final OptionsStrategy optionsStrategy = itty.next();
             final Map<String, Object> options = optionsStrategy.getOptions();
-            if (options.containsKey(ARGS_EVAL_TIMEOUT))
-                builder.timeout(((Number) options.get(ARGS_EVAL_TIMEOUT)).longValue());
+            if (options.containsKey(TIMEOUT_MS))
+                builder.timeoutMs(((Number) options.get(TIMEOUT_MS)).longValue());
             if (options.containsKey(ARGS_BATCH_SIZE))
                 builder.batchSize(((Number) options.get(ARGS_BATCH_SIZE)).intValue());
             if (options.containsKey(ARGS_MATERIALIZE_PROPERTIES))
@@ -126,7 +126,7 @@ public final class RequestOptions {
         private Map<String, Object> internalParameters = null;
         private String parametersString = null;
         private Integer batchSize = null;
-        private Long timeout = null;
+        private Long timeoutMs = null;
         private String materializeProperties = null;
         private String language = null;
         private String bulkResults = null;
@@ -142,7 +142,7 @@ public final class RequestOptions {
             builder.graphOrTraversalSource = options.graphOrTraversalSource;
             builder.parametersString = options.parameters;
             builder.batchSize = options.batchSize;
-            builder.timeout = options.timeout;
+            builder.timeoutMs = options.timeoutMs;
             builder.materializeProperties = options.materializeProperties;
             builder.language = options.language;
             builder.bulkResults = options.bulkResults;
@@ -208,11 +208,12 @@ public final class RequestOptions {
         }
 
         /**
-         * The per client request override in milliseconds for the server configured {@code evaluationTimeout}.
-         * If this value is not set, then the configuration for the server is used.
+         * The per client request override in milliseconds for the server configured {@code timeoutMs} (the maximum
+         * time a request is allowed to execute on the server before it times out). If this value is not set, then the
+         * configuration for the server is used.
          */
-        public Builder timeout(final long timeout) {
-            this.timeout = timeout;
+        public Builder timeoutMs(final long timeoutMs) {
+            this.timeoutMs = timeoutMs;
             return this;
         }
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/InterceptorTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/InterceptorTest.java
@@ -171,7 +171,7 @@ public class InterceptorTest {
         assertEquals("g.V()", json.get("gremlin").asText());
         assertEquals("g", json.get("g").asText());
         assertEquals("gremlin-lang", json.get("language").asText());
-        assertEquals(5000, json.get("timeoutMs").asLong());
+        assertEquals(5000, json.get("timeoutMillis").asLong());
         assertEquals("true", json.get("bulkResults").asText());
     }
 

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
@@ -39,20 +39,20 @@ public class DriverRemoteConnectionTest {
                 g.with("x").
                         with("y", 100).
                         with(Tokens.ARGS_BATCH_SIZE, 1000).
-                        with(Tokens.TIMEOUT_MS, 100000L).
+                        with(Tokens.TIMEOUT_MILLIS, 100000L).
                         with(Tokens.ARGS_USER_AGENT, "test").
                         V().asAdmin().getGremlinLang());
         assertEquals(1000, options.getBatchSize().get().intValue());
-        assertEquals(100000L, options.getTimeoutMs().get().longValue());
+        assertEquals(100000L, options.getTimeoutMillis().get().longValue());
     }
 
     @Test
     public void shouldBuildRequestOptionsWithNumerics() {
         final RequestOptions options = getRequestOptions(
                 g.with(Tokens.ARGS_BATCH_SIZE, 100).
-                  with(Tokens.TIMEOUT_MS, 1000).
+                  with(Tokens.TIMEOUT_MILLIS, 1000).
                   V().asAdmin().getGremlinLang());
         assertEquals(Integer.valueOf(100), options.getBatchSize().get());
-        assertEquals(Long.valueOf(1000), options.getTimeoutMs().get());
+        assertEquals(Long.valueOf(1000), options.getTimeoutMillis().get());
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
@@ -39,20 +39,20 @@ public class DriverRemoteConnectionTest {
                 g.with("x").
                         with("y", 100).
                         with(Tokens.ARGS_BATCH_SIZE, 1000).
-                        with(Tokens.ARGS_EVAL_TIMEOUT, 100000L).
+                        with(Tokens.TIMEOUT_MS, 100000L).
                         with(Tokens.ARGS_USER_AGENT, "test").
                         V().asAdmin().getGremlinLang());
         assertEquals(1000, options.getBatchSize().get().intValue());
-        assertEquals(100000L, options.getTimeout().get().longValue());
+        assertEquals(100000L, options.getTimeoutMs().get().longValue());
     }
 
     @Test
     public void shouldBuildRequestOptionsWithNumerics() {
         final RequestOptions options = getRequestOptions(
                 g.with(Tokens.ARGS_BATCH_SIZE, 100).
-                  with(Tokens.ARGS_EVAL_TIMEOUT, 1000).
+                  with(Tokens.TIMEOUT_MS, 1000).
                   V().asAdmin().getGremlinLang());
         assertEquals(Integer.valueOf(100), options.getBatchSize().get());
-        assertEquals(Long.valueOf(1000), options.getTimeout().get());
+        assertEquals(Long.valueOf(1000), options.getTimeoutMs().get());
     }
 }

--- a/gremlin-go/driver/client.go
+++ b/gremlin-go/driver/client.go
@@ -324,7 +324,7 @@ func applyOptionsConfig(builder *RequestOptionsBuilder, config map[string]interf
 	// via SetParametersString in submitGremlinLang, and including it here would
 	// trigger the mutual exclusion panic between SetParameters and SetParametersString.
 	setterMap := map[string]string{
-		"evaluationTimeout":     "SetEvaluationTimeout",
+		"timeoutMs":             "SetTimeoutMs",
 		"batchSize":             "SetBatchSize",
 		"userAgent":             "SetUserAgent",
 		"materializeProperties": "SetMaterializeProperties",

--- a/gremlin-go/driver/client.go
+++ b/gremlin-go/driver/client.go
@@ -324,7 +324,7 @@ func applyOptionsConfig(builder *RequestOptionsBuilder, config map[string]interf
 	// via SetParametersString in submitGremlinLang, and including it here would
 	// trigger the mutual exclusion panic between SetParameters and SetParametersString.
 	setterMap := map[string]string{
-		"timeoutMs":             "SetTimeoutMs",
+		"timeoutMillis":         "SetTimeoutMillis",
 		"batchSize":             "SetBatchSize",
 		"userAgent":             "SetUserAgent",
 		"materializeProperties": "SetMaterializeProperties",

--- a/gremlin-go/driver/gremlinlang_test.go
+++ b/gremlin-go/driver/gremlinlang_test.go
@@ -599,7 +599,7 @@ func Test_GremlinLang(t *testing.T) {
 		},
 		{
 			assert: func(g *GraphTraversalSource) *GraphTraversal {
-				return g.WithStrategies(OptionsStrategy(map[string]interface{}{"evaluationTimeout": 500})).V().Count()
+				return g.WithStrategies(OptionsStrategy(map[string]interface{}{"timeoutMs": 500})).V().Count()
 			},
 			// OptionsStrategy are now extracted into request message and is no longer sent with the script
 			equals: "g.V().count()",

--- a/gremlin-go/driver/gremlinlang_test.go
+++ b/gremlin-go/driver/gremlinlang_test.go
@@ -599,7 +599,7 @@ func Test_GremlinLang(t *testing.T) {
 		},
 		{
 			assert: func(g *GraphTraversalSource) *GraphTraversal {
-				return g.WithStrategies(OptionsStrategy(map[string]interface{}{"timeoutMs": 500})).V().Count()
+				return g.WithStrategies(OptionsStrategy(map[string]interface{}{"timeoutMillis": 500})).V().Count()
 			},
 			// OptionsStrategy are now extracted into request message and is no longer sent with the script
 			equals: "g.V().count()",

--- a/gremlin-go/driver/request.go
+++ b/gremlin-go/driver/request.go
@@ -56,8 +56,8 @@ func MakeStringRequest(stringGremlin string, traversalSource string, requestOpti
 		newFields["parameters"] = requestOptions.parametersString
 	}
 
-	if requestOptions.timeoutMs != 0 {
-		newFields["timeoutMs"] = requestOptions.timeoutMs
+	if requestOptions.timeoutMillis != 0 {
+		newFields["timeoutMillis"] = requestOptions.timeoutMillis
 	}
 
 	if requestOptions.batchSize != 0 {
@@ -89,7 +89,7 @@ func MakeStringRequest(stringGremlin string, traversalSource string, requestOpti
 // allowedReqArgs contains the arguments that will be extracted from the
 // bytecode and sent with the request.
 var allowedReqArgs = map[string]bool{
-	"timeoutMs":             true,
+	"timeoutMillis":         true,
 	"batchSize":             true,
 	"userAgent":             true,
 	"materializeProperties": true,

--- a/gremlin-go/driver/request.go
+++ b/gremlin-go/driver/request.go
@@ -56,8 +56,8 @@ func MakeStringRequest(stringGremlin string, traversalSource string, requestOpti
 		newFields["parameters"] = requestOptions.parametersString
 	}
 
-	if requestOptions.evaluationTimeout != 0 {
-		newFields["evaluationTimeout"] = requestOptions.evaluationTimeout
+	if requestOptions.timeoutMs != 0 {
+		newFields["timeoutMs"] = requestOptions.timeoutMs
 	}
 
 	if requestOptions.batchSize != 0 {
@@ -89,7 +89,7 @@ func MakeStringRequest(stringGremlin string, traversalSource string, requestOpti
 // allowedReqArgs contains the arguments that will be extracted from the
 // bytecode and sent with the request.
 var allowedReqArgs = map[string]bool{
-	"evaluationTimeout":     true,
+	"timeoutMs":             true,
 	"batchSize":             true,
 	"userAgent":             true,
 	"materializeProperties": true,

--- a/gremlin-go/driver/requestOptions.go
+++ b/gremlin-go/driver/requestOptions.go
@@ -20,7 +20,7 @@ under the License.
 package gremlingo
 
 type RequestOptions struct {
-	evaluationTimeout     int
+	timeoutMs     int
 	batchSize             int
 	userAgent             string
 	parametersString      string
@@ -30,7 +30,7 @@ type RequestOptions struct {
 }
 
 type RequestOptionsBuilder struct {
-	evaluationTimeout     int
+	timeoutMs     int
 	batchSize             int
 	userAgent             string
 	parameters            map[string]interface{}
@@ -40,8 +40,8 @@ type RequestOptionsBuilder struct {
 	transactionId         string
 }
 
-func (builder *RequestOptionsBuilder) SetEvaluationTimeout(evaluationTimeout int) *RequestOptionsBuilder {
-	builder.evaluationTimeout = evaluationTimeout
+func (builder *RequestOptionsBuilder) SetTimeoutMs(timeoutMs int) *RequestOptionsBuilder {
+	builder.timeoutMs = timeoutMs
 	return builder
 }
 
@@ -100,7 +100,7 @@ func (builder *RequestOptionsBuilder) AddParameter(key string, parameter interfa
 func (builder *RequestOptionsBuilder) Create() RequestOptions {
 	requestOptions := new(RequestOptions)
 
-	requestOptions.evaluationTimeout = builder.evaluationTimeout
+	requestOptions.timeoutMs = builder.timeoutMs
 	requestOptions.batchSize = builder.batchSize
 	requestOptions.userAgent = builder.userAgent
 	requestOptions.materializeProperties = builder.materializeProperties

--- a/gremlin-go/driver/requestOptions.go
+++ b/gremlin-go/driver/requestOptions.go
@@ -20,7 +20,7 @@ under the License.
 package gremlingo
 
 type RequestOptions struct {
-	timeoutMs     int
+	timeoutMillis         int
 	batchSize             int
 	userAgent             string
 	parametersString      string
@@ -30,7 +30,7 @@ type RequestOptions struct {
 }
 
 type RequestOptionsBuilder struct {
-	timeoutMs     int
+	timeoutMillis         int
 	batchSize             int
 	userAgent             string
 	parameters            map[string]interface{}
@@ -40,8 +40,8 @@ type RequestOptionsBuilder struct {
 	transactionId         string
 }
 
-func (builder *RequestOptionsBuilder) SetTimeoutMs(timeoutMs int) *RequestOptionsBuilder {
-	builder.timeoutMs = timeoutMs
+func (builder *RequestOptionsBuilder) SetTimeoutMillis(timeoutMillis int) *RequestOptionsBuilder {
+	builder.timeoutMillis = timeoutMillis
 	return builder
 }
 
@@ -100,7 +100,7 @@ func (builder *RequestOptionsBuilder) AddParameter(key string, parameter interfa
 func (builder *RequestOptionsBuilder) Create() RequestOptions {
 	requestOptions := new(RequestOptions)
 
-	requestOptions.timeoutMs = builder.timeoutMs
+	requestOptions.timeoutMillis = builder.timeoutMillis
 	requestOptions.batchSize = builder.batchSize
 	requestOptions.userAgent = builder.userAgent
 	requestOptions.materializeProperties = builder.materializeProperties

--- a/gremlin-go/driver/requestOptions_test.go
+++ b/gremlin-go/driver/requestOptions_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func TestRequestOptions(t *testing.T) {
-	t.Run("Test RequestOptionsBuilder with custom timeoutMs", func(t *testing.T) {
-		r := new(RequestOptionsBuilder).SetTimeoutMs(1234).Create()
-		assert.Equal(t, 1234, r.timeoutMs)
+	t.Run("Test RequestOptionsBuilder with custom timeoutMillis", func(t *testing.T) {
+		r := new(RequestOptionsBuilder).SetTimeoutMillis(1234).Create()
+		assert.Equal(t, 1234, r.timeoutMillis)
 	})
 	t.Run("Test RequestOptionsBuilder with custom batchSize", func(t *testing.T) {
 		r := new(RequestOptionsBuilder).SetBatchSize(123).Create()

--- a/gremlin-go/driver/requestOptions_test.go
+++ b/gremlin-go/driver/requestOptions_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func TestRequestOptions(t *testing.T) {
-	t.Run("Test RequestOptionsBuilder with custom evaluationTimeout", func(t *testing.T) {
-		r := new(RequestOptionsBuilder).SetEvaluationTimeout(1234).Create()
-		assert.Equal(t, 1234, r.evaluationTimeout)
+	t.Run("Test RequestOptionsBuilder with custom timeoutMs", func(t *testing.T) {
+		r := new(RequestOptionsBuilder).SetTimeoutMs(1234).Create()
+		assert.Equal(t, 1234, r.timeoutMs)
 	})
 	t.Run("Test RequestOptionsBuilder with custom batchSize", func(t *testing.T) {
 		r := new(RequestOptionsBuilder).SetBatchSize(123).Create()

--- a/gremlin-go/driver/request_test.go
+++ b/gremlin-go/driver/request_test.go
@@ -34,10 +34,10 @@ func TestRequest(t *testing.T) {
 		assert.Nil(t, r.Fields["parameters"])
 	})
 
-	t.Run("Test makeStringRequest() with custom timeoutMs", func(t *testing.T) {
+	t.Run("Test makeStringRequest() with custom timeoutMillis", func(t *testing.T) {
 		r := MakeStringRequest("g.V()", "g",
-			new(RequestOptionsBuilder).SetTimeoutMs(1234).Create())
-		assert.Equal(t, 1234, r.Fields["timeoutMs"])
+			new(RequestOptionsBuilder).SetTimeoutMillis(1234).Create())
+		assert.Equal(t, 1234, r.Fields["timeoutMillis"])
 	})
 
 	t.Run("Test makeStringRequest() with custom batchSize", func(t *testing.T) {

--- a/gremlin-go/driver/request_test.go
+++ b/gremlin-go/driver/request_test.go
@@ -34,10 +34,10 @@ func TestRequest(t *testing.T) {
 		assert.Nil(t, r.Fields["parameters"])
 	})
 
-	t.Run("Test makeStringRequest() with custom evaluationTimeout", func(t *testing.T) {
+	t.Run("Test makeStringRequest() with custom timeoutMs", func(t *testing.T) {
 		r := MakeStringRequest("g.V()", "g",
-			new(RequestOptionsBuilder).SetEvaluationTimeout(1234).Create())
-		assert.Equal(t, 1234, r.Fields["evaluationTimeout"])
+			new(RequestOptionsBuilder).SetTimeoutMs(1234).Create())
+		assert.Equal(t, 1234, r.Fields["timeoutMs"])
 	})
 
 	t.Run("Test makeStringRequest() with custom batchSize", func(t *testing.T) {

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTChecker.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTChecker.groovy
@@ -40,8 +40,7 @@ final class GremlinASTChecker {
     private static final AstBuilder astBuilder = new AstBuilder()
     public static final Result EMPTY_RESULT = new Result(0)
 
-    private static final List<String> tokens = ["evaluationTimeout", "scriptEvaluationTimeout",
-                                                "ARGS_EVAL_TIMEOUT", "ARGS_SCRIPT_EVAL_TIMEOUT"]
+    private static final List<String> tokens = ["timeoutMs", "TIMEOUT_MS"]
 
     /**
      * Parses a Gremlin script and extracts a {@code Result} containing properties that are relevant to the checker.
@@ -125,7 +124,7 @@ final class GremlinASTChecker {
 //import org.apache.commons.lang.RandomStringUtils
 //rand = new java.util.Random()
 //engine = new groovy.text.SimpleTemplateEngine()
-//baseScript = 'g.with("evaluationTimeout",1).V().out("$a").in().where(outE().has("weight",$b).count().is($c)).order().by("name",desc).limit($d).project("x","y").by("name").by(outE().fold());'
+//baseScript = 'g.with("timeoutMs",1).V().out("$a").in().where(outE().has("weight",$b).count().is($c)).order().by("name",desc).limit($d).project("x","y").by("name").by(outE().fold());'
 //[1,10,50,100,500,1000,5000,10000].collect {
 //    def binding = [a: RandomStringUtils.random(30), b: rand.nextDouble(), c: rand.nextInt(), d: rand.nextInt()]
 //    def longScript = (0..<it).collect{engine.createTemplate(baseScript).make(binding)}.join()

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTChecker.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTChecker.groovy
@@ -40,7 +40,7 @@ final class GremlinASTChecker {
     private static final AstBuilder astBuilder = new AstBuilder()
     public static final Result EMPTY_RESULT = new Result(0)
 
-    private static final List<String> tokens = ["timeoutMs", "TIMEOUT_MS"]
+    private static final List<String> tokens = ["timeoutMillis", "TIMEOUT_MILLIS"]
 
     /**
      * Parses a Gremlin script and extracts a {@code Result} containing properties that are relevant to the checker.
@@ -124,7 +124,7 @@ final class GremlinASTChecker {
 //import org.apache.commons.lang.RandomStringUtils
 //rand = new java.util.Random()
 //engine = new groovy.text.SimpleTemplateEngine()
-//baseScript = 'g.with("timeoutMs",1).V().out("$a").in().where(outE().has("weight",$b).count().is($c)).order().by("name",desc).limit($d).project("x","y").by("name").by(outE().fold());'
+//baseScript = 'g.with("timeoutMillis",1).V().out("$a").in().where(outE().has("weight",$b).count().is($c)).order().by("name",desc).limit($d).project("x","y").by("name").by(outE().fold());'
 //[1,10,50,100,500,1000,5000,10000].collect {
 //    def binding = [a: RandomStringUtils.random(30), b: rand.nextDouble(), c: rand.nextInt(), d: rand.nextInt()]
 //    def longScript = (0..<it).collect{engine.createTemplate(baseScript).make(binding)}.join()

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -80,7 +80,7 @@ public class GremlinExecutor implements AutoCloseable {
     private GremlinScriptEngineManager gremlinScriptEngineManager;
 
     private final Map<String, Map<String, Map<String,Object>>> plugins;
-    private final long evaluationTimeout;
+    private final long timeoutMs;
     private final Bindings globalBindings;
     private final ExecutorService executorService;
     private final ScheduledExecutorService scheduledExecutorService;
@@ -101,7 +101,7 @@ public class GremlinExecutor implements AutoCloseable {
         this.afterTimeout = builder.afterTimeout;
         this.afterFailure = builder.afterFailure;
         this.plugins = builder.plugins;
-        this.evaluationTimeout = builder.evaluationTimeout;
+        this.timeoutMs = builder.timeoutMs;
         this.globalBindings = builder.globalBindings;
 
         this.gremlinScriptEngineManager = new CachedGremlinScriptEngineManager(builder.allowedEngineNames);
@@ -264,7 +264,7 @@ public class GremlinExecutor implements AutoCloseable {
     public CompletableFuture<Object> eval(final String gremlin, final String language, final Bindings boundVars, final Long timeOut,
                                           final Function<Object, Object> transformResult, final Consumer<Object> withResult) {
         final LifeCycle lifeCycle = LifeCycle.build()
-                .evaluationTimeoutOverride(timeOut)
+                .timeoutMsOverride(timeOut)
                 .transformResult(transformResult)
                 .withResult(withResult).create();
 
@@ -294,7 +294,7 @@ public class GremlinExecutor implements AutoCloseable {
         // options then allow that value to override what's provided on the lifecycle
         final Optional<Long> timeoutDefinedInScript = GremlinScriptChecker.parse(gremlin).getTimeout();
         final long scriptEvalTimeOut = timeoutDefinedInScript.orElse(
-                lifeCycle.getEvaluationTimeoutOverride().orElse(evaluationTimeout));
+                lifeCycle.getTimeoutMsOverride().orElse(timeoutMs));
 
         final CompletableFuture<Object> evaluationFuture = new CompletableFuture<>();
         final FutureTask<Void> evalFuture = new FutureTask<>(() -> {
@@ -333,7 +333,7 @@ public class GremlinExecutor implements AutoCloseable {
                         || root instanceof InterruptedIOException) {
                     lifeCycle.getAfterTimeout().orElse(afterTimeout).accept(bindings, root);
                     evaluationFuture.completeExceptionally(new TimeoutException(
-                            String.format("Evaluation exceeded the configured 'evaluationTimeout' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]: %s", scriptEvalTimeOut, gremlin, root.getMessage())));
+                            String.format("Evaluation exceeded the configured 'timeoutMs' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]: %s", scriptEvalTimeOut, gremlin, root.getMessage())));
                 } else {
                     lifeCycle.getAfterFailure().orElse(afterFailure).accept(bindings, root);
                     evaluationFuture.completeExceptionally(root);
@@ -352,7 +352,7 @@ public class GremlinExecutor implements AutoCloseable {
                     final CompletableFuture<Object> ef = evaluationFutureRef.get();
                     if (ef != null) {
                         ef.completeExceptionally(new TimeoutException(
-                                String.format("Evaluation exceeded the configured 'evaluationTimeout' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]", scriptEvalTimeOut, gremlin)));
+                                String.format("Evaluation exceeded the configured 'timeoutMs' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]", scriptEvalTimeOut, gremlin)));
                     }
                 }
             }, scriptEvalTimeOut, TimeUnit.MILLISECONDS);
@@ -488,7 +488,7 @@ public class GremlinExecutor implements AutoCloseable {
     }
 
     public final static class Builder {
-        private long evaluationTimeout = 8000;
+        private long timeoutMs = 8000;
 
         private Map<String, Map<String, Map<String,Object>>> plugins = new HashMap<>();
 
@@ -544,11 +544,11 @@ public class GremlinExecutor implements AutoCloseable {
          * as well as any time needed for a post result transformation (if the transformation function is supplied
          * to the {@link GremlinExecutor#eval}).
          *
-         * @param evaluationTimeout Time in milliseconds that an evaluation is allowed to run and its
+         * @param timeoutMs Time in milliseconds that an evaluation is allowed to run and its
          *                          results potentially transformed. Set to zero to have no timeout set.
          */
-        public Builder evaluationTimeout(final long evaluationTimeout) {
-            this.evaluationTimeout = evaluationTimeout;
+        public Builder timeoutMs(final long timeoutMs) {
+            this.timeoutMs = timeoutMs;
             return this;
         }
 
@@ -655,7 +655,7 @@ public class GremlinExecutor implements AutoCloseable {
         private final Optional<Consumer<Bindings>> afterSuccess;
         private final Optional<BiConsumer<Bindings, Throwable>> afterTimeout;
         private final Optional<BiConsumer<Bindings, Throwable>> afterFailure;
-        private final Optional<Long> evaluationTimeoutOverride;
+        private final Optional<Long> timeoutMsOverride;
 
         private LifeCycle(final Builder builder) {
             beforeEval = Optional.ofNullable(builder.beforeEval);
@@ -664,11 +664,11 @@ public class GremlinExecutor implements AutoCloseable {
             afterSuccess = Optional.ofNullable(builder.afterSuccess);
             afterTimeout = Optional.ofNullable(builder.afterTimeout);
             afterFailure = Optional.ofNullable(builder.afterFailure);
-            evaluationTimeoutOverride = Optional.ofNullable(builder.evaluationTimeoutOverride);
+            timeoutMsOverride = Optional.ofNullable(builder.timeoutMsOverride);
         }
 
-        public Optional<Long> getEvaluationTimeoutOverride() {
-            return evaluationTimeoutOverride;
+        public Optional<Long> getTimeoutMsOverride() {
+            return timeoutMsOverride;
         }
 
         public Optional<Consumer<Bindings>> getBeforeEval() {
@@ -706,7 +706,7 @@ public class GremlinExecutor implements AutoCloseable {
             private Consumer<Bindings> afterSuccess = null;
             private BiConsumer<Bindings, Throwable> afterTimeout = null;
             private BiConsumer<Bindings, Throwable> afterFailure = null;
-            private Long evaluationTimeoutOverride = null;
+            private Long timeoutMsOverride = null;
 
             /**
              * Specifies the function to execute prior to the script being evaluated.  This function can also be
@@ -783,11 +783,11 @@ public class GremlinExecutor implements AutoCloseable {
             }
 
             /**
-             * An override to the global {@code evaluationTimeout} setting on the script engine. If this value
+             * An override to the global {@code timeoutMs} setting on the script engine. If this value
              * is set to {@code null} (the default) it will use the global setting.
              */
-            public Builder evaluationTimeoutOverride(final Long evaluationTimeoutOverride) {
-                this.evaluationTimeoutOverride = evaluationTimeoutOverride;
+            public Builder timeoutMsOverride(final Long timeoutMsOverride) {
+                this.timeoutMsOverride = timeoutMsOverride;
                 return this;
             }
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -80,7 +80,7 @@ public class GremlinExecutor implements AutoCloseable {
     private GremlinScriptEngineManager gremlinScriptEngineManager;
 
     private final Map<String, Map<String, Map<String,Object>>> plugins;
-    private final long timeoutMs;
+    private final long timeoutMillis;
     private final Bindings globalBindings;
     private final ExecutorService executorService;
     private final ScheduledExecutorService scheduledExecutorService;
@@ -101,7 +101,7 @@ public class GremlinExecutor implements AutoCloseable {
         this.afterTimeout = builder.afterTimeout;
         this.afterFailure = builder.afterFailure;
         this.plugins = builder.plugins;
-        this.timeoutMs = builder.timeoutMs;
+        this.timeoutMillis = builder.timeoutMillis;
         this.globalBindings = builder.globalBindings;
 
         this.gremlinScriptEngineManager = new CachedGremlinScriptEngineManager(builder.allowedEngineNames);
@@ -264,7 +264,7 @@ public class GremlinExecutor implements AutoCloseable {
     public CompletableFuture<Object> eval(final String gremlin, final String language, final Bindings boundVars, final Long timeOut,
                                           final Function<Object, Object> transformResult, final Consumer<Object> withResult) {
         final LifeCycle lifeCycle = LifeCycle.build()
-                .timeoutMsOverride(timeOut)
+                .timeoutMillisOverride(timeOut)
                 .transformResult(transformResult)
                 .withResult(withResult).create();
 
@@ -294,7 +294,7 @@ public class GremlinExecutor implements AutoCloseable {
         // options then allow that value to override what's provided on the lifecycle
         final Optional<Long> timeoutDefinedInScript = GremlinScriptChecker.parse(gremlin).getTimeout();
         final long scriptEvalTimeOut = timeoutDefinedInScript.orElse(
-                lifeCycle.getTimeoutMsOverride().orElse(timeoutMs));
+                lifeCycle.getTimeoutMillisOverride().orElse(timeoutMillis));
 
         final CompletableFuture<Object> evaluationFuture = new CompletableFuture<>();
         final FutureTask<Void> evalFuture = new FutureTask<>(() -> {
@@ -333,7 +333,7 @@ public class GremlinExecutor implements AutoCloseable {
                         || root instanceof InterruptedIOException) {
                     lifeCycle.getAfterTimeout().orElse(afterTimeout).accept(bindings, root);
                     evaluationFuture.completeExceptionally(new TimeoutException(
-                            String.format("Evaluation exceeded the configured 'timeoutMs' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]: %s", scriptEvalTimeOut, gremlin, root.getMessage())));
+                            String.format("Evaluation exceeded the configured 'timeoutMillis' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]: %s", scriptEvalTimeOut, gremlin, root.getMessage())));
                 } else {
                     lifeCycle.getAfterFailure().orElse(afterFailure).accept(bindings, root);
                     evaluationFuture.completeExceptionally(root);
@@ -352,7 +352,7 @@ public class GremlinExecutor implements AutoCloseable {
                     final CompletableFuture<Object> ef = evaluationFutureRef.get();
                     if (ef != null) {
                         ef.completeExceptionally(new TimeoutException(
-                                String.format("Evaluation exceeded the configured 'timeoutMs' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]", scriptEvalTimeOut, gremlin)));
+                                String.format("Evaluation exceeded the configured 'timeoutMillis' threshold of %s ms or evaluation was otherwise cancelled directly for request [%s]", scriptEvalTimeOut, gremlin)));
                     }
                 }
             }, scriptEvalTimeOut, TimeUnit.MILLISECONDS);
@@ -488,7 +488,7 @@ public class GremlinExecutor implements AutoCloseable {
     }
 
     public final static class Builder {
-        private long timeoutMs = 8000;
+        private long timeoutMillis = 8000;
 
         private Map<String, Map<String, Map<String,Object>>> plugins = new HashMap<>();
 
@@ -544,11 +544,11 @@ public class GremlinExecutor implements AutoCloseable {
          * as well as any time needed for a post result transformation (if the transformation function is supplied
          * to the {@link GremlinExecutor#eval}).
          *
-         * @param timeoutMs Time in milliseconds that an evaluation is allowed to run and its
+         * @param timeoutMillis Time in milliseconds that an evaluation is allowed to run and its
          *                          results potentially transformed. Set to zero to have no timeout set.
          */
-        public Builder timeoutMs(final long timeoutMs) {
-            this.timeoutMs = timeoutMs;
+        public Builder timeoutMillis(final long timeoutMillis) {
+            this.timeoutMillis = timeoutMillis;
             return this;
         }
 
@@ -655,7 +655,7 @@ public class GremlinExecutor implements AutoCloseable {
         private final Optional<Consumer<Bindings>> afterSuccess;
         private final Optional<BiConsumer<Bindings, Throwable>> afterTimeout;
         private final Optional<BiConsumer<Bindings, Throwable>> afterFailure;
-        private final Optional<Long> timeoutMsOverride;
+        private final Optional<Long> timeoutMillisOverride;
 
         private LifeCycle(final Builder builder) {
             beforeEval = Optional.ofNullable(builder.beforeEval);
@@ -664,11 +664,11 @@ public class GremlinExecutor implements AutoCloseable {
             afterSuccess = Optional.ofNullable(builder.afterSuccess);
             afterTimeout = Optional.ofNullable(builder.afterTimeout);
             afterFailure = Optional.ofNullable(builder.afterFailure);
-            timeoutMsOverride = Optional.ofNullable(builder.timeoutMsOverride);
+            timeoutMillisOverride = Optional.ofNullable(builder.timeoutMillisOverride);
         }
 
-        public Optional<Long> getTimeoutMsOverride() {
-            return timeoutMsOverride;
+        public Optional<Long> getTimeoutMillisOverride() {
+            return timeoutMillisOverride;
         }
 
         public Optional<Consumer<Bindings>> getBeforeEval() {
@@ -706,7 +706,7 @@ public class GremlinExecutor implements AutoCloseable {
             private Consumer<Bindings> afterSuccess = null;
             private BiConsumer<Bindings, Throwable> afterTimeout = null;
             private BiConsumer<Bindings, Throwable> afterFailure = null;
-            private Long timeoutMsOverride = null;
+            private Long timeoutMillisOverride = null;
 
             /**
              * Specifies the function to execute prior to the script being evaluated.  This function can also be
@@ -783,11 +783,11 @@ public class GremlinExecutor implements AutoCloseable {
             }
 
             /**
-             * An override to the global {@code timeoutMs} setting on the script engine. If this value
+             * An override to the global {@code timeoutMillis} setting on the script engine. If this value
              * is set to {@code null} (the default) it will use the global setting.
              */
-            public Builder timeoutMsOverride(final Long timeoutMsOverride) {
-                this.timeoutMsOverride = timeoutMsOverride;
+            public Builder timeoutMillisOverride(final Long timeoutMillisOverride) {
+                this.timeoutMillisOverride = timeoutMillisOverride;
                 return this;
             }
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
@@ -93,7 +93,7 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
         /**
          * Introduces timed checks to loops and other portions of a script to provide an interrupt for a long running
          * script. This configuration should not be used in conjunction with the Gremlin Server which has its own
-         * {@code timeoutMs} which performs a similar task but in a more complete way specific to the
+         * {@code timeoutMillis} which performs a similar task but in a more complete way specific to the
          * server. Configuring both may lead to inconsistent timeout errors returning from the server. This
          * configuration should only be used if configuring a standalone instance fo the {@link GremlinGroovyScriptEngine}.
          */

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyCompilerGremlinPlugin.java
@@ -93,7 +93,7 @@ public class GroovyCompilerGremlinPlugin extends AbstractGremlinPlugin {
         /**
          * Introduces timed checks to loops and other portions of a script to provide an interrupt for a long running
          * script. This configuration should not be used in conjunction with the Gremlin Server which has its own
-         * {@code evaluationTimeout} which performs a similar task but in a more complete way specific to the
+         * {@code timeoutMs} which performs a similar task but in a more complete way specific to the
          * server. Configuring both may lead to inconsistent timeout errors returning from the server. This
          * configuration should only be used if configuring a standalone instance fo the {@link GremlinGroovyScriptEngine}.
          */

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorOverGraphTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorOverGraphTest.java
@@ -54,7 +54,7 @@ public class GremlinExecutorOverGraphTest {
 
         final ExecutorService evalExecutor = Executors.newSingleThreadExecutor(testingThreadFactory);
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .timeoutMs(60000)
+                .timeoutMillis(60000)
                 .afterSuccess(b -> {
                     final GraphTraversalSource ig = (GraphTraversalSource) b.get("g");
                     if (ig.getGraph().features().graph().supportsTransactions())
@@ -66,11 +66,11 @@ public class GremlinExecutorOverGraphTest {
         bindings.put("g", g);
 
         try {
-            gremlinExecutor.eval("g.with('timeoutMs',100).V().repeat(both()).toList()", bindings).get();
+            gremlinExecutor.eval("g.with('timeoutMillis',100).V().repeat(both()).toList()", bindings).get();
             fail("Should have timed out");
         } catch (ExecutionException ex) {
             // should die in 100ms not 60000
-            assertThat(ex.getCause().getMessage(), startsWith("Evaluation exceeded the configured 'timeoutMs' threshold of 100 ms"));
+            assertThat(ex.getCause().getMessage(), startsWith("Evaluation exceeded the configured 'timeoutMillis' threshold of 100 ms"));
         }
     }
 

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorOverGraphTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorOverGraphTest.java
@@ -54,7 +54,7 @@ public class GremlinExecutorOverGraphTest {
 
         final ExecutorService evalExecutor = Executors.newSingleThreadExecutor(testingThreadFactory);
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .evaluationTimeout(60000)
+                .timeoutMs(60000)
                 .afterSuccess(b -> {
                     final GraphTraversalSource ig = (GraphTraversalSource) b.get("g");
                     if (ig.getGraph().features().graph().supportsTransactions())
@@ -66,11 +66,11 @@ public class GremlinExecutorOverGraphTest {
         bindings.put("g", g);
 
         try {
-            gremlinExecutor.eval("g.with('evaluationTimeout',100).V().repeat(both()).toList()", bindings).get();
+            gremlinExecutor.eval("g.with('timeoutMs',100).V().repeat(both()).toList()", bindings).get();
             fail("Should have timed out");
         } catch (ExecutionException ex) {
             // should die in 100ms not 60000
-            assertThat(ex.getCause().getMessage(), startsWith("Evaluation exceeded the configured 'evaluationTimeout' threshold of 100 ms"));
+            assertThat(ex.getCause().getMessage(), startsWith("Evaluation exceeded the configured 'timeoutMs' threshold of 100 ms"));
         }
     }
 

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
@@ -267,7 +267,7 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .evaluationTimeout(250)
+                .timeoutMs(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
@@ -294,7 +294,7 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .evaluationTimeout(250)
+                .timeoutMs(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
@@ -321,13 +321,13 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .evaluationTimeout(10000)
+                .timeoutMs(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
-                    .evaluationTimeoutOverride(250L).create();
+                    .timeoutMsOverride(250L).create();
             gremlinExecutor.eval("Thread.sleep(1000);10", "gremlin-groovy", new SimpleBindings(), lifeCycle).get();
             fail("This script should have timed out with an exception");
         } catch (Exception ex) {
@@ -350,13 +350,13 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .evaluationTimeout(10000)
+                .timeoutMs(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
-                    .evaluationTimeoutOverride(100L).create();
+                    .timeoutMsOverride(100L).create();
             gremlinExecutor.eval("Thread.sleep(9000);10", "gremlin-groovy", new SimpleBindings(), lifeCycle).get();
             fail("This script should have timed out with an exception");
         } catch (Exception ex) {
@@ -460,28 +460,28 @@ public class GremlinExecutorTest {
 
     @Test
     public void shouldCancelTimeoutOnSuccessfulScript() throws Exception {
-        final long evaluationTimeout = 15_000;
+        final long timeoutMs = 15_000;
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .evaluationTimeout(evaluationTimeout)
+                .timeoutMs(timeoutMs)
                 .create();
 
         final long now = System.currentTimeMillis();
         assertEquals(2, gremlinExecutor.eval("1+1").get());
         gremlinExecutor.close();
-        assertTrue(System.currentTimeMillis() - now < evaluationTimeout);
+        assertTrue(System.currentTimeMillis() - now < timeoutMs);
     }
 
     @Test
     public void shouldCancelTimeoutOnSuccessfulEval() throws Exception {
-        final long evaluationTimeout = 15_000;
+        final long timeoutMs = 15_000;
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .evaluationTimeout(evaluationTimeout)
+                .timeoutMs(timeoutMs)
                 .create();
 
         final long now = System.currentTimeMillis();
         assertEquals(2, gremlinExecutor.eval("1+1").get());
         gremlinExecutor.close();
-        assertTrue(System.currentTimeMillis() - now < evaluationTimeout);
+        assertTrue(System.currentTimeMillis() - now < timeoutMs);
     }
 
     @Test

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
@@ -267,7 +267,7 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .timeoutMs(250)
+                .timeoutMillis(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
@@ -294,7 +294,7 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .timeoutMs(250)
+                .timeoutMillis(250)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
@@ -321,13 +321,13 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .timeoutMs(10000)
+                .timeoutMillis(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
-                    .timeoutMsOverride(250L).create();
+                    .timeoutMillisOverride(250L).create();
             gremlinExecutor.eval("Thread.sleep(1000);10", "gremlin-groovy", new SimpleBindings(), lifeCycle).get();
             fail("This script should have timed out with an exception");
         } catch (Exception ex) {
@@ -350,13 +350,13 @@ public class GremlinExecutorTest {
         final CountDownLatch timeOutCount = new CountDownLatch(1);
 
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .timeoutMs(10000)
+                .timeoutMillis(10000)
                 .afterFailure((b, e) -> failureCalled.set(true))
                 .afterSuccess((b) -> successCalled.set(true))
                 .afterTimeout((b) -> timeOutCount.countDown()).create();
         try {
             final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build()
-                    .timeoutMsOverride(100L).create();
+                    .timeoutMillisOverride(100L).create();
             gremlinExecutor.eval("Thread.sleep(9000);10", "gremlin-groovy", new SimpleBindings(), lifeCycle).get();
             fail("This script should have timed out with an exception");
         } catch (Exception ex) {
@@ -460,28 +460,28 @@ public class GremlinExecutorTest {
 
     @Test
     public void shouldCancelTimeoutOnSuccessfulScript() throws Exception {
-        final long timeoutMs = 15_000;
+        final long timeoutMillis = 15_000;
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .timeoutMs(timeoutMs)
+                .timeoutMillis(timeoutMillis)
                 .create();
 
         final long now = System.currentTimeMillis();
         assertEquals(2, gremlinExecutor.eval("1+1").get());
         gremlinExecutor.close();
-        assertTrue(System.currentTimeMillis() - now < timeoutMs);
+        assertTrue(System.currentTimeMillis() - now < timeoutMillis);
     }
 
     @Test
     public void shouldCancelTimeoutOnSuccessfulEval() throws Exception {
-        final long timeoutMs = 15_000;
+        final long timeoutMillis = 15_000;
         final GremlinExecutor gremlinExecutor = GremlinExecutor.build()
-                .timeoutMs(timeoutMs)
+                .timeoutMillis(timeoutMillis)
                 .create();
 
         final long now = System.currentTimeMillis();
         assertEquals(2, gremlinExecutor.eval("1+1").get());
         gremlinExecutor.close();
-        assertTrue(System.currentTimeMillis() - now < timeoutMs);
+        assertTrue(System.currentTimeMillis() - now < timeoutMillis);
     }
 
     @Test

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTCheckerTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTCheckerTest.java
@@ -41,49 +41,49 @@ public class GremlinASTCheckerTest {
 
     @Test(expected = MultipleCompilationErrorsException.class)
     public void shouldNotParse() {
-        GremlinASTChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows'))");
+        GremlinASTChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows'))");
     }
 
     @Test
     public void shouldNotFindTimeoutCozWeCommentedItOut() {
         assertEquals(Optional.empty(), GremlinASTChecker.parse("g.\n" +
-                "                                                  // with('evaluationTimeout', 1000L).\n" +
+                "                                                  // with('timeoutMs', 1000L).\n" +
                 "                                                  with(true).V().out('knows')").getTimeout());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsStringKey() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinASTChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKey() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with(Tokens.ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinASTChecker.parse("g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKeyWithoutClassName() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinASTChecker.parse("g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyMultipleTimeouts() {
-        assertEquals(6000, GremlinASTChecker.parse("g.with('evaluationTimeout', 1000L).with(true).V().out('knows');" +
-                "g.with('evaluationTimeout', 1000L).with(true).V().out('knows')\n" +
-                "                                                   //g.with('evaluationTimeout', 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with('evaluationTimeout', 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with(Tokens.ARGS_SCRIPT_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with(ARGS_EVAL_TIMEOUT, 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with('scriptEvaluationTimeout', 1000L).with(true).V().out('knows')").
+        assertEquals(6000, GremlinASTChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows');" +
+                "g.with('timeoutMs', 1000L).with(true).V().out('knows')\n" +
+                "                                                   //g.with('timeoutMs', 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldParseLong() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with('evaluationTimeout', 1000L).addV().property(id, 'blue').as('b').\n" +
+        assertEquals(1000, GremlinASTChecker.parse("g.with('timeoutMs', 1000L).addV().property(id, 'blue').as('b').\n" +
                 "  addV().property(id, 'orange').as('o').\n" +
                 "  addV().property(id, 'red').as('r').\n" +
                 "  addV().property(id, 'green').as('g').\n" +

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTCheckerTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/ast/GremlinASTCheckerTest.java
@@ -41,49 +41,49 @@ public class GremlinASTCheckerTest {
 
     @Test(expected = MultipleCompilationErrorsException.class)
     public void shouldNotParse() {
-        GremlinASTChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows'))");
+        GremlinASTChecker.parse("g.with('timeoutMillis', 1000L).with(true).V().out('knows'))");
     }
 
     @Test
     public void shouldNotFindTimeoutCozWeCommentedItOut() {
         assertEquals(Optional.empty(), GremlinASTChecker.parse("g.\n" +
-                "                                                  // with('timeoutMs', 1000L).\n" +
+                "                                                  // with('timeoutMillis', 1000L).\n" +
                 "                                                  with(true).V().out('knows')").getTimeout());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsStringKey() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinASTChecker.parse("g.with('timeoutMillis', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKey() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinASTChecker.parse("g.with(Tokens.TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyTimeoutAsTokenKeyWithoutClassName() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')").
+        assertEquals(1000, GremlinASTChecker.parse("g.with(TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldIdentifyMultipleTimeouts() {
-        assertEquals(6000, GremlinASTChecker.parse("g.with('timeoutMs', 1000L).with(true).V().out('knows');" +
-                "g.with('timeoutMs', 1000L).with(true).V().out('knows')\n" +
-                "                                                   //g.with('timeoutMs', 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with(Tokens.TIMEOUT_MS, 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with(TIMEOUT_MS, 1000L).with(true).V().out('knows')\n" +
-                "                                                   g.with('timeoutMs', 1000L).with(true).V().out('knows')").
+        assertEquals(6000, GremlinASTChecker.parse("g.with('timeoutMillis', 1000L).with(true).V().out('knows');" +
+                "g.with('timeoutMillis', 1000L).with(true).V().out('knows')\n" +
+                "                                                   //g.with('timeoutMillis', 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with('timeoutMillis', 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with(Tokens.TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with(TIMEOUT_MILLIS, 1000L).with(true).V().out('knows')\n" +
+                "                                                   g.with('timeoutMillis', 1000L).with(true).V().out('knows')").
                 getTimeout().get().longValue());
     }
 
     @Test
     public void shouldParseLong() {
-        assertEquals(1000, GremlinASTChecker.parse("g.with('timeoutMs', 1000L).addV().property(id, 'blue').as('b').\n" +
+        assertEquals(1000, GremlinASTChecker.parse("g.with('timeoutMillis', 1000L).addV().property(id, 'blue').as('b').\n" +
                 "  addV().property(id, 'orange').as('o').\n" +
                 "  addV().property(id, 'red').as('r').\n" +
                 "  addV().property(id, 'green').as('g').\n" +

--- a/gremlin-js/gremlin-javascript/lib/driver/client.ts
+++ b/gremlin-js/gremlin-javascript/lib/driver/client.ts
@@ -25,7 +25,7 @@ export type RequestOptions = {
   parameters?: any;
   language?: string;
   accept?: string;
-  timeoutMs?: number;
+  timeoutMillis?: number;
   batchSize?: number;
   userAgent?: string;
   materializeProperties?: string;
@@ -123,8 +123,8 @@ export default class Client {
     if (requestOptions?.materializeProperties) {
       requestBuilder.addMaterializeProperties(requestOptions.materializeProperties);
     }
-    if (requestOptions?.timeoutMs) {
-      requestBuilder.addTimeoutMillis(requestOptions.timeoutMs);
+    if (requestOptions?.timeoutMillis) {
+      requestBuilder.addTimeoutMillis(requestOptions.timeoutMillis);
     }
     // Per-request value wins (including an explicit `false`); otherwise apply the
     // connection-level default only when it is true.

--- a/gremlin-js/gremlin-javascript/lib/driver/client.ts
+++ b/gremlin-js/gremlin-javascript/lib/driver/client.ts
@@ -25,7 +25,7 @@ export type RequestOptions = {
   parameters?: any;
   language?: string;
   accept?: string;
-  evaluationTimeout?: number;
+  timeoutMs?: number;
   batchSize?: number;
   userAgent?: string;
   materializeProperties?: string;
@@ -123,8 +123,8 @@ export default class Client {
     if (requestOptions?.materializeProperties) {
       requestBuilder.addMaterializeProperties(requestOptions.materializeProperties);
     }
-    if (requestOptions?.evaluationTimeout) {
-      requestBuilder.addTimeoutMillis(requestOptions.evaluationTimeout);
+    if (requestOptions?.timeoutMs) {
+      requestBuilder.addTimeoutMillis(requestOptions.timeoutMs);
     }
     // Per-request value wins (including an explicit `false`); otherwise apply the
     // connection-level default only when it is true.

--- a/gremlin-js/gremlin-javascript/lib/driver/driver-remote-connection.ts
+++ b/gremlin-js/gremlin-javascript/lib/driver/driver-remote-connection.ts
@@ -83,8 +83,7 @@ export default class DriverRemoteConnection extends RemoteConnection {
     if (strategies.length > 0) {
       requestOptions = {};
       const allowedKeys = [
-        'evaluationTimeout',
-        'scriptEvaluationTimeout',
+        'timeoutMs',
         'batchSize',
         'requestId',
         'userAgent',

--- a/gremlin-js/gremlin-javascript/lib/driver/driver-remote-connection.ts
+++ b/gremlin-js/gremlin-javascript/lib/driver/driver-remote-connection.ts
@@ -83,7 +83,7 @@ export default class DriverRemoteConnection extends RemoteConnection {
     if (strategies.length > 0) {
       requestOptions = {};
       const allowedKeys = [
-        'timeoutMs',
+        'timeoutMillis',
         'batchSize',
         'requestId',
         'userAgent',

--- a/gremlin-js/gremlin-javascript/lib/driver/request-message.ts
+++ b/gremlin-js/gremlin-javascript/lib/driver/request-message.ts
@@ -25,7 +25,7 @@ const Tokens = {
   ARGS_PARAMETERS: 'parameters',
   ARGS_G: 'g',
   ARGS_MATERIALIZE_PROPERTIES: 'materializeProperties',
-  TIMEOUT_MS: 'timeoutMs',
+  TIMEOUT_MILLIS: 'timeoutMillis',
   BULK_RESULTS: 'bulkResults',
   BATCH_SIZE: 'batchSize',
   MATERIALIZE_PROPERTIES_TOKENS: 'tokens',
@@ -38,7 +38,7 @@ const Tokens = {
 export class RequestMessage {
   private gremlin: string;
   private language: string;
-  private timeoutMs?: number;
+  private timeoutMillis?: number;
   private parameters?: object;
   private g?: string;
   private materializeProperties?: string;
@@ -49,7 +49,7 @@ export class RequestMessage {
   private constructor(
     gremlin: string,
     language: string,
-    timeoutMs: number | undefined,
+    timeoutMillis: number | undefined,
     parameters: object | undefined,
     g: string | undefined,
     materializeProperties: string | undefined,
@@ -63,7 +63,7 @@ export class RequestMessage {
 
     this.gremlin = gremlin;
     this.language = language;
-    this.timeoutMs = timeoutMs;
+    this.timeoutMillis = timeoutMillis;
     this.parameters = parameters;
     this.g = g;
     this.materializeProperties = materializeProperties;
@@ -80,8 +80,8 @@ export class RequestMessage {
     return this.language;
   }
 
-  getTimeoutMs(): number | undefined {
-    return this.timeoutMs;
+  getTimeoutMillis(): number | undefined {
+    return this.timeoutMillis;
   }
 
   getParameters(): object | undefined {
@@ -128,8 +128,8 @@ export class RequestMessage {
     if (this.parameters !== undefined) {
       payload['parameters'] = this.parameters;
     }
-    if (this.timeoutMs !== undefined) {
-      payload['timeoutMs'] = this.timeoutMs;
+    if (this.timeoutMillis !== undefined) {
+      payload['timeoutMillis'] = this.timeoutMillis;
     }
     if (this.materializeProperties) {
       payload['materializeProperties'] = this.materializeProperties;
@@ -162,7 +162,7 @@ export class Builder {
   private readonly parameters = {};
   private parametersString?: string;
   public language: string;
-  public timeoutMs?: number;
+  public timeoutMillis?: number;
   public g?: string;
   public materializeProperties?: string;
   public bulkResults?: boolean;
@@ -233,7 +233,7 @@ export class Builder {
 
   addTimeoutMillis(timeout: number): Builder {
     if (timeout < 0) throw new Error('timeout argument cannot be negative.');
-    this.timeoutMs = timeout;
+    this.timeoutMillis = timeout;
     return this;
   }
 
@@ -269,7 +269,7 @@ export class Builder {
     return new RequestMessage(
       this.gremlin,
       this.language || 'gremlin-lang',
-      this.timeoutMs,
+      this.timeoutMillis,
       parameters,
       this.g,
       this.materializeProperties,

--- a/gremlin-js/gremlin-javascript/lib/structure/io/binary/internals/GraphBinaryWriter.js
+++ b/gremlin-js/gremlin-javascript/lib/structure/io/binary/internals/GraphBinaryWriter.js
@@ -52,9 +52,9 @@ export default class GraphBinaryWriter {
       if (parameters && Object.keys(parameters).length > 0) {
         fields.set('parameters', parameters);
       }
-      const timeoutMs = requestMessage.getTimeoutMs();
-      if (timeoutMs !== undefined) {
-        fields.set('timeoutMs', timeoutMs);
+      const timeoutMillis = requestMessage.getTimeoutMillis();
+      if (timeoutMillis !== undefined) {
+        fields.set('timeoutMillis', timeoutMillis);
       }
       const materializeProperties = requestMessage.getMaterializeProperties();
       if (materializeProperties) {

--- a/gremlin-js/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-js/gremlin-javascript/test/integration/traversal-test.js
@@ -322,8 +322,8 @@ describe('Traversal', function () {
       });
       return g.V().out().iterate().then(() => assert.fail("should have tanked"), (err) => assert.strictEqual(err.statusCode, 500));
     });
-    it('should allow with_(timeoutMs,10)', function() {
-      const g = anon.traversal().with_(connection).with_('x').with_('timeoutMs', 10);
+    it('should allow with_(timeoutMillis,10)', function() {
+      const g = anon.traversal().with_(connection).with_('x').with_('timeoutMillis', 10);
       return g.V().repeat(__.both()).iterate().then(() => assert.fail("should have tanked"), (err) => assert.strictEqual(err.statusCode, 500));
     });
     it('should allow SeedStrategy', function () {

--- a/gremlin-js/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-js/gremlin-javascript/test/integration/traversal-test.js
@@ -322,8 +322,8 @@ describe('Traversal', function () {
       });
       return g.V().out().iterate().then(() => assert.fail("should have tanked"), (err) => assert.strictEqual(err.statusCode, 500));
     });
-    it('should allow with_(evaluationTimeout,10)', function() {
-      const g = anon.traversal().with_(connection).with_('x').with_('evaluationTimeout', 10);
+    it('should allow with_(timeoutMs,10)', function() {
+      const g = anon.traversal().with_(connection).with_('x').with_('timeoutMs', 10);
       return g.V().repeat(__.both()).iterate().then(() => assert.fail("should have tanked"), (err) => assert.strictEqual(err.statusCode, 500));
     });
     it('should allow SeedStrategy', function () {

--- a/gremlin-js/gremlin-javascript/test/unit/graphbinary/GraphBinaryWriter-test.js
+++ b/gremlin-js/gremlin-javascript/test/unit/graphbinary/GraphBinaryWriter-test.js
@@ -52,16 +52,16 @@ describe('GraphBinaryWriter', () => {
   });
 
   describe('fields with entries', () => {
-    it('map with timeoutMs entry', () => {
+    it('map with timeoutMillis entry', () => {
       const fields = new Map();
-      fields.set('timeoutMs', 1000);
+      fields.set('timeoutMillis', 1000);
       const result = writer.writeRequest({ gremlin: 'g.V()', fields });
       const expected = Buffer.from([
         0x84, // version
         0x00, 0x00, 0x00, 0x01, // map length=1
         0x03, 0x00, // key type_code=STRING, value_flag=0x00
-        0x00, 0x00, 0x00, 0x09, // key string length=9
-        0x74, 0x69, 0x6D, 0x65, 0x6F, 0x75, 0x74, 0x4D, 0x73, // "timeoutMs"
+        0x00, 0x00, 0x00, 0x0D, // key string length=13
+        0x74, 0x69, 0x6D, 0x65, 0x6F, 0x75, 0x74, 0x4D, 0x69, 0x6C, 0x6C, 0x69, 0x73, // "timeoutMillis"
         0x01, 0x00, // value type_code=INT, value_flag=0x00
         0x00, 0x00, 0x03, 0xE8, // value int=1000
         0x00, 0x00, 0x00, 0x05, // gremlin string length=5

--- a/gremlin-js/gremlin-javascript/test/unit/graphbinary/GraphBinaryWriter-test.js
+++ b/gremlin-js/gremlin-javascript/test/unit/graphbinary/GraphBinaryWriter-test.js
@@ -52,16 +52,16 @@ describe('GraphBinaryWriter', () => {
   });
 
   describe('fields with entries', () => {
-    it('map with evaluationTimeout entry', () => {
+    it('map with timeoutMs entry', () => {
       const fields = new Map();
-      fields.set('evaluationTimeout', 1000);
+      fields.set('timeoutMs', 1000);
       const result = writer.writeRequest({ gremlin: 'g.V()', fields });
       const expected = Buffer.from([
         0x84, // version
         0x00, 0x00, 0x00, 0x01, // map length=1
         0x03, 0x00, // key type_code=STRING, value_flag=0x00
-        0x00, 0x00, 0x00, 0x11, // key string length=17
-        0x65, 0x76, 0x61, 0x6C, 0x75, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x54, 0x69, 0x6D, 0x65, 0x6F, 0x75, 0x74, // "evaluationTimeout"
+        0x00, 0x00, 0x00, 0x09, // key string length=9
+        0x74, 0x69, 0x6D, 0x65, 0x6F, 0x75, 0x74, 0x4D, 0x73, // "timeoutMs"
         0x01, 0x00, // value type_code=INT, value_flag=0x00
         0x00, 0x00, 0x03, 0xE8, // value int=1000
         0x00, 0x00, 0x00, 0x05, // gremlin string length=5

--- a/gremlin-js/gremlin-javascript/test/unit/gremlin-lang-test.js
+++ b/gremlin-js/gremlin-javascript/test/unit/gremlin-lang-test.js
@@ -226,9 +226,9 @@ describe('GremlinLang', function () {
       // #93
       [g.withStrategies(new ReadOnlyStrategy(), new SubgraphStrategy({vertices: __.has('region','US-TX')})).V().count(), "g.withStrategies(ReadOnlyStrategy,new SubgraphStrategy(vertices:__.has('region','US-TX'))).V().count()"],
       // #94 - OptionsStrategy extracted, not serialized
-      [g.with_('evaluationTimeout',500).V().count(), 'g.V().count()'],
+      [g.with_('timeoutMs',500).V().count(), 'g.V().count()'],
       // #95 - OptionsStrategy extracted, not serialized
-      [g.withStrategies(new OptionsStrategy({evaluationTimeout: 500})).V().count(), 'g.V().count()'],
+      [g.withStrategies(new OptionsStrategy({timeoutMs: 500})).V().count(), 'g.V().count()'],
       // #96
       [g.withStrategies(new PartitionStrategy({partitionKey: '_partition', writePartition: 'a', readPartitions: ['a','b']})).addV('test'), "g.withStrategies(new PartitionStrategy(partitionKey:'_partition',writePartition:'a',readPartitions:['a','b'])).addV('test')"],
       // #97
@@ -373,7 +373,7 @@ describe('GremlinLang', function () {
     });
 
     it('should handle OptionsStrategy extraction', function () {
-      const t = g.with_('evaluationTimeout', 500).V().count();
+      const t = g.with_('timeoutMs', 500).V().count();
       assert.strictEqual(t.getGremlinLang().getGremlin(), 'g.V().count()');
       assert.strictEqual(t.getGremlinLang().getOptionsStrategies().length, 1);
     });

--- a/gremlin-js/gremlin-javascript/test/unit/gremlin-lang-test.js
+++ b/gremlin-js/gremlin-javascript/test/unit/gremlin-lang-test.js
@@ -226,9 +226,9 @@ describe('GremlinLang', function () {
       // #93
       [g.withStrategies(new ReadOnlyStrategy(), new SubgraphStrategy({vertices: __.has('region','US-TX')})).V().count(), "g.withStrategies(ReadOnlyStrategy,new SubgraphStrategy(vertices:__.has('region','US-TX'))).V().count()"],
       // #94 - OptionsStrategy extracted, not serialized
-      [g.with_('timeoutMs',500).V().count(), 'g.V().count()'],
+      [g.with_('timeoutMillis',500).V().count(), 'g.V().count()'],
       // #95 - OptionsStrategy extracted, not serialized
-      [g.withStrategies(new OptionsStrategy({timeoutMs: 500})).V().count(), 'g.V().count()'],
+      [g.withStrategies(new OptionsStrategy({timeoutMillis: 500})).V().count(), 'g.V().count()'],
       // #96
       [g.withStrategies(new PartitionStrategy({partitionKey: '_partition', writePartition: 'a', readPartitions: ['a','b']})).addV('test'), "g.withStrategies(new PartitionStrategy(partitionKey:'_partition',writePartition:'a',readPartitions:['a','b'])).addV('test')"],
       // #97
@@ -373,7 +373,7 @@ describe('GremlinLang', function () {
     });
 
     it('should handle OptionsStrategy extraction', function () {
-      const t = g.with_('timeoutMs', 500).V().count();
+      const t = g.with_('timeoutMillis', 500).V().count();
       assert.strictEqual(t.getGremlinLang().getGremlin(), 'g.V().count()');
       assert.strictEqual(t.getGremlinLang().getOptionsStrategies().length, 1);
     });

--- a/gremlin-js/gremlin-javascript/test/unit/http-request-test.js
+++ b/gremlin-js/gremlin-javascript/test/unit/http-request-test.js
@@ -107,7 +107,7 @@ describe('HttpRequest', function () {
       assert.strictEqual(parsed.gremlin, "g.V().has('age',x)");
       assert.strictEqual(parsed.g, 'gCustom');
       assert.strictEqual(parsed.language, 'gremlin-lang');
-      assert.strictEqual(parsed.timeoutMs, 5000);
+      assert.strictEqual(parsed.timeoutMillis, 5000);
       assert.strictEqual(parsed.materializeProperties, 'all');
       assert.strictEqual(parsed.bulkResults, true);
       assert.strictEqual(parsed.customKey, 'customValue');

--- a/gremlin-python/src/main/python/gremlin_python/driver/request.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/request.py
@@ -24,5 +24,5 @@ RequestMessage = collections.namedtuple(
     'RequestMessage', ['fields', 'gremlin'])
 
 Tokens = ['batchSize', 'parameters', 'g', 'gremlin', 'language',
-          'materializeProperties', 'timeoutMs', 'userAgent', 'bulkResults',
+          'materializeProperties', 'timeoutMillis', 'userAgent', 'bulkResults',
           'transactionId']

--- a/gremlin-python/src/main/python/gremlin_python/driver/request.py
+++ b/gremlin-python/src/main/python/gremlin_python/driver/request.py
@@ -24,5 +24,5 @@ RequestMessage = collections.namedtuple(
     'RequestMessage', ['fields', 'gremlin'])
 
 Tokens = ['batchSize', 'parameters', 'g', 'gremlin', 'language',
-          'evaluationTimeout', 'materializeProperties', 'timeoutMs', 'userAgent', 'bulkResults',
+          'materializeProperties', 'timeoutMs', 'userAgent', 'bulkResults',
           'transactionId']

--- a/gremlin-python/src/main/python/tests/integration/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/integration/driver/test_driver_remote_connection.py
@@ -46,20 +46,20 @@ class TestDriverRemoteConnection(object):
 
     def test_extract_request_options(self, remote_connection):
         g = traversal().with_(remote_connection)
-        t = g.with_("evaluationTimeout", 1000).with_("batchSize", 100).V().count()
+        t = g.with_("timeoutMs", 1000).with_("batchSize", 100).V().count()
         assert remote_connection.extract_request_options(t.gremlin_lang) == {'batchSize': 100,
-                                                                             'evaluationTimeout': 1000,
+                                                                             'timeoutMs': 1000,
                                                                              'bulkResults': True}
         assert 6 == t.to_list()[0]
 
     @pytest.mark.skip(reason="TINKERPOP-3126: g.V() with a variable/parameter argument fails to parse in gremlin-lang")
     def test_extract_request_options_with_params(self, remote_connection):
         g = traversal().with_(remote_connection)
-        t = g.with_("evaluationTimeout",
+        t = g.with_("timeoutMs",
                     1000).with_("batchSize", 100).with_("userAgent",
                                                         "test").V(GValue('ids', [1, 2, 3])).count()
         assert remote_connection.extract_request_options(t.gremlin_lang) == {'batchSize': 100,
-                                                                             'evaluationTimeout': 1000,
+                                                                             'timeoutMs': 1000,
                                                                              'userAgent': 'test',
                                                                              'bulkResults': True,
                                                                              'parameters': "['ids':[1,2,3]]"}

--- a/gremlin-python/src/main/python/tests/integration/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/integration/driver/test_driver_remote_connection.py
@@ -46,20 +46,20 @@ class TestDriverRemoteConnection(object):
 
     def test_extract_request_options(self, remote_connection):
         g = traversal().with_(remote_connection)
-        t = g.with_("timeoutMs", 1000).with_("batchSize", 100).V().count()
+        t = g.with_("timeoutMillis", 1000).with_("batchSize", 100).V().count()
         assert remote_connection.extract_request_options(t.gremlin_lang) == {'batchSize': 100,
-                                                                             'timeoutMs': 1000,
+                                                                             'timeoutMillis': 1000,
                                                                              'bulkResults': True}
         assert 6 == t.to_list()[0]
 
     @pytest.mark.skip(reason="TINKERPOP-3126: g.V() with a variable/parameter argument fails to parse in gremlin-lang")
     def test_extract_request_options_with_params(self, remote_connection):
         g = traversal().with_(remote_connection)
-        t = g.with_("timeoutMs",
+        t = g.with_("timeoutMillis",
                     1000).with_("batchSize", 100).with_("userAgent",
                                                         "test").V(GValue('ids', [1, 2, 3])).count()
         assert remote_connection.extract_request_options(t.gremlin_lang) == {'batchSize': 100,
-                                                                             'timeoutMs': 1000,
+                                                                             'timeoutMillis': 1000,
                                                                              'userAgent': 'test',
                                                                              'bulkResults': True,
                                                                              'parameters': "['ids':[1,2,3]]"}

--- a/gremlin-python/src/main/python/tests/unit/driver/test_client_options.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_client_options.py
@@ -115,10 +115,10 @@ class TestRequestMessageNoMutation:
 
         original = RequestMessage(fields={'g': 'g'}, gremlin='g.V()')
 
-        client.submit_async(original, request_options={'evaluationTimeout': 1000})
+        client.submit_async(original, request_options={'timeoutMs': 1000})
         # The caller's original message must be untouched.
         assert 'batchSize' not in original.fields
-        assert 'evaluationTimeout' not in original.fields
+        assert 'timeoutMs' not in original.fields
         assert original.fields == {'g': 'g'}
 
         # Resubmit the same message with different options; it must not carry
@@ -126,7 +126,7 @@ class TestRequestMessageNoMutation:
         client.submit_async(original, request_options={'batchSize': 5})
         sent = conn.write.call_args[0][0]
         assert sent.fields['batchSize'] == 5
-        assert 'evaluationTimeout' not in sent.fields
+        assert 'timeoutMs' not in sent.fields
         # And the original is still pristine.
         assert original.fields == {'g': 'g'}
 

--- a/gremlin-python/src/main/python/tests/unit/driver/test_client_options.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_client_options.py
@@ -115,10 +115,10 @@ class TestRequestMessageNoMutation:
 
         original = RequestMessage(fields={'g': 'g'}, gremlin='g.V()')
 
-        client.submit_async(original, request_options={'timeoutMs': 1000})
+        client.submit_async(original, request_options={'timeoutMillis': 1000})
         # The caller's original message must be untouched.
         assert 'batchSize' not in original.fields
-        assert 'timeoutMs' not in original.fields
+        assert 'timeoutMillis' not in original.fields
         assert original.fields == {'g': 'g'}
 
         # Resubmit the same message with different options; it must not carry
@@ -126,7 +126,7 @@ class TestRequestMessageNoMutation:
         client.submit_async(original, request_options={'batchSize': 5})
         sent = conn.write.call_args[0][0]
         assert sent.fields['batchSize'] == 5
-        assert 'timeoutMs' not in sent.fields
+        assert 'timeoutMillis' not in sent.fields
         # And the original is still pristine.
         assert original.fields == {'g': 'g'}
 

--- a/gremlin-python/src/main/python/tests/unit/driver/test_interceptor.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_interceptor.py
@@ -116,7 +116,7 @@ class TestSerializeBody:
 
     def test_includes_all_fields_in_json(self):
         msg = RequestMessage(
-            fields={"g": "g", "language": "gremlin-lang", "timeoutMs": 5000},
+            fields={"g": "g", "language": "gremlin-lang", "timeoutMillis": 5000},
             gremlin="g.V()"
         )
         request = HttpRequest(method="POST", url="http://localhost:8182/gremlin",
@@ -127,7 +127,7 @@ class TestSerializeBody:
         assert parsed["gremlin"] == "g.V()"
         assert parsed["g"] == "g"
         assert parsed["language"] == "gremlin-lang"
-        assert parsed["timeoutMs"] == 5000
+        assert parsed["timeoutMillis"] == 5000
 
     def test_raises_on_unsupported_body_type(self):
         request = HttpRequest(method="POST", url="http://localhost:8182/gremlin",

--- a/gremlin-python/src/main/python/tests/unit/process/test_gremlin_lang.py
+++ b/gremlin-python/src/main/python/tests/unit/process/test_gremlin_lang.py
@@ -362,11 +362,11 @@ class TestGremlinLang(object):
                       "g.withStrategies(ReadOnlyStrategy,new SubgraphStrategy(vertices:__.has('region','US-TX'))).V().count()"])
 
         # 95 Note with_() options are now extracted into request message and is no longer sent with the script
-        tests.append([g.with_('evaluationTimeout', 500).V().count(),
+        tests.append([g.with_('timeoutMs', 500).V().count(),
                       "g.V().count()"])
 
         # 96 Note OptionsStrategy are now extracted into request message and is no longer sent with the script
-        tests.append([g.with_strategies(OptionsStrategy(evaluationTimeout=500)).V().count(),
+        tests.append([g.with_strategies(OptionsStrategy(timeoutMs=500)).V().count(),
                       "g.V().count()"])
 
         # 97

--- a/gremlin-python/src/main/python/tests/unit/process/test_gremlin_lang.py
+++ b/gremlin-python/src/main/python/tests/unit/process/test_gremlin_lang.py
@@ -362,11 +362,11 @@ class TestGremlinLang(object):
                       "g.withStrategies(ReadOnlyStrategy,new SubgraphStrategy(vertices:__.has('region','US-TX'))).V().count()"])
 
         # 95 Note with_() options are now extracted into request message and is no longer sent with the script
-        tests.append([g.with_('timeoutMs', 500).V().count(),
+        tests.append([g.with_('timeoutMillis', 500).V().count(),
                       "g.V().count()"])
 
         # 96 Note OptionsStrategy are now extracted into request message and is no longer sent with the script
-        tests.append([g.with_strategies(OptionsStrategy(timeoutMs=500)).V().count(),
+        tests.append([g.with_strategies(OptionsStrategy(timeoutMillis=500)).V().count(),
                       "g.V().count()"])
 
         # 97

--- a/gremlin-server/conf/gremlin-server-airroutes.yaml
+++ b/gremlin-server/conf/gremlin-server-airroutes.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
@@ -27,10 +27,10 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV4, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/json
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4}                                                                                                            # application/vnd.graphbinary-v4.0
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server-airroutes.yaml
+++ b/gremlin-server/conf/gremlin-server-airroutes.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-classic.yaml
+++ b/gremlin-server/conf/gremlin-server-classic.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 lifecycleHooks:
@@ -27,10 +27,10 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server-classic.yaml
+++ b/gremlin-server/conf/gremlin-server-classic.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 lifecycleHooks:

--- a/gremlin-server/conf/gremlin-server-min.yaml
+++ b/gremlin-server/conf/gremlin-server-min.yaml
@@ -20,4 +20,4 @@ port: 8182
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}

--- a/gremlin-server/conf/gremlin-server-modern-readonly.yaml
+++ b/gremlin-server/conf/gremlin-server-modern-readonly.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 graphs: {
   graph: {
     configuration: conf/tinkergraph-empty.properties,

--- a/gremlin-server/conf/gremlin-server-modern-readonly.yaml
+++ b/gremlin-server/conf/gremlin-server-modern-readonly.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 graphs: {
   graph: {
     configuration: conf/tinkergraph-empty.properties,
@@ -29,10 +29,10 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-modern.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
@@ -27,10 +27,10 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV4, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/json
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4}                                                                                                            # application/vnd.graphbinary-v4.0
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-modern.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-rest-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-modern.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
@@ -29,7 +29,7 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-rest-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-modern.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -25,7 +25,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -25,17 +25,17 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
 serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}            # application/json
 metrics: {
-  consoleReporter: {enabled: true, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  consoleReporter: {enabled: true, intervalMillis: 180000},
+  csvReporter: {enabled: true, intervalMillis: 180000, fileName: /tmp/gremlin-server-metrics.csv},
   jmxReporter: {enabled: true},
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -25,7 +25,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -25,7 +25,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
@@ -34,13 +34,13 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
-  consoleReporter: {enabled: true, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  consoleReporter: {enabled: true, intervalMillis: 180000},
+  csvReporter: {enabled: true, intervalMillis: 180000, fileName: /tmp/gremlin-server-metrics.csv},
   jmxReporter: {enabled: true},
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server-spark.yaml
+++ b/gremlin-server/conf/gremlin-server-spark.yaml
@@ -40,7 +40,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/hadoop-gryo.properties}

--- a/gremlin-server/conf/gremlin-server-spark.yaml
+++ b/gremlin-server/conf/gremlin-server-spark.yaml
@@ -40,7 +40,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/hadoop-gryo.properties}
@@ -56,13 +56,13 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
-  consoleReporter: {enabled: true, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  consoleReporter: {enabled: true, intervalMillis: 180000},
+  csvReporter: {enabled: true, intervalMillis: 180000, fileName: /tmp/gremlin-server-metrics.csv},
   jmxReporter: {enabled: true},
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server-transaction.yaml
+++ b/gremlin-server/conf/gremlin-server-transaction.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkertransactiongraph-empty.properties}

--- a/gremlin-server/conf/gremlin-server-transaction.yaml
+++ b/gremlin-server/conf/gremlin-server-transaction.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkertransactiongraph-empty.properties}
@@ -26,15 +26,15 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
-  consoleReporter: {enabled: true, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  consoleReporter: {enabled: true, intervalMillis: 180000},
+  csvReporter: {enabled: true, intervalMillis: 180000, fileName: /tmp/gremlin-server-metrics.csv},
   jmxReporter: {enabled: true},
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleTransactionTimeout: 60000
-maxTransactionLifetime: 600000
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleTransactionTimeoutMillis: 60000
+maxTransactionLifetimeMillis: 600000
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server.yaml
+++ b/gremlin-server/conf/gremlin-server.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-timeoutMs: 30000
+timeoutMillis: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}
@@ -26,13 +26,13 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4 }                                                                                                           # application/vnd.graphbinary-v1.0
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV4, config: { serializeResultToString: true }}                                                                 # application/vnd.graphbinary-v1.0-stringd
 metrics: {
-  consoleReporter: {enabled: true, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  consoleReporter: {enabled: true, intervalMillis: 180000},
+  csvReporter: {enabled: true, intervalMillis: 180000, fileName: /tmp/gremlin-server-metrics.csv},
   jmxReporter: {enabled: true},
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/conf/gremlin-server.yaml
+++ b/gremlin-server/conf/gremlin-server.yaml
@@ -17,7 +17,7 @@
 
 host: localhost
 port: 8182
-evaluationTimeout: 30000
+timeoutMs: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
 graphs: {
   graph: conf/tinkergraph-empty.properties}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -135,8 +135,8 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
                 final SSLFactory sslFactory = createSSLFactoryBuilder(settings).withSwappableTrustMaterial().withSwappableIdentityMaterial().build();
                 this.sslContext = Optional.of(createSSLContext(sslFactory));
 
-                if (settings.ssl.refreshInterval > 0) {
-                    // At the scheduled refreshInterval, check whether the keyStore or trustStore has been modified. If they were,
+                if (settings.ssl.refreshIntervalMillis > 0) {
+                    // At the scheduled refreshIntervalMillis, check whether the keyStore or trustStore has been modified. If they were,
                     // reload the SSLFactory which will reload the underlying KeyManager/TrustManager that Netty SSLHandler uses.
                     scheduledExecutorService.scheduleAtFixedRate(
                             new SSLStoreFilesModificationWatcher(settings.ssl.keyStore, settings.ssl.trustStore, () -> {
@@ -147,7 +147,7 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
                                     logger.error("Failed to reload SSLFactory", e);
                                 }
                             }),
-                            settings.ssl.refreshInterval, settings.ssl.refreshInterval, TimeUnit.MILLISECONDS
+                            settings.ssl.refreshIntervalMillis, settings.ssl.refreshIntervalMillis, TimeUnit.MILLISECONDS
                     );
                 }
             }
@@ -174,8 +174,8 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
         // checks for no activity on a channel and triggers an event that is consumed by the OpSelectorHandler
         // and either closes the connection or sends a ping to see if the client is still alive
         if (supportsIdleMonitor()) {
-            final int idleConnectionTimeout = (int) (settings.idleConnectionTimeout / 1000);
-            final int keepAliveInterval = (int) (settings.keepAliveInterval / 1000);
+            final int idleConnectionTimeout = (int) (settings.idleConnectionTimeoutMillis / 1000);
+            final int keepAliveInterval = (int) (settings.keepAliveIntervalMillis / 1000);
             pipeline.addLast(new IdleStateHandler(idleConnectionTimeout, keepAliveInterval, 0));
         }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
@@ -103,7 +103,7 @@ public class Context {
     /**
      * The timeout for the request. If the request is a script it examines the script for a timeout setting using
      * {@code with()}. If that is not found then it examines the request itself to see if the timeout is provided by
-     * {@link Tokens#TIMEOUT_MS}. If that is not provided then the {@link Settings#timeoutMs} is
+     * {@link Tokens#TIMEOUT_MILLIS}. If that is not provided then the {@link Settings#timeoutMillis} is
      * utilized as the default.
      */
     public long getRequestTimeout() {
@@ -209,8 +209,8 @@ public class Context {
 
     private long determineTimeout() {
         // per-request timeout override falls back to the server-configured default when not supplied
-        final Long timeoutMs = requestMessage.getField(Tokens.TIMEOUT_MS);
-        final long seto = (null != timeoutMs) ? timeoutMs : settings.getTimeoutMs();
+        final Long timeoutMillis = requestMessage.getField(Tokens.TIMEOUT_MILLIS);
+        final long seto = (null != timeoutMillis) ? timeoutMillis : settings.getTimeoutMillis();
 
         // override the timeout if the lifecycle has a value assigned. if the script contains with(timeout)
         // options then allow that value to override what's provided on the lifecycle

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
@@ -103,7 +103,7 @@ public class Context {
     /**
      * The timeout for the request. If the request is a script it examines the script for a timeout setting using
      * {@code with()}. If that is not found then it examines the request itself to see if the timeout is provided by
-     * {@link Tokens#TIMEOUT_MS}. If that is not provided then the {@link Settings#evaluationTimeout} is
+     * {@link Tokens#TIMEOUT_MS}. If that is not provided then the {@link Settings#timeoutMs} is
      * utilized as the default.
      */
     public long getRequestTimeout() {
@@ -208,10 +208,9 @@ public class Context {
     }
 
     private long determineTimeout() {
-        // timeout override - handle both deprecated and newly named configuration. earlier logic should prevent
-        // both configurations from being submitted at the same time
+        // per-request timeout override falls back to the server-configured default when not supplied
         final Long timeoutMs = requestMessage.getField(Tokens.TIMEOUT_MS);
-        final long seto = (null != timeoutMs) ? timeoutMs : settings.getEvaluationTimeout();
+        final long seto = (null != timeoutMs) ? timeoutMs : settings.getTimeoutMs();
 
         // override the timeout if the lifecycle has a value assigned. if the script contains with(timeout)
         // options then allow that value to override what's provided on the lifecycle

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -206,10 +206,10 @@ public class GremlinServer {
 
             final Channelizer c = (Channelizer) o;
             if (c.supportsIdleMonitor()) {
-                logger.info("idleConnectionTimeout was set to {} which resolves to {} seconds when configuring this value - this feature will be {}",
-                        settings.idleConnectionTimeout, settings.idleConnectionTimeout / 1000, settings.idleConnectionTimeout < 1000 ? "disabled" : "enabled");
-                logger.info("keepAliveInterval was set to {} which resolves to {} seconds when configuring this value - this feature will be {}",
-                        settings.keepAliveInterval, settings.keepAliveInterval / 1000, settings.keepAliveInterval < 1000 ? "disabled" : "enabled");
+                logger.info("idleConnectionTimeoutMillis was set to {} which resolves to {} seconds when configuring this value - this feature will be {}",
+                        settings.idleConnectionTimeoutMillis, settings.idleConnectionTimeoutMillis / 1000, settings.idleConnectionTimeoutMillis < 1000 ? "disabled" : "enabled");
+                logger.info("keepAliveIntervalMillis was set to {} which resolves to {} seconds when configuring this value - this feature will be {}",
+                        settings.keepAliveIntervalMillis, settings.keepAliveIntervalMillis / 1000, settings.keepAliveIntervalMillis < 1000 ? "disabled" : "enabled");
             }
 
             return c;
@@ -402,11 +402,11 @@ public class GremlinServer {
     private static void configureMetrics(final Settings.ServerMetrics settings) {
         final MetricManager metrics = MetricManager.INSTANCE;
         settings.optionalConsoleReporter().ifPresent(config -> {
-            if (config.enabled) metrics.addConsoleReporter(config.interval);
+            if (config.enabled) metrics.addConsoleReporter(config.intervalMillis);
         });
 
         settings.optionalCsvReporter().ifPresent(config -> {
-            if (config.enabled) metrics.addCsvReporter(config.interval, config.fileName);
+            if (config.enabled) metrics.addCsvReporter(config.intervalMillis, config.fileName);
         });
 
         settings.optionalJmxReporter().ifPresent(config -> {
@@ -414,14 +414,14 @@ public class GremlinServer {
         });
 
         settings.optionalSlf4jReporter().ifPresent(config -> {
-            if (config.enabled) metrics.addSlf4jReporter(config.interval, config.loggerName);
+            if (config.enabled) metrics.addSlf4jReporter(config.intervalMillis, config.loggerName);
         });
 
         settings.optionalGangliaReporter().ifPresent(config -> {
             if (config.enabled) {
                 try {
                     metrics.addGangliaReporter(config.host, config.port,
-                            config.addressingMode, config.ttl, config.protocol31, config.hostUUID, config.spoof, config.interval);
+                            config.addressingMode, config.ttl, config.protocol31, config.hostUUID, config.spoof, config.intervalMillis);
                 } catch (IOException ioe) {
                     logger.warn("Error configuring the Ganglia Reporter.", ioe);
                 }
@@ -429,7 +429,7 @@ public class GremlinServer {
         });
 
         settings.optionalGraphiteReporter().ifPresent(config -> {
-            if (config.enabled) metrics.addGraphiteReporter(config.host, config.port, config.prefix, config.interval);
+            if (config.enabled) metrics.addGraphiteReporter(config.host, config.port, config.prefix, config.intervalMillis);
         });
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -108,7 +108,7 @@ public class Settings {
      * The maximum time in milliseconds that a request is allowed to execute on the server before it times out.
      * Serves as the server-wide default which may be overridden on a per-request basis. Defaults to 30000.
      */
-    public long timeoutMs = 30000L;
+    public long timeoutMillis = 30000L;
 
     /**
      * Number of items in a particular resultset to iterate and serialize prior to pushing the data down the wire
@@ -162,19 +162,19 @@ public class Settings {
     /**
      * Time in milliseconds that the server will allow a channel to not receive requests from a client before it
      * automatically closes. If enabled, the value provided should typically exceed the amount of time given to
-     * {@link #keepAliveInterval}. Note that while this value is to be provided as milliseconds it will resolve to
+     * {@link #keepAliveIntervalMillis}. Note that while this value is to be provided as milliseconds it will resolve to
      * second precision. Set this value to 0 to disable this feature.
      */
-    public long idleConnectionTimeout = 0;
+    public long idleConnectionTimeoutMillis = 0;
 
     /**
      * Time in milliseconds that the server will allow a channel to not send responses to a client before it sends
      * a "ping" to see if it is still present. If it is present, the client should respond with a "pong" which will
-     * thus reset the {@link #idleConnectionTimeout} and keep the channel open. If enabled, this number should be
-     * smaller than the value provided to the {@link #idleConnectionTimeout}. Note that while this value is to be
+     * thus reset the {@link #idleConnectionTimeoutMillis} and keep the channel open. If enabled, this number should be
+     * smaller than the value provided to the {@link #idleConnectionTimeoutMillis}. Note that while this value is to be
      * provided as milliseconds it will resolve to second precision. Set this value to 0 to disable this feature.
      */
-    public long keepAliveInterval = 0;
+    public long keepAliveIntervalMillis = 0;
 
     /**
      * If set to {@code true} the {@code aliases} option is required on requests and Gremlin Server will use that
@@ -189,16 +189,16 @@ public class Settings {
      * Time in milliseconds that a transaction can remain idle (no operation running or queued) before it is
      * automatically rolled back. This prevents resource leaks from abandoned transactions. The idle timer is suspended
      * while an operation is in progress, so a long-running operation does not trip it (its duration is instead bounded
-     * by {@link #timeoutMs}). Set to {@code 0} to disable idle reclamation entirely. Default is 60000
+     * by {@link #timeoutMillis}). Set to {@code 0} to disable idle reclamation entirely. Default is 60000
      * (1 minute).
      */
-    public long idleTransactionTimeout = 60000L;
+    public long idleTransactionTimeoutMillis = 60000L;
 
     /**
      * Time in milliseconds to wait for a transaction commit or rollback operation to complete.
      * Default is 10000 (10 seconds).
      */
-    public long perGraphCloseTimeout = 10000L;
+    public long perGraphCloseTimeoutMillis = 10000L;
 
     /**
      * Maximum number of concurrent transactions allowed on the server.
@@ -208,14 +208,14 @@ public class Settings {
 
     /**
      * Absolute ceiling, in milliseconds, on the total age of a transaction regardless of activity. Unlike
-     * {@link #idleTransactionTimeout} (which only reclaims idle transactions), this cap fires even while an operation is
+     * {@link #idleTransactionTimeoutMillis} (which only reclaims idle transactions), this cap fires even while an operation is
      * running, interrupting it and rolling the transaction back, so it bounds how long a single transaction can hold its
      * dedicated worker thread and concurrency slot. The bound on transaction lifetime and slot occupancy is absolute;
-     * the bound on thread occupancy is best-effort in the same way {@link #timeoutMs} is, since interrupting a
+     * the bound on thread occupancy is best-effort in the same way {@link #timeoutMillis} is, since interrupting a
      * running operation only takes effect when it reaches an interruptible point. Set to {@code 0} to disable the cap.
      * Default is 600000 (10 minutes).
      */
-    public long maxTransactionLifetime = 600000L;
+    public long maxTransactionLifetimeMillis = 600000L;
 
     /**
      * The full class name of the {@link Channelizer} to use in Gremlin Server.
@@ -331,8 +331,8 @@ public class Settings {
         return Optional.ofNullable(ssl);
     }
 
-    public long getTimeoutMs() {
-        return timeoutMs;
+    public long getTimeoutMillis() {
+        return timeoutMillis;
     }
 
     /**
@@ -651,7 +651,7 @@ public class Settings {
          * The interval, in milliseconds, at which the trustStore and keyStore files are checked for updates.
          * The default interval is 60 seconds.
          */
-        public long refreshInterval = 60000L;
+        public long refreshIntervalMillis = 60000L;
 
         private SslContext sslContext;
 
@@ -768,7 +768,7 @@ public class Settings {
     }
 
     public static abstract class IntervalMetrics extends BaseMetrics {
-        public long interval = 60000;
+        public long intervalMillis = 60000;
     }
 
     public static abstract class BaseMetrics {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -105,9 +105,10 @@ public class Settings {
     public int threadPoolBoss = 1;
 
     /**
-     * Time in milliseconds to wait for a request to complete execution. Defaults to 30000.
+     * The maximum time in milliseconds that a request is allowed to execute on the server before it times out.
+     * Serves as the server-wide default which may be overridden on a per-request basis. Defaults to 30000.
      */
-    public long evaluationTimeout = 30000L;
+    public long timeoutMs = 30000L;
 
     /**
      * Number of items in a particular resultset to iterate and serialize prior to pushing the data down the wire
@@ -188,7 +189,7 @@ public class Settings {
      * Time in milliseconds that a transaction can remain idle (no operation running or queued) before it is
      * automatically rolled back. This prevents resource leaks from abandoned transactions. The idle timer is suspended
      * while an operation is in progress, so a long-running operation does not trip it (its duration is instead bounded
-     * by {@link #evaluationTimeout}). Set to {@code 0} to disable idle reclamation entirely. Default is 60000
+     * by {@link #timeoutMs}). Set to {@code 0} to disable idle reclamation entirely. Default is 60000
      * (1 minute).
      */
     public long idleTransactionTimeout = 60000L;
@@ -210,7 +211,7 @@ public class Settings {
      * {@link #idleTransactionTimeout} (which only reclaims idle transactions), this cap fires even while an operation is
      * running, interrupting it and rolling the transaction back, so it bounds how long a single transaction can hold its
      * dedicated worker thread and concurrency slot. The bound on transaction lifetime and slot occupancy is absolute;
-     * the bound on thread occupancy is best-effort in the same way {@link #evaluationTimeout} is, since interrupting a
+     * the bound on thread occupancy is best-effort in the same way {@link #timeoutMs} is, since interrupting a
      * running operation only takes effect when it reaches an interruptible point. Set to {@code 0} to disable the cap.
      * Default is 600000 (10 minutes).
      */
@@ -330,8 +331,8 @@ public class Settings {
         return Optional.ofNullable(ssl);
     }
 
-    public long getEvaluationTimeout() {
-        return evaluationTimeout;
+    public long getTimeoutMs() {
+        return timeoutMs;
     }
 
     /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -192,10 +192,9 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
         final Optional<UnmanagedTransaction> txForRequest =
                 isTransactionalOp ? transactionManager.get(requestCtx.getTransactionId()) : Optional.empty();
 
-        // timeout override - handle both deprecated and newly named configuration. earlier logic should prevent
-        // both configurations from being submitted at the same time
+        // per-request timeout override falls back to the server-configured default when not supplied
         final Long timeoutMs = requestMessage.getField(Tokens.TIMEOUT_MS);
-        final long seto = (null != timeoutMs) ? timeoutMs : requestCtx.getSettings().getEvaluationTimeout();
+        final long seto = (null != timeoutMs) ? timeoutMs : requestCtx.getSettings().getTimeoutMs();
 
         final FutureTask<Void> evalFuture = new FutureTask<>(() -> {
             try {
@@ -323,7 +322,7 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
                     executionFuture.cancel(true);
                     // If the lifetime cap fired for this same operation (it flags the Context before interrupting),
                     // report the cap's 504 even when this eval-timeout task is the one that writes - so a cap-kill is
-                    // never mislabeled as a generic "increase evaluationTimeout" 500 just because of writer ordering.
+                    // never mislabeled as a generic "increase timeoutMs" 500 just because of writer ordering.
                     coordinator.writeError(requestCtx.isClosedByLifetimeCap()
                             ? GremlinError.transactionTimeout(requestCtx.getTransactionId(), "execute")
                             : GremlinError.timeout(requestMessage));
@@ -403,7 +402,7 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
             // An interrupt here is normally an evaluation timeout, but it is also how a transaction's absolute lifetime
             // cap stops a running operation. In the cap case the transaction flagged this request's Context before
             // interrupting, so report an accurate transaction-timeout (504) rather than the generic "increase
-            // evaluationTimeout" error (500), whose advice would be misleading for a lifetime-cap kill.
+            // timeoutMs" error (500), whose advice would be misleading for a lifetime-cap kill.
             if (requestCtx != null && requestCtx.isClosedByLifetimeCap()) {
                 return GremlinError.transactionTimeout(requestCtx.getTransactionId(), "execute");
             }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -193,8 +193,8 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
                 isTransactionalOp ? transactionManager.get(requestCtx.getTransactionId()) : Optional.empty();
 
         // per-request timeout override falls back to the server-configured default when not supplied
-        final Long timeoutMs = requestMessage.getField(Tokens.TIMEOUT_MS);
-        final long seto = (null != timeoutMs) ? timeoutMs : requestCtx.getSettings().getTimeoutMs();
+        final Long timeoutMillis = requestMessage.getField(Tokens.TIMEOUT_MILLIS);
+        final long seto = (null != timeoutMillis) ? timeoutMillis : requestCtx.getSettings().getTimeoutMillis();
 
         final FutureTask<Void> evalFuture = new FutureTask<>(() -> {
             try {
@@ -322,7 +322,7 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
                     executionFuture.cancel(true);
                     // If the lifetime cap fired for this same operation (it flags the Context before interrupting),
                     // report the cap's 504 even when this eval-timeout task is the one that writes - so a cap-kill is
-                    // never mislabeled as a generic "increase timeoutMs" 500 just because of writer ordering.
+                    // never mislabeled as a generic "increase timeoutMillis" 500 just because of writer ordering.
                     coordinator.writeError(requestCtx.isClosedByLifetimeCap()
                             ? GremlinError.transactionTimeout(requestCtx.getTransactionId(), "execute")
                             : GremlinError.timeout(requestMessage));
@@ -402,7 +402,7 @@ public class HttpGremlinEndpointHandler extends SimpleChannelInboundHandler<Requ
             // An interrupt here is normally an evaluation timeout, but it is also how a transaction's absolute lifetime
             // cap stops a running operation. In the cap case the transaction flagged this request's Context before
             // interrupting, so report an accurate transaction-timeout (504) rather than the generic "increase
-            // timeoutMs" error (500), whose advice would be misleading for a lifetime-cap kill.
+            // timeoutMillis" error (500), whose advice would be misleading for a lifetime-cap kill.
             if (requestCtx != null && requestCtx.isClosedByLifetimeCap()) {
                 return GremlinError.transactionTimeout(requestCtx.getTransactionId(), "execute");
             }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoder.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoder.java
@@ -201,8 +201,8 @@ public class HttpRequestMessageDecoder extends MessageToMessageDecoder<FullHttpR
         final JsonNode chunkSizeNode = body.get(Tokens.ARGS_BATCH_SIZE);
         if (null != chunkSizeNode) builder.addChunkSize(chunkSizeNode.asInt());
 
-        final JsonNode timeoutMsNode = body.get(Tokens.TIMEOUT_MS);
-        if (null != timeoutMsNode) builder.addTimeoutMillis(timeoutMsNode.asLong());
+        final JsonNode timeoutMillisNode = body.get(Tokens.TIMEOUT_MILLIS);
+        if (null != timeoutMillisNode) builder.addTimeoutMillis(timeoutMillisNode.asLong());
 
         final JsonNode matPropsNode = body.get(Tokens.ARGS_MATERIALIZE_PROPERTIES);
         if (null != matPropsNode) builder.addMaterializeProperties(matPropsNode.asText());

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/transaction/TransactionManager.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/transaction/TransactionManager.java
@@ -49,36 +49,36 @@ public class TransactionManager {
     private final ConcurrentMap<String, ScheduledFuture<?>> lifetimeTimers = new ConcurrentHashMap<>();
     private final ScheduledExecutorService scheduledExecutorService;
     private final GraphManager graphManager;
-    private final long idleTransactionTimeoutMs;
-    private final long maxTransactionLifetimeMs;
+    private final long idleTransactionTimeoutMillis;
+    private final long maxTransactionLifetimeMillis;
     private final int maxConcurrentTransactions;
-    private final long perGraphCloseMs;
+    private final long perGraphCloseMillis;
 
     /**
      * Creates a new TransactionManager with the specified configuration.
      *
      * @param scheduledExecutorService Scheduler for timeout management
      * @param graphManager The graph manager for accessing traversal sources
-     * @param idleTransactionTimeoutMs Inactivity timeout in milliseconds before auto-rollback; {@code 0} disables it
-     * @param maxTransactionLifetimeMs Absolute cap in milliseconds on total transaction age; {@code 0} disables it
+     * @param idleTransactionTimeoutMillis Inactivity timeout in milliseconds before auto-rollback; {@code 0} disables it
+     * @param maxTransactionLifetimeMillis Absolute cap in milliseconds on total transaction age; {@code 0} disables it
      * @param maxConcurrentTransactions Maximum number of concurrent transactions allowed
      */
     public TransactionManager(final ScheduledExecutorService scheduledExecutorService,
                               final GraphManager graphManager,
-                              final long idleTransactionTimeoutMs,
-                              final long maxTransactionLifetimeMs,
+                              final long idleTransactionTimeoutMillis,
+                              final long maxTransactionLifetimeMillis,
                               final int maxConcurrentTransactions,
-                              final long perGraphCloseMs) {
+                              final long perGraphCloseMillis) {
         this.scheduledExecutorService = scheduledExecutorService;
         this.graphManager = graphManager;
-        this.idleTransactionTimeoutMs = idleTransactionTimeoutMs;
-        this.maxTransactionLifetimeMs = maxTransactionLifetimeMs;
+        this.idleTransactionTimeoutMillis = idleTransactionTimeoutMillis;
+        this.maxTransactionLifetimeMillis = maxTransactionLifetimeMillis;
         this.maxConcurrentTransactions = maxConcurrentTransactions;
-        this.perGraphCloseMs = perGraphCloseMs;
+        this.perGraphCloseMillis = perGraphCloseMillis;
 
         MetricManager.INSTANCE.getGauge(transactions::size, name(GremlinServer.class, "transactions"));
-        logger.info("TransactionManager initialized with idleTransactionTimeout={}ms, maxTransactionLifetime={}ms, maxTransactions={}",
-                idleTransactionTimeoutMs, maxTransactionLifetimeMs, maxConcurrentTransactions);
+        logger.info("TransactionManager initialized with idleTransactionTimeoutMillis={}, maxTransactionLifetimeMillis={}, maxTransactions={}",
+                idleTransactionTimeoutMillis, maxTransactionLifetimeMillis, maxConcurrentTransactions);
     }
 
     /**
@@ -138,8 +138,8 @@ public class TransactionManager {
                     traversalSourceName,
                     graph,
                     scheduledExecutorService,
-                    idleTransactionTimeoutMs,
-                    perGraphCloseMs
+                    idleTransactionTimeoutMillis,
+                    perGraphCloseMillis
             );
         } while (transactions.putIfAbsent(transactionId, transaction) != null);
 
@@ -149,10 +149,10 @@ public class TransactionManager {
         // unreclaimable transaction holding a worker thread and slot. Scheduling after registration guarantees the cap
         // can always tear the transaction down; destroy() cancels it on every close path. The clock effectively starts
         // at construction (registration follows within microseconds), so it bounds total transaction age including begin.
-        if (maxTransactionLifetimeMs > 0) {
+        if (maxTransactionLifetimeMillis > 0) {
             final UnmanagedTransaction registered = transaction; // effectively-final copy for the scheduled method ref
             lifetimeTimers.put(transactionId, scheduledExecutorService.schedule(
-                    registered::onLifetimeCap, maxTransactionLifetimeMs, TimeUnit.MILLISECONDS));
+                    registered::onLifetimeCap, maxTransactionLifetimeMillis, TimeUnit.MILLISECONDS));
         }
 
         return transaction;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/transaction/UnmanagedTransaction.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/transaction/UnmanagedTransaction.java
@@ -212,7 +212,7 @@ public class UnmanagedTransaction {
      * Invoked from {@link SingleThreadTransactionExecutor#beforeExecute} and, as a backstop, from {@link #submit}.
      * <p>
      * A long-running operation must not trip the idle timeout: while an operation is in progress the idle timer is
-     * simply not armed (the operation's own duration is bounded by the per-request {@code timeoutMs} instead).
+     * simply not armed (the operation's own duration is bounded by the per-request {@code timeoutMillis} instead).
      */
     private void cancelIdleTimer() {
         idleFuture.updateAndGet(future -> {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/transaction/UnmanagedTransaction.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/transaction/UnmanagedTransaction.java
@@ -212,7 +212,7 @@ public class UnmanagedTransaction {
      * Invoked from {@link SingleThreadTransactionExecutor#beforeExecute} and, as a backstop, from {@link #submit}.
      * <p>
      * A long-running operation must not trip the idle timeout: while an operation is in progress the idle timer is
-     * simply not armed (the operation's own duration is bounded by the per-request {@code evaluationTimeout} instead).
+     * simply not armed (the operation's own duration is bounded by the per-request {@code timeoutMs} instead).
      */
     private void cancelIdleTimer() {
         idleFuture.updateAndGet(future -> {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
@@ -100,7 +100,7 @@ public class GremlinError {
 
     // execution errors
     public static GremlinError timeout(final RequestMessage requestMessage ) {
-        final String message = String.format("A timeout occurred during traversal evaluation of [%s] - consider increasing the limit given to timeoutMs (the maximum time in milliseconds a request may execute on the server)",
+        final String message = String.format("A timeout occurred during traversal evaluation of [%s] - consider increasing the limit given to timeoutMillis (the maximum time in milliseconds a request may execute on the server)",
                 requestMessage);
         return new GremlinError(HttpResponseStatus.INTERNAL_SERVER_ERROR, message, "ServerTimeoutExceededException");
     }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/GremlinError.java
@@ -100,7 +100,7 @@ public class GremlinError {
 
     // execution errors
     public static GremlinError timeout(final RequestMessage requestMessage ) {
-        final String message = String.format("A timeout occurred during traversal evaluation of [%s] - consider increasing the limit given to evaluationTimeout",
+        final String message = String.format("A timeout occurred during traversal evaluation of [%s] - consider increasing the limit given to timeoutMs (the maximum time in milliseconds a request may execute on the server)",
                 requestMessage);
         return new GremlinError(HttpResponseStatus.INTERNAL_SERVER_ERROR, message, "ServerTimeoutExceededException");
     }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
@@ -143,7 +143,7 @@ public class ServerGremlinExecutor {
         allowedEngines.add("gremlin-lang");
 
         final GremlinExecutor.Builder gremlinExecutorBuilder = GremlinExecutor.build()
-                .timeoutMs(settings.getTimeoutMs())
+                .timeoutMillis(settings.getTimeoutMillis())
                 .afterFailure((b, e) -> this.graphManager.rollbackAll())
                 .beforeEval(b -> this.graphManager.rollbackAll())
                 .afterTimeout((b, e) -> this.graphManager.rollbackAll())
@@ -179,7 +179,7 @@ public class ServerGremlinExecutor {
                 if (!engineName.equals("gremlin-lang") && !engineName.equals("groovy-test")) {
                     // use no timeout on the engine initialization - perhaps this can be a configuration later
                     final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build().
-                            timeoutMsOverride(0L).create();
+                            timeoutMillisOverride(0L).create();
                     gremlinExecutor.eval("1+1", engineName, new SimpleBindings(Collections.emptyMap()), lifeCycle).join();
                 }
 
@@ -306,10 +306,10 @@ public class ServerGremlinExecutor {
         transactionManager = new TransactionManager(
                 scheduledExecutorService,
                 graphManager,
-                settings.idleTransactionTimeout,
-                settings.maxTransactionLifetime,
+                settings.idleTransactionTimeoutMillis,
+                settings.maxTransactionLifetimeMillis,
                 settings.maxConcurrentTransactions,
-                settings.perGraphCloseTimeout
+                settings.perGraphCloseTimeoutMillis
         );
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
@@ -143,7 +143,7 @@ public class ServerGremlinExecutor {
         allowedEngines.add("gremlin-lang");
 
         final GremlinExecutor.Builder gremlinExecutorBuilder = GremlinExecutor.build()
-                .evaluationTimeout(settings.getEvaluationTimeout())
+                .timeoutMs(settings.getTimeoutMs())
                 .afterFailure((b, e) -> this.graphManager.rollbackAll())
                 .beforeEval(b -> this.graphManager.rollbackAll())
                 .afterTimeout((b, e) -> this.graphManager.rollbackAll())
@@ -179,7 +179,7 @@ public class ServerGremlinExecutor {
                 if (!engineName.equals("gremlin-lang") && !engineName.equals("groovy-test")) {
                     // use no timeout on the engine initialization - perhaps this can be a configuration later
                     final GremlinExecutor.LifeCycle lifeCycle = GremlinExecutor.LifeCycle.build().
-                            evaluationTimeoutOverride(0L).create();
+                            timeoutMsOverride(0L).create();
                     gremlinExecutor.eval("1+1", engineName, new SimpleBindings(Collections.emptyMap()), lifeCycle).join();
                 }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -73,10 +73,10 @@ public abstract class AbstractGremlinServerIntegrationTest {
      * the running server.
      * @param timeoutInMillis new request timeout in milliseconds
      */
-    protected void overrideTimeoutMs(final long timeoutInMillis) {
+    protected void overrideTimeoutMillis(final long timeoutInMillis) {
         // Note: overriding settings in a running server is not guaranteed to work for all settings.
         // It works for the timeout, though, because GremlinExecutor is re-created for each evaluation.
-        overriddenSettings.timeoutMs = timeoutInMillis;
+        overriddenSettings.timeoutMillis = timeoutInMillis;
     }
 
     public InputStream getSettingsInputStream() {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -69,14 +69,14 @@ public abstract class AbstractGremlinServerIntegrationTest {
     }
 
     /**
-     * This method may be called after {@link #startServer()} to (re-)set the evaluation timeout in
+     * This method may be called after {@link #startServer()} to (re-)set the request timeout in
      * the running server.
-     * @param timeoutInMillis new evaluation timeout
+     * @param timeoutInMillis new request timeout in milliseconds
      */
-    protected void overrideEvaluationTimeout(final long timeoutInMillis) {
+    protected void overrideTimeoutMs(final long timeoutInMillis) {
         // Note: overriding settings in a running server is not guaranteed to work for all settings.
-        // It works for the evaluation timeout, though, because GremlinExecutor is re-created for each evaluation.
-        overriddenSettings.evaluationTimeout = timeoutInMillis;
+        // It works for the timeout, though, because GremlinExecutor is re-created for each evaluation.
+        overriddenSettings.timeoutMs = timeoutInMillis;
     }
 
     public InputStream getSettingsInputStream() {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ClientWithOptionsIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ClientWithOptionsIntegrateTest.java
@@ -48,7 +48,7 @@ public class ClientWithOptionsIntegrateTest extends AbstractGremlinServerIntegra
         final Client client = cluster.connect();
         final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(client, "ggrateful"));
         assertThrows(CompletionException.class, () -> {
-            final List<Vertex> res = g.with("timeoutMs", 1).V().both().both().both().toList();
+            final List<Vertex> res = g.with("timeoutMillis", 1).V().both().both().both().toList();
             fail("Failed to time out. Result: " + res);
         });
     }
@@ -58,7 +58,7 @@ public class ClientWithOptionsIntegrateTest extends AbstractGremlinServerIntegra
         final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect().alias("ggrateful");
         assertThrows(ExecutionException.class, () -> {
-            final List<Result> res = client.submit("g.with(\"timeoutMs\", 1).V().both().both().both();").all().get();
+            final List<Result> res = client.submit("g.with(\"timeoutMillis\", 1).V().both().both().both();").all().get();
             fail("Failed to time out. Result: " + res);
         });
     }
@@ -68,7 +68,7 @@ public class ClientWithOptionsIntegrateTest extends AbstractGremlinServerIntegra
         final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect();
         assertThrows(ExecutionException.class, () -> {
-            final List<Result> res = client.submit("ggrateful.with(\"timeoutMs\", 1).V().both().both().both();").all().get();
+            final List<Result> res = client.submit("ggrateful.with(\"timeoutMillis\", 1).V().both().both().both();").all().get();
             fail("Failed to time out. Result: " + res);
         });
     }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ClientWithOptionsIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ClientWithOptionsIntegrateTest.java
@@ -48,7 +48,7 @@ public class ClientWithOptionsIntegrateTest extends AbstractGremlinServerIntegra
         final Client client = cluster.connect();
         final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(client, "ggrateful"));
         assertThrows(CompletionException.class, () -> {
-            final List<Vertex> res = g.with("evaluationTimeout", 1).V().both().both().both().toList();
+            final List<Vertex> res = g.with("timeoutMs", 1).V().both().both().both().toList();
             fail("Failed to time out. Result: " + res);
         });
     }
@@ -58,7 +58,7 @@ public class ClientWithOptionsIntegrateTest extends AbstractGremlinServerIntegra
         final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect().alias("ggrateful");
         assertThrows(ExecutionException.class, () -> {
-            final List<Result> res = client.submit("g.with(\"evaluationTimeout\", 1).V().both().both().both();").all().get();
+            final List<Result> res = client.submit("g.with(\"timeoutMs\", 1).V().both().both().both();").all().get();
             fail("Failed to time out. Result: " + res);
         });
     }
@@ -68,7 +68,7 @@ public class ClientWithOptionsIntegrateTest extends AbstractGremlinServerIntegra
         final Cluster cluster = TestClientFactory.build().create();
         final Client client = cluster.connect();
         assertThrows(ExecutionException.class, () -> {
-            final List<Result> res = client.submit("ggrateful.with(\"evaluationTimeout\", 1).V().both().both().both();").all().get();
+            final List<Result> res = client.submit("ggrateful.with(\"timeoutMs\", 1).V().both().both().both();").all().get();
             fail("Failed to time out. Result: " + res);
         });
     }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ContextTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ContextTest.java
@@ -53,7 +53,7 @@ public class ContextTest {
     {
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         final RequestMessage request =
-                RequestMessage.build("g.with('evaluationTimeout', 1000).with(true).with('materializeProperties', 'tokens').V().out('knows')")
+                RequestMessage.build("g.with('timeoutMs', 1000).with(true).with('materializeProperties', 'tokens').V().out('knows')")
                     .create();
         final Settings settings = new Settings();
         final Context context = new Context(request, ctx, settings, null, null, null);
@@ -67,7 +67,7 @@ public class ContextTest {
     {
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         final RequestMessage request =
-                RequestMessage.build("g.with('evaluationTimeout', 1000).with(true).with('materializeProperties', 'some-invalid-value').V().out('knows')")
+                RequestMessage.build("g.with('timeoutMs', 1000).with(true).with('materializeProperties', 'some-invalid-value').V().out('knows')")
                     .create();
         final Settings settings = new Settings();
         final Context context = new Context(request, ctx, settings, null, null, null);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ContextTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/ContextTest.java
@@ -53,7 +53,7 @@ public class ContextTest {
     {
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         final RequestMessage request =
-                RequestMessage.build("g.with('timeoutMs', 1000).with(true).with('materializeProperties', 'tokens').V().out('knows')")
+                RequestMessage.build("g.with('timeoutMillis', 1000).with(true).with('materializeProperties', 'tokens').V().out('knows')")
                     .create();
         final Settings settings = new Settings();
         final Context context = new Context(request, ctx, settings, null, null, null);
@@ -67,7 +67,7 @@ public class ContextTest {
     {
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         final RequestMessage request =
-                RequestMessage.build("g.with('timeoutMs', 1000).with(true).with('materializeProperties', 'some-invalid-value').V().out('knows')")
+                RequestMessage.build("g.with('timeoutMillis', 1000).with(true).with('materializeProperties', 'some-invalid-value').V().out('knows')")
                     .create();
         final Settings settings = new Settings();
         final Context context = new Context(request, ctx, settings, null, null, null);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -160,12 +160,12 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
                 useTinkerTransactionGraph(settings);
                 break;
             case "shouldProcessSessionRequestsInOrderAfterTimeout":
-                settings.timeoutMs = 250;
+                settings.timeoutMillis = 250;
                 settings.threadPoolWorker = 1;
                 break;
             case "shouldProcessTraversalInterruption":
             case "shouldProcessEvalInterruption":
-                settings.timeoutMs = 1500;
+                settings.timeoutMillis = 1500;
                 break;
         }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -160,12 +160,12 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
                 useTinkerTransactionGraph(settings);
                 break;
             case "shouldProcessSessionRequestsInOrderAfterTimeout":
-                settings.evaluationTimeout = 250;
+                settings.timeoutMs = 250;
                 settings.threadPoolWorker = 1;
                 break;
             case "shouldProcessTraversalInterruption":
             case "shouldProcessEvalInterruption":
-                settings.evaluationTimeout = 1500;
+                settings.timeoutMs = 1500;
                 break;
         }
 

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverTransactionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverTransactionIntegrateTest.java
@@ -86,10 +86,10 @@ public class GremlinDriverTransactionIntegrateTest extends AbstractGremlinServer
             case "shouldTimeoutIdleTransaction":
             case "shouldTimeoutIdleTransactionWithNoOperations":
             case "shouldRejectLateCommitAfterTimeout":
-                settings.idleTransactionTimeout = 1000;
+                settings.idleTransactionTimeoutMillis = 1000;
                 break;
             case "shouldTimeoutOnlyIdleTransactionNotActiveOne":
-                settings.idleTransactionTimeout = 2000;
+                settings.idleTransactionTimeoutMillis = 2000;
                 break;
         }
         return settings;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
@@ -77,7 +77,7 @@ import static org.apache.tinkerpop.gremlin.server.handler.HttpRequestIdHandler.R
 import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_MATERIALIZE_PROPERTIES;
 import static org.apache.tinkerpop.gremlin.util.Tokens.MATERIALIZE_PROPERTIES_ALL;
 import static org.apache.tinkerpop.gremlin.util.Tokens.MATERIALIZE_PROPERTIES_TOKENS;
-import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MS;
+import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MILLIS;
 import static org.apache.tinkerpop.gremlin.util.ser.SerTokens.TOKEN_DATA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -138,8 +138,8 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
             case "should200OnPOSTWithAuthorizationHeader":
                 configureForAuthentication(settings);
                 break;
-            case "should500OnPOSTWithTimeoutMs":
-                settings.timeoutMs = 5000;
+            case "should500OnPOSTWithTimeoutMillis":
+                settings.timeoutMillis = 5000;
                 settings.gremlinPool = 1;
                 break;
             case "shouldRespectCorsAllowedOrigins":
@@ -924,7 +924,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     }
 
     @Test(timeout = 10000) // Add test timeout to prevent incorrect timeout behavior from stopping test run.
-    public void should500OnPOSTWithTimeoutMs() throws Exception {
+    public void should500OnPOSTWithTimeoutMillis() throws Exception {
         // Related to TINKERPOP-2769. This is a similar test to the one for the WebSocketChannelizer.
         final CloseableHttpClient firstClient = HttpClients.createDefault();
         final CloseableHttpClient secondClient = HttpClients.createDefault();
@@ -1314,7 +1314,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
 
     @Test
     public void shouldAcceptTimeoutInRequestBody() throws Exception {
-        final String body = "{ \"gremlin\": \"" + "Thread.sleep(5000)" + "\",\"language\":\"gremlin-groovy\",\"" + TIMEOUT_MS + "\":\"100\"}";
+        final String body = "{ \"gremlin\": \"" + "Thread.sleep(5000)" + "\",\"language\":\"gremlin-groovy\",\"" + TIMEOUT_MILLIS + "\":\"100\"}";
         final CloseableHttpClient httpclient = HttpClients.createDefault();
         final HttpPost httppost = new HttpPost(TestClientFactory.createURLString());
         httppost.addHeader("Content-Type", "application/json");

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpIntegrateTest.java
@@ -138,8 +138,8 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
             case "should200OnPOSTWithAuthorizationHeader":
                 configureForAuthentication(settings);
                 break;
-            case "should500OnPOSTWithEvaluationTimeout":
-                settings.evaluationTimeout = 5000;
+            case "should500OnPOSTWithTimeoutMs":
+                settings.timeoutMs = 5000;
                 settings.gremlinPool = 1;
                 break;
             case "shouldRespectCorsAllowedOrigins":
@@ -924,7 +924,7 @@ public class GremlinServerHttpIntegrateTest extends AbstractGremlinServerIntegra
     }
 
     @Test(timeout = 10000) // Add test timeout to prevent incorrect timeout behavior from stopping test run.
-    public void should500OnPOSTWithEvaluationTimeout() throws Exception {
+    public void should500OnPOSTWithTimeoutMs() throws Exception {
         // Related to TINKERPOP-2769. This is a similar test to the one for the WebSocketChannelizer.
         final CloseableHttpClient firstClient = HttpClients.createDefault();
         final CloseableHttpClient secondClient = HttpClients.createDefault();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpTransactionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpTransactionIntegrateTest.java
@@ -547,7 +547,7 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
     public void shouldNotIdleTimeoutLongRunningOperation() throws Exception {
         // With a short idle timeout (500ms), a single operation that runs LONGER than the idle timeout must still
         // succeed -- the idle timer is suspended while an operation is in progress, so a long-running op is not
-        // reclaimed mid-execution (it is instead bounded by evaluationTimeout, left at its default here).
+        // reclaimed mid-execution (it is instead bounded by timeoutMs, left at its default here).
         final String txId = beginTx(client, GTX);
 
         // Seed two vertices and an edge so repeat(both()) has something to traverse and keeps the executor busy. Each

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpTransactionIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerHttpTransactionIntegrateTest.java
@@ -93,32 +93,32 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
                 break;
             case "shouldTimeoutFreeSlotUnderMaxConcurrentTransactions":
                 settings.maxConcurrentTransactions = 1;
-                settings.idleTransactionTimeout = 1000;
+                settings.idleTransactionTimeoutMillis = 1000;
                 break;
             case "shouldTimeoutIdleTransactionWithNoOperations":
-                settings.idleTransactionTimeout = 500;
+                settings.idleTransactionTimeoutMillis = 500;
                 break;
             case "shouldTimeoutAndRejectLateCommit":
             case "shouldTrackTransactionCountAccurately":
-                settings.idleTransactionTimeout = 1000;
+                settings.idleTransactionTimeoutMillis = 1000;
                 break;
             case "shouldRollbackAbandonedTransaction":
-                settings.idleTransactionTimeout = 300;
+                settings.idleTransactionTimeoutMillis = 300;
                 break;
             case "shouldNotIdleTimeoutLongRunningOperation":
                 // Short idle timeout, but a single long operation must NOT trip it (idle suspended while busy).
-                settings.idleTransactionTimeout = 500;
+                settings.idleTransactionTimeoutMillis = 500;
                 break;
             case "shouldReclaimTransactionExceedingMaxLifetime":
                 // Short absolute cap with the idle timer disabled, so only the lifetime cap can reclaim the transaction.
-                settings.idleTransactionTimeout = 0;
-                settings.maxTransactionLifetime = 800;
+                settings.idleTransactionTimeoutMillis = 0;
+                settings.maxTransactionLifetimeMillis = 800;
                 break;
-            case "shouldHonorPerRequestTimeoutMsZeroInTransaction":
-                // Both transaction timers disabled: a per-request timeoutMs of 0 is honored (not silently overridden),
+            case "shouldHonorPerRequestTimeoutMillisZeroInTransaction":
+                // Both transaction timers disabled: a per-request timeoutMillis of 0 is honored (not silently overridden),
                 // so the operation is bounded only by its own request, exactly as on the non-transactional path.
-                settings.idleTransactionTimeout = 0;
-                settings.maxTransactionLifetime = 0;
+                settings.idleTransactionTimeoutMillis = 0;
+                settings.maxTransactionLifetimeMillis = 0;
                 break;
             case "shouldRejectMismatchedGraphAliasInTransaction": {
                 final Settings.GraphSettings gs = new Settings.GraphSettings();
@@ -547,7 +547,7 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
     public void shouldNotIdleTimeoutLongRunningOperation() throws Exception {
         // With a short idle timeout (500ms), a single operation that runs LONGER than the idle timeout must still
         // succeed -- the idle timer is suspended while an operation is in progress, so a long-running op is not
-        // reclaimed mid-execution (it is instead bounded by timeoutMs, left at its default here).
+        // reclaimed mid-execution (it is instead bounded by timeoutMillis, left at its default here).
         final String txId = beginTx(client, GTX);
 
         // Seed two vertices and an edge so repeat(both()) has something to traverse and keeps the executor busy. Each
@@ -612,8 +612,8 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
     }
 
     @Test
-    public void shouldHonorPerRequestTimeoutMsZeroInTransaction() throws Exception {
-        // With both transaction timers disabled, a per-request timeoutMs of 0 is honored rather than overridden: the
+    public void shouldHonorPerRequestTimeoutMillisZeroInTransaction() throws Exception {
+        // With both transaction timers disabled, a per-request timeoutMillis of 0 is honored rather than overridden: the
         // server does not reject the begin or silently substitute another timeout - the operation runs as requested.
         // (Server-side defaults keep transactions bounded out of the box; disabling them is a deliberate operator
         // choice and must not turn into a client-facing failure.)
@@ -621,7 +621,7 @@ public class GremlinServerHttpTransactionIntegrateTest extends AbstractGremlinSe
 
         try (final CloseableHttpResponse r = postJson(client,
                 "{\"gremlin\":\"g.addV()\",\"g\":\"" + GTX +
-                "\",\"transactionId\":\"" + txId + "\",\"timeoutMs\":\"0\"}")) {
+                "\",\"transactionId\":\"" + txId + "\",\"timeoutMillis\":\"0\"}")) {
             assertEquals(200, r.getStatusLine().getStatusCode());
             // The operation runs and returns a normal result body, with no timeout error: the request was honored, not
             // bounded by a substituted timeout or rejected at begin.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -82,7 +82,7 @@ import static org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPl
 import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE;
 import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE_CONNECTION_CLASS;
 import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
-import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MS;
+import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MILLIS;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -152,7 +152,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.writeBufferLowWaterMark = 32;
                 break;
             case "shouldReceiveFailureTimeOutOnScriptEval":
-                settings.timeoutMs = 1000;
+                settings.timeoutMillis = 1000;
                 break;
             case "shouldBlockRequestWhenTooBig":
                 settings.maxRequestContentLength = 1024;
@@ -177,7 +177,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.maxParameters = 1;
                 break;
             case "shouldTimeOutRemoteTraversal":
-                settings.timeoutMs = 500;
+                settings.timeoutMillis = 500;
                 break;
             case "ensureScriptEngineDefaultsToGremlinLang":
                 settings.scriptEngines = new HashMap<>();
@@ -388,7 +388,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
         try {
             // tests sleeping thread
-            g.with(TIMEOUT_MS, 500L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(10000)")).iterate();
+            g.with(TIMEOUT_MILLIS, 500L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(10000)")).iterate();
             fail("This traversal should have timed out");
         } catch (Exception ex) {
             final Throwable t = ex.getCause();
@@ -401,7 +401,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
         try {
             // tests an "unending" traversal
-            g.with(TIMEOUT_MS, 500L).V().repeat(__.out()).until(__.outE().count().is(0)).iterate();
+            g.with(TIMEOUT_MILLIS, 500L).V().repeat(__.out()).until(__.outE().count().is(0)).iterate();
             fail("This traversal should have timed out");
         } catch (Exception ex) {
             final Throwable t = ex.getCause();
@@ -429,7 +429,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         // Note: this test may have a false negative result, but a failure  would indicate a real problem.
         for(int i = 0; i < 30; i++) {
             int timeout = 1 + i;
-            overrideTimeoutMs(timeout);
+            overrideTimeoutMillis(timeout);
 
             try {
                 client.submit("g.inject(2)").all().get().get(0).getInt();
@@ -712,7 +712,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldReceiveFailureTimeOutOnScriptEvalOfOutOfControlLoop() throws Exception {
         try (SimpleClient client = TestClientFactory.createSimpleHttpClient()){
             // timeout configured for 1 second so the timed interrupt should trigger prior to the
-            // timeoutMs which is at 30 seconds by default
+            // timeoutMillis which is at 30 seconds by default
             final List<ResponseMessage> responses = client.submit(
                     RequestMessage.build("while(true){}").addLanguage("gremlin-groovy").create()
             );
@@ -963,9 +963,9 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldHandleMultipleLambdaTranslationsInParallel() throws Exception {
         final GraphTraversalSource g = traversal().withRemote(conf);
 
-        final CompletableFuture<Traversal<Object, Object>> firstRes = g.with("timeoutMs", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
-        final CompletableFuture<Traversal<Object, Object>> secondRes = g.with("timeoutMs", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
-        final CompletableFuture<Traversal<Object, Object>> thirdRes = g.with("timeoutMs", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> firstRes = g.with("timeoutMillis", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> secondRes = g.with("timeoutMillis", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> thirdRes = g.with("timeoutMillis", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
 
         try {
             firstRes.get();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -82,7 +82,7 @@ import static org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPl
 import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE;
 import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE_CONNECTION_CLASS;
 import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
-import static org.apache.tinkerpop.gremlin.util.Tokens.ARGS_EVAL_TIMEOUT;
+import static org.apache.tinkerpop.gremlin.util.Tokens.TIMEOUT_MS;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -152,7 +152,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.writeBufferLowWaterMark = 32;
                 break;
             case "shouldReceiveFailureTimeOutOnScriptEval":
-                settings.evaluationTimeout = 1000;
+                settings.timeoutMs = 1000;
                 break;
             case "shouldBlockRequestWhenTooBig":
                 settings.maxRequestContentLength = 1024;
@@ -177,7 +177,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.maxParameters = 1;
                 break;
             case "shouldTimeOutRemoteTraversal":
-                settings.evaluationTimeout = 500;
+                settings.timeoutMs = 500;
                 break;
             case "ensureScriptEngineDefaultsToGremlinLang":
                 settings.scriptEngines = new HashMap<>();
@@ -388,7 +388,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
         try {
             // tests sleeping thread
-            g.with(ARGS_EVAL_TIMEOUT, 500L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(10000)")).iterate();
+            g.with(TIMEOUT_MS, 500L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(10000)")).iterate();
             fail("This traversal should have timed out");
         } catch (Exception ex) {
             final Throwable t = ex.getCause();
@@ -401,7 +401,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
 
         try {
             // tests an "unending" traversal
-            g.with(ARGS_EVAL_TIMEOUT, 500L).V().repeat(__.out()).until(__.outE().count().is(0)).iterate();
+            g.with(TIMEOUT_MS, 500L).V().repeat(__.out()).until(__.outE().count().is(0)).iterate();
             fail("This traversal should have timed out");
         } catch (Exception ex) {
             final Throwable t = ex.getCause();
@@ -429,7 +429,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         // Note: this test may have a false negative result, but a failure  would indicate a real problem.
         for(int i = 0; i < 30; i++) {
             int timeout = 1 + i;
-            overrideEvaluationTimeout(timeout);
+            overrideTimeoutMs(timeout);
 
             try {
                 client.submit("g.inject(2)").all().get().get(0).getInt();
@@ -712,7 +712,7 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldReceiveFailureTimeOutOnScriptEvalOfOutOfControlLoop() throws Exception {
         try (SimpleClient client = TestClientFactory.createSimpleHttpClient()){
             // timeout configured for 1 second so the timed interrupt should trigger prior to the
-            // evaluationTimeout which is at 30 seconds by default
+            // timeoutMs which is at 30 seconds by default
             final List<ResponseMessage> responses = client.submit(
                     RequestMessage.build("while(true){}").addLanguage("gremlin-groovy").create()
             );
@@ -963,9 +963,9 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldHandleMultipleLambdaTranslationsInParallel() throws Exception {
         final GraphTraversalSource g = traversal().withRemote(conf);
 
-        final CompletableFuture<Traversal<Object, Object>> firstRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
-        final CompletableFuture<Traversal<Object, Object>> secondRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
-        final CompletableFuture<Traversal<Object, Object>> thirdRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> firstRes = g.with("timeoutMs", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> secondRes = g.with("timeoutMs", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> thirdRes = g.with("timeoutMs", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
 
         try {
             firstRes.get();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/SettingsTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/SettingsTest.java
@@ -151,8 +151,8 @@ public class SettingsTest {
 
         // Out of the box a transaction is bounded without any operator configuration: idle reclamation at 1 minute and
         // an absolute lifetime cap at 10 minutes.
-        assertEquals(60000L, settings.idleTransactionTimeout);
-        assertEquals(600000L, settings.maxTransactionLifetime);
+        assertEquals(60000L, settings.idleTransactionTimeoutMillis);
+        assertEquals(600000L, settings.maxTransactionLifetimeMillis);
     }
 
     @Test
@@ -161,6 +161,6 @@ public class SettingsTest {
         final Settings settings = Settings.read(stream);
 
         // Confirms a YAML-provided value overrides the code default (600000); the resource sets it to 480000.
-        assertEquals(480000L, settings.maxTransactionLifetime);
+        assertEquals(480000L, settings.maxTransactionLifetimeMillis);
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandlerTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandlerTest.java
@@ -85,7 +85,7 @@ public class HttpGremlinEndpointHandlerTest {
     }
 
     @Test
-    public void shouldMapInterruptToTimeoutMsWhenNotClosedByLifetimeCap() {
+    public void shouldMapInterruptToTimeoutMillisWhenNotClosedByLifetimeCap() {
         // An ordinary evaluation-timeout interrupt (cap flag unset) must keep the existing 500 timeout behavior.
         final RequestMessage message = RequestMessage.build("g.V()").create();
         final Context ctx = mock(Context.class);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandlerTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandlerTest.java
@@ -85,7 +85,7 @@ public class HttpGremlinEndpointHandlerTest {
     }
 
     @Test
-    public void shouldMapInterruptToEvaluationTimeoutWhenNotClosedByLifetimeCap() {
+    public void shouldMapInterruptToTimeoutMsWhenNotClosedByLifetimeCap() {
         // An ordinary evaluation-timeout interrupt (cap flag unset) must keep the existing 500 timeout behavior.
         final RequestMessage message = RequestMessage.build("g.V()").create();
         final Context ctx = mock(Context.class);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoderTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpRequestMessageDecoderTest.java
@@ -314,7 +314,7 @@ public class HttpRequestMessageDecoderTest {
         final UUID rid = UUID.randomUUID();
         final ByteBuf buffer = allocator.buffer();
         buffer.writeCharSequence("{\"gremlin\":\"g.V().limit(2)\",\"batchSize\":\"10\",\"language\":\"gremlin-lang\"," +
-                "\"g\":\"gmodern\",\"parameters\":\"[\\\"x\\\":1]\",\"timeoutMs\":\"12\"," +
+                "\"g\":\"gmodern\",\"parameters\":\"[\\\"x\\\":1]\",\"timeoutMillis\":\"12\"," +
                 "\"materializeProperties\":\"" + Tokens.MATERIALIZE_PROPERTIES_TOKENS + "\"}", CharsetUtil.UTF_8);
 
         final HttpHeaders headers = new DefaultHttpHeaders();
@@ -332,7 +332,7 @@ public class HttpRequestMessageDecoderTest {
         assertEquals("gremlin-lang", decodedRequest.getField(Tokens.ARGS_LANGUAGE));
         assertEquals("gmodern", decodedRequest.getField(Tokens.ARGS_G));
         assertEquals("[\"x\":1]", decodedRequest.getField(Tokens.ARGS_PARAMETERS));
-        assertEquals(12, (long) decodedRequest.getField(Tokens.TIMEOUT_MS));
+        assertEquals(12, (long) decodedRequest.getField(Tokens.TIMEOUT_MILLIS));
         assertEquals(Tokens.MATERIALIZE_PROPERTIES_TOKENS, decodedRequest.getField(Tokens.ARGS_MATERIALIZE_PROPERTIES));
     }
 }

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -29,10 +29,10 @@
 
 host: 0.0.0.0
 port: 45940
-timeoutMs: 30000
+timeoutMillis: 30000
 # Set below the code default (600000) so SettingsTest can confirm a YAML-provided value is honored; still far larger
 # than any integration test's runtime (8 minutes), so it never fires during a test.
-maxTransactionLifetime: 480000
+maxTransactionLifetimeMillis: 480000
 graphs: {
   graph: {
     configuration: conf/tinkergraph-empty.properties,
@@ -79,11 +79,11 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}
 metrics: {
-  slf4jReporter: {enabled: true, interval: 180000}}
+  slf4jReporter: {enabled: true, intervalMillis: 180000}}
 gremlinPool: 8
 strictTransactionManagement: false
-idleConnectionTimeout: 0
-keepAliveInterval: 0
+idleConnectionTimeoutMillis: 0
+keepAliveIntervalMillis: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -29,7 +29,7 @@
 
 host: 0.0.0.0
 port: 45940
-evaluationTimeout: 30000
+timeoutMs: 30000
 # Set below the code default (600000) so SettingsTest can confirm a YAML-provided value is honored; still far larger
 # than any integration test's runtime (8 minutes), so it never fires during a test.
 maxTransactionLifetime: 480000

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinGroovyScriptEngineBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinGroovyScriptEngineBenchmark.java
@@ -104,7 +104,7 @@ public class GremlinGroovyScriptEngineBenchmark extends AbstractBenchmarkBase {
         if (binding && id != null) throw new IllegalArgumentException("If binding is true then the id should be null");
 
         final StringBuilder b = new StringBuilder();
-        b.append("g.with('evaluationTimeout', 1000L).addV('person').property(id,");
+        b.append("g.with('timeoutMs', 1000L).addV('person').property(id,");
 
         if (!binding) b.append("'");
         b.append(null == id ? "x" : id);

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinGroovyScriptEngineBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinGroovyScriptEngineBenchmark.java
@@ -104,7 +104,7 @@ public class GremlinGroovyScriptEngineBenchmark extends AbstractBenchmarkBase {
         if (binding && id != null) throw new IllegalArgumentException("If binding is true then the id should be null");
 
         final StringBuilder b = new StringBuilder();
-        b.append("g.with('timeoutMs', 1000L).addV('person').property(id,");
+        b.append("g.with('timeoutMillis', 1000L).addV('person').property(id,");
 
         if (!binding) b.append("'");
         b.append(null == id ? "x" : id);

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinScriptCheckerBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinScriptCheckerBenchmark.java
@@ -44,6 +44,6 @@ public class GremlinScriptCheckerBenchmark extends AbstractBenchmarkBase {
 
     @Benchmark
     public GremlinScriptChecker.Result testParseAll() {
-        return GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with('materializeProperties', 'all').with('requestId', '4F53FB59-CFC9-4984-B477-452073A352FD').with(true).V().out('knows')");
+        return GremlinScriptChecker.parse("g.with('timeoutMillis', 1000L).with('materializeProperties', 'all').with('requestId', '4F53FB59-CFC9-4984-B477-452073A352FD').with(true).V().out('knows')");
     }
 }

--- a/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinScriptCheckerBenchmark.java
+++ b/gremlin-tools/gremlin-benchmark/src/main/java/org/apache/tinkerpop/jsr223/GremlinScriptCheckerBenchmark.java
@@ -44,6 +44,6 @@ public class GremlinScriptCheckerBenchmark extends AbstractBenchmarkBase {
 
     @Benchmark
     public GremlinScriptChecker.Result testParseAll() {
-        return GremlinScriptChecker.parse("g.with('evaluationTimeout', 1000L).with('materializeProperties', 'all').with('requestId', '4F53FB59-CFC9-4984-B477-452073A352FD').with(true).V().out('knows')");
+        return GremlinScriptChecker.parse("g.with('timeoutMs', 1000L).with('materializeProperties', 'all').with('requestId', '4F53FB59-CFC9-4984-B477-452073A352FD').with(true).V().out('knows')");
     }
 }

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
@@ -69,12 +69,6 @@ public final class Tokens {
     public static final String ARGS_LANGUAGE = "language";
 
     /**
-     * Argument name that allows the override of the server setting that determines the maximum time to wait for a
-     * request to execute on the server.
-     */
-    public static final String ARGS_EVAL_TIMEOUT = "evaluationTimeout";
-
-    /**
      * The name of the argument that allows to control the serialization of properties on the server.
      */
     public static final String ARGS_MATERIALIZE_PROPERTIES = "materializeProperties";
@@ -92,7 +86,9 @@ public final class Tokens {
     public static final String MATERIALIZE_PROPERTIES_TOKENS = "tokens";
 
     /**
-     * The key for the per request server-side timeout in milliseconds.
+     * The key for the per request server-side timeout in milliseconds. This overrides the server's configured
+     * default ({@code timeoutMs}) and determines the maximum time a request is allowed to execute on the server
+     * before it times out.
      */
     public static final String TIMEOUT_MS = "timeoutMs";
 

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/Tokens.java
@@ -87,10 +87,10 @@ public final class Tokens {
 
     /**
      * The key for the per request server-side timeout in milliseconds. This overrides the server's configured
-     * default ({@code timeoutMs}) and determines the maximum time a request is allowed to execute on the server
+     * default ({@code timeoutMillis}) and determines the maximum time a request is allowed to execute on the server
      * before it times out.
      */
-    public static final String TIMEOUT_MS = "timeoutMs";
+    public static final String TIMEOUT_MILLIS = "timeoutMillis";
 
     /**
      * The key for server to bulk result as a form of optimization for driver requests.

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/RequestMessage.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/message/RequestMessage.java
@@ -169,7 +169,7 @@ public final class RequestMessage {
         public Builder addTimeoutMillis(final long timeout) {
             if (timeout < 0) throw new IllegalArgumentException("timeout argument cannot be negative.");
 
-            this.fields.put(Tokens.TIMEOUT_MS, timeout);
+            this.fields.put(Tokens.TIMEOUT_MILLIS, timeout);
             return this;
         }
 

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/AbstractGraphSONMessageSerializerV4.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/AbstractGraphSONMessageSerializerV4.java
@@ -327,9 +327,9 @@ public abstract class AbstractGraphSONMessageSerializerV4 extends AbstractMessag
             if (data.containsKey(SerTokens.TOKEN_PARAMETERS)) {
                 builder.addParameters(data.get(SerTokens.TOKEN_PARAMETERS).toString());
             }
-            if (data.containsKey(Tokens.TIMEOUT_MS)) {
+            if (data.containsKey(Tokens.TIMEOUT_MILLIS)) {
                 // Can be int for untyped JSON and long for typed GraphSON.
-                builder.addTimeoutMillis(Long.parseLong(data.get(Tokens.TIMEOUT_MS).toString()));
+                builder.addTimeoutMillis(Long.parseLong(data.get(Tokens.TIMEOUT_MILLIS).toString()));
             }
             if (data.containsKey(Tokens.ARGS_MATERIALIZE_PROPERTIES)) {
                 builder.addMaterializeProperties(data.get(Tokens.ARGS_MATERIALIZE_PROPERTIES).toString());

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/SerTokens.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/SerTokens.java
@@ -34,7 +34,7 @@ public final class SerTokens {
     public static final String TOKEN_LANGUAGE = "language";
     public static final String TOKEN_PARAMETERS = "parameters";
     public static final String TOKEN_G = "g";
-    public static final String TOKEN_TIMEOUT_MS = "timeoutMs";
+    public static final String TOKEN_TIMEOUT_MILLIS = "timeoutMillis";
     public static final String TOKEN_MATERIALIZE_PROPERTIES = "materializeProperties";
 
     public static final String MIME_JSON = "application/json";

--- a/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/RequestMessageSerializer.java
+++ b/gremlin-util/src/main/java/org/apache/tinkerpop/gremlin/util/ser/binary/RequestMessageSerializer.java
@@ -61,8 +61,8 @@ public class RequestMessageSerializer {
             if (fields.containsKey(SerTokens.TOKEN_PARAMETERS)) {
                 builder.addParameters(fields.get(SerTokens.TOKEN_PARAMETERS).toString());
             }
-            if (fields.containsKey(Tokens.TIMEOUT_MS)) {
-                builder.addTimeoutMillis(((Number) fields.get(Tokens.TIMEOUT_MS)).longValue());
+            if (fields.containsKey(Tokens.TIMEOUT_MILLIS)) {
+                builder.addTimeoutMillis(((Number) fields.get(Tokens.TIMEOUT_MILLIS)).longValue());
             }
             if (fields.containsKey(Tokens.ARGS_MATERIALIZE_PROPERTIES)) {
                 builder.addMaterializeProperties(fields.get(Tokens.ARGS_MATERIALIZE_PROPERTIES).toString());

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/structure/io/AbstractCompatibilityTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/structure/io/AbstractCompatibilityTest.java
@@ -141,14 +141,14 @@ public abstract class AbstractCompatibilityTest {
         assertEquals(resource.<Map>getField(SerTokens.TOKEN_PARAMETERS), recycled.getField(SerTokens.TOKEN_PARAMETERS));
         assertEquals(resource.<String>getField(SerTokens.TOKEN_LANGUAGE), recycled.getField(SerTokens.TOKEN_LANGUAGE));
         assertEquals(resource.<String>getField(SerTokens.TOKEN_G), recycled.getField(SerTokens.TOKEN_G));
-        assertEquals(resource.<Long>getField(SerTokens.TOKEN_TIMEOUT_MS), recycled.getField(SerTokens.TOKEN_TIMEOUT_MS));
+        assertEquals(resource.<Long>getField(SerTokens.TOKEN_TIMEOUT_MILLIS), recycled.getField(SerTokens.TOKEN_TIMEOUT_MILLIS));
         assertEquals(resource.<String>getField(SerTokens.TOKEN_MATERIALIZE_PROPERTIES), recycled.getField(SerTokens.TOKEN_MATERIALIZE_PROPERTIES));
 
         assertEquals(resource.getGremlin(), fromStatic.getGremlin());
         assertEquals(resource.<Map>getField(SerTokens.TOKEN_PARAMETERS), fromStatic.getField(SerTokens.TOKEN_PARAMETERS));
         assertEquals(resource.<String>getField(SerTokens.TOKEN_LANGUAGE), fromStatic.getField(SerTokens.TOKEN_LANGUAGE));
         assertEquals(resource.<String>getField(SerTokens.TOKEN_G), fromStatic.getField(SerTokens.TOKEN_G));
-        assertEquals(resource.<Long>getField(SerTokens.TOKEN_TIMEOUT_MS), fromStatic.getField(SerTokens.TOKEN_TIMEOUT_MS));
+        assertEquals(resource.<Long>getField(SerTokens.TOKEN_TIMEOUT_MILLIS), fromStatic.getField(SerTokens.TOKEN_TIMEOUT_MILLIS));
         assertEquals(resource.<String>getField(SerTokens.TOKEN_MATERIALIZE_PROPERTIES), fromStatic.getField(SerTokens.TOKEN_MATERIALIZE_PROPERTIES));
     }
 }

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/message/RequestMessageTest.java
@@ -99,7 +99,7 @@ public class RequestMessageTest {
     public void shouldSetTimeout() {
         final long timeout = 101L;
         final RequestMessage msg = RequestMessage.build("g").addTimeoutMillis(timeout).create();
-        assertEquals(timeout, (long) msg.getField(Tokens.TIMEOUT_MS));
+        assertEquals(timeout, (long) msg.getField(Tokens.TIMEOUT_MILLIS));
     }
 
     @Test

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/MessageSerializerTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/binary/MessageSerializerTest.java
@@ -149,7 +149,7 @@ public class MessageSerializerTest {
 
     @Test
     public void shouldDeserializeRequestWithIntegerNumericFields() throws SerializationException, IOException {
-        // Simulates what happens when a client (e.g., JavaScript) serializes timeoutMs and batchSize
+        // Simulates what happens when a client (e.g., JavaScript) serializes timeoutMillis and batchSize
         // as GraphBinary INT (4 bytes) instead of LONG/INT. The server must handle both numeric widths.
         final GraphBinaryWriter writer = new GraphBinaryWriter();
         final GraphBinaryReader reader = new GraphBinaryReader();
@@ -159,7 +159,7 @@ public class MessageSerializerTest {
         // Build a fields map with Integer values (as a JS client would produce for INT32-range values)
         final Map<String, Object> fields = new HashMap<>();
         fields.put(SerTokens.TOKEN_LANGUAGE, "gremlin-lang");
-        fields.put(Tokens.TIMEOUT_MS, 5000);          // Integer, not Long
+        fields.put(Tokens.TIMEOUT_MILLIS, 5000);          // Integer, not Long
         fields.put(Tokens.ARGS_BATCH_SIZE, 64);        // Integer, not Long (though normally int)
 
         final String gremlin = "g.V()";
@@ -172,7 +172,7 @@ public class MessageSerializerTest {
         writer.writeValue(gremlin, buffer, false);
 
         final RequestMessage deserialized = requestSerializer.readValue(byteBuf, reader);
-        assertEquals(5000L, (long) deserialized.getField(Tokens.TIMEOUT_MS));
+        assertEquals(5000L, (long) deserialized.getField(Tokens.TIMEOUT_MILLIS));
         assertEquals(64, (int) deserialized.getField(Tokens.ARGS_BATCH_SIZE));
         assertEquals(gremlin, deserialized.getGremlin());
 


### PR DESCRIPTION
Collapses the per-request execution timeout onto a single name, `timeoutMs`, across the server config, the script `with()` token, the internal executor, error messages, and all five GLV APIs. The legacy `evaluationTimeout` and `scriptEvaluationTimeout` names are removed with no alias.

The point of the change was to eliminate a dual-name inconsistency, so it made little sense to stop halfway. The 4.x wire protocol already used `timeoutMs` while the config key, script token, and three drivers still spoke `evaluationTimeout` — the server even resolved the effective timeout by checking both names. Renaming only some surfaces would relocate that confusion rather than remove it, and leaving the driver builder methods on the old name would trade a wire-vs-config mismatch for a wire-vs-API one.

Review guide:
This is another PR that is mostly a search and replace of `evaluationTimeout` to `timeoutMs`. What's important for other reviewers to decide is whether this change should have applied as widely as it did. This effectively changes it everywhere including in the server where the YAML will just read `timeoutMs`. `evaluationTimeout` is arguably a more descriptive name, but an effort was made to try and explain what timeoutMs is everywhere that it is used.

VOTE +1
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->