### PR TITLE
Note that asDate() returns OffsetDateTime in Java as of 3.8.0

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -822,6 +822,8 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 
 The `asDate()`-step (*map*) converts string or numeric input to Date.
 
+NOTE: Starting in version 3.8.0, in Java this step returns a `java.time.OffsetDateTime`.
+
 For string input only ISO-8601 format is supported. For numbers, the value is considered as the number of the
 milliseconds since "the epoch" (January 1, 1970, 00:00:00 GMT). Date input is passed without changes.
 


### PR DESCRIPTION
The reference documentation for the `asDate()`-step describes its result as a `Date`. As of version 3.8.0, the step returns a `java.time.OffsetDateTime` in Java.

This adds a single `NOTE` admonition to the asDate()-step section clarifying the 3.8.0 Java return type. It is an additive clarification only — the existing `Date` prose is left unchanged, and no other section is touched.

The docs render cleanly and the NOTE displays as a proper admonition box in the reference guide.