### PR TITLE
Clarify provider-dependent behavior of call() step in reference docs

### DIFF
--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1249,6 +1249,14 @@ g.call().with('verbose').with('service', 'xyz-service') <3>
 <2> Produce a Map of detailed service information by name
 <3> Produce the detailed service information for the 'xyz-service'
 
+NOTE: The result of `call()` is entirely dependent on the graph provider in use, since each provider decides which
+services (if any) it exposes. The default TinkerGraph used by the Gremlin Console registers no callable services out
+of the box, so the directory-service examples above return an empty result rather than an error. TinkerGraph does ship
+two example services - `tinker.search` and `tinker.degree.centrality` - which can be registered with the
+`gremlin.tinkergraph.service` configuration option to see `call()` produce real output; consult your graph provider's
+documentation for the services it exposes. The `xyz-service` used in the examples below is a fictional placeholder and
+is not callable on any graph.
+
 The first argument to `call()` is always the name of the service call. Additionally, service calls can accept both
 static and dynamically produced parameters. Static parameters can be passed as a `Map` to the `call()` as the second
 argument. Individual static parameters can also be added using the `.with()` modulator. Dynamic parameters can be


### PR DESCRIPTION
The Call Step section showed directory-service and xyz-service examples with no indication of expected output. On the default TinkerGraph, which registers no callable services, these examples return an empty result, leaving readers unable to tell correct behavior from a broken setup. Add a note explaining that call() results are entirely provider-dependent, that the default TinkerGraph exposes no services (so the examples return empty), how to register TinkerGraph's example services to see real output, and that xyz-service is a fictional placeholder.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.7 (non-breaking only)
    3.8-dev -> 3.8.2 (non-breaking only)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->