### PR TITLE
Fix GraphSON Java writer snippets so they compile

### DIFF
--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -33,17 +33,30 @@ serialization. In other words, the output of:
 
 [source,java]
 ----
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.io.GraphWriter;
+import org.apache.tinkerpop.gremlin.structure.io.IoCore;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import java.io.FileOutputStream;
+
 final Graph graph = TinkerFactory.createModern();
-final GraphWriter writer = graph.io(IoCore.graphson()).writer();
-writer.writeGraph("tinkerpop-modern.json");
+final GraphWriter writer = graph.io(IoCore.graphson()).writer().create();
+writer.writeGraph(new FileOutputStream("tinkerpop-modern.json"), graph);
 ----
 
 will be different of:
 
 [source,java]
 ----
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.io.GraphWriter;
+import org.apache.tinkerpop.gremlin.structure.io.IoCore;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+
 final Graph graph = TinkerFactory.createModern();
-final GraphWriter writer = graph.io(IoCore.graphson()).writer();
+final GraphWriter writer = graph.io(IoCore.graphson()).writer().create();
 final OutputStream os = new FileOutputStream("tinkerpop-modern.json");
 writer.writeObject(os, graph);
 ----
@@ -67,8 +80,22 @@ At a glance, one can see that this is not a valid JSON document. While that form
 The "graph" format is designed by default to be splittable, such that distributed systems like Spark can easily divide
 the GraphSON file for processing. If this data were represented as an "array of vertices" with square brackets at the
 beginning and end of the file, the format would be less conducive to fit that purpose. It is possible to change this
-behavior by building the `GraphSONWriter` with the `wrapAdjacencyList` setting set to `true`, in which case the output
-will be a valid JSON document that looks like this:
+behavior by building the `GraphSONWriter` with the `wrapAdjacencyList` setting set to `true`:
+
+[source,java]
+----
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.io.GraphWriter;
+import org.apache.tinkerpop.gremlin.structure.io.IoCore;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import java.io.FileOutputStream;
+
+final Graph graph = TinkerFactory.createModern();
+final GraphWriter writer = graph.io(IoCore.graphson()).writer().wrapAdjacencyList(true).create();
+writer.writeGraph(new FileOutputStream("tinkerpop-modern.json"), graph);
+----
+
+In this case the output will be a valid JSON document that looks like this:
 
 [source,json]
 ----


### PR DESCRIPTION
The GraphSON section of the IO reference showed two Java writer examples that do not compile.

- `graph.io(IoCore.graphson()).writer()` returns a `GraphSONWriter.Builder`, not a `GraphWriter`, so a `.create()` call is required.
- `writer.writeGraph("tinkerpop-modern.json")` does not compile because `writeGraph` has no String overload. The real signature is `writeGraph(OutputStream, Graph)`.

This corrects both snippets and adds the imports they reference (`Graph`, `GraphWriter`, `IoCore`, `TinkerFactory`, `FileOutputStream`, and `OutputStream` for the `writeObject` example). It also adds a short snippet showing the `wrapAdjacencyList(true)` builder form immediately before the wrapped adjacency-list JSON output, so the example that produces that valid-JSON document is shown alongside it.

The static JSON output blocks and the unrelated GraphSON mapper/version sections are unchanged. Only `docs/src/dev/io/graphson.asciidoc` is touched.