### PR TITLE
Clarify local scope semantics and add explicit type check in SumLocalStep

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -528,6 +528,38 @@ fully demonstrative of Gremlin step semantics. It is also hard to simply read th
 step is meant to behave. This section discusses the semantics for individual steps to help users and providers
 understand implementation expectations.
 
+[[gremlin-semantics-local-scope-boxing]]
+=== Local scope and single values
+
+Many steps accept a `Scope` argument. When `Scope.local` is specified, the step operates on the
+*contents* of the current traverser rather than on the traversal stream as a whole. The reference
+implementation coerces the traverser's value into an iterable sequence using the following dispatch:
+
+* A `LIST`, `SET`, or other `Iterable` is iterated directly.
+* An array (including primitive arrays) is iterated element by element.
+* A `MAP` is iterated over its entry set.
+* Any other non-null value (including a single number) is wrapped into a **single-element sequence**.
+
+This means that a `Scope.local` reducing step (e.g. `sum(local)`, `min(local)`, `max(local)`,
+`mean(local)`) applied to a scalar numeric value will produce that same value back (identity), because
+the scalar is wrapped into a one-element sequence before the reduction is applied. For example:
+
+----
+g.inject([1,2,3]).sum(local) ==> 6      // reduces the list
+g.inject(1,2,3).sum(local)   ==> 1,2,3  // each scalar is wrapped into [n], sum([n]) = n
+----
+
+If elements within the collection (or the scalar itself) are not compatible with the reducing operation,
+a type error will be raised at runtime (e.g. attempting `sum(local)` on a non-numeric value). This
+applies regardless of whether the input is a multi-element collection or a single scalar that was
+wrapped into a one-element sequence.
+
+Providers implementing `Scope.local` steps are expected to replicate this wrapping behavior to maintain
+compatibility with the reference implementation. Individual step entries in this document will reference
+this section rather than restating the rule.
+
+See: link:https://github.com/apache/tinkerpop/tree/x.y.z/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtils.java[source (reference implementation)]
+
 [llms-summary="The formal semantics of the all() step: filters array data from the Traversal Stream if all of the array's items match the supplied predicate."]
 [[all-step]]
 === all()

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStep.java
@@ -49,6 +49,10 @@ public final class SumLocalStep<E extends Number, S extends Iterable<E>> extends
             if (iterator.hasNext()) {
                 // forward the iterator to the first non-null or return null
                 E result = untilNonNull(iterator);
+                if (result != null && !(result instanceof Number)) {
+                    throw new ClassCastException(
+                            String.format("%s cannot be cast to %s", result.getClass().getName(), Number.class.getName()));
+                }
                 while (iterator.hasNext()) {
                     final Number n = iterator.next();
                     if (n != null) {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxLocalStepTest.java
@@ -23,8 +23,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -34,5 +39,27 @@ public class MaxLocalStepTest extends StepTest {
     @Override
     protected List<Traversal> getTraversals() {
         return Collections.singletonList(__.max(Scope.local));
+    }
+
+    @Test
+    public void shouldReturnIdentityOnNumericSingleScalar() {
+        assertEquals(7, __.inject(7).max(Scope.local).next());
+    }
+
+    @Test
+    public void shouldReturnIdentityOnStringSingleScalar() {
+        // String is Comparable, so max(local) on a single String is valid (identity)
+        assertEquals("hello", __.inject("hello").max(Scope.local).next());
+    }
+
+    @Test
+    public void shouldFindMaxOfStringList() {
+        // max(local) on Comparable types (Strings) should work via compareTo
+        assertEquals("cherry", __.inject(Arrays.asList("cherry", "apple", "banana")).max(Scope.local).next());
+    }
+
+    @Test
+    public void shouldFindMaxOfNumericList() {
+        assertEquals(3, __.inject(Arrays.asList(3, 1, 2)).max(Scope.local).next());
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MeanLocalStepTest.java
@@ -49,4 +49,15 @@ public class MeanLocalStepTest extends StepTest {
         assertEquals(BigDecimal.ONE, __.__((short) 1, BigInteger.ONE).fold().mean(Scope.local).next());
         assertEquals(BigDecimal.ONE, __.__(BigInteger.ONE, (short) 1).fold().mean(Scope.local).next());
     }
+
+    @Test
+    public void shouldReturnIdentityOnNumericSingleScalar() {
+        // mean of a single element is that element divided by 1
+        assertEquals(42d, __.inject(42).mean(Scope.local).next());
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void shouldThrowOnNonNumericSingleScalar() {
+        __.inject("hello").mean(Scope.local).next();
+    }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MinLocalStepTest.java
@@ -23,8 +23,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -34,5 +39,27 @@ public class MinLocalStepTest extends StepTest {
     @Override
     protected List<Traversal> getTraversals() {
         return Collections.singletonList(__.min(Scope.local));
+    }
+
+    @Test
+    public void shouldReturnIdentityOnNumericSingleScalar() {
+        assertEquals(7, __.inject(7).min(Scope.local).next());
+    }
+
+    @Test
+    public void shouldReturnIdentityOnStringSingleScalar() {
+        // String is Comparable, so min(local) on a single String is valid (identity)
+        assertEquals("hello", __.inject("hello").min(Scope.local).next());
+    }
+
+    @Test
+    public void shouldFindMinOfStringList() {
+        // min(local) on Comparable types (Strings) should work via compareTo
+        assertEquals("apple", __.inject(Arrays.asList("cherry", "apple", "banana")).min(Scope.local).next());
+    }
+
+    @Test
+    public void shouldFindMinOfNumericList() {
+        assertEquals(1, __.inject(Arrays.asList(3, 1, 2)).min(Scope.local).next());
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SumLocalStepTest.java
@@ -19,11 +19,14 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
 
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.Test;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -35,5 +38,16 @@ public class SumLocalStepTest extends StepTest {
         return Arrays.asList(
                 __.identity()
         );
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void shouldThrowOnNonNumericSingleScalar() {
+        __.inject("hello").sum(Scope.local).next();
+    }
+
+    @Test
+    public void shouldReturnIdentityOnNumericSingleScalar() {
+        final Number result = (Number) __.inject(42).sum(Scope.local).next();
+        org.junit.Assert.assertEquals(42, result);
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtilsTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtilsTest.java
@@ -216,6 +216,24 @@ public class IteratorUtilsTest {
     }
 
     @Test
+    public void shouldWrapNumberAsSingletonIterator() {
+        final Iterator itty = IteratorUtils.asIterator(42);
+        assertTrue(itty.hasNext());
+        assertEquals(42, itty.next());
+        assertFalse(itty.hasNext());
+    }
+
+    @Test
+    public void shouldWrapNonIterableObjectAsSingletonIterator() {
+        // A non-numeric, non-collection object is also wrapped as a singleton
+        final Object obj = new Object();
+        final Iterator itty = IteratorUtils.asIterator(obj);
+        assertTrue(itty.hasNext());
+        assertThat(itty.next(), is(obj));
+        assertFalse(itty.hasNext());
+    }
+
+    @Test
     public void shouldConvertIterableToList() {
         final List<String> iterable = new ArrayList<>();
         iterable.add("test1");

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/Gremlin.cs
@@ -1247,6 +1247,8 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
                {"g_injectXlistXnull_10_5_nullXX_sumXlocalX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(p["xx1"]).Sum<object>(Scope.Local)}}, 
                {"g_VX1X_valuesXageX_sumXlocalX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.V(p["vid1"]).Values<object>("age").Sum<object>(Scope.Local)}}, 
                {"g_V_localXunionXvaluesXageX_outE_valuesXweightXX_foldX_sumXlocalX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.V().Local<object>(__.Union<object>(__.Values<object>("age"),__.OutE().Values<object>("weight")).Fold()).Sum<object>(Scope.Local)}}, 
+               {"g_injectXlistXa_bXX_sumXlocalX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(p["xx1"]).Sum<object>(Scope.Local)}}, 
+               {"g_injectXhelloX_sumXlocalX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(p["xx1"]).Sum<object>(Scope.Local)}}, 
                {"g_injectXfeature_test_nullX_toLower", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject<object>("FEATURE","tESt",null).ToLower()}}, 
                {"g_injectXfeature_test_nullX_toLowerXlocalX", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(p["xx1"]).ToLower<object>(Scope.Local)}}, 
                {"g_injectXListXa_bXX_toLower", new List<Func<GraphTraversalSource, IDictionary<string, object>, ITraversal>> {(g,p) =>g.Inject(p["xx1"]).ToLower()}}, 

--- a/gremlin-go/driver/cucumber/gremlin.go
+++ b/gremlin-go/driver/cucumber/gremlin.go
@@ -1218,6 +1218,8 @@ var translationMap = map[string][]func(g *gremlingo.GraphTraversalSource, p map[
     "g_injectXlistXnull_10_5_nullXX_sumXlocalX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(p["xx1"]).Sum(gremlingo.Scope.Local)}}, 
     "g_VX1X_valuesXageX_sumXlocalX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.V(p["vid1"]).Values("age").Sum(gremlingo.Scope.Local)}}, 
     "g_V_localXunionXvaluesXageX_outE_valuesXweightXX_foldX_sumXlocalX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.V().Local(gremlingo.T__.Union(gremlingo.T__.Values("age"), gremlingo.T__.OutE().Values("weight")).Fold()).Sum(gremlingo.Scope.Local)}}, 
+    "g_injectXlistXa_bXX_sumXlocalX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(p["xx1"]).Sum(gremlingo.Scope.Local)}}, 
+    "g_injectXhelloX_sumXlocalX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(p["xx1"]).Sum(gremlingo.Scope.Local)}}, 
     "g_injectXfeature_test_nullX_toLower": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject("FEATURE", "tESt", nil).ToLower()}}, 
     "g_injectXfeature_test_nullX_toLowerXlocalX": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(p["xx1"]).ToLower(gremlingo.Scope.Local)}}, 
     "g_injectXListXa_bXX_toLower": {func(g *gremlingo.GraphTraversalSource, p map[string]interface{}) *gremlingo.GraphTraversal {return g.Inject(p["xx1"]).ToLower()}}, 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/gremlin.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/gremlin.js
@@ -1238,6 +1238,8 @@ const gremlins = {
     g_injectXlistXnull_10_5_nullXX_sumXlocalX: [function({g, xx1}) { return g.inject(xx1).sum(Scope.local) }], 
     g_VX1X_valuesXageX_sumXlocalX: [function({g, vid1}) { return g.V(vid1).values("age").sum(Scope.local) }], 
     g_V_localXunionXvaluesXageX_outE_valuesXweightXX_foldX_sumXlocalX: [function({g}) { return g.V().local(__.union(__.values("age"),__.outE().values("weight")).fold()).sum(Scope.local) }], 
+    g_injectXlistXa_bXX_sumXlocalX: [function({g, xx1}) { return g.inject(xx1).sum(Scope.local) }], 
+    g_injectXhelloX_sumXlocalX: [function({g, xx1}) { return g.inject(xx1).sum(Scope.local) }], 
     g_injectXfeature_test_nullX_toLower: [function({g}) { return g.inject("FEATURE","tESt",null).toLower() }], 
     g_injectXfeature_test_nullX_toLowerXlocalX: [function({g, xx1}) { return g.inject(xx1).toLower(Scope.local) }], 
     g_injectXListXa_bXX_toLower: [function({g, xx1}) { return g.inject(xx1).toLower() }], 

--- a/gremlin-python/src/main/python/tests/feature/gremlin.py
+++ b/gremlin-python/src/main/python/tests/feature/gremlin.py
@@ -1220,6 +1220,8 @@ world.gremlins = {
     'g_injectXlistXnull_10_5_nullXX_sumXlocalX': [(lambda g, xx1=None:g.inject(xx1).sum_(Scope.local))], 
     'g_VX1X_valuesXageX_sumXlocalX': [(lambda g, vid1=None:g.V(vid1).age.sum_(Scope.local))], 
     'g_V_localXunionXvaluesXageX_outE_valuesXweightXX_foldX_sumXlocalX': [(lambda g:g.V().local(__.union(__.age,__.out_e().weight).fold()).sum_(Scope.local))], 
+    'g_injectXlistXa_bXX_sumXlocalX': [(lambda g, xx1=None:g.inject(xx1).sum_(Scope.local))], 
+    'g_injectXhelloX_sumXlocalX': [(lambda g, xx1=None:g.inject(xx1).sum_(Scope.local))], 
     'g_injectXfeature_test_nullX_toLower': [(lambda g:g.inject('FEATURE','tESt',None).to_lower())], 
     'g_injectXfeature_test_nullX_toLowerXlocalX': [(lambda g, xx1=None:g.inject(xx1).to_lower(Scope.local))], 
     'g_injectXListXa_bXX_toLower': [(lambda g, xx1=None:g.inject(xx1).to_lower())], 

--- a/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/Sum.feature
+++ b/gremlin-test/src/main/resources/org/apache/tinkerpop/gremlin/test/features/map/Sum.feature
@@ -217,3 +217,27 @@ Feature: Step - sum()
       | d[27].i |
       | d[33.4].d |
       | d[35.2].d |
+
+  # Verifies that sum(local) on a list with non-numeric values throws ClassCastException
+  @GraphComputerVerificationInjectionNotSupported
+  Scenario: g_injectXlistXa_bXX_sumXlocalX
+    Given the modern graph
+    And using the parameter xx1 defined as "l[a,b]"
+    And the traversal of
+      """
+      g.inject(xx1).sum(local)
+      """
+    When iterated to list
+    Then the traversal will raise an error
+
+  # Verifies that sum(local) on a single non-numeric scalar raises an error (not identity)
+  @GraphComputerVerificationInjectionNotSupported
+  Scenario: g_injectXhelloX_sumXlocalX
+    Given the modern graph
+    And using the parameter xx1 defined as "hello"
+    And the traversal of
+      """
+      g.inject(xx1).sum(local)
+      """
+    When iterated to list
+    Then the traversal will raise an error


### PR DESCRIPTION
  ## Summary
  
  Fixes a non-deterministic type-safety hole in `SumLocalStep` and documents the `Scope.local` boxing semantics in the
  provider semantics specification.
  
  ## Problem
  
  `sum(local)` on a single non-numeric scalar (e.g. `g.inject("hello").sum(local)`) would non-deterministically either
  throw `ClassCastException` or pass the value through as identity, depending on JIT compilation state. This is because
  the generic bound `E extends Number` is erased at runtime, and the arithmetic call that would enforce it
  (`NumberHelper.add`) is only reached when there are 2+ elements. `mean(local)` was already correct (always calls
  `div()`), while `min(local)`/`max(local)` are unaffected (they use `Comparable` bounds, and `NumberHelper.min/max`
  correctly falls back to `compareTo` for non-Numbers).
  
  ## Fix
  
  Added an explicit `instanceof Number` check in `SumLocalStep` after `untilNonNull()` returns the first element, making
  the error deterministic.
  
  ## Documentation
  
  Added a "Local scope and single values" section (`[[gremlin-semantics-local-scope-boxing]]`) to
  `gremlin-semantics.asciidoc` specifying:
  - The wrapping dispatch (LIST/SET/array/MAP iterate directly; anything else wraps to a single-element sequence)
  - Scalar numeric identity behavior (`sum(local)` on `29` → `29`)
  - Type error contract for incompatible input (regardless of collection size)
  
  ## Tests
  
  - **Gherkin** (`Sum.feature`): `sum(local)` on a non-numeric list (error) and a single non-numeric scalar (error),
  with GLV translations for .NET, Go, JS, Python
  - **Unit** (`SumLocalStepTest`): numeric scalar identity + non-numeric error
  - **Unit** (`MeanLocalStepTest`): numeric scalar identity + non-numeric error
  - **Unit** (`MinLocalStepTest`): numeric identity, String identity (valid Comparable), String-list min, numeric-list
  min
  - **Unit** (`MaxLocalStepTest`): numeric identity, String identity, String-list max, numeric-list max
  - **Unit** (`IteratorUtilsTest`): Number singleton wrapping + generic Object singleton wrapping
  
 ---

VOTE +1