### PR TITLE
Expand Times Step reference docs with an example and fix javadoc link text

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -5599,12 +5599,22 @@ link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gre
 [[times-step]]
 === Times Step
 
-The `times`-step is not an actual step, but is instead a step modulator for `<<repeat-step,repeat()>>` (find more
-documentation on the `times()` there).
+The `times`-step is not an actual step, but is instead a step modulator for `<<repeat-step,repeat()>>`. It sets
+the number of times the `repeat()` body is executed: `times(N)` loops the body exactly `N` times. It has no
+effect on its own and must accompany a `repeat()`.
+
+[gremlin-groovy,modern]
+----
+g.V(1).repeat(out()).times(2)
+----
+
+Whether `times()` is placed before or after `repeat()` determines the loop semantics (while-do versus do-while),
+as with `<<until-step,until()>>`. See the <<repeat-step,`repeat()`>>-step section for those positioning details
+and the general loop semantics.
 
 *Additional References*
 
-link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#times(int)++[`until(Predicate)`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#times(int)++[`times(int)`],
 `<<emit-step,emit()>>`, `<<repeat-step,repeat()>>`, `<<until-step,until()>>`
 
 [[to-step]]


### PR DESCRIPTION
## What

Improves the **Times Step** section in `docs/src/reference/the-traversal.asciidoc`.

Previously the section was a single sentence deferring to `repeat()` with no runnable example, and its *Additional References* javadoc link displayed the text `until(Predicate)` even though its URL targets `GraphTraversal#times(int)`.

This change:

1. Adds a brief explanation that `times(N)` sets the number of times the `repeat()` body executes and has no effect on its own without a `repeat()`.
2. Adds one short, executable `[gremlin-groovy,modern]` example (`g.V(1).repeat(out()).times(2)`) so newcomers have something to copy and can see the output.
3. Cross-references the `repeat()`-step section for the positioning (while-do vs do-while) and general loop semantics rather than duplicating that material here, since `times()` is a modulator of `repeat()`.
4. Corrects the mislabeled *Additional References* link text from `until(Predicate)` to `times(int)` (the URL was already correct).

## Why

The section didn't give a reader enough to learn what `times()` does or any code to try, and the mislabeled link was misleading. The scope is intentionally kept tight: the substantive loop documentation continues to live with `repeat()`.

## Testing

Built the docs locally with the live-code doc build; the new example renders its expected output and the reference book builds cleanly.