### PR TITLE
Add runnable count(local) examples to the Count Step docs

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1311,8 +1311,23 @@ g.V().hasLabel('person').outE('created').count().map {it.get() * 10}.path() <2>
 <1> `count()`-step is a <<a-note-on-barrier-steps,reducing barrier step>> meaning that all of the previous traversers are folded into a new traverser.
 <2> The path of the traverser emanating from `count()` starts at `count()`.
 
-IMPORTANT: `count(local)` counts the current, local object (not the objects in the traversal stream). This works for
-`Collection`- and `Map`-type objects. For any other object, a count of 1 is returned.
+The `count(local)`-step counts the current, local object rather than the objects in the traversal stream. The
+value it returns depends on the type of that object: for a `Collection` it returns the number of elements, for a
+`Map` it returns the number of entries, and for a <<path-data-structure,`Path`>> it returns the number of objects
+in the path. For any other object, a count of `1` is returned.
+
+[gremlin-groovy,modern]
+----
+g.V().fold().count(local)               <1>
+g.V().group().by(label).count(local)    <2>
+g.V(1).out().path().count(local)        <3>
+g.V(1).count(local)                     <4>
+----
+
+<1> <<fold-step,`fold()`>> gathers all vertices into a single `Collection`, so `count(local)` returns the number of elements in that list.
+<2> <<group-step,`group()`>> produces a `Map` keyed by vertex label, so `count(local)` returns the number of entries in the map (one per distinct label).
+<3> <<path-step,`path()`>> emits a `Path` for each traverser, so `count(local)` returns the number of objects contained in each path.
+<4> A single vertex is neither a `Collection`, a `Map`, nor a `Path`, so `count(local)` returns `1`.
 
 *Additional References*
 


### PR DESCRIPTION
The `count(local)` behavior in the Count Step section of the reference documentation was described only in an `IMPORTANT` prose callout, with no executable examples. The callout also omitted the `Path` case: it stated that a count of `1` is returned "for any other object," but `CountLocalStep` returns the path length for a `Path`.

This change:

- Removes the prose-only callout and repurposes its content as explanatory prose that correctly covers all object kinds the step handles: `Collection` (number of elements), `Map` (number of entries), `Path` (number of objects in the path), and any other object (`1`).
- Adds a runnable example block against the modern graph so the per-object-kind counts render as live output at build time and are self-verifying:
  - `g.V().fold().count(local)` → `6` (Collection)
  - `g.V().group().by(label).count(local)` → `2` (Map)
  - `g.V(1).out().path().count(local)` → `2, 2, 2` (Path)
  - `g.V(1).count(local)` → `1` (any other object)
- Cross-links the examples to `fold()`, `group()`, `path()`, and the path data structure so a reader can follow the behavior in context.

The reference book builds and the count-step section reads coherently with the rendered live output matching the documented counts.