### PR TITLE
Fix incorrect step name in PropertyMap reference docs

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -4477,7 +4477,7 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 [[propertymap-step]]
 === PropertyMap Step
 
-The `propertiesMap()`-step yields a Map representation of the properties of an element.
+The `propertyMap()`-step yields a Map representation of the properties of an element.
 
 [gremlin-groovy,modern]
 ----


### PR DESCRIPTION
The prose in the PropertyMap section of `docs/src/reference/the-traversal.asciidoc` referred to the step as `propertiesMap()`, but the actual step is `propertyMap()` (no "s"). The section's executable examples already use the correct `propertyMap()`, so only the prose was wrong.

This is worth correcting because the wrong name fails silently rather than loudly. In Groovy, `propertiesMap()` does not raise an error; it resolves to a lookup for a property key that does not exist and returns empty results. A newcomer copying the name from the prose therefore gets empty output with no error and no indication of what went wrong.

The fix changes a single line of prose to `propertyMap()` so it matches the runnable examples directly below it. The examples remain the standard executable `[gremlin-groovy,modern]` blocks, so their output is rendered at build time (including the empty `==>[]` maps for vertices without the requested property, which illustrates the behavior clearly).