### PR TITLE
Clarify asDate() semantics in the Gremlin semantics specification

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -894,14 +894,14 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#asBool-step[reference]
 [[asDate-step]]
 === asDate()
 
-*Description:* Parse the value of incoming traverser as date. Supported ISO-8601 strings and Unix time numbers.
+*Description:* Parse the value of the incoming traverser as a `DATETIME`. ISO-8601 strings and numeric Unix-time values are supported.
 
 *Syntax:* `asDate()`
 
 [width="100%",options="header"]
 |=========================================================
 |Start Step |Mid Step |Modulated |Domain |Range
-|N |Y |N |`any` |`any`
+|N |Y |N |`STRING`/`NUMBER`/`DATETIME` |`DATETIME`
 |=========================================================
 
 *Arguments:*
@@ -914,7 +914,7 @@ None
 
 *Considerations:*
 
-Incoming date remains unchanged.
+A `DATETIME` input passes through unchanged. A `STRING` input is parsed as an ISO-8601 datetime, and a numeric input is interpreted as the count of milliseconds since the Unix epoch.
 
 *Exceptions:*
 


### PR DESCRIPTION
State that asDate() yields a DATETIME value rather than a bare date, document that numeric input is interpreted as milliseconds since the Unix epoch, and reconcile the Domain column with the accepted input types and the Exceptions list (STRING, NUMBER, and DATETIME).

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->