### PR TITLE
Clarify that difference() and intersect() return a Set

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1790,8 +1790,9 @@ link:++https://tinkerpop.apache.org/docs/x.y.z/dev/provider/#dedup-step++[`Seman
 === Difference Step
 
 The `difference()`-step (*map*) calculates the difference between the incoming list traverser and the provided list
-argument. More specifically, this provides the set operation A-B where A is the traverser and B is the argument. This
-step only expects list data (array or Iterable) and will throw an `IllegalArgumentException` if any other type is
+argument. More specifically, this provides the set operation A-B where A is the traverser and B is the argument. The
+result is returned as a `Set`, so element order is not preserved and duplicates are removed. This step only expects
+list data (array or Iterable) as input and will throw an `IllegalArgumentException` if any other type is
 encountered (including `null`).
 
 [gremlin-groovy,modern]
@@ -2528,7 +2529,8 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 === Intersect Step
 
 The `intersect()`-step (*map*) calculates the intersection between the incoming list traverser and the provided list
-argument. This step only expects list data (array or Iterable) and will throw an `IllegalArgumentException` if any other
+argument. The result is returned as a `Set`, so element order is not preserved and duplicates are removed. This step
+only expects list data (array or Iterable) as input and will throw an `IllegalArgumentException` if any other
 type is encountered (including `null`).
 
 [gremlin-groovy,modern]


### PR DESCRIPTION
The reference documentation for the difference()- and intersect()-steps described their result as a list, but both steps return a Set: element order is not preserved and duplicate elements are removed. Both sections now state this while keeping the existing description of the A-B and intersection semantics, the array/Iterable input expectation, and the IllegalArgumentException thrown for other input types (including null).
