### PR TITLE
Clarify that sum(local) also accepts a scalar Number

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -5493,7 +5493,8 @@ g.V().repeat(both()).times(3).values('age').sum()
 ----
 
 When called as `sum(local)` it determines the sum of the current, local object (not the objects in the traversal
-stream). This works for `Collection`-type objects.
+stream). This works for `Collection`-type objects (summing their numeric elements) and for scalar `Number` values
+(returning the number itself).
 
 [gremlin-groovy,modern]
 ----


### PR DESCRIPTION
The `sum()`-step reference section states that `sum(local)` "works for `Collection`-type objects," which reads as though a Collection is the only accepted input.

In practice, `sum(local)` also accepts a scalar `Number` and returns that number itself as an identity operation, in addition to summing the numeric elements of a Collection. This change updates the one sentence so both cases are documented:

> This works for `Collection`-type objects (summing their numeric elements) and for scalar `Number` values (returning the number itself).

The documentation was incomplete rather than incorrect, so this is a small wording fix scoped to the `sum()`-step section. Verified by rendering the reference docs locally.