### PR TITLE
Expand Until Step reference docs with an example and overload note

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -5820,12 +5820,23 @@ g.union(V().has('person','name','vadas'),
 
 link:++https://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.html#union(org.apache.tinkerpop.gremlin.process.traversal.Traversal...)++[`union(Traversal...)`]
 
-[llms-summary="The until-step is not an actual step, but is instead a step modulator for repeat() (find more documentation on the until() there)."]
+[llms-summary="The until-step is not an actual step, but is instead a step modulator for repeat() that specifies the break condition controlling how long the repeat() body loops. The until(Predicate) overload tests the traverser directly, while until(Traversal) tests whether its child traversal produces a result."]
 [[until-step]]
 === Until Step
 
-The `until`-step is not an actual step, but is instead a step modulator for `<<repeat-step,repeat()>>` (find more
-documentation on the `until()` there).
+The `until`-step is not an actual step, but is instead a step modulator for `<<repeat-step,repeat()>>`. It specifies
+the break condition that controls how long the `repeat()` body loops. It has no effect on its own and must accompany
+a `repeat()`. The `until(Predicate)` overload tests the traverser directly, while `until(Traversal)` tests whether its
+child traversal produces a result.
+
+[gremlin-groovy,modern]
+----
+g.V(1).repeat(out()).until(has('name','ripple'))
+----
+
+Whether `until()` is placed before or after `repeat()` determines the loop semantics (while-do versus do-while),
+as with `<<times-step,times()>>`. See the <<repeat-step,`repeat()`>>-step section for those positioning details
+and the general loop semantics.
 
 *Additional References*
 


### PR DESCRIPTION
The Until Step section of the reference documentation was a two-sentence stub that deferred entirely to `repeat()`, with no example and no mention of what `until()` actually controls.

This expands it to mirror the existing Times Step section in shape and tone. `until()` is a step modulator for `repeat()`, so the section stays lean and defers the general loop semantics to the `repeat()`-step section rather than duplicating them:

- A short intro paragraph describing `until()` as a step modulator for `repeat()` that specifies the break condition controlling how long the `repeat()` body loops, with no effect on its own.
- A one-sentence note on the two overloads: `until(Predicate)` tests the traverser directly, while `until(Traversal)` tests whether its child traversal produces a result.
- One runnable example, `g.V(1).repeat(out()).until(has('name','ripple'))`.
- A sentence noting that placing `until()` before or after `repeat()` determines while-do versus do-while semantics, deferring to the `repeat()`-step section for the positioning details.

The existing Additional References links are preserved unchanged. Only the until-step section is touched.