### PR TITLE
Correct Python cardinality functions and add format_() to steps list

### DIFF
--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -3907,7 +3907,7 @@ that makes traversals a bit more concise.
 In situations where Python reserved words and global functions overlap with standard Gremlin steps and tokens, those
 bits of conflicting Gremlin get an underscore appended as a suffix:
 
-*Steps* - <<all-step,all_()>>, <<and-step,and_()>>, <<any-step,any_()>>, <<as-step,as_()>>, <<filter-step,filter_()>>, <<from-step,from_()>>,
+*Steps* - <<all-step,all_()>>, <<and-step,and_()>>, <<any-step,any_()>>, <<as-step,as_()>>, <<filter-step,filter_()>>, <<format-step,format_()>>, <<from-step,from_()>>,
 <<id-step,id_()>>, <<is-step,is_()>>, <<in-step,in_()>>, <<max-step,max_()>>,
 <<min-step,min_()>>, <<not-step,not_()>>, <<or-step,or_()>>, <<range-step,range_()>>, <<sum-step,sum_()>>,
 <<with-step,with_()>>
@@ -3915,8 +3915,9 @@ bits of conflicting Gremlin get an underscore appended as a suffix:
 *Tokens* - <<a-note-on-scopes,Scope.global_>>, `Direction.from_`, `Operator.sum_`
 
 In addition, the enum construct for `Cardinality` cannot have functions attached to it the way it can be done in Java,
-therefore cardinality functions that take a value like `list()`, `set()`, and `single()` are referenced from a
-`CardinalityValue` class rather than `Cardinality` itself.
+therefore cardinality functions that take a value like `single()`, `list_()`, and `set_()` are referenced from a
+`CardinalityValue` class rather than `Cardinality` itself. Note that `list` and `set` overlap with Python built-ins and
+so are spelled with a trailing underscore, while `single()` is unchanged.
 
 [[gremlin-python-limitations]]
 === Limitations


### PR DESCRIPTION
The Gremlin-Python Differences section listed the value-taking cardinality functions as list(), set() and single(), but CardinalityValue actually exposes single(), list_() and set_(). Calling CardinalityValue.list() or CardinalityValue.set() raises AttributeError, so the documented spelling does not work. Correct the sentence and note that list and set are renamed with a trailing underscore because they overlap with Python built-ins.

Also add the missing format_() step to the list of underscore-suffixed steps.
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->