### PR TITLE
Fix stale fail() Step console output to include message argument

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1646,14 +1646,14 @@ gremlin> g.V().has('person','name','stephen').fold().
 ......2>            fail('stephen should exist')).
 ......3>   property('k',100)
 fail() Step Triggered
-===========================================================================================================================
+=================================================================================================================================================
 Message > stephen should exist
 Traverser> []
   Bulk   > 1
-Traversal> fail()
-Parent   > CoalesceStep [V().has("person","name","stephen").fold().coalesce(__.unfold(),__.fail()).property("k",(int) 100)]
+Traversal> fail("stephen should exist")
+Parent   > CoalesceStep [V().has("person","name","stephen").fold().coalesce(__.unfold(),__.fail("stephen should exist")).property("k",(int) 100)]
 Metadata > {}
-===========================================================================================================================
+=================================================================================================================================================
 ----
 
 The code example above exemplifies the latter use case where there is essentially an assertion that there is a vertex


### PR DESCRIPTION
The fail() Step section in the reference docs contains a static `[source,text]` output block for the 'stephen' example that omits the string message argument passed to `fail()`. The `Traversal>` and `Parent>` lines showed bare `fail()` / `__.fail()` instead of the actual rendered output which includes the error-message text.

This was empirically confirmed stale on both 3.7.3 and 3.8.0 — the real `Failure.format()` output (driven by `GroovyTranslator`) includes the message argument in both lines.

**Changes:**
- `Traversal> fail()` → `Traversal> fail("stephen should exist")`
- `__.fail()` → `__.fail("stephen should exist")` in the Parent line
- Separator `===` lines extended from 123 to 145 characters to match the updated longest line

No other content altered. Docs dry-run build passes cleanly.