### PR TITLE
Clarify dateDiff() subtraction direction and result sign in docs

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -1476,7 +1476,9 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#dateAdd-step[reference]
 [[dateDiff-step]]
 === dateDiff()
 
-*Description:* Returns the difference between two Dates in epoch time.
+*Description:* Returns the difference between two Dates in epoch time (milliseconds), computed as the incoming
+traverser `DATETIME` minus the argument `DATETIME`. A positive result means the incoming date is later than the
+argument date, while a negative result means the incoming date is earlier.
 
 *Syntax:* `dateDiff(value: DATETIME)` | `dateDiff(dateTraversal: Traversal<any, DATETIME>)`
 
@@ -1488,9 +1490,9 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#dateAdd-step[reference]
 
 *Arguments:*
 
-* `value` - Date for subtraction.
-* `dateTraversal` - The `Traversal` value must resolve to a `DATETIME`. The first result returned from the traversal will be
-subtracted with the incoming traverser.
+* `value` - The `DATETIME` to subtract from the incoming traverser (result = incoming `DATETIME` - `value`).
+* `dateTraversal` - The `Traversal` value must resolve to a `DATETIME`. The first result returned from the traversal
+is subtracted from the incoming traverser (result = incoming `DATETIME` - traversal result).
 
 *Modulation:*
 

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1685,7 +1685,11 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 [[dateDiff-step]]
 === DateDiff Step
 
-The `dateDiff()`-step (*map*) returns the difference between two Dates in epoch time in milliseconds. 
+The `dateDiff()`-step (*map*) returns the difference between two Dates in epoch time in milliseconds. The result is
+computed as the incoming traverser date minus the argument date. A positive result means the incoming date is later
+than the argument date, while a negative result means the incoming date is earlier. In the example below, the incoming
+date (`2023-08-02`) is one day earlier than the argument date (`2023-08-03`), so the result is `-86400000`
+(one day in milliseconds).
 If the incoming traverser is not a Date or OffsetDateTime, then an `IllegalArgumentException` will be thrown.
 
 [gremlin-groovy,modern]


### PR DESCRIPTION
The `dateDiff()` documentation described the step as returning "the difference between two Dates" but never stated which operand is subtracted from which, so the sign of the result was unexplained. A newcomer running the reference example sees a negative value with no indication of why.

This change documents the direction and sign in both places that describe the step:

- **`docs/src/reference/the-traversal.asciidoc`** (dateDiff-step): adds prose stating the result is computed as the incoming traverser date minus the argument date, where a positive result means the incoming date is later and a negative result means it is earlier, and explains why the example returns `-86400000` (the incoming date is one day earlier than the argument). The live example block already renders its `==> -86400000` output.
- **`docs/src/dev/provider/gremlin-semantics.asciidoc`** (dateDiff()): updates the Description to state the same direction and sign meaning, and replaces the ambiguous "The first result returned from the traversal will be subtracted with the incoming traverser" wording with an explicit "result = incoming DATETIME - argument" formulation for both the `value` and `dateTraversal` arguments.

This is a documentation-only clarification; the behavior is unchanged and was verified against `DateDiffStep` (`Duration.between(argument, incoming)`). The docs build renders both sections cleanly.