### PR TITLE
[TINKERPOP-2085]: Remove Mono dependency from gremlin-dotnet build/release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Added `FailResponseException` to `gremlin-driver` which is thrown `fail()` step is triggered on the server making it more consistent with embedded behavior.
 * Fixed `hasId()` to only unroll a collection when it is supplied as the single argument, aligning its behavior with `g.V()`/`g.E()`.
 * Fixed conjoin has incorrect null handling.
+* Removed the Mono dependency from the `gremlin-dotnet` build/release process, using `dotnet pack`/`dotnet nuget push` instead of `mono nuget.exe`.
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 * Add Node 26 support for `gremlin-javascript` and `gremlint`.
 * Corrected numerous inaccuracies in the reference documentation, including wrong default values (connection pool sizes, buffer sizes, ports, timeouts), stale serializer class names, removed options documented as available, and broken code examples across the JVM, Python, `.NET`, Go, and JavaScript drivers.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,15 +24,13 @@ RUN apt-get -y install software-properties-common python3-software-properties ap
 RUN add-apt-repository ppa:openjdk-r/ppa
 RUN sh -c 'curl -s https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb'
 RUN sh -c 'dpkg -i packages-microsoft-prod.deb'
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN apt-get install apt-transport-https gnupg ca-certificates
-RUN sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list'
+
 RUN apt-get update
 
 # include both java 8/11 so that we can use the same docker image for future builds on that version of the jdk as we do
 # for the older release branches. the java version to use is just controlled by JAVA_HOME hardcoded below
 RUN apt-get install -y openjdk-8-jdk openjdk-11-jdk gawk git maven openssh-server subversion zip
-RUN apt-get install -y --force-yes dotnet-sdk-8.0 mono-devel
+RUN apt-get install -y --force-yes dotnet-sdk-8.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y python3 python3.8 python3-dev python3.8-dev python3-pip build-essential checkinstall zlib1g-dev libreadline-gplv2-dev \

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -250,10 +250,8 @@ and `test` directories of the `gremlin-dotnet` module which will signify to Mave
 The `.glv` file need not have any contents and is ignored by Git. A standard `mvn clean install` will then build
 `gremlin-dotnet` in full.
 
-In order to pack the Gremlin.Net.Template project, it is also necessary to install link:http://www.mono-project.com/[Mono].
-The template can still be built and tested without Mono but packing will be skipped.
-To pack the template (which will also download the link:https://docs.microsoft.com/en-us/nuget/tools/nuget-exe-cli-reference[NuGet CLI tool])
-the `nuget` property has to be set:
+Packing the Gremlin.Net.Template project uses `dotnet pack` directly — no additional tooling beyond the .NET SDK is
+required. To pack the template, the `nuget` property has to be set:
 
 [source,text]
 mvn clean install -Dnuget
@@ -377,21 +375,19 @@ link:https://pypi.org/manage/account/token/[account settings] and then the usern
 and the password to the token value. Please see link:https://pypi.org/help/#apitoken[PyPI documentation] for more
 details.
 
-For .NET releases, install link:http://www.mono-project.com/[Mono]. The release process is known to work with 6.12.0,
-so it is best to probably install that version. Release managers should probably also do an install of
-link:https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe[nuget 3.4.4] as it will help with environmental setup.
-To get an environment ready to deploy to NuGet, it is necessary to have a NuGet API key. First, create an account with
+For .NET releases, the .NET SDK (already required for building) provides all necessary tooling — no additional
+Mono or `nuget.exe` installation is needed. To get an environment ready to deploy to NuGet, it is necessary to have a
+NuGet API key. First, create an account with
 link:https://www.nuget.org[nuget] and request that a PMC member add your account to the Gremlin.Net and
 the Gremlin.Net.Template package in nuget so that you can deploy. Next, generate an API key for your account on the
-nuget website. The API key should be added to `NuGet.Config` with the following:
+nuget website. Unlike the old `nuget.exe setApiKey` approach, `dotnet nuget push` does not store the API key in a
+config file; instead, the build passes it via the `NUGET_API_KEY` environment variable, which the release manager
+must set before running `mvn deploy`:
 
 [source,text]
 ----
-mono nuget.exe setApiKey [your-api-key]
+export NUGET_API_KEY=[your-api-key]
 ----
-
-This should update `~/.config/NuGet/NuGet.Config` a file with an entry containing the encrypted API key. On
-`mvn deploy`, this file will be referenced on the automated `nuget push`.
 
 To deploy JavaScript / TypeScript artifacts on the link:https://www.npmjs.com[npm registry], the release manager must
 set the authentication information on the ~/.npmrc file. The easiest way to do that is to use the `npm adduser`

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -381,13 +381,15 @@ NuGet API key. First, create an account with
 link:https://www.nuget.org[nuget] and request that a PMC member add your account to the Gremlin.Net and
 the Gremlin.Net.Template package in nuget so that you can deploy. Next, generate an API key for your account on the
 nuget website. The old `mono nuget.exe setApiKey` approach stored the key encrypted (via Windows DPAPI) in
-`NuGet.Config`, which the `dotnet` CLI cannot decrypt on Linux/macOS. Instead, set the key in the `NUGET_API_KEY`
-environment variable before running `mvn deploy`, which the build passes explicitly to `dotnet nuget push --api-key`:
+`NuGet.Config`, which the `dotnet` CLI cannot decrypt on Linux/macOS. Instead, supply the key with the `nuget.apiKey`
+Maven property when running `mvn deploy`, which the build passes explicitly to `dotnet nuget push --api-key`:
 
 [source,text]
 ----
-export NUGET_API_KEY=[your-api-key]
+mvn deploy -pl :gremlin-dotnet-source -Dnuget -Dnuget.apiKey=[your-api-key]
 ----
+
+If `nuget.apiKey` is not supplied, the build will fail fast with a message explaining how to set it.
 
 To deploy JavaScript / TypeScript artifacts on the link:https://www.npmjs.com[npm registry], the release manager must
 set the authentication information on the ~/.npmrc file. The easiest way to do that is to use the `npm adduser`

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -250,8 +250,7 @@ and `test` directories of the `gremlin-dotnet` module which will signify to Mave
 The `.glv` file need not have any contents and is ignored by Git. A standard `mvn clean install` will then build
 `gremlin-dotnet` in full.
 
-Packing the Gremlin.Net.Template project uses `dotnet pack` directly — no additional tooling beyond the .NET SDK is
-required. To pack the template, the `nuget` property has to be set:
+To pack the Gremlin.Net.Template, the `nuget` property has to be set:
 
 [source,text]
 mvn clean install -Dnuget
@@ -375,21 +374,16 @@ link:https://pypi.org/manage/account/token/[account settings] and then the usern
 and the password to the token value. Please see link:https://pypi.org/help/#apitoken[PyPI documentation] for more
 details.
 
-For .NET releases, the .NET SDK (already required for building) provides all necessary tooling — no additional
-Mono or `nuget.exe` installation is needed. To get an environment ready to deploy to NuGet, it is necessary to have a
-NuGet API key. First, create an account with
+For .NET releases, it is necessary to have a NuGet API key. First, create an account with
 link:https://www.nuget.org[nuget] and request that a PMC member add your account to the Gremlin.Net and
 the Gremlin.Net.Template package in nuget so that you can deploy. Next, generate an API key for your account on the
-nuget website. The old `mono nuget.exe setApiKey` approach stored the key encrypted (via Windows DPAPI) in
-`NuGet.Config`, which the `dotnet` CLI cannot decrypt on Linux/macOS. Instead, supply the key with the `nuget.apiKey`
+nuget website. During deployments, supply the key with the `nuget.apiKey`
 Maven property when running `mvn deploy`, which the build passes explicitly to `dotnet nuget push --api-key`:
 
 [source,text]
 ----
 mvn deploy -pl :gremlin-dotnet-source -Dnuget -Dnuget.apiKey=[your-api-key]
 ----
-
-If `nuget.apiKey` is not supplied, the build will fail fast with a message explaining how to set it.
 
 To deploy JavaScript / TypeScript artifacts on the link:https://www.npmjs.com[npm registry], the release manager must
 set the authentication information on the ~/.npmrc file. The easiest way to do that is to use the `npm adduser`

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -380,9 +380,9 @@ Mono or `nuget.exe` installation is needed. To get an environment ready to deplo
 NuGet API key. First, create an account with
 link:https://www.nuget.org[nuget] and request that a PMC member add your account to the Gremlin.Net and
 the Gremlin.Net.Template package in nuget so that you can deploy. Next, generate an API key for your account on the
-nuget website. Unlike the old `nuget.exe setApiKey` approach, `dotnet nuget push` does not store the API key in a
-config file; instead, the build passes it via the `NUGET_API_KEY` environment variable, which the release manager
-must set before running `mvn deploy`:
+nuget website. The old `mono nuget.exe setApiKey` approach stored the key encrypted (via Windows DPAPI) in
+`NuGet.Config`, which the `dotnet` CLI cannot decrypt on Linux/macOS. Instead, set the key in the `NUGET_API_KEY`
+environment variable before running `mvn deploy`, which the build passes explicitly to `dotnet nuget push --api-key`:
 
 [source,text]
 ----

--- a/docs/src/dev/developer/release.asciidoc
+++ b/docs/src/dev/developer/release.asciidoc
@@ -61,7 +61,7 @@ development artifacts must be generated and deployed separately with additional 
 mvn clean install -Pglv-python
 mvn deploy -pl gremlin-python -Dpypi
 mvn clean install -pl :gremlin-dotnet,:gremlin-dotnet-source -Dnuget
-mvn deploy -pl :gremlin-dotnet-source -Dnuget
+mvn deploy -pl :gremlin-dotnet-source -Dnuget -Dnuget.apiKey=[your-api-key]
 mvn deploy -pl gremlin-javascript -Dnpm`
 ----
 
@@ -257,7 +257,7 @@ the help of a PMC member for those steps.
 .. This build will likely occur from the tag for the release, so be sure to checkout the tag first before executing this step.
 .. `mvn clean install -DskipTests -Dnuget`
 .. `mvn deploy -pl gremlin-python -DskipTests -Dpypi`
-.. `mvn deploy -pl :gremlin-dotnet-source -DskipTests -Dnuget`
+.. `mvn deploy -pl :gremlin-dotnet-source -DskipTests -Dnuget -Dnuget.apiKey=[your-api-key]`
 .. `mvn deploy -pl gremlin-javascript -DskipTests -Dnpm`
 ... Consider direct deploy with `npm publish --otp <otp>` from `gremlin-javascript/src/main/javascript/gremlin-javascript/` - if using this method, ensure the `npm` version aligns with the one expected by the branch.
 .. `mvn deploy -pl gremlint -DskipTests -Dnpm`

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Gremlin.Net.Template.csproj
@@ -21,6 +21,8 @@ limitations under the License.
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <NuspecFile>Gremlin.Net.Template.nuspec</NuspecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -262,20 +262,23 @@ limitations under the License.
                                     <target>
                                         <!--
                                         the NuGet API key is passed explicitly via the "api-key" option, sourced
-                                        from the NUGET_API_KEY environment variable, which must be set by the
-                                        release manager prior to running "mvn deploy -Dnuget". NuGet 7.6+ (bundled
-                                        with .NET SDK 10.0.300+) can read NUGET_API_KEY automatically without that
-                                        option, but this build currently targets .NET SDK 8.0, whose bundled NuGet
-                                        CLI predates that feature, so the option is passed explicitly. The old
-                                        "nuget.exe setApiKey" config file approach is not viable here: it encrypts
-                                        the key with Windows DPAPI, which the dotnet CLI cannot decrypt on
+                                        from the "nuget.apiKey" Maven property, which the release manager must set
+                                        with "-Dnuget.apiKey=..." when running "mvn deploy -Dnuget". NuGet 7.6+
+                                        (bundled with .NET SDK 10.0.300+) can read a NUGET_API_KEY environment
+                                        variable automatically instead, but this build currently targets .NET SDK
+                                        8.0, whose bundled NuGet CLI predates that feature. The old
+                                        "nuget.exe setApiKey" config file approach is not viable here either: it
+                                        encrypts the key with Windows DPAPI, which the dotnet CLI cannot decrypt on
                                         Linux/macOS release hosts.
                                         -->
+                                        <fail unless="nuget.apiKey">
+Deploying to NuGet requires an API key. Please supply one with "-Dnuget.apiKey=[your-api-key]" when running "mvn deploy -Dnuget".
+                                        </fail>
                                         <exec executable="dotnet" failonerror="true">
-                                            <arg line="nuget push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${env.NUGET_API_KEY}"/>
+                                            <arg line="nuget push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${nuget.apiKey}"/>
                                         </exec>
                                         <exec executable="dotnet" failonerror="true">
-                                            <arg line="nuget push Gremlin.Net.Template.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${env.NUGET_API_KEY}"/>
+                                            <arg line="nuget push Gremlin.Net.Template.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${nuget.apiKey}"/>
                                         </exec>
                                     </target>
                                 </configuration>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -260,11 +260,15 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <target>
+                                        <!--
+                                        the NuGet API key is read from the NUGET_API_KEY environment variable, which
+                                        must be set by the release manager prior to running "mvn deploy -Dnuget".
+                                        -->
                                         <exec executable="dotnet" failonerror="true">
-                                            <arg line="nuget push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg --source https://api.nuget.org/v3/index.json"/>
+                                            <arg line="nuget push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${env.NUGET_API_KEY}"/>
                                         </exec>
                                         <exec executable="dotnet" failonerror="true">
-                                            <arg line="nuget push Gremlin.Net.Template.${project.version}.nupkg --source https://api.nuget.org/v3/index.json"/>
+                                            <arg line="nuget push Gremlin.Net.Template.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${env.NUGET_API_KEY}"/>
                                         </exec>
                                     </target>
                                 </configuration>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -261,8 +261,15 @@ limitations under the License.
                                 <configuration>
                                     <target>
                                         <!--
-                                        the NuGet API key is read from the NUGET_API_KEY environment variable, which
-                                        must be set by the release manager prior to running "mvn deploy -Dnuget".
+                                        the NuGet API key is passed explicitly via the "api-key" option, sourced
+                                        from the NUGET_API_KEY environment variable, which must be set by the
+                                        release manager prior to running "mvn deploy -Dnuget". NuGet 7.6+ (bundled
+                                        with .NET SDK 10.0.300+) can read NUGET_API_KEY automatically without that
+                                        option, but this build currently targets .NET SDK 8.0, whose bundled NuGet
+                                        CLI predates that feature, so the option is passed explicitly. The old
+                                        "nuget.exe setApiKey" config file approach is not viable here: it encrypts
+                                        the key with Windows DPAPI, which the dotnet CLI cannot decrypt on
+                                        Linux/macOS release hosts.
                                         -->
                                         <exec executable="dotnet" failonerror="true">
                                             <arg line="nuget push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${env.NUGET_API_KEY}"/>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -229,11 +229,6 @@ limitations under the License.
             </properties>
             <build>
                 <plugins>
-                    <!--
-                      not seeing much point to making this OS agnostic really. as far as it is known, no one who does
-                      deployments will do so from a windows machine. the dotnet CLI handles packing and pushing
-                      natively - no additional tooling required beyond the .NET SDK.
-                     -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
@@ -263,16 +258,10 @@ limitations under the License.
                                         <!--
                                         the NuGet API key is passed explicitly via the "api-key" option, sourced
                                         from the "nuget.apiKey" Maven property, which the release manager must set
-                                        with "-Dnuget.apiKey=..." when running "mvn deploy -Dnuget". NuGet 7.6+
-                                        (bundled with .NET SDK 10.0.300+) can read a NUGET_API_KEY environment
-                                        variable automatically instead, but this build currently targets .NET SDK
-                                        8.0, whose bundled NuGet CLI predates that feature. The old
-                                        "nuget.exe setApiKey" config file approach is not viable here either: it
-                                        encrypts the key with Windows DPAPI, which the dotnet CLI cannot decrypt on
-                                        Linux/macOS release hosts.
+                                        with "-Dnuget.apiKey=..." when running "mvn deploy -Dnuget".
                                         -->
                                         <fail unless="nuget.apiKey">
-Deploying to NuGet requires an API key. Please supply one with "-Dnuget.apiKey=[your-api-key]" when running "mvn deploy -Dnuget".
+                                            Deploying to NuGet requires an API key. Please supply one with "-Dnuget.apiKey=[your-api-key]" when running "mvn deploy -Dnuget".
                                         </fail>
                                         <exec executable="dotnet" failonerror="true">
                                             <arg line="nuget push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${nuget.apiKey}"/>

--- a/gremlin-dotnet/src/pom.xml
+++ b/gremlin-dotnet/src/pom.xml
@@ -26,10 +26,6 @@ limitations under the License.
     <artifactId>gremlin-dotnet-source</artifactId>
     <name>Apache TinkerPop :: Gremlin.Net - Source</name>
     <packaging>${packaging.type}</packaging>
-    <properties>
-        <nugetVersion>6.11.1</nugetVersion>
-        <nugetExe>nuget-${nugetVersion}.exe</nugetExe>
-    </properties>
 
     <build>
         <plugins>
@@ -235,8 +231,8 @@ limitations under the License.
                 <plugins>
                     <!--
                       not seeing much point to making this OS agnostic really. as far as it is known, no one who does
-                      deployments will do so from a windows machine. this part of the build requires mono. note that
-                      the "correct" version of nuget is downloaded as part of the process.
+                      deployments will do so from a windows machine. the dotnet CLI handles packing and pushing
+                      natively - no additional tooling required beyond the .NET SDK.
                      -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -250,30 +246,9 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" />                                       
-                                        <if>
-                                            <available file="mono" filepath="${env.PATH}"/>
-                                            <then>
-                                                <if>
-                                                    <available file="${nugetExe}"/>
-                                                    <then>
-                                                        <echo>nuget.exe already downloaded.</echo>
-                                                    </then>
-
-                                                    <else>
-                                                        <exec executable="wget" failonerror="true">
-                                                            <arg line="https://dist.nuget.org/win-x86-commandline/v${nugetVersion}/nuget.exe -O ${nugetExe}"/>
-                                                        </exec>
-                                                    </else>
-                                                </if>
-                                                <exec executable="mono" failonerror="true">
-                                                    <arg line="${nugetExe} pack Gremlin.Net.Template/Gremlin.Net.Template.nuspec"/>
-                                                </exec>
-                                            </then>
-                                            <else>
-                                                <echo>Skipping packaging of Gremlin.Net.Template as mono is not available</echo>
-                                            </else>
-                                        </if>
+                                        <exec executable="dotnet" failonerror="true">
+                                            <arg line="pack Gremlin.Net.Template/Gremlin.Net.Template.csproj --configuration Release --output ."/>
+                                        </exec>
                                     </target>
                                 </configuration>
                             </execution>
@@ -285,41 +260,16 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
-                                        <if>
-                                            <available file="${nugetExe}"/>
-                                            <then>
-                                                <echo>nuget.exe already downloaded.</echo>
-                                            </then>
-
-                                            <else>
-                                                <exec executable="wget" failonerror="true">
-                                                    <arg line="https://dist.nuget.org/win-x86-commandline/v${nugetVersion}/nuget.exe -O ${nugetExe}"/>
-                                                </exec>
-                                            </else>
-                                        </if>
-
-                                        <!--
-                                        until https://github.com/NuGet/Home/issues/4095 we have to have to specify
-                                        the "ConfigFile" option to nuget.
-                                        -->
-                                        <exec executable="mono" failonerror="true">
-                                            <arg line="${nugetExe} push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg -Source https://api.nuget.org/v3/index.json -ConfigFile ${user.home}/.config/NuGet/NuGet.Config"/>
+                                        <exec executable="dotnet" failonerror="true">
+                                            <arg line="nuget push Gremlin.Net/bin/Gremlin.Net.${project.version}.nupkg --source https://api.nuget.org/v3/index.json"/>
                                         </exec>
-                                        <exec executable="mono" failonerror="true">
-                                            <arg line="${nugetExe} push Gremlin.Net.Template.${project.version}.nupkg -Source https://api.nuget.org/v3/index.json -ConfigFile ${user.home}/.config/NuGet/NuGet.Config"/>
+                                        <exec executable="dotnet" failonerror="true">
+                                            <arg line="nuget push Gremlin.Net.Template.${project.version}.nupkg --source https://api.nuget.org/v3/index.json"/>
                                         </exec>
                                     </target>
                                 </configuration>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ant-contrib</groupId>
-                                <artifactId>ant-contrib</artifactId>
-                                <version>20020829</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.gmavenplus</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2085

Removes Mono from the gremlin-dotnet packaging/deploy pipeline, replacing mono nuget.exe pack/push with native dotnet pack/dotnet nuget push. Mono was only needed to run the Windows-only nuget.exe on Linux; the dotnet CLI has supported equivalent pack/push functionality since SDK 2.1+, so no functionality is 
lost.

One behavioral change for release managers: the modern dotnet nuget push has no equivalent to the old nuget.exe setApiKey, which stored the key encrypted (via Windows DPAPI) in NuGet.Config — that encryption isn't available on Linux/macOS. Deploys now require an explicit -Dnuget.apiKey=[key] Maven property, 
with a fail-fast check if it's omitted. (https://github.com/NuGet/Home/issues/6437)

Changes:
- Replace mono nuget.exe pack → dotnet pack for Gremlin.Net.Template (adds <NuspecFile>/<IsPackable> to its .csproj)
- Replace mono nuget.exe push → dotnet nuget push, gated behind a new -Dnuget.apiKey property with a fail-fast Ant <fail> check
- Remove now-dead nugetVersion/nugetExe properties and the ant-contrib antrun dependency
- Remove Mono APT repo, GPG key import, and mono-devel from docker/Dockerfile
- Update development-environment.asciidoc and release.asciidoc for the new pack/push/API-key workflow

I haven't yet tested this against a deployment to a live environment, my intention is to pull this forward to master, and try it out during the upcoming deployment of 4.0.0-beta.3. I will make any adjustments as necessary during that process.

VOTE +1