### PR TITLE
Fix and clarify the VertexProgram listing in the Program Step docs

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -3792,6 +3792,14 @@ WARNING: Developing a `VertexProgram` is for expert users. Moreover, developing 
 a traversal requires yet more expertise. This information is recommended to advanced users with a deep understanding of the
 mechanics of Gremlin OLAP (<<graphcomputer,`GraphComputer`>>).
 
+The excerpts below highlight the key `VertexProgram` methods — `loadState()`, `storeState()`, `setup()`,
+`execute()`, and `terminate()` — involved in propagating traversal and traverser information. They are
+illustrative fragments rather than a complete, compilable class: the enclosing class declaration, field and
+import definitions, and the remaining `VertexProgram` interface methods are omitted for brevity. For a
+complete, runnable implementation to model against, see the `TestProgram` vertex program in `ProgramTest`
+(`gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProgramTest.java`).
+
+.Key `VertexProgram` method excerpts (not a complete class)
 [source,java]
 ----
 private TraverserSet<Object> haltedTraversers;
@@ -3841,6 +3849,7 @@ public void execute(Vertex vertex, Messenger messenger, Memory memory) {
     memory.add(TraversalVertexProgram.HALTED_TRAVERSERS,
                new TraverserSet<>(this.traversal().get().getTraverserGenerator().generate("an example", this.programStep, 1l)));
   }
+}
 
 public boolean terminate(Memory memory) {
   // the master-traversal will have halted traversers


### PR DESCRIPTION
The Java listing in the Program Step section of the reference docs (`reference/the-traversal.asciidoc#program-step`) had two problems that could block a reader trying to use it as a starting point.

**Unbalanced braces.** The listing was missing the closing brace for `execute()`, so the block had eight opening braces and only seven closing ones. As written, `terminate()` read as if it were nested inside `execute()`. This restores the missing brace so the listing is balanced.

**Presented as a complete class, but it is not.** The listing shows only selected methods and omits the class declaration, field and import definitions, and several of the `VertexProgram` interface methods, so it does not compile on its own. Rather than expand it into a full class, this labels it honestly as key-method excerpts: a short lead-in explains that the fragments are illustrative, a block title marks the listing as excerpts, and readers are pointed to a complete, runnable implementation to model against — the `TestProgram` vertex program in `gremlin-test` (`gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProgramTest.java`).

The existing `PageRankVertexProgram` example that shows how a vertex program is passed to `program()` is left unchanged. No other section or file is touched.