### PR TITLE
Add server-start prerequisite to Connecting via Console section

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -732,8 +732,19 @@ and details in the <<gremlin-drivers-variants,Gremlin Drivers and Variants>> Sec
 [[connecting-via-console]]
 === Connecting via Console
 
-Gremlin Console can be used to send remote traversals to a running Gremlin Server. Start Gremlin Console as
-follows:
+Gremlin Console can be used to send remote traversals to a running Gremlin Server, so a compatible server must be
+started first. The examples in this section query the "modern" toy graph (i.e. vertices such as "marko", "vadas" and
+"lop"), which is served by the `conf/gremlin-server-modern.yaml` configuration that is packaged with the Gremlin Server
+distribution. Start Gremlin Server with that configuration as described in <<starting-gremlin-server,Starting Gremlin
+Server>>:
+
+[source,text]
+bin/gremlin-server.sh conf/gremlin-server-modern.yaml
+
+NOTE: Starting Gremlin Server with a different configuration (such as the default) serves a different or empty graph, in
+which case the traversals shown below will not return the results demonstrated here.
+
+With the server running, start Gremlin Console as follows:
 
 [source,text]
 ----


### PR DESCRIPTION
The `Connecting via Console` section of the reference docs shows Gremlin traversals against the modern toy graph (`marko`, `vadas`, `lop`, ...), but it never tells the reader that a compatible Gremlin Server has to be running first, nor which configuration to use. A newcomer who follows the section as written—or who starts the server with the default configuration—gets an empty or incompatible graph, so every traversal shown returns nothing with no explanation.

This adds a short prerequisite before the console instructions:

- Start Gremlin Server with `conf/gremlin-server-modern.yaml`, with a cross-link to the existing *Starting Gremlin Server* section.
- A NOTE clarifying that a different (or the default) configuration serves a different or empty graph, so the examples would not return the results shown.

The existing properties-file, `DriverRemoteConnection`, and client examples are unchanged; only the prerequisite was added. The docs were rendered locally (full live build) and the new content appears correctly in the Connecting via Console section.