### PR TITLE
Remove stale/incorrect absent-key null-sort claim from order()-step docs

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3404,17 +3404,6 @@ g.V().groupCount().by(inE().count()).order(local).by(keys, asc) <4>
 
 NOTE: The `values` and `keys` enums are from `Column` which is used to select "columns" from a `Map`, `Map.Entry`, or `Path`.
 
-If a property key does not exist, then it will be treated as `null` which will sort it first for `Order.asc` and last
-for `Order.desc`.
-
-[gremlin-groovy,modern]
-----
-g.V().order().by("age").elementMap()
-----
-
-NOTE: Prior to version 3.3.4, ordering was defined by `Order.incr` for ascending order and `Order.decr` for descending
-order. Those tokens were deprecated and eventually removed in 3.5.0.
-
 *Additional References*
 
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#order()++[`order()`],


### PR DESCRIPTION
The Order Step section of the reference documentation (`docs/src/reference/the-traversal.asciidoc`) claimed that when the property key being sorted on does not exist on an element, that element is treated as `null` and placed first for `Order.asc` or last for `Order.desc`.

This is incorrect. Elements missing the sort key are silently filtered out of the result, not ranked at the ends. Because the statement is false rather than merely imprecise, this PR removes it (and the example that demonstrated the claimed behavior) rather than rewording it.

This PR removes three items from the Order Step section:

1. The false sentence: "If a property key does not exist, then it will be treated as `null` which will sort it first for `Order.asc` and last for `Order.desc`."
2. The example that demonstrated the claimed null-sort behavior: `g.V().order().by("age").elementMap()`.
3. The obsolete `NOTE: Prior to version 3.3.4, ...` callout about the long-removed `Order.incr`/`Order.decr` tokens.

The rest of the Order Step section is unchanged; it now flows directly from the `Column` values/keys NOTE to the Additional References.