### PR TITLE
Update GraphSON reference examples for 4.x HTTP behavior

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1045,7 +1045,7 @@ available GraphSON serializers that can be configured:
 |=========================================================
 |Version |Embedded Types |Mime Type |Class
 |4.0 |yes |`application/vnd.gremlin-v4.0+json` |`GraphSONMessageSerializerV4`
-|4.0 |no |`application/vnd.gremlin-v4.0+json;types=false` |`GraphSONMessageSerializerV4`
+|4.0 |no |`application/vnd.gremlin-v4.0+json;types=false` |`GraphSONUntypedMessageSerializerV4`
 |=========================================================
 
 The above serializer classes can be found in the `org.apache.tinkerpop.gremlin.util.ser` package of `gremlin-util`.
@@ -1085,14 +1085,12 @@ NOTE: The below examples use GraphSON 1.0 and GraphSON 3.0 for example purposes,
 [INFO] AbstractChannelizer - application/json already has org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1 configured - it will not be replaced by org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3, change order of serialization configuration if this is not desired.
 ----
 
-Given the above, using GraphSON 3.0 under this configuration will require that the user specific the type:
+A request that does not specify an `Accept` header returns a response serialized with the default GraphSON serializer:
 
 [source,text]
 ----
-$ curl -X POST -d "{\"gremlin\":\"100-1\"}" "http://localhost:8182"
-{"requestId":"f8720ad9-2c8b-4eef-babe-21792a3e3157","status":{"message":"","code":200,"attributes":{}},"result":{"data":[99],"meta":{}}}
-$ curl -H "Accept:application/vnd.gremlin-v3.0+json" -X POST -d "{\"gremlin\":\"100-1\"}" "http://localhost:8182"
-{"requestId":"9fdf0892-d86c-41f2-94b5-092785c473eb","status":{"message":"","code":200,"attributes":{"@type":"g:Map","@value":[]}},"result":{"data":{"@type":"g:List","@value":[{"@type":"g:Int32","@value":99}]},"meta":{"@type":"g:Map","@value":[]}}
+$ curl -X POST -d "{\"gremlin\":\"g.inject(99)\"}" "http://localhost:8182"
+{"result":{"data":[99]},"status":{"code":200}}
 ----
 
 [[server-graphbinary]]


### PR DESCRIPTION
The GraphSON section of `reference/gremlin-applications.asciidoc` still described 3.x behavior, which no longer matches a 4.0 server.

This updates the section so every example reflects 4.x:

- The curl example used `100-1`, which the 4.x parser rejects (no Groovy scripting). It now uses the valid gremlin-lang expression `g.inject(99)`, which is why the documented result data is `[99]`.
- The shown response envelope was the old 3.x shape (`requestId`, nested `status`/`result` with `meta`). It now shows the actual 4.0 shape: `{"result":{"data":[99]},"status":{"code":200}}`.
- The GraphSON 3.0 `Accept`-header example was removed. It cannot succeed on 4.x (the server returns HTTP 400 for `application/vnd.gremlin-v3.0+json`) and contradicted the adjacent note that says v3.0 is no longer available. Its intro line was reworded to describe the remaining default-request example.
- The serializer table's untyped row listed `GraphSONMessageSerializerV4`. The correct class for the untyped configuration is `GraphSONUntypedMessageSerializerV4`.

The docs build (`bin/process-docs.sh`) renders cleanly and the rendered section was checked to contain the corrected content.