### PR TITLE
Specify per-type asString() rendering in the Gremlin semantics

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -992,7 +992,35 @@ None
 
 *Considerations:*
 
-Each value is converted to its canonical String representation.
+Under the `global` scope the incoming value is rendered to its canonical String representation. That representation is
+defined per type as follows:
+
+[width="100%",options="header"]
+|=========================================================
+|Type |Rendering |Example
+|`INT`, `LONG` |The decimal value with no type suffix. |`123`, `5`
+|`FLOAT`, `DOUBLE`, `BIGDECIMAL` |The decimal value with no type suffix. The three types render identically and are
+indistinguishable once converted. |`1.5`
+|`BOOLEAN` |The literal `true` or `false`. |`true`
+|`DATETIME` |An ISO-8601 timestamp with trailing zero-valued components elided. |`2023-08-02T00:00Z`
+|`Vertex` |The vertex identifier wrapped as `v[<id>]`. |`v[1]`
+|=========================================================
+
+A `LIST` under the `global` scope is rendered as a whole, producing a single `STRING` in which the elements appear
+bracketed and comma-separated:
+
+[source,text]
+----
+[1, 2, 3] -> "[1, 2, 3]"
+----
+
+Under `Scope.local` the incoming value is a `LIST` and each element is rendered individually. The list structure is
+preserved, yielding a `LIST` of `STRING` rather than a single `STRING`:
+
+[source,text]
+----
+[1, 2, 3] -> ["1", "2", "3"]
+----
 
 *Exceptions:*
 


### PR DESCRIPTION
Replace the vague statement that each value is converted to its canonical String representation in the asString()-step Considerations section with an explicit per-type rendering table and examples. The table covers integer and long, floating-point, boolean, datetime, and vertex values, and two examples distinguish list rendering under the global scope from element-wise rendering under Scope.local. The null and scope Exceptions block is unchanged.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->