### PR TITLE
Clarify difference() step semantics in the provider documentation

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -1640,9 +1640,22 @@ None
 
 *Considerations:*
 
-Set difference (`A-B`) is an ordered operation. The incoming traverser is treated as `A` and the provided argument is
-treated as `B`. A set is returned after the difference operation is applied so there won't be duplicates. This step only
-applies to list types which means that non-iterable types (including null) will cause exceptions to be thrown.
+Set difference (`A-B`) is a directional operation. The incoming traverser is treated as `A` and the provided argument
+as `B`, so `A-B` and `B-A` generally yield different results. This directionality is the only sense in which the
+operation is ordered. The result is a `SET`, so it contains no duplicates, and its iteration order is unspecified. In
+particular the result does not preserve the order of the incoming list, so a traversal that depends on a particular
+member order orders the result explicitly.
+
+Membership of the result is decided by comparing each member of `A` against the members of `B` by value and by type.
+Numerically equal values of different numeric types, such as an `INT` and a `LONG` of the same magnitude, are treated
+as distinct members, so a value from `A` is removed only when `B` contains a member of the same type and value. A
+`NULL` is a legal member of either list and is compared in the same way, so a `NULL` in `A` is removed only when `B`
+also contains a `NULL`.
+
+This step only applies to lists. An error is raised when the incoming traverser or the argument is itself `NULL` or is
+not iterable, while a `NULL` that appears as an element of an otherwise iterable list is permitted and behaves as
+described above. When the argument is supplied as a `Traversal`, that traversal produces the comparison list as a
+single result rather than as a stream of separate results.
 
 *Exceptions:*
 


### PR DESCRIPTION
Expand the Considerations for the difference() step in gremlin-semantics.asciidoc with language-agnostic behavioral detail. The result is a SET whose iteration order is unspecified and does not preserve the incoming list order, and A-B is directional rather than order-preserving. Membership compares members by both value and type, so numerically equal values of different types are distinct, and a null is a legal list element while a null or non-iterable whole traverser or argument raises an error. It also notes that a traversal supplied as the argument produces the comparison list as a single result.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->