### PR TITLE
Bump Netty to 4.1.136.Final and jackson-databind to 2.18.9

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Fixed `hasId()` to only unroll a collection when it is supplied as the single argument, aligning its behavior with `g.V()`/`g.E()`.
 * Allowed float literals without a leading digit (e.g. `.5`, `.5f`, `.5d`) in the Gremlin grammar to better match Groovy.
 * Fixed conjoin has incorrect null handling.
+* Bump Netty to 4.1.136.
 * Removed the Mono dependency from the `gremlin-dotnet` build/release process, using `dotnet pack`/`dotnet nuget push` instead of `mono nuget.exe`.
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 * Add Node 26 support for `gremlin-javascript` and `gremlint`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Allowed float literals without a leading digit (e.g. `.5`, `.5f`, `.5d`) in the Gremlin grammar to better match Groovy.
 * Fixed conjoin has incorrect null handling.
 * Bump Netty to 4.1.136.
+* Bumped `jackson-databind` to 2.18.9. `InetAddress` values in GraphSON must now be literal IP addresses as hostnames are no longer resolved during deserialization. *(breaking)*
 * Removed the Mono dependency from the `gremlin-dotnet` build/release process, using `dotnet pack`/`dotnet nuget push` instead of `mono nuget.exe`.
 * Expanded `gremlin-python` CI matrix to test against Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 * Add Node 26 support for `gremlin-javascript` and `gremlint`.

--- a/bin/process-docs.sh
+++ b/bin/process-docs.sh
@@ -186,7 +186,7 @@ POM
   mvn -q -f "${NEO4J_POM}" dependency:copy-dependencies -DoutputDirectory="${NEO4J_PLUGIN_LIB}"
   # Drop ONLY the conflicting io.netty 4.x jar that Neo4j pulls in (netty-all-4.1.24): it
   # contains an older io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker13 that
-  # shadows the console driver's 4.1.125 class and breaks ':remote' server connections with a
+  # shadows the console driver's 4.1.136 class and breaks ':remote' server connections with a
   # NoSuchMethodError. Keep netty-3.9.x (org.jboss.netty package) -- it does NOT conflict and
   # is required by Neo4j 3.4's IO layer.
   rm -f "${NEO4J_PLUGIN_LIB}"/netty-all-4.*.jar

--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -3369,7 +3369,7 @@ The following example is a `Duration` of five days.
 ----
 {
   "@type" : "gx:InetAddress",
-  "@value" : "localhost"
+  "@value" : "127.0.0.1"
 }
 ----
 
@@ -5738,7 +5738,7 @@ The following example is a `Duration` of five days.
 ----
 {
   "@type" : "gx:InetAddress",
-  "@value" : "localhost"
+  "@value" : "127.0.0.1"
 }
 ----
 

--- a/docs/src/upgrade/release-3.7.x.asciidoc
+++ b/docs/src/upgrade/release-3.7.x.asciidoc
@@ -119,6 +119,18 @@ removed in 4.0.0. This deprecation applies across all Gremlin Language Variants.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-3042[TINKERPOP-3042]
 
+==== InetAddress GraphSON Deserialization No Longer Resolves Hostnames
+
+TinkerPop's Jackson dependency was upgraded to jackson-databind 2.18.9 to address a number of CVEs. As part of that
+upgrade, Jackson changed how it deserializes `java.net.InetAddress` values from GraphSON, it will no longer perform a
+DNS lookup to resolve a hostname string (e.g. `"localhost"`, `"example.com"`) into an `InetAddress`. Only literal IPv4
+or IPv6 address strings (e.g. `"127.0.0.1"`, `"::1"`) are now accepted, anything else fails deserialization with an
+error such as `Not a valid IP address string literal`.
+
+Applications that store or transmit `InetAddress` values via GraphSON (as a vertex/edge property, or as a bound
+Gremlin parameter) must use literal IP address strings going forward. Existing serialized data containing hostname
+strings will fail to deserialize after upgrading and will need to be migrated to literal IP addresses.
+
 == TinkerPop 3.7.6
 
 *Release Date: April 1, 2026*

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -54,7 +54,7 @@ HPPC borrowed code, ideas or both from:
    (Apache license)
 
 ------------------------------------------------------------------------
-Jackson-Databind, Jackson-Annotation and Jackson-Core 2.15.2 (Included through gremlin-shaded)
+Jackson-Databind, Jackson-Annotation and Jackson-Core 2.18.9 (Included through gremlin-shaded)
 ------------------------------------------------------------------------
 It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
 been in development since 2007.

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -86,7 +86,7 @@ JavaTuples 1.2
 Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
 
 ------------------------------------------------------------------------
-Netty 4.1.125.Final
+Netty 4.1.136.Final
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializerProvider.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializerProvider.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.structure.io.graphson;
 import org.apache.tinkerpop.shaded.jackson.databind.JsonSerializer;
 import org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig;
 import org.apache.tinkerpop.shaded.jackson.databind.SerializerProvider;
+import org.apache.tinkerpop.shaded.jackson.databind.cfg.CacheProvider;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.DefaultSerializerProvider;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.SerializerFactory;
 import org.apache.tinkerpop.shaded.jackson.databind.ser.std.ToStringSerializer;
@@ -55,6 +56,11 @@ final class GraphSONSerializerProvider extends DefaultSerializerProvider {
         this.unknownTypeSerializer = unknownTypeSerializer;
     }
 
+    protected GraphSONSerializerProvider(final GraphSONSerializerProvider src, final CacheProvider cacheProvider) {
+        super(src, cacheProvider);
+        this.unknownTypeSerializer = src.unknownTypeSerializer;
+    }
+
     @Override
     public JsonSerializer<Object> getUnknownTypeSerializer(final Class<?> aClass) {
         return unknownTypeSerializer;
@@ -68,5 +74,10 @@ final class GraphSONSerializerProvider extends DefaultSerializerProvider {
         // when the object was first constructed through the public constructor
         // that has a GraphSONVersion.
         return new GraphSONSerializerProvider(this, config, jsf, unknownTypeSerializer);
+    }
+
+    @Override
+    public GraphSONSerializerProvider withCaches(final CacheProvider cacheProvider) {
+        return new GraphSONSerializerProvider(this, cacheProvider);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeDeserializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTypeDeserializer.java
@@ -184,14 +184,14 @@ public class GraphSONTypeDeserializer extends TypeDeserializerBase {
                         // detected the type pattern entirely but the Map contained other properties
                         // For now we error out because we assume that pattern is *only* reserved to
                         // typed values.
-                        throw deserializationContext.mappingException("Detected the type pattern in the JSON payload " +
+                        deserializationContext.reportInputMismatch(baseType, "Detected the type pattern in the JSON payload " +
                                 "but the map containing the types and values contains other fields. This is not " +
                                 "allowed by the deserializer.");
                     }
                 }
             }
         } catch (Exception e) {
-            throw deserializationContext.mappingException("Could not deserialize the JSON value as required. Nested exception: " + e.toString());
+            deserializationContext.reportInputMismatch(baseType, "Could not deserialize the JSON value as required. Nested exception: " + e.toString());
         }
 
         // Type pattern wasn't detected, however,

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONStreamConstraintsTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONStreamConstraintsTest.java
@@ -48,8 +48,8 @@ public class GraphSONStreamConstraintsTest extends AbstractGraphSONTest{
             serializeDeserializeAuto(mapper, serializedData);
         });
         assertTrue("Expected StreamConstraintsException for exceeding max number length, found: "+exception.getMessage(),
-                exception.getMessage().contains("org.apache.tinkerpop.shaded.jackson.core.exc.StreamConstraintsException: Number length")
-                && exception.getMessage().contains("exceeds the maximum length (2)"));
+                exception.getMessage().contains("org.apache.tinkerpop.shaded.jackson.core.exc.StreamConstraintsException: Number value length")
+                && exception.getMessage().contains("exceeds the maximum allowed (2, from `StreamReadConstraints.getMaxNumberLength()`)"));
     }
 
     @Test
@@ -66,8 +66,8 @@ public class GraphSONStreamConstraintsTest extends AbstractGraphSONTest{
             serializeDeserializeAuto(mapper, serializedData);
         });
         assertTrue("Expected StreamConstraintsException for exceeding max String length, found: "+exception.getMessage(),
-                exception.getMessage().contains("String length")
-                        && exception.getMessage().contains("exceeds the maximum length (20)"));
+                exception.getMessage().contains("String value length")
+                        && exception.getMessage().contains("exceeds the maximum allowed (20, from `StreamReadConstraints.getMaxStringLength()`)"));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class GraphSONStreamConstraintsTest extends AbstractGraphSONTest{
             serializeDeserializeAuto(mapper, serializedData);
         });
         assertTrue("Expected StreamConstraintsException for exceeding max nesting depth,  found: "+exception.getMessage(),
-                exception.getMessage().contains("org.apache.tinkerpop.shaded.jackson.core.exc.StreamConstraintsException: Depth")
-                        && exception.getMessage().contains("exceeds the maximum allowed nesting depth (1)"));
+                exception.getMessage().contains("org.apache.tinkerpop.shaded.jackson.core.exc.StreamConstraintsException: Document nesting depth")
+                        && exception.getMessage().contains("exceeds the maximum allowed (1, from `StreamReadConstraints.getMaxNestingDepth()`)"));
     }
 }

--- a/gremlin-driver/src/main/static/NOTICE
+++ b/gremlin-driver/src/main/static/NOTICE
@@ -49,7 +49,7 @@ JavaTuples 1.2
 Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
 
 ------------------------------------------------------------------------
-Netty 4.1.125.Final
+Netty 4.1.136.Final
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
 

--- a/gremlin-driver/src/main/static/NOTICE
+++ b/gremlin-driver/src/main/static/NOTICE
@@ -17,7 +17,7 @@ HPPC borrowed code, ideas or both from:
    (Apache license)
 
 ------------------------------------------------------------------------
-Jackson-Databind, Jackson-Annotation and Jackson-Core 2.15.2 (Included through gremlin-shaded)
+Jackson-Databind, Jackson-Annotation and Jackson-Core 2.18.9 (Included through gremlin-shaded)
 ------------------------------------------------------------------------
 It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
 been in development since 2007.

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -120,7 +120,7 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
         <!-- Optional depenency needed for Netty's SelfSignedCertificate generation on JDKs which doesn't provide sun.security.x509 package -->
-        <!-- https://github.com/netty/netty/blob/netty-4.1.125.Final/pom.xml#L963 -->
+        <!-- https://github.com/netty/netty/blob/netty-4.1.136.Final/pom.xml#L1011 -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -87,7 +87,7 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------
-Netty 4.1.125.Final
+Netty 4.1.136.Final
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
 

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -41,7 +41,7 @@ HPPC borrowed code, ideas or both from:
    (Apache license)
 
 ------------------------------------------------------------------------
-Jackson-Databind, Jackson-Annotation and Jackson-Core 2.15.2 (Included through gremlin-shaded)
+Jackson-Databind, Jackson-Annotation and Jackson-Core 2.18.9 (Included through gremlin-shaded)
 ------------------------------------------------------------------------
 It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
 been in development since 2007.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtilTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtilTest.java
@@ -69,7 +69,7 @@ public class HttpHandlerUtilTest {
         final HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaderNames.CONTENT_TYPE, SerTokens.MIME_GRAPHBINARY_V1);
 
-        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some uri",
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some-uri",
                 buffer, headers, new DefaultHttpHeaders());
 
         final Map<String, MessageSerializer<?>> serializers = new HashMap<>();
@@ -96,7 +96,7 @@ public class HttpHandlerUtilTest {
         final HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaderNames.CONTENT_TYPE, SerTokens.MIME_GRAPHBINARY_V1);
 
-        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some uri",
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some-uri",
                 buffer, headers, new DefaultHttpHeaders());
 
         final Map<String, MessageSerializer<?>> serializers = new HashMap<>();
@@ -119,7 +119,7 @@ public class HttpHandlerUtilTest {
         final HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaderNames.CONTENT_TYPE, SerTokens.MIME_JSON);
 
-        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some uri",
+        final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "some-uri",
                 buffer, headers, new DefaultHttpHeaders());
 
         final Map<String, MessageSerializer<?>> serializers = new HashMap<>();

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -48,7 +48,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.18.9</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/gremlin-shaded/src/main/static/NOTICE
+++ b/gremlin-shaded/src/main/static/NOTICE
@@ -5,7 +5,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------
-Jackson-Databind, Jackson-Annotation and Jackson-Core 2.15.2
+Jackson-Databind, Jackson-Annotation and Jackson-Core 2.18.9
 ------------------------------------------------------------------------
 It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
 been in development since 2007.

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/structure/io/Model.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/structure/io/Model.java
@@ -217,7 +217,7 @@ public class Model {
         addExtendedEntry("x".charAt(0), "Char", "");
         addExtendedEntry(Duration.ofDays(5), "Duration","The following example is a `Duration` of five days.");
         try {
-            addEntry("Extended", InetAddress.getByName("localhost"), "InetAddress", "");
+            addEntry("Extended", InetAddress.getByName("127.0.0.1"), "InetAddress", "");
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/AbstractRoundTripTest.java
+++ b/gremlin-util/src/test/java/org/apache/tinkerpop/gremlin/util/ser/AbstractRoundTripTest.java
@@ -205,7 +205,7 @@ public abstract class AbstractRoundTripTest {
                 new Object[] {"Traverser", new DefaultRemoteTraverser<>("marko", 100), null},
                 new Object[] {"Class", Bytecode.class, null},
                 new Object[] {"ByteBuffer", ByteBuffer.wrap(new byte[]{ 1, 2, 3 }), null},
-                new Object[] {"InetAddressV4", InetAddress.getByName("localhost"), null},
+                new Object[] {"InetAddressV4", InetAddress.getByName("127.0.0.1"), null},
                 new Object[] {"InetAddressV6", InetAddress.getByName("::1"), null},
                 new Object[] {"Lambda0", Lambda.supplier("return 1"), null},
                 new Object[] {"Lambda1", Lambda.consumer("it"), null},

--- a/gremlin-util/src/test/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/inetaddress-v2.json
+++ b/gremlin-util/src/test/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/inetaddress-v2.json
@@ -1,4 +1,4 @@
 {
   "@type" : "gx:InetAddress",
-  "@value" : "localhost"
+  "@value" : "127.0.0.1"
 }

--- a/gremlin-util/src/test/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/inetaddress-v3.json
+++ b/gremlin-util/src/test/resources/org/apache/tinkerpop/gremlin/structure/io/graphson/inetaddress-v3.json
@@ -1,4 +1,4 @@
 {
   "@type" : "gx:InetAddress",
-  "@value" : "localhost"
+  "@value" : "127.0.0.1"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -174,12 +174,12 @@ limitations under the License.
         <logback.version>1.2.13</logback.version>
         <metrics.version>3.0.2</metrics.version>
         <mockito.version>3.10.0</mockito.version>
-        <netty.version>4.1.125.Final</netty.version>
+        <netty.version>4.1.136.Final</netty.version>
         <slf4j.version>1.7.25</slf4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spark.version>3.3.2</spark.version>
         <!-- Version aligned with Netty's optional bcpkix dependency used for SelfSignedCertificate -->
-        <bouncycastle.version>1.69</bouncycastle.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
         <ayza.version>10.0.0</ayza.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -716,7 +716,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.6.2</version>
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
                     </configuration>


### PR DESCRIPTION
Dependency upgrades to address accumulated CVEs.

### Netty 4.1.136.Final
- Bumps `bouncycastle.version` 1.69 → 1.70 to match Netty's own pinned `bcpkix-jdk15on` version.
- Fixes `HttpHandlerUtilTest` (Netty's stricter HTTP request-line validation now rejects the test's placeholder URI containing a space).
- Updates `NOTICE` files in `gremlin-console`, `gremlin-driver`, `gremlin-server`.

### jackson-databind 2.18.9
- Fixes compile breaks from removed/changed Jackson APIs (`DefaultSerializerProvider.withCaches`, `DeserializationContext.mappingException`).
- Updates `GraphSONStreamConstraintsTest` assertions for Jackson's reworded exception messages (behavior unchanged).
- Bumps `maven-shade-plugin` 3.4.1 → 3.6.2 (required for jackson-databind 2.18.9's Java 21 multi-release JAR classes; no relocation/behavior changes for our use case).

**Breaking change:** jackson-databind 2.18.9 hardens `InetAddress` deserialization to reject hostnames, accepting only literal IP addresses (closes a DNS-lookup-on-untrusted-input vector, jackson-databind#6058, related to CVE-2026-54514). No upstream opt-out exists. This restriction is adopted as-is rather than reintroducing hostname resolution via a custom deserializer. Any GraphSON data with `InetAddress` values stored as hostnames (e.g. `"localhost"`) will fail to deserialize after this upgrade and must be migrated to literal IP addresses. Documented in `docs/src/upgrade/release-3.7.x.asciidoc`.

VOTE +1