### PR TITLE
Document string-to-number coercion for asNumber() in Gremlin semantics

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -947,13 +947,9 @@ None
 
 *Considerations:*
 
-*Modulation:*
-
-None
-
-*Considerations:*
-
 If no type token is provided, the incoming number remains unchanged. A `DATE` input is converted to milliseconds since epoch. A `null` input passes through as `null`.
+
+When no type token is provided and the incoming traverser is a `STRING`, the string is parsed according to its numeric value. A string that represents an integer value is parsed to the smallest of `INT`, `LONG`, or `BIGINT` that can represent it. A string containing a decimal point or an exponent is parsed to `FLOAT` when the value is representable as such, and otherwise to a wider floating-point type (`DOUBLE`, then `BIGDECIMAL`).
 
 *Exceptions:*
 


### PR DESCRIPTION
Add a Considerations rule describing how asNumber() parses a string with no type token: integer-valued strings resolve to the smallest of INT, LONG, or BIGINT that fits, and decimal or exponent-notation strings resolve to FLOAT (then DOUBLE or BIGDECIMAL). Also remove a duplicated Modulation/Considerations heading block in the asNumber() section.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->