### PR TITLE
Fix stale class name and Gryo comment in io() step reference docs

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2219,11 +2219,11 @@ name of one.
 ----
 g.io(someInputFile).
     with(IO.reader, IO.gryo).
-    with(IO.registry, TinkerIoRegistryV3d0.instance())
+    with(IO.registry, TinkerIoRegistryV3.instance())
   read().iterate()
 g.io(someOutputFile).
     with(IO.writer,IO.graphson).
-    with(IO.registry, "org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0")
+    with(IO.registry, "org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3")
   write().iterate()
 ----
 
@@ -2321,7 +2321,7 @@ other.  Failure to do so, may result in errors.
 [source,java]
 ----
 // expects a file extension of .kryo to interpret that
-// a GraphSON reader/writer should be used
+// a Gryo reader/writer should be used
 g.io("graph.kryo").read().iterate()
 g.io("graph.kryo").write().iterate()
 ----


### PR DESCRIPTION
The io() step section of the reference documentation had two small errors in its examples.

The `IoRegistry` example referenced `TinkerIoRegistryV3d0`, a class that does not exist on this branch, in both its short-name (`TinkerIoRegistryV3d0.instance()`) and fully-qualified (`org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0`) forms. The class is named `TinkerIoRegistryV3`, so as written the example throws `ClassNotFoundException`. Both references are updated to `TinkerIoRegistryV3`.

In the Gryo subsection, the comment above the `.kryo` read/write calls read `// a GraphSON reader/writer should be used`. That comment now correctly refers to a Gryo reader/writer. The identical comment in the GraphSON subsection is left unchanged, as it is correct there.

No functional code changes; documentation only.