### PR TITLE
Document how clients select a named traversal source

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -519,6 +519,17 @@ Each entry supports:
 
 Graphs with explicit `traversalSources` entries are excluded from auto-creation.
 
+NOTE: A client does not write a query directly against these names — for example, `gReadOnly.V()` will not
+work, because a `gremlin-lang` traversal must begin with `g`.  Instead, a client chooses which named
+`TraversalSource` to run against through the request-level `g` alias and still writes the traversal as
+`g.V()...`.  The drivers expose this alias as the traversal source argument supplied when creating a remote
+connection (see <<connecting-via-drivers>>): supplying `gReadOnly` in place of `g` routes the request to the
+read-only source declared above, while the query itself remains unchanged.
+
+TIP: A server configuration that declares only `graphs` (with or without explicit `traversalSources`) is
+valid on its own.  The remaining server settings — such as host, port, thread pools, and serializers — fall
+back to sensible defaults when they are omitted.
+
 [[server-lifecycle-hooks]]
 ==== LifeCycleHooks
 


### PR DESCRIPTION
The *Declarative TraversalSources* section of the Gremlin Server reference shows how to declare named traversal sources (for example `g` and `gReadOnly`) in the server YAML, but it does not explain how a client actually routes a query to one of those named sources. A newcomer who configures `gReadOnly` has no way to discover that a bare `gReadOnly.V()` will not work, because a `gremlin-lang` traversal must begin with `g`.

This adds two short admonitions after the `traversalSources` declaration content:

- A NOTE explaining that a client chooses which named `TraversalSource` to run against through the request-level `g` alias (the traversal-source argument supplied when creating a remote connection, cross-referenced to *Connecting via Drivers*), while the traversal itself is still written as `g.V()...`.
- A TIP noting that a `graphs`-only server configuration is valid on its own because the remaining server settings fall back to sensible defaults.

The change is additive prose only — the existing YAML declaration content is unchanged and no unrelated content was touched. The docs render cleanly.