### PR TITLE
Clarify GraphSON id-type behavior in TinkerGraph configuration docs

### DIFF
--- a/docs/src/reference/implementations-tinkergraph.asciidoc
+++ b/docs/src/reference/implementations-tinkergraph.asciidoc
@@ -197,10 +197,27 @@ If the TinkerGraph is configured for persistence with `gremlin.tinkergraph.graph
 format when `Graph.close()` is called.  In addition, if these settings are present, TinkerGraph will attempt to
 load the graph from the specified location.
 
-IMPORTANT: If choosing `graphson` as the `gremlin.tinkergraph.graphFormat`, be sure to also establish the  various
-`IdManager` settings as well to ensure that identifiers are properly coerced to the appropriate types as GraphSON
-can lose the identifier's type during serialization (i.e. it will assume `Integer` when the default for TinkerGraph
-is `Long`, which could lead to load errors that result in a message like, "Vertex with id already exists").
+IMPORTANT: If choosing `graphson` as the `gremlin.tinkergraph.graphFormat` with untyped GraphSON, be sure to also
+establish the various `IdManager` settings to ensure that identifiers are properly coerced to the appropriate types,
+as untyped GraphSON can lose the identifier's type during serialization (i.e. it will assume `Integer` when the
+default for TinkerGraph is `Long`, which could lead to load errors that result in a message like, "Vertex with id
+already exists"). Typed GraphSON preserves the identifier's type across the serialization round-trip (for example, a
+`Long` identifier is written as `{"@type":"g:Int64","@value":...}`), so the `IdManager` coercion above is not
+required in that case.
+
+These settings can be supplied programmatically by building a `Configuration` and passing it to `TinkerGraph.open()`.
+For example, to persist to disk as GraphSON while keeping `Long` identifiers:
+
+[source,java]
+----
+BaseConfiguration conf = new BaseConfiguration();
+conf.setProperty("gremlin.tinkergraph.graphLocation", "/tmp/tinkergraph.json");
+conf.setProperty("gremlin.tinkergraph.graphFormat", "graphson");
+conf.setProperty("gremlin.tinkergraph.vertexIdManager", "LONG");
+Graph graph = TinkerGraph.open(conf);
+// ... work with the graph ...
+graph.close(); // persists the graph to the configured graphLocation
+----
 
 It is important to consider the data being imported to TinkerGraph with respect to `defaultVertexPropertyCardinality`
 setting.  For example, if a `.gryo` file is known to contain multi-property data, be sure to set the default


### PR DESCRIPTION
The IMPORTANT admonition about IdManager coercion applied broadly to graphson, but typed GraphSON preserves identifier types across the serialization round-trip (e.g. Long as g:Int64), so the coercion is only needed for untyped GraphSON. Rescope the note accordingly and add a short Java example that builds a Configuration and opens a TinkerGraph with it.

Assisted-by: Kiro:claude-opus-4.8

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->