### PR TITLE
Add gremlin/io package export exposing GraphBinary serializers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 === TinkerPop 4.0.0 (Release Date: NOT OFFICIALLY RELEASED YET)
 
 * Added GraphBinary `Tree` (`0x2b`) serialization and deserialization with a native tree-shaped API to `gremlin-python`, `gremlin-dotnet`, `gremlin-go`, and `gremlin-javascript`.
+* Added a `gremlin/io` package export in `gremlin-javascript` exposing the GraphBinary type serializers.
 * Raised the minimum Java version to 17 for building and running *(breaking)*.
 * Enabled building and running with Java 21 and Java 25.
 * Bumped Groovy to 4.0.32, Hadoop to 3.4.3, Spark to 4.1.2 (Scala 2.13), and Netty to 4.2.7 to support Java 25.

--- a/gremlin-js/gremlin-javascript/package.json
+++ b/gremlin-js/gremlin-javascript/package.json
@@ -33,6 +33,10 @@
     "./language": {
       "import": "./build/esm/language/index.js",
       "types": "./build/esm/language/index.d.ts"
+    },
+    "./io": {
+      "import": "./build/esm/structure/io/binary/GraphBinary.js",
+      "types": "./build/esm/structure/io/binary/GraphBinary.d.ts"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
Adds a `gremlin/io` package export exposing the GraphBinary type serializers.

They are currently only reachable by importing past the `exports` map into `build/`, which couples consumers to internal file layout and breaks under bundlers that honour `exports` (e.g. esbuild/wrangler). This lets server-side v4 protocol implementations reuse them cleanly:

```js
import ioc from 'gremlin/io';
```

Follows the `./language` subpath precedent (`import` + `types`). CHANGELOG updated. Happy to rename the subpath or add a CJS `require` entry if you'd prefer.

Not tied to a JIRA yet (glad to file one). Scope is the export map + changelog only; not run through the full Maven build locally. Drafted with AI assistance (`Assisted-by` trailer on the commit).
