### PR TITLE
Fix gremlin-go PartitionStrategy panic and gremlin-python ProductiveByStrategy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,8 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 * Add Node 26 support for `gremlin-javascript` and `gremlint`.
 * Corrected numerous inaccuracies in the reference documentation, including wrong default values (connection pool sizes, buffer sizes, ports, timeouts), stale serializer class names, removed options documented as available, and broken code examples across the JVM, Python, `.NET`, Go, and JavaScript drivers.
+* Fixed a panic in `gremlin-go` `PartitionStrategy` when `ReadPartitions` was left unset.
+* Fixed `gremlin-python` `ProductiveByStrategy` to pass through the `productiveKeys` argument, which was previously accepted but never serialized to the server.
 
 [[release-3-7-6]]
 === TinkerPop 3.7.6 (Release Date: April 1, 2026)

--- a/gremlin-go/driver/strategies.go
+++ b/gremlin-go/driver/strategies.go
@@ -86,7 +86,7 @@ func PartitionStrategy(config PartitionStrategyConfig) TraversalStrategy {
 	if config.WritePartition != "" {
 		configMap["writePartition"] = config.WritePartition
 	}
-	if len(config.ReadPartitions.ToSlice()) != 0 {
+	if config.ReadPartitions != nil && len(config.ReadPartitions.ToSlice()) != 0 {
 		configMap["readPartitions"] = config.ReadPartitions
 	}
 	return &traversalStrategy{name: decorationNamespace + "PartitionStrategy", configuration: configMap}

--- a/gremlin-go/driver/strategies_test.go
+++ b/gremlin-go/driver/strategies_test.go
@@ -414,3 +414,34 @@ func TestStrategy(t *testing.T) {
 		assert.Equal(t, int32(6), val)
 	})
 }
+
+func Test_StrategyConfig_partitionNilReadPartitions(t *testing.T) {
+	t.Run("Test PartitionStrategy with nil ReadPartitions does not panic", func(t *testing.T) {
+		config := PartitionStrategyConfig{
+			PartitionKey:   "partition",
+			WritePartition: "write",
+			// ReadPartitions intentionally left unset (nil interface).
+		}
+		var strategy TraversalStrategy
+		assert.NotPanics(t, func() {
+			strategy = PartitionStrategy(config)
+		})
+		assert.NotNil(t, strategy)
+		configMap := strategy.(*traversalStrategy).configuration
+		_, ok := configMap["readPartitions"]
+		assert.False(t, ok)
+	})
+
+	t.Run("Test PartitionStrategy with non-empty ReadPartitions sets readPartitions", func(t *testing.T) {
+		config := PartitionStrategyConfig{
+			PartitionKey:   "partition",
+			WritePartition: "write",
+			ReadPartitions: NewSimpleSet("read"),
+		}
+		strategy := PartitionStrategy(config)
+		assert.NotNil(t, strategy)
+		configMap := strategy.(*traversalStrategy).configuration
+		_, ok := configMap["readPartitions"]
+		assert.True(t, ok)
+	})
+}

--- a/gremlin-python/src/main/python/gremlin_python/process/strategies.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/strategies.py
@@ -188,6 +188,8 @@ class PathRetractionStrategy(TraversalStrategy):
 class ProductiveByStrategy(TraversalStrategy):
     def __init__(self, productiveKeys=None):
         TraversalStrategy.__init__(self, fqcn=optimization_namespace + 'ProductiveByStrategy')
+        if productiveKeys is not None:
+            self.configuration["productiveKeys"] = productiveKeys
 
 
 class CountStrategy(TraversalStrategy):

--- a/gremlin-python/src/main/python/tests/unit/process/test_strategies.py
+++ b/gremlin-python/src/main/python/tests/unit/process/test_strategies.py
@@ -110,6 +110,18 @@ class TestTraversalStrategies(object):
         assert 1 == len(strategy.configuration)
         assert __.has("name","marko") == strategy.configuration["vertices"]
         ###
+        bytecode = g.withStrategies(ProductiveByStrategy(productiveKeys=["name", "age"])).bytecode
+        assert 1 == len(bytecode.source_instructions)
+        assert 2 == len(bytecode.source_instructions[0])
+        assert "withStrategies" == bytecode.source_instructions[0][0]
+        assert ProductiveByStrategy() == bytecode.source_instructions[0][1]
+        strategy = bytecode.source_instructions[0][1]
+        assert 1 == len(strategy.configuration)
+        assert ["name", "age"] == strategy.configuration["productiveKeys"]
+        ###
+        bytecode = g.withStrategies(ProductiveByStrategy()).bytecode
+        assert 0 == len(bytecode.source_instructions[0][1].configuration)
+        ###
         bytecode = g.withStrategies(OptionsStrategy(options={"x": "test", "y": True})).bytecode
         assert 1 == len(bytecode.source_instructions)
         assert 2 == len(bytecode.source_instructions[0])


### PR DESCRIPTION
# Fix gremlin-go PartitionStrategy panic and gremlin-python ProductiveByStrategy productiveKeys

## 1. gremlin-go: `PartitionStrategy` panics when `ReadPartitions` is unset

File: `gremlin-go/driver/strategies.go`

`PartitionStrategy` called `config.ReadPartitions.ToSlice()` with no nil check. `ReadPartitions` is a `Set` interface, so leaving it unset (a valid, documented configuration - "zeroed values are ignored") caused a nil-interface method call and crashed the caller.

### Use case

Configure a write-only partition (write to partition `a`, read from everywhere), leaving `ReadPartitions` unset:

```go
g = g.WithStrategies(gremlingo.PartitionStrategy(gremlingo.PartitionStrategyConfig{
    PartitionKey:   "_partition",
    WritePartition: "a",
    // ReadPartitions intentionally not set
}))
```

### Behaviour

| | Result |
|---|---|
| Before | Panics at strategy construction: `runtime error: invalid memory address or nil pointer dereference` |
| After | Constructs normally; `readPartitions` is simply omitted from the configuration when unset |

## 2. gremlin-python: `ProductiveByStrategy` drops `productiveKeys`

File: `gremlin-python/src/main/python/gremlin_python/process/strategies.py`

`ProductiveByStrategy.__init__` accepted a `productiveKeys` argument but never stored it in `self.configuration`, so it was silently discarded before the request was built. The strategy was therefore always sent with no keys (the empty singleton), and the caller's `productiveKeys` had no effect. Every other GLV (Java, Go, JavaScript, .NET) carries `productiveKeys` correctly, so gremlin-python was the lone outlier.

### Use case

Scope the strategy to specific keys:

```python
g = traversal().withStrategies(ProductiveByStrategy(productiveKeys=["name", "age"]))
```

### Behaviour

| | Result |
|---|---|
| Before | `productiveKeys` is ignored; the strategy serializes as the bare `ProductiveByStrategy` singleton (empty configuration), so `by()`-modulation productivity does not match what was configured and differs from every other driver |
| After | `productiveKeys` is carried in the configuration (`{"productiveKeys": ["name", "age"]}`) and serialized to the server, matching the other GLVs |

## Tests
- `gremlin-go/driver/strategies_test.go`: `PartitionStrategy` with `ReadPartitions` unset no longer panics and produces the expected configuration.
- `gremlin-python/.../tests/unit/process/test_strategies.py` (`test_configurable`): `ProductiveByStrategy(productiveKeys=[...])` stores the keys in its configuration, and `ProductiveByStrategy()` yields an empty configuration.

Assisted-by: Kiro: Claude Opus 4.8