### PR TITLE
Fix reference documentation inaccuracies

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed conjoin has incorrect null handling.
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 * Add Node 26 support for `gremlin-javascript` and `gremlint`.
+* Corrected numerous inaccuracies in the reference documentation, including wrong default values (connection pool sizes, buffer sizes, ports, timeouts), stale serializer class names, removed options documented as available, and broken code examples across the JVM, Python, `.NET`, Go, and JavaScript drivers.
 
 [[release-3-7-6]]
 === TinkerPop 3.7.6 (Release Date: April 1, 2026)

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -81,9 +81,9 @@ $ bin/gremlin.sh
          \,,,/
          (o o)
 -----oOOo-(3)-oOOo-----
-plugin loaded: tinkerpop.server
-plugin loaded: tinkerpop.utilities
-plugin loaded: tinkerpop.tinkergraph
+plugin activated: tinkerpop.server
+plugin activated: tinkerpop.utilities
+plugin activated: tinkerpop.tinkergraph
 gremlin>
 ----
 
@@ -1027,7 +1027,7 @@ The following table describes the various YAML configuration options that Gremli
 |keepAliveInterval |Time in milliseconds that the server will allow a channel to not send responses to a client before it sends a "ping" to see if it is still present. If it is present, the client should respond with a "pong" which will thus reset the `idleConnectionTimeout` and keep the channel open. If enabled, this number should be smaller than the value provided to the `idleConnectionTimeout`. Note that while this value is to be provided as milliseconds it will resolve to second precision. Set this value to `0` to disable this feature. |0
 |maxAccumulationBufferComponents |Maximum number of request components that can be aggregated for a message. |1024
 |maxChunkSize |The maximum length of the content or each chunk.  If the content length exceeds this value, the transfer encoding of the decoded request will be converted to 'chunked' and the content will be split into multiple `HttpContent` objects.  If the transfer encoding of the HTTP request is 'chunked' already, each chunk will be split into smaller chunks if the length of the chunk exceeds this value. |8192
-|maxContentLength |The maximum length of the aggregated content for a message.  Works in concert with `maxChunkSize` where chunked requests are accumulated back into a single message.  A request exceeding this size will return a `413 - Request Entity Too Large` status code.  A response exceeding this size will raise an internal exception. |65536
+|maxContentLength |The maximum length of the aggregated content for a message.  Works in concert with `maxChunkSize` where chunked requests are accumulated back into a single message.  A request exceeding this size will return a `413 - Request Entity Too Large` status code.  A response exceeding this size will raise an internal exception. |10485760
 |maxHeaderSize |The maximum length of all headers. |8192
 |maxInitialLineLength |The maximum length of the initial line (e.g.  "GET / HTTP/1.0") processed in a request, which essentially controls the maximum length of the submitted URI. |4096
 |maxParameters |The maximum number of parameters that can be passed on a request. Larger numbers may impact performance for scripts. This configuration only applies to the `UnifiedChannelizer`. |16
@@ -1173,12 +1173,12 @@ available GraphSON serializers that can be configured:
 [width="100%",cols="2,2,4,4",options="header"]
 |=========================================================
 |Version |Embedded Types |Mime Type |Class
-|1.0 |yes |`application/vnd.gremlin-v1.0+json` |`GraphSONMessageSerializerGremlinV1`
+|1.0 |yes |`application/vnd.gremlin-v1.0+json` |`GraphSONMessageSerializerV1`
 |1.0 |no |`application/vnd.gremlin-v1.0+json;types=false` |`GraphSONUntypedMessageSerializerV1`
 |2.0 |yes |`application/vnd.gremlin-v2.0+json` |`GraphSONMessageSerializerV2`
 |2.0 |no |`application/vnd.gremlin-v2.0+json;types=false` |`GraphSONUntypedMessageSerializerV2`
 |3.0 |yes |`application/vnd.gremlin-v3.0+json` |`GraphSONMessageSerializerV3`
-|3.0 |no |`application/vnd.gremlin-v3.0+json;types=false` |`GraphSONMessageSerializerV3`
+|3.0 |no |`application/vnd.gremlin-v3.0+json;types=false` |`GraphSONUntypedMessageSerializerV3`
 |=========================================================
 
 The above serializer classes can be found in the `org.apache.tinkerpop.gremlin.util.ser` package of `gremlin-util`.
@@ -1210,7 +1210,7 @@ JSON format which is a bit easier to consume than its successors which embed dat
 of GraphSON tends to be the one that users like to utilize when <<connecting-via-http,connecting via HTTP>> and is still
 used by some <<connecting-rgp, Remote Gremlin Providers>> for this purpose.
 
-To configure Gremlin Server this way, the `GraphSONMessageSerializerV1d0` must be included:
+To configure Gremlin Server this way, the `GraphSONMessageSerializerV1` must be included:
 
 [source,yaml]
 ----
@@ -1218,7 +1218,7 @@ To configure Gremlin Server this way, the `GraphSONMessageSerializerV1d0` must b
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3 }
 ----
 
-In the above situation, both `GraphSONMessageSerializerV1d0` and `GraphSONMessageSerializerV3d0` each bind to the
+In the above situation, both `GraphSONMessageSerializerV1` and `GraphSONMessageSerializerV3` each bind to the
 `application/json` mime type. When such conflicts arise, Gremlin Server will use the order of the serializers to
 determine priority such that the first serializer to bind to a type will be used and the others ignored. The following
 log message will indicate how the server is ultimately configured:

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -167,7 +167,7 @@ provide most of the typical functionality required to use Gremlin:
 [source,go]
 ----
 import (
-	"github.com/apache/tinkerpop/gremlin-go/driver"
+	"github.com/apache/tinkerpop/gremlin-go/v3/driver"
 )
 ----
 
@@ -191,19 +191,19 @@ can be passed to the `NewClient` or `NewDriverRemoteConnection` functions as con
 |Key |Description |Default
 |TraversalSource |Traversal source. |"g"
 |TransporterType |Transporter type. |Gorilla
-|LogVerbosity |Log verbosity.|gremlingo.INFO
+|LogVerbosity |Log verbosity.|gremlingo.Info
 |Logger |Instance of logger. |log
 |Language |Language used for logging messages. |language.English
 |AuthInfo |Authentification info, can be build with BasicAuthInfo() or HeaderAuthInfo(). |empty
 |TlsConfig |TLS configuration. |empty
 |KeepAliveInterval |Keep connection alive interval. |5 seconds
 |WriteDeadline |Write deadline. |3 seconds
-|ConnectionTimeout | Timeout for establishing connection. |45 seconds
+|ConnectionTimeout | Timeout for establishing connection. |5 seconds
 |NewConnectionThreshold | Minimum amount of concurrent active traversals on a connection to trigger creation of a new connection. |4
 |MaximumConcurrentConnections | Maximum number of concurrent connections. |number of runtime processors
 |EnableCompression |Flag to enable compression. |false
-|ReadBufferSize |Specify I/O buffer sizes in bytes. If a buffer size is zero, then a useful default size is used |0
-|WriteBufferSize |Specify I/O buffer sizes in bytes. If a buffer size is zero, then a useful default size is used |0
+|ReadBufferSize |Specify I/O buffer sizes in bytes. If a buffer size is zero, then a useful default size is used |1048576
+|WriteBufferSize |Specify I/O buffer sizes in bytes. If a buffer size is zero, then a useful default size is used |1048576
 |Session |Session ID. |""
 |EnableUserAgentOnConnect |Enables sending a user agent to the server during connection requests.
 More details can be found in provider docs
@@ -849,14 +849,14 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.keyStore |The private key in JKS or PKCS#12 format. |_none_
 |connectionPool.keyStorePassword |The password of the `keyStore` if it is password-protected. |_none_
 |connectionPool.keyStoreType |`JKS` (Java 8 default) or `PKCS12` (Java 9+ default)|_none_
-|connectionPool.maxContentLength |The maximum length in bytes that a message can be sent to the server. This number can be no greater than the setting of the same name in the server configuration. |65536
+|connectionPool.maxContentLength |The maximum length in bytes that a message can be sent to the server. This number can be no greater than the setting of the same name in the server configuration. |10485760
 |connectionPool.maxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |4
 |connectionPool.maxSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |16
 |connectionPool.maxSize |The maximum size of a connection pool for a host. |8
-|connectionPool.maxWaitForConnection |The amount of time in milliseconds to wait for a new connection before timing out. |3000
+|connectionPool.maxWaitForConnection |The amount of time in milliseconds to wait for a new connection before timing out. |16000
 |connectionPool.maxWaitForClose |The amount of time in milliseconds to wait for pending messages to be returned from the server before closing the connection. |3000
 |connectionPool.minInProcessPerConnection |The minimum number of in-flight requests that can occur on a connection. |1
-|connectionPool.minSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |8
+|connectionPool.minSimultaneousUsagePerConnection |The minimum number of times that a connection should be borrowed from the pool simultaneously before it can be released when under low use. |8
 |connectionPool.minSize |The minimum size of a connection pool for a host. |2
 |connectionPool.reconnectInterval |The amount of time in milliseconds to wait before trying to reconnect to a dead host. |1000
 |connectionPool.resultIterationBatchSize |The override value for the size of the result batches to be returned from the server. |64
@@ -874,7 +874,7 @@ The following table describes the various configuration options for the Gremlin 
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors
 |password |The password to submit on requests that require authentication. |_none_
 |path |The URL path to the Gremlin Server. |_/gremlin_
-|port |The port of the Gremlin Server to connect to. The same port will be applied for all hosts. |8192
+|port |The port of the Gremlin Server to connect to. The same port will be applied for all hosts. |8182
 |protocol |Sets the `AuthProperties.Property.PROTOCOL` properties for authentication to Gremlin Server. |_none_
 |reuseConnectionsForSessions |Uses a `Client` that will attempt to reuse `Connections` when managing remote transactions with a `DriverRemoteConnection`. |false
 |serializer.className |The fully qualified class name of the `MessageSerializer` that will be used to communicate with the server. Note that the serializer configured on the client should be supported by the server configuration. |_none_
@@ -1569,7 +1569,7 @@ Some connection options can also be set on individual requests made through the 
 const vertices = await g.with_('evaluationTimeout', 500).V().out('knows').toList()
 ----
 
-The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent` and
+The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent`, `materializeProperties` and
 `evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated).
 
 [[gremlin-javascript-imports]]
@@ -1601,7 +1601,6 @@ const order = gremlin.process.order
 const scope = gremlin.process.scope
 const t = gremlin.process.t
 const cardinality = gremlin.process.cardinality
-const CardinalityValue = gremlin.process.CardinalityValue
 ----
 
 By defining these imports it becomes possible to write Gremlin in the more shorthand, canonical style that is
@@ -1638,9 +1637,6 @@ can be passed in the constructor of a new `Client` or `DriverRemoteConnection` :
 |options.enableCompression |Boolean |Enables permessage-deflate compression. Note that use of compression may increase vulnerability to attacks such as CRIME/BREACH.|false
 |options.enableUserAgentOnConnect |Boolean |Determines if a user agent will be sent during connection handshake. |true
 |options.headers |Object |An associative array containing the additional header key/values for the initial request. |undefined
-|options.pingEnabled |Boolean |Setup ping interval. |true
-|options.pingInterval |Number |Ping request interval in ms if ping enabled. |60000
-|options.pongTimeout |Number |Timeout of pong response in ms after sending a ping. |30000
 |=========================================================
 
 [[gremlin-javascript-logging]]
@@ -2110,8 +2106,8 @@ on the `ConnectionPoolSettings` instance that can be passed to the `GremlinClien
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Key |Description |Default
-|PoolSize |The size of the connection pool. |4
-|MaxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |32
+|PoolSize |The size of the connection pool. |8
+|MaxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |16
 |ReconnectionAttempts |The number of attempts to get an open connection from the pool to submit a request. |4
 |ReconnectionBaseDelay |The base delay used for the exponential backoff for the reconnection attempts. |1 s
 |EnableUserAgentOnConnect |Enables sending a user agent to the server during connection requests.
@@ -2119,7 +2115,7 @@ More details can be found in provider docs
 link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|true
 |=========================================================
 
-A `NoConnectionAvailableException` is thrown if all connections have reached the `MaxInProcessPerConnection` limit
+A `ConnectionPoolBusyException` is thrown if all connections have reached the `MaxInProcessPerConnection` limit
 when a new request comes in.
 A `ServerUnavailableException` is thrown if no connection is available to the server to submit a request after
 `ReconnectionAttempts` retries.
@@ -2548,7 +2544,7 @@ Some connection options can also be set on individual requests made through the 
 vertices = g.with_('evaluationTimeout', 500).V().out('knows').to_list()
 ----
 
-The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent` and
+The following options are allowed on a per-request basis in this fashion: `batchSize`, `requestId`, `userAgent`, `materializeProperties` and
 `evaluationTimeout` (formerly `scriptEvaluationTimeout` which is also supported but now deprecated).
 
 anchor:python-imports[]
@@ -2636,15 +2632,15 @@ can be passed to the `Client` or `DriverRemoteConnection` instance as keyword ar
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Key |Description |Default
-|enable_compression |Enables sending a user agent to the server during connection requests. |False
+|enable_compression |Enables compression of messages sent to the server. |False
 |enable_user_agent_on_connect |Enables sending a user agent to the server during connection requests. More details can be found in provider docs
 link:https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#_graph_driver_provider_requirements[here].|True
 |headers |Additional headers that will be added to each request message. |`None`
-|kerberized_service |the first part of the principal name configured for the gremlin service|"""
-|max_workers |Maximum number of worker threads. |Number of CPUs * 5
+|kerberized_service |the first part of the principal name configured for the gremlin service|""
+|max_workers |Maximum number of worker threads. |Same as pool_size (default 8)
 |message_serializer |The message serializer implementation.|`gremlin_python.driver.serializer.GraphBinarySerializersV1`
 |password |The password to submit on requests that require authentication. |""
-|pool_size |The number of connections used by the pool. |4
+|pool_size |The number of connections used by the pool. |8
 |protocol_factory |A callable that returns an instance of `AbstractBaseProtocol`. |`gremlin_python.driver.protocol.GremlinServerWSProtocol`
 |session | A unique string-based identifier (typically a UUID) to enable a <<sessions,session-based connection>>. This is not a valid configuration for `DriverRemoteConnection`. |None
 |transport_factory |A callable that returns an instance of `AbstractBaseTransport`. |`gremlin_python.driver.aiohttp.transport.AiohttpTransport`

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -291,7 +291,7 @@ main difference is the usage of HA configuration options that enable the cluster
 from the TinkerPop perspective is largely the same.
 
 In configuring for HA the most important thing to realize is that all Neo4j HA settings are simply passed through the
-TinkerPop configuration settings given to the `GraphFactory.open()` or `Neo4j.open()` methods. For example, to
+TinkerPop configuration settings given to the `GraphFactory.open()` or `Neo4jGraph.open()` methods. For example, to
 provide the all-important `ha.server_id` configuration option through TinkerPop, simply prefix that key with the
 TinkerPop Neo4j key of `gremlin.neo4j.conf`.
 

--- a/docs/src/reference/implementations-tinkergraph.asciidoc
+++ b/docs/src/reference/implementations-tinkergraph.asciidoc
@@ -170,7 +170,7 @@ NOTE: To use <<tinkergraph-gremlin-tx, transactions>>, configure `gremlin.graph`
 `org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerTransactionGraph`.
 
 The `IdManager` settings above refer to how TinkerGraph will control identifiers for vertices, edges and vertex
-properties.  There are several options for each of these settings: `ANY`, `LONG`, `INTEGER`, `UUID`, or the fully
+properties.  There are several options for each of these settings: `ANY`, `LONG`, `INTEGER`, `UUID`, `STRING`, or the fully
 qualified class name of an `IdManager` implementation on the classpath.  When not specified, the default values
 for all settings is `ANY`, meaning that the graph will work with any object on the JVM as the identifier and will
 generate new identifiers from `Long` when the identifier is not user supplied.  TinkerGraph will also expect the
@@ -266,7 +266,7 @@ public class GraphService {
 // suitable test graph replacement for our actual production graph.
 public class GraphServiceTest {
     private static final TinkerTransactionGraph graph = TinkerTransactionGraph.open();
-    private static final GraphTraversalSource g = traversal.withEmbedded(graph);
+    private static final GraphTraversalSource g = traversal().withEmbedded(graph);
     private static final GraphService service = new GraphService(g);
 
     @Test
@@ -286,8 +286,8 @@ public class GraphServiceTest {
 // with this approach you could also configure your production graph directly or use custom
 // build options to trigger different test configurations for a more dynamic approach
 public class GraphServiceTest {
-    private static final GraphTraversalSource g = traversal.withRemote(
-            new DriverRemoteConnection('ws://localhost:8182/gremlin'));
+    private static final GraphTraversalSource g = traversal().withRemote(
+            new DriverRemoteConnection("ws://localhost:8182/gremlin"));
     private static final GraphService service = new GraphService(g);
 
     @Test

--- a/docs/src/reference/intro.asciidoc
+++ b/docs/src/reference/intro.asciidoc
@@ -157,7 +157,7 @@ NOTE: The TinkerPop API rides a fine line between providing concise "query langu
 Java method naming standards. The general convention used throughout TinkerPop is that if a method is "user exposed,"
 then a concise name is provided (e.g. `out()`, `path()`, `repeat()`). If the method is primarily for graph systems
 providers, then the standard Java naming convention is followed (e.g. `getNextStep()`, `getSteps()`,
-`getElementComputeKeys()`).
+`getVertexComputeKeys()`).
 
 [[graph-structure]]
 === The Graph Structure

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -459,8 +459,8 @@ The `ShortestPathVertexProgram.Builder` provides the following configuration met
 | `edgeTraversal(Traversal)` | Sets a traversal that emits the edges to traverse from the current vertex. | `__.bothE()`
 | `distanceProperty(String)` | Sets the edge property to use for the distance calculations. | none
 | `distanceTraversal(Traversal)` | Sets the traversal that calculates the distance for the current edge. | `__.constant(1)`
-| `maxDistance(Traversal)` | Limits the shortest path distance. | none
-| `includeEdges(Boolean)` | Whether to include edges in shortest paths or not. | `false`
+| `maxDistance(Number)` | Limits the shortest path distance. | none
+| `includeEdges(boolean)` | Whether to include edges in shortest paths or not. | `false`
 |=========================================================
 
 IMPORTANT: If a maximum distance is provided, the discovery process will only stop to follow a path at this distance if there was no

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -901,7 +901,7 @@ robust steps like <<choose-step, choose()>> and <<union-step,union()>>.
 
 *Additional References*
 
-link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#branch(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`map(Traversal)`]
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#branch(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`branch(Traversal)`]
 
 [[by-step]]
 === By Step
@@ -1695,7 +1695,7 @@ information.
 
 *Additional References*
 
-link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#filter(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`map(Traversal)`]
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#filter(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`filter(Traversal)`]
 
 [[flatmap-step]]
 === FlatMap Step
@@ -1705,7 +1705,7 @@ process. Please see the <<general-steps, General Steps>> section for more inform
 
 *Additional References*
 
-link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#flatMap(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`map(Traversal)`]
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#flatMap(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`flatMap(Traversal)`]
 
 [[format-step]]
 === Format Step
@@ -4413,7 +4413,7 @@ see the <<general-steps, General Steps>> section for more information.
 
 *Additional References*
 
-link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#sideEffect(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`map(Traversal)`]
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#sideEffect(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`sideEffect(Traversal)`]
 
 [[simplepath-step]]
 === SimplePath Step

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 final class Settings {
 
     /**
-     * The port of the Gremlin Server to connect to which defaults to {@code 8192}. The same port will be applied for
+     * The port of the Gremlin Server to connect to which defaults to {@code 8182}. The same port will be applied for
      * all {@link #hosts}.
      */
     public int port = 8182;
@@ -382,7 +382,7 @@ final class Settings {
 
         /**
          * The amount of time in milliseconds to wait for a new connection before timing out where the default value
-         * is 3000.
+         * is 16000.
          */
         public int maxWaitForConnection = Connection.MAX_WAIT_FOR_CONNECTION;
 
@@ -395,7 +395,7 @@ final class Settings {
 
         /**
          * The maximum length in bytes that a message can be sent to the server. This number can be no greater than
-         * the setting of the same name in the server configuration. The default value is 65536.
+         * the setting of the same name in the server configuration. The default value is 10485760.
          */
         public int maxContentLength = Connection.MAX_CONTENT_LENGTH;
 


### PR DESCRIPTION
## Summary

The reference documentation under `docs/src/reference/` described driver
configuration options, default values, class names, and code examples that no
longer matched the source. This PR corrects those inaccuracies across all five
drivers (JVM, Python, .NET, Go, JavaScript), fixes three stale javadoc comments
in `gremlin-driver` that were the origin of some doc errors, and adds a
`CHANGELOG` entry. All changes are documentation or comment only; no runtime
behavior changes.

## What changed and why

### JavaScript
* Removed `pingEnabled` / `pingInterval` / `pongTimeout`: the JavaScript driver has no ping/pong logic, so these documented options are non-functional.
* Removed `CardinalityValue` from Common Imports: `gremlin.process.CardinalityValue` resolves to `undefined` because `index.js` does not surface it on the `process` namespace (it is only exported from `lib/process/graph-traversal.js`).
* Added `materializeProperties`: it is accepted in the driver's per-request `allowedKeys` (`driver-remote-connection.js`) but was missing from the documented list.

### Python
* `pool_size` 4 -> 8: the implementation default is 8 (`client.py`); the doc value was stale.
* `max_workers`: the doc claimed "CPUs * 5" but the code defaults it to `pool_size`.
* `enable_compression` description: copy-pasted verbatim from the neighboring `enable_user_agent_on_connect` row when both were added in `ca5414fcb7` (Oct 2024).
* Added `materializeProperties`: accepted by `_extract_request_options` but omitted from the list.
* `kerberized_service` default: rendered as `"""` (a quoting artifact); corrected to `""` (empty string).

### .NET
* `PoolSize` 4 -> 8: implementation default is 8 (`ConnectionPoolSettings`); doc value stale.
* `MaxInProcessPerConnection` 32 -> 16: implementation default is 16; doc value stale.
* `ConnectionPoolBusyException`: the pool-busy case throws this, not the base `NoConnectionAvailableException` the doc named.

### Go
* `/v3` import path: the module moved to a v3 major version, so the import path requires `/v3`.
* `gremlingo.INFO` -> `Info`: the constant is named `Info`; `INFO` never existed.
* `ConnectionTimeout` 45s -> 5s: implementation default is 5s (`gorillaTransporter.go`); doc value stale.
* `ReadBufferSize` / `WriteBufferSize` 0 -> 1048576: the driver initializes these to 1 MB; the doc showed 0.

### JVM driver
* `port` 8192 -> 8182: the doc copied the stale `Settings.java` javadoc; the field value is 8182.
* `maxWaitForConnection` 3000 -> 16000: the doc copied a stale javadoc; the constant is 16000.
* `maxContentLength` 65536 -> 10485760: the doc copied a stale javadoc; the constant is 10 MB.
* `minSimultaneousUsagePerConnection` description: it was copy-pasted from the max-variant row.

### Server / Console
* GraphSON serializer class names: the docs used pre-3.3/3.5 `Gremlin` / `d0` names for classes that were later renamed (`GraphSONMessageSerializerV1`, `GraphSONUntypedMessageSerializerV3`).
* Server `maxContentLength` 65536 -> 10485760: the server default is 10 MB; the doc value was stale.
* `plugin activated:`: the console prints "activated", not "loaded", so the example output was wrong.

### Examples and references
* `traversal().withEmbedded(...)` / `traversal().withRemote(...)`: the examples omitted the parentheses on the static factory and would not compile; the URL was also single-quoted, which is invalid as a Java String literal.
* `Neo4jGraph.open()`: there is no class named `Neo4j`; the factory lives on `Neo4jGraph`.
* `getVertexComputeKeys()`: `getElementComputeKeys()` is a pre-3.2 name that was renamed.
* IdManager options: added `STRING`, a valid selectable value in the `DefaultIdManager` enum that was omitted from the list.
* `maxDistance(Number)`: the builder method takes a `Number`, not a `Traversal`.
* `includeEdges(boolean)`: the builder method takes a primitive `boolean`.
* Step-reference link labels: the `branch()`, `filter()`, `flatMap()`, and `sideEffect()` "Additional References" links displayed the label `map(Traversal)` (a copy-paste artifact; the link anchors were already correct). Corrected each label to match its own step.

### Code comments
* `Settings.java` javadocs (`port`, `maxWaitForConnection`, `maxContentLength`): the comments stated defaults that no longer matched the field/constant values and were the source of the doc-table errors.

## Verification

Every corrected value was cross-checked against the source at all layers that
determine the effective default a user receives: the constant, the settings
object, and the builder for the JVM driver; and both the direct client and the
remote-connection wrapper for each language variant. This confirmed the
documented value matches actual behavior and is not contradicted by another file.

Assisted-by: Kiro: Claude Opus 4.8