### PR TITLE
Show optimization strategies firing in the Unnecessary Steps recipe

### DIFF
--- a/docs/src/recipes/anti-patterns.asciidoc
+++ b/docs/src/recipes/anti-patterns.asciidoc
@@ -154,6 +154,32 @@ g.V().hasLabel("person").out("created").dedup()
 g.V().hasLabel("software").inE("created").count()
 ----
 
+These rewrites can be observed rather than taken on faith. The `explain()`-step reports how a traversal is compiled once
+all registered traversal strategies have been applied, which makes the optimizations visible. Running `explain()` on the
+two original (unoptimized) queries shows the relevant strategies firing:
+
+[gremlin-groovy,modern]
+----
+g.V().hasLabel("person").outE("created").inV().dedup().explain()
+g.V().hasLabel("software").inE("created").outV().count().explain()
+----
+
+Each row of the explanation is the state of the traversal after the strategy named in the first column has been applied.
+The second column is the strategy category: [D]ecoration, [O]ptimization, [P]rovider optimization,
+[F]inalization, or [V]erification. In the first explanation, the `IncidentToAdjacentStrategy` (an optimization)
+is the row that folds `outE("created").inV()` into a single `out("created")` step, matching the manual rewrite shown
+above. In the second explanation two strategies cooperate. The `IncidentToAdjacentStrategy` first collapses
+`inE("created").outV()` to `in("created")`, and then the `AdjacentToIncidentStrategy` rewrites that counted adjacency
+back onto the incident edges so that the vertex step becomes an edge step again, which is the `inE("created").count()`
+form. The `Final Traversal` line at the bottom of each explanation is the execution plan that actually runs.
+
+Further detail on these execution plans, including how to measure their runtime effect rather than only inspect them, is
+available in the link:https://tinkerpop.apache.org/docs/x.y.z/reference/#explain-step[`explain()`] and
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#profile-step[`profile()`] steps, as well as the
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#traversalstrategy[traversal strategies] section of the Reference
+Documentation, which catalogs the full set of optimizations (`IncidentToAdjacentStrategy` and
+`AdjacentToIncidentStrategy` among them).
+
 Another anti-pattern that is commonly seen is the chaining of `where()`-steps using predicates. Consider the following traversal:
 
 [gremlin-groovy,modern]


### PR DESCRIPTION
The "Unnecessary Steps" section of the anti-patterns recipe correctly teaches the manual rewrites (`outE().inV()` to `out()`, and folding a counted adjacency onto its incident edges), and states that TinkerPop performs these rewrites automatically through optimization strategies. However the section gave a reader no way to confirm that claim, never named the strategies involved, and offered no pointer to further reading.

This change addresses that gap:

- Adds a runnable `explain()` example on the two original (unoptimized) queries so the optimizations are visible in the compiled traversal rather than taken on faith. The block is executed at doc-build time against the modern graph, so the transcript is real output.
- Names the two strategies responsible: `IncidentToAdjacentStrategy` (which folds `outE("created").inV()` into a single `out("created")` step) and `AdjacentToIncidentStrategy` (which rewrites the counted adjacency back onto the incident edges), and explains how to read the strategy/category columns and the `Final Traversal` line.
- Cross-references the `explain()` and `profile()` steps and the traversal strategies section of the reference documentation.

The change is scoped to `docs/src/recipes/anti-patterns.asciidoc` (+26 lines). The rendered recipes book was previewed locally to confirm the live `explain()` transcript renders and the new prose displays cleanly.