### PR TITLE
Document product()-step return type and Map argument behavior

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3586,8 +3586,11 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 === Product Step
 
 The `product()`-step (*map*) calculates the cartesian product between the incoming list traverser and the provided list
-argument. This step only expects list data (array or Iterable) and will throw an `IllegalArgumentException` if any
-other type is encountered (including `null`).
+argument. The result is returned as a `List` in which each element is itself a two-element `List` pairing one item from
+the incoming list with one item from the argument list, so element order and duplicates are preserved. This step only
+expects list data (array or Iterable) as input and will throw an `IllegalArgumentException` if any other type is
+encountered (including `null`). A `Map` is not accepted and will also throw an `IllegalArgumentException`, as it is
+neither an array nor an `Iterable`.
 
 [gremlin-groovy,modern]
 ----


### PR DESCRIPTION
The reference documentation for the `product()`-step described the cartesian-product semantics and the array/Iterable input expectation, but did not state the shape of the result.

This adds that clarification to the Product Step section of `the-traversal.asciidoc`:

- The result is a `List` in which each element is itself a two-element `List`, one for each combination of an item from the incoming list with an item from the argument list.
- Element order and duplicates are preserved (the result is a list of all combinations, not a de-duplicated set).
- A `Map` argument is not accepted and throws an `IllegalArgumentException`, since a `Map` is neither an array nor an `Iterable`.

This mirrors the return-type clarification style used elsewhere for the set-oriented steps, adapted to `product()`'s list-of-pairs semantics. The change is scoped to the Product Step section only.

Verified against the modern toy graph: `g.V().values("name").fold().product(["james","jen"])` yields the twelve two-element lists `[[marko, james], [marko, jen], ..., [peter, jen]]`, and passing a `Map` throws `IllegalArgumentException` ("product step can only take an array or an Iterable as an argument").