### PR TITLE
TINKERPOP-3277 Fix gremlin-go GraphBinary serialization of zero BigInteger/BigDecimal

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed `gremlin-python` `ProductiveByStrategy` to pass through the `productiveKeys` argument, which was previously accepted but never serialized to the server.
 * Deprecated `ProductiveByStrategy` which was introduced as a temporary way to mimic pre-3.5.0 null processing behavior.
 * Fixed `gremlin-python` GraphBinary serialization of `BigInteger`/`BigDecimal` negative boundary values (e.g. `-129`) that raised `OverflowError`.
+* Fixed `gremlin-go` GraphBinary serialization of zero `BigInteger`/`BigDecimal` values, which were encoded with zero length and rejected by Java servers.
 
 [[release-3-7-6]]
 === TinkerPop 3.7.6 (Release Date: April 1, 2026)

--- a/gremlin-go/driver/graphBinary.go
+++ b/gremlin-go/driver/graphBinary.go
@@ -318,7 +318,7 @@ func getSignedBytesFromBigInt(n *big.Int) []byte {
 		}
 		return b
 	}
-	return []byte{}
+	return []byte{0}
 }
 
 // Format: {length}{value_0}...{value_n}

--- a/gremlin-go/driver/graphBinary_test.go
+++ b/gremlin-go/driver/graphBinary_test.go
@@ -192,6 +192,34 @@ func TestGraphBinaryV1(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, new(big.Int).SetUint64(uint64(source)), res)
 		})
+		t.Run("write bigInt zero exact bytes", func(t *testing.T) {
+			var buffer bytes.Buffer
+			buf, err := bigIntWriter(*big.NewInt(0), &buffer, nil)
+			assert.Nil(t, err)
+			assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x01, 0x00}, buf)
+		})
+		t.Run("read-write bigInt zero", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := big.NewInt(0)
+			buf, err := bigIntWriter(*source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readBigInt(&buf, &pos)
+			assert.Nil(t, err)
+			assert.Equal(t, 0, source.Cmp(res.(*big.Int)))
+		})
+		t.Run("read-write bigDecimal zero unscaled", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := &BigDecimal{0, *big.NewInt(0)}
+			buf, err := bigDecimalWriter(source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readBigDecimal(&buf, &pos)
+			assert.Nil(t, err)
+			actual := res.(*BigDecimal)
+			assert.Equal(t, source.Scale, actual.Scale)
+			assert.Equal(t, 0, source.UnscaledValue.Cmp(&actual.UnscaledValue))
+		})
 		t.Run("read-write list", func(t *testing.T) {
 			pos := 0
 			var buffer bytes.Buffer


### PR DESCRIPTION
## Summary

`gremlin-go` serialized a zero `BigInteger` as a GraphBinary length of `0` with no value
bytes. Java's `new BigInteger(new byte[0])` throws `NumberFormatException`, so a Java server
could not read zero values sent by Go. The fix encodes zero as the canonical single `0x00`
byte (length 1), matching Java's `BigInteger.toByteArray()`. `BigDecimal` with a zero unscaled
value is fixed transitively (it serializes its unscaled value as a `BigInteger`).

## Before vs After

| Value | Before | After |
|---|---|---|
| `BigInteger(0)` | `00 00 00 00` (Java rejects) | `00 00 00 01 00` |
| `BigDecimal` with unscaled `0` | `...00 00 00 00` (Java rejects) | `...00 00 00 01 00` |

### Example

```go
// Sending a zero-valued BigInteger property to a Java Gremlin Server
g.AddV("event").Property("count", big.NewInt(0)).Iterate()
```

Before: the Java server fails to deserialize the request (`NumberFormatException: Zero length BigInteger`).
After: zero serializes to canonical bytes and is read correctly.

## Changes

- `gremlin-go/driver/graphBinary.go` - `getSignedBytesFromBigInt` returns `[]byte{0}` for zero.
- `gremlin-go/driver/graphBinary_test.go` - added zero exact-bytes, zero round-trip, and
  zero-unscaled `BigDecimal` tests.

## Testing

Added `TestGraphBinaryV1` subtests for the zero cases.

Assisted-by: Kiro:claude-opus-4.8
