### PR TITLE
Show visible output for simplePath() from()/to() by(label) examples

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -5318,19 +5318,23 @@ g.V(1).both().both()
 g.V(1).both().both().simplePath()
 g.V(1).both().both().simplePath().path()
 g.V(1).both().both().simplePath().by('age') <1>
-g.V().out().as('a').out().as('b').out().as('c').
+g.V().as('a').out().as('b').out().as('c').
   simplePath().by(label).
-  path()
-g.V().out().as('a').out().as('b').out().as('c').
+  path().by('name') <2>
+g.V().as('a').out().as('b').out().as('c').
   simplePath().
     by(label).
     from('b').
     to('c').
   path().
-    by('name')
+    by('name') <3>
 ----
 
 <1> The "age" property is not <<by-step,productive>> for all vertices and therefore those values are filtered.
+<2> Comparing labels across the whole path filters every result: each two-hop out-path begins with two `person`
+vertices (e.g. `marko` then `josh`), so no path is simple when analyzed by label.
+<3> Restricting the `simplePath()` check to the `b`..`c` segment with `from()`/`to()` compares only those two
+labels (`person` and `software`), so the paths are retained.
 
 By using the `from()` and `to()` modulators traversers can ensure that only certain sections of the path are acyclic.
 


### PR DESCRIPTION
The last two simplePath() examples in the modern-graph block used three out() hops, but the modern graph has no three-hop outgoing paths, so both examples rendered empty output with no explanation. This left the from()/to() segment-scoping semantics undemonstrated and made the empty results look like a mistake.

Reduce the examples to two out() hops and add callouts. The whole-path by(label) example is now meaningfully empty (each path starts with two person vertices), while scoping the check to the b..c segment with from()/to() retains the paths, producing visible contrasting output.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->