### PR TITLE
Fix graph.computer() typo in GraphComputer Graph Filter docs

### DIFF
--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -590,7 +590,7 @@ Most OLAP jobs do not require the entire source graph to faithfully execute thei
 
 [source,java]
 ----
-graph.computer().
+graph.compute().
   vertices(hasLabel("person")).
   vertexProperties(__.properties("name")).
   edges(bothE("knows")).


### PR DESCRIPTION
The `[source,java]` example in the *Graph Filter* section of `docs/src/reference/the-graphcomputer.asciidoc` called `graph.computer()`, which is not a method on the `Graph` interface (`Graph` exposes `compute()` and `compute(Class)`). The correct OLAP entry point is `graph.compute()`, as used by every other example on the same page. This one-word fix corrects `graph.computer()` to `graph.compute()` so a reader copying the snippet gets valid code. No other lines are changed.