### PR TITLE
Scope Considering Transactions docs section to Gremlin Server

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -2042,7 +2042,7 @@ above with the use of the `maximumSize`.
 [[considering-transactions]]
 ==== Considering Transactions
 
-Every traversal executes within a transaction. TinkerPop distinguishes between two modes:
+Every traversal sent to Gremlin Server executes within a transaction. There are two transactional modes to distinguish from each other:
 
 * *Implicit transactions* are the default. Each traversal submitted through `g` is a self-contained unit of work. All
 graphs participate in implicit transactions. When the graph supports explicit transactions, implicit transactions are


### PR DESCRIPTION
The `Considering Transactions` section in the reference docs lives within the Gremlin Server documentation, where each request is wrapped in its own transaction and auto-committed on success.

Its intro sentence framed transactions in general terms ("Every traversal executes within a transaction. TinkerPop distinguishes between two modes:"), which made the section's per-request auto-commit statements — for example, that a bare `g.addV('person')` is persisted on success without an explicit `commit()` — read as applying to every execution context. That is not accurate for embedded/console use of a transactional graph such as `TinkerTransactionGraph`, where the transaction stays open and a `rollback()` discards the change; auto-commit-on-success applies to remote Gremlin Server submissions.

This rewords only the section's first sentence to scope it to traversals sent to Gremlin Server:

> Every traversal sent to Gremlin Server executes within a transaction. There are two transactional modes to distinguish from each other:

Since the section already sits within the Gremlin Server docs, framing the traversals as server-submitted makes the existing statements correct. No other content is changed.