### PR TITLE
Clarify path() traverser-level filtering of non-productive properties

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3483,12 +3483,16 @@ image::path-step.png[width=650]
 
 [gremlin-groovy,modern]
 ----
+graph = TinkerFactory.createModern()
+g = traversal().withEmbedded(graph)
 g.V().out().out().values('name')
 g.V().out().out().values('name').path()
 g.V().both().path().by('age') <1>
 ----
 
-<1> The "age" property is not <<by-step,productive>> for all vertices and therefore those values are filtered.
+<1> The "age" property is not <<by-step,productive>> for all vertices; any path that contains an element without a
+productive "age" value is filtered out in its entirety (the entire traverser is removed, not just the missing value),
+which reduces the number of results from 12 to 4.
 
 If edges are required in the path, then be sure to traverse those edges explicitly.
 


### PR DESCRIPTION
## Summary

Improves the `path()`-step documentation in the reference book (`reference/the-traversal.asciidoc`).

The first `path()` example uses `g.V().both().path().by('age')` and carries a callout explaining why the result count is smaller than expected. The previous wording — "the age property is not productive for all vertices and therefore those values are filtered" — reads as if only the missing *values* are omitted from otherwise-intact paths. In fact the filtering is at the *traverser* level: when any element of a path lacks a productive value for the `by()`-projected property, the whole path (traverser) is dropped. That is why the result count falls from 12 to 4.

## Changes

- Reworded callout 1 so it unambiguously describes traverser-level filtering (the entire path is removed, not just the missing value), and notes the resulting 12 → 4 drop.
- Added the standard modern-graph setup lines (`graph = TinkerFactory.createModern()` / `g = traversal().withEmbedded(graph)`) to the example block so the snippet is self-contained, matching the convention used by other examples in the book.

## Notes

- Scope is limited to the `path()`-step section's first callout and its example setup. The Path Data Structure section is unchanged.
- Verified against the modern graph: `g.V().both().count()` returns 12, and `g.V().both().path().by('age')` returns 4 paths (only the person↔person `knows` pairs survive; every path touching a software vertex, which has no `age`, is dropped in full).