### PR TITLE
Fix inaccurate vertex label description in reference docs

### DIFF
--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -237,8 +237,7 @@ g.V().has('name','tux').out('livesIn').values('name','biome')        <3>
 not limited to exactly one for this graph.
 <2> Filtering by a single label, such as "endangered", surfaces every animal that carries it, regardless of what
 other labels are also present.
-<3> Habitats, like "lagoon" and "canopy", are modeled as ordinary single-labeled vertices connected to their
-resident animals with a "livesIn" edge.
+<3> Find the name and biome of the habitat that "tux" lives in.
 
 [[nullable-property-values]]
 === Nullable Property Values


### PR DESCRIPTION
The Vertex Labels section of the reference documentation includes a Gremlin example against The Zoo toy graph. The callout annotating the habitat query (`g.V().has('name','tux').out('livesIn').values('name','biome')`) stated that habitats are modeled as ordinary single-labeled vertices.

That description is inaccurate for The Zoo: the `lagoon` habitat vertex carries more than one label, so the claim that habitats are single-labeled does not hold. This replaces the callout with a plain description of what the query retrieves, which removes the incorrect claim without introducing any new assertions about label cardinality.

Documentation-only change. Callouts 1 and 2, the queries, and the surrounding prose are unchanged.