### PR TITLE
Add TinkerPop Sample Data documentation book

### DIFF
--- a/docs/src/data/grateful-dead.asciidoc
+++ b/docs/src/data/grateful-dead.asciidoc
@@ -1,0 +1,124 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+[[grateful-dead]]
+[llms-summary="The Grateful Dead graph: a larger, real-world graph of songs and artists linked by concert play order. Includes its GQL Graph Types schema and runnable Gremlin examples, including a recommendation traversal."]
+== The Grateful Dead Graph
+
+The Grateful Dead graph is built from concert data for the band the Grateful Dead. Its vertices are
+`song` and `artist` records, and its edges capture three relationships: a song was `sungBy` an
+artist, a song was `writtenBy` an artist, and one song was `followedBy` another in a concert set
+list. The `followedBy` edge carries a `weight` that counts how often that particular transition
+occurred across the recorded performances, so the graph encodes not just which songs exist but the
+order in which they tended to be played.
+
+With 808 vertices and 8049 edges, it is substantially larger than the other sample graphs, and its
+data reflects real-world structure rather than a hand-built illustration. That combination makes it
+the best choice for demonstrating more involved traversals: aggregation over many results,
+ranking by edge weight, and recommendation queries that follow the play-order transitions to
+suggest what to listen to next. The graph is created with `TinkerFactory.createGratefulDead()` and
+ships as `data/grateful-dead.*`. It is too large to depict as a single diagram.
+
+=== Schema
+
+[source,gql]
+----
+-- node types
+(:song => { name :: STRING NOT NULL, songType :: STRING, performances :: INT }),
+(:artist => { name :: STRING NOT NULL }),
+
+-- edge types
+(:song)-[:followedBy { weight :: INT }]->(:song),
+(:song)-[:sungBy]->(:artist),
+(:song)-[:writtenBy]->(:artist)
+----
+
+A `song` records the number of times it was played in its `performances` property and whether it is
+an `original` or a `cover` in its `songType` property. Some songs have an empty `songType`. The
+`sungBy` and `writtenBy` edges form an edge type family in the GQL sense: they share the same
+`song` to `artist` endpoints and carry no properties, differing only in label.
+
+=== Examples
+
+A first look at the data summarizes the songs by type and finds those that were performed most
+often.
+
+[gremlin-groovy,grateful]
+----
+g.V().hasLabel('song').groupCount().by('songType') <1>
+g.V().hasLabel('song').
+      order().by('performances',desc).
+      limit(5).
+      valueMap('name','performances') <2>
+----
+
+<1> Count the songs of each `songType`. The empty-string group holds songs whose type was not
+recorded.
+<2> The five most frequently performed songs, with their `performances` count.
+
+The `writtenBy` edge connects a song to its author, so the incoming direction of that label on an
+artist yields the songs that artist wrote.
+
+[gremlin-groovy,grateful]
+----
+g.V().has('artist','name','Hunter').in('writtenBy').count() <1>
+g.V().has('artist','name','Hunter').in('writtenBy').
+      order().by('performances',desc).
+      limit(5).values('name') <2>
+----
+
+<1> The number of songs written by the lyricist Robert Hunter.
+<2> His five most performed songs.
+
+A basic recommendation follows the `followedBy` transitions out of a song and ranks them by
+`weight`, which answers the question of what was most often played next.
+
+[gremlin-groovy,grateful]
+----
+g.V().has('song','name','DARK STAR').
+      outE('followedBy'). <1>
+      order().by('weight',desc).
+      limit(5).
+      inV().values('name') <2>
+----
+
+<1> Step onto the outgoing `followedBy` edges of "DARK STAR" so the transition `weight` is
+available for ordering.
+<2> Rank those transitions by `weight` and report the songs that most frequently followed
+"DARK STAR" in concert.
+
+A recommendation that reaches beyond the immediate successors looks two transitions ahead. It
+collects the songs that directly followed "DARK STAR", then follows their transitions in turn and
+counts where they lead, excluding the direct successors so the result surfaces songs a step further
+out in the set list.
+
+[gremlin-groovy,grateful]
+----
+g.V().has('song','name','DARK STAR').
+      out('followedBy').aggregate('direct'). <1>
+      out('followedBy').
+      where(without('direct')). <2>
+      groupCount().by('name').
+      order(local).by(values,desc).
+      limit(local,5) <3>
+----
+
+<1> Gather the songs that directly followed "DARK STAR" into a side collection named `direct`.
+<2> From those songs, take another `followedBy` step and discard any song already in `direct`.
+<3> Count how often each remaining song is reached and keep the five most common, giving songs that
+tend to appear soon after "DARK STAR" without immediately following it.

--- a/docs/src/data/index.asciidoc
+++ b/docs/src/data/index.asciidoc
@@ -1,0 +1,59 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+:docinfo: shared
+:docinfodir: ../
+:toc-position: left
+
+image::apache-tinkerpop-logo.png[width=500,link="https://tinkerpop.apache.org"]
+
+*x.y.z*
+
+[llms-summary="A reference for the sample graphs bundled with TinkerPop. Each section describes a graph's nature, origin and best use, presents its schema in GQL Graph Types, and demonstrates it with runnable Gremlin.",allow-oversize="true"]
+= TinkerPop Sample Data
+
+image:gremlin-standing.png[width=125]
+
+TinkerPop bundles a small collection of sample graphs, often called "toy graphs", that appear
+throughout the reference documentation, the tutorials, and the test suites. They are deliberately
+small and self-contained so that a traversal can be read alongside the data it operates on, and
+they are available in every distribution without any external data source or configuration. Each
+graph is constructed by a factory method on
+link:https://github.com/apache/tinkerpop/blob/master/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerFactory.java[`TinkerFactory`]
+and also ships as data files under the `data/` directory of the distribution in the GraphSON,
+GraphML, and Gryo formats.
+
+This book serves as a reference for those graphs. Each section describes one graph: the nature of
+its data, where it came from, and the kinds of problems it illustrates best. Every graph is then
+given a schema expressed in link:https://learn.microsoft.com/en-us/fabric/graph/gql-graph-types[GQL
+Graph Types], a declarative notation that states the node and edge labels a graph may contain,
+their properties and value types, and how edges connect the nodes. Finally, each section presents
+Gremlin examples that exercise the data and demonstrate the traversal patterns the graph was
+designed to teach.
+
+The examples in this book are executable and run against the corresponding graph at build time, so
+their results are the actual output produced by the graph. The same graphs are available in the
+Gremlin Console through `TinkerFactory`, which makes it convenient to follow along and experiment
+with variations of the queries shown here.
+
+include::modern.asciidoc[]
+
+include::the-crew.asciidoc[]
+
+include::grateful-dead.asciidoc[]

--- a/docs/src/data/modern.asciidoc
+++ b/docs/src/data/modern.asciidoc
@@ -1,0 +1,106 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+[[modern]]
+[llms-summary="The modern graph: TinkerPop's canonical example graph of people and the software they created, used throughout the documentation. Includes its GQL Graph Types schema and runnable Gremlin examples."]
+== The Modern Graph
+
+The modern graph is the canonical example graph of Apache TinkerPop and the one used for the
+majority of the examples throughout the documentation. It models a small community of people and
+the software they created: `marko`, `vadas`, `josh`, and `peter` are people, while `lop` and
+`ripple` are software projects written in Java. People are connected to one another by `knows`
+edges and to software by `created` edges, and both kinds of edge carry a `weight` that indicates
+the strength of the relationship.
+
+The graph originates in the "classic" toy graph that shipped with TinkerPop 2.x. It preserves that
+same six-vertex, six-edge structure but adopts the 3.x feature of vertex labels, distinguishing
+`person` vertices from `software` vertices rather than leaving every vertex unlabeled. Its small
+size and mix of two vertex labels and two edge labels make it well suited to demonstrating the
+fundamentals of Gremlin: navigating between adjacent vertices, filtering on labels and properties,
+and working with edge properties. It is created with `TinkerFactory.createModern()` and ships as
+`data/tinkerpop-modern.*`.
+
+.The Modern Graph
+image::tinkerpop-modern.png[width=500]
+
+=== Schema
+
+[source,gql]
+----
+-- node types
+(:person => { name :: STRING NOT NULL, age :: INT }),
+(:software => { name :: STRING NOT NULL, lang :: STRING }),
+
+-- edge types
+(:person)-[:knows { weight :: DOUBLE }]->(:person),
+(:person)-[:created { weight :: DOUBLE }]->(:software)
+----
+
+The `weight` property on both edge labels is a double-precision floating point value. This is one
+of the few differences from the older classic graph, where the same `weight` is a single-precision
+float.
+
+=== Examples
+
+The examples below introduce the people, then follow the two edge labels to explore who knows whom
+and who created what.
+
+[gremlin-groovy,modern]
+----
+g.V().hasLabel('person').valueMap('name','age') <1>
+g.V().hasLabel('software').values('name') <2>
+g.V().has('person','name','marko').out('knows').values('name') <3>
+g.V().has('person','name','marko').out('created').values('name') <4>
+----
+
+<1> The four people in the graph, each with a `name` and an `age`.
+<2> The two software projects. Software vertices carry a `lang` property rather than an `age`.
+<3> The people that `marko` knows, reached by following outgoing `knows` edges.
+<4> The software that `marko` created, reached by following outgoing `created` edges.
+
+Because `created` edges point from people to software, the incoming direction of that same label
+identifies the authors of each project. Grouping by the software name summarizes who contributed
+to what.
+
+[gremlin-groovy,modern]
+----
+g.V().hasLabel('software').
+      group().
+        by('name').
+        by(__.in('created').values('name').fold()) <1>
+----
+
+<1> For each software project, collect the names of the people who created it. Both `lop` and
+`ripple` are reached through `created` edges, and `lop` has more than one author.
+
+The `weight` on a `created` edge records how much of a project a person contributed. Traversing the
+edge itself, rather than stepping straight to the adjacent vertex, makes that value available.
+
+[gremlin-groovy,modern]
+----
+g.V().has('software','name','lop').
+      inE('created').as('contribution'). <1>
+      outV().as('contributor').
+      select('contributor','contribution').
+        by('name').
+        by('weight') <2>
+----
+
+<1> Step onto the incoming `created` edges of `lop` and label them so the edge property can be
+selected later.
+<2> Pair each contributor's `name` with the `weight` of their contribution to `lop`.

--- a/docs/src/data/the-crew.asciidoc
+++ b/docs/src/data/the-crew.asciidoc
@@ -1,0 +1,122 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+[[the-crew]]
+[llms-summary="The crew graph: a TinkerPop 3.x showcase for meta-properties, multi-properties and graph variables. Includes its GQL Graph Types schema and runnable Gremlin examples that exercise those features."]
+== The Crew Graph
+
+The crew graph models a group of contributors and the software they work on. `marko`, `stephen`,
+`matthias`, and `daniel` are people, while `gremlin` and `tinkergraph` are software. People
+`develops` and `uses` software, the `develops` edge records the year work began and the `uses` edge
+records a skill level, and one piece of software `traverses` another.
+
+The graph was created to provide examples and test coverage for the structural features introduced
+in TinkerPop 3.x, and it is the reference example for three of them. First, a person's `location` is
+a multi-property: each person has held several locations over time, so the single `location` key
+holds a list of values. Second, each `location` value carries meta-properties, `startTime` and an
+optional `endTime`, that record the span during which the person lived there. A location with no
+`endTime` is the person's current one. Third, the graph itself carries graph variables that hold
+metadata about the graph. These features make the crew graph the right choice for demonstrating
+multi-properties, meta-properties, and graph variables. It is created with
+`TinkerFactory.createTheCrew()` and ships as `data/tinkerpop-crew.*`.
+
+.The Crew Graph
+image::the-crew-graph.png[width=685]
+
+=== Schema
+
+[source,gql]
+----
+-- node types
+(:person => { name :: STRING NOT NULL, location :: LIST<STRING> }),
+(:software => { name :: STRING NOT NULL }),
+
+-- edge types
+(:person)-[:develops { since :: INT }]->(:software),
+(:person)-[:uses { skill :: INT }]->(:software),
+(:software)-[:traverses]->(:software)
+----
+
+GQL Graph Types describes the shape of vertices and edges but does not model every TinkerPop
+structural feature. The `location` multi-property is captured above as a `LIST<STRING>`, but the
+`startTime` and `endTime` meta-properties attached to each individual `location` value have no
+representation in the schema language, because meta-properties are properties on a property rather
+than on the vertex. The graph variables `creator`, `lastModified`, and `comment` are likewise
+metadata about the graph as a whole and fall outside the node and edge type definitions. Both are
+demonstrated in the examples below.
+
+=== Examples
+
+Because `location` is a multi-property whose values carry meta-properties, the current location of
+each person is the `location` value that has no `endTime`.
+
+[gremlin-groovy,theCrew]
+----
+g.V().as('a').
+      properties('location').as('b').
+      hasNot('endTime').as('c'). <1>
+      select('a','b','c').by('name').by(value).by('startTime') <2>
+----
+
+<1> Keep only the `location` value that has no `endTime` meta-property, which is the current one.
+<2> Report each person's `name`, current location `value`, and the `startTime` meta-property that
+records when they moved there.
+
+The full residence history of a person is obtained by ordering all of their `location` values by
+`startTime`. A location that is still current has no `endTime`, so `coalesce()` supplies a stand-in
+value in that case.
+
+[gremlin-groovy,theCrew]
+----
+g.V().has('person','name','daniel').
+      properties('location'). <1>
+      order().by('startTime',asc).
+      project('city','from','to').
+        by(value).
+        by('startTime').
+        by(coalesce(values('endTime'), constant('present'))) <2>
+----
+
+<1> Stream all of `daniel`'s `location` values rather than stepping to the vertex, so the
+meta-properties on each value remain reachable.
+<2> For each location, project the city name, the `startTime`, and the `endTime` (or `present` when
+the location is current).
+
+The `uses` edge carries a `skill` property, which makes it possible to rank the users of a piece of
+software by proficiency.
+
+[gremlin-groovy,theCrew]
+----
+g.V().has('name','gremlin').inE('uses').
+      order().by('skill',asc).as('a'). <1>
+      outV().as('b').
+      select('a','b').by('skill').by('name') <2>
+----
+
+<1> Order the incoming `uses` edges of `gremlin` by their `skill` value.
+<2> Pair each `skill` level with the `name` of the person who holds it.
+
+Graph variables are read from the `Graph` instance itself rather than through a traversal.
+
+[gremlin-groovy,theCrew]
+----
+graph.variables().asMap() <1>
+----
+
+<1> The crew graph records its `creator`, the year it was `lastModified`, and a `comment`
+describing its purpose.

--- a/docs/src/dev/io/graphml.asciidoc
+++ b/docs/src/dev/io/graphml.asciidoc
@@ -30,7 +30,8 @@ support.
 In TinkerPop, GraphML is also not extended for purpose of serializing just any type (i.e. serialize just a `Vertex` to
 XML). It is only supported for a `Graph` instance.
 
-The following example is a representation of the Modern toy graph in GraphML:
+The following example is a representation of the
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#modern[Modern toy graph] in GraphML:
 
 [source,xml]
 ----

--- a/docs/src/dev/io/graphson.asciidoc
+++ b/docs/src/dev/io/graphson.asciidoc
@@ -64,7 +64,8 @@ writer.writeObject(os, graph);
 Generalized object serialization will be discussed later in this section, so for now the focus will be on the "graph"
 format. Unlike GraphML, GraphSON does not use an edge list format. It uses an adjacency list. In the adjacency list,
 each vertex is essentially a line in the file and the vertex line contains a list of all the edges associated with
-that vertex. The GraphSON 3.0 representation looks like this for the Modern toy graph:
+that vertex. The GraphSON 3.0 representation looks like this for the
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#modern[Modern toy graph]:
 
 [source,json]
 ----

--- a/docs/src/index.asciidoc
+++ b/docs/src/index.asciidoc
@@ -46,6 +46,9 @@ be more convenient in some cases.
 8. link:https://tinkerpop.apache.org/docs/x.y.z/upgrade/[Upgrade Documentation] - Notes related to upgrading from one
 version of TinkerPop to the next. This document describes breaking changes, major new features and other important
 information related to a particular version.
+9. link:https://tinkerpop.apache.org/docs/x.y.z/data/[Sample Data] - A reference for the sample graphs bundled with
+TinkerPop. It describes the nature, origin and best use of each graph, presents its schema, and demonstrates it with
+runnable Gremlin.
 
 NOTE: Some of the documentation listed here leads to third-party web sites. Such documentation is supplemental to
 Apache TinkerPop. Third-party documentation is marked as such in the listings below.

--- a/docs/src/recipes/centrality.asciidoc
+++ b/docs/src/recipes/centrality.asciidoc
@@ -106,7 +106,7 @@ g.V().as("v").                                                                  
 
 WARNING: Since the betweeness centrality algorithm requires the shortest path between any pair of vertices in the graph,
 its practical applications are very limited. It's recommended to use this algorithm only on small subgraphs (graphs like
-the link:https://tinkerpop.apache.org/docs/x.y.z/reference/#grateful-dead[Grateful Dead graph] with only 808 vertices
+the link:https://tinkerpop.apache.org/docs/x.y.z/data/#grateful-dead[Grateful Dead graph] with only 808 vertices
 and 8049 edges already require a massive amount of compute resources to determine the shortest paths between all vertex
 pairs).
 
@@ -144,7 +144,7 @@ g.withSack(1f).V().as("v").                                                     
 
 WARNING: Since the closeness centrality algorithm requires the shortest path between any pair of vertices in the graph,
 its practical applications are very limited. It's recommended to use this algorithm only on small subgraphs (graphs like
-the link:https://tinkerpop.apache.org/docs/x.y.z/reference/#grateful-dead[Grateful Dead graph] with only 808 vertices
+the link:https://tinkerpop.apache.org/docs/x.y.z/data/#grateful-dead[Grateful Dead graph] with only 808 vertices
 and 8049 edges already require a massive amount of compute resources to determine the shortest paths between all vertex
 pairs).
 

--- a/docs/src/reference/intro.asciidoc
+++ b/docs/src/reference/intro.asciidoc
@@ -110,8 +110,9 @@ TIP: Get to know this graph structure as it is used extensively throughout the d
 well. It is referred to as "TinkerPop Modern" as it is a modern variation of the original demo graph distributed with
 TinkerPop0 back in 2009 (i.e. the good ol' days -- it was the best of times and it was the worst of times).
 
-TIP: All of the toy graphs available in TinkerPop are described in
-link:https://tinkerpop.apache.org/docs/x.y.z/tutorials/the-gremlin-console/#toy-graphs[The Gremlin Console] tutorial.
+TIP: The link:https://tinkerpop.apache.org/docs/x.y.z/data/#modern[modern graph] and all of the other sample graphs
+that TinkerPop provides are described in full, with their schemas and example traversals, in the
+link:https://tinkerpop.apache.org/docs/x.y.z/data/[TinkerPop Sample Data] reference.
 
 Similar to computing in general, graph computing makes a distinction between *structure* (graph) and *process*
 (traversal). The structure of the graph is the data model defined by a vertex/edge/property

--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -164,6 +164,8 @@ associated vertex).
 [[the-crew-toy-graph]]
 TIP: A toy graph demonstrating all of the new TinkerPop graph structure features is available at
 `TinkerFactory.createTheCrew()` and `data/tinkerpop-crew*`. This graph demonstrates multi-properties and meta-properties.
+Its full schema and example traversals are documented in the
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#the-crew[Crew Graph] section of the TinkerPop Sample Data reference.
 
 .TinkerPop Crew
 image::the-crew-graph.png[width=685]

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2615,7 +2615,8 @@ image::grateful-dead-schema.png[width=475]
 
 `MatchStep` brings functionality similar to link:http://en.wikipedia.org/wiki/SPARQL[SPARQL] to Gremlin. Like SPARQL,
 MatchStep conjoins a set of patterns applied to a graph.  For example, the following traversal finds exactly those
-songs which Jerry Garcia has both sung and written (using the Grateful Dead graph distributed in the `data/` directory):
+songs which Jerry Garcia has both sung and written (using the
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#grateful-dead[Grateful Dead graph] distributed in the `data/` directory):
 
 [gremlin-groovy]
 ----

--- a/docs/src/tutorials/getting-started/index.asciidoc
+++ b/docs/src/tutorials/getting-started/index.asciidoc
@@ -122,6 +122,9 @@ For your first graph, use the "Modern" graph, which looks like this:
 
 image:tinkerpop-modern.png[width=500]
 
+TIP: The full schema of the modern graph and further example traversals are described in the
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#modern[Modern Graph] section of the TinkerPop Sample Data reference.
+
 It can be instantiated in the console this way:
 
 [gremlin-groovy]

--- a/docs/src/tutorials/the-gremlin-console/index.asciidoc
+++ b/docs/src/tutorials/the-gremlin-console/index.asciidoc
@@ -105,15 +105,18 @@ Now that you have an empty TinkerGraph instance, you could load a sample of your
 traversals.  Of course, you might also try one of the "toy" graphs (i.e. graphs with sample data) that TinkerPop
 packages with the console through the `TinkerFactory`.  `TinkerFactory` has a number of static methods that can be
 called to create these standard `TinkerGraph` instances.  They are "standard" in the sense that they are typically used
-for all TinkerPop examples and test cases.
+for all TinkerPop examples and test cases.  The full schema, origin, and example traversals for each graph are
+documented in the link:https://tinkerpop.apache.org/docs/x.y.z/data/[TinkerPop Sample Data] reference.
 
 * `createClassic()` - The original TinkerPop 2.x toy graph (link:https://tinkerpop.apache.org/docs/x.y.z/images/tinkerpop-classic.png[diagram]).
 * `createModern()` - The TinkerPop 3.x representation of the "classic" graph, where the main difference is that vertex
 labels are defined and the "weight" edge property is a `double` rather than a `float`
-(link:https://tinkerpop.apache.org/docs/x.y.z/images/tinkerpop-modern.png[diagram]).
+(link:https://tinkerpop.apache.org/docs/x.y.z/images/tinkerpop-modern.png[diagram],
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#modern[reference]).
 * `createTheCrew()` - A graph that demonstrates usage of the new structural features of TinkerPop 3.x such as
 link:https://tinkerpop.apache.org/docs/x.y.z/reference/#vertex-properties[vertex meta-properties and multi-properties]
-(link:https://tinkerpop.apache.org/docs/x.y.z/images/the-crew-graph.png[diagram]).
+(link:https://tinkerpop.apache.org/docs/x.y.z/images/the-crew-graph.png[diagram],
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#the-crew[reference]).
 
 [gremlin-groovy]
 ----
@@ -126,7 +129,8 @@ the output of the Gremlin Console itself, these toy graphs are small (only a few
 to have a small graph when learning Gremlin, so that you can easily see if you are getting the results you expect. Even
 though these graphs are "small", they are robust enough in structure to try out many different kinds of traversals.
 However, if you find that a larger graph might be helpful, there is another option: The Grateful Dead
-(link:https://tinkerpop.apache.org/docs/x.y.z/images/grateful-dead-schema.png[schema]).
+(link:https://tinkerpop.apache.org/docs/x.y.z/images/grateful-dead-schema.png[schema],
+link:https://tinkerpop.apache.org/docs/x.y.z/data/#grateful-dead[reference]).
 
 [gremlin-groovy]
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -1359,6 +1359,37 @@ limitations under the License.
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>data-book</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceDirectory>${asciidoc.input.dir}/data</sourceDirectory>
+                                    <sourceDocumentName>index.asciidoc</sourceDocumentName>
+                                    <outputDirectory>${htmlsingle.output.dir}/data</outputDirectory>
+                                    <backend>html5</backend>
+                                    <doctype>book</doctype>
+                                    <attributes>
+                                        <imagesdir>../images</imagesdir>
+                                        <encoding>UTF-8</encoding>
+                                        <toc>true</toc>
+                                        <toclevels>2</toclevels>
+                                        <toc-position>left</toc-position>
+                                        <stylesdir>${asciidoctor.style.dir}</stylesdir>
+                                        <stylesheet>tinkerpop.css</stylesheet>
+                                        <source-highlighter>coderay</source-highlighter>
+                                        <basedir>${project.basedir}</basedir>
+                                        <docinfo>shared</docinfo>
+                                        <docinfodir>${project.basedir}/docs/src</docinfodir>
+                                        <gremlin-docs-console-home>${gremlin.docs.console.home}</gremlin-docs-console-home>
+                                        <gremlin-docs-hadoop-libs>${gremlin.docs.hadoop.libs}</gremlin-docs-hadoop-libs>
+                                        <gremlin-docs-dryrun>${gremlin.docs.dryrun}</gremlin-docs-dryrun>
+                                        <tinkerpop-version>${project.version}</tinkerpop-version>
+                                    </attributes>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>tutorial-getting-started</id>
                                 <phase>generate-resources</phase>
                                 <goals>
@@ -1609,6 +1640,30 @@ limitations under the License.
                                     <sourceDirectory>${asciidoc.input.dir}/recipes</sourceDirectory>
                                     <sourceDocumentName>index.asciidoc</sourceDocumentName>
                                     <outputDirectory>${markdown.output.dir}/recipes</outputDirectory>
+                                    <backend>tpmarkdown</backend>
+                                    <doctype>book</doctype>
+                                    <attributes>
+                                        <imagesdir>../images</imagesdir>
+                                        <encoding>UTF-8</encoding>
+                                        <outfilesuffix>.md</outfilesuffix>
+                                        <basedir>${project.basedir}</basedir>
+                                        <gremlin-docs-console-home>${gremlin.docs.console.home}</gremlin-docs-console-home>
+                                        <gremlin-docs-hadoop-libs>${gremlin.docs.hadoop.libs}</gremlin-docs-hadoop-libs>
+                                        <gremlin-docs-dryrun>${gremlin.docs.dryrun}</gremlin-docs-dryrun>
+                                        <tinkerpop-version>${project.version}</tinkerpop-version>
+                                    </attributes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>data-book-markdown</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceDirectory>${asciidoc.input.dir}/data</sourceDirectory>
+                                    <sourceDocumentName>index.asciidoc</sourceDocumentName>
+                                    <outputDirectory>${markdown.output.dir}/data</outputDirectory>
                                     <backend>tpmarkdown</backend>
                                     <doctype>book</doctype>
                                     <attributes>


### PR DESCRIPTION
New reference book at docs/src/data/ describing the bundled sample graphs (modern, the crew, grateful dead): the nature, origin and best use of each, a schema in GQL Graph Types, and runnable Gremlin examples. Wired into the docs build (data-book and data-book-markdown) and linked from the Compendium. Descriptive references to these graphs across the reference, tutorial, recipe and IO books now link to the book as their authoritative source.

Assisted-by: Claude Code:claude-opus-4-8

VOTE +1