### PR TITLE
TINKERPOP-3271 `subgraph()` throws a descriptive error for non-Edge input

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 [[release-3-7-7]]
 === TinkerPop 3.7.7 (Release Date: NOT OFFICIALLY RELEASED YET)
 
+* Fixed `subgraph()` to throw a descriptive error identifying the required `Edge` input instead of an internal `ClassCastException` when the traversal produces a non-edge value.
 * Fixed `PeerPressure.property_name` in `gremlin-python` incorrectly mapping to the `pageRank` property name token.
 * Added `NextN(n)` to `Traversal` in `gremlin-go` for batched result iteration, providing API parity with `next(n)` in the Java, Python, and .NET GLVs.
 * Added `next(n)` to `Traversal` in `gremlin-javascript` for batched result iteration, providing API parity with `next(n)` in the Java, Python, and .NET GLVs.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphStep.java
@@ -78,7 +78,15 @@ public final class SubgraphStep extends SideEffectStep<Edge> implements SideEffe
 
         subgraphSupportsMetaProperties = subgraph.features().vertex().supportsMetaProperties();
 
-        addEdgeToSubgraph(traverser.get());
+        // subgraph() produces an edge-induced subgraph and therefore requires Edge input. if the traverser value is
+        // not an Edge we throw a descriptive error.
+        final Object value = traverser.get();
+        if (!(value instanceof Edge))
+            throw new IllegalStateException(String.format(
+                    "subgraph() requires Edge input but encountered %s; use an edge step such as outE(), inE(), or bothE()",
+                    null == value ? "null" : value.getClass().getSimpleName()));
+
+        addEdgeToSubgraph((Edge) value);
     }
 
     @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
@@ -26,7 +26,6 @@ import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,7 +40,6 @@ import static org.apache.tinkerpop.gremlin.structure.Graph.Features.ElementFeatu
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -55,10 +53,6 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, String> get_g_V_withSideEffectXsgX_repeatXbothEXcreatedX_subgraphXsgX_outVX_timesX5X_name_dedup(final Graph subgraph);
 
     public abstract Traversal<Vertex, Vertex> get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(final Graph subgraph);
-
-    public abstract Traversal<?, ?> get_g_injectX1X_subgraphXsgX();
-
-    public abstract Traversal<Vertex, Edge> get_g_addVX_subgraphXsgX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -134,33 +128,6 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         graphProvider.clear(subgraph, config);
     }
 
-    @Test
-    public void g_injectX1X_subgraphXsgX() {
-        final Traversal<?, ?> traversal = get_g_injectX1X_subgraphXsgX();
-        printTraversalForm(traversal);
-        try {
-            traversal.iterate();
-            fail("subgraph() should throw an IllegalStateException when the input is not an Edge");
-        } catch (IllegalStateException ise) {
-            assertThat(ise.getMessage(), containsString("requires Edge input"));
-            assertThat(ise.getMessage(), containsString("Integer"));
-        }
-    }
-
-    @Test
-    @LoadGraphWith(MODERN)
-    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = FEATURE_ADD_VERTICES)
-    public void g_addVX_subgraphXsgX() {
-        final Traversal<Vertex, Edge> traversal = get_g_addVX_subgraphXsgX();
-        printTraversalForm(traversal);
-        try {
-            traversal.iterate();
-            fail("subgraph() should throw an IllegalStateException when the input is not an Edge");
-        } catch (IllegalStateException ise) {
-            assertThat(ise.getMessage(), containsString("requires Edge input"));
-        }
-    }
-
     public static class Traversals extends SubgraphTest {
 
         @Override
@@ -176,16 +143,6 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(final Graph subgraph) {
             return g.withSideEffect("sg", () -> subgraph).V().has("name","daniel").outE().subgraph("sg").inV();
-        }
-
-        @Override
-        public Traversal<?, ?> get_g_injectX1X_subgraphXsgX() {
-            return g.inject(1).subgraph("sg");
-        }
-
-        @Override
-        public Traversal<Vertex, Edge> get_g_addVX_subgraphXsgX() {
-            return g.addV().subgraph("sg");
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +41,7 @@ import static org.apache.tinkerpop.gremlin.structure.Graph.Features.ElementFeatu
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -53,6 +55,10 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, String> get_g_V_withSideEffectXsgX_repeatXbothEXcreatedX_subgraphXsgX_outVX_timesX5X_name_dedup(final Graph subgraph);
 
     public abstract Traversal<Vertex, Vertex> get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(final Graph subgraph);
+
+    public abstract Traversal<?, ?> get_g_injectX1X_subgraphXsgX();
+
+    public abstract Traversal<Vertex, Edge> get_g_addVX_subgraphXsgX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -128,6 +134,33 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         graphProvider.clear(subgraph, config);
     }
 
+    @Test
+    public void g_injectX1X_subgraphXsgX() {
+        final Traversal<?, ?> traversal = get_g_injectX1X_subgraphXsgX();
+        printTraversalForm(traversal);
+        try {
+            traversal.iterate();
+            fail("subgraph() should throw an IllegalStateException when the input is not an Edge");
+        } catch (IllegalStateException ise) {
+            assertThat(ise.getMessage(), containsString("requires Edge input"));
+            assertThat(ise.getMessage(), containsString("Integer"));
+        }
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = FEATURE_ADD_VERTICES)
+    public void g_addVX_subgraphXsgX() {
+        final Traversal<Vertex, Edge> traversal = get_g_addVX_subgraphXsgX();
+        printTraversalForm(traversal);
+        try {
+            traversal.iterate();
+            fail("subgraph() should throw an IllegalStateException when the input is not an Edge");
+        } catch (IllegalStateException ise) {
+            assertThat(ise.getMessage(), containsString("requires Edge input"));
+        }
+    }
+
     public static class Traversals extends SubgraphTest {
 
         @Override
@@ -143,6 +176,16 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(final Graph subgraph) {
             return g.withSideEffect("sg", () -> subgraph).V().has("name","daniel").outE().subgraph("sg").inV();
+        }
+
+        @Override
+        public Traversal<?, ?> get_g_injectX1X_subgraphXsgX() {
+            return g.inject(1).subgraph("sg");
+        }
+
+        @Override
+        public Traversal<Vertex, Edge> get_g_addVX_subgraphXsgX() {
+            return g.addV().subgraph("sg");
         }
     }
 }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphSubgraphStepTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphSubgraphStepTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.step.sideEffect;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.fail;
+
+/**
+ * Verifies {@code subgraph()} throws a descriptive {@link IllegalStateException} for non-{@code Edge} input.
+ */
+public class TinkerGraphSubgraphStepTest {
+
+    @Test
+    public void shouldThrowDescriptiveExceptionWhenSubgraphReceivesNonEdgePrimitiveInput() throws Exception {
+        try (final TinkerGraph graph = TinkerGraph.open()) {
+            final GraphTraversalSource g = graph.traversal();
+            try {
+                g.inject(1).subgraph("sg").iterate();
+                fail("subgraph() should throw an IllegalStateException when the input is not an Edge");
+            } catch (IllegalStateException ise) {
+                assertThat(ise.getMessage(), containsString("requires Edge input"));
+                assertThat(ise.getMessage(), containsString("Integer"));
+            }
+        }
+    }
+
+    @Test
+    public void shouldThrowDescriptiveExceptionWhenSubgraphReceivesVertexInput() throws Exception {
+        try (final TinkerGraph graph = TinkerGraph.open()) {
+            final GraphTraversalSource g = graph.traversal();
+            try {
+                g.addV().subgraph("sg").iterate();
+                fail("subgraph() should throw an IllegalStateException when the input is not an Edge");
+            } catch (IllegalStateException ise) {
+                assertThat(ise.getMessage(), containsString("requires Edge input"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`subgraph()` produces an edge-induced subgraph and must be called at an edge step.
When the traversal instead feeds it a non-Edge value, `SubgraphStep` passed that
value straight into an `Edge`-typed method, producing a raw `ClassCastException`
with no indication of what went wrong.

This change validates the traverser value at runtime and throws a descriptive
`IllegalStateException` naming the required `Edge` input, consistent with the
existing pattern in `AddPropertyStep` and `AddEdgeStep`. Valid queries are
unaffected; only the failure message for already-invalid queries changes.

This is a backward-compatible diagnostics fix (runtime validation only, no API or
generics change).

## Before vs After

### Non-edge (primitive) input
```groovy
g.inject(1).subgraph('sg').cap('sg').iterate()
```
- Before: `ClassCastException: class java.lang.Integer cannot be cast to class ...Edge`
- After: `IllegalStateException: subgraph() requires Edge input but encountered Integer; use an edge step such as outE(), inE(), or bothE()`

### Vertex input
```groovy
g.addV().subgraph('sg').cap('sg').iterate()
```
- Before: `ClassCastException: class ...TinkerVertex cannot be cast to class ...Edge`
- After: `IllegalStateException: subgraph() requires Edge input but encountered TinkerVertex; use an edge step such as outE(), inE(), or bothE()`

### Correct usage (unchanged)
```groovy
g.V().has('v',1).outE('X').subgraph('sg').cap('sg')  // edges in -> builds subgraph
```
- Before and after: works identically

## Changes
- `gremlin-core`: runtime `Edge` validation in `SubgraphStep.sideEffect(...)`
- `gremlin-test`: two negative tests added to the `SubgraphTest` suite
- `CHANGELOG.asciidoc`: entry under 3.7.7


Assisted-by: Kiro: Claude Opus 4.8