### PR TITLE
Explain properties()-step stream transformation and meta-properties

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3767,14 +3767,30 @@ g.V().hasLabel('person').
 [[properties-step]]
 === Properties Step
 
-The `properties()`-step (*map*) extracts properties from an `Element` in the traversal stream.
+The `properties()`-step (*map*) extracts properties from an `Element` in the traversal stream. Unlike
+`values()`, which emits the raw property values, `properties()` transforms the stream so that it contains
+`VertexProperty` elements rather than the original `Vertex` elements. A `VertexProperty` is itself an
+`Element`, which means it can carry its own properties — called meta-properties (see
+<<vertex-properties,vertex properties>>) — and can therefore be traversed further with steps like `has()`
+and `valueMap()`. The examples below use the <<the-crew-toy-graph,"TinkerPop Crew">> toy graph, whose
+vertex `1` (marko) has a multi-valued `location` property whose values carry `startTime` and `endTime`
+meta-properties.
 
 [gremlin-groovy,theCrew]
 ----
-g.V(1).properties()
-g.V(1).properties('location').valueMap()
-g.V(1).properties('location').has('endTime').valueMap()
+g.V(1).properties()                                      <1>
+g.V(1).properties('location').valueMap()                 <2>
+g.V(1).properties('location').has('endTime').valueMap()  <3>
 ----
+
+<1> With no arguments, `properties()` emits a `VertexProperty` for every property on vertex `1`.
+<2> Supplying the `location` key emits one `VertexProperty` per value, so the stream now holds four
+`VertexProperty` elements. Because those elements are the `location` vertex properties themselves,
+`valueMap()` returns the meta-properties (`startTime` and `endTime`) of each one — four rows — rather than
+the vertex's own properties.
+<3> Since the elements in the stream are `VertexProperty` objects, `has('endTime')` filters on their
+meta-properties: only the three `location` values that carry an `endTime` meta-property pass, so
+`valueMap()` reports three rows.
 
 *Additional References*
 


### PR DESCRIPTION
The `properties()`-step section in the reference documentation lists three examples run against The Crew graph, but the surrounding prose only states that `properties()` "extracts properties from an `Element`". It never explains two things a reader needs in order to predict the output:

1. `properties()` changes the traversal stream so that it contains `VertexProperty` elements rather than the original `Vertex` elements.
2. A `VertexProperty` is itself an `Element`, so it can carry its own properties — meta-properties — which is why `has('endTime')` and `valueMap()` applied after `properties('location')` filter and read the meta-properties of each vertex property, not the vertex's own properties.

Without this, it is not obvious why `g.V(1).properties('location').valueMap()` returns four rows of `startTime`/`endTime` maps and why adding `has('endTime')` reduces that to three.

This change:

- Expands the intro prose to describe the `Vertex` -> `VertexProperty` stream transformation and the meta-property concept.
- Cross-references the existing vertex-properties and The Crew toy-graph sections rather than duplicating them.
- Adds callouts to the three examples so the four-rows-to-three-rows filtering is explained alongside the live output.

The examples remain executable (`[gremlin-groovy,theCrew]`), so the rendered output stays self-verifying. Built the reference book locally and confirmed the section renders coherently: `properties('location').valueMap()` shows four rows and `properties('location').has('endTime').valueMap()` shows three.

Scoped to the `properties()`-step section; no neighboring steps were touched.