### PR TITLE
Added Java driver tests for coverage

### DIFF
--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ConnectionOptionsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ConnectionOptionsTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -227,5 +228,19 @@ public class ConnectionOptionsTest {
     @Test(expected = IllegalArgumentException.class)
     public void shouldRejectUrlWhenContactPointsAlreadyAdded() {
         Cluster.build().addContactPoints("host1", "host2").url("http://localhost:8182/gremlin");
+    }
+
+    @Test
+    public void shouldRejectUnparseableUrl() {
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> Cluster.build().url("http://not a valid uri"));
+        assertEquals("Invalid url: http://not a valid uri", ex.getMessage());
+    }
+
+    @Test
+    public void shouldRejectUrlWithoutHost() {
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> Cluster.build().url("http:///gremlin"));
+        assertEquals("Invalid url, no host could be parsed from: http:///gremlin", ex.getMessage());
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ConnectionPoolTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ConnectionPoolTest.java
@@ -28,13 +28,21 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ConnectionPoolTest {
@@ -95,5 +103,68 @@ public class ConnectionPoolTest {
 
         assertNotNull(conn00);
         assertEquals(2, connectionsCreated.get());
+    }
+
+    private static Cluster mockCluster() {
+        final Cluster cluster = mock(Cluster.class);
+        when(cluster.connectionPoolSettings()).thenReturn(new Settings.ConnectionPoolSettings());
+        when(cluster.connectionScheduler()).thenReturn(new ScheduledThreadPoolExecutor(2,
+                new BasicThreadFactory.Builder().namingPattern("gremlin-driver-conn-scheduler-%d").build()));
+        return cluster;
+    }
+
+    private static Connection mockConnection() {
+        final Connection conn = mock(Connection.class);
+        when(conn.isBorrowed()).thenReturn(new AtomicBoolean(false));
+        when(conn.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        return conn;
+    }
+
+    private static ConnectionPool poolWith(final Connection conn) {
+        final ConnectionFactory factory = mock(ConnectionFactory.class);
+        when(factory.create(any(ConnectionPool.class))).thenReturn(conn);
+        return new ConnectionPool(mock(Host.class), new Client.ClusteredClient(mockCluster()), Optional.of(2), factory);
+    }
+
+    @Test
+    public void shouldThrowWhenReturningConnectionToClosedPool() throws Exception {
+        final Connection conn = mockConnection();
+        final ConnectionPool pool = poolWith(conn);
+        final Connection borrowed = pool.borrowConnection(100, TimeUnit.MILLISECONDS);
+
+        pool.closeAsync();
+
+        final ConnectionException ex = assertThrows(ConnectionException.class,
+                () -> pool.returnConnection(borrowed));
+        assertTrue(ex.getMessage().contains("Pool is shutdown"));
+    }
+
+    @Test
+    public void shouldReturnSameFutureAndCloseConnectionsOnRepeatedCloseAsync() throws Exception {
+        final Connection conn = mockConnection();
+        final ConnectionPool pool = poolWith(conn);
+        pool.borrowConnection(100, TimeUnit.MILLISECONDS); // ensure a connection exists in the pool
+
+        final CompletableFuture<Void> f1 = pool.closeAsync();
+        final CompletableFuture<Void> f2 = pool.closeAsync();
+
+        assertSame("closeAsync must be idempotent and return the same future", f1, f2);
+        assertTrue(pool.isClosed());
+        verify(conn, atLeastOnce()).closeAsync();
+    }
+
+    @Test
+    public void shouldDestroyConnectionRemovingItFromBinAndClosingIt() throws Exception {
+        final ConnectionPool pool = poolWith(mockConnection());
+
+        final Connection victim = mockConnection();
+        when(victim.isClosing()).thenReturn(false);
+        when(victim.isDead()).thenReturn(false);
+
+        pool.destroyConnection(victim);
+
+        // a non-borrowed, non-closing connection is closed for good and removed from the cleanup bin
+        verify(victim).closeAsync();
+        assertEquals(0, pool.numConnectionsWaitingToCleanup());
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/HostTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/HostTest.java
@@ -46,4 +46,12 @@ public class HostTest {
         assertEquals("http://localhost:8183/argh", webSocketUri.toString());
     }
 
+
+    @Test
+    public void shouldConstructHostWithHttpsSchemeWhenSslEnabled() {
+        final InetSocketAddress addy = new InetSocketAddress("localhost", 8182);
+        final Host host = new Host(addy, Cluster.build().enableSsl(true).create());
+        final URI webSocketUri = host.getHostUri();
+        assertEquals("https://localhost:8182/gremlin", webSocketUri.toString());
+    }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/LoadBalancingStrategyTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/LoadBalancingStrategyTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link LoadBalancingStrategy.RoundRobin}. The {@code select} method ignores its
+ * {@code RequestMessage} argument, so {@code null} is passed throughout.
+ */
+public class LoadBalancingStrategyTest {
+
+    private static Host availableHost() {
+        final Host host = mock(Host.class);
+        when(host.isAvailable()).thenReturn(true);
+        return host;
+    }
+
+    private static Host unavailableHost() {
+        final Host host = mock(Host.class);
+        when(host.isAvailable()).thenReturn(false);
+        return host;
+    }
+
+    private static List<Host> drain(final Iterator<Host> itr) {
+        final List<Host> hosts = new ArrayList<>();
+        itr.forEachRemaining(hosts::add);
+        return hosts;
+    }
+
+    /**
+     * Forces the internal {@code index} counter to a known value so the index-related branches of
+     * {@code select} (overflow reset and negative-modulo correction) can be exercised deterministically.
+     */
+    private static void setIndex(final LoadBalancingStrategy.RoundRobin strategy, final int value) throws Exception {
+        final Field field = LoadBalancingStrategy.RoundRobin.class.getDeclaredField("index");
+        field.setAccessible(true);
+        ((AtomicInteger) field.get(strategy)).set(value);
+    }
+
+    private static int getIndex(final LoadBalancingStrategy.RoundRobin strategy) throws Exception {
+        final Field field = LoadBalancingStrategy.RoundRobin.class.getDeclaredField("index");
+        field.setAccessible(true);
+        return ((AtomicInteger) field.get(strategy)).get();
+    }
+
+    @Test
+    public void shouldSelectEachAvailableHostExactlyOncePerIterator() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        final Host h2 = availableHost();
+        final Host h3 = availableHost();
+        strategy.onNew(h1);
+        strategy.onNew(h2);
+        strategy.onNew(h3);
+
+        final List<Host> selected = drain(strategy.select(null));
+
+        assertEquals(3, selected.size());
+        assertTrue(selected.containsAll(Arrays.asList(h1, h2, h3)));
+        // each host appears exactly once
+        assertEquals(1, selected.stream().filter(h -> h == h1).count());
+        assertEquals(1, selected.stream().filter(h -> h == h2).count());
+        assertEquals(1, selected.stream().filter(h -> h == h3).count());
+    }
+
+    @Test
+    public void shouldSkipUnavailableHosts() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host up1 = availableHost();
+        final Host down = unavailableHost();
+        final Host up2 = availableHost();
+        strategy.onNew(up1);
+        strategy.onNew(down);
+        strategy.onNew(up2);
+
+        final List<Host> selected = drain(strategy.select(null));
+
+        assertEquals(2, selected.size());
+        assertTrue(selected.contains(up1));
+        assertTrue(selected.contains(up2));
+        assertFalse(selected.contains(down));
+    }
+
+    @Test
+    public void shouldReturnEmptyIteratorWhenNoHostsAreAvailable() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        strategy.onNew(unavailableHost());
+        strategy.onNew(unavailableHost());
+
+        final Iterator<Host> itr = strategy.select(null);
+
+        assertFalse(itr.hasNext());
+        assertEquals(0, drain(itr).size());
+    }
+
+    @Test
+    public void shouldAdvanceStartingHostOnConsecutiveSelects() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        final Host h2 = availableHost();
+        final Host h3 = availableHost();
+        strategy.onNew(h1);
+        strategy.onNew(h2);
+        strategy.onNew(h3);
+
+        // The starting point rotates by one on each select, so the first host returned should differ
+        // across consecutive calls and cycle through the full set.
+        final Host first1 = strategy.select(null).next();
+        final Host first2 = strategy.select(null).next();
+        final Host first3 = strategy.select(null).next();
+
+        assertEquals(3, new java.util.HashSet<>(Arrays.asList(first1, first2, first3)).size());
+    }
+
+    @Test
+    public void shouldReflectHostAddedAndRemovedViaCallbacks() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        final Host h2 = availableHost();
+        strategy.onNew(h1);
+        strategy.onNew(h2);
+
+        assertTrue(drain(strategy.select(null)).contains(h1));
+
+        // onRemove delegates to onUnavailable which drops the host from the pool
+        strategy.onRemove(h1);
+        final List<Host> afterRemove = drain(strategy.select(null));
+        assertFalse(afterRemove.contains(h1));
+        assertTrue(afterRemove.contains(h2));
+        assertEquals(1, afterRemove.size());
+
+        // onNew delegates to onAvailable which adds a fresh host
+        final Host h3 = availableHost();
+        strategy.onNew(h3);
+        final List<Host> afterAdd = drain(strategy.select(null));
+        assertTrue(afterAdd.contains(h3));
+        assertTrue(afterAdd.contains(h2));
+        assertEquals(2, afterAdd.size());
+    }
+
+    @Test
+    public void shouldNotAddDuplicateHostOnRepeatedCallbacks() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        // addIfAbsent semantics: adding the same host twice should not duplicate it
+        strategy.onNew(h1);
+        strategy.onAvailable(h1);
+
+        final List<Host> selected = drain(strategy.select(null));
+        assertEquals(1, selected.size());
+        assertTrue(selected.contains(h1));
+    }
+
+    @Test
+    public void shouldToggleHostViaAvailabilityCallbacks() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        final Host h2 = availableHost();
+        strategy.onAvailable(h1);
+        strategy.onAvailable(h2);
+        assertEquals(2, drain(strategy.select(null)).size());
+
+        strategy.onUnavailable(h2);
+        final List<Host> selected = drain(strategy.select(null));
+        assertEquals(1, selected.size());
+        assertTrue(selected.contains(h1));
+        assertFalse(selected.contains(h2));
+    }
+
+    @Test
+    public void shouldInitializeWithSeededHostsAndSelectThemAll() {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        final Host h2 = availableHost();
+        strategy.initialize(null, Arrays.asList(h1, h2));
+
+        final List<Host> selected = drain(strategy.select(null));
+        assertEquals(2, selected.size());
+        assertTrue(selected.containsAll(Arrays.asList(h1, h2)));
+    }
+
+    @Test
+    public void shouldInitializeWithEmptyHostsWithoutError() {
+        // initialize uses Math.max(hosts.size(), 1) to seed the index, so an empty collection must not fail
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        strategy.initialize(null, new ArrayList<>());
+
+        assertFalse(strategy.select(null).hasNext());
+    }
+
+    @Test
+    public void shouldResetIndexWhenApproachingIntegerMaxValue() throws Exception {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        final Host h2 = availableHost();
+        final Host h3 = availableHost();
+        strategy.onNew(h1);
+        strategy.onNew(h2);
+        strategy.onNew(h3);
+
+        // Just above the reset threshold (Integer.MAX_VALUE - 10000) so select() resets the counter to 0.
+        setIndex(strategy, Integer.MAX_VALUE - 5000);
+
+        drain(strategy.select(null));
+
+        // the discriminating behavior: the counter was reset as part of the overflow guard
+        assertEquals(0, getIndex(strategy));
+    }
+
+    @Test
+    public void shouldCorrectNegativeModuloWhenIndexIsNegative() throws Exception {
+        final LoadBalancingStrategy.RoundRobin strategy = new LoadBalancingStrategy.RoundRobin();
+        final Host h1 = availableHost();
+        final Host h2 = availableHost();
+        final Host h3 = availableHost();
+        strategy.onNew(h1);
+        strategy.onNew(h2);
+        strategy.onNew(h3);
+
+        // A negative starting index drives the (c < 0) correction branch in the returned iterator.
+        setIndex(strategy, -3);
+
+        final List<Host> selected = drain(strategy.select(null));
+
+        // -3, -2, -1 modulo three (after correction) map to 0, 1, 2 - every host exactly once
+        assertEquals(3, selected.size());
+        assertTrue(selected.containsAll(Arrays.asList(h1, h2, h3)));
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultTest.java
@@ -29,6 +29,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -149,5 +152,34 @@ public class ResultTest {
 
         assertEquals(p, result.getPath());
         assertEquals(p, result.get(Path.class));
+    }
+
+
+    @Test
+    public void shouldBeNullWhenWrappingNull() {
+        final Result result = new Result(null);
+
+        assertTrue(result.isNull());
+    }
+
+    @Test
+    public void shouldNotBeNullWhenWrappingNonNull() {
+        final Result result = new Result("not null");
+
+        assertFalse(result.isNull());
+    }
+
+    @Test
+    public void shouldToStringForNonNull() {
+        final Result result = new Result("string");
+
+        assertEquals("result{object=string class=java.lang.String}", result.toString());
+    }
+
+    @Test
+    public void shouldToStringForNull() {
+        final Result result = new Result(null);
+
+        assertEquals("result{object=null class=null}", result.toString());
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/AuthTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/auth/AuthTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.auth;
+
+import org.apache.tinkerpop.gremlin.driver.Settings;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link Auth} factory dispatch. {@link Auth#from(Settings.AuthSettings)} selects the concrete
+ * interceptor implementation from the configured {@code type}, so this verifies each supported type maps to the
+ * right implementation and that an unrecognized type is rejected with a clear message.
+ */
+public class AuthTest {
+
+    @Test
+    public void shouldCreateBasicAuthFromSettings() {
+        final Settings.AuthSettings settings = new Settings.AuthSettings();
+        settings.type = Auth.AUTH_BASIC;
+        settings.username = "user";
+        settings.password = "secret";
+        assertTrue(Auth.from(settings) instanceof Basic);
+    }
+
+    @Test
+    public void shouldCreateSigv4AuthFromSettings() {
+        final Settings.AuthSettings settings = new Settings.AuthSettings();
+        settings.type = Auth.AUTH_SIGV4;
+        settings.region = "us-east-1";
+        settings.serviceName = "neptune-db";
+        assertTrue(Auth.from(settings) instanceof Sigv4);
+    }
+
+    @Test
+    public void shouldThrowForUnknownAuthType() {
+        final Settings.AuthSettings settings = new Settings.AuthSettings();
+        settings.type = "bogus";
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Auth.from(settings));
+        org.junit.Assert.assertEquals("Unknown auth type: bogus", ex.getMessage());
+    }
+
+    @Test
+    public void shouldThrowForDefaultEmptyAuthType() {
+        // AuthSettings.type defaults to the empty string, which is not a recognized type
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> Auth.from(new Settings.AuthSettings()));
+        org.junit.Assert.assertEquals("Unknown auth type: ", ex.getMessage());
+    }
+
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/ByteBufQueueInputStreamTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/ByteBufQueueInputStreamTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -142,5 +143,91 @@ public class ByteBufQueueInputStreamTest {
 
         assertEquals(0, buf1.refCnt());
         assertEquals(0, buf2.refCnt());
+    }
+
+    @Test
+    public void shouldReleaseLateBufferOfferedAfterClose() throws Exception {
+        // A chunk that arrives after the stream is closed must be released immediately so it does not leak, and
+        // must not be enqueued for reading.
+        final ByteBufQueueInputStream stream = new ByteBufQueueInputStream();
+        stream.close();
+
+        final ByteBuf late = ByteBufAllocator.DEFAULT.buffer(2);
+        late.writeBytes(new byte[]{1, 2});
+        assertEquals(1, late.refCnt());
+
+        stream.offer(late);
+
+        assertEquals("late buffer should have been released", 0, late.refCnt());
+        assertEquals("stream is closed so nothing is readable", -1, stream.read());
+    }
+
+    @Test
+    public void shouldIgnoreAlreadyReleasedBufferOfferedAfterClose() throws Exception {
+        // Offering an already-released buffer after close must not attempt a double-release.
+        final ByteBufQueueInputStream stream = new ByteBufQueueInputStream();
+        stream.close();
+
+        final ByteBuf released = ByteBufAllocator.DEFAULT.buffer(1);
+        released.release();
+        assertEquals(0, released.refCnt());
+
+        stream.offer(released); // refCnt == 0 branch: the guard skips the release so no double-release is attempted
+        // Assert real behavior instead of the tautological refCnt == 0: the buffer was not enqueued, so a closed
+        // stream still reports end-of-stream. The double-release guard is verified implicitly - removing it would
+        // make offer() call release() on an already-released buffer and throw IllegalReferenceCountException.
+        assertEquals(-1, stream.read());
+    }
+
+    @Test(timeout = 5000)
+    public void shouldReturnZeroForZeroLengthRead() throws Exception {
+        // Nothing is ever offered, so the queue is empty. A zero-length read must short-circuit via
+        // "if (len == 0) return 0;" and return immediately. If that short-circuit were removed, the read would
+        // block waiting on the empty queue and the timeout would fail the test.
+        final ByteBufQueueInputStream stream = new ByteBufQueueInputStream();
+
+        assertEquals(0, stream.read(new byte[4], 0, 0));
+    }
+
+    @Test
+    public void shouldReturnMinusOneOnReadsAfterEndOfStream() throws Exception {
+        final ByteBufQueueInputStream stream = new ByteBufQueueInputStream();
+        stream.offer(Unpooled.wrappedBuffer(new byte[]{5}));
+        stream.signalEndOfStream();
+
+        assertEquals(5, stream.read());
+        assertEquals(-1, stream.read()); // reaches END_OF_STREAM, sets eof
+        // subsequent reads short-circuit on the eof guard
+        assertEquals(-1, stream.read());
+        assertEquals(-1, stream.read(new byte[4], 0, 4));
+    }
+
+    @Test(timeout = 10000)
+    public void shouldThrowIOExceptionAndPreserveInterruptWhenReaderInterrupted() throws Exception {
+        final ByteBufQueueInputStream stream = new ByteBufQueueInputStream(0L);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final AtomicBoolean interruptPreserved = new AtomicBoolean(false);
+        final CountDownLatch started = new CountDownLatch(1);
+
+        final Thread reader = new Thread(() -> {
+            started.countDown();
+            try {
+                stream.read();
+            } catch (Throwable t) {
+                failure.set(t);
+                interruptPreserved.set(Thread.currentThread().isInterrupted());
+            }
+        });
+        reader.start();
+
+        assertTrue(started.await(1, TimeUnit.SECONDS));
+        Thread.sleep(200); // let the reader block in queue.take()
+        reader.interrupt();
+        reader.join(5000);
+
+        assertFalse("reader should have unblocked after interrupt", reader.isAlive());
+        assertTrue("expected an IOException", failure.get() instanceof IOException);
+        assertEquals("Interrupted while waiting for data", failure.get().getMessage());
+        assertTrue("interrupt status should be restored", interruptPreserved.get());
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/GremlinResponseHandlerTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/GremlinResponseHandlerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.handler;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.tinkerpop.gremlin.driver.Result;
+import org.apache.tinkerpop.gremlin.driver.ResultSet;
+import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
+import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.tinkerpop.gremlin.driver.Channelizer.HttpChannelizer.LAST_CONTENT_READ_RESPONSE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Drives {@link GremlinResponseHandler#channelRead0} directly through an {@link EmbeddedChannel}, asserting the real
+ * effects the handler has on the pending {@link ResultSet} for each status/branch, without a live server.
+ */
+public class GremlinResponseHandlerTest {
+
+    private ExecutorService executor;
+
+    @Before
+    public void setup() {
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void teardown() {
+        executor.shutdownNow();
+    }
+
+    private ResultSet newResultSet() {
+        return new ResultSet(executor, RequestMessage.build("g.V()").create(), null);
+    }
+
+    private EmbeddedChannel newChannel(final AtomicReference<ResultSet> pending, final Runnable onComplete,
+                                       final boolean streaming) {
+        return new EmbeddedChannel(new GremlinResponseHandler(pending, onComplete, streaming));
+    }
+
+    /**
+     * A bulked response lays data out as [obj, bulk, obj, bulk, ...] and must be unrolled into
+     * {@link DefaultRemoteTraverser}-backed results that carry the reported bulk.
+     */
+    @Test
+    public void shouldUnrollBulkedResultsHonoringBulk() {
+        final ResultSet rs = newResultSet();
+        final AtomicReference<ResultSet> pending = new AtomicReference<>(rs);
+        final EmbeddedChannel channel = newChannel(pending, () -> {}, false);
+        channel.attr(HttpGremlinResponseStreamDecoder.IS_BULKED).set(true);
+
+        final ResponseMessage msg = ResponseMessage.build().code(HttpResponseStatus.OK)
+                .result(Arrays.asList("x", 2L, "y", 3L)).create();
+        channel.writeInbound(msg);
+
+        // two (value,bulk) pairs collapse into two results
+        assertEquals(2, rs.getAvailableItemCount());
+
+        final Result first = rs.one();
+        assertTrue(first.getObject() instanceof DefaultRemoteTraverser);
+        final DefaultRemoteTraverser<?> firstTraverser = (DefaultRemoteTraverser<?>) first.getObject();
+        assertEquals("x", firstTraverser.get());
+        assertEquals(2L, firstTraverser.bulk());
+
+        final Result second = rs.one();
+        assertTrue(second.getObject() instanceof DefaultRemoteTraverser);
+        final DefaultRemoteTraverser<?> secondTraverser = (DefaultRemoteTraverser<?>) second.getObject();
+        assertEquals("y", secondTraverser.get());
+        assertEquals(3L, secondTraverser.bulk());
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * An error status is buffered until end-of-stream; the following LAST_CONTENT signal marks the
+     * {@link ResultSet} with that error, clears the pending reference, and runs the completion callback.
+     */
+    @Test
+    public void shouldMarkErrorOnErrorStatusFollowedByLastContent() throws Exception {
+        final ResultSet rs = newResultSet();
+        final AtomicReference<ResultSet> pending = new AtomicReference<>(rs);
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final EmbeddedChannel channel = newChannel(pending, () -> completed.set(true), false);
+
+        final ResponseMessage error = ResponseMessage.build()
+                .code(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                .statusMessage("boom").create();
+        channel.writeInbound(error);
+
+        // the error is only buffered until all content is read - nothing should be finalized yet
+        assertFalse(completed.get());
+        assertFalse(rs.allItemsAvailable());
+        assertEquals(rs, pending.get());
+
+        channel.writeInbound(LAST_CONTENT_READ_RESPONSE);
+
+        assertTrue(completed.get());
+        assertNull(pending.get());
+
+        try {
+            rs.all().get(5, TimeUnit.SECONDS);
+            fail("Expected the ResultSet to complete exceptionally with the buffered error");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof ResponseException);
+            final ResponseException re = (ResponseException) e.getCause();
+            assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, re.getResponseStatusCode());
+            assertEquals("boom", re.getMessage());
+        }
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * An OK non-bulked response adds one {@link Result} per data item in order and does not complete the stream
+     * until the LAST_CONTENT signal arrives; that signal then completes the {@link ResultSet} cleanly, clears the
+     * pending reference, runs the completion callback, and preserves the data in order.
+     */
+    @Test
+    public void shouldAddResultsInOrderThenCompleteOnLastContent() throws Exception {
+        final ResultSet rs = newResultSet();
+        final AtomicReference<ResultSet> pending = new AtomicReference<>(rs);
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final EmbeddedChannel channel = newChannel(pending, () -> completed.set(true), false);
+        channel.attr(HttpGremlinResponseStreamDecoder.IS_BULKED).set(false);
+
+        // one Result per data item is added, but with no LAST_CONTENT yet the stream is not finished
+        channel.writeInbound(ResponseMessage.build().code(HttpResponseStatus.OK)
+                .result(Arrays.asList("a", "b", "c")).create());
+        assertEquals(3, rs.getAvailableItemCount());
+        assertFalse(completed.get());
+        assertFalse(rs.allItemsAvailable());
+
+        // the LAST_CONTENT signal completes the ResultSet, clears pending, runs the callback, and preserves order
+        channel.writeInbound(LAST_CONTENT_READ_RESPONSE);
+        assertTrue(completed.get());
+        assertNull(pending.get());
+        assertTrue(rs.allItemsAvailable());
+
+        final List<Result> all = rs.all().get(5, TimeUnit.SECONDS);
+        assertEquals(3, all.size());
+        assertEquals("a", all.get(0).getString());
+        assertEquals("b", all.get(1).getString());
+        assertEquals("c", all.get(2).getString());
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * A NO_CONTENT status is a "success with no results" and must not record an error. A subsequent
+     * LAST_CONTENT signal then completes the stream cleanly.
+     */
+    @Test
+    public void shouldNotRecordErrorOnNoContentStatus() throws Exception {
+        final ResultSet rs = newResultSet();
+        final AtomicReference<ResultSet> pending = new AtomicReference<>(rs);
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final EmbeddedChannel channel = newChannel(pending, () -> completed.set(true), false);
+
+        // a distinct NO_CONTENT message (not the LAST_CONTENT_READ_RESPONSE sentinel) must not buffer an error
+        channel.writeInbound(ResponseMessage.build().code(HttpResponseStatus.NO_CONTENT).create());
+        assertFalse(completed.get());
+
+        channel.writeInbound(LAST_CONTENT_READ_RESPONSE);
+
+        assertTrue(completed.get());
+        assertNull(pending.get());
+        assertTrue(rs.allItemsAvailable());
+
+        // completes normally with no results and no error
+        final List<Result> all = rs.all().get(5, TimeUnit.SECONDS);
+        assertTrue(all.isEmpty());
+
+        channel.finishAndReleaseAll();
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoderTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoderTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.handler;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.FullHttpRequest;
+import org.apache.tinkerpop.gremlin.driver.HttpRequest;
+import org.apache.tinkerpop.gremlin.driver.RequestInterceptor;
+import org.apache.tinkerpop.gremlin.driver.UserAgent;
+import org.apache.tinkerpop.gremlin.driver.auth.Auth;
+import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
+import org.apache.tinkerpop.gremlin.process.traversal.GremlinLang;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.ser.Serializers;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.SocketAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link HttpGremlinRequestEncoder} covering the request-rejection, header-population, transaction-id
+ * promotion, interceptor-failure and unconnected-channel branches. Uses {@link EmbeddedChannel} to push
+ * {@link RequestMessage} instances through the encoder and inspect the produced {@link FullHttpRequest}.
+ */
+public class HttpGremlinRequestEncoderTest {
+
+    private final MessageSerializer<?> serializer = Serializers.GRAPHBINARY_V4.simpleInstance();
+    private final URI uri = URI.create("http://localhost:8182/gremlin");
+
+    // A resolved loopback address so getRemoteAddress().getAddress().getHostAddress() works (createUnresolved would
+    // yield a null InetAddress).
+    private static final SocketAddress RESOLVED_REMOTE = new InetSocketAddress(InetAddress.getLoopbackAddress(), 8182);
+
+    // EmbeddedChannel's default remoteAddress is an EmbeddedSocketAddress which the encoder cannot cast to
+    // InetSocketAddress, so override remoteAddress0() to return exactly what the test needs (or null to simulate an
+    // unconnected channel).
+    private static EmbeddedChannel channelWith(final SocketAddress remote, final HttpGremlinRequestEncoder encoder) {
+        return new EmbeddedChannel(encoder) {
+            @Override
+            protected SocketAddress remoteAddress0() {
+                return remote;
+            }
+        };
+    }
+
+    private EmbeddedChannel connectedChannel(final HttpGremlinRequestEncoder encoder) {
+        return channelWith(RESOLVED_REMOTE, encoder);
+    }
+
+    private HttpGremlinRequestEncoder encoder(final List<RequestInterceptor> interceptors, final boolean userAgentEnabled,
+                                              final boolean bulkResults, final boolean compressionEnabled) {
+        return new HttpGremlinRequestEncoder(serializer, interceptors, userAgentEnabled, bulkResults, compressionEnabled, uri);
+    }
+
+    private static <T extends Throwable> T findCause(final Throwable thrown, final Class<T> type) {
+        for (Throwable t = thrown; t != null; t = t.getCause()) {
+            if (type.isInstance(t)) {
+                return type.cast(t);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * A {@link RequestMessage} whose {@code gremlin} field holds a {@link GremlinLang} instance cannot be sent over
+     * HTTP and must be rejected before any serialization occurs.
+     */
+    @Test
+    public void shouldRejectGremlinLangGremlinField() throws Exception {
+        final EmbeddedChannel channel = connectedChannel(encoder(Collections.emptyList(), false, false, false));
+        final RequestMessage request = RequestMessage.build("unused")
+                .add("gremlin", new GremlinLang())
+                .create();
+
+        final Throwable thrown = assertThrows(Throwable.class, () -> channel.writeOutbound(request));
+
+        final ResponseException cause = findCause(thrown, ResponseException.class);
+        assertNotNull("Expected a ResponseException in the cause chain of " + thrown, cause);
+        assertTrue("ResponseException message should mention GremlinLang: " + cause.getMessage(),
+                cause.getMessage().contains("GremlinLang"));
+    }
+
+    /**
+     * With user-agent, compression and bulk-results all enabled, the produced request must carry the HOST, ACCEPT,
+     * ACCEPT_ENCODING (deflate), USER_AGENT and bulk-results headers.
+     */
+    @Test
+    public void shouldPopulateOptionalHeadersWhenFlagsEnabled() throws Exception {
+        final EmbeddedChannel channel = connectedChannel(encoder(Collections.emptyList(), true, true, true));
+        final RequestMessage request = RequestMessage.build("g.V()").create();
+
+        assertTrue(channel.writeOutbound(request));
+        final FullHttpRequest produced = channel.readOutbound();
+        assertNotNull(produced);
+
+        assertNotNull("HOST header should be present", produced.headers().get(HttpRequest.Headers.HOST));
+        assertEquals(serializer.mimeTypesSupported()[0], produced.headers().get(HttpRequest.Headers.ACCEPT));
+        assertEquals(HttpRequest.Headers.DEFLATE, produced.headers().get(HttpRequest.Headers.ACCEPT_ENCODING));
+        assertEquals(UserAgent.USER_AGENT, produced.headers().get(HttpRequest.Headers.USER_AGENT));
+        assertEquals("true", produced.headers().get(Tokens.BULK_RESULTS));
+
+        produced.release();
+    }
+
+    /**
+     * With user-agent, compression and bulk-results all disabled, the corresponding optional headers must be absent
+     * while the mandatory HOST and ACCEPT headers remain.
+     */
+    @Test
+    public void shouldOmitOptionalHeadersWhenFlagsDisabled() throws Exception {
+        final EmbeddedChannel channel = connectedChannel(encoder(Collections.emptyList(), false, false, false));
+        final RequestMessage request = RequestMessage.build("g.V()").create();
+
+        assertTrue(channel.writeOutbound(request));
+        final FullHttpRequest produced = channel.readOutbound();
+        assertNotNull(produced);
+
+        assertNotNull("HOST header should be present", produced.headers().get(HttpRequest.Headers.HOST));
+        assertEquals(serializer.mimeTypesSupported()[0], produced.headers().get(HttpRequest.Headers.ACCEPT));
+        assertFalse("ACCEPT_ENCODING should be absent", produced.headers().contains(HttpRequest.Headers.ACCEPT_ENCODING));
+        assertFalse("USER_AGENT should be absent", produced.headers().contains(HttpRequest.Headers.USER_AGENT));
+        assertFalse("bulk-results header should be absent", produced.headers().contains(Tokens.BULK_RESULTS));
+
+        produced.release();
+    }
+
+    /**
+     * A transaction id carried in the request fields must be promoted to the {@code X-Transaction-Id} HTTP header.
+     */
+    @Test
+    public void shouldPromoteTransactionIdToHeader() throws Exception {
+        final EmbeddedChannel channel = connectedChannel(encoder(Collections.emptyList(), false, false, false));
+        final String transactionId = "d3b07384-d9a0-4c9b-8f4a-000000000001";
+        final RequestMessage request = RequestMessage.build("g.tx().commit()")
+                .add(Tokens.ARGS_TRANSACTION_ID, transactionId)
+                .create();
+
+        assertTrue(channel.writeOutbound(request));
+        final FullHttpRequest produced = channel.readOutbound();
+        assertNotNull(produced);
+
+        assertEquals(transactionId, produced.headers().get(Tokens.Headers.TRANSACTION_ID));
+
+        produced.release();
+    }
+
+    /**
+     * An interceptor that fails authentication must cause the encode to surface a {@link ResponseException} whose
+     * message identifies the failure as an authentication error.
+     */
+    @Test
+    public void shouldWrapAuthenticationExceptionAsResponseException() throws Exception {
+        final RequestInterceptor failingInterceptor = request -> {
+            throw new Auth.AuthenticationException(new IOException("bad credentials"));
+        };
+        final EmbeddedChannel channel = connectedChannel(
+                encoder(Collections.singletonList(failingInterceptor), false, false, false));
+        final RequestMessage request = RequestMessage.build("g.V()").create();
+
+        final Throwable thrown = assertThrows(Throwable.class, () -> channel.writeOutbound(request));
+
+        final ResponseException cause = findCause(thrown, ResponseException.class);
+        assertNotNull("Expected a ResponseException in the cause chain of " + thrown, cause);
+        assertTrue("ResponseException message should mention authentication: " + cause.getMessage(),
+                cause.getMessage().contains("authentication"));
+    }
+
+    /**
+     * When the channel is not connected (null remote address) and no inbound SSL exception is recorded, encoding must
+     * fail with a {@link RuntimeException} explaining that the channel is not connected.
+     */
+    @Test
+    public void shouldFailWhenChannelNotConnected() {
+        // remoteAddress0() returns null to simulate an unconnected channel.
+        final EmbeddedChannel channel = channelWith(null, encoder(Collections.emptyList(), false, false, false));
+        final RequestMessage request = RequestMessage.build("g.V()").create();
+
+        final Throwable thrown = assertThrows(Throwable.class, () -> channel.writeOutbound(request));
+
+        final RuntimeException cause = findCause(thrown, RuntimeException.class);
+        assertNotNull("Expected a RuntimeException in the cause chain of " + thrown, cause);
+        assertTrue("Message should mention that the channel is not connected: " + cause.getMessage(),
+                cause.getMessage().contains("not connected"));
+    }
+
+    /**
+     * When the channel is not connected because of a recorded inbound SSL exception, encoding must fail with a
+     * {@link RuntimeException} that attributes the failure to the ssl error.
+     */
+    @Test
+    public void shouldFailWithSslReasonWhenSslExceptionRecorded() {
+        final EmbeddedChannel channel = channelWith(null, encoder(Collections.emptyList(), false, false, false));
+        channel.attr(GremlinResponseHandler.INBOUND_SSL_EXCEPTION).set(new RuntimeException("handshake failed"));
+        final RequestMessage request = RequestMessage.build("g.V()").create();
+
+        final Throwable thrown = assertThrows(Throwable.class, () -> channel.writeOutbound(request));
+
+        final RuntimeException cause = findCause(thrown, RuntimeException.class);
+        assertNotNull("Expected a RuntimeException in the cause chain of " + thrown, cause);
+        assertTrue("Message should attribute the failure to an ssl error: " + cause.getMessage(),
+                cause.getMessage().contains("ssl"));
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoderTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinResponseDecoderTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.handler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.util.ser.SerTokens;
+import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
+import org.apache.tinkerpop.gremlin.util.ser.Serializers;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.apache.tinkerpop.gremlin.driver.Channelizer.HttpChannelizer.LAST_CONTENT_READ_RESPONSE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for {@link HttpGremlinResponseDecoder} exercising the error-status, content-type and error-handling
+ * branches that are not covered by the round-trip serialization path. Uses {@link EmbeddedChannel} to push
+ * {@link FullHttpResponse} instances directly through the decoder.
+ */
+public class HttpGremlinResponseDecoderTest {
+
+    private final MessageSerializer<?> serializer = Serializers.GRAPHBINARY_V4.simpleInstance();
+
+    /**
+     * Error status with a non-serializer content type is treated as a JSON error body. When a {@code message} field
+     * is present it should be surfaced as the status message.
+     */
+    @Test
+    public void shouldDecodeErrorResponseUsingJsonMessage() {
+        final EmbeddedChannel testChannel = initializeChannel();
+        final FullHttpResponse response = jsonResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                "{\"message\":\"something failed\"}");
+
+        testChannel.writeInbound(response);
+
+        final ResponseMessage decoded = testChannel.readInbound();
+        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, decoded.getStatus().getCode());
+        assertEquals("something failed", decoded.getStatus().getMessage());
+    }
+
+    /**
+     * Error status JSON body without a {@code message} field should fall back to the status reason phrase.
+     */
+    @Test
+    public void shouldFallBackToReasonPhraseWhenJsonHasNoMessage() {
+        final EmbeddedChannel testChannel = initializeChannel();
+        final FullHttpResponse response = jsonResponse(HttpResponseStatus.BAD_REQUEST, "{\"other\":\"value\"}");
+
+        testChannel.writeInbound(response);
+
+        final ResponseMessage decoded = testChannel.readInbound();
+        assertEquals(HttpResponseStatus.BAD_REQUEST, decoded.getStatus().getCode());
+        assertEquals(HttpResponseStatus.BAD_REQUEST.reasonPhrase(), decoded.getStatus().getMessage());
+    }
+
+    /**
+     * A present-but-empty {@code message} field should also fall back to the reason phrase (covers the
+     * {@code message.isEmpty()} branch of the ternary).
+     */
+    @Test
+    public void shouldFallBackToReasonPhraseWhenJsonMessageIsEmpty() {
+        final EmbeddedChannel testChannel = initializeChannel();
+        final FullHttpResponse response = jsonResponse(HttpResponseStatus.NOT_FOUND, "{\"message\":\"\"}");
+
+        testChannel.writeInbound(response);
+
+        final ResponseMessage decoded = testChannel.readInbound();
+        assertEquals(HttpResponseStatus.NOT_FOUND, decoded.getStatus().getCode());
+        assertEquals(HttpResponseStatus.NOT_FOUND.reasonPhrase(), decoded.getStatus().getMessage());
+    }
+
+    /**
+     * Even when the status is an error, if the content type matches the serializer's mime type the body must be
+     * deserialized as a binary response (the error footer carries the code), not parsed as JSON.
+     */
+    @Test
+    public void shouldDeserializeBinaryWhenErrorStatusHasSerializerContentType() throws SerializationException {
+        final EmbeddedChannel testChannel = initializeChannel();
+        final ResponseMessage errorResponse = ResponseMessage.build()
+                .code(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                .statusMessage("boom")
+                .result(Collections.emptyList())
+                .create();
+        final ByteBuf buffer = serializer.serializeResponseAsBinary(errorResponse, ByteBufAllocator.DEFAULT);
+        final HttpHeaders headers = new DefaultHttpHeaders().add(CONTENT_TYPE, SerTokens.MIME_GRAPHBINARY_V4);
+        final FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1,
+                HttpResponseStatus.INTERNAL_SERVER_ERROR, buffer, headers, new DefaultHttpHeaders());
+
+        testChannel.writeInbound(response);
+
+        final ResponseMessage decoded = testChannel.readInbound();
+        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, decoded.getStatus().getCode());
+        assertEquals("boom", decoded.getStatus().getMessage());
+    }
+
+    /**
+     * A malformed binary body (first byte lacking the required most-significant bit) causes the serializer to throw
+     * a {@link SerializationException}, which the decoder must wrap in a {@link RuntimeException}.
+     */
+    @Test
+    public void shouldWrapSerializationExceptionInRuntimeException() {
+        final EmbeddedChannel testChannel = initializeChannel();
+        // OK status routes to deserializeBinaryResponse; 0x00 has its MSB unset so GraphBinary rejects it.
+        final ByteBuf content = Unpooled.wrappedBuffer(new byte[]{0x00, 0x01, 0x02});
+        final FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK, content,
+                new DefaultHttpHeaders(), new DefaultHttpHeaders());
+
+        try {
+            testChannel.writeInbound(response);
+            fail("Expected an exception wrapping a SerializationException.");
+        } catch (Exception e) {
+            // The meaningful behavior is that the production code surfaces the underlying SerializationException;
+            // MessageToMessageDecoder wraps the decoder's failure in a DecoderException, so search the whole chain.
+            boolean sawSerialization = false;
+            for (Throwable t = e; t != null; t = t.getCause()) {
+                sawSerialization |= t instanceof SerializationException;
+            }
+            assertTrue("Expected a SerializationException in the cause chain of " + e, sawSerialization);
+        }
+    }
+
+    /**
+     * After a successful decode the decoder must emit the decoded {@link ResponseMessage} followed by the
+     * {@link org.apache.tinkerpop.gremlin.driver.Channelizer.HttpChannelizer#LAST_CONTENT_READ_RESPONSE} signal, and
+     * must record that bytes were read on the channel so the inactivity handler treats the connection as live.
+     */
+    @Test
+    public void shouldEmitLastContentSignalAndMarkBytesRead() throws SerializationException {
+        final EmbeddedChannel testChannel = initializeChannel();
+        final ResponseMessage ok = ResponseMessage.build()
+                .code(HttpResponseStatus.OK)
+                .result(Collections.singletonList("value"))
+                .create();
+        final ByteBuf buffer = serializer.serializeResponseAsBinary(ok, ByteBufAllocator.DEFAULT);
+        final FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK, buffer,
+                new DefaultHttpHeaders(), new DefaultHttpHeaders());
+
+        testChannel.writeInbound(response);
+
+        final ResponseMessage decoded = testChannel.readInbound();
+        assertEquals("value", decoded.getResult().getData().get(0));
+
+        final ResponseMessage lastContentSignal = testChannel.readInbound();
+        assertSame(LAST_CONTENT_READ_RESPONSE, lastContentSignal);
+
+        final Integer bytesRead = testChannel.attr(InactiveChannelHandler.BYTES_READ).get();
+        assertNotNull("BYTES_READ should be set so the connection is treated as active", bytesRead);
+        assertEquals(Integer.valueOf(0), bytesRead);
+    }
+
+    private EmbeddedChannel initializeChannel() {
+        return new EmbeddedChannel(new HttpGremlinResponseDecoder(serializer));
+    }
+
+    private FullHttpResponse jsonResponse(final HttpResponseStatus status, final String json) {
+        final ByteBuf content = Unpooled.copiedBuffer(json, CharsetUtil.UTF_8);
+        final HttpHeaders headers = new DefaultHttpHeaders().add(CONTENT_TYPE, SerTokens.MIME_JSON);
+        return new DefaultFullHttpResponse(HTTP_1_1, status, content, headers, new DefaultHttpHeaders());
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/HttpStreamingResponseHandlerTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/HttpStreamingResponseHandlerTest.java
@@ -239,6 +239,64 @@ public class HttpStreamingResponseHandlerTest {
         channel.finishAndReleaseAll();
     }
 
+    @Test
+    public void shouldFallBackToReasonPhraseForNonGraphBinaryErrorWithEmptyBody() throws Exception {
+        final ResultSet rs = new ResultSet(executor, RequestMessage.build("g.V()").create(), null);
+        final AtomicReference<ResultSet> pending = new AtomicReference<>(rs);
+        final EmbeddedChannel channel = createChannel(pending);
+
+        // Error status with a non-GraphBinary content type routes through handleNonGraphBinaryError().
+        final HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+        channel.writeInbound(response);
+
+        // Empty body, so no bytes are accumulated and the handler falls back to the status reason phrase.
+        channel.writeInbound(new DefaultLastHttpContent());
+
+        try {
+            rs.all().get();
+            fail("Expected exception");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof ResponseException);
+            final ResponseException re = (ResponseException) e.getCause();
+            assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, re.getResponseStatusCode());
+            assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase(), re.getMessage());
+        }
+
+        assertNull(pending.get());
+
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void shouldFallBackToReasonPhraseForNonGraphBinaryErrorWithMalformedJson() throws Exception {
+        final ResultSet rs = new ResultSet(executor, RequestMessage.build("g.V()").create(), null);
+        final AtomicReference<ResultSet> pending = new AtomicReference<>(rs);
+        final EmbeddedChannel channel = createChannel(pending);
+
+        final HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+        channel.writeInbound(response);
+
+        // Malformed JSON body, so parsing throws and the handler falls back to the status reason phrase.
+        final String malformed = "{not valid json";
+        channel.writeInbound(new DefaultLastHttpContent(Unpooled.copiedBuffer(malformed, CharsetUtil.UTF_8)));
+
+        try {
+            rs.all().get();
+            fail("Expected exception");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof ResponseException);
+            final ResponseException re = (ResponseException) e.getCause();
+            assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, re.getResponseStatusCode());
+            assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase(), re.getMessage());
+        }
+
+        assertNull(pending.get());
+
+        channel.finishAndReleaseAll();
+    }
+
     private byte[] toBytes(final io.netty.buffer.ByteBuf buf) {
         final byte[] bytes = new byte[buf.readableBytes()];
         buf.readBytes(bytes);

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/InputStreamBufferTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/handler/InputStreamBufferTest.java
@@ -23,6 +23,16 @@ import org.apache.tinkerpop.gremlin.driver.stream.ByteBufQueueInputStream;
 import org.apache.tinkerpop.gremlin.driver.stream.InputStreamBuffer;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static org.junit.Assert.*;
 
 public class InputStreamBufferTest {
@@ -90,5 +100,178 @@ public class InputStreamBufferTest {
     @Test(expected = UnsupportedOperationException.class)
     public void shouldThrowOnNioBuffer() {
         new InputStreamBuffer(new ByteBufQueueInputStream()).nioBuffer();
+    }
+
+    @Test
+    public void shouldRoundTripBoundaryPrimitiveValues() throws Exception {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        final DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeBoolean(false);
+        dos.writeByte(-1);
+        dos.writeShort(Short.MIN_VALUE);
+        dos.writeInt(Integer.MIN_VALUE);
+        dos.writeLong(Long.MAX_VALUE);
+        dos.writeFloat(Float.NaN);
+        dos.writeDouble(Double.NEGATIVE_INFINITY);
+
+        final InputStreamBuffer buffer = bufferOf(bos.toByteArray());
+        assertFalse(buffer.readBoolean());
+        assertEquals((byte) -1, buffer.readByte());
+        assertEquals(Short.MIN_VALUE, buffer.readShort());
+        assertEquals(Integer.MIN_VALUE, buffer.readInt());
+        assertEquals(Long.MAX_VALUE, buffer.readLong());
+        assertTrue(Float.isNaN(buffer.readFloat()));
+        assertEquals(Double.NEGATIVE_INFINITY, buffer.readDouble(), 0.0);
+        // 1 + 1 + 2 + 4 + 8 + 4 + 8 = 28 bytes consumed
+        assertEquals(28, buffer.readerIndex());
+    }
+
+    @Test
+    public void shouldReadBytesIntoArrayWithOffsetAndLength() {
+        final InputStreamBuffer buffer = bufferOf(new byte[]{10, 20, 30, 40});
+        final byte[] dest = new byte[6];
+        buffer.readBytes(dest, 1, 4);
+        assertArrayEquals(new byte[]{0, 10, 20, 30, 40, 0}, dest);
+        assertEquals(4, buffer.readerIndex());
+    }
+
+    @Test
+    public void shouldReadBytesIntoByteBuffer() {
+        final InputStreamBuffer buffer = bufferOf(new byte[]{1, 2, 3, 4});
+        final ByteBuffer dst = ByteBuffer.allocate(4);
+        buffer.readBytes(dst);
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, dst.array());
+        assertEquals(4, buffer.readerIndex());
+    }
+
+    @Test
+    public void shouldReadBytesIntoOutputStream() throws Exception {
+        final InputStreamBuffer buffer = bufferOf(new byte[]{5, 6, 7});
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        buffer.readBytes(out, 3);
+        assertArrayEquals(new byte[]{5, 6, 7}, out.toByteArray());
+        assertEquals(3, buffer.readerIndex());
+    }
+
+    @Test
+    public void shouldWrapIOExceptionFromUnderlyingStreamOnRead() {
+        final List<BufferOp> reads = Arrays.asList(
+                InputStreamBuffer::readBoolean,
+                InputStreamBuffer::readByte,
+                InputStreamBuffer::readShort,
+                InputStreamBuffer::readInt,
+                InputStreamBuffer::readLong,
+                InputStreamBuffer::readFloat,
+                InputStreamBuffer::readDouble,
+                b -> b.readBytes(new byte[1]),
+                b -> b.readBytes(new byte[1], 0, 1),
+                b -> b.readBytes(ByteBuffer.allocate(1)));
+
+        for (final BufferOp read : reads) {
+            // an empty stream forces DataInputStream to throw EOFException, which the class wraps
+            final InputStreamBuffer buffer = bufferOf(new byte[0]);
+            try {
+                read.apply(buffer);
+                fail("expected RuntimeException wrapping an IOException");
+            } catch (RuntimeException e) {
+                assertTrue("cause should be an IOException but was " + e.getCause(),
+                        e.getCause() instanceof IOException);
+            }
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void shouldPropagateIOExceptionFromReadBytesToOutputStream() throws Exception {
+        // this overload declares throws IOException, so the EOFException is not wrapped
+        bufferOf(new byte[0]).readBytes(new ByteArrayOutputStream(), 4);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowOnGetBytes() {
+        bufferOf(new byte[0]).getBytes(0, new byte[1]);
+    }
+
+    @Test
+    public void shouldNotBeDirect() {
+        assertFalse(bufferOf(new byte[0]).isDirect());
+    }
+
+    @Test
+    public void shouldThrowUnsupportedOnWriteAndRandomAccessOperations() {
+        final List<BufferOp> unsupported = Arrays.asList(
+                b -> b.writeBoolean(true),
+                b -> b.writeByte(1),
+                b -> b.writeShort(1),
+                b -> b.writeLong(1L),
+                b -> b.writeFloat(1f),
+                b -> b.writeDouble(1d),
+                b -> b.writeBytes(new byte[1]),
+                b -> b.writeBytes(ByteBuffer.allocate(1)),
+                b -> b.writeBytes(new byte[1], 0, 1),
+                InputStreamBuffer::writerIndex,
+                b -> b.writerIndex(0),
+                InputStreamBuffer::markWriterIndex,
+                InputStreamBuffer::resetWriterIndex,
+                b -> b.readerIndex(0),
+                InputStreamBuffer::capacity,
+                InputStreamBuffer::retain,
+                InputStreamBuffer::referenceCount,
+                InputStreamBuffer::nioBufferCount,
+                InputStreamBuffer::nioBuffers,
+                b -> b.nioBuffers(0, 1),
+                b -> b.nioBuffer(0, 1));
+
+        for (final BufferOp op : unsupported) {
+            final InputStreamBuffer buffer = bufferOf(new byte[0]);
+            try {
+                op.apply(buffer);
+                fail("expected UnsupportedOperationException");
+            } catch (UnsupportedOperationException expected) {
+                // expected
+            }
+        }
+    }
+
+    @Test
+    public void shouldReleaseAndCloseUnderlyingStream() {
+        final AtomicBoolean closed = new AtomicBoolean(false);
+        final InputStream in = new ByteArrayInputStream(new byte[]{1, 2, 3}) {
+            @Override
+            public void close() throws IOException {
+                closed.set(true);
+                super.close();
+            }
+        };
+
+        final InputStreamBuffer buffer = new InputStreamBuffer(in);
+        assertTrue(buffer.release());
+        assertTrue("underlying stream should be closed by release()", closed.get());
+    }
+
+    @Test
+    public void shouldReturnTrueFromReleaseEvenWhenCloseFails() {
+        final InputStream in = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException("close failure should be swallowed");
+            }
+        };
+
+        // release() performs a best-effort close and must still report success
+        assertTrue(new InputStreamBuffer(in).release());
+    }
+
+    private static InputStreamBuffer bufferOf(final byte[] bytes) {
+        return new InputStreamBuffer(new ByteArrayInputStream(bytes));
+    }
+
+    @FunctionalInterface
+    private interface BufferOp {
+        void apply(InputStreamBuffer buffer);
     }
 }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteConnectionTest.java
@@ -18,9 +18,13 @@
  */
 package org.apache.tinkerpop.gremlin.driver.remote;
 
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.RequestOptions;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
+import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.GremlinLang;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
@@ -33,9 +37,12 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.tinkerpop.gremlin.driver.RequestOptions.getRequestOptions;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -48,6 +55,14 @@ import static org.mockito.Mockito.when;
  */
 public class DriverRemoteConnectionTest {
     private static final GraphTraversalSource g = EmptyGraph.instance().traversal();
+
+    /**
+     * Builds a {@link Cluster} that never connects to a live server. Creation and {@code connect()}/{@code alias()}
+     * are lazy in the driver, so no I/O happens until a traversal is submitted.
+     */
+    private static Cluster newCluster() {
+        return Cluster.build("localhost").port(45940).create();
+    }
 
     @Test
     public void shouldBuildRequestOptions() {
@@ -70,6 +85,157 @@ public class DriverRemoteConnectionTest {
                   V().asAdmin().getGremlinLang());
         assertEquals(Integer.valueOf(100), options.getBatchSize().get());
         assertEquals(Long.valueOf(1000), options.getTimeoutMillis().get());
+    }
+
+    @Test
+    public void shouldConnectUsingClusterWithDefaultTraversalSource() throws Exception {
+        final Cluster cluster = newCluster();
+        try {
+            final DriverRemoteConnection connection = DriverRemoteConnection.using(cluster);
+            assertThat(connection.toString(), containsString("[graph=g]"));
+            // safe to close; leaves the caller-supplied cluster open (tryCloseCluster == false)
+            connection.close();
+            assertFalse(cluster.isClosed());
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void shouldConnectUsingClusterWithCustomTraversalSource() throws Exception {
+        final Cluster cluster = newCluster();
+        try {
+            final DriverRemoteConnection connection = DriverRemoteConnection.using(cluster, "gods");
+            assertThat(connection.toString(), containsString("[graph=gods]"));
+            connection.close();
+        } finally {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void shouldConnectUsingClientWithDefaultTraversalSource() throws Exception {
+        final Cluster cluster = newCluster();
+        try {
+            final Client client = cluster.connect();
+            final DriverRemoteConnection connection = DriverRemoteConnection.using(client);
+            assertThat(connection.toString(), containsString("[graph=g]"));
+            // close() is a no-op for the using(Client) path so the supplied client remains usable
+            connection.close();
+        } finally {
+            cluster.close();
+        }
+    }
+
+
+    @Test
+    public void shouldConnectUsingHostAndPort() throws Exception {
+        final DriverRemoteConnection connection = DriverRemoteConnection.using("localhost", 45940);
+        try {
+            assertThat(connection.toString(), containsString("[graph=g]"));
+        } finally {
+            // the underlying cluster is created internally; close it to avoid leaking resources
+            connection.client.getCluster().close();
+        }
+    }
+
+
+    @Test
+    public void shouldConstructFromConfigurationWithDefaults() throws Exception {
+        // No clusterFile and no clusterConfiguration => defaults to Cluster.open() (localhost) and source "g"
+        final Configuration conf = new BaseConfiguration();
+        final DriverRemoteConnection connection = new DriverRemoteConnection(conf);
+        try {
+            assertThat(connection.toString(), containsString("[graph=g]"));
+        } finally {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldConstructFromConfigurationWithSourceName() throws Exception {
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty(DriverRemoteConnection.GREMLIN_REMOTE_DRIVER_SOURCENAME, "gods");
+        final DriverRemoteConnection connection = new DriverRemoteConnection(conf);
+        try {
+            assertThat(connection.toString(), containsString("[graph=gods]"));
+        } finally {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldConstructFromConfigurationWithClusterConfiguration() throws Exception {
+        // 'clusterConfiguration' subset is passed to Cluster.open(Configuration); hosts is required
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty("clusterConfiguration.hosts", "localhost");
+        conf.setProperty("clusterConfiguration.port", 45940);
+        conf.setProperty(DriverRemoteConnection.GREMLIN_REMOTE_DRIVER_SOURCENAME, "gods");
+        final DriverRemoteConnection connection = new DriverRemoteConnection(conf);
+        try {
+            assertThat(connection.toString(), containsString("[graph=gods]"));
+        } finally {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldThrowOnConfigurationWithBothClusterFileAndClusterConfiguration() {
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty(DriverRemoteConnection.GREMLIN_REMOTE_DRIVER_CLUSTERFILE, "conf/remote-objects.yaml");
+        conf.setProperty("clusterConfiguration.hosts", "localhost");
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> new DriverRemoteConnection(conf));
+        assertThat(ex.getMessage(), containsString("should not contain both"));
+    }
+
+    @Test
+    public void shouldConstructFromClusterAndConfiguration() throws Exception {
+        // package-private constructor used for testing: reads sourceName and 'attachment' from the configuration
+        final Cluster cluster = newCluster();
+        try {
+            final Configuration conf = new BaseConfiguration();
+            conf.setProperty(DriverRemoteConnection.GREMLIN_REMOTE_DRIVER_SOURCENAME, "gods");
+            conf.setProperty(RemoteConnection.GREMLIN_REMOTE + "attachment", true);
+            final DriverRemoteConnection connection = new DriverRemoteConnection(cluster, conf);
+            assertThat(connection.toString(), containsString("[graph=gods]"));
+            // tryCloseCluster is false for this constructor, so the supplied cluster stays open
+            connection.close();
+            assertFalse(cluster.isClosed());
+        } finally {
+            cluster.close();
+        }
+    }
+
+
+    @Test
+    public void shouldThrowOnUsingConfigurationWithBothClusterFileAndClusterConfiguration() {
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty("clusterConfigurationFile", "conf/remote-objects.yaml");
+        conf.setProperty("clusterConfiguration", "localhost");
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> DriverRemoteConnection.using(conf));
+        assertEquals("A configuration should not contain both 'clusterConfigurationFile' and 'clusterConfiguration'",
+                ex.getMessage());
+    }
+
+    @Test
+    public void shouldThrowOnUsingConfigurationWithNeitherClusterFileNorClusterConfiguration() {
+        final Configuration conf = new BaseConfiguration();
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> DriverRemoteConnection.using(conf));
+        assertEquals("A configuration must contain either 'clusterConfigurationFile' and 'clusterConfiguration'",
+                ex.getMessage());
+    }
+
+    @Test
+    public void shouldThrowOnUsingNonExistentClusterConfigurationFile() {
+        // Cluster.open(file) finds no file on disk, then tries the classpath; getResource returns null for a truly
+        // missing file, so resource.getFile() throws NPE. using(String, String) wraps that as IllegalStateException.
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> DriverRemoteConnection.using("this-file-does-not-exist.yaml", "g"));
+        assertTrue("expected the underlying NullPointerException as the wrapped cause",
+                ex.getCause() instanceof NullPointerException);
     }
 
     @Test

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/DriverRemoteTraversalTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.remote;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.Result;
+import org.apache.tinkerpop.gremlin.driver.ResultSet;
+import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.apache.tinkerpop.gremlin.process.remote.RemoteConnection.GREMLIN_REMOTE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DriverRemoteTraversal} covering the {@code next()}/{@code hasNext()} bulk-unrolling logic and
+ * the {@link DriverRemoteTraversal.AttachingTraverserIterator} attachment path. These exercise the traversal's result
+ * iteration directly (backed by a mocked {@link ResultSet}) without a live server.
+ */
+public class DriverRemoteTraversalTest {
+
+    private static <E> DriverRemoteTraversal<?, E> traversalOf(final List<Result> results, final boolean attach,
+                                                               final Optional<Configuration> conf) {
+        final ResultSet rs = mock(ResultSet.class);
+        when(rs.iterator()).thenReturn(results.iterator());
+        return new DriverRemoteTraversal<>(rs, mock(Client.class), attach, conf);
+    }
+
+    @Test
+    public void shouldUnrollBulkedTraverserAcrossNextAndHasNext() {
+        // a single traverser with bulk 3 should yield the same value three times via next()/hasNext()
+        final Result r = new Result(new DefaultRemoteTraverser<>("a", 3L));
+        final DriverRemoteTraversal<?, String> t = traversalOf(Arrays.asList(r), false, Optional.empty());
+
+        final List<String> out = new ArrayList<>();
+        while (t.hasNext()) out.add(t.next());
+
+        assertEquals(Arrays.asList("a", "a", "a"), out);
+        assertFalse(t.hasNext());
+    }
+
+    @Test
+    public void shouldWrapRawResultsAsSingleBulkTraversers() {
+        // non-RemoteTraverser results are wrapped as bulk-1 traversers by the TraverserIterator
+        final DriverRemoteTraversal<?, String> t = traversalOf(
+                Arrays.asList(new Result("x"), new Result("y")), false, Optional.empty());
+
+        assertTrue(t.hasNext());
+        assertEquals("x", t.next());
+        assertEquals("y", t.next());
+        assertFalse(t.hasNext());
+    }
+
+    @Test
+    public void shouldAttachDetachedElementsToConfiguredGraph() {
+        final TinkerGraph graph = TinkerGraph.open();
+        final Vertex hostVertex = graph.addVertex(T.id, 1, T.label, "person");
+        final DetachedVertex detached = DetachedFactory.detach(hostVertex, true);
+
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty(GREMLIN_REMOTE + "attachment", (Supplier<Graph>) () -> graph);
+
+        final DriverRemoteTraversal<?, Vertex> t = traversalOf(
+                Arrays.asList(new Result(new DefaultRemoteTraverser<>(detached, 1L))), true, Optional.of(conf));
+
+        final Vertex attached = t.next();
+        // the detached vertex is attached to the host graph, resolving to the real host vertex
+        assertEquals(hostVertex, attached);
+        assertEquals(hostVertex.id(), attached.id());
+    }
+
+    @Test
+    public void shouldPassThroughNonAttachableResultsWhenAttaching() {
+        final TinkerGraph graph = TinkerGraph.open();
+        final Configuration conf = new BaseConfiguration();
+        conf.setProperty(GREMLIN_REMOTE + "attachment", (Supplier<Graph>) () -> graph);
+
+        final DriverRemoteTraversal<?, String> t = traversalOf(
+                Arrays.asList(new Result("plain")), true, Optional.of(conf));
+
+        assertEquals("plain", t.next());
+    }
+
+    @Test
+    public void shouldThrowWhenAttachRequestedWithoutConfiguration() {
+        final ResultSet rs = mock(ResultSet.class);
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> new DriverRemoteTraversal<>(rs, mock(Client.class), true, Optional.empty()));
+        assertEquals("Traverser can't be reattached for testing", ex.getMessage());
+    }
+}

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/HttpRemoteTransactionTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/remote/HttpRemoteTransactionTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.remote;
+
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.Host;
+import org.apache.tinkerpop.gremlin.driver.RequestOptions;
+import org.apache.tinkerpop.gremlin.driver.Result;
+import org.apache.tinkerpop.gremlin.driver.ResultSet;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link HttpRemoteTransaction} covering its observable lifecycle behavior with a mocked
+ * {@link Client.PinnedClient}. These exercise the client-side state machine (begin/commit/rollback/close and their
+ * idempotency and error semantics) without a live server. The one behavior that cannot be observed here - that the
+ * server actually persists or discards work - is covered by the {@code gremlin-server} integration tests.
+ */
+public class HttpRemoteTransactionTest {
+
+    private static final String BEGIN = "g.tx().begin()";
+    private static final String COMMIT = "g.tx().commit()";
+    private static final String ROLLBACK = "g.tx().rollback()";
+
+    private Client.PinnedClient client;
+    private Cluster cluster;
+
+    @Before
+    public void setUp() {
+        client = mock(Client.PinnedClient.class);
+        cluster = mock(Cluster.class);
+        final Host host = mock(Host.class);
+
+        // Constructor reads the pinned host and cluster from the client; cleanUp() closes the client view.
+        when(client.getPinnedHost()).thenReturn(host);
+        when(client.getCluster()).thenReturn(cluster);
+        when(client.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+
+        // begin() sends BEGIN and reads the server-assigned id from the first result; every other script (commit,
+        // rollback, user submits) resolves to an empty, already-completed result set.
+        when(client.submit(anyString(), any(RequestOptions.class))).thenAnswer(inv -> {
+            final String gremlin = inv.getArgument(0);
+            return BEGIN.equals(gremlin) ? beginResultSet("tx-42") : emptyResultSet();
+        });
+    }
+
+    /**
+     * A result set whose header and body futures are already complete and whose body is empty. Mirrors what the
+     * server returns for commit/rollback and lets {@code submitInternal()} (which blocks on {@code
+     * headersReceivedAsync()} and {@code all()}) return without a real network round trip.
+     */
+    private static ResultSet emptyResultSet() {
+        final ResultSet rs = mock(ResultSet.class);
+        when(rs.headersReceivedAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        when(rs.all()).thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+        return rs;
+    }
+
+    /**
+     * A begin() response carrying a single result map with the given {@code transactionId}, matching how
+     * {@link HttpRemoteTransaction} extracts the id the server assigns.
+     */
+    @SuppressWarnings("unchecked")
+    private static ResultSet beginResultSet(final String transactionId) {
+        final Result result = mock(Result.class);
+        when(result.get(Map.class)).thenReturn(Collections.singletonMap("transactionId", transactionId));
+        final ResultSet rs = mock(ResultSet.class);
+        when(rs.headersReceivedAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        when(rs.all()).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(result)));
+        return rs;
+    }
+
+    private HttpRemoteTransaction newTransaction() {
+        return new HttpRemoteTransaction(client, "g");
+    }
+
+
+    @Test
+    public void shouldBeginAndExposeServerAssignedTransactionId() {
+        final HttpRemoteTransaction tx = newTransaction();
+        final GraphTraversalSource g = tx.begin(GraphTraversalSource.class);
+
+        assertTrue(tx.isOpen());
+        assertEquals("tx-42", tx.getTransactionId());
+        // begin() must send exactly one begin script and register the transaction with the cluster for tracking.
+        verify(client, times(1)).submit(eq(BEGIN), any(RequestOptions.class));
+        verify(cluster, times(1)).trackTransaction(tx);
+        // a usable, transaction-bound traversal source is returned
+        assertNotNull(g);
+    }
+
+    @Test
+    public void shouldSendCommitScriptOnCommit() {
+        final HttpRemoteTransaction tx = newTransaction();
+        tx.begin(GraphTraversalSource.class);
+        tx.commit();
+
+        verify(client, times(1)).submit(eq(COMMIT), any(RequestOptions.class));
+        verify(client, never()).submit(eq(ROLLBACK), any(RequestOptions.class));
+        // committing closes the transaction and untracks it
+        assertFalse(tx.isOpen());
+        verify(cluster, times(1)).untrackTransaction(tx);
+    }
+
+    @Test
+    public void shouldSendRollbackScriptOnRollback() {
+        final HttpRemoteTransaction tx = newTransaction();
+        tx.begin(GraphTraversalSource.class);
+        tx.rollback();
+
+        verify(client, times(1)).submit(eq(ROLLBACK), any(RequestOptions.class));
+        verify(client, never()).submit(eq(COMMIT), any(RequestOptions.class));
+        assertFalse(tx.isOpen());
+        verify(cluster, times(1)).untrackTransaction(tx);
+    }
+
+
+    @Test
+    public void shouldHonorCustomCloseConsumerOverDefaultRollback() {
+        final HttpRemoteTransaction tx = newTransaction();
+        tx.begin(GraphTraversalSource.class);
+
+        final AtomicBoolean invoked = new AtomicBoolean(false);
+        assertEquals(tx, tx.onClose(t -> invoked.set(true)));
+        tx.close();
+
+        // a custom onClose consumer replaces the default: it runs, and no rollback is sent to the server
+        assertTrue(invoked.get());
+        verify(client, never()).submit(eq(ROLLBACK), any(RequestOptions.class));
+        verify(client, never()).submit(eq(COMMIT), any(RequestOptions.class));
+    }
+
+
+    @Test
+    public void shouldRejectSubmitBeforeBegin() {
+        final HttpRemoteTransaction tx = newTransaction();
+        assertThrows(IllegalStateException.class, () -> tx.submit("g.V()"));
+    }
+
+
+    @Test
+    public void shouldRejectConfigurableTransactionBehaviors() {
+        final HttpRemoteTransaction tx = newTransaction();
+        // remote transactions are always manually controlled and cannot carry listeners
+        assertThrows(UnsupportedOperationException.class, tx::readWrite);
+        assertThrows(UnsupportedOperationException.class, () -> tx.onReadWrite(t -> {}));
+        assertThrows(UnsupportedOperationException.class, () -> tx.addTransactionListener(s -> {}));
+        assertThrows(UnsupportedOperationException.class, () -> tx.removeTransactionListener(s -> {}));
+        assertThrows(UnsupportedOperationException.class, tx::clearTransactionListeners);
+    }
+}


### PR DESCRIPTION
# Increase gremlin-driver test coverage

Adds targeted unit tests for `gremlin-driver` that exercise previously-untested library
code: the HTTP request/response codecs, remote traversal and transaction handling,
round-robin load balancing, `Auth` factory dispatch, connection-pool lifecycle, stream
buffers, and `Cluster`/`Host` configuration. **Tests only, no production code changes.**

## Coverage (gremlin-driver aggregate: unit + integration)

| Metric | Baseline (master) | With added tests |
|---|---|---|
| Instructions | 76.19% | 82.68% |
| Branch | 64.01% | 72.28% |

~83 new driver unit tests. The full `gremlin-driver` + `gremlin-server` unit and
integration suites pass.

## Coverage reports

Baseline (master: 2e56ccc):
<img width="671" height="252" alt="Screenshot 2026-07-27 at 9 08 17 AM" src="https://github.com/user-attachments/assets/6f66048e-7051-40b0-ac2d-211f2b210c86" />

With added tests:
<img width="663" height="272" alt="Screenshot 2026-07-25 at 4 45 43 PM" src="https://github.com/user-attachments/assets/3a63d5b0-22c4-4aa2-b751-d86d99c663f7" />



Assisted-by: Kiro: Claude Opus 4.8
