### PR TITLE
Document that asBool() trims whitespace before parsing strings

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -864,11 +864,11 @@ None
 
 *Considerations:*
 
-Booleans are passed as is, numbers evaluate to `true` if non-zero, and `false` if zero or `NaN`. Strings only accept "true" or "false" (case-insensitive).
+Booleans are passed as is, numbers evaluate to `true` if non-zero, and `false` if zero or `NaN`. Strings are accepted when, after trimming leading and trailing whitespace (spaces, tabs, newlines, and carriage returns), they equal "true" or "false" (case-insensitive). For example, " true", "false\t", and "\nTRUE" are all accepted.
 
 *Exceptions:*
 
-If the incoming traverser type is unsupported, a string other than "true" or "false", or `null`, then an `Argument Error` is raised.
+If the incoming traverser type is unsupported, a string that (after trimming leading and trailing whitespace) is neither "true" nor "false", or `null`, then an `Argument Error` is raised.
 
 See: link:https://github.com/apache/tinkerpop/tree/x.y.z/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/AsBoolStep.java[source],
 link:https://tinkerpop.apache.org/docs/x.y.z/reference/#asBool-step[reference]

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -928,9 +928,11 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 === AsBool Step
 
 The `asBool()`-step (*map*) converts the incoming traverser to a boolean value. If the traverser is already a boolean value, it is passed as-is. Numbers evaluate to
-`true` if non-zero, and to `false` if zero or `NaN`. Strings are only accepted when
-equal to `"true"` or `"false"` (case-insensitive), otherwise an `IllegalArgumentException` is thrown.
-All other types (including `null`) will throw an `IllegalArgumentException`.
+`true` if non-zero, and to `false` if zero or `NaN`. Strings are accepted when, after trimming
+leading and trailing whitespace (spaces, tabs, newlines, and carriage returns), they equal `"true"`
+or `"false"` (case-insensitive). For example, `" true"`, `"false\t"`, and `"\nTRUE"` are all
+accepted. Any other string, and all other types (including `null`), will throw an
+`IllegalArgumentException`.
 
 [gremlin-groovy,modern]
 ----


### PR DESCRIPTION
The `asBool()` step trims leading and trailing whitespace (spaces, tabs, newlines, and carriage returns) from string input before comparing it, case-insensitively, against `"true"` and `"false"`. As a result, values such as `" true"`, `"false\t"`, and `"\nTRUE"` are accepted and do not throw.

The reference documentation (asBool()-step) and the Gremlin semantics provider documentation both stated that strings were only accepted when exactly equal to `"true"` or `"false"`, which did not reflect this trimming behavior. This updates both sections to describe the trimming and adds a few accepted padded-input examples.

Documentation only. The rules for numbers, `null`, and other input types are unchanged. Both books render cleanly.

Files:
- `docs/src/reference/the-traversal.asciidoc` (asBool()-step section)
- `docs/src/dev/provider/gremlin-semantics.asciidoc` (asBool section: Considerations and Exceptions)