### PR TITLE
Preserve float type in DotNetTranslator

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/DotNetTranslator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/translator/DotNetTranslator.java
@@ -197,6 +197,10 @@ public final class DotNetTranslator implements Translator.ScriptTranslator {
                     return (o instanceof Float ? "Single" : "Double") + ".PositiveInfinity";
                 if (NumberHelper.isNegativeInfinity(o))
                     return (o instanceof Float ? "Single" : "Double") + ".NegativeInfinity";
+                // a bare decimal literal is a double in C#, so a float needs an explicit suffix to
+                // preserve its type through translation
+                if (o instanceof Float)
+                    return o + "f";
             }
             return o.toString();
         }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/DotNetTranslatorTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/translator/DotNetTranslatorTest.java
@@ -113,6 +113,16 @@ public class DotNetTranslatorTest {
     }
 
     @Test
+    public void shouldTranslateFloatingPointLiterals() {
+        // a float needs an explicit suffix so it is not read back as a double, while a double
+        // is the default type for a bare decimal literal in C# and needs no suffix
+        assertEquals("g.Inject(0.5f)",
+                translator.translate(g.inject(0.5f).asAdmin().getBytecode()).getScript());
+        assertEquals("g.Inject(0.5)",
+                translator.translate(g.inject(0.5d).asAdmin().getBytecode()).getScript());
+    }
+
+    @Test
     public void shouldTranslateGroup() {
         final String script = translator.translate(g.V().group("x").group().by("name").asAdmin().getBytecode()).getScript();
         assertEquals("g.V().Group(\"x\").Group<object,object>().By(\"name\")", script);

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/GherkinTestRunner.cs
@@ -49,8 +49,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             {
                 // Add here the name of scenarios to ignore and the reason, e.g.:
                 {"g_withStrategiesXProductiveByStrategyX_V_group_byXageX", IgnoreReason.NullKeysInMapNotSupported},
-                {"g_withStrategiesXProductiveByStrategyX_V_groupCount_byXageX", IgnoreReason.NullKeysInMapNotSupported},
-                {"g_injectXpoint5fX", IgnoreReason.FloatLiteralTypeNotPreserved}
+                {"g_withStrategiesXProductiveByStrategyX_V_groupCount_byXageX", IgnoreReason.NullKeysInMapNotSupported}
             };
 
         private static class Keywords

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
@@ -1540,7 +1540,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
                {"g_injectX1_3lX_injectX100_300X", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(1,3).Inject(100,300)}}, 
                {"g_injectXbigintBoundaryValuesX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(p["xx1"],p["xx2"],p["xx3"])}}, 
                {"g_injectXpoint5X", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(0.5)}}, 
-               {"g_injectXpoint5fX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(0.5)}}, 
+               {"g_injectXpoint5fX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(0.5f)}}, 
                {"g_injectXpoint5dX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(0.5)}}, 
                {"g_injectX1to5X", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(new List<object> {1, 2, 3, 4, 5})}}, 
                {"g_injectXaTocX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(new List<object> {"a", "b", "c"})}}, 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/IgnoreException.cs
@@ -60,12 +60,6 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
         /// <summary>
         /// The GLV suite does not test against a graph that has null property values enabled.
         /// </summary>
-        NullPropertyValuesNotSupportedOnTestGraph,
-
-        /// <summary>
-        /// The translator does not preserve the numeric type of a float literal, so a value such as
-        /// <c>.5f</c> is emitted as a bare <c>0.5</c> and read back as a <c>double</c> rather than a <c>float</c>.
-        /// </summary>
-        FloatLiteralTypeNotPreserved
+        NullPropertyValuesNotSupportedOnTestGraph
     }
 }


### PR DESCRIPTION
`DotNetTranslator` emitted a Java Float as a bare 0.5, which C# reads as a double. Now it emits 0.5f so the type round-trips.

This re-enables the `g_injectXpoint5fX` .NET Gherkin scenario, previously ignored (`FloatLiteralTypeNotPreserved`).