### PR TITLE
Expand To Step reference docs with argument forms and a live example

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -5615,13 +5615,33 @@ The `to()`-step is not an actual step, but instead is a "step-modulator" similar
 <<by-step,`by()`>>. If a step is able to accept traversals or strings then `to()` is the
 means by which they are added. The general pattern is `step().to()`. See <<from-step,`from()`>>-step.
 
+When used to modulate <<addedge-step,`addE()`>>, `to()` identifies the incoming (head) vertex of the new edge
+and accepts one of three argument forms:
+
+* `to(String)` -- a step-label previously set by <<as-step,`as()`>>, referring to a vertex encountered earlier
+in the traversal.
+* `to(Traversal)` -- a child traversal that resolves to a vertex (or a vertex id).
+* `to(Vertex)` -- an explicit `Vertex` object. This is a convenience exposed by the language variant (e.g.
+Gremlin-Java), which resolves the `Vertex` down to its id, rather than a canonical Gremlin argument form.
+
 The list of steps that support `to()`-modulation are: <<simplepath-step,`simplePath()`>>, <<cyclicpath-step,`cyclicPath()`>>,
  <<path-step,`path()`>>, and <<addedge-step,`addE()`>>.
 
+[gremlin-groovy,modern]
+----
+g.V().has('name','marko').as('a').out('knows').addE('friend').to('a') <1>
+g.V().has('name','peter').addE('created').to(V().has('name','lop')) <2>
+----
+
+<1> `to(String)` uses the `as()`-labeled step `'a'` (the marko-vertex) as the incoming vertex, while each
+incoming traverser (marko's `knows`-neighbors) supplies the outgoing vertex.
+<2> `to(Traversal)` supplies a child traversal that resolves to a vertex -- here the lop-vertex -- as the
+incoming vertex, while the incoming traverser (the peter-vertex) supplies the outgoing vertex.
+
 *Additional References*
 
-link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#to(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`to(Direction,String...)`],
-link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#to(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`to(String)`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#to(org.apache.tinkerpop.gremlin.structure.Direction,java.lang.String...)++[`to(Direction,String...)`],
+link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#to(java.lang.String)++[`to(String)`],
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#to(org.apache.tinkerpop.gremlin.process.traversal.Traversal)++[`to(Traversal)`],
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#to(org.apache.tinkerpop.gremlin.structure.Vertex)++[`to(Vertex)`],
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#toE(org.apache.tinkerpop.gremlin.structure.Direction,java.lang.String...)++[`toE(Direction,String)`],


### PR DESCRIPTION
The `to()` reference section (`reference/#to-step`) was a bare stub: it described `to()`'s arguments only as "traversals or strings", carried no runnable example, and its *Additional References* block had two mislabeled javadoc anchors.

This change, scoped to the To Step section only:

- Adds prose describing the three argument forms when modulating `addE()`:
  - `to(String)` — a step-label previously set by `as()`.
  - `to(Traversal)` — a child traversal that resolves to a vertex (or a vertex id).
  - `to(Vertex)` — an explicit `Vertex` object (a language-variant convenience that resolves the vertex to its id).
- Adds a runnable `[gremlin-groovy,modern]` example demonstrating `addE().to()` with both an `as()`-label and a child traversal, so its `==>` output is rendered at doc-build time.
- Corrects the two *Additional References* links so `to(Direction,String...)` and `to(String)` point to their own javadoc anchors instead of the `to(Traversal)` anchor.

Built and rendered locally; the To Step example executes and renders its output correctly.