### PR TITLE
Clarify Gremlin-Groovy __. prefix guidance and datetime() return type

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -864,9 +864,14 @@ compile group: 'org.apache.tinkerpop', name: 'gremlin-driver', version: 'x.y.z'
 [[gremlin-groovy-differences]]
 === Differences
 
-In Groovy, `as`, `in`, and `not` are reserved words. Gremlin-Groovy does not allow these steps to be called
-statically from the anonymous traversal `+__+` and therefore, must always be prefixed with `+__.+` For instance:
-`+g.V().as('a').in().as('b').where(__.not(__.as('a').out().as('b')))+`
+In Groovy, `as`, `in`, and `not` overlap with reserved words and predicate functions, so calling them as bare
+functions is not guaranteed to resolve to the anonymous traversal step you intend. For deterministic, portable
+results, be explicit: prefix an anonymous traversal step with `+__.+` and use `P.` when you actually want a
+predicate. For instance: `+g.V().as('a').in().as('b').where(__.not(__.as('a').out().as('b')))+`
+
+This is especially important for `not`: a bare `+not(...)+` resolves to `+P.not(P)+` (predicate negation), whereas
+`+__.not(traversal)+` is the filter step. Prefer `+__.not(...)+` for the step and `+P.not(...)+` for the predicate to
+avoid the ambiguity.
 
 Care needs to be taken when using the `any(P)` step as you may accidentally invoke Groovy's `any(Closure)` method. This
 typically happens when calling `any()` without arguments. You can tell if Groovy's `any` has been called if the return
@@ -883,6 +888,8 @@ time zone offset of UTC(+00:00):
 * `2018-03-22T00:35:44.741`
 * `2018-03-22T00:35:44.741Z`
 * `2018-03-22T00:35:44.741+1600`
+
+The `datetime()` function returns a `java.time.OffsetDateTime`.
 
 anchor:connecting-via-remotegraph[]
 anchor:connecting-via-java[]

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -6392,7 +6392,7 @@ script requests.
 |Float |`1.0F` |A floating-point number with an `F` suffix and a value within the bounds of `Float`.
 |Double |`1.0`, `1.0D` |A floating-point number with an optional `D` suffix.
 |BigDecimal |`1.0M` |A floating-point number with an `M` suffix.
-|DateTime |`DateTime("2018-03-22T00:35:44Z")`, `DateTime()` |An ISO-8601 date or date-time string. `DateTime()` evaluates to the current time.
+|DateTime |`DateTime("2018-03-22T00:35:44Z")`, `DateTime()` |An ISO-8601 date or date-time string. `DateTime()` evaluates to the current time. The all-lowercase form `datetime` is also accepted (for example `datetime("2018-03-22T00:35:44Z")`).
 |UUID |`UUID("f47af10b-58cc-4372-a567-0f02b2f3d479")`, `UUID()` |A UUID string in the textual form written as 8-4-4-4-12 hexadecimal digit groups. `UUID()` generates a random UUID.
 |Duration |`Duration(3600,0)`, `Duration(30,0,false)` |The first argument is non-negative seconds. The second is nanoseconds from `0` to `999999999`. The optional third argument is a boolean sign flag with `false` negating the duration.
 |Binary |`Binary("AQID")` |A Base64-encoded string.


### PR DESCRIPTION
This is a small, conservative documentation fix touching two reference sections.

## Gremlin-Groovy differences (`reference/gremlin-variants.asciidoc`)
The section previously stated that `as`, `in`, and `not` are reserved words that "must always be prefixed with `__.`". The recommendation to use the `__.` prefix is kept, but the justification is reframed: rather than a hard reserved-word parser rule, the reason to be explicit is to get deterministic, portable resolution — use `__.` for an anonymous traversal step, and `P.` when you actually want a predicate.

This is clarified especially for `not`: a bare `not(...)` resolves to `P.not(P)` (predicate negation), whereas `__.not(traversal)` is the filter step. Being explicit (`__.not(...)` for the step, `P.not(...)` for the predicate) avoids the ambiguity.

A note is also added that `datetime()` returns a `java.time.OffsetDateTime`, which the section did not previously state.

## Canonical Gremlin literal types (`reference/the-traversal.asciidoc`)
The `DateTime` row now notes that the all-lowercase `datetime` form is also accepted (the grammar accepts `datetime`, `DateTime`, and `DATETIME`).

## Testing
Built the rendered documentation locally (`bin/process-docs.sh`) and reviewed the affected pages in the HTML output; all three changes render as intended.