### PR TITLE
Clarify group()-step callouts for non-productive key vs value projection

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2256,8 +2256,8 @@ g.V().group().by('age').by('name') <1>
 g.V().group().by('name').by('age') <2>
 ----
 
-<1> The "age" property is not <<by-step,productive>> for all vertices and therefore those keys are filtered.
-<2> The "age" property is not <<by-step,productive>> for all vertices and therefore those values are filtered.
+<1> The "age" property is not <<by-step,productive>> for all vertices, so those vertices are excluded from the result map entirely (no key is produced for them). Compare with the following example, where a non-productive value-projection instead retains the key with an empty list.
+<2> The "age" property is not <<by-step,productive>> for all vertices; those vertices still appear as keys (since "name" is productive for all) but their value lists are empty because no age value exists to collect.
 
 
 *Additional References*


### PR DESCRIPTION
The two `group()`-step examples in `reference/the-traversal.asciidoc` that project `age` first as a key and then as a value were annotated with symmetric callouts, both saying the non-productive entries are "filtered". Their runtime behavior is actually asymmetric:

- A non-productive **key**-projection (`by('age').by('name')`) drops the vertex from the result map entirely — no key is produced for vertices lacking an `age` value.
- A non-productive **value**-projection (`by('name').by('age')`) keeps the key (since `name` is productive for every vertex) but leaves its value list empty, e.g. `ripple=[]`, `lop=[]`.

The old symmetric wording made the `{ripple:[], lop:[]}` output surprising. This change rewrites callout `<2>` to explain that keys are retained with empty value lists, and updates callout `<1>` to state the entry is dropped entirely, drawing an explicit contrast between the two cases. The `productive` cross-reference is preserved.

Only the two callouts changed; the example code lines are untouched and still render their live output at build time, which confirms the reworded prose matches what the reader sees.