### PR TITLE
Specify project() by()/key count mismatch semantics

### DIFF
--- a/docs/src/dev/provider/gremlin-semantics.asciidoc
+++ b/docs/src/dev/provider/gremlin-semantics.asciidoc
@@ -2820,8 +2820,9 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#product-step[reference]
 
 *Modulation:*
 
-* `by()` - Determines how to transform the current object for each key in the resulting map. The number of `by()`
-modulations should match the number of keys provided.
+* `by()` - Determines how to transform the current object for each key in the resulting map. The `by()` modulations
+are matched to the keys in the order both are provided. A mismatch between the number of `by()` modulations and the
+number of keys does not raise an error and is resolved as described in the considerations below.
 
 *Considerations:*
 
@@ -2829,6 +2830,12 @@ The `project()` step is similar to `select()` but instead of retrieving historic
 current state of the traverser. Each key in the resulting map corresponds to a `by()` modulation in the order they are
 provided. If a `by()` modulation doesn't produce a value for a particular key (not productive), that key will be omitted
 from the resulting `MAP`.
+
+The number of `by()` modulations need not equal the number of keys, and any mismatch is resolved without raising an
+error. When fewer `by()` modulations than keys are provided, the modulations are reused cyclically across the keys in
+round-robin order, so a single `by()` is applied to every key. When more `by()` modulations than keys are provided, the
+surplus modulations are never consumed and are silently ignored. When no `by()` modulation is provided, every key maps
+to the current object unchanged.
 
 *Exceptions:*
 


### PR DESCRIPTION
The project() section stated only that the number of by() modulations should match the number of keys, without describing what happens when they do not. Replace that soft guidance with the concrete, no-error behavior: fewer by() modulations than keys are reused cyclically in round-robin order, surplus by() modulations are silently ignored, and with no by() every key maps to the current object unchanged.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->