### PR TITLE
Fix index() step callout cross-reference and typo

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -2578,7 +2578,7 @@ g.V().hasLabel("person").values("name").fold().
 
 <1> Indexing non-collection items results in multiple indexed single-item collections.
 <2> Index all software names in their alphabetical order.
-<3> Same as statement 1, but with an explicitely specified list indexer.
+<3> Same as statement 2, but with an explicitly specified list indexer.
 <4> Index all person names in their alphabetical order and store the result in an ordered map.
 
 *Additional References*


### PR DESCRIPTION
In the Index Step section of the reference documentation (`docs/src/reference/the-traversal.asciidoc`, `#index-step`), callout 3 read:

> Same as statement 1, but with an explicitely specified list indexer.

This was misleading in two ways:

- The third example is structurally identical to the **second** example — both use the list indexer, and the third simply specifies it explicitly via `with(WithOptions.indexer, WithOptions.list)`. Referencing statement 1 misdirects a reader trying to understand why examples 2 and 3 produce identical output. Changed the reference to statement 2.
- "explicitely" is misspelled; corrected to "explicitly".

This is a minimal, single-line documentation fix — no examples or other callouts were changed.