### PR TITLE
Make hasValue() value-matching semantics explicit in provider docs

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -2159,7 +2159,14 @@ None
 
 *Considerations:*
 
-* Equivalent to `has(T.value, ...)`.
+* `hasValue(value)` is equivalent to `has(T.value, value)`.
+* When multiple values are supplied, `hasValue(value, otherValues...)` is equivalent to
+  `has(T.value, within(value, otherValues...))`: the property matches if its value equals *any* of the
+  supplied values (any-of / OR semantics).
+* Value matching uses Gremlin equality, so it follows the rules described in
+  <<gremlin-semantics-equality-comparability, Equality and Comparability>>, including cross-type numeric
+  coercion (for example, the integer `1` matches the long `1L`, per <<Numeric Type Promotion>>).
+* A `null` argument matches nothing (produces an empty result) and does not raise an error.
 * Operates on `Property` or `VertexProperty` traversers (typically reached via `properties()`).
 * Child traversals must be read-only; mutating steps are rejected with an `Argument Error`.
 


### PR DESCRIPTION
Clarify the value-matching contract for hasValue() in the Gremlin semantics provider guide: multiple values use within-set (any-of) matching, value comparison follows Gremlin equality and comparability including cross-type numeric coercion, and a null argument matches nothing without raising an error.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->