### PR TITLE
Added Python driver tests for coverage

### DIFF
--- a/gremlin-python/src/main/python/tests/integration/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/integration/driver/test_driver_remote_connection.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import os
+import time
 
 import pytest
 
@@ -51,6 +52,19 @@ class TestDriverRemoteConnection(object):
                                                                              'timeoutMillis': 1000,
                                                                              'bulkResults': True}
         assert 6 == t.to_list()[0]
+
+    def test_timeout_millis_aborts_query_server_side(self, remote_connection):
+        # A small per-request timeoutMillis is forwarded to the server, which aborts the
+        # long-running traversal fast; the <10s bound proves our timeout fired, not the 30s default.
+        g = traversal().with_(remote_connection)
+        t = g.with_("timeoutMillis", 500).inject(1).repeat(__.side_effect(__.constant(1))).times(100000000)
+        start = time.time()
+        with pytest.raises(GremlinServerError) as exc_info:
+            t.to_list()
+        elapsed = time.time() - start
+        assert exc_info.value.status_code == 500
+        assert 'timeout' in str(exc_info.value).lower()
+        assert elapsed < 10, f"expected the 500ms per-request timeout to fire, but took {elapsed:.1f}s (server default is 30s)"
 
     @pytest.mark.skip(reason="TINKERPOP-3126: g.V() with a variable/parameter argument fails to parse in gremlin-lang")
     def test_extract_request_options_with_params(self, remote_connection):

--- a/gremlin-python/src/main/python/tests/unit/driver/test_client_options.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_client_options.py
@@ -28,6 +28,8 @@ import pytest
 
 from gremlin_python.driver.client import Client
 from gremlin_python.driver.connection import Connection
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from gremlin_python.driver.remote_connection import RemoteStrategy, RemoteTraversal
 from gremlin_python.driver.request import RequestMessage
 from gremlin_python.process.traversal import GremlinLang, GValue
 
@@ -355,3 +357,266 @@ class TestSigV4CredentialsProvider:
         MockSession.return_value.get_credentials.assert_called_once()
         args, _ = MockAuth.call_args
         assert args[0] is resolved
+
+
+# ===========================================================================
+# --- DriverRemoteConnection / RemoteStrategy ---
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs
+# ---------------------------------------------------------------------------
+
+class _OptionsStrategy:
+    """Mimics an options strategy that exposes a ``configuration`` dict.
+
+    extract_request_options only pulls keys from configuration that are present
+    in gremlin_python.driver.request.Tokens.
+    """
+
+    def __init__(self, configuration):
+        self.configuration = configuration
+
+
+class _GremlinLangStub:
+    """Minimal stand-in for a GremlinLang object.
+
+    Exposes only the attributes/methods that DriverRemoteConnection touches:
+    get_gremlin, options_strategies, get_parameters_as_string.
+    """
+
+    def __init__(self, gremlin='g.V()', options_strategies=None,
+                 parameters_string='[:]'):
+        self._gremlin = gremlin
+        self.options_strategies = options_strategies or []
+        self._parameters_string = parameters_string
+
+    def get_gremlin(self):
+        return self._gremlin
+
+    def get_parameters_as_string(self):
+        return self._parameters_string
+
+
+class _TraversalStub:
+    """Lightweight traversal for exercising RemoteStrategy.apply/apply_async.
+
+    RemoteStrategy only reads .traversers and .gremlin_lang and writes
+    .remote_results and .traversers.
+    """
+
+    def __init__(self, traversers=None, gremlin_lang=None):
+        self.traversers = traversers
+        self.gremlin_lang = gremlin_lang or _GremlinLangStub()
+        self.remote_results = None
+
+
+def _make_drc():
+    """Build a DriverRemoteConnection with a fully mocked Client.
+
+    Follows the pattern in TestDriverRemoteConnectionOptions:
+    patch the Client symbol, then set _url/_traversal_source on the instance the
+    constructor reads back from the client.
+    """
+    with patch('gremlin_python.driver.driver_remote_connection.client.Client') as MockClient:
+        instance = MockClient.return_value
+        instance._url = 'http://localhost:8182/gremlin'
+        instance._traversal_source = 'g'
+        drc = DriverRemoteConnection('http://localhost:8182/gremlin', 'g')
+    # drc._client is the MockClient.return_value MagicMock; return both.
+    return drc, instance
+
+
+# ---------------------------------------------------------------------------
+# 1. extract_request_options -- PURE, no client involved
+# ---------------------------------------------------------------------------
+
+class TestExtractRequestOptions:
+
+    def test_bulk_results_defaults_to_true_when_omitted(self):
+        gl = _GremlinLangStub(options_strategies=[])
+        opts = DriverRemoteConnection.extract_request_options(gl)
+        assert opts['bulkResults'] is True
+
+    def test_bulk_results_from_configuration_is_preserved(self):
+        # When an options strategy already supplies bulkResults, the default
+        # must not clobber it.
+        gl = _GremlinLangStub(
+            options_strategies=[_OptionsStrategy({'bulkResults': False})])
+        opts = DriverRemoteConnection.extract_request_options(gl)
+        assert opts['bulkResults'] is False
+
+    def test_tokens_merged_from_each_strategy(self):
+        # Two strategies each contribute recognized Tokens; both are merged.
+        gl = _GremlinLangStub(options_strategies=[
+            _OptionsStrategy({'timeoutMillis': 1000, 'batchSize': 10}),
+            _OptionsStrategy({'userAgent': 'ua', 'materializeProperties': 'tokens'}),
+        ])
+        opts = DriverRemoteConnection.extract_request_options(gl)
+        assert opts['timeoutMillis'] == 1000
+        assert opts['batchSize'] == 10
+        assert opts['userAgent'] == 'ua'
+        assert opts['materializeProperties'] == 'tokens'
+
+    def test_non_token_configuration_keys_are_ignored(self):
+        # Keys that are not in request.Tokens must not be copied through.
+        gl = _GremlinLangStub(
+            options_strategies=[_OptionsStrategy({'notAToken': 'x', 'g': 'g'})])
+        opts = DriverRemoteConnection.extract_request_options(gl)
+        assert 'notAToken' not in opts
+        assert opts['g'] == 'g'
+
+    def test_parameters_omitted_when_empty_map(self):
+        gl = _GremlinLangStub(parameters_string='[:]')
+        opts = DriverRemoteConnection.extract_request_options(gl)
+        assert 'parameters' not in opts
+
+    def test_parameters_added_when_non_empty(self):
+        gl = _GremlinLangStub(parameters_string='[a:1]')
+        opts = DriverRemoteConnection.extract_request_options(gl)
+        assert opts['parameters'] == '[a:1]'
+
+
+# ---------------------------------------------------------------------------
+# 2. submit
+# ---------------------------------------------------------------------------
+
+class TestSubmit:
+
+    def test_submit_calls_client_and_wraps_result(self):
+        drc, client = _make_drc()
+        result_set = MagicMock(name='result_set')
+        client.submit.return_value = result_set
+        gl = _GremlinLangStub(gremlin='g.V().count()')
+
+        remote_traversal = drc.submit(gl)
+
+        # client.submit called with the gremlin string and the request options
+        # produced by extract_request_options (bulkResults default present).
+        client.submit.assert_called_once()
+        args, kwargs = client.submit.call_args
+        assert args[0] == 'g.V().count()'
+        assert kwargs['request_options'] == \
+            DriverRemoteConnection.extract_request_options(gl)
+        assert kwargs['request_options']['bulkResults'] is True
+
+        # A RemoteTraversal wrapping the client's result_set is returned.
+        assert isinstance(remote_traversal, RemoteTraversal)
+        assert remote_traversal.traversers is result_set
+
+
+# ---------------------------------------------------------------------------
+# 3. submit_async
+# ---------------------------------------------------------------------------
+
+class TestSubmitAsync:
+
+    def test_client_submit_async_called(self):
+        drc, client = _make_drc()
+        client_future = Future()
+        client.submit_async.return_value = client_future
+        gl = _GremlinLangStub(gremlin='g.V()')
+
+        drc.submit_async(gl)
+
+        client.submit_async.assert_called_once()
+        args, kwargs = client.submit_async.call_args
+        assert args[0] == 'g.V()'
+        assert kwargs['request_options'] == \
+            DriverRemoteConnection.extract_request_options(gl)
+
+    def test_success_callback_resolves_to_remote_traversal(self):
+        drc, client = _make_drc()
+        client_future = Future()
+        client.submit_async.return_value = client_future
+        gl = _GremlinLangStub()
+
+        returned_future = drc.submit_async(gl)
+        assert isinstance(returned_future, Future)
+        assert not returned_future.done()
+
+        # Completing the client's future should drive the done-callback and
+        # resolve the returned future to a RemoteTraversal wrapping the result.
+        result_set = MagicMock(name='result_set')
+        client_future.set_result(result_set)
+
+        remote_traversal = returned_future.result(timeout=1)
+        assert isinstance(remote_traversal, RemoteTraversal)
+        assert remote_traversal.traversers is result_set
+
+    def test_error_callback_propagates_exception(self):
+        drc, client = _make_drc()
+        client_future = Future()
+        client.submit_async.return_value = client_future
+        gl = _GremlinLangStub()
+
+        returned_future = drc.submit_async(gl)
+
+        boom = RuntimeError('submit failed')
+        client_future.set_exception(boom)
+
+        with pytest.raises(RuntimeError, match='submit failed'):
+            returned_future.result(timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# 4. RemoteStrategy.apply / apply_async
+# ---------------------------------------------------------------------------
+
+class TestRemoteStrategyApply:
+
+    def test_apply_submits_and_sets_results_when_traversers_none(self):
+        remote_connection = MagicMock()
+        remote_traversal = RemoteTraversal(MagicMock(name='traversers'))
+        remote_connection.submit.return_value = remote_traversal
+
+        strategy = RemoteStrategy(remote_connection)
+        traversal = _TraversalStub(traversers=None)
+
+        strategy.apply(traversal)
+
+        remote_connection.submit.assert_called_once_with(traversal.gremlin_lang)
+        assert traversal.remote_results is remote_traversal
+        assert traversal.traversers is remote_traversal.traversers
+
+    def test_apply_is_idempotent_when_traversers_already_set(self):
+        remote_connection = MagicMock()
+        strategy = RemoteStrategy(remote_connection)
+        existing = MagicMock(name='existing_traversers')
+        traversal = _TraversalStub(traversers=existing)
+
+        strategy.apply(traversal)
+
+        remote_connection.submit.assert_not_called()
+        assert traversal.traversers is existing
+        assert traversal.remote_results is None
+
+
+class TestRemoteStrategyApplyAsync:
+
+    def test_apply_async_submits_and_sets_remote_results_when_none(self):
+        remote_connection = MagicMock()
+        async_result = MagicMock(name='future')
+        remote_connection.submit_async.return_value = async_result
+
+        strategy = RemoteStrategy(remote_connection)
+        traversal = _TraversalStub(traversers=None)
+
+        strategy.apply_async(traversal)
+
+        remote_connection.submit_async.assert_called_once_with(traversal.gremlin_lang)
+        assert traversal.remote_results is async_result
+        # apply_async does NOT populate traversers (only remote_results); this
+        # asserts the ACTUAL current behavior of remote_connection.py.
+        assert traversal.traversers is None
+
+    def test_apply_async_is_idempotent_when_traversers_already_set(self):
+        remote_connection = MagicMock()
+        strategy = RemoteStrategy(remote_connection)
+        existing = MagicMock(name='existing_traversers')
+        traversal = _TraversalStub(traversers=existing)
+
+        strategy.apply_async(traversal)
+
+        remote_connection.submit_async.assert_not_called()
+        assert traversal.remote_results is None

--- a/gremlin-python/src/main/python/tests/unit/driver/test_connection_options.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_connection_options.py
@@ -24,10 +24,12 @@ Connection request path, the DriverRemoteConnection surface, and the SigV4
 credentials-provider variant. They avoid any network I/O.
 """
 
+import asyncio
 import socket
 import warnings
 from unittest.mock import MagicMock, patch
 
+import aiohttp
 import pytest
 
 from gremlin_python.driver.aiohttp.transport import (
@@ -35,10 +37,12 @@ from gremlin_python.driver.aiohttp.transport import (
     _normalize_compression,
     _keep_alive_socket_options,
     _keep_alive_socket_factory,
+    _run_read,
     DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_IDLE_TIMEOUT,
     DEFAULT_KEEP_ALIVE_TIME,
 )
+from gremlin_python.driver.exceptions import ReadTimeoutError
 
 
 # ---------------------------------------------------------------------------
@@ -310,3 +314,56 @@ class TestTransportWriteCompression:
         assert captured['post_kwargs'].get('proxy') == 'http://proxy:3128'
         t._client_session = None
         t.close()
+
+
+# ---------------------------------------------------------------------------
+# Read-timeout normalization
+# ---------------------------------------------------------------------------
+# _run_read must convert aiohttp's ServerTimeoutError into the driver-owned
+# ReadTimeoutError (which subclasses the builtin TimeoutError).
+
+class TestReadTimeoutNormalization:
+
+    def test_read_timeout_error_is_builtin_timeout_error_subclass(self):
+        assert issubclass(ReadTimeoutError, TimeoutError)
+
+    def test_server_timeout_normalized_to_read_timeout(self):
+        loop = asyncio.new_event_loop()
+
+        async def timing_out():
+            raise aiohttp.ServerTimeoutError("read timed out")
+
+        try:
+            with pytest.raises(ReadTimeoutError) as exc_info:
+                _run_read(loop, 5, timing_out())
+        finally:
+            loop.close()
+
+        # The read_timeout value is surfaced in the message ...
+        assert "5" in str(exc_info.value)
+        # ... and the original aiohttp error is preserved as the cause.
+        assert isinstance(exc_info.value.__cause__, aiohttp.ServerTimeoutError)
+
+    def test_read_timeout_can_be_caught_as_timeout_error(self):
+        loop = asyncio.new_event_loop()
+
+        async def timing_out():
+            raise aiohttp.ServerTimeoutError("read timed out")
+
+        try:
+            with pytest.raises(TimeoutError):
+                _run_read(loop, 10, timing_out())
+        finally:
+            loop.close()
+
+    def test_successful_read_returns_value_unchanged(self):
+        # The non-timeout path simply returns the coroutine's result.
+        loop = asyncio.new_event_loop()
+
+        async def succeeds():
+            return "response-body"
+
+        try:
+            assert _run_read(loop, 5, succeeds()) == "response-body"
+        finally:
+            loop.close()

--- a/gremlin-python/src/main/python/tests/unit/driver/test_http_streaming.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_http_streaming.py
@@ -1309,6 +1309,28 @@ class TestConnectionWriteRequest:
         written = conn._transport.write.call_args[0][0]
         assert written['headers']['x-custom'] == "value"
 
+    def test_transaction_id_promoted_to_header(self):
+        """A transactionId field is promoted to the X-Transaction-Id HTTP header."""
+        conn = self._make_connection()
+        conn._write_request(RequestMessage(fields={"transactionId": "abc-123"}, gremlin="g.V()"))
+        written = conn._transport.write.call_args[0][0]
+        assert written['headers']['X-Transaction-Id'] == "abc-123"
+
+    def test_transaction_id_remains_in_serialized_body(self):
+        """The transactionId is transmitted both as a header and in the serialized body."""
+        conn = self._make_connection()
+        conn._write_request(RequestMessage(fields={"transactionId": "abc-123"}, gremlin="g.V()"))
+        written = conn._transport.write.call_args[0][0]
+        assert written['headers']['X-Transaction-Id'] == "abc-123"
+        assert json.loads(written['payload'])['transactionId'] == "abc-123"
+
+    def test_no_transaction_id_header_when_absent(self):
+        """A request without a transactionId field must not set the X-Transaction-Id header."""
+        conn = self._make_connection()
+        conn._write_request(RequestMessage(fields={}, gremlin="g.V()"))
+        written = conn._transport.write.call_args[0][0]
+        assert 'X-Transaction-Id' not in written['headers']
+
 
 class TestConnectionInterceptorValidation:
     """Tests for interceptor validation in Connection.__init__."""

--- a/gremlin-python/src/main/python/tests/unit/driver/test_serializer.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_serializer.py
@@ -1,0 +1,115 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""GraphBinarySerializersV4: PDT-registry merge and finalize_message byte layout."""
+
+from gremlin_python.driver.request import RequestMessage
+from gremlin_python.driver.serializer import GraphBinarySerializersV4
+from gremlin_python.structure.graph import PDTRegistry
+
+
+class TestConfigurePdtRegistryMerge:
+    """
+    configure_pdt_registry sets the reader's registry on first call, but on
+    subsequent calls it MERGES the four adapter maps into the existing registry
+    rather than replacing it.
+    """
+
+    def test_second_registry_merges_all_adapter_maps(self):
+        s = GraphBinarySerializersV4()
+
+        first = PDTRegistry()
+        first.register("com.example.Alpha", lambda fields: fields)
+        first.register_primitive("Uint32", lambda v: int(v))
+
+        second = PDTRegistry()
+        second.register("com.example.Beta", lambda fields: fields)
+        second.register_primitive("Uint64", lambda v: int(v))
+
+        s.configure_pdt_registry(first)
+        # First call installs the registry directly.
+        assert s._graphbinary_reader.pdt_registry is first
+
+        s.configure_pdt_registry(second)
+        merged = s._graphbinary_reader.pdt_registry
+
+        # Still the first registry object (merged into, not replaced).
+        assert merged is first
+
+        # Composite adapters from BOTH registries are present.
+        assert "com.example.Alpha" in merged._composite_adapters_by_name
+        assert "com.example.Beta" in merged._composite_adapters_by_name
+
+        # Primitive adapters from BOTH registries are present.
+        assert "Uint32" in merged._primitive_adapters_by_name
+        assert "Uint64" in merged._primitive_adapters_by_name
+
+    def test_merge_covers_by_class_maps(self):
+        s = GraphBinarySerializersV4()
+
+        first = PDTRegistry()
+        first.register("com.example.Alpha",
+                       deserialize_fn=lambda fields: fields,
+                       serialize_fn=lambda o: {}, target_class=list)
+
+        second = PDTRegistry()
+        second.register("com.example.Beta",
+                        deserialize_fn=lambda fields: fields,
+                        serialize_fn=lambda o: {}, target_class=set)
+
+        s.configure_pdt_registry(first)
+        s.configure_pdt_registry(second)
+        merged = s._graphbinary_reader.pdt_registry
+
+        # by_class maps merged from both registries.
+        assert merged.get_composite_adapter_by_class(list) is not None
+        assert merged.get_composite_adapter_by_class(set) is not None
+
+
+class TestFinalizeMessageBytes:
+    """
+    serialize_message -> build_message -> finalize_message produces the canonical
+    GraphBinary V4 request byte layout:
+      - 0x84 header byte
+      - int32 field count
+      - each field key/value as fully-qualified GraphBinary values
+      - gremlin string value with its 2-byte (type-code + null-flag) prefix stripped
+    """
+
+    def test_empty_fields_canonical_bytes(self):
+        s = GraphBinarySerializersV4()
+        result = s.serialize_message(RequestMessage(fields={}, gremlin='g.V()'))
+        # 0x84 | int32(0) field count | int32(5) string length | b'g.V()'
+        assert result == b'\x84\x00\x00\x00\x00\x00\x00\x00\x05g.V()'
+
+    def test_non_empty_fields_canonical_bytes(self):
+        s = GraphBinarySerializersV4()
+        result = s.serialize_message(RequestMessage(fields={'k': 'v'}, gremlin='g.V()'))
+        # 0x84
+        # | int32(1) field count
+        # | key 'k'  : string type-code 0x03 + null-flag 0x00 + int32(1) + b'k'
+        # | value 'v': string type-code 0x03 + null-flag 0x00 + int32(1) + b'v'
+        # | gremlin  : int32(5) + b'g.V()'  (type-code + null-flag stripped)
+        assert result == (
+            b'\x84'
+            b'\x00\x00\x00\x01'
+            b'\x03\x00\x00\x00\x00\x01k'
+            b'\x03\x00\x00\x00\x00\x01v'
+            b'\x00\x00\x00\x05g.V()'
+        )

--- a/gremlin-python/src/main/python/tests/unit/driver/test_sigv4.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_sigv4.py
@@ -27,10 +27,13 @@ header, so Python's SignedHeaders is ``host;x-amz-date`` (the body hash is still
 signature via the canonical request's mandatory payload-hash line). This is the SDK's natural
 behavior and is intentionally left as-is.
 """
+from unittest.mock import patch
+
 from botocore.credentials import Credentials
 
 from gremlin_python.driver.auth import sigv4
 from gremlin_python.driver.http_request import HttpRequest
+from gremlin_python.driver.request import RequestMessage
 
 ACCESS_KEY = "foo"
 SECRET_KEY = "bar"
@@ -80,3 +83,32 @@ class TestSigV4SignedHeaders:
         assert _signed_headers(request) == "host;x-amz-date;x-amz-security-token"
         lower = {k.lower(): v for k, v in request.headers.items()}
         assert lower["x-amz-security-token"] == "MOCK_TOKEN"
+
+
+def _make_basic_request():
+    msg = RequestMessage(fields={"g": "g"}, gremlin="g.V()")
+    return HttpRequest(method="POST", url="http://localhost:8182/gremlin",
+                       headers={}, body=msg)
+
+
+class TestSigV4Auth:
+
+    def test_writes_signed_headers_onto_request(self):
+        # Asserts the interceptor copies the signer's headers onto the request;
+        # credential resolution is covered by TestSigV4CredentialsProvider.
+        def provider():
+            return object()
+
+        def fake_add_auth(aws_request):
+            aws_request.headers['Authorization'] = 'AWS4-HMAC-SHA256 Credential=AKID/...'
+            aws_request.headers['X-Amz-Date'] = '20260715T000000Z'
+
+        with patch('botocore.auth.SigV4Auth') as MockAuth:
+            MockAuth.return_value.add_auth.side_effect = fake_add_auth
+            interceptor = sigv4('us-east-1', 'neptune-db', credentials=provider)
+            request = _make_basic_request()
+            interceptor(request)
+
+        # Both signer-produced headers were written back onto the request.
+        assert request.headers['Authorization'].startswith('AWS4-HMAC-SHA256')
+        assert request.headers['X-Amz-Date'] == '20260715T000000Z'

--- a/gremlin-python/src/main/python/tests/unit/driver/test_transaction.py
+++ b/gremlin-python/src/main/python/tests/unit/driver/test_transaction.py
@@ -1,0 +1,306 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""Explicit-transaction lifecycle
+(gremlin_python.driver.transaction.Transaction and
+GraphTraversalSource.execute_in_tx). A MagicMock stands in for the Client; assertions target the actual scripts
+submitted and the tracked open/closed state."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gremlin_python.driver.transaction import Transaction
+
+
+def _make_client(transaction_id='tx-123'):
+    """A mock Client whose submit(...).all().result() yields the server's
+    begin response (a list with a transactionId dict). The same mock serves
+    commit/rollback submits, whose result value is ignored by the code."""
+    client = MagicMock()
+    client._url = 'http://localhost:8182/gremlin'
+    client._traversal_source = 'g'
+    result = MagicMock()
+    result.all.return_value.result.return_value = [{'transactionId': transaction_id}]
+    client.submit.return_value = result
+    return client
+
+
+def _scripts_submitted(client):
+    """The first positional arg (the gremlin-lang script) of each submit call."""
+    return [c.args[0] for c in client.submit.call_args_list if c.args]
+
+
+class TestBegin:
+
+    def test_begin_opens_transaction_and_returns_bound_gts(self):
+        client = _make_client()
+        tx = Transaction(client)
+        gts = tx.begin()
+        assert tx.is_open
+        assert tx.transaction_id == 'tx-123'
+        # begin returns a GraphTraversalSource bound to the transaction
+        assert gts is not None
+        client.track_transaction.assert_called_once_with(tx)
+
+    def test_begin_is_idempotent_when_already_open(self):
+        # Calling begin() again must not re-issue "g.tx().begin()" nor raise;
+        # it reuses the existing transactionId.
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        tx.begin()
+        begin_calls = [s for s in _scripts_submitted(client) if s == 'g.tx().begin()']
+        assert len(begin_calls) == 1
+        assert tx.is_open
+        # track_transaction is only invoked on the initial open
+        client.track_transaction.assert_called_once_with(tx)
+
+    def test_begin_after_close_raises_single_use(self):
+        # A transaction is single-use: after it is closed, begin() must raise.
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        tx.commit()
+        with pytest.raises(Exception, match="closed and cannot be reused"):
+            tx.begin()
+
+
+class TestCommitRollback:
+
+    def test_commit_submits_commit_script_with_transaction_id(self):
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        tx.commit()
+        assert 'g.tx().commit()' in _scripts_submitted(client)
+        # commit is a terminal state
+        assert not tx.is_open
+        client.untrack_transaction.assert_called_once_with(tx)
+        # the transactionId is attached to the commit submit
+        commit_call = next(c for c in client.submit.call_args_list
+                           if c.args and c.args[0] == 'g.tx().commit()')
+        assert commit_call.kwargs['request_options'] == {'transactionId': 'tx-123'}
+
+    def test_rollback_submits_rollback_script_with_transaction_id(self):
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        tx.rollback()
+        assert 'g.tx().rollback()' in _scripts_submitted(client)
+        assert not tx.is_open
+        client.untrack_transaction.assert_called_once_with(tx)
+        rollback_call = next(c for c in client.submit.call_args_list
+                             if c.args and c.args[0] == 'g.tx().rollback()')
+        assert rollback_call.kwargs['request_options'] == {'transactionId': 'tx-123'}
+
+    def test_commit_when_not_open_raises(self):
+        client = _make_client()
+        tx = Transaction(client)
+        with pytest.raises(Exception, match="Transaction is not open"):
+            tx.commit()
+
+
+class TestClose:
+
+    def test_close_defaults_to_rollback_not_commit(self):
+        # close() on an open transaction rolls back (it does not commit).
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        tx.close()
+        scripts = _scripts_submitted(client)
+        assert 'g.tx().rollback()' in scripts
+        assert 'g.tx().commit()' not in scripts
+        assert not tx.is_open
+
+    def test_close_is_noop_when_never_opened(self):
+        # close() on a transaction that was never begun must not raise and
+        # must not submit anything.
+        client = _make_client()
+        tx = Transaction(client)
+        tx.close()
+        assert client.submit.call_count == 0
+
+    def test_close_is_idempotent_after_already_closed(self):
+        # After commit the transaction is closed; a follow-up close() must not
+        # raise and must not issue a second rollback/commit.
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        tx.commit()
+        submit_count_after_commit = client.submit.call_count
+        tx.close()  # no throw
+        assert client.submit.call_count == submit_count_after_commit
+
+
+class TestContextManager:
+
+    def test_enter_returns_transaction(self):
+        client = _make_client()
+        tx = Transaction(client)
+        assert tx.__enter__() is tx
+
+    def test_exit_rolls_back_open_transaction_on_clean_exit(self):
+        # ACTUAL semantics: __exit__ rolls back an open transaction even on a
+        # clean (exception-free) exit; it does NOT commit.
+        client = _make_client()
+        tx = Transaction(client)
+        with tx as t:
+            t.begin()
+            assert t.is_open
+        assert not tx.is_open
+        scripts = _scripts_submitted(client)
+        assert 'g.tx().rollback()' in scripts
+        assert 'g.tx().commit()' not in scripts
+
+    def test_exit_returns_false_to_not_suppress_exceptions(self):
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        assert tx.__exit__(None, None, None) is False
+
+    def test_exit_is_noop_when_not_open(self):
+        client = _make_client()
+        tx = Transaction(client)
+        with tx:
+            pass  # never begun
+        assert client.submit.call_count == 0
+
+
+def _make_gts(client):
+    """Build a real GraphTraversalSource whose RemoteStrategy wraps a mock
+    RemoteConnection backed by the given Client, so g.tx()/execute_in_tx work
+    without a network."""
+    from gremlin_python.process.graph_traversal import GraphTraversalSource
+    from gremlin_python.process.traversal import TraversalStrategies, GremlinLang
+    from gremlin_python.driver.remote_connection import RemoteStrategy
+
+    remote_connection = MagicMock()
+    remote_connection._client = client
+    strategies = TraversalStrategies()
+    strategies.add_strategies([RemoteStrategy(remote_connection)])
+    return GraphTraversalSource(None, strategies, GremlinLang())
+
+
+class TestExecuteInTx:
+
+    def test_commits_and_returns_body_value_on_success(self):
+        client = _make_client()
+        g = _make_gts(client)
+
+        seen = {}
+
+        def body(gtx):
+            seen['gtx'] = gtx
+            return 42
+
+        result = g.execute_in_tx(body)
+
+        assert result == 42
+        # the body was handed a (transaction-bound) GraphTraversalSource
+        assert seen['gtx'] is not None
+        scripts = _scripts_submitted(client)
+        assert 'g.tx().begin()' in scripts
+        assert 'g.tx().commit()' in scripts
+        assert 'g.tx().rollback()' not in scripts
+
+    def test_rolls_back_and_reraises_when_body_raises(self):
+        client = _make_client()
+        g = _make_gts(client)
+
+        def body(gtx):
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            g.execute_in_tx(body)
+
+        scripts = _scripts_submitted(client)
+        assert 'g.tx().begin()' in scripts
+        assert 'g.tx().rollback()' in scripts
+        assert 'g.tx().commit()' not in scripts
+
+
+class TestBeginErrorPaths:
+
+    def test_begin_reraises_when_submit_raises_and_marks_failed(self):
+        # If the client submit for "g.tx().begin()" raises, begin() marks the
+        # transaction _failed and re-raises the original error. Because _failed
+        # is terminal, a subsequent begin() takes the guard branch and reports
+        # the single-use transaction as unusable rather than retrying.
+        client = _make_client()
+        client.submit.side_effect = RuntimeError("connection lost")
+        tx = Transaction(client)
+        with pytest.raises(RuntimeError, match="connection lost"):
+            tx.begin()
+        assert not tx.is_open
+        with pytest.raises(Exception, match="closed and cannot be reused"):
+            tx.begin()
+
+    def test_begin_raises_when_server_returns_empty_result(self):
+        # An empty result list means the server sent no transaction ID.
+        client = _make_client()
+        client.submit.return_value.all.return_value.result.return_value = []
+        tx = Transaction(client)
+        with pytest.raises(Exception, match="Server did not return transaction ID"):
+            tx.begin()
+        assert not tx.is_open
+
+    def test_begin_raises_when_result_is_not_a_dict(self):
+        # results[0] must be a dict; a non-dict payload is an unexpected format.
+        client = _make_client()
+        client.submit.return_value.all.return_value.result.return_value = ["not-a-dict"]
+        tx = Transaction(client)
+        with pytest.raises(Exception, match="expected format"):
+            tx.begin()
+        assert not tx.is_open
+
+    def test_begin_raises_when_transaction_id_is_empty(self):
+        # A dict that carries a falsy transactionId is rejected as empty.
+        client = _make_client()
+        client.submit.return_value.all.return_value.result.return_value = [{'transactionId': None}]
+        tx = Transaction(client)
+        with pytest.raises(Exception, match="Server returned empty transaction ID"):
+            tx.begin()
+        assert not tx.is_open
+
+
+class TestSubmitDirect:
+
+    def test_submit_merges_transaction_id_into_request_options(self):
+        # Transaction.submit() injects the transactionId and merges any caller
+        # supplied request_options on top of it.
+        client = _make_client()
+        tx = Transaction(client)
+        tx.begin()
+        client.submit.reset_mock()
+
+        tx.submit('g.V()', request_options={'k': 1})
+
+        client.submit.assert_called_once()
+        call = client.submit.call_args
+        assert call.args[0] == 'g.V()'
+        assert call.kwargs['parameters'] is None
+        assert call.kwargs['request_options'] == {'transactionId': 'tx-123', 'k': 1}
+
+    def test_submit_when_not_open_raises(self):
+        client = _make_client()
+        tx = Transaction(client)
+        with pytest.raises(Exception, match="Transaction is not open"):
+            tx.submit('g.V()')

--- a/gremlin-python/src/main/python/tests/unit/process/test_gremlin_lang.py
+++ b/gremlin-python/src/main/python/tests/unit/process/test_gremlin_lang.py
@@ -23,7 +23,8 @@ import uuid
 
 from gremlin_python.process.strategies import ReadOnlyStrategy, SubgraphStrategy, OptionsStrategy, PartitionStrategy
 from gremlin_python.process.traversal import within, eq, T, Order, Scope, Column, Operator, P, Pop, Cardinality, \
-    between, inside, WithOptions, ShortestPath, starting_with, ending_with, containing, gt, lte, GValue
+    between, inside, WithOptions, ShortestPath, starting_with, ending_with, containing, gt, lte, GValue, Merge, \
+    CardinalityValue
 from gremlin_python.statics import SingleByte, short, long, bigint, BigDecimal, SingleChar
 from gremlin_python.structure.graph import Graph, Vertex
 from gremlin_python.process.anonymous_traversal import traversal
@@ -482,6 +483,35 @@ class TestGremlinLang(object):
             gremlin_lang = tests[t][0].gremlin_lang.get_gremlin()
             assert gremlin_lang == tests[t][1]
 
+    def test_binary_arg_rendering(self):
+        g = traversal().with_(None)
+
+        # Binary: bytes render as Binary("<base64>") via GremlinLang._arg_as_string
+        assert g.inject(b'\x01\x02').gremlin_lang.get_gremlin() == "g.inject(Binary(\"AQI=\"))"
+        assert g.V().constant(b'hello').gremlin_lang.get_gremlin() == "g.V().constant(Binary(\"aGVsbG8=\"))"
+
+    def test_duration_arg_rendering(self):
+        g = traversal().with_(None)
+
+        # Duration: positive timedelta renders as Duration(seconds,nanos)
+        assert g.V().constant(timedelta(days=1, hours=2, minutes=3, seconds=4)).gremlin_lang.get_gremlin() == \
+               "g.V().constant(Duration(93784,0))"
+        # positive duration with sub-second (microseconds -> nanos) component
+        assert g.V().constant(timedelta(seconds=5, microseconds=500000)).gremlin_lang.get_gremlin() == \
+               "g.V().constant(Duration(5,500000000))"
+        # negative timedelta renders with the 3-arg negative form Duration(seconds,nanos,false)
+        assert g.V().constant(timedelta(hours=-2)).gremlin_lang.get_gremlin() == \
+               "g.V().constant(Duration(7200,0,false))"
+        # mixed-sign timedelta normalizes to an overall negative duration
+        assert g.V().constant(timedelta(days=-1, hours=2)).gremlin_lang.get_gremlin() == \
+               "g.V().constant(Duration(79200,0,false))"
+
+    def test_subgraph_step_rendering(self):
+        g = traversal().with_(None)
+
+        # subgraph side-effect step
+        assert g.E().subgraph('sg').gremlin_lang.get_gremlin() == "g.E().subgraph('sg')"
+
     def test_gvalue_name_cannot_be_null(self):
         try:
             GValue(None, [1, 2, 3])
@@ -708,6 +738,142 @@ class TestGremlinLang(object):
         assert ("g.match('" + query + "')") == g.match(query).gremlin_lang.get_gremlin()
         params = {'name': 'marko'}
         assert ("g.match('" + query + "',['name':'marko'])") == g.match(query, params).gremlin_lang.get_gremlin()
+
+    def test_multi_label_steps(self):
+        g = traversal().with_(None)
+
+        tests = list()
+        # labels() step
+        tests.append([g.V().labels(),
+                      "g.V().labels()"])
+        # addLabel() step - single and multiple labels
+        tests.append([g.V().add_label('a'),
+                      "g.V().addLabel('a')"])
+        tests.append([g.V().add_label('a', 'b'),
+                      "g.V().addLabel('a','b')"])
+        # addLabel() carrying a child traversal argument
+        tests.append([g.V().add_label(__.values('lbl')),
+                      "g.V().addLabel(__.values('lbl'))"])
+        # dropLabel() step - single and multiple labels
+        tests.append([g.V().drop_label('a'),
+                      "g.V().dropLabel('a')"])
+        tests.append([g.V().drop_label('a', 'b'),
+                      "g.V().dropLabel('a','b')"])
+        # dropLabels() step (drops all labels)
+        tests.append([g.V().drop_labels(),
+                      "g.V().dropLabels()"])
+        # with('multilabel') applied together with elementMap()/valueMap()
+        tests.append([g.V().element_map().with_('multilabel'),
+                      "g.V().elementMap().with('multilabel')"])
+        tests.append([g.V().value_map().with_('multilabel'),
+                      "g.V().valueMap().with('multilabel')"])
+        # multi-label addV using label varargs
+        tests.append([g.add_v('a', 'b'),
+                      "g.addV('a','b')"])
+        # multi-label mergeV using a list-valued T.label in the merge map
+        tests.append([g.merge_v({T.label: ['a', 'b']}),
+                      "g.mergeV([(T.label):['a','b']])"])
+
+        for t in range(len(tests)):
+            gremlin_lang = tests[t][0].gremlin_lang.get_gremlin()
+            assert gremlin_lang == tests[t][1]
+
+    def test_child_traversal_arguments(self):
+        g = traversal().with_(None)
+
+        tests = list()
+        # Steps taking a child traversal as an argument
+        tests.append([g.V().has('k', __.out()),
+                      "g.V().has('k',__.out())"])
+        tests.append([g.V().has_label(__.values('x')),
+                      "g.V().hasLabel(__.values('x'))"])
+        tests.append([g.V().is_(__.constant(1)),
+                      "g.V().is(__.constant(1))"])
+        tests.append([g.V().property('k', __.constant(1)),
+                      "g.V().property('k',__.constant(1))"])
+
+        # P predicates carrying a single child traversal argument
+        tests.append([g.V().where(P.eq(__.constant(1))),
+                      "g.V().where(eq(__.constant(1)))"])
+        tests.append([g.V().where(P.neq(__.constant(1))),
+                      "g.V().where(neq(__.constant(1)))"])
+        tests.append([g.V().where(P.gt(__.constant(1))),
+                      "g.V().where(gt(__.constant(1)))"])
+        tests.append([g.V().where(P.lt(__.constant(1))),
+                      "g.V().where(lt(__.constant(1)))"])
+        tests.append([g.V().where(P.gte(__.constant(1))),
+                      "g.V().where(gte(__.constant(1)))"])
+        tests.append([g.V().where(P.lte(__.constant(1))),
+                      "g.V().where(lte(__.constant(1)))"])
+        tests.append([g.V().where(P.within(__.constant(1))),
+                      "g.V().where(within(__.constant(1)))"])
+        tests.append([g.V().where(P.without(__.constant(1))),
+                      "g.V().where(without(__.constant(1)))"])
+
+        # Multi-traversal within()/without() render as comma-separated args (no brackets)
+        tests.append([g.V().where(P.within(__.constant(1), __.constant(2))),
+                      "g.V().where(within(__.constant(1),__.constant(2)))"])
+        tests.append([g.V().where(P.without(__.constant(1), __.constant(2))),
+                      "g.V().where(without(__.constant(1),__.constant(2)))"])
+
+        # TextP predicate carrying a child traversal argument
+        tests.append([g.V().has('k', containing(__.constant('x'))),
+                      "g.V().has('k',containing(__.constant('x')))"])
+
+        # V()/E() as start steps seeded from a child traversal
+        tests.append([g.V(__.V()),
+                      "g.V(__.V())"])
+        tests.append([g.E(__.E()),
+                      "g.E(__.E())"])
+
+        for t in range(len(tests)):
+            gremlin_lang = tests[t][0].gremlin_lang.get_gremlin()
+            assert gremlin_lang == tests[t][1]
+
+    def test_non_trivial_argument_rendering(self):
+        g = traversal().with_(None)
+
+        tests = list()
+        # from_(Vertex)/to(Vertex): GraphTraversal.from_/to detect a Vertex arg and rewrite it to
+        # __.V(<id>) (see graph_traversal.py from_/to), so only the vertex id is emitted inside
+        # an anonymous V() traversal - the label ('person') is dropped.
+        tests.append([g.add_e('route').from_(Vertex(1, 'person')).to(Vertex(2, 'person')),
+                      "g.addE('route').from(__.V(1)).to(__.V(2))"])
+
+        # Merge tokens: enum members with a mid-name underscore render camelCased by
+        # GremlinLang._arg_as_string (on_create -> onCreate, on_match -> onMatch, out_v -> outV,
+        # in_v -> inV).
+        tests.append([g.merge_v({'name': 'marko'}).option(Merge.on_create, {'name': 'stephen'}),
+                      "g.mergeV(['name':'marko']).option(Merge.onCreate,['name':'stephen'])"])
+        # Non-str dict keys (the T and Merge enum tokens) are paren-wrapped by
+        # GremlinLang._process_dict, e.g. (T.label) and (Merge.outV); str keys are not wrapped.
+        tests.append([g.merge_e({T.label: 'knows', Merge.out_v: 1, Merge.in_v: 2}),
+                      "g.mergeE([(T.label):'knows',(Merge.outV):1,(Merge.inV):2])"])
+
+        # CardinalityValue renders via the CardinalityValueTraversal branch of
+        # GremlinLang._add_to_gremlin as Cardinality.<card>(<value>); list_ -> Cardinality.list,
+        # set_ -> Cardinality.set (trailing underscore stripped by the enum handling).
+        tests.append([g.merge_v({'name': 'marko'}).option(Merge.on_match, {'age': CardinalityValue.list_(33)}),
+                      "g.mergeV(['name':'marko']).option(Merge.onMatch,['age':Cardinality.list(33)])"])
+        tests.append([g.V().has('name', 'foo').property({'name': CardinalityValue.set_('bar'), 'age': 43}),
+                      "g.V().has('name','foo').property(['name':Cardinality.set('bar'),'age':43])"])
+
+        # Operator enum forms: mid-name underscore camelCases (add_all -> addAll,
+        # sum_long -> sumLong) while a trailing underscore is stripped (and_ -> and, or_ -> or).
+        tests.append([g.inject(Operator.add_all, Operator.sum_long, Operator.and_, Operator.or_),
+                      "g.inject(Operator.addAll,Operator.sumLong,Operator.and,Operator.or)"])
+
+        for t in range(len(tests)):
+            gremlin_lang = tests[t][0].gremlin_lang.get_gremlin()
+            assert gremlin_lang == tests[t][1]
+
+    def test_source_level_with_multilabel_uses_double_quotes(self):
+        g = traversal().with_(None)
+        # Source-level GraphTraversalSource.with_ special-cases 'multilabel'/'singlelabel' and
+        # emits the option key with DOUBLE quotes: .with("multilabel"). This differs from the
+        # step-level with_ (and every other string arg), which renders via _arg_as_string using
+        # repr() and therefore SINGLE quotes, e.g. .with('...').
+        assert 'g.with("multilabel").V()' == g.with_('multilabel').V().gremlin_lang.get_gremlin()
 
     def test_eq_different_gremlin_steps_not_equal(self):
         # Same (empty) parameters but different gremlin steps must not compare equal.

--- a/gremlin-python/src/main/python/tests/unit/process/test_strategies.py
+++ b/gremlin-python/src/main/python/tests/unit/process/test_strategies.py
@@ -104,3 +104,41 @@ class TestTraversalStrategies(object):
             booleanKey=True
         )).gremlin_lang
         assert "withStrategies(new CustomConfigurableStrategy(stringKey:'string value',intKey:5,booleanKey:true))" in str(gremlin_script)
+
+    def test_configured_strategy_full_strings(self):
+        # Assert the exact 'g.withStrategies(new <Name>(key:value,...)).V()' string for
+        # configured strategies (option order = configuration-dict insertion order).
+        g = traversal().with_(None)
+
+        tests = list()
+        # EdgeLabelVerificationStrategy: always emits logWarning + throwException (both stored
+        # unconditionally in __init__), so even a configured instance lists both keys.
+        tests.append([g.with_strategies(
+            EdgeLabelVerificationStrategy(log_warning=True, throw_exception=True)).V(),
+            "g.withStrategies(new EdgeLabelVerificationStrategy(logWarning:true,throwException:true)).V()"])
+        # Default EdgeLabelVerificationStrategy() still renders as configured (both flags False).
+        tests.append([g.with_strategies(EdgeLabelVerificationStrategy()).V(),
+            "g.withStrategies(new EdgeLabelVerificationStrategy(logWarning:false,throwException:false)).V()"])
+        # ReservedKeysVerificationStrategy defaults keys=['id','label'] -> rendered as a list literal.
+        tests.append([g.with_strategies(ReservedKeysVerificationStrategy()).V(),
+            "g.withStrategies(new ReservedKeysVerificationStrategy(logWarning:false,throwException:false,keys:['id','label'])).V()"])
+        # SeedStrategy: single int option, emitted bare (no type suffix).
+        tests.append([g.with_strategies(SeedStrategy(seed=999999)).V(),
+            "g.withStrategies(new SeedStrategy(seed:999999)).V()"])
+        # HaltedTraverserStrategy: string option -> repr()'d with single quotes.
+        tests.append([g.with_strategies(HaltedTraverserStrategy(halted_traverser_factory='detached')).V(),
+            "g.withStrategies(new HaltedTraverserStrategy(haltedTraverserFactory:'detached')).V()"])
+        # SubgraphStrategy: only the provided (non-None) checkAdjacentVertices option is emitted.
+        tests.append([g.with_strategies(SubgraphStrategy(check_adjacent_vertices=True)).V(),
+            "g.withStrategies(new SubgraphStrategy(checkAdjacentVertices:true)).V()"])
+        # PartitionStrategy: options emitted in insertion order (partitionKey, writePartition,
+        # readPartitions, includeMetaProperties); readPartitions is a list literal.
+        tests.append([g.with_strategies(PartitionStrategy(
+            partition_key='p', write_partition='a', read_partitions=['a', 'b'], include_meta_properties=True)).V(),
+            "g.withStrategies(new PartitionStrategy(partitionKey:'p',writePartition:'a',readPartitions:['a','b'],includeMetaProperties:true)).V()"])
+        # VertexProgramStrategy: exercise its config path with a single non-None option (workers).
+        tests.append([g.with_strategies(VertexProgramStrategy(workers=4)).V(),
+            "g.withStrategies(new VertexProgramStrategy(workers:4)).V()"])
+
+        for t in range(len(tests)):
+            assert tests[t][0].gremlin_lang.get_gremlin() == tests[t][1]

--- a/gremlin-python/src/main/python/tests/unit/process/test_traversal.py
+++ b/gremlin-python/src/main/python/tests/unit/process/test_traversal.py
@@ -1,0 +1,490 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""
+gremlin_python.process.traversal.
+
+These tests exercise the Traversal iteration protocol and the traversal.py
+object model (Traverser, TraversalStrategies, TraversalStrategy, AtomicInteger,
+and GremlinLang copy/convert helpers).
+
+All assertions target the *actual* current behavior of the source. Where a
+suspected bug is found, the test asserts the real behavior and flags the bug in
+a comment rather than asserting idealized behavior or modifying the source.
+"""
+import copy
+
+import pytest
+
+from gremlin_python.statics import long
+from gremlin_python.process.traversal import (
+    Traversal,
+    Traverser,
+    TraversalStrategies,
+    TraversalStrategy,
+    AtomicInteger,
+    GremlinLang,
+    P,
+    TextP,
+)
+
+
+class _FakeStrategies(object):
+    """Minimal stand-in for TraversalStrategies.
+
+    apply_strategies() populates traversal.traversers from a fixed list, which
+    is exactly the wiring Traversal.__next__/next_traverser/has_next rely on.
+    This lets us drive the iteration protocol with no server.
+    """
+
+    def __init__(self, traversers):
+        self._traversers = list(traversers)
+        self.applied = 0
+
+    def apply_strategies(self, traversal):
+        self.applied += 1
+        traversal.traversers = iter(self._traversers)
+
+
+def _make_traversal(traversers, graph=None):
+    # Real __init__ signature is (graph, traversal_strategies, gremlin_lang).
+    return Traversal(graph, _FakeStrategies(traversers), GremlinLang())
+
+
+# ---------------------------------------------------------------------------
+# 1. Traversal iteration protocol
+# ---------------------------------------------------------------------------
+
+class TestTraversalIteration(object):
+
+    def test_next_bulk_expansion_of_traverser(self):
+        # Traverser(obj, bulk=2) must yield obj twice before advancing;
+        # a non-Traverser value yields exactly once.
+        t = _make_traversal([Traverser('a', bulk=2), 'b'])
+        assert t.__next__() == 'a'
+        assert t.__next__() == 'a'
+        assert t.__next__() == 'b'
+        with pytest.raises(StopIteration):
+            t.__next__()
+
+    def test_next_no_amount_delegates_to_dunder_next(self):
+        t = _make_traversal(['only'])
+        assert t.next() == 'only'
+
+    def test_next_with_amount_returns_up_to_n_and_stops_early(self):
+        # Requesting more than available returns what's there without raising.
+        t = _make_traversal(['x', 'y'])
+        assert t.next(5) == ['x', 'y']
+
+    def test_next_with_amount_returns_exactly_n_when_available(self):
+        t = _make_traversal(['x', 'y', 'z'])
+        assert t.next(2) == ['x', 'y']
+
+    def test_to_list_drains_all(self):
+        t = _make_traversal(['x', 'y', 'z'])
+        assert t.to_list() == ['x', 'y', 'z']
+
+    def test_to_set_dedups(self):
+        t = _make_traversal(['a', 'a', 'b'])
+        assert t.to_set() == {'a', 'b'}
+
+    def test_iterate_drains_and_returns_self(self):
+        t = _make_traversal(['a', 'b', 'c'])
+        result = t.iterate()
+        assert result is t
+        # iterate() appends a 'discard' step to the gremlin bytecode.
+        assert 'discard' in t.gremlin_lang.get_gremlin()
+
+    def test_next_traverser_returns_raw_traverser(self):
+        # next_traverser must return the Traverser itself, not the unwrapped object.
+        t = _make_traversal([Traverser('a', bulk=2)])
+        raw = t.next_traverser()
+        assert isinstance(raw, Traverser)
+        assert raw.object == 'a'
+        assert raw.bulk == 2
+
+    def test_iter_returns_self(self):
+        t = _make_traversal(['x'])
+        assert iter(t) is t
+
+    def test_eq_equal_gremlin_strings_are_equal(self):
+        t1 = _make_traversal([])
+        t1.gremlin_lang.add_step('V')
+        t2 = _make_traversal([])
+        t2.gremlin_lang.add_step('V')
+        assert t1 == t2
+
+    def test_eq_different_gremlin_strings_not_equal(self):
+        t1 = _make_traversal([])
+        t1.gremlin_lang.add_step('V')
+        t2 = _make_traversal([])
+        t2.gremlin_lang.add_step('E')
+        assert t1 != t2
+
+    def test_eq_non_traversal_is_not_equal(self):
+        t = _make_traversal([])
+        assert (t == 'not a traversal') is False
+
+    def test_repr_is_gremlin_string(self):
+        t = _make_traversal([])
+        t.gremlin_lang.add_step('V')
+        assert repr(t) == t.gremlin_lang.get_gremlin()
+        assert repr(t) == 'g.V()'
+
+    def test_has_next_false_when_exhausted_true_when_items_remain(self):
+        # has_next() pulls one traverser and caches it; on an empty traversal
+        # the underlying next() raises StopIteration and has_next() returns
+        # False, while a non-empty traversal returns True.
+        assert _make_traversal([]).has_next() is False
+        assert _make_traversal([Traverser('a')]).has_next() is True
+
+    def test_has_next_caches_traverser_returned_by_next_traverser(self):
+        # has_next() stores the pulled traverser in last_traverser; the very
+        # next next_traverser() must return that SAME cached instance instead of
+        # advancing the iterator again.
+        tr = Traverser('a', bulk=2)
+        t = _make_traversal([tr])
+        assert t.has_next() is True
+        assert t.next_traverser() is tr
+
+
+# ---------------------------------------------------------------------------
+# 2. Traverser
+# ---------------------------------------------------------------------------
+
+class TestTraverser(object):
+
+    def test_bulk_defaults_to_long_one(self):
+        tr = Traverser('x')
+        assert tr.bulk == long(1)
+
+    def test_explicit_bulk_is_kept(self):
+        tr = Traverser('x', bulk=7)
+        assert tr.bulk == 7
+
+    def test_eq_compares_only_object_ignoring_bulk(self):
+        assert Traverser('x', bulk=2) == Traverser('x', bulk=99)
+        assert Traverser('x') != Traverser('y')
+
+    def test_eq_non_traverser_is_not_equal(self):
+        assert (Traverser('x') == 'x') is False
+
+    def test_repr_equals_str_of_object(self):
+        assert repr(Traverser(42)) == str(42)
+        assert repr(Traverser('abc')) == 'abc'
+
+
+# ---------------------------------------------------------------------------
+# 3. TraversalStrategies
+# ---------------------------------------------------------------------------
+
+class TestTraversalStrategies(object):
+
+    def test_default_init_is_empty(self):
+        ts = TraversalStrategies()
+        assert ts.traversal_strategies == []
+
+    def test_copy_constructor_takes_source_list(self):
+        source = TraversalStrategies()
+        s1, s2 = TraversalStrategy(), TraversalStrategy()
+        source.traversal_strategies = [s1, s2]
+        copied = TraversalStrategies(source)
+        assert copied.traversal_strategies == [s1, s2]
+
+    def test_add_strategies_concatenates(self):
+        ts = TraversalStrategies()
+        a, b, c = TraversalStrategy(), TraversalStrategy(), TraversalStrategy()
+        ts.traversal_strategies = [a]
+        ts.add_strategies([b, c])
+        assert ts.traversal_strategies == [a, b, c]
+
+
+# ---------------------------------------------------------------------------
+# 4. TraversalStrategy
+# ---------------------------------------------------------------------------
+
+class _MyStrategy(TraversalStrategy):
+    pass
+
+
+class TestTraversalStrategy(object):
+
+    def test_strategy_name_defaults_to_class_name(self):
+        assert TraversalStrategy().strategy_name == 'TraversalStrategy'
+        assert _MyStrategy().strategy_name == '_MyStrategy'
+
+    def test_explicit_strategy_name_is_kept(self):
+        assert TraversalStrategy(strategy_name='Custom').strategy_name == 'Custom'
+
+    def test_kwargs_merged_into_configuration(self):
+        s = TraversalStrategy(a=1, b=2)
+        assert s.configuration == {'a': 1, 'b': 2}
+
+    def test_configuration_takes_precedence_over_kwargs(self):
+        # Source merges as {**kwargs, **self.configuration}, so an explicit
+        # configuration value wins over a same-named kwarg.
+        s = TraversalStrategy(configuration={'x': 'cfg'}, x='kwarg', y='kwarg')
+        assert s.configuration == {'x': 'cfg', 'y': 'kwarg'}
+
+    def test_eq_true_for_same_class_regardless_of_config(self):
+        assert TraversalStrategy(a=1) == TraversalStrategy(b=2)
+
+    def test_eq_false_for_different_class(self):
+        assert (TraversalStrategy() == _MyStrategy()) is False
+
+    def test_hash_uses_strategy_name(self):
+        assert hash(TraversalStrategy()) == hash('TraversalStrategy')
+        assert hash(_MyStrategy()) == hash('_MyStrategy')
+
+
+# ---------------------------------------------------------------------------
+# 5. AtomicInteger
+# ---------------------------------------------------------------------------
+
+class TestAtomicInteger(object):
+
+    def test_get_and_increment_returns_pre_increment_values(self):
+        ai = AtomicInteger()
+        assert ai.get_and_increment() == 0
+        assert ai.get_and_increment() == 1
+        assert ai.get_and_increment() == 2
+        assert ai.value == 3
+
+    def test_set_returns_new_value(self):
+        ai = AtomicInteger()
+        assert ai.set(10) == 10
+        assert ai.value == 10
+
+    def test_value_property_reflects_state(self):
+        ai = AtomicInteger()
+        assert ai.value == 0
+        ai.get_and_increment()
+        assert ai.value == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. GremlinLang.__copy__ / __deepcopy__
+# ---------------------------------------------------------------------------
+
+class TestGremlinLangCopy(object):
+
+    def test_copy_shares_parameters_and_gremlin_references(self):
+        gl = GremlinLang()
+        gl.add_step('V')
+        gl.parameters['k'] = 'v'
+        shallow = copy.copy(gl)
+        # __copy__ assigns the same underlying list/dict objects.
+        assert shallow.gremlin is gl.gremlin
+        assert shallow.parameters is gl.parameters
+
+    def test_deepcopy_is_independent(self):
+        gl = GremlinLang()
+        gl.add_step('V')
+        gl.parameters['k'] = 'v'
+        deep = copy.deepcopy(gl)
+        assert deep.gremlin is not gl.gremlin
+        assert deep.parameters is not gl.parameters
+        assert deep.gremlin == gl.gremlin
+        assert deep.parameters == gl.parameters
+        # Mutating the deep copy must not affect the original.
+        deep.gremlin.append('.mutated')
+        deep.parameters['new'] = 'x'
+        assert '.mutated' not in gl.gremlin
+        assert 'new' not in gl.parameters
+
+
+# ---------------------------------------------------------------------------
+# 7. GremlinLang._convert_argument
+# ---------------------------------------------------------------------------
+
+class TestConvertArgument(object):
+
+    def test_non_anonymous_child_traversal_raises_type_error(self):
+        gl = GremlinLang()
+        # A child traversal spawned from a source (graph is not None) is illegal.
+        child = Traversal('some-graph', _FakeStrategies([]), GremlinLang())
+        with pytest.raises(TypeError) as excinfo:
+            gl._convert_argument(child)
+        assert 'spawned anonymously' in str(excinfo.value)
+
+    def test_anonymous_child_traversal_converted_to_gremlin_lang(self):
+        gl = GremlinLang()
+        anon = Traversal(None, _FakeStrategies([]), GremlinLang())
+        assert gl._convert_argument(anon) is anon.gremlin_lang
+
+    def test_nested_dict_list_set_of_plain_values_unchanged(self):
+        gl = GremlinLang()
+        assert gl._convert_argument({1: [2, 3]}) == {1: [2, 3]}
+        assert gl._convert_argument([1, [2, 3]]) == [1, [2, 3]]
+        assert gl._convert_argument({1, 2, 3}) == {1, 2, 3}
+
+    def test_nested_anonymous_traversal_inside_container_converted(self):
+        gl = GremlinLang()
+        anon = Traversal(None, _FakeStrategies([]), GremlinLang())
+        converted = gl._convert_argument([anon])
+        assert converted == [anon.gremlin_lang]
+
+
+
+# ---------------------------------------------------------------------------
+# 8. P / TextP predicate object model
+# ---------------------------------------------------------------------------
+
+class TestPRepr(object):
+    def test_single_arg_repr(self):
+        # other is None -> "operator(value)"
+        assert repr(P.eq(2)) == "eq(2)"
+        assert repr(P.gt(5)) == "gt(5)"
+
+    def test_two_arg_repr(self):
+        # other is not None -> "operator(value,other)" (no space after comma)
+        assert repr(P.between(1, 2)) == "between(1,2)"
+        assert repr(P.inside(1, 10)) == "inside(1,10)"
+
+    def test_repr_uses_str_of_operands(self):
+        # value/other are stringified via str()
+        assert repr(P.within([1, 2, 3])) == "within([1, 2, 3])"
+
+
+class TestPEquality(object):
+    def test_equal_same_fields(self):
+        assert P.eq(2) == P.eq(2)
+        assert P.between(1, 2) == P.between(1, 2)
+
+    def test_not_equal_different_value(self):
+        assert P.eq(2) != P.eq(3)
+
+    def test_not_equal_different_operator(self):
+        assert P.eq(2) != P.gt(2)
+
+    def test_not_equal_different_other(self):
+        assert P.between(1, 2) != P.between(1, 3)
+
+    def test_not_equal_non_p(self):
+        # isinstance guard makes comparison against a plain value False
+        assert P.eq(2) != 2
+
+
+class TestPTextPSubclassEquality(object):
+    def test_p_equals_textp_is_false_this_direction(self):
+        p = P.eq(2)
+        t = TextP("eq", 2)
+        # reflected priority calls TextP.__eq__(p); isinstance(p, TextP) is False -> False.
+        assert (p == t) is False
+
+    def test_textp_equals_p_is_false_reverse_direction(self):
+        p = P.eq(2)
+        t = TextP("eq", 2)
+        # self is TextP; isinstance(p, TextP) is False -> False.
+        assert (t == p) is False
+
+
+class TestPBooleanComposition(object):
+    def test_and_builds_nested_p(self):
+        left = P.gt(0)
+        right = P.lt(10)
+        combined = left.and_(right)
+        # and_ -> P("and", self, arg): value holds self, other holds arg
+        assert combined.operator == "and"
+        assert combined.value is left
+        assert combined.other is right
+
+    def test_or_builds_nested_p(self):
+        left = P.gt(0)
+        right = P.lt(10)
+        combined = left.or_(right)
+        assert combined.operator == "or"
+        assert combined.value is left
+        assert combined.other is right
+
+
+class TestPWithinWithoutBranches(object):
+    def test_within_single_list_kept_as_is(self):
+        source = [1, 2, 3]
+        p = P.within(source)
+        assert p.operator == "within"
+        # the exact list object is retained (not copied)
+        assert p.value is source
+
+    def test_within_single_set_converted_to_list(self):
+        p = P.within({1, 2, 3})
+        assert p.operator == "within"
+        assert isinstance(p.value, list)
+        assert set(p.value) == {1, 2, 3}
+
+    def test_within_single_traversal_passthrough(self):
+        trav = Traversal(None, None, None)
+        p = P.within(trav)
+        assert p.operator == "within"
+        # a lone Traversal is passed through untouched (not wrapped in a list)
+        assert p.value is trav
+
+    def test_within_varargs_becomes_list(self):
+        p = P.within(1, 2, 3)
+        assert p.operator == "within"
+        assert p.value == [1, 2, 3]
+
+    def test_without_single_list_kept_as_is(self):
+        source = [1, 2, 3]
+        p = P.without(source)
+        assert p.operator == "without"
+        assert p.value is source
+
+    def test_without_single_set_converted_to_list(self):
+        p = P.without({1, 2, 3})
+        assert p.operator == "without"
+        assert isinstance(p.value, list)
+        assert set(p.value) == {1, 2, 3}
+
+    def test_without_single_traversal_passthrough(self):
+        trav = Traversal(None, None, None)
+        p = P.without(trav)
+        assert p.operator == "without"
+        assert p.value is trav
+
+    def test_without_varargs_becomes_list(self):
+        p = P.without(1, 2, 3)
+        assert p.operator == "without"
+        assert p.value == [1, 2, 3]
+
+
+class TestPUnhashable(object):
+    # P (and TextP) define __eq__ but not __hash__, so Python sets __hash__ to
+    # None, making instances unhashable. Documented, not fixed.
+    def test_p_is_unhashable(self):
+        with pytest.raises(TypeError):
+            hash(P.eq(1))
+
+    def test_textp_is_unhashable(self):
+        with pytest.raises(TypeError):
+            hash(TextP.containing("x"))
+
+
+class TestTextPObjectModel(object):
+    def test_textp_repr_single_arg(self):
+        assert repr(TextP.containing("x")) == "containing(x)"
+
+    def test_textp_equality_same_class(self):
+        assert TextP.containing("x") == TextP.containing("x")
+        assert TextP.containing("x") != TextP.containing("y")
+
+    def test_textp_operator_and_value(self):
+        t = TextP.starting_with("ab")
+        assert t.operator == "startingWith"
+        assert t.value == "ab"
+        assert t.other is None

--- a/gremlin-python/src/main/python/tests/unit/structure/io/test_graphbinaryV4.py
+++ b/gremlin-python/src/main/python/tests/unit/structure/io/test_graphbinaryV4.py
@@ -21,6 +21,8 @@ import uuid
 import math
 from collections import OrderedDict
 
+import pytest
+
 from datetime import datetime, timedelta, timezone
 from gremlin_python.statics import long, bigint, BigDecimal, SingleByte, SingleChar
 from gremlin_python.structure.graph import Graph, Vertex, Edge, Property, VertexProperty, Path, CompositePDT
@@ -441,3 +443,24 @@ class TestGraphBinaryV4(object):
         result = self.graphbinary_reader.read_object(self.graphbinary_writer.write_object(pdt))
         assert result.fields['value'] is None
         assert result.fields['name'] == 'test'
+
+    def test_read_unregistered_type_code_raises(self):
+        # to_object() looks the leading type-code byte up in the deserializer
+        # map; an unregistered code (0x7f is not a DataType) takes the KeyError
+        # branch and is re-raised as ValueError "<code> is not a valid DataType".
+        with pytest.raises(ValueError, match='is not a valid DataType'):
+            self.graphbinary_reader.read_object(bytearray([0x7f]))
+
+    def test_long_overflow_raises(self):
+        # LongIO.dictify rejects values outside the signed int64 range and
+        # points the user at the bigint type instead of silently truncating.
+        with pytest.raises(Exception, match='Value too big'):
+            self.graphbinary_writer.write_object(long(9223372036854775808))
+        with pytest.raises(Exception, match='Value too big'):
+            self.graphbinary_writer.write_object(long(-9223372036854775809))
+
+    def test_naive_datetime_raises(self):
+        # DateTimeIO.dictify requires tz-aware datetimes; a naive datetime
+        # (tzinfo is None) raises AttributeError before any bytes are written.
+        with pytest.raises(AttributeError, match='Timezone information'):
+            self.graphbinary_writer.write_object(datetime(2022, 5, 20))

--- a/gremlin-python/src/main/python/tests/unit/structure/io/test_graphbinaryv4model.py
+++ b/gremlin-python/src/main/python/tests/unit/structure/io/test_graphbinaryv4model.py
@@ -118,9 +118,9 @@ def test_sign_boundary_pos_biginteger():
     run_writeread("sign-boundary-pos-biginteger")
 
 def test_sign_boundary_neg_biginteger():
-    # gremlin-python can't serialize -129 because BigIntIO computes a byte length
-    # that is too small for signed two's-complement encoding.
-    run_read("sign-boundary-neg-biginteger")
+    # -129 round-trips by value; use run_writeread rather than byte-exact run()
+    # because reading narrows the bigint to a plain int (re-serialized via IntIO).
+    run_writeread("sign-boundary-neg-biginteger")
 
 def test_uint8_primitive_pdt():
     run("uint8-primitive-pdt")

--- a/gremlin-python/src/main/python/tests/unit/structure/io/test_util.py
+++ b/gremlin-python/src/main/python/tests/unit/structure/io/test_util.py
@@ -17,7 +17,10 @@
 # under the License.
 #
 
-from gremlin_python.structure.io.util import SymbolUtil
+import pytest
+
+from gremlin_python.statics import SingleByte
+from gremlin_python.structure.io.util import SymbolUtil, HashableDict, Marker
 
 
 class TestSymbolUtil(object):
@@ -33,5 +36,67 @@ class TestSymbolUtil(object):
         assert SymbolUtil.to_snake_case("sum_long") == "sum_long"
         assert SymbolUtil.to_snake_case("sum") == "sum"
         assert SymbolUtil.to_snake_case("onMerge") == "on_merge"
+
+
+class TestHashableDict(object):
+
+    def test_of_converts_nested_dict_to_hashable(self):
+        """HashableDict.of recursively converts nested dicts into HashableDict."""
+        result = HashableDict.of({'k': {'inner': [1, 2]}})
+        assert isinstance(result, HashableDict)
+        assert isinstance(result['k'], HashableDict)
+        # Nested list values are converted to tuples so they are hashable.
+        assert result['k']['inner'] == (1, 2)
+
+    def test_of_result_is_hashable(self):
+        """The result of HashableDict.of is hashable."""
+        result = HashableDict.of({'k': {'inner': [1, 2]}})
+        assert isinstance(hash(result), int)
+
+    def test_of_equal_inputs_are_equal_and_hash_equal(self):
+        """Equal inputs produce equal HashableDicts with equal hashes."""
+        a = HashableDict.of({'k': {'inner': [1, 2]}})
+        b = HashableDict.of({'k': {'inner': [1, 2]}})
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_of_passthrough_for_scalars(self):
+        """Non-collection values are returned unchanged."""
+        assert HashableDict.of(42) == 42
+        assert HashableDict.of("x") == "x"
+
+    def test_of_converts_collections_to_tuples(self):
+        """Lists and sets become tuples of converted elements."""
+        assert HashableDict.of([1, 2, 3]) == (1, 2, 3)
+        assert HashableDict.of([{'a': 1}])[0] == HashableDict.of({'a': 1})
+
+    def test_hash_fallback_with_unsortable_mixed_keys(self):
+        """Keys of mutually unsortable types fall back to string-based hashing without error."""
+        # int and str keys cannot be sorted against each other in Python 3,
+        # so __hash__ must use its except-branch fallback.
+        d = HashableDict({1: 'a', 'b': 2})
+        assert isinstance(hash(d), int)
+
+    def test_hash_fallback_is_stable(self):
+        """The fallback hash is stable across equal dicts."""
+        d1 = HashableDict({1: 'a', 'b': 2})
+        d2 = HashableDict({1: 'a', 'b': 2})
+        assert hash(d1) == hash(d2)
+
+
+class TestMarker(object):
+
+    def test_of_zero_is_end_of_stream(self):
+        """Marker.of(0) returns the end-of-stream marker singleton."""
+        assert Marker.of(0) == Marker.end_of_stream()
+
+    def test_of_nonzero_raises_value_error(self):
+        """Marker.of with a non-zero value raises ValueError."""
+        with pytest.raises(ValueError):
+            Marker.of(1)
+
+    def test_end_of_stream_value(self):
+        """The end-of-stream marker wraps SingleByte(0)."""
+        assert Marker.end_of_stream().get_value() == SingleByte(0)
 
 

--- a/gremlin-python/src/main/python/tests/unit/structure/test_graph.py
+++ b/gremlin-python/src/main/python/tests/unit/structure/test_graph.py
@@ -19,6 +19,8 @@
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
+import pytest
+
 from gremlin_python.statics import long
 from gremlin_python.structure.graph import Edge
 from gremlin_python.structure.graph import Graph
@@ -26,6 +28,10 @@ from gremlin_python.structure.graph import Property
 from gremlin_python.structure.graph import Vertex
 from gremlin_python.structure.graph import VertexProperty
 from gremlin_python.structure.graph import Path
+from gremlin_python.structure.graph import Tree
+from gremlin_python.structure.graph import CompositePDT
+from gremlin_python.structure.graph import PrimitivePDT
+from gremlin_python.structure.graph import PDTRegistry
 
 
 class TestGraph(object):
@@ -248,3 +254,83 @@ class TestGraph(object):
         # supports the pattern: vertex[key] if key in vertex else None
         assert v["name"] if "name" in v else None == "marko"
         assert v["missing"] if "missing" in v else None is None
+
+
+class TestEdgeLabels(object):
+    def test_edge_labels_property_is_frozenset(self):
+        e = Edge(1, Vertex(2), "knows", Vertex(3), labels=["knows", "likes"])
+        assert e.labels == frozenset({"knows", "likes"})
+        assert isinstance(e.labels, frozenset)
+        # label (singular) is derived from the first of the provided labels
+        assert e.label in {"knows", "likes"}
+
+
+class TestCompositePDT(object):
+    def test_equal_composites_hash_equal(self):
+        a = CompositePDT("point", {"x": 1, "y": 2})
+        b = CompositePDT("point", {"x": 1, "y": 2})
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_hash_with_unhashable_field_falls_back_to_name(self):
+        # frozenset(items) raises TypeError when a field value is unhashable
+        # (e.g. a list); __hash__ then falls back to hash(name) without raising.
+        pdt = CompositePDT("thing", {"vals": [1, 2, 3]})
+        assert hash(pdt) == hash("thing")
+
+    def test_repr_format(self):
+        pdt = CompositePDT("point", {"x": 1})
+        assert repr(pdt) == "pdt[point]{'x': 1}"
+
+
+class TestPDTRegistryRegisterPrimitive(object):
+    def test_register_with_target_class_populates_by_class_map(self):
+        class MyType(object):
+            pass
+
+        reg = PDTRegistry()
+        reg.register_primitive("myType", from_value=lambda s: MyType(),
+                                to_value=str, target_class=MyType)
+        adapter = reg.get_primitive_adapter_by_class(MyType)
+        assert adapter is not None
+        assert adapter["type_name"] == "myType"
+        assert adapter["to_value"] is str
+
+    def test_register_without_target_class_leaves_by_class_map_empty(self):
+        class MyType(object):
+            pass
+
+        reg = PDTRegistry()
+        reg.register_primitive("myType", from_value=lambda s: MyType())
+        assert reg.get_primitive_adapter_by_class(MyType) is None
+
+
+class TestPDTRegistryHydratePrimitive(object):
+    def test_non_primitive_input_returned_unchanged(self):
+        reg = PDTRegistry()
+        composite = CompositePDT("point", {"x": 1})
+        assert reg.hydrate_primitive(composite) is composite
+
+
+class TestTree(object):
+    def test_init_rejects_non_tree_child(self):
+        with pytest.raises(TypeError):
+            Tree([("k", "not-a-tree")])
+
+    def test_eq_against_non_tree(self):
+        t = Tree([("a", Tree())])
+        # __eq__ returns NotImplemented for non-Tree; Python resolves to False
+        assert (t == "not-a-tree") is False
+        assert (t != "not-a-tree") is True
+
+    def test_eq_same_size_different_root_key(self):
+        t1 = Tree([("a", Tree())])
+        t2 = Tree([("b", Tree())])
+        # equal number of root entries but differing keys -> not equal
+        assert len(t1.root_nodes()) == len(t2.root_nodes())
+        assert t1 != t2
+
+    def test_repr_format(self):
+        assert repr(Tree()) == "{}"
+        assert repr(Tree([("a", Tree())])) == "{a={}}"
+        assert repr(Tree([("a", Tree([("b", Tree())]))])) == "{a={b={}}}"


### PR DESCRIPTION
# Increase gremlin-python test coverage

Adds targeted unit tests for `gremlin-python` that exercise previously-untested library
code: the explicit-transaction lifecycle (`Transaction` / `execute_in_tx`), the GraphBinary
V4 serializer internals (`configure_pdt_registry` merge and `finalize_message` byte layout),
the `Traversal` iteration protocol and `traversal.py` object model (`Traverser`,
`TraversalStrategies`/`TraversalStrategy`, `P`/`TextP`, `AtomicInteger`, `GremlinLang`
copy/convert), `DriverRemoteConnection`/`RemoteStrategy` wiring and `extract_request_options`,
the SigV4 auth interceptor, the aiohttp read-timeout normalization (`ServerTimeoutError` ->
`ReadTimeoutError`), GraphBinary V4 error branches (unknown type code, long overflow, naive
datetime), and several `structure/graph.py` object-model / PDT-registry paths. Also adds one
integration test for the server-enforced per-request `timeoutMillis`. **Tests only, no
production code changes.**

## Coverage (gremlin-python: unit + integration + feature)

| Metric | Baseline (master) | With added tests |
|--------|-------------------|------------------|
| Line   | 88.1%             | 90.0%            |


## Coverage reports

Baseline (master: b907ebbed0) and with-tests HTML reports were generated with
`coverage.py` (unit + integration + radish):
<img width="672" height="832" alt="Screenshot 2026-07-30 at 8 20 59 AM" src="https://github.com/user-attachments/assets/5cc36608-03db-445f-a603-3b1edf3b84bc" />

With added tests:
<img width="687" height="842" alt="Screenshot 2026-07-29 at 5 05 29 PM" src="https://github.com/user-attachments/assets/dfdac5b4-f921-4bec-a13d-6efd40b75d43" />


Assisted-by: Kiro: Claude Opus 4.8